### PR TITLE
Morgan.lupton/add synthetics pl endpoints

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -35,7 +35,7 @@ further_reading:
     - `gcp-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}
     - `http-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}
   - [Synthetics private location][11] workers rely on the endpoints below to submit test results:
-      - `intake.synthetics.datadoghq.com` - For sending API test results from worker versions >0.1.6
+      - `intake.synthetics.datadoghq.com` - For sending API test results from worker versions >0.1.6. For worker versions >=1.5.0 this is the only endpoint you need to configure. 
       - `intake-v2.synthetics.datadoghq.com` - For sending browser test results for worker versions >0.2.0
       - `api.datadoghq.com` - For sending API test results from older worker versions <0.1.5
 

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -37,7 +37,7 @@ further_reading:
   - [Synthetics private location][11] workers rely on the endpoints below to submit test results:
       - `intake.synthetics.datadoghq.com` - For sending API test results from worker versions >0.1.6
       - `intake-v2.synthetics.datadoghq.com` - For sending browser test results for worker versions >0.2.0
-      - `api.datadoghq.com` - (Deprecated) For sending API test results from worker versions <0.1.5
+      - `api.datadoghq.com` - For sending API test results from older worker versions <0.1.5
 
   - All other Agent data:
       - **Agents < 5.2.0** `app.`{{< region-param key="dd_site" code="true" >}}

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -35,9 +35,9 @@ further_reading:
     - `gcp-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}
     - `http-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}
   - [Synthetics private location][11] workers rely on the endpoints below to submit test results:
-      - `intake.synthetics.datadoghq.com` - For sending API test results from worker versions >0.1.6. For worker versions >=1.5.0 this is the only endpoint you need to configure. 
-      - `intake-v2.synthetics.datadoghq.com` - For sending browser test results for worker versions >0.2.0
-      - `api.datadoghq.com` - For sending API test results from older worker versions <0.1.5
+      - `intake.synthetics.datadoghq.com` for sending API test results from worker versions >0.1.6. For worker versions >=1.5.0 this is the only endpoint you need to configure. 
+      - `intake-v2.synthetics.datadoghq.com` for sending browser test results for worker versions >0.2.0
+      - `api.datadoghq.com` for sending API test results from older worker versions <0.1.5
 
   - All other Agent data:
       - **Agents < 5.2.0** `app.`{{< region-param key="dd_site" code="true" >}}

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -34,6 +34,11 @@ further_reading:
     - `lambda-tcp-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}
     - `gcp-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}
     - `http-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}
+  - [Synthetics Private Location][11] Workers rely on one of the three endpoints below to submit test results:
+      - `api.datadoghq.com` - For worker versions <0.1.5
+      - `intake.synthetics.datadoghq.com` - For worker versions 0.1.6 to 0.2.0
+      - `intake-v2.synthetics.datadoghq.com` - For worker versions >0.2.0
+    
   - All other Agent data:
       - **Agents < 5.2.0** `app.`{{< region-param key="dd_site" code="true" >}}
       - **Agents >= 5.2.0** `<VERSION>-app.agent.`{{< region-param key="dd_site" code="true" >}}
@@ -44,6 +49,7 @@ Since v6.1.0, the Agent also queries Datadog's API to provide non-critical funct
 
 - **Agent >= 7.18.0/6.18.0** `api.`{{< region-param key="dd_site" code="true" >}}
 - **Agent < 7.18.0/6.18.0** `app.`{{< region-param key="dd_site" code="true" >}}
+
 
 All of these domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at `https://ip-ranges.`{{< region-param key="dd_site" code="true" >}}.
 
@@ -172,3 +178,4 @@ To avoid running out of storage space, the Agent stores the metrics on disk only
 [8]: /security/logs/#hipaa-enabled-customers
 [9]: /agent/proxy/
 [10]: /tracing/profiler/
+[11]: /synthetics/private_locations

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -34,11 +34,11 @@ further_reading:
     - `lambda-tcp-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}
     - `gcp-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}
     - `http-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}
-  - [Synthetics Private Location][11] Workers rely on one of the three endpoints below to submit test results:
-      - `api.datadoghq.com` - For worker versions <0.1.5
-      - `intake.synthetics.datadoghq.com` - For worker versions 0.1.6 to 0.2.0
-      - `intake-v2.synthetics.datadoghq.com` - For worker versions >0.2.0
-    
+  - [Synthetics private location][11] workers rely on the endpoints below to submit test results:
+      - `intake.synthetics.datadoghq.com` - For sending API test results from worker versions >0.1.6
+      - `intake-v2.synthetics.datadoghq.com` - For sending browser test results for worker versions >0.2.0
+      - `api.datadoghq.com` - (Deprecated) For sending API test results from worker versions <0.1.5
+
   - All other Agent data:
       - **Agents < 5.2.0** `app.`{{< region-param key="dd_site" code="true" >}}
       - **Agents >= 5.2.0** `<VERSION>-app.agent.`{{< region-param key="dd_site" code="true" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds Synthetics Private Locations URLs to the Network page where they won't visible previously. 

### Motivation
We commonly refer to the network page when setting up Firewall Rules for PoCs, so figured it would be a good idea to include this data here. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
