### PR TITLE
[serverless] bump aws lambda extension version to v7

### DIFF
--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -52,7 +52,7 @@ Then, add the Datadog Lambda Extension to your container image by adding the fol
 COPY --from=public.ecr.aws/datadog/lambda-extension:<TAG> /opt/extensions/ /opt/extensions
 ```
 
-Replace `<TAG>` with either a specific version number (for example, `6`) or with `latest`. You can see a complete list of possible tags in the [Amazon ECR repository][11].
+Replace `<TAG>` with either a specific version number (for example, `7`) or with `latest`. You can see a complete list of possible tags in the [Amazon ECR repository][11].
 
 ## Log collection
 

--- a/content/en/serverless/datadog_lambda_library/extension.md
+++ b/content/en/serverless/datadog_lambda_library/extension.md
@@ -33,8 +33,8 @@ The Datadog Lambda Extension is distributed as its own Lambda Layer (separate fr
 
     Replace the placeholder values in the ARN as follows:
     - Replace `<AWS_REGION>` with the same AWS region as your Lambda Function, for example, `us-east-1`.
-    - Replace `<VERSION_NUMBER>` with the version of the Datadog Lambda Extension you would like to use, for example `6`. You can identify the current version by viewing the newest image tags in the [Amazon ECR repository][11].
-    
+    - Replace `<VERSION_NUMBER>` with the version of the Datadog Lambda Extension you would like to use, for example `7`. You can identify the current version by viewing the newest image tags in the [Amazon ECR repository][11].
+
     **Note**: This Layer is separate from the Datadog Lambda Library. If you installed the Datadog Lambda Library as a Lambda Layer,
     your function should now have two Lambda Layers attached.
 
@@ -52,7 +52,7 @@ Then, add the Datadog Lambda Extension to your container image by adding the fol
 COPY --from=public.ecr.aws/datadog/lambda-extension:<TAG> /opt/extensions/ /opt/extensions
 ```
 
-Replace `<TAG>` with either a specific version number (for example, `6`) or with `latest`. You can see a complete list of possible tags in the [Amazon ECR repository][11]. 
+Replace `<TAG>` with either a specific version number (for example, `6`) or with `latest`. You can see a complete list of possible tags in the [Amazon ECR repository][11].
 
 ## Log collection
 

--- a/content/fr/serverless/datadog_lambda_library/extension.md
+++ b/content/fr/serverless/datadog_lambda_library/extension.md
@@ -23,7 +23,7 @@ L'extension Datadog est distribuée sous forme de couche Lambda autonome (distin
 2. Ajoutez la couche Lambda pour l'extension Datadog à votre fonction AWS Lambda :
 
     ```
-    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:6
+    arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:7
     ```
 
     Remplacez le paramètre fictif `AWS_REGION` dans l'ARN de la couche Lambda par les valeurs adéquates.

--- a/content/ja/serverless/datadog_lambda_library/extension.md
+++ b/content/ja/serverless/datadog_lambda_library/extension.md
@@ -20,7 +20,7 @@ Datadog 拡張機能は、AWS Lambda 関数の実行中にカスタムメトリ�
 
 ### Lambda レイヤーとして
 
-Datadog Lambda 拡張機能は、独自の Lambda レイヤー ([Datadog Lambda ライブラリ][3]とは別) として配布されます。 
+Datadog Lambda 拡張機能は、独自の Lambda レイヤー ([Datadog Lambda ライブラリ][3]とは別) として配布されます。
 
 1. Datadog Lambda ライブラリをインストールして、[Python][4] または [Node.js][5] アプリケーションをインスツルメントします。
 
@@ -32,7 +32,7 @@ Datadog Lambda 拡張機能は、独自の Lambda レイヤー ([Datadog Lambda 
 
     ARN のプレイスホルダーの値を次のように置き換えます。
     - Replace `<AWS_REGION>` を Lambda 関数と同じ AWS リージョンに置き換えます。例、 `us-east-1`
-    - `<VERSION_NUMBER>` を使用する Datadog Lambda 拡張機能のバージョン（たとえば `6` ）に置き換えます。 現在のバージョンを確認するには、[Amazon ECR リポジトリ][11]で最新のイメージタグを表示します。
+    - `<VERSION_NUMBER>` を使用する Datadog Lambda 拡張機能のバージョン（たとえば `7` ）に置き換えます。 現在のバージョンを確認するには、[Amazon ECR リポジトリ][11]で最新のイメージタグを表示します。
 
     **注**: このレイヤーは Datadog Lambda ライブラリとは別のものです。Datadog Lambda ライブラリを Lambda レイヤーとしてインストールした場合、
     関数には 2 つの Lambda レイヤーがアタッチされることになります。


### PR DESCRIPTION
### What does this PR do?
Bumps the version referenced in the AWS Lambda Extension documentation to v7. Eventually we want to move this to a link to the releases tab on github.

### Motivation

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/darcy.rayner/bump-lambda-extension-6/content/en/serverless/datadog_lambda_library/extension.md 

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
