### PR TITLE
Added descriptor/link under alert-grouping

### DIFF
--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -97,7 +97,7 @@ Alerts are grouped automatically based on your selection of the `group by` step 
 Simple alerts aggregate over all reporting sources. You receive one alert when the aggregated value meets the set conditions. This works best to monitor a metric from a single host or the sum of a metric across many hosts.
 
 Multi alerts apply the alert to each source according to your group parameters. You receive an alert for each group that meets the set conditions. For example, you could group `system.disk.in_use` by `host` and `device` to receive a separate alert for each host device that is running out of space. 
-Note that if your metric is only reporting by `host` with no `device` tag, it would not be detected by a monitor group by both `host` and `device`.
+Note that if your metric is only reporting by `host` with no `device` tag, it would not be detected by a monitor group by both `host` and `device`. [Tag Variables][6] are available for every group evaluated in the multi-alert to dynamically fill in notifications with useful context.
 
 ### Set alert conditions
 
@@ -211,3 +211,4 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 [3]: /dashboards/querying/#advanced-graphing
 [4]: /monitors/faq/what-are-recovery-thresholds/
 [5]: /monitors/notifications/
+[6]: /monitors/notifications/?tab=is_alert#tag-variables


### PR DESCRIPTION
Suggested change to satisfy a customer's recommendation to include reference to how tag variables correspond with mult-alert grouping. (see ticket 469637 for full motivation/impact)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds a link to reference the tag variables that become available with mult-alert groupings

### Motivation
<!-- What inspired you to submit this pull request?-->

Citizens bank reached out because they included tags that were not assigned to all resources in the query for the purposes of having the tag variables available (resulting in expected groups not evaluating). Requested a clear explanation to link the conditions for tag variables in the docs. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
