### PR TITLE
Fix CPU Recommendation for ECS Agent

### DIFF
--- a/content/en/agent/amazon_ecs/apm.md
+++ b/content/en/agent/amazon_ecs/apm.md
@@ -21,7 +21,7 @@ After following the [Amazon ECS agent installation instructions][1], enable trac
     {
       "name": "datadog-agent",
       "image": "gcr.io/datadoghq/agent:latest",
-      "cpu": 10,
+      "cpu": 100,
       "memory": 256,
       "essential": true,
       "portMappings": [


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update the sample Task Definition to list 100 CPU Units rather than 10. 

### Motivation
<!-- What inspired you to submit this pull request?-->
Same as DOCS-1920 and https://github.com/DataDog/documentation/pull/10275

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jack.davenport/ecs_agent_cpu/agent/amazon_ecs/apm/?tab=ec2metadataendpoint
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
