### PR TITLE
Break agent expressions and event attributes into two pages.

### DIFF
--- a/content/en/security_platform/cloud_workload_security/agent_expressions.md
+++ b/content/en/security_platform/cloud_workload_security/agent_expressions.md
@@ -1,0 +1,49 @@
+---
+title: Agent Expressions
+kind: documentation
+description: "Agent expression attributes and operators for Cloud Workload Security Rules"
+further_reading:
+- link: "/security_platform/cloud_workload_security/getting_started/"
+  tag: "Documentation"
+  text: "Get started with Datadog Cloud Workload Security"
+- link: "/security_platform/cloud_workload_security/getting_started/"
+  tag: "Documentation"
+  text: "Event attributes for Cloud Workload Security"
+---
+
+## Agent Expression Syntax
+Rules for Cloud Workload Security (CWS) are first evaluated in the datadog-agent, to decide what system activity to collect. This portion of a CWS rule is called the agent expression. Agent expressions use Datadog's Security Language (SECL). The standard format of a SECL expression is as follows:
+
+```
+<event>.<event-attribute> <operator> <event-attribute....>
+```
+
+## Event
+Events correspond to types of activity seen by the system. The currently supported set of event types is:
+
+| SECL Event           | Type             |  Definition                           | Agent Version |
+|----------------------|------------------|---------------------------------------|---------------|
+| `exec`               | Process          | A process was executed or forked      | 7.27          |
+| `open`               | File             | A file was opened                     | 7.27          |
+| `chmod`              | File             | A file's permissions were changed     | 7.27          |
+| `chown`              | File             | A file's owner was changed            | 7.27          |
+| `mkdir`              | File             | A directory was created               | 7.27          |
+| `rmdir`              | File             | A directory was removed               | 7.27          |
+| `rename`             | File             | A file/directory was renamed          | 7.27          |
+| `unlink`             | File             | A file was deleted                    | 7.27          |
+| `utimes`             | File             | Change file access/modification times | 7.27          |
+| `link`               | File             | Create a new name/alias for a file    | 7.27          |
+| `setxattr`           | File             | Set exteneded attributes              | 7.27          |
+| `removexattr`        | File             | Remove extended attributes            | 7.27          |
+| `mount`              | File             | Mount a filesystem                    | 7.27          |
+| `unmount`            | File             | Unmount a filesystem                  | 7.27          |
+
+## Attributes
+Attributes can be used to specify exact data/behavior for a rule. Attributes are based on CWS event attributes which can be found LINK here LINK
+
+## Operators
+SECL operators are used to comibine event attributes together into a full expression. The following operators are available:
+TBD OPERATORS
+
+## Helpers
+TBD HELPERS

--- a/content/en/security_platform/cloud_workload_security/event_types_and_attributes.md
+++ b/content/en/security_platform/cloud_workload_security/event_types_and_attributes.md
@@ -1,76 +1,511 @@
 ---
-title: Event Types and Attributes
+title: Event Attributes
 kind: documentation
-description: "A list of supported event types and attributes for Cloud Workload Security"
+description: "Event format, schema, and attributes for Cloud Workload Security"
 further_reading:
 - link: "/security_platform/cloud_workload_security/getting_started/"
   tag: "Documentation"
   text: "Get started with Datadog Cloud Workload Security"
 ---
 
-## Chmod
+## Base Event Format
 
-Chmod events can be used to detect changes in the file permissions of a file or a directory. It is possible to filter those events based on multiple attributes including the original and target mode of chmod.
+All Cloud Workload Security (CWS) events share a basic event format. CWS events include metadata about event types, and policy/rule information, followed by three core sets of context: file process, and user.
 
-### Input
-
-```json
-SCHEMA HERE
-```
-
-### Output
+### Base Event Format
+All events have `agent`, `evt`, `file`, `process`, and `user` contexts. Optionally, if activity is associated with a container, then there will also be a `container` context.
 
 ```json
-SCHEMA HERE
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "base-payload.json",
+  "type": "object",
+  "anyOf": [
+        {
+            "allOf": [
+                {
+                    "$ref": "file:///event.json"
+                },
+                {
+                    "$ref": "file:///file.json"
+                },
+                {
+                    "$ref": "file:///usr.json"
+                },
+                {
+                    "$ref": "file:///process_context.json"
+                },
+                {
+                    "$ref": "file:///container_context.json"
+                }
+            ]
+        },
+        {
+            "allOf": [
+                {
+                    "$ref": "file:///event.json"
+                },
+                {
+                    "$ref": "file:///file.json"
+                },
+                {
+                    "$ref": "file:///usr.json"
+                },
+                {
+                    "$ref": "file:///process_context.json"
+                }
+            ]
+        }
+    ],
+    "allOf": [
+        {
+            "if": {
+                "properties": {
+                    "file": {
+                        "type": "object",
+                        "required": [
+                            "container_path"
+                        ]
+                    }
+                }
+            },
+            "then": {
+                "required": [
+                    "container"
+                ]
+            }
+        },
+        {
+            "if": {
+                "required": [
+                    "container"
+                ]
+            },
+            "then": {
+                "properties": {
+                    "file": {
+                        "type": "object",
+                        "required": [
+                            "container_path"
+                        ]
+                    }
+                }
+            }
+        }
+    ] 
+}
 ```
 
-### Reference
-
-| SECL accessor        | Type             | Exported JSON  | Definition                            | Agent Version |
-|----------------------|------------------|----------------|---------------------------------------|---------------|
-| `chmod.file.uid`     | number           | file.uid       | User ID of the file / directory       | 7.27          |
-| `chmod.file.user`    | string           | file.user      | Resolved user of the file / directory | 7.27          |
-
-### SECL legacy support
-
-#### Input
+### Event Context
+The event context contains information about the type of activity that triggered a rule. This includes activity category, name, and whether or not the activity was successful (i.e a process failing or succeeding to execute).
 
 ```json
-SCHEMA HERE
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "event.json",
+    "type": "object",
+    "properties": {
+        "evt": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "category": {
+                    "type": "string"
+                },
+                "outcome": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "category",
+                "outcome"
+            ]
+        },
+        "date": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "evt",
+        "date"
+    ]
+}
 ```
 
-#### Output
+### Agent Context
+Agent context contains information about what policy is running on the given agent, which version of that policy, and which specific rule from the policy was matched to trigger the event in question.
 
 ```json
-SCHEMA HERE
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "agent.json",
+    "type": "object",
+    "properties": {
+        "agent": {
+            "type": "object",
+            "properties": {
+                "policy_name": {
+                    "type": "string"
+                },
+                "policy_version": {
+                    "type": "string"
+                },
+                "rule_id": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "policy_name",
+                "policy_version",
+                "rule_id"
+            ]
+        }
+    },
+    "required": [
+        "agent"
+    ]
+}
 ```
 
-#### Reference
-
-| SECL accessor        | Now alias of             | Was introduced in |
-|----------------------|--------------------------|-------------------|
-| `chown.filename`     | `chown.file.path`        | 7.25              |
-| `chown.filename`     | `chown.overlay_numlower` | 7.25              |
-
-## Chown
-
-Chown events can be used to detect ownership changes on a file or a directory. It is possible to filter those events based on multiple attributes including the original and target user / group of chown.
-
-### Input
+### File Context
+File context includes all of the information known about a file. This includes the files path, flags, inode, mount, and more. If the file is associated with a container, then the container mount path is also included.
 
 ```json
-SCHEMA HERE
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "file.json",
+    "type": "object",
+    "properties": {
+        "file": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "container_path": {
+                    "$ref": "file:///container_path.json"
+                },
+                "inode": {
+                    "type": "integer"
+                },
+                "mode": {
+                    "type": "integer"
+                },
+                "mount_id": {
+                    "type": "integer"
+                },
+                "filesystem": {
+                    "type": "string"
+                },
+                "user": {
+                    "type": "string"
+                },
+                "group": {
+                    "type": "string"
+                },
+                "modification_time": {
+                    "type": "string"
+                },
+                "change_time": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "path",
+                "name",
+                "inode",
+                "mode",
+                "mount_id",
+                "filesystem",
+                "user",
+                "group",
+                "modification_time",
+                "change_time"
+            ]
+        }
+    }
+}
 ```
 
-### Output
+#### Process Context
+Process context includes all information known about the process associated with the activity in question. This includes process-specific information, as well as a full process ancestory tree, container information if available, and specific parent process information.
 
 ```json
-SCHEMA HERE
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "process_context.json",
+    "type": "object",
+    "properties": {
+        "process": {
+            "allOf": [
+                {
+                    "$ref": "file:///process.json"
+                },
+                {
+                    "properties": {
+                        "parent": {
+                            "$ref": "file:///process.json"
+                        },
+                        "ancestors": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "file:///process.json"
+                            }
+                        },
+                        "container": {
+                            "$ref": "file:///container.json"
+                        }
+                    },
+                    "required": [
+                        "parent",
+                        "ancestors"
+                    ]
+                }
+            ]
+        }
+    },
+    "required": [
+        "process"
+    ]
 ```
 
-### Reference
+#### Process
+Cloud Worload Security collects highly detailed process information, such as the process path, name, arguments, environment variable keys, tty, user/group information, and kernel capabilities (effective and permitted). Note: some information is not collected for ancestors, such and arguments, and environment variables
 
-| SECL accessor        | Type             | Exported JSON  | Definition                                                          | Agent Version |
-|----------------------|------------------|----------------|---------------------------------------------------------------------|---------------|
-| `chown.file.uid`     | number           | file.uid       | User ID of the file / directory before the execution of chown       | 7.27          |
-| `chown.file.user`    | string           | file.user      | Resolved user of the file / directory before the execution of chown | 7.27          |
+```json
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "process.json",
+    "type": "object",
+    "properties": {
+        "tid": {
+            "type": "integer"
+        },
+        "uid": {
+            "type": "integer"
+        },
+        "gid": {
+            "type": "integer"
+        },
+        "user": {
+            "type": "string"
+        },
+        "group": {
+            "type": "string"
+        },
+        "executable_container_path": {
+            "$ref": "file:///container_path.json"
+        },
+        "executable_path": {
+            "type": "string"
+        },
+        "comm": {
+            "type": "string"
+        },
+        "executable_inode": {
+            "type": "integer"
+        },
+        "executable_mount_id": {
+            "type": "integer"
+        },
+        "tty": {
+            "type": "string"
+        },
+        "credentials": {
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "integer"
+                },
+                "user": {
+                    "type": "string"
+                },
+                "gid": {
+                    "type": "integer"
+                },
+                "group": {
+                    "type": "string"
+                },
+                "euid": {
+                    "type": "integer"
+                },
+                "euser": {
+                    "type": "string"
+                },
+                "egid": {
+                    "type": "integer"
+                },
+                "egroup": {
+                    "type": "string"
+                },
+                "fsuid": {
+                    "type": "integer"
+                },
+                "fsuser": {
+                    "type": "string"
+                },
+                "fsgid": {
+                    "type": "integer"
+                },
+                "fsgroup": {
+                    "type": "string"
+                },
+                "cap_effective": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
+                "cap_permitted": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                }
+            },
+            "required": [
+                "uid",
+                "gid",
+                "euid",
+                "euser",
+                "egid",
+                "egroup",
+                "fsuid",
+                "fsuser",
+                "fsgid",
+                "fsgroup",
+                "cap_effective",
+                "cap_permitted"
+            ]
+        },
+        "executable": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "container_path": {
+                    "$ref": "file:///container_path.json"
+                },
+                "inode": {
+                    "type": "integer"
+                },
+                "mode": {
+                    "type": "integer"
+                },
+                "mount_id": {
+                    "type": "integer"
+                },
+                "filesystem": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "integer"
+                },
+                "gid": {
+                    "type": "integer"
+                },
+                "modification_time": {
+                    "type": "string"
+                },
+                "change_time": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "path",
+                "name",
+                "inode",
+                "mode",
+                "mount_id",
+                "filesystem",
+                "uid",
+                "gid",
+                "modification_time",
+                "change_time"
+            ]
+        },
+        "container": {
+            "$ref": "file:///container.json"
+        }
+    },
+    "oneOf": [
+        {
+            "properties": {
+                "pid": {
+                    "type": "integer",
+                    "enum": [1]
+                }
+            },
+            "required": ["pid"]
+        },
+        {
+            "properties": {
+                "pid": {
+                    "type": "integer",
+                    "minimum": 2
+                },
+                "ppid": {
+                    "type": "integer"
+                }
+            },
+            "required": ["pid", "ppid"]
+        }
+    ],
+    "required": [
+        "tid",
+        "uid",
+        "gid",
+        "executable_path",
+        "comm",
+        "executable_inode",
+        "executable_mount_id",
+        "credentials",
+        "executable"
+    ],
+    "dependencies": {
+        "executable_container_path": ["container"],
+        "container": ["executable_container_path"]
+    }
+}
+```
+
+#### User Context
+User context includes the resolved user and group information of the executing process. Note: This information is resolved at the time of collection. Therefore, it is possible for resolved users and groups to have changed since the activity took place, or after the activity is collected. 
+
+```json
+
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "file.json",
+    "type": "object",
+    "properties": {
+        "usr": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "group": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "id",
+                "group"
+            ]
+        }
+    }
+}
+```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
