### PR TITLE
add templated dd_url to synthetics intake endpoints

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -35,9 +35,9 @@ further_reading:
     - `gcp-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}
     - `http-encrypted-intake.logs.`{{< region-param key="dd_site" code="true" >}}
   - [Synthetics private location][11] workers rely on the endpoints below to submit test results:
-      - `intake.synthetics.datadoghq.com` for sending API test results from worker versions >0.1.6. For worker versions >=1.5.0 this is the only endpoint you need to configure. 
-      - `intake-v2.synthetics.datadoghq.com` for sending browser test results for worker versions >0.2.0
-      - `api.datadoghq.com` for sending API test results from older worker versions <0.1.5
+      - `intake.synthetics.`{{< region-param key="dd_site" code="true" >}} for sending API test results from worker versions >0.1.6. For worker versions >=1.5.0 this is the only endpoint you need to configure. 
+      - `intake-v2.synthetics.`{{< region-param key="dd_site" code="true" >}} for sending browser test results for worker versions >0.2.0
+      - `api.`{{< region-param key="dd_site" code="true" >}} for sending API test results from older worker versions <0.1.5
 
   - All other Agent data:
       - **Agents < 5.2.0** `app.`{{< region-param key="dd_site" code="true" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
URLs were not templated in in my earlier PR. This should take care of that. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
