### PR TITLE
profiler: fix go get install instructions

### DIFF
--- a/content/en/tracing/profiler/getting_started.md
+++ b/content/en/tracing/profiler/getting_started.md
@@ -186,7 +186,7 @@ The Datadog Profiler requires Go 1.12+. To begin profiling applications:
 2. Get `dd-trace-go` using the command:
 
     ```shell
-    go get gopkg.in/DataDog/dd-trace-go.v1
+    go get gopkg.in/DataDog/dd-trace-go.v1/profiler
     ```
 
      **Note**: Profiler is available in the `dd-trace-go` library for versions 1.23.0+.


### PR DESCRIPTION
### What does this PR do? / Motivation

`go get gopkg.in/DataDog/dd-trace-go.v1` was giving the user
errors/warnings and didn't update the go.mod file.

In Go1.16 the error currently looks like this:

```
go: downloading gopkg.in/DataDog/dd-trace-go.v1 v1.31.0
gopkg.in/DataDog/dd-trace-go.v1: no Go source files
package gopkg.in/DataDog/dd-trace-go.v1: build constraints exclude all Go files in /Users/ec2-user/go/pkg/mod/gopkg.in/!data!dog/dd-trace-go.v1@v1.31.0
```

In Go1.14 and Go1.15 it looks like this:

```
go: downloading gopkg.in/DataDog/dd-trace-go.v1 v1.31.0
go: gopkg.in/DataDog/dd-trace-go.v1 upgrade => v1.31.0
go get gopkg.in/DataDog/dd-trace-go.v1: no Go source files
```

With his patch applied, the output looks like shown below, and the
go.mod file gets updated accordingly:

```
go: downloading gopkg.in/DataDog/dd-trace-go.v1 v1.31.0
go: downloading github.com/DataDog/gostackparse v0.5.0
go: downloading github.com/google/pprof v0.0.0-20210125172800-10e9aeb4a998
go: downloading github.com/DataDog/datadog-go v4.4.0+incompatible
go: downloading github.com/google/uuid v1.2.0
go: downloading github.com/Microsoft/go-winio v0.5.0
go: downloading golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
go get: added github.com/Microsoft/go-winio v0.5.0
go get: added github.com/google/uuid v1.2.0
go get: added gopkg.in/DataDog/dd-trace-go.v1 v1.31.0
```

See https://github.com/DataDog/dd-trace-go/issues/911#issuecomment-828501266 for more information.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### Preview

https://docs-staging.datadoghq.com/felix.geisendoerfer/profiler-install-instructions/tracing/profiler/getting_started/?code-lang=go

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
