### PR TITLE
integration improvements

### DIFF
--- a/content/ja/integrations/directory.md
+++ b/content/ja/integrations/directory.md
@@ -17,7 +17,7 @@ display_name: Directory
 draft: false
 git_integration_title: directory
 guid: 0c38c4ef-5266-4667-9fb1-de8f2b73708a
-integration_id: システム
+integration_id: system
 integration_title: Directory
 is_public: true
 kind: インテグレーション

--- a/content/ja/integrations/disk.md
+++ b/content/ja/integrations/disk.md
@@ -17,7 +17,7 @@ display_name: Disk
 draft: false
 git_integration_title: disk
 guid: 94588b23-111e-4ed2-a2af-fd6e4caeea04
-integration_id: システム
+integration_id: system
 integration_title: Disk
 is_public: true
 kind: インテグレーション

--- a/content/ja/integrations/nfsstat.md
+++ b/content/ja/integrations/nfsstat.md
@@ -16,7 +16,7 @@ dependencies:
 display_name: Nfsstat
 git_integration_title: nfsstat
 guid: 9f2fe3a7-ae19-4da9-a253-ae817a5557ab
-integration_id: システム
+integration_id: system
 integration_title: Nfsstat
 is_public: true
 kind: インテグレーション

--- a/content/ja/integrations/tcp_check.md
+++ b/content/ja/integrations/tcp_check.md
@@ -21,7 +21,7 @@ display_name: TCP
 draft: false
 git_integration_title: tcp_check
 guid: c514029e-0ed8-4c9f-abe5-2fd4096726ba
-integration_id: システム
+integration_id: system
 integration_title: TCP チェック
 is_public: true
 kind: インテグレーション

--- a/layouts/integrations/single.html
+++ b/layouts/integrations/single.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
-    {{ partial "integration-breadcrumbs/integration-breadcrumbs.html" . }}
     <h1 id="pagetitle">{{ if .Params.integration_title }}{{ .Params.integration_title }}{{ else }}{{.Title}}{{ end }}</h1>
     {{ partial "integration-labels/integration-labels.html" . }}
+    {{ partial "integration-breadcrumbs/integration-breadcrumbs.html" . }}
     {{ .Content }}
 {{ end }}

--- a/layouts/shortcodes/integrations.html
+++ b/layouts/shortcodes/integrations.html
@@ -1,13 +1,11 @@
 {{ $dot := . }}
 
 <!-- From data file -->
-{{ $kind := "integration" }}
-{{ if eq site.Language.Lang "ja"}}
-    {{ $kind = "インテグレーション"}}
-{{ end }}
-{{ $integration_list := (where site.Pages "Params.kind" "=" $kind) }}
+{{ $integration_list := site.Pages }}
+{{ $integration_list := $integration_list | intersect (where $integration_list ".Section" "=" "integrations") }}
 {{ $integration_list := $integration_list | intersect (where $integration_list ".Params.beta" "!=" true) }}
 {{ $integration_list := $integration_list | intersect (where $integration_list ".Params.is_public" "=" true) }}
+{{ $integration_list := $integration_list | intersect (where $integration_list ".Params.placeholder" "!=" true) }}
 {{ $integration_list := $integration_list | intersect (where $integration_list ".Params.integration_id" "!=" "datadog-agent") }}
 {{ $integration_list := sort $integration_list ".File.BaseFileName" }}
 
@@ -31,6 +29,14 @@
 <!-- build tiles -->
 {{- $s := newScratch -}}
 {{- range $k, $v := $integration_list -}}
+  {{- $enpage := $v -}}
+  {{- if $v.IsTranslated -}}
+    {{- range $v.Translations -}}
+      {{- if eq .Lang "en" -}}
+          {{- $enpage = . -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
   {{- $path := (print $v.File.BaseFileName) -}}
   {{- $s.SetInMap $path "id" $k -}}
   {{- $s.SetInMap $path "name" ($v.Params.name | default ($v.File.TranslationBaseName | lower))  -}}
@@ -39,6 +45,7 @@
   {{- $s.SetInMap $path "blurb" $v.Params.short_description -}}
   {{- $s.SetInMap $path "public_title" $v.Params.public_title -}}
   {{- $s.SetInMap $path "integration_title" $v.Params.integration_title -}}
+  {{- $s.SetInMap $path "is_marketplace" (in $enpage.Params.categories "marketplace") -}}
   {{- $curr_categories := slice -}}
   {{- range $i, $e := $v.Params.categories -}}
     {{- $curr_categories = $curr_categories | append (print "cat-" (replace $e "/" "" | urlize)) -}}
@@ -92,7 +99,7 @@
         {{ if $integration.int_logo }}
             <div id="mixid_{{ $integration.id }}" class="col-6 col-sm-4 col-md-3 col-lg-3 col-xl-2-4 mix text-center {{ range $cat := $integration.tags }} {{ $cat }} {{ end }}" data-id="{{ $integration.id }}" data-ref="item">
                 <div id="{{ $integration.name }}" class="card">
-                    {{ if in $integration.tags "cat-marketplace" }}
+                    {{ if $integration.is_marketplace }}
                         <div class="card-banner">
                             <p class="font-primary font-weight-bold text-uppercase">Marketplace</p>
                         </div>

--- a/src/styles/components/_integration-breadcrumbs.scss
+++ b/src/styles/components/_integration-breadcrumbs.scss
@@ -1,4 +1,6 @@
 .integrations-breadcrumbs {
+  position: absolute;
+  top: 0;
   line-height:24px;
   color:#B6B6B6;
   text-transform:uppercase;

--- a/src/styles/components/_integrations.scss
+++ b/src/styles/components/_integrations.scss
@@ -21,6 +21,9 @@ $ddpurple:    #632CA6;
 }
 
 .integrations-single {
+  h1#pagetitle {
+    margin-top:50px;
+  }
   img {
     max-width: 100%;
     height: auto;
@@ -109,6 +112,10 @@ $ddpurple:    #632CA6;
         font-size: 12px;
         line-height: 16px;
         margin-top: 0.5px;
+        &:lang(ja) {
+          font-size: 11px !important;
+          line-height: 18px !important;
+        }
       }
     }
 


### PR DESCRIPTION
### What does this PR do?

This PR:
- grabs the integrations by section instead of `.kind` to remove reliance on translated `.kind` strings. Also to show integrations that were not before.
- sources the english equivalent integration to determine marketplace banner status. Again to avoid translated category comparisons
- improves marketplace banner text spacing on ja
- Moves the integration breadcrumb to be below the h1 in code. SEO wise its giving it more importance than it should have.

### Motivation

integration improvements

### Preview

Check breadcrumb still looks good
https://docs-staging.datadoghq.com/david.jones/int-improvements/integrations/activemq/

Check nothing seems odd
https://docs-staging.datadoghq.com/david.jones/int-improvements/ja/integrations/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
