### PR TITLE
Add a missing alias in fr doc

### DIFF
--- a/content/fr/serverless/distributed_tracing/_index.md
+++ b/content/fr/serverless/distributed_tracing/_index.md
@@ -1,6 +1,9 @@
 ---
 title: Tracing distribué
 kind: documentation
+aliases:
+  - /fr/tracing/serverless_functions
+  - /fr/tracing/setup_overview/serverless_functions/
 further_reading:
   - link: tracing/serverless_functions
     tag: Documentation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This adds a missing alias that's missing, leading to a deadlink in the sidebar here 
https://github.com/DataDog/documentation/blob/8a28f704dd96244fe1d0de5b90a9f216dcbccd3f/config/_default/menus/menus.fr.yaml#L1335-L1339

### Motivation
<!-- What inspired you to submit this pull request?-->
One of the link in the sidebar is dead on the French version, while it redirects to `serverless/distributed_tracing` on the English one

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
