### PR TITLE
[RUM/APM] clarify allowedTracingOrigins

### DIFF
--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -43,7 +43,7 @@ datadogRum.init({
 })
 ```
 
-**Note**: `allowedTracingOrigins` accepts Javascript String and RegExp that should match the origins called by you browser application, with origin defined as: `<scheme> "://" <hostname> [ ":" <port> ]`
+**Note**: `allowedTracingOrigins` accepts Javascript String and RegExp that should match the origins called by your browser application, with origin defined as: `<scheme> "://" <hostname> [ ":" <port> ]`
 
 [1]: /real_user_monitoring/browser/
 {{% /tab %}}

--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -34,7 +34,7 @@ Use frontend data from RUM, and backend, infrastructure, and log information fro
 
 ```javascript
 import { datadogRum } from '@datadog/browser-rum'
- 
+
 datadogRum.init({
     applicationId: '<DATADOG_APPLICATION_ID>',
     clientToken: '<DATADOG_CLIENT_TOKEN>',
@@ -43,14 +43,14 @@ datadogRum.init({
 })
 ```
 
-**Note**: `allowedTracingOrigins` accepts Javascript String and RegExp.
+**Note**: `allowedTracingOrigins` accepts Javascript String and RegExp that should match the origins called by you browser application, with origin defined as: `<scheme> "://" <hostname> [ ":" <port> ]`
 
 [1]: /real_user_monitoring/browser/
 {{% /tab %}}
 {{% tab "Android RUM" %}}
 
 1.  Set up [Android Real User Monitoring][1].
-    
+
 2.  Configure the `OkHttpClient` interceptor with the list of internal (first party) origins called by your Android application.
 ```java
 val tracedHosts =  listOf("example.com", "example.eu")
@@ -69,7 +69,7 @@ val okHttpClient = OkHttpClient.Builder()
 {{% tab "iOS RUM" %}}
 
 1.  Set up [iOS Real User Monitoring][1].
-    
+
 2.  Set the `firstPartyHosts` initialization parameter with the list of internal (first party) origins called by your iOS application.
 ```swift
 Datadog.initialize(
@@ -109,7 +109,7 @@ The following Datadog tracing libraries are supported:
 | [JavaScript][10]                  | [0.10.0][11]                |
 | [PHP][12]                  | [0.33.0][13]                |
 | [.NET][14]                  | [1.18.2][15]                |
-    
+
 
 ## How are RUM resources linked to traces?
 Datadog uses the distributed tracing protocol and sets up the following HTTP headers:
@@ -119,7 +119,7 @@ Datadog uses the distributed tracing protocol and sets up the following HTTP hea
 | `x-datadog-trace-id `            | Generated from the Real User Monitoring SDK. Allows Datadog to link the trace with the RUM resource.   |
 | `x-datadog-parent-id`            | Generated from the Real User Monitoring SDK. Allows Datadog to generate the first span from the trace. |
 | `x-datadog-origin: rum`          | To make sure the generated traces from Real User Monitoring don’t affect your APM Index Spans counts.  |
-| `x-datadog-sampling-priority: 1` | To make sure that the Agent keeps the trace.                                                           |  
+| `x-datadog-sampling-priority: 1` | To make sure that the Agent keeps the trace.                                                           |
 | `x-datadog-sampled: 1`           | Generated from the Real User Monitoring SDK. Indicates this request is selected for sampling.          |
 
 ## How are APM quotas affected?


### PR DESCRIPTION
### What does this PR do?

Clarify `allowedTracingOrigins` configuration param by explaining:
- how the values will be used
- what is an origin

### Motivation

Misconfiguration from users from time to time.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bcaudan/origin/real_user_monitoring/connect_rum_and_traces?tab=browserrum

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
