### PR TITLE
geoffrey-kwan/spelling-error

### DIFF
--- a/content/en/logs/faq/log-collection-is-the-datadog-agent-losing-logs.md
+++ b/content/en/logs/faq/log-collection-is-the-datadog-agent-losing-logs.md
@@ -15,7 +15,7 @@ further_reading:
 ## Log rotate
 
 When a file is rotated, the Agent keeps tailing the old file while starting to tail the newly created file in parallel.
-Although the Agent continues to tail the old file, a 60-second timeout after the log rotation is set to ensure the agent is using its ressources to tail the most up-to-date files.
+Although the Agent continues to tail the old file, a 60-second timeout after the log rotation is set to ensure the agent is using its resources to tail the most up-to-date files.
 
 ## Network issues
 


### PR DESCRIPTION
Correcting a spelling error on this page

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->'

Changes "ressources" to "resources"

### Motivation
<!-- What inspired you to submit this pull request?-->

Was reading this documentation to send to a customer and realized there's a spelling error that should be corrected

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
