### PR TITLE
[WEB-1384]add serverless vid to doc

### DIFF
--- a/content/en/serverless/_index.md
+++ b/content/en/serverless/_index.md
@@ -22,7 +22,6 @@ further_reading:
 
 {{< vimeo 543362476 >}}
 
-## Overview
 
 Serverless is a concept where you write event-driven code and upload it to a cloud provider, which manages all of the underlying computational resources. [Datadog Serverless][1] brings together metrics, traces, and logs from your AWS Lambda functions running serverless applications into one view.
 

--- a/content/en/serverless/_index.md
+++ b/content/en/serverless/_index.md
@@ -20,7 +20,7 @@ further_reading:
   text: "Monitor AWS Lambda functions deployed using container images"
 ---
 
-{{< img src="serverless/datadog_serverless_overview.png" alt="Datadog Serverless Overview"  style="width:100%;">}}
+{{< vimeo 543362476 >}}
 
 ## Overview
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
embed new serverless product video to docs page
### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/browse/WEB-1384?atlOrigin=eyJpIjoiMGM2MzA3MmY4YmRlNDdhNDhkOWZhM2UzOTcyYWYzN2MiLCJwIjoiaiJ9
### Preview
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/ang/add-serverless-vid/serverless/
<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
n/a
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
