### PR TITLE
Cache the most commonly used partials

### DIFF
--- a/layouts/_default/404-baseof.html
+++ b/layouts/_default/404-baseof.html
@@ -44,12 +44,12 @@
       </div>
     </div>
   </div>
-  {{ partial "header/header.html" . }}
+  {{ partialCached "header/header.html" . }}
 
   <div class="container h-100">
     <div class="row h-100">
       <div class="d-none d-lg-flex col-12 col-sm-3 side">
-        {{ partial "sidenav/main-sidenav.html" . }}
+        {{ partialCached "sidenav/main-sidenav.html" . }}
       </div>
       <div class="col-12 col-lg-9 main">
         {{ block "main" . }}{{ end }}
@@ -57,7 +57,7 @@
     </div>
   </div>
 
-  {{ partial "footer/footer.html" . }}
+  {{ partialCached "footer/footer.html" . }}
 
   <script src="{{ (index $.Site.Data.manifest "vendor.js") | relURL}}"></script>
   <script src="{{ (index $.Site.Data.manifest "main-dd-js.js") | relURL}}"></script>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -49,19 +49,19 @@
       </div>
     </div>
   </div>
-  {{ partial "header/header.html" . }}
+  {{ partialCached "header/header.html" . }}
 
   <div class="container h-100 pt-1">
     <div class="row h-100 position-relative js-content-container">
       <div class="d-none d-lg-flex col-12 col-sm-3 side">
-        {{ partial "sidenav/main-sidenav.html" . }}
+        {{ partialCached "sidenav/main-sidenav.html" . }}
       </div>
 
       <div class="mainContent-wrapper order-2 order-lg-0 col-12 {{ if eq .Params.disable_sidebar true }}col-lg-9{{ else }}col-lg-7{{ end }} main">
         <div class="{{ if and (eq $.Section "integrations") (eq $.Kind "page") }}integrations-single{{ end }}"
           id="mainContent">
           {{ block "main" . }}{{ end }}
-          {{ partial "page-edit.html" (dict "ctx" $ctx "type" "contribute") }}
+          {{ partialCached "page-edit.html" (dict "ctx" $ctx "type" "contribute") }}
         </div>
       </div>
 
@@ -77,7 +77,7 @@
     </div>
   </div>
 
-  {{ partial "footer/footer.html" . }}
+  {{ partialCached "footer/footer.html" . }}
 
   <script src="{{ (index $.Site.Data.manifest "vendor.js") | relURL}}"></script>
   <script src="{{ (index $.Site.Data.manifest "main-dd-js.js") | relURL}}"></script>

--- a/layouts/api/baseof.html
+++ b/layouts/api/baseof.html
@@ -38,7 +38,7 @@
 data-spy="scroll" data-target="#navbar-example2" data-offset="5"
   class="{{ .Site.Language.Lang }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }}">
 
-  {{ partial "header/header.html" . }}
+  {{ partialCached "header/header.html" . }}
 
   <div class="container">
     <div class="row">
@@ -52,7 +52,7 @@ data-spy="scroll" data-target="#navbar-example2" data-offset="5"
     </div>
   </div>
 
-  {{ partial "footer/footer.html" . }}
+  {{ partialCached "footer/footer.html" . }}
 
   <script src="{{ (index $.Site.Data.manifest "vendor.js") | relURL}}"></script>
   <script src="{{ (index $.Site.Data.manifest "main-dd-js.js") | relURL}}"></script>

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -162,7 +162,7 @@
                     {{ partial "api/response.html" (dict "responses" $endpoint.action.responses "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "translate_action" $translate_action "version" $versionNum) }}
 
                     <!-- code example -->
-                    {{ partial "api/code-example.html" (dict "context" $dot "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "securitySchemes" $adat.components.securitySchemes "endpoint" $endpoint) }}
+                    {{ partialCached "api/code-example.html" (dict "context" $dot "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "securitySchemes" $adat.components.securitySchemes "endpoint" $endpoint) }}
                 </div>
             </div>
         </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -53,7 +53,7 @@
 <body class="{{ .Site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }} {{ $customClass }}">
 
 
-    {{ partial "header/header.html" . }}
+    {{ partialCached "header/header.html" . }}
 
     {{ partial "home-header.html" . }}
 
@@ -120,7 +120,7 @@
 
     </main>
 
-    {{ partial "footer/footer.html" . }}
+    {{ partialCached "footer/footer.html" . }}
 
     <script src="{{ (index $.Site.Data.manifest "vendor.js") | relURL}}"></script>
     <script src="{{ (index $.Site.Data.manifest "main-dd-js.js") | relURL}}"></script>

--- a/layouts/partials/nav/main-mobile-menu.html
+++ b/layouts/partials/nav/main-mobile-menu.html
@@ -4,15 +4,15 @@
     <div class="row">
         <div class="col">
             <a href="{{ "" | absLangURL }}"><h4>{{ i18n "datadog_docs" }}</h4></a>
-            
+
             {{ partial "search-mobile.html" . }}
 
             <div class="sidenav-nav sidenav-nav-main">
                 <!-- This was placed with js for build speed increase -->
-                {{ partial "nav/main-menu.html" . }}
+                {{ partialCached "nav/main-menu.html" . }}
 
 
-                
+
             </div>
         </div>
     </div>

--- a/layouts/partials/page-edit.html
+++ b/layouts/partials/page-edit.html
@@ -38,7 +38,7 @@
 
     {{ with $ctx.File }}
         {{ $editLink := ( printf "https://github.com/DataDog/documentation/edit/master/content/%s/%s/" $ctx.Page.Lang $ctx.File.Path ) }}
-        {{ partial "page-edit-body.html" (dict "ctx" $ctx "link" $editLink "type" $type) }}
+        {{ partialCached "page-edit-body.html" (dict "ctx" $ctx "link" $editLink "type" $type) }}
     {{ end }}
 
 {{ end }}

--- a/layouts/partials/sidenav/main-sidenav.html
+++ b/layouts/partials/sidenav/main-sidenav.html
@@ -3,12 +3,12 @@
 <aside class="sidenav">
     <div class="row sticky">
         <div class="col">
-            
+
             <h4 class="text-brand-primary"><a class="text-primary" href="{{ "" | absLangURL  }}">{{ i18n "datadog_docs" }}</a></h4>
             {{ partial "search.html" . }}
 
             <div class="sidenav-nav sidenav-nav-main">
-                {{ partial "nav/main-menu.html" . }}
+                {{ partialCached "nav/main-menu.html" . }}
             </div>
         </div>
     </div>

--- a/layouts/partials/table-of-contents/table-of-contents.html
+++ b/layouts/partials/table-of-contents/table-of-contents.html
@@ -4,7 +4,7 @@
     <div class="toc">
         <div class="js-toc {{ if .Params.disable_toc }} d-none {{ else }} {{ end }}">
             {{ if ne .Params.disable_edit true }}
-                {{ partial "page-edit.html" (dict "ctx" $ctx "type" "edit") }}
+                {{ partialCached "page-edit.html" (dict "ctx" $ctx "type" "edit") }}
             {{ end }}
             <p class="text-uppercase text-gray-darkish font-semibold mb-2 toc-title js-toc-title {{ if .Params.disable_toc }} d-none {{ else }} {{ end }}">{{ i18n "table_of_contents_heading"}}</p>
             {{ if ne .Params.disable_toc true }}{{ .TableOfContents }}{{ end }}

--- a/layouts/shortcodes/partial.html
+++ b/layouts/shortcodes/partial.html
@@ -1,7 +1,7 @@
 {{- $partial_name := .Get "name" -}}
 {{- $markdown := .Get "markdown" -}}
 {{- if $markdown -}}
-  {{- partial $partial_name . | markdownify -}}
+  {{- partialCached $partial_name . | markdownify -}}
 {{- else -}}
-  {{- partial $partial_name . -}}
+  {{- partialCached $partial_name . -}}
 {{- end -}}


### PR DESCRIPTION
This PR applies caching to some of the most commonly used partials (as determined by `hugo --templateMetrics --templateMetricsHints`). This has the effect of speeding up the build pretty dramatically (roughly 5x on my machine but tricky to generalize). As far as I can tell it should be okay to cache these specific partials but if there are potential pitfalls I should be aware of, I'm all ears.

We *could* get significantly more aggressive with this but probably best to start small and ensure that there are no unwanted side effects before really getting out the scissors.

## Preview

https://docs-staging.datadoghq.com/lucperkins/cached-partials