### PR TITLE
[rum] added an info panel clarifying support of e2e tracing

### DIFF
--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -45,6 +45,8 @@ datadogRum.init({
 
 **Note**: `allowedTracingOrigins` accepts Javascript String and RegExp that should match the origins called by your browser application, with origin defined as: `<scheme> "://" <hostname> [ ":" <port> ]`
 
+<div class="alert alert-info">The browser SDK must be initialized in order to link browser requests to backend traces. End-to-end tracing of the initial HTML document, and early browser requests, is not currently supported.</div>
+
 [1]: /real_user_monitoring/browser/
 {{% /tab %}}
 {{% tab "Android RUM" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* [rum] added an info panel clarifying support of e2e tracing

### Motivation
<!-- What inspired you to submit this pull request?-->
Confusion in support tickets

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/initial-document-tracing/real_user_monitoring/connect_rum_and_traces/?tab=browserrum

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
