### PR TITLE
Add alt text to the site help button

### DIFF
--- a/layouts/partials/language-region-select.html
+++ b/layouts/partials/language-region-select.html
@@ -26,7 +26,7 @@
     <div class="d-flex">
       <p class="text-uppercase">Site</p>
       <a href="/getting_started/site/" class="{{ if ne .Page.Type "api" }}ml-1{{ else }}mr-1{{ end }} d-inline-flex">
-        <img src="{{ .Site.Params.img_url }}images/icons/help-druids.svg" height="18" width="18" />
+        <img src="{{ .Site.Params.img_url }}images/icons/help-druids.svg" height="18" width="18" alt="Site help" />
       </a>
     </div>
     <div class="dropdown bootstrap-dropdown-custom js-region-select">


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds alt text to the little "?" next to the site selector text

### Motivation
Docs hackathon

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jorie/add-alt-text/


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
