### PR TITLE
switch net logo

### DIFF
--- a/layouts/partials/apm/apm-connect-logs-and-traces.html
+++ b/layouts/partials/apm/apm-connect-logs-and-traces.html
@@ -32,7 +32,7 @@
       </a>
       <a class="card" href="dotnet" style="width: 25%" >
         <div class="card-body text-center py-2 px-1">
-          {{ partial "img.html" (dict "root" . "src" "integrations_logos/net.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
         </div>
       </a>
       <a class="card" href="php" style="width: 25%" >

--- a/layouts/partials/apm/apm-languages.html
+++ b/layouts/partials/apm/apm-languages.html
@@ -40,7 +40,7 @@
     <div class="card-deck">
       <a class="card" href="dotnet">
         <div class="card-body text-center py-2 px-1">
-          {{ partial "img.html" (dict "root" . "src" "integrations_logos/net.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
         </div>
       </a>
       <a class="card" href="dotnet-core">

--- a/layouts/partials/apm/apm-manual-instrumentation.html
+++ b/layouts/partials/apm/apm-manual-instrumentation.html
@@ -37,7 +37,7 @@
       </a>
       <a class="card" href="dotnet">
         <div class="card-body text-center py-2 px-1">
-          {{ partial "img.html" (dict "root" . "src" "integrations_logos/net.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
         </div>
       </a>
       <a class="card" href="php">

--- a/layouts/partials/apm/apm-opentracing.html
+++ b/layouts/partials/apm/apm-opentracing.html
@@ -32,7 +32,7 @@
       </a>
       <a class="card" href="dotnet">
         <div class="card-body text-center py-2 px-1">
-          {{ partial "img.html" (dict "root" . "src" "integrations_logos/net.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
         </div>
       </a>
       <a class="card" href="php">

--- a/layouts/partials/logs/logs-languages.html
+++ b/layouts/partials/logs/logs-languages.html
@@ -24,7 +24,7 @@
             </a>
             <a class="card" href="/logs/log_collection/csharp">
                 <div class="card-body text-center py-2 px-1">
-                    {{ partial "img.html" (dict "root" . "src" "integrations_logos/net.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
+                    {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
                 </div>
             </a>
         </div>

--- a/layouts/partials/serverless/getting-started-languages.html
+++ b/layouts/partials/serverless/getting-started-languages.html
@@ -32,7 +32,7 @@
             </a>
             <a class="card" href="/serverless/installation/dotnet/">
                 <div class="card-body text-center py-2 px-1">
-                    {{ partial "img.html" (dict "root" . "src" "integrations_logos/net.png" "class" "img-fluid" "alt" ".NET" "width" "400") }}
+                    {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet.png" "class" "img-fluid" "alt" ".NET" "width" "400") }}
                 </div>
             </a>
         </div>

--- a/layouts/partials/serverless/serverless-apm-recommendations.html
+++ b/layouts/partials/serverless/serverless-apm-recommendations.html
@@ -32,7 +32,7 @@
             </a>
             <a class="card" href="/serverless/distributed_tracing#net">
                 <div class="card-body text-center py-2 px-1">
-                    {{ partial "img.html" (dict "root" . "src" "integrations_logos/net.png" "class" "img-fluid" "alt" ".NET" "width" "400") }}
+                    {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet.png" "class" "img-fluid" "alt" ".NET" "width" "400") }}
                 </div>
             </a>
         </div>


### PR DESCRIPTION
### What does this PR do?

switch `net.png` to `dotnet.png` logo in various locations

### Motivation

slack

### Preview

https://docs-staging.datadoghq.com/david.jones/net/tracing/setup_overview/
https://docs-staging.datadoghq.com/david.jones/net/tracing/setup_overview/custom_instrumentation/
https://docs-staging.datadoghq.com/david.jones/net/tracing/connect_logs_and_traces/
https://docs-staging.datadoghq.com/david.jones/net/serverless/
https://docs-staging.datadoghq.com/david.jones/net/serverless/distributed_tracing/
https://docs-staging.datadoghq.com/david.jones/net/logs/log_collection/?tab=application

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
