### PR TITLE
[RUM] Update browser-sdk default branch

### DIFF
--- a/content/en/real_user_monitoring/browser/advanced_configuration.md
+++ b/content/en/real_user_monitoring/browser/advanced_configuration.md
@@ -396,5 +396,5 @@ var context = window.DD_RUM && DD_RUM.getRumGlobalContext();
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: https://github.com/DataDog/browser-sdk/blob/master/packages/rum-core/src/rumEvent.types.ts
+[1]: https://github.com/DataDog/browser-sdk/blob/main/packages/rum-core/src/rumEvent.types.ts
 [2]: /logs/processing/attributes_naming_convention/#user-related-attributes

--- a/content/en/real_user_monitoring/browser/troubleshooting.md
+++ b/content/en/real_user_monitoring/browser/troubleshooting.md
@@ -10,7 +10,7 @@ further_reading:
       text: 'Content Security Policy'
 ---
 
-If you experience unexpected behavior with Datadog Browser RUM, this guide may help resolve issues quickly. Reach out to [Datadog support][1] for further assistance. Regularly update to the latest version of the [RUM Browser SDK][2], as each release contains improvements and fixes. 
+If you experience unexpected behavior with Datadog Browser RUM, this guide may help resolve issues quickly. Reach out to [Datadog support][1] for further assistance. Regularly update to the latest version of the [RUM Browser SDK][2], as each release contains improvements and fixes.
 
 ## Missing data
 
@@ -58,7 +58,7 @@ The Browser RUM SDK relies on cookies to store session information and follow a 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /help
-[2]: https://github.com/DataDog/browser-sdk/blob/master/CHANGELOG.md
+[2]: https://github.com/DataDog/browser-sdk/blob/main/CHANGELOG.md
 [3]: /real_user_monitoring/browser/#npm
 [4]: /real_user_monitoring/faq/proxy_rum_data/?tab=npm
 [5]: /real_user_monitoring/faq/content_security_policy/

--- a/content/fr/logs/log_collection/javascript.md
+++ b/content/fr/logs/log_collection/javascript.md
@@ -2,7 +2,7 @@
 aliases:
   - /fr/logs/log_collection/web_browser
 dependencies:
-  - 'https://github.com/DataDog/browser-sdk/blob/master/packages/logs/README.md'
+  - 'https://github.com/DataDog/browser-sdk/blob/main/packages/logs/README.md'
 kind: documentation
 title: Collecte de logs à partir des navigateurs
 ---
@@ -595,5 +595,5 @@ window.DD_LOGS && DD_LOGS.logger.setHandler('<HANDLER>')
 [1]: /fr/account_management/api-app-keys/#api-keys
 [2]: /fr/account_management/api-app-keys/#client-tokens
 [3]: https://www.npmjs.com/package/@datadog/browser-logs
-[4]: https://github.com/DataDog/browser-sdk/blob/master/packages/logs/BROWSER_SUPPORT.md
-[5]: https://github.com/DataDog/browser-sdk/blob/master/packages/logs/src/logsEvent.types.ts
+[4]: https://github.com/DataDog/browser-sdk/blob/main/packages/logs/BROWSER_SUPPORT.md
+[5]: https://github.com/DataDog/browser-sdk/blob/main/packages/logs/src/logsEvent.types.ts

--- a/content/fr/real_user_monitoring/browser/_index.md
+++ b/content/fr/real_user_monitoring/browser/_index.md
@@ -2,7 +2,7 @@
 aliases:
   - /fr/real_user_monitoring/setup
 dependencies:
-  - 'https://github.com/DataDog/browser-sdk/blob/master/packages/rum/README.md'
+  - 'https://github.com/DataDog/browser-sdk/blob/main/packages/rum/README.md'
 kind: documentation
 title: Surveillance Browser RUM
 ---

--- a/content/fr/real_user_monitoring/browser/advanced_configuration.md
+++ b/content/fr/real_user_monitoring/browser/advanced_configuration.md
@@ -402,5 +402,5 @@ Dans l'exemple ci-dessus, le SDK RUM recueille le nombre d'articles dans un pani
 
 
 [1]: https://github.com/DataDog/browser-sdk
-[2]: https://github.com/DataDog/browser-sdk/blob/master/packages/rum/src/rumEvent.types.ts
+[2]: https://github.com/DataDog/browser-sdk/blob/main/packages/rum/src/rumEvent.types.ts
 [3]: /fr/logs/processing/attributes_naming_convention/#user-related-attributes

--- a/content/fr/real_user_monitoring/browser/troubleshooting.md
+++ b/content/fr/real_user_monitoring/browser/troubleshooting.md
@@ -9,7 +9,7 @@ further_reading:
     tag: Documentation
     text: Stratégie de sécurité de contenu
 ---
-Si la fonctionnalité RUM Browser de Datadog se comporte de manière inattendue, consultez ce guide pour voir les solutions proposées. Si vous ne parvenez pas à résoudre votre problème, contactez l'[assistance Datadog][1] pour obtenir de l'aide. Assurez-vous de mettre régulièrement à jour le [SDK RUM Browser][2], car chaque version contient des améliorations et des correctifs. 
+Si la fonctionnalité RUM Browser de Datadog se comporte de manière inattendue, consultez ce guide pour voir les solutions proposées. Si vous ne parvenez pas à résoudre votre problème, contactez l'[assistance Datadog][1] pour obtenir de l'aide. Assurez-vous de mettre régulièrement à jour le [SDK RUM Browser][2], car chaque version contient des améliorations et des correctifs.
 
 ## Données manquantes
 
@@ -57,7 +57,7 @@ Le SDK RUM Browser utilise des cookies pour stocker des informations de session 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /fr/help
-[2]: https://github.com/DataDog/browser-sdk/blob/master/CHANGELOG.md
+[2]: https://github.com/DataDog/browser-sdk/blob/main/CHANGELOG.md
 [3]: /fr/real_user_monitoring/browser/#npm
 [4]: /fr/real_user_monitoring/faq/proxy_rum_data/?tab=npm
 [5]: /fr/real_user_monitoring/faq/content_security_policy/

--- a/content/ja/logs/log_collection/javascript.md
+++ b/content/ja/logs/log_collection/javascript.md
@@ -2,7 +2,7 @@
 aliases:
   - /ja/logs/log_collection/web_browser
 dependencies:
-  - 'https://github.com/DataDog/browser-sdk/blob/master/packages/logs/README.md'
+  - 'https://github.com/DataDog/browser-sdk/blob/main/packages/logs/README.md'
 kind: documentation
 title: ブラウザログ収集
 ---
@@ -596,5 +596,5 @@ window.DD_LOGS && DD_LOGS.logger.setHandler('<HANDLER>')
 [1]: /ja/account_management/api-app-keys/#api-keys
 [2]: /ja/account_management/api-app-keys/#client-tokens
 [3]: https://www.npmjs.com/package/@datadog/browser-logs
-[4]: https://github.com/DataDog/browser-sdk/blob/master/packages/logs/BROWSER_SUPPORT.md
-[5]: https://github.com/DataDog/browser-sdk/blob/master/packages/logs/src/logsEvent.types.ts
+[4]: https://github.com/DataDog/browser-sdk/blob/main/packages/logs/BROWSER_SUPPORT.md
+[5]: https://github.com/DataDog/browser-sdk/blob/main/packages/logs/src/logsEvent.types.ts

--- a/content/ja/real_user_monitoring/browser/_index.md
+++ b/content/ja/real_user_monitoring/browser/_index.md
@@ -2,7 +2,7 @@
 aliases:
   - /ja/real_user_monitoring/setup
 dependencies:
-  - 'https://github.com/DataDog/browser-sdk/blob/master/packages/rum/README.md'
+  - 'https://github.com/DataDog/browser-sdk/blob/main/packages/rum/README.md'
 kind: ドキュメント
 title: RUM ブラウザモニタリング
 ---
@@ -183,4 +183,4 @@ init(configuration: {
 [5]: https://docs.datadoghq.com/ja/account_management/api-app-keys/#client-tokens
 [6]: https://docs.datadoghq.com/ja/real_user_monitoring/data_collected/user_action/#automatic-collection-of-user-actions
 [7]: https://docs.datadoghq.com/ja/real_user_monitoring/faq/proxy_rum_data/
-[8]: https://github.com/DataDog/browser-sdk/blob/master/packages/rum/BROWSER_SUPPORT.md
+[8]: https://github.com/DataDog/browser-sdk/blob/main/packages/rum/BROWSER_SUPPORT.md

--- a/content/ja/real_user_monitoring/browser/advanced_configuration.md
+++ b/content/ja/real_user_monitoring/browser/advanced_configuration.md
@@ -395,5 +395,5 @@ var context = window.DD_RUM && DD_RUM.getRumGlobalContext();
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: https://github.com/DataDog/browser-sdk/blob/master/packages/rum-core/src/rumEvent.types.ts
+[1]: https://github.com/DataDog/browser-sdk/blob/main/packages/rum-core/src/rumEvent.types.ts
 [2]: /ja/logs/processing/attributes_naming_convention/#user-related-attributes

--- a/content/ja/real_user_monitoring/browser/troubleshooting.md
+++ b/content/ja/real_user_monitoring/browser/troubleshooting.md
@@ -57,7 +57,7 @@ Browser RUM SDK は、クッキーに依存してセッション情報を保存�
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /ja/help
-[2]: https://github.com/DataDog/browser-sdk/blob/master/CHANGELOG.md
+[2]: https://github.com/DataDog/browser-sdk/blob/main/CHANGELOG.md
 [3]: /ja/real_user_monitoring/browser/#npm
 [4]: /ja/real_user_monitoring/faq/proxy_rum_data/?tab=npm
 [5]: /ja/real_user_monitoring/faq/content_security_policy/

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -413,27 +413,27 @@
   - repo_name: browser-sdk
     contents:
     - action: pull-and-push-file
-      branch: master
+      branch: main
       globs:
       - 'packages/rum/README.md'
       options:
         dest_path: '/real_user_monitoring/browser/'
         file_name: '_index.md'
         front_matters:
-          dependencies: ["https://github.com/DataDog/browser-sdk/blob/master/packages/rum/README.md"]
+          dependencies: ["https://github.com/DataDog/browser-sdk/blob/main/packages/rum/README.md"]
           title: RUM Browser Monitoring
           kind: documentation
           aliases:
             - /real_user_monitoring/setup
     - action: pull-and-push-file
-      branch: master
+      branch: main
       globs:
       - 'packages/logs/README.md'
       options:
         dest_path: '/logs/log_collection/'
         file_name: 'javascript.md'
         front_matters:
-          dependencies: ["https://github.com/DataDog/browser-sdk/blob/master/packages/logs/README.md"]
+          dependencies: ["https://github.com/DataDog/browser-sdk/blob/main/packages/logs/README.md"]
           title: Browser Log Collection
           kind: documentation
           aliases:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -412,27 +412,27 @@
   - repo_name: browser-sdk
     contents:
     - action: pull-and-push-file
-      branch: master
+      branch: main
       globs:
       - 'packages/rum/README.md'
       options:
         dest_path: '/real_user_monitoring/browser/'
         file_name: '_index.md'
         front_matters:
-          dependencies: ["https://github.com/DataDog/browser-sdk/blob/master/packages/rum/README.md"]
+          dependencies: ["https://github.com/DataDog/browser-sdk/blob/main/packages/rum/README.md"]
           title: RUM Browser Monitoring
           kind: documentation
           aliases:
             - /real_user_monitoring/setup
     - action: pull-and-push-file
-      branch: master
+      branch: main
       globs:
       - 'packages/logs/README.md'
       options:
         dest_path: '/logs/log_collection/'
         file_name: 'javascript.md'
         front_matters:
-          dependencies: ["https://github.com/DataDog/browser-sdk/blob/master/packages/logs/README.md"]
+          dependencies: ["https://github.com/DataDog/browser-sdk/blob/main/packages/logs/README.md"]
           title: Browser Log Collection
           kind: documentation
           aliases:


### PR DESCRIPTION
### What does this PR do?

Rename browser SDK `master` references to `main`.

### Motivation

Renaming of the default branch in browser-sdk repo, cf https://github.com/DataDog/browser-sdk/pull/830

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bcaudan/browser-sdk-branch/real_user_monitoring/browser/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
