### PR TITLE
Remove sentence that directs user to configure NPM using main agent config

### DIFF
--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -87,8 +87,6 @@ Network Performance Monitoring supports use of the following provisioning system
 
 ## Setup
 
-To enable Network Performance Monitoring, configure it in your [Agent's main configuration file][13] based on your system setup.
-
 Given this tool's focus and strength is in analyzing traffic _between_ network endpoints and mapping network dependencies, it is recommended to install it on a meaningful subset of your infrastructure and a **_minimum of 2 hosts_** to maximize value.
 
 {{< tabs >}}


### PR DESCRIPTION
### What does this PR do?

Remove sentence that directs user to configure NPM using main agent config file.

### Motivation

This sentence is inaccurate. NPM has always used a separate configuration file `system-probe.yaml`.

### Preview

https://docs-staging.datadoghq.com/bryce.kahle/npm-setup-file-location/network_monitoring/performance/setup/?#setup

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
