### PR TITLE
[WEB-1376] ci image and hugo extended

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ cache: &cache
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:david.jones_untracked
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:david.jones_img-update
   tags:
     - "runner:main"
     - "size:2xlarge"

--- a/package.json
+++ b/package.json
@@ -133,5 +133,8 @@
         "webpack-bundle-analyzer": "^3.3.2",
         "webpack-cli": "^3.3.6",
         "webpack-merge": "^4.2.1"
+    },
+    "hugo-bin": {
+      "buildTags": "extended"
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR:

- Updates to use a new build image https://github.com/DataDog/corp-ci/pull/98
- Updates to use hugo extended version. This shouldn't change the build output the extended version just has additional capabilities that we aren't using just yet.

### Motivation

In support of using hugo modules
https://datadoghq.atlassian.net/browse/WEB-1376

### Preview

Please review as much of the site as possible especially sections where we rely on external dependencies.
https://docs-staging.datadoghq.com/david.jones/img-update/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
