### PR TITLE
Use loader:core as default for snmp listener

### DIFF
--- a/content/en/network_monitoring/devices/setup.md
+++ b/content/en/network_monitoring/devices/setup.md
@@ -111,6 +111,7 @@ snmp_listener:
       tags:
       - "key1:val1"
       - "key2:val2"
+      loader: core # use SNMP corecheck implementation
     - network: 2.3.4.5/24
       version: 2
       port: 161
@@ -118,6 +119,7 @@ snmp_listener:
       tags:
       - "key1:val1"
       - "key2:val2"
+      loader: core
 ```
 
 {{% /tab %}}
@@ -141,6 +143,7 @@ snmp_listener:
       tags:
         - "key1:val1"
         - "key2:val2"
+      loader: core
     - network: 2.3.4.5/24
       version: 3
       snmp_version: 3
@@ -152,6 +155,7 @@ snmp_listener:
       tags:
         - "key1:val1"
         - "key2:val2"
+      loader: core
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Use loader:core as default for snmp listener

### Motivation

snmp corecheck implementation is recommended.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
