### PR TITLE
Add Role Permissions synonyms

### DIFF
--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -254,7 +254,7 @@
             ["microsoft azure", "azure"],
             ["gcp", "google cloud platform"],
             ["aws", "amazon web service"],
-            ["RUM", "rum", "real user monitoring"]
+            ["RUM", "rum", "real user monitoring"],
             ["Role Permissions", "permissions"]
         ]
     },

--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -255,6 +255,7 @@
             ["gcp", "google cloud platform"],
             ["aws", "amazon web service"],
             ["RUM", "rum", "real user monitoring"]
+            ["Role Permissions", "permissions"]
         ]
     },
     "only_content_level": true,

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -254,7 +254,7 @@
             ["microsoft azure", "azure"],
             ["gcp", "google cloud platform"],
             ["aws", "amazon web service"],
-            ["RUM", "rum", "real user monitoring"]
+            ["RUM", "rum", "real user monitoring"],
             ["Role Permissions", "permissions"]
         ]
     },

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -255,6 +255,7 @@
             ["gcp", "google cloud platform"],
             ["aws", "amazon web service"],
             ["RUM", "rum", "real user monitoring"]
+            ["Role Permissions", "permissions"]
         ]
     },
     "only_content_level": true,


### PR DESCRIPTION
### What does this PR do?
Add Role Permissions synonyms to the Algolia config to populate Datadog Role Permissions docs.

### Motivation
Searching `Permissions` didn't formerly populate `Datadog Role Permissions` docs within search.

### Preview
https://docs-staging.datadoghq.com/sarina/permissions-algolia/


### Additional Notes
Search for `Permissions` in both the docs homepage and in a few subsequent pages to test to ensure `Datadog Role Permissions` populates. Ran locally and this fix seemed to do the trick.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
