### PR TITLE
[monitors] Clarify rrule support in downtimes

### DIFF
--- a/content/en/monitors/guide/supress-alert-with-downtimes.md
+++ b/content/en/monitors/guide/supress-alert-with-downtimes.md
@@ -162,7 +162,7 @@ To plan more advanced maintenance schedules, you can use RRULE.
 
 RRULE - or recurrence rule - is a property name from [iCalendar RFC][4], which is the standard for defining recurring events.
 
-Any RRULE listed in the [RFC][4] is supported. You can use [this tool][5] to generate RRULEs and paste them into your API call.
+Attributes specifying the duration in `RRULE` are not supported (for example, `DTSTART`, `DTEND`, `DURATION`), see the [RFC][4] for the possible attributes. You can use [this tool][5] to generate RRULEs and paste them into your API call.
 
 **Example**: The ERP app is updated every 2nd Tuesday of the month to apply patches and fixes between 8AM and 10AM. Monitors for this are scoped with `app:erp`, so we use this in the downtime scope.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Clarify that we don't support the full RRULE spec.

### Motivation
<!-- What inspired you to submit this pull request?-->

Make this guide match the api spec: https://docs.datadoghq.com/api/latest/downtimes/#schedule-a-downtime (under recurrence, see rrule description.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/pb/clarify-rrule-support/en/monitors/guide/supress-alert-with-downtimes

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
