### PR TITLE
Verify some images w/ Docker Content Trust

### DIFF
--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -47,7 +47,7 @@ If you haven’t installed the Docker Agent, follow the [in-app installation ins
 {{% tab "Standard" %}}
 
 ```shell
-docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> gcr.io/datadoghq/agent:7
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> datadog/agent
 ```
 
 **Note**: If you're using a different registry besides GCR, make sure to update the image.
@@ -58,13 +58,13 @@ docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v
 For Amazon Linux < v2:
 
 ```shell
-docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> gcr.io/datadoghq/agent:7
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> datadog/agent
 ```
 
 For Amazon Linux v2:
 
 ```shell
-docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> gcr.io/datadoghq/agent:7
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> datadog/agent
 ```
 
 {{% /tab %}}
@@ -73,7 +73,7 @@ docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v
 The Datadog Agent is supported in Windows Server 2019 (LTSC) and version 1909 (SAC).
 
 ```shell
-docker run -d --name dd-agent -e DD_API_KEY=<API_KEY> -v \\.\pipe\docker_engine:\\.\pipe\docker_engine gcr.io/datadoghq/agent
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -e DD_API_KEY=<API_KEY> -v \\.\pipe\docker_engine:\\.\pipe\docker_engine datadog/agent
 ```
 
 {{% /tab %}}
@@ -82,7 +82,7 @@ docker run -d --name dd-agent -e DD_API_KEY=<API_KEY> -v \\.\pipe\docker_engine:
 (Optional) To run an unprivileged installation, add `--group-add=<DOCKER_GROUP_ID>` to the install command, for example:
 
 ```shell
-docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> gcr.io/datadoghq/agent:7 --group-add=<DOCKER_GROUP_ID>
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> datadog/agent --group-add=<DOCKER_GROUP_ID>
 ```
 
 {{% /tab %}}

--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -34,10 +34,10 @@ The Datadog Docker Agent is the containerized version of the host [Agent][1]. Th
 
 Images are available for 64-bit x86 and Arm v8 architectures.
 
-| Docker Hub                                             | GCR                                                             |
-|--------------------------------------------------------|-----------------------------------------------------------------|
-| [Agent v6+][2]<br>`docker pull datadog/agent`          | [Agent v6+][3]<br>`docker pull gcr.io/datadoghq/agent`          |
-| [Agent v5][4]<br>`docker pull datadog/docker-dd-agent` | [Agent v5][5]<br>`docker pull gcr.io/datadoghq/docker-dd-agent` |
+| Docker Hub                                                           | GCR                                                             |
+|----------------------------------------------------------------------|-----------------------------------------------------------------|
+| [Agent v6+][2]<br>`DOCKER_CONTENT_TRUST=1 docker pull datadog/agent` | [Agent v6+][3]<br>`docker pull gcr.io/datadoghq/agent`          |
+| [Agent v5][4]<br>`docker pull datadog/docker-dd-agent`               | [Agent v5][5]<br>`docker pull gcr.io/datadoghq/docker-dd-agent` |
 
 ## Setup
 

--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -26,7 +26,7 @@ further_reading:
       text: "Assign tags to all data emitted by a container"
 ---
 
-Enable the Trace Agent in the `gcr.io/datadoghq/agent` container by passing `DD_APM_ENABLED=true` as an environment variable.
+Enable the Trace Agent in the `datadog/agent` container by passing `DD_APM_ENABLED=true` as an environment variable.
 
 ## Tracing from the host
 
@@ -40,23 +40,25 @@ For example, the following command allows the Agent to receive traces from your 
 {{% tab "Linux" %}}
 
 ```shell
-docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+              -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
               -p 127.0.0.1:8126:8126/tcp \
               -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 {{% /tab %}}
 {{% tab "Windows" %}}
 
 ```shell
-docker run -d -p 127.0.0.1:8126:8126/tcp \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+              -p 127.0.0.1:8126:8126/tcp \
               -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 {{% /tab %}}
@@ -106,7 +108,8 @@ Then start the Agent and the application container, connected to the network pre
 
 ```bash
 # Datadog Agent
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+              --name datadog-agent \
               --network <NETWORK_NAME> \
               -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
@@ -114,7 +117,7 @@ docker run -d --name datadog-agent \
               -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 
 # Application
 docker run -d --name app \
@@ -128,12 +131,13 @@ docker run -d --name app \
 
 ```bash
 # Datadog Agent
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+              --name datadog-agent \
               --network "<NETWORK_NAME>" \
               -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 
 # Application
 docker run -d --name app \

--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -46,7 +46,8 @@ Configuring log collection depends on your current environment. Choose one of th
 To run a [Docker container][1] that embeds the Datadog Agent to monitor your host, use the following command:
 
 ```shell
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+           --name datadog-agent \
            -e DD_API_KEY=<DATADOG_API_KEY> \
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
@@ -57,13 +58,14 @@ docker run -d --name datadog-agent \
            -v /proc/:/host/proc/:ro \
            -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
            -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-           gcr.io/datadoghq/agent:latest
+           datadog/agent
 ```
 
 **Note**: On Windows systems, run this command without any volume mounts. That is:
 
 ```shell
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+           --name datadog-agent \
            -e DD_API_KEY=<DATADOG_API_KEY> \
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
@@ -71,7 +73,7 @@ docker run -d --name datadog-agent \
            -e DD_CONTAINER_EXCLUDE="name:datadog-agent" \
            -v \\.\pipe\docker_engine:\\.\pipe\docker_engine \
            -v c:\programdata\docker\containers:c:\programdata\docker\containers:ro
-           gcr.io/datadoghq/agent:latest
+           datadog/agent
 ```
 
 It is recommended that you pick the latest version of the Datadog Agent. Consult the full list of available [images for Agent v6][2] on GCR.

--- a/content/en/agent/docker/prometheus.md
+++ b/content/en/agent/docker/prometheus.md
@@ -43,7 +43,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
               -e DD_API_KEY="<DATADOG_API_KEY>" \
               -e DD_SITE="<YOUR_DATADOG_SITE>" \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 {{% /tab %}}
@@ -56,7 +56,7 @@ docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro \
                               -v /cgroup/:/host/sys/fs/cgroup:ro \
                               -e DD_API_KEY="<DATADOG_API_KEY>" \
                               -e DD_SITE="<YOUR_DATADOG_SITE>" \
-                              gcr.io/datadoghq/agent:latest
+                              datadog/agent
 
 ```
 
@@ -67,7 +67,7 @@ docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro \
 DOCKER_CONTENT_TRUST=1 \
 docker run -d -e DD_API_KEY="<DATADOG_API_KEY>" \
               -e DD_SITE="<YOUR_DATADOG_SITE>" \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 {{% /tab %}}
@@ -147,7 +147,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
               -e DD_API_KEY="<DATADOG_API_KEY>" \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
     {{% /tab %}}
     {{% tab "Windows" %}}
@@ -155,7 +155,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
 ```shell
 DOCKER_CONTENT_TRUST=1 \
 docker run -d -e DD_API_KEY="<DATADOG_API_KEY>" \
-              gcr.io/datadoghq/agent:latest \
+              datadog/agent \
               -v \\.\pipe\docker_engine:\\.\pipe\docker_engine
 ```
     {{% /tab %}}

--- a/content/en/agent/guide/container-images-for-docker-environments.md
+++ b/content/en/agent/guide/container-images-for-docker-environments.md
@@ -23,7 +23,7 @@ If you are currently using Docker, there are several container images available 
 | Docker Agent (v 5)                      | [Docker Agent (v5)][3]                   | `docker pull datadog/docker-dd-agent`                      |
 | [DogStatsD][4]                          | [DogStatsD][5]                           | `DOCKER_CONTENT_TRUST=1 docker pull datadog/dogstatsd`     |
 | [Datadog Cluster Agent][6]              | [Cluster Agent][7]                       | `DOCKER_CONTENT_TRUST=1 docker pull datadog/cluster-agent` |
-| [Synthetics Private Location Worker][8] | [Synthetics Private Location Worker][9]  | `docker pull synthetics-private-location-worker`           |
+| [Synthetics Private Location Worker][8] | [Synthetics Private Location Worker][9]  | `docker pull datadog/synthetics-private-location-worker`           |
 
 [1]: /agent/docker/
 [2]: https://hub.docker.com/r/datadog/agent

--- a/content/en/agent/guide/container-images-for-docker-environments.md
+++ b/content/en/agent/guide/container-images-for-docker-environments.md
@@ -17,13 +17,13 @@ If you are currently using Docker, there are several container images available 
 {{< tabs >}}
 {{% tab "Docker Hub" %}}
 
-| Datadog Product                         | Docker Hub                               | Docker Pull Command                              |
-|-----------------------------------------|------------------------------------------|--------------------------------------------------|
-| [Docker Agent][1]                       | [Docker Agent (v6+)][2]                  | `docker pull datadog/agent`                      |
-| Docker Agent (v 5)                      | [Docker Agent (v5)][3]                   | `docker pull datadog/docker-dd-agent`            |
-| [DogStatsD][4]                          | [DogStatsD][5]                           | `docker pull datadog/dogstatsd`                  |
-| [Datadog Cluster Agent][6]              | [Cluster Agent][7]                       | `docker pull datadog/cluster-agent`              |
-| [Synthetics Private Location Worker][8] | [Synthetics Private Location Worker][9]  | `docker pull synthetics-private-location-worker` |
+| Datadog Product                         | Docker Hub                               | Docker Pull Command                                        |
+|-----------------------------------------|------------------------------------------|------------------------------------------------------------|
+| [Docker Agent][1]                       | [Docker Agent (v6+)][2]                  | `DOCKER_CONTENT_TRUST=1 docker pull datadog/agent`         |
+| Docker Agent (v 5)                      | [Docker Agent (v5)][3]                   | `docker pull datadog/docker-dd-agent`                      |
+| [DogStatsD][4]                          | [DogStatsD][5]                           | `DOCKER_CONTENT_TRUST=1 docker pull datadog/dogstatsd`     |
+| [Datadog Cluster Agent][6]              | [Cluster Agent][7]                       | `DOCKER_CONTENT_TRUST=1 docker pull datadog/cluster-agent` |
+| [Synthetics Private Location Worker][8] | [Synthetics Private Location Worker][9]  | `docker pull synthetics-private-location-worker`           |
 
 [1]: /agent/docker/
 [2]: https://hub.docker.com/r/datadog/agent

--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -92,7 +92,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC="true" \
               -p 8125:8125/udp \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 If you need to change the port used to collect StatsD metrics, use the `DD_DOGSTATSD_PORT="<NEW_DOGSTATSD_PORT>` environment variable. You can also configure DogStatsD to use a [Unix domain socket][1]:

--- a/content/en/logs/faq/how-to-tail-logs-from-host-using-a-container-agent.md
+++ b/content/en/logs/faq/how-to-tail-logs-from-host-using-a-container-agent.md
@@ -117,7 +117,8 @@ and mount it into `/conf.d/`. The file name can be anything:
 Your Agent’s Docker installation command should look like this:
 
 ```
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+           --name datadog-agent \
            -e DD_API_KEY=<DATADOG_API_KEY> \
            -e DD_LOGS_ENABLED=true \
            -v /var/run/docker.sock:/var/run/docker.sock:ro \
@@ -126,7 +127,7 @@ docker run -d --name datadog-agent \
            -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
            -v /<host log directory>/:<container log directory>/ \
            -v /<config location>/logs.yaml:/conf.d/logs.yaml \
-           gcr.io/datadoghq/agent:latest
+           datadog/agent
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/logs/guide/how-to-set-up-only-logs.md
+++ b/content/en/logs/guide/how-to-set-up-only-logs.md
@@ -37,7 +37,8 @@ To disable payloads, you must be running Agent v6.4+. This disables metric data 
 If you are using the container Agent, set the environment variable `DD_ENABLE_PAYLOADS_EVENTS`, `DD_ENABLE_PAYLOADS_SERIES`, `DD_ENABLE_PAYLOADS_SERVICE_CHECKS`, and `DD_ENABLE_PAYLOADS_SKETCHES` to `false` in addition to your Agent configuration:
 
 ```shell
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+           --name datadog-agent \
            -e DD_API_KEY=<DATADOG_API_KEY> \
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
@@ -50,7 +51,7 @@ docker run -d --name datadog-agent \
            -v /proc/:/host/proc/:ro \
            -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
            -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-           gcr.io/datadoghq/agent:latest
+           datadog/agent
 ```
 
 {{% /tab %}}

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -309,7 +309,7 @@ If you already have the [Agent running with a manifest][4]:
 To enable Network Performance Monitoring in Docker, use the following configuration when starting the container Agent:
 
 ```shell
-$ docker run -e DD_API_KEY="<DATADOG_API_KEY>" \
+$ DOCKER_CONTENT_TRUST=1 docker run -e DD_API_KEY="<DATADOG_API_KEY>" \
 -e DD_SYSTEM_PROBE_ENABLED=true \
 -e DD_PROCESS_AGENT_ENABLED=true \
       -v /var/run/docker.sock:/var/run/docker.sock:ro \
@@ -322,7 +322,7 @@ $ docker run -e DD_API_KEY="<DATADOG_API_KEY>" \
 --cap-add=SYS_PTRACE \
 --cap-add=NET_ADMIN \
 --cap-add=IPC_LOCK \
-datadog/agent:latest
+datadog/agent
 ```
 
 Replace `<DATADOG_API_KEY>` with your [Datadog API key][1].

--- a/content/fr/agent/docker/_index.md
+++ b/content/fr/agent/docker/_index.md
@@ -47,7 +47,7 @@ Si vous n'avez pas encore installé l'Agent Docker, consultez les informations c
 {{% tab "Installation standard" %}}
 
 ```shell
-DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<CLÉ_API_DATADOG> gcr.io/datadoghq/agent:7
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<CLÉ_API_DATADOG> datadog/agent
 ```
 
 **Remarque** : mettez à jour l'image si vous utilisez un autre registre que GCR.
@@ -56,7 +56,7 @@ DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/va
 {{% tab "Amazon Linux < v2" %}}
 
 ```shell
-DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<CLÉ_API_DATADOG> gcr.io/datadoghq/agent:7
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<CLÉ_API_DATADOG> datadog/agent
 ```
 
 {{% /tab %}}
@@ -65,7 +65,7 @@ DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/va
 L'Agent Datadog est pris en charge dans Windows Server version 2019 (LTSC) et 1909 (SAC).
 
 ```shell
-docker run -d --name dd-agent -e DD_API_KEY=<CLÉ_API> -v \\.\pipe\docker_engine:\\.\pipe\docker_engine gcr.io/datadoghq/agent
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -e DD_API_KEY=<CLÉ_API> -v \\.\pipe\docker_engine:\\.\pipe\docker_engine datadog/agent
 ```
 
 {{% /tab %}}
@@ -74,7 +74,7 @@ docker run -d --name dd-agent -e DD_API_KEY=<CLÉ_API> -v \\.\pipe\docker_engine
 (Facultatif) Pour exécuter une installation sans privilèges, ajoutez `--group-add=<ID_GROUPE_DOCKER>` à la commande d'installation. Par exemple :
 
 ```shell
-DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<CLÉ_API_DATADOG> gcr.io/datadoghq/agent:7 --group-add=<ID_GROUPE_DOCKER>
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<CLÉ_API_DATADOG> datadog/agent --group-add=<ID_GROUPE_DOCKER>
 ```
 
 {{% /tab %}}

--- a/content/fr/agent/docker/_index.md
+++ b/content/fr/agent/docker/_index.md
@@ -34,10 +34,10 @@ L'Agent Docker Datadog est la version conteneurisée de l'[Agent][1] pour host. 
 
 L'image est disponible en versions pour architectures x86 64 bits et Arm v8.
 
-| Docker Hub      | GCR             |
-|-----------------|-----------------|
-| [Agent v6+][2]<br>`docker pull datadog/agent`             | [Agent v6+][3]<br>`docker pull gcr.io/datadoghq/agent`           |
-| [Agent v5][4]<br>`docker pull datadog/docker-dd-agent`   | [Agent v5][5]<br>`docker pull gcr.io/datadoghq/docker-dd-agent`  |
+| Docker Hub                                                           | GCR                                                             |
+|----------------------------------------------------------------------|-----------------------------------------------------------------|
+| [Agent v6+][2]<br>`DOCKER_CONTENT_TRUST=1 docker pull datadog/agent` | [Agent v6+][3]<br>`docker pull gcr.io/datadoghq/agent`          |
+| [Agent v5][4]<br>`docker pull datadog/docker-dd-agent`               | [Agent v5][5]<br>`docker pull gcr.io/datadoghq/docker-dd-agent` |
 
 ## Configuration
 

--- a/content/fr/agent/docker/apm.md
+++ b/content/fr/agent/docker/apm.md
@@ -25,7 +25,7 @@ further_reading:
     tag: Documentation
     text: Attribuer des tags à toutes les données émises par un conteneur
 ---
-Activez l'Agent de trace dans le conteneur  `gcr.io/datadoghq/agent` en transmettant `DD_APM_ENABLED=true` en tant que variable d'environnement.
+Activez l'Agent de trace dans le conteneur  `datadog/agent` en transmettant `DD_APM_ENABLED=true` en tant que variable d'environnement.
 
 ## Tracing depuis le host
 
@@ -39,23 +39,25 @@ Par exemple, la commande suivante permet à l'Agent de recevoir des traces depui
 {{% tab "Linux" %}}
 
 ```shell
-docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+              -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
               -p 127.0.0.1:8126:8126/tcp \
               -e DD_API_KEY="<CLÉ_API_DATADOG>" \
               -e DD_APM_ENABLED=true \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 {{% /tab %}}
 {{% tab "Windows" %}}
 
 ```shell
-docker run -d -p 127.0.0.1:8126:8126/tcp \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+              -p 127.0.0.1:8126:8126/tcp \
               -e DD_API_KEY="<CLÉ_API_DATADOG>" \
               -e DD_APM_ENABLED=true \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 {{% /tab %}}
@@ -104,7 +106,8 @@ Démarrez ensuite l'Agent et le conteneur de l'application, connectés au résea
 
 ```bash
 # Agent Datadog
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+              --name datadog-agent \
               --network <NOM_RÉSEAU> \
               -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
@@ -112,7 +115,7 @@ docker run -d --name datadog-agent \
               -e DD_API_KEY="<CLÉ_API_DATADOG>" \
               -e DD_APM_ENABLED=true \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 
 # Application
 docker run -d --name app \
@@ -125,12 +128,13 @@ docker run -d --name app \
 
 ```bash
 # Agent Datadog
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+              --name datadog-agent \
               --network "<NOM_RÉSEAU>" \
               -e DD_API_KEY="<CLÉ_API_DATADOG>" \
               -e DD_APM_ENABLED=true \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 
 # Application
 docker run -d --name app \

--- a/content/fr/agent/docker/log.md
+++ b/content/fr/agent/docker/log.md
@@ -45,7 +45,8 @@ La configuration de la collecte de logs dépend de votre environnement actuel. C
 Afin de lancer un [conteneur Docker][1] qui intègre l'Agent Datadog pour surveiller votre host, utilisez la commande suivante :
 
 ```shell
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+           --name datadog-agent \
            -e DD_API_KEY="<CLÉ_API_DATADOG>" \
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
@@ -54,19 +55,20 @@ docker run -d --name datadog-agent \
            -v /proc/:/host/proc/:ro \
            -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
            -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-           gcr.io/datadoghq/agent:latest
+           datadog/agent
 ```
 
 **Remarque** : sur les systèmes Windows, exécutez cette commande sans les montages de volume. C'est-à-dire :
 
 ```shell
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+           --name datadog-agent \
            -e DD_API_KEY="<CLÉ_API_DATADOG>" \
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
            -e DD_CONTAINER_EXCLUDE="name:datadog-agent" \
            -v \\.\pipe\docker_engine:\\.\pipe\docker_engine \
-           gcr.io/datadoghq/agent:latest
+           datadog/agent
 ```
 
 Nous vous conseillons de choisir la dernière version de l'Agent Datadog. La liste complète des [images de l'Agent v6][2] est disponible sur GCR.

--- a/content/fr/agent/docker/prometheus.md
+++ b/content/fr/agent/docker/prometheus.md
@@ -42,7 +42,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
               -e DD_API_KEY="<CLÉ_API_DATADOG>" \
               -e DD_SITE="<VOTRE_SITE_DATADOG>" \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 {{% /tab %}}
@@ -55,7 +55,7 @@ docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro \
                               -v /cgroup/:/host/sys/fs/cgroup:ro \
                               -e DD_API_KEY="<CLÉ_API_DATADOG>" \
                               -e DD_SITE="<VOTRE_SITE_DATADOG>" \
-                              gcr.io/datadoghq/agent:latest
+                              datadog/agent
 
 ```
 
@@ -66,7 +66,7 @@ docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro \
 DOCKER_CONTENT_TRUST=1 \
 docker run -d -e DD_API_KEY="<CLÉ_API_DATADOG>" \
               -e DD_SITE="<VOTRE_SITE_DATADOG>" \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 {{% /tab %}}
@@ -141,7 +141,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
               -e DD_API_KEY="<CLÉ_API_DATADOG>" \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
     {{% /tab %}}
     {{% tab "Windows" %}}
@@ -149,7 +149,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
 ```shell
 DOCKER_CONTENT_TRUST=1 \
 docker run -d -e DD_API_KEY="<CLÉ_API_DATADOG>" \
-              gcr.io/datadoghq/agent:latest \
+              datadog/agent \
               -v \\.\pipe\docker_engine:\\.\pipe\docker_engine
 ```
     {{% /tab %}}

--- a/content/fr/agent/guide/container-images-for-docker-environments.md
+++ b/content/fr/agent/guide/container-images-for-docker-environments.md
@@ -16,13 +16,13 @@ Si vous utilisez actuellement Docker, plusieurs images de conteneur disponibles 
 {{< tabs >}}
 {{% tab "Docker Hub" %}}
 
-| Produit Datadog                         | Docker Hub                               | Commande Pull Docker                              |
-|-----------------------------------------|------------------------------------------|--------------------------------------------------|
-| [Agent Docker][1]                       | [Agent Docker (v6+)][2]                  | `docker pull datadog/agent`                      |
-| Agent Docker (v5)                      | [Agent Docker (v5)][3]                   | `docker pull datadog/docker-dd-agent`            |
-| [DogStatsD][4]                          | [DogStatsD][5]                           | `docker pull datadog/dogstatsd`                  |
-| [Agent de cluster Datadog][6]              | [Agent de cluster][7]                       | `docker pull datadog/cluster-agent`              |
-| [Worker d'emplacement privé Synthetic][8] | [Worker d'emplacement privé Synthetic][9]  | `docker pull synthetics-private-location-worker` |
+| Produit Datadog                           | Docker Hub                                | Commande Pull Docker                                       |
+|-------------------------------------------|-------------------------------------------|------------------------------------------------------------|
+| [Agent Docker][1]                         | [Agent Docker (v6+)][2]                   | `DOCKER_CONTENT_TRUST=1 docker pull datadog/agent`         |
+| Agent Docker (v5)                         | [Agent Docker (v5)][3]                    | `docker pull datadog/docker-dd-agent`                      |
+| [DogStatsD][4]                            | [DogStatsD][5]                            | `DOCKER_CONTENT_TRUST=1 docker pull datadog/dogstatsd`     |
+| [Agent de cluster Datadog][6]             | [Agent de cluster][7]                     | `DOCKER_CONTENT_TRUST=1 docker pull datadog/cluster-agent` |
+| [Worker d'emplacement privé Synthetic][8] | [Worker d'emplacement privé Synthetic][9] | `docker pull synthetics-private-location-worker`           |
 
 [1]: /fr/agent/docker/
 [2]: https://hub.docker.com/r/datadog/agent
@@ -37,13 +37,13 @@ Si vous utilisez actuellement Docker, plusieurs images de conteneur disponibles 
 {{% /tab %}}
 {{% tab "GCR" %}}
 
-| Produit Datadog                          | GCR                                      | Commande Pull GCR                                                  |
-|------------------------------------------|------------------------------------------|-------------------------------------------------------------------|
-| [Agent Docker][1]                        | [Agent Docker (v6+)][2]                  | `docker pull gcr.io/datadoghq/agent`                              |
-| Agent Docker (v5)                       | [Agent Docker (v5)][2]                   | `docker pull gcr.io/datadoghq/docker-dd-agent`                    |
-| [DogStatsD][3]                           | [DogStatsD][4]                           | `docker pull gcr.io/datadoghq/dogstatsd`                          |
-| [Agent de cluster Datadog][5]               | [Agent de Cluster][6]                       | `docker pull gcr.io/datadoghq/cluster-agent`                      |
-| [Worker d'emplacement privé Synthetic][7]  | [Worker d'emplacement privé Synthetic][8]  | `docker pull gcr.io/datadoghq/synthetics-private-location-worker` |
+| Produit Datadog                           | GCR                                       | Commande Pull GCR                                                 |
+|-------------------------------------------|-------------------------------------------|-------------------------------------------------------------------|
+| [Agent Docker][1]                         | [Agent Docker (v6+)][2]                   | `docker pull gcr.io/datadoghq/agent`                              |
+| Agent Docker (v5)                         | [Agent Docker (v5)][2]                    | `docker pull gcr.io/datadoghq/docker-dd-agent`                    |
+| [DogStatsD][3]                            | [DogStatsD][4]                            | `docker pull gcr.io/datadoghq/dogstatsd`                          |
+| [Agent de cluster Datadog][5]             | [Agent de Cluster][6]                     | `docker pull gcr.io/datadoghq/cluster-agent`                      |
+| [Worker d'emplacement privé Synthetic][7] | [Worker d'emplacement privé Synthetic][8] | `docker pull gcr.io/datadoghq/synthetics-private-location-worker` |
 
 [1]: /fr/agent/docker/
 [2]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/agent

--- a/content/fr/agent/guide/container-images-for-docker-environments.md
+++ b/content/fr/agent/guide/container-images-for-docker-environments.md
@@ -22,7 +22,7 @@ Si vous utilisez actuellement Docker, plusieurs images de conteneur disponibles 
 | Agent Docker (v5)                         | [Agent Docker (v5)][3]                    | `docker pull datadog/docker-dd-agent`                      |
 | [DogStatsD][4]                            | [DogStatsD][5]                            | `DOCKER_CONTENT_TRUST=1 docker pull datadog/dogstatsd`     |
 | [Agent de cluster Datadog][6]             | [Agent de cluster][7]                     | `DOCKER_CONTENT_TRUST=1 docker pull datadog/cluster-agent` |
-| [Worker d'emplacement privé Synthetic][8] | [Worker d'emplacement privé Synthetic][9] | `docker pull synthetics-private-location-worker`           |
+| [Worker d'emplacement privé Synthetic][8] | [Worker d'emplacement privé Synthetic][9] | `docker pull datadog/synthetics-private-location-worker`           |
 
 [1]: /fr/agent/docker/
 [2]: https://hub.docker.com/r/datadog/agent

--- a/content/fr/developers/dogstatsd/_index.md
+++ b/content/fr/developers/dogstatsd/_index.md
@@ -91,7 +91,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -e DD_API_KEY="<CLÉ_API_DATADOG>" \
               -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC="true" \
               -p 8125:8125/udp \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 Si vous devez modifier le port utilisé pour recueillir des métriques StatsD, utilisez la variable d'environnement `DD_DOGSTATSD_PORT="<NOUVEAU_PORT_DOGSTATSD>`. Vous pouvez également configurer DogStatsD de façon à utiliser un [socket de domaine Unix][1] :

--- a/content/fr/integrations/k6.md
+++ b/content/fr/integrations/k6.md
@@ -72,7 +72,7 @@ Pour obtenir des instructions détaillées, consultez la [documentation de k6][2
         -e DD_API_KEY=<YOUR_DATADOG_API_KEY> \
         -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=1 \
         -p 8125:8125/udp \
-        datadog/agent:latest
+        datadog/agent
     ```
 
     **Remarque** : remplacez `<YOUR_DATADOG_API_KEY>` par votre clé d'[API][5]. Si votre compte utilise le site européen de Datadog, définissez `DD_SITE` sur `datadoghq.eu`.

--- a/content/fr/integrations/mesos.md
+++ b/content/fr/integrations/mesos.md
@@ -29,6 +29,7 @@ et bien plus encore.
 L'installation se fait de la même façon que vous utilisiez Mesos avec ou sans DC/OS. Exécutez le conteneur datadog-agent sur chacun de vos nœuds Mesos Master :
 
 ```shell
+DOCKER_CONTENT_TRUST=1 \
 docker run -d --name datadog-agent \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
   -v /proc/:/host/proc/:ro \
@@ -36,7 +37,7 @@ docker run -d --name datadog-agent \
   -e DD_API_KEY= \
   -e MESOS_MASTER=true \
   -e MARATHON_URL=http://leader.mesos:8080 \
-  datadog/agent:latest
+  datadog/agent
 ```
 
 Spécifiez votre clé d'API Datadog et votre URL d'API Mesos Master dans la commande ci-dessus.

--- a/content/fr/integrations/systemd.md
+++ b/content/fr/integrations/systemd.md
@@ -60,12 +60,13 @@ Le check Systemd est inclus avec le paquet de l'[Agent Datadog][1]. Vous n'avez 
 Pour les environnements conteneurisés, montez le dossier `/run/systemd/`, qui contient le socket `/run/systemd/private` nécessaire pour récupérer les données Systemd. Exemple :
 
 ```bash
+DOCKER_CONTENT_TRUST=1 \
 docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup/:ro \
               -v /run/systemd/:/host/run/systemd/:ro \
               -e DD_API_KEY=<VOTRE_CLÉ_API> \
-              datadog/agent:latest
+              datadog/agent
 ```
 
 ### Configuration

--- a/content/fr/network_monitoring/performance/setup.md
+++ b/content/fr/network_monitoring/performance/setup.md
@@ -355,7 +355,7 @@ Si l'[Agent est déjà exécuté avec un manifeste][4] :
 Pour configurer la fonctionnalité Network Performance Monitoring dans Docker, utilisez la configuration suivante lorsque vous lancez l'Agent de conteneur :
 
 ```shell
-$ docker run -e DD_API_KEY="<CLÉ_API_DATADOG>" \
+$ DOCKER_CONTENT_TRUST=1 docker run -e DD_API_KEY="<CLÉ_API_DATADOG>" \
 -e DD_SYSTEM_PROBE_ENABLED=true \
 -e DD_PROCESS_AGENT_ENABLED=true \
       -v /var/run/docker.sock:/var/run/docker.sock:ro \
@@ -368,7 +368,7 @@ $ docker run -e DD_API_KEY="<CLÉ_API_DATADOG>" \
 --cap-add=SYS_PTRACE \
 --cap-add=NET_ADMIN \
 --cap-add=IPC_LOCK \
-datadog/agent:latest
+datadog/agent
 ```
 
 Remplacez `<CLÉ_API_DATADOG>` par votre [clé d'API Datadog][1].

--- a/content/fr/network_performance_monitoring/installation.md
+++ b/content/fr/network_performance_monitoring/installation.md
@@ -305,7 +305,7 @@ Si l'[Agent est déjà exécuté avec un manifeste][3] :
 Pour configurer la fonctionnalité Network Performance Monitoring dans Docker, utilisez la configuration suivante lorsque vous lancez l'Agent de conteneur :
 
 ```shell
-$ docker run -e DD_API_KEY="<CLÉ_API_DATADOG>" \
+$ DOCKER_CONTENT_TRUST=1 docker run -e DD_API_KEY="<CLÉ_API_DATADOG>" \
 -e DD_SYSTEM_PROBE_ENABLED=true \
 -e DD_PROCESS_AGENT_ENABLED=true \
       -v /var/run/docker.sock:/var/run/docker.sock:ro \
@@ -318,7 +318,7 @@ $ docker run -e DD_API_KEY="<CLÉ_API_DATADOG>" \
 --cap-add=SYS_PTRACE \
 --cap-add=NET_ADMIN \
 --cap-add=IPC_LOCK \
-datadog/agent:latest
+datadog/agent
 ```
 
 Remplacez `<CLÉ_API_DATADOG>` par votre [clé d'API Datadog][1].

--- a/content/ja/agent/docker/_index.md
+++ b/content/ja/agent/docker/_index.md
@@ -33,10 +33,10 @@ Datadog Docker Agent は、ホスト [Agent][1] をコンテナ化したバー�
 
 64-bit x86 および Arm v8 アーキテクチャ用のイメージをご用意しています。
 
-| Docker Hub                                             | GCR                                                             |
-|--------------------------------------------------------|-----------------------------------------------------------------|
-| [Agent v6+][2]<br>`docker pull datadog/agent`          | [Agent v6+][3]<br>`docker pull gcr.io/datadoghq/agent`          |
-| [Agent v5][4]<br>`docker pull datadog/docker-dd-agent` | [Agent v5][5]<br>`docker pull gcr.io/datadoghq/docker-dd-agent` |
+| Docker Hub                                                           | GCR                                                             |
+|----------------------------------------------------------------------|-----------------------------------------------------------------|
+| [Agent v6+][2]<br>`DOCKER_CONTENT_TRUST=1 docker pull datadog/agent` | [Agent v6+][3]<br>`docker pull gcr.io/datadoghq/agent`          |
+| [Agent v5][4]<br>`docker pull datadog/docker-dd-agent`               | [Agent v5][5]<br>`docker pull gcr.io/datadoghq/docker-dd-agent` |
 
 ## セットアップ
 

--- a/content/ja/agent/docker/_index.md
+++ b/content/ja/agent/docker/_index.md
@@ -46,7 +46,7 @@ Docker Agent をまだインストールしていない場合は、以下の手�
 {{% tab "標準" %}}
 
 ```shell
-docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> gcr.io/datadoghq/agent:7
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> datadog/agent
 ```
 
 **注**: GCR 以外の別のレジストリを使用している場合は、必ずイメージを更新してください。
@@ -57,13 +57,13 @@ docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v
 Amazon Linux < v2 の場合:
 
 ```shell
-docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> gcr.io/datadoghq/agent:7
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> datadog/agent
 ```
 
 Amazon Linux v2 の場合:
 
 ```shell
-docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> gcr.io/datadoghq/agent:7
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> datadog/agent
 ```
 
 {{% /tab %}}
@@ -72,7 +72,7 @@ docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v
 Datadog Agent は、Windows Server 2019 (LTSC) とバージョン 1909 (SAC) でサポートされています。
 
 ```shell
-docker run -d --name dd-agent -e DD_API_KEY=<API_KEY> -v \\.\pipe\docker_engine:\\.\pipe\docker_engine gcr.io/datadoghq/agent
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -e DD_API_KEY=<API_KEY> -v \\.\pipe\docker_engine:\\.\pipe\docker_engine datadog/agent
 ```
 
 {{% /tab %}}
@@ -81,7 +81,7 @@ docker run -d --name dd-agent -e DD_API_KEY=<API_KEY> -v \\.\pipe\docker_engine:
 (オプション) 非特権インストールを実行するには、インストールコマンドに `--group-add=<DOCKER_GROUP_ID>` を追加します。次に例を示します。
 
 ```shell
-docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> gcr.io/datadoghq/agent:7 --group-add=<DOCKER_GROUP_ID>
+DOCKER_CONTENT_TRUST=1 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=<DATADOG_API_KEY> datadog/agent --group-add=<DOCKER_GROUP_ID>
 ```
 
 {{% /tab %}}

--- a/content/ja/agent/docker/apm.md
+++ b/content/ja/agent/docker/apm.md
@@ -25,7 +25,7 @@ further_reading:
     tag: ドキュメント
     text: コンテナから送信された全データにタグを割り当て
 ---
-環境変数として `DD_APM_ENABLED=true` を渡すことで、`gcr.io/datadoghq/agent` コンテナで Trace Agent を有効にします。
+環境変数として `DD_APM_ENABLED=true` を渡すことで、`datadog/agent` コンテナで Trace Agent を有効にします。
 
 ## ホストからのトレース
 
@@ -39,23 +39,25 @@ _任意のホスト_ からトレースを利用するには、`-p 8126:8126/tcp
 {{% tab "Linux" %}}
 
 ```shell
-docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+              -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
               -p 127.0.0.1:8126:8126/tcp \
               -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 {{% /tab %}}
 {{% tab "Windows" %}}
 
 ```shell
-docker run -d -p 127.0.0.1:8126:8126/tcp \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+              -p 127.0.0.1:8126:8126/tcp \
               -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 {{% /tab %}}
@@ -105,7 +107,8 @@ docker network create <NETWORK_NAME>
 
 ```bash
 # Datadog Agent
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+              --name datadog-agent \
               --network <NETWORK_NAME> \
               -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
@@ -113,7 +116,7 @@ docker run -d --name datadog-agent \
               -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 
 # Application
 docker run -d --name app \
@@ -127,12 +130,13 @@ docker run -d --name app \
 
 ```bash
 # Datadog Agent
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+              --name datadog-agent \
               --network "<NETWORK_NAME>" \
               -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 
 # Application
 docker run -d --name app \

--- a/content/ja/agent/docker/log.md
+++ b/content/ja/agent/docker/log.md
@@ -45,7 +45,8 @@ Datadog Agent 6 以降は、コンテナからログを収集します。2 通�
 Datadog Agent を埋め込みホストを監視する [Docker コンテナ][1] を実行するには、次のコマンドを使用します。
 
 ```shell
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+           --name datadog-agent \
            -e DD_API_KEY=<DATADOG_API_KEY> \
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
@@ -54,19 +55,20 @@ docker run -d --name datadog-agent \
            -v /proc/:/host/proc/:ro \
            -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
            -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-           gcr.io/datadoghq/agent:latest
+           datadog/agent
 ```
 
 **注**: Windows システムでは、このコマンドをボリュームマウントなしで実行します。つまり以下のようになります。
 
 ```shell
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+           --name datadog-agent \
            -e DD_API_KEY=<DATADOG_API_KEY> \
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
            -e DD_CONTAINER_EXCLUDE="name:datadog-agent" \
            -v \\.\pipe\docker_engine:\\.\pipe\docker_engine \
-           gcr.io/datadoghq/agent:latest
+           datadog/agent
 ```
 
 最新版の Datadog Agent の使用が推奨されます。GCR で利用できる [Agent v6 のイメージ][2]リストを参照してください。

--- a/content/ja/agent/docker/prometheus.md
+++ b/content/ja/agent/docker/prometheus.md
@@ -42,7 +42,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
               -e DD_API_KEY="<DATADOG_API_KEY>" \
               -e DD_SITE="<YOUR_DATADOG_SITE>" \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 {{% /tab %}}
@@ -55,7 +55,7 @@ docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro \
                               -v /cgroup/:/host/sys/fs/cgroup:ro \
                               -e DD_API_KEY="<DATADOG_API_KEY>" \
                               -e DD_SITE="<YOUR_DATADOG_SITE>" \
-                              gcr.io/datadoghq/agent:latest
+                              datadog/agent
 
 ```
 
@@ -66,7 +66,7 @@ docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro \
 DOCKER_CONTENT_TRUST=1 \
 docker run -d -e DD_API_KEY="<DATADOG_API_KEY>" \
               -e DD_SITE="<YOUR_DATADOG_SITE>" \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 {{% /tab %}}
@@ -141,7 +141,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
               -e DD_API_KEY="<DATADOG_API_KEY>" \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
     {{% /tab %}}
     {{% tab "Windows" %}}
@@ -149,7 +149,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
 ```shell
 DOCKER_CONTENT_TRUST=1 \
 docker run -d -e DD_API_KEY="<DATADOG_API_KEY>" \
-              gcr.io/datadoghq/agent:latest \
+              datadog/agent \
               -v \\.\pipe\docker_engine:\\.\pipe\docker_engine
 ```
     {{% /tab %}}

--- a/content/ja/agent/guide/container-images-for-docker-environments.md
+++ b/content/ja/agent/guide/container-images-for-docker-environments.md
@@ -16,13 +16,13 @@ further_reading:
 {{< tabs >}}
 {{% tab "Docker Hub" %}}
 
-| Datadog 製品                         | Docker Hub                               | Docker プルコマンド                              |
-|-----------------------------------------|------------------------------------------|--------------------------------------------------|
-| [Docker Agent][1]                       | [Docker Agent (v6+)][2]                  | `docker pull datadog/agent`                      |
-| Docker Agent (v 5)                      | [Docker Agent (v5)][3]                   | `docker pull datadog/docker-dd-agent`            |
-| [DogStatsD][4]                          | [DogStatsD][5]                           | `docker pull datadog/dogstatsd`                  |
-| [Datadog クラスター Agent][6]              | [クラスター Agent][7]                       | `docker pull datadog/cluster-agent`              |
-| [Synthetics プライベートロケーションワーカー][8] | [Synthetics プライベートロケーションワーカー][9]  | `docker pull synthetics-private-location-worker` |
+| Datadog 製品                                | Docker Hub                                 | Docker プルコマンド                                           |
+|--------------------------------------------|--------------------------------------------|-------------------------------------------------------------|
+| [Docker Agent][1]                          | [Docker Agent (v6+)][2]                    | `DOCKER_CONTENT_TRUST=1 docker pull datadog/agent`          |
+| Docker Agent (v 5)                         | [Docker Agent (v5)][3]                     | `docker pull datadog/docker-dd-agent`                       |
+| [DogStatsD][4]                             | [DogStatsD][5]                             | `DOCKER_CONTENT_TRUST=1 docker pull datadog/dogstatsd`      |
+| [Datadog クラスター Agent][6]                | [クラスター Agent][7]                        | `DOCKER_CONTENT_TRUST=1 docker pull datadog/cluster-agent` |
+| [Synthetics プライベートロケーションワーカー][8] | [Synthetics プライベートロケーションワーカー][9] | `docker pull synthetics-private-location-worker`          |
 
 [1]: /ja/agent/docker/
 [2]: https://hub.docker.com/r/datadog/agent

--- a/content/ja/agent/guide/container-images-for-docker-environments.md
+++ b/content/ja/agent/guide/container-images-for-docker-environments.md
@@ -22,7 +22,7 @@ further_reading:
 | Docker Agent (v 5)                         | [Docker Agent (v5)][3]                     | `docker pull datadog/docker-dd-agent`                       |
 | [DogStatsD][4]                             | [DogStatsD][5]                             | `DOCKER_CONTENT_TRUST=1 docker pull datadog/dogstatsd`      |
 | [Datadog クラスター Agent][6]                | [クラスター Agent][7]                        | `DOCKER_CONTENT_TRUST=1 docker pull datadog/cluster-agent` |
-| [Synthetics プライベートロケーションワーカー][8] | [Synthetics プライベートロケーションワーカー][9] | `docker pull synthetics-private-location-worker`          |
+| [Synthetics プライベートロケーションワーカー][8] | [Synthetics プライベートロケーションワーカー][9] | `docker pull datadog/synthetics-private-location-worker`          |
 
 [1]: /ja/agent/docker/
 [2]: https://hub.docker.com/r/datadog/agent

--- a/content/ja/developers/dogstatsd/_index.md
+++ b/content/ja/developers/dogstatsd/_index.md
@@ -91,7 +91,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -e DD_API_KEY="<DATADOG_API_KEY>" \
               -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC="true" \
               -p 8125:8125/udp \
-              gcr.io/datadoghq/agent:latest
+              datadog/agent
 ```
 
 StatsD メトリクスの収集に使用するポートを変更する必要がある場合は、`DD_DOGSTATSD_PORT="<新しい_DOGSTATSD_ポート>` 環境変数を使用します。[Unix ドメインソケット][1]を使用するように DogStatsD を構成することもできます。

--- a/content/ja/integrations/k6.md
+++ b/content/ja/integrations/k6.md
@@ -72,7 +72,7 @@ k6 インテグレーションを使用すると、k6 テストのパフォー�
         -e DD_API_KEY=<YOUR_DATADOG_API_KEY> \
         -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=1 \
         -p 8125:8125/udp \
-        datadog/agent:latest
+        datadog/agent
     ```
 
     **注**: `<Datadog API キー>` を [API][5] キーに置き換えます。アカウントが Datadog EU に登録されている場合は、`DD_SITE` を `datadoghq.eu` にします。

--- a/content/ja/integrations/mesos.md
+++ b/content/ja/integrations/mesos.md
@@ -29,14 +29,15 @@ short_description: クラスターリソース使用状況、マスターおよ�
 DC/OS の有無にかかわらず、Mesos でのインストールは同じです。各 Mesos マスターノードで datadog-agent コンテナを実行します。
 
 ```shell
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+  --name datadog-agent \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
   -v /proc/:/host/proc/:ro \
   -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
   -e DD_API_KEY=<YOUR_DATADOG_API_KEY> \
   -e MESOS_MASTER=true \
   -e MARATHON_URL=http://leader.mesos:8080 \
-  datadog/agent:latest
+  datadog/agent
 ```
 
 上のコマンドの Datadog API キーと Mesos Master の API URL は、適切な値に置き換えてください。

--- a/content/ja/integrations/systemd.md
+++ b/content/ja/integrations/systemd.md
@@ -60,12 +60,13 @@ Systemd チェックは [Datadog Agent][1] パッケージに含まれていま�
 コンテナ環境の場合は、Systemd データの取得に必要なソケット `/run/systemd/private` を含む `/run/systemd/` フォルダーをマウントする必要があります。たとえば、以下のとおりです。
 
 ```bash
-docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+              -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup/:ro \
               -v /run/systemd/:/host/run/systemd/:ro \
               -e DD_API_KEY=<YOUR_API_KEY> \
-              datadog/agent:latest
+              datadog/agent
 ```
 
 ### コンフィギュレーション

--- a/content/ja/logs/guide/how-to-set-up-only-logs.md
+++ b/content/ja/logs/guide/how-to-set-up-only-logs.md
@@ -36,7 +36,8 @@ kind: documentation
 コンテナ Agent を使用している場合は、環境変数 `DD_ENABLE_PAYLOADS_EVENTS`、`DD_ENABLE_PAYLOADS_SERIES`、`DD_ENABLE_PAYLOADS_SERVICE_CHECKS`、`DD_ENABLE_PAYLOADS_SKETCHES` を `false` に設定し、Agent のコンフィギュレーションを以下のようにします。
 
 ```shell
-docker run -d --name datadog-agent \
+DOCKER_CONTENT_TRUST=1 docker run -d \
+           --name datadog-agent \
            -e DD_API_KEY="<DATADOG_API_KEY>" \
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
@@ -49,7 +50,7 @@ docker run -d --name datadog-agent \
            -v /proc/:/host/proc/:ro \
            -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
            -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-           gcr.io/datadoghq/agent:latest
+           datadog/agent
 ```
 
 {{% /tab %}}

--- a/content/ja/network_monitoring/performance/setup.md
+++ b/content/ja/network_monitoring/performance/setup.md
@@ -354,7 +354,7 @@ Helm をお使いでない場合は、Kubernetes を使用してネットワー�
 Docker でネットワークパフォーマンスのモニタリングを有効化するには、コンテナ Agent を起動する際に、次のコンフィギュレーションを使用します。
 
 ```shell
-$ docker run -e DD_API_KEY="<DATADOG_API_キー>" \
+$ DOCKER_CONTENT_TRUST=1 docker run -e DD_API_KEY="<DATADOG_API_キー>" \
 -e DD_SYSTEM_PROBE_ENABLED=true \
 -e DD_PROCESS_AGENT_ENABLED=true \
       -v /var/run/docker.sock:/var/run/docker.sock:ro \
@@ -367,7 +367,7 @@ $ docker run -e DD_API_KEY="<DATADOG_API_キー>" \
 --cap-add=SYS_PTRACE \
 --cap-add=NET_ADMIN \
 --cap-add=IPC_LOCK \
-datadog/agent:latest
+datadog/agent
 ```
 
 `<API_キー>` を、ご使用の [Datadog API キー][1]に置き換えます。

--- a/content/ja/network_performance_monitoring/installation.md
+++ b/content/ja/network_performance_monitoring/installation.md
@@ -307,7 +307,7 @@ Kubernetes を使用してネットワークパフォーマンスのモニタリ
 Docker でネットワークパフォーマンスのモニタリングを有効化するには、コンテナ Agent を起動する際に、次のコンフィギュレーションを使用します。
 
 ```shell
-$ docker run -e DD_API_KEY="<DATADOG_API_キー>" \
+$ DOCKER_CONTENT_TRUST=1 docker run -e DD_API_KEY="<DATADOG_API_キー>" \
 -e DD_SYSTEM_PROBE_ENABLED=true \
 -e DD_PROCESS_AGENT_ENABLED=true \
       -v /var/run/docker.sock:/var/run/docker.sock:ro \
@@ -320,7 +320,7 @@ $ docker run -e DD_API_KEY="<DATADOG_API_キー>" \
 --cap-add=SYS_PTRACE \
 --cap-add=NET_ADMIN \
 --cap-add=IPC_LOCK \
-datadog/agent:latest
+datadog/agent
 ```
 
 `<API_キー>` を、ご使用の [Datadog API キー][1]に置き換えます。


### PR DESCRIPTION
### What does this PR do?

Verify the core agent, dogstatds, and cluster agent on Docker Hub with Docker Content Trust (DCT).

### Motivation

Previously, the images were verified using DCT, but it appears that new documentation overhaul removed this.

### Preview

<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes

N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
