### PR TITLE
[SSV-547]Add Synthetics run unit to documentation

### DIFF
--- a/content/en/developers/metrics/units.md
+++ b/content/en/developers/metrics/units.md
@@ -48,6 +48,7 @@ The following units may be associated with metrics submitted to Datadog:
 | CURRENT     | milliampere / ampere                                                                                                                                                                                                                                                                                                       |
 | POTENTIAL   | millivolt / volt                                                                                                                                                                                                                                                                                                           |
 | APM         | span                                                                                                                                                                                                                                                                                                                       |
+| SYNTHETICS  | run                                                                                                                                                                                                                                                                                                                        |
 
 ## Number formatting
 


### PR DESCRIPTION
### What does this PR do?
Adds the Synthetics `run` unit, that represents test runs.

### Motivation
We want to add a new unit for Synthetics test runs.

### Preview
Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/antonin/add_run_unit/developers/metrics/units/

### Additional Notes
Linked to https://github.com/DataDog/dogweb/pull/60065/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
