### PR TITLE
Refactor webpack node tracing troubleshooting

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1040,8 +1040,8 @@ main:
     parent: serverless
     identifier: serverless_troubleshooting
     weight: 11
-  - name: Node.js Lambda Tracing and Webpack Compatibility
-    url: serverless/serverless_tracing_and_webpack
+  - name: Webpack Compatibility
+    url: serverless/troubleshooting/serverless_tracing_and_webpack
     parent: serverless_troubleshooting
     weight: 1101
   - name: Azure App Services Extension

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1040,6 +1040,10 @@ main:
     parent: serverless
     identifier: serverless_troubleshooting
     weight: 11
+  - name: Node.js Lambda Tracing and Webpack Compatibility
+    url: serverless/serverless_tracing_and_webpack
+    parent: serverless_troubleshooting
+    weight: 1101
   - name: Azure App Services Extension
     url: serverless/azure_app_services
     parent: serverless

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -59,40 +59,15 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
     ```
     More information on the Datadog Forwarder ARN or installation can be found [here][2]. For additional settings, see the [plugin documentation][1].
 
-4. (Optional - only applies if you're using Webpack)
-
-    `dd-trace` is known to be not compatible with webpack due to the use of conditional import and other issues. If using webpack, make sure to mark `datadog-lambda-js` and `dd-trace` as [externals](https://webpack.js.org/configuration/externals/) for webpack, so webpack knows these dependencies will be available in the runtime. You should also remove `datadog-lambda-js` and `dd-trace` from `package.json` and the build process to ensure you're using the versions provided by the Datadog Lambda Layer.
-
-    If using `serverless-webpack`, make sure to also exclude `datadog-lambda-js` and `dd-trace` in your `serverless.yml` in addition to declaring them as external in your webpack config file.
-
-    **webpack.config.js**
-
-    ```
-    var nodeExternals = require("webpack-node-externals");
-
-    module.exports = {
-      // we use webpack-node-externals to excludes all node deps.
-      // You can manually set the externals too.
-      externals: [nodeExternals(), "dd-trace", "datadog-lambda-js"],
-    };
-    ```
-
-    **serverless.yml**
-
-    ```
-    custom:
-      webpack:
-        includeModules:
-          forceExclude:
-            - dd-trace
-            - datadog-lambda-js
-    ```
+**Note**: You need to follow these [additional configuration steps][4] if your Lambda function is simultaneously using Datadog's tracing libraries and [webpack][5].
 
 
 
 [1]: https://docs.datadoghq.com/serverless/serverless_integrations/plugin
 [2]: https://docs.datadoghq.com/serverless/forwarder/
 [3]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
+[4]: /serverless/troubleshooting/serverless_tracing_and_webpack/
+[5]: https://webpack.js.org/
 {{% /tab %}}
 {{% tab "AWS SAM" %}}
 
@@ -335,22 +310,25 @@ See the [latest release][4].
 3. Set the environment variable `DD_TRACE_ENABLED` to `true`.
 4. Set the environment variable `DD_FLUSH_TO_LOG` to `true`.
 5. Optionally add a `service` and `env` tag with appropriate values to your function.
-6. If you're using webpack, please note that `dd-trace` is known to be not compatible with webpack due to the use of conditional import and other issues. Make sure to mark `datadog-lambda-js` and `dd-trace` as [externals](https://webpack.js.org/configuration/externals/) for webpack, so webpack knows these dependencies will be available in the runtime. You should also remove `datadog-lambda-js` and `dd-trace` from `package.json` and the build process to ensure you're using the versions provided by the Datadog Lambda Layer.
+
+**Note**: You need to follow these [additional configuration steps][5] if your Lambda function is simultaneously using Datadog's tracing libraries and [webpack][6].
 
 ### Subscribe the Datadog Forwarder to the log groups
 
 You need to subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces, and logs to Datadog.
 
-1. [Install the Datadog Forwarder if you haven't][5].
-2. [Subscribe the Datadog Forwarder to your function's log groups][6].
+1. [Install the Datadog Forwarder if you haven't][7].
+2. [Subscribe the Datadog Forwarder to your function's log groups][8].
 
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
 [2]: https://github.com/DataDog/datadog-lambda-layer-js/releases
 [3]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
 [4]: https://www.npmjs.com/package/datadog-lambda-js
-[5]: https://docs.datadoghq.com/serverless/forwarder/
-[6]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
+[5]: /serverless/troubleshooting/serverless_tracing_and_webpack/
+[6]: https://webpack.js.org/
+[7]: https://docs.datadoghq.com/serverless/forwarder/
+[8]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/serverless/troubleshooting/serverless_tracing_and_webpack.md
+++ b/content/en/serverless/troubleshooting/serverless_tracing_and_webpack.md
@@ -1,0 +1,43 @@
+---
+title: Node.js Lambda Tracing and Webpack Compatibility 
+kind: documentation
+further_reading:
+    - link: 'serverless/installation/node'
+      tag: 'Documentation'
+---
+
+# Compatibility
+
+Datadog's tracing libraries (`dd-trace`) are known to be not compatible with [webpack][1] due to the use of conditional imports and other issues. If using webpack and tracing your Node.js serverless functions:
+
+1. Mark `datadog-lambda-js` and `dd-trace` as [externals][5] for webpack, so webpack knows these dependencies will be available in the Lambda runtime.
+
+    **webpack.config.js**
+
+    ```
+    var nodeExternals = require("webpack-node-externals");
+
+    module.exports = {
+      // we use webpack-node-externals to excludes all node deps.
+      // You can manually set the externals too.
+      externals: [nodeExternals(), "dd-trace", "datadog-lambda-js"],
+    };
+    ```
+
+2. Remove `datadog-lambda-js` and `dd-trace` from your `package.json` and the build process. Instead, ensure you're importing these packages via [Lambda Layers][2].
+3. If you are using `serverless-webpack` and the Serverless Framework, exclude `datadog-lambda-js` and `dd-trace` from your `serverless.yml`.
+
+    **serverless.yml**
+
+    ```
+    custom:
+      webpack:
+        includeModules:
+          forceExclude:
+            - dd-trace
+            - datadog-lambda-js
+    ```
+
+
+[1]: https://webpack.js.org
+[2]: https://github.com/DataDog/datadog-lambda-js/releases


### PR DESCRIPTION
Follow up to PR: https://github.com/DataDog/documentation/pull/10483

Refactoring the webpack instructions to a separate troubleshooting page, adding a note to the main installation instructions.

https://docs-staging.datadoghq.com/alex.cuoci/refactor-webpack-troubleshooting-instructions