### PR TITLE
add instruction for monitor renotification

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -53,7 +53,19 @@ Add tags to your monitor (optional). Monitor tags are different than metric tags
 
 ### Renotify
 
-Enable monitor renotification (optional), which is useful to remind your team a problem is not solved. If enabled, you are given the option to include an escalation message sent any time the monitor renotifies. The original notification message is also included.
+Enable monitor renotification (optional), which is useful to remind your team a problem is not solved. 
+If enabled, you are given the option to include an escalation message sent any time the monitor remain in the `alert` or `no data` state for the configured time.
+The escalation message can be added in two ways:
+
+* In the escalation_message box (UI) or attribute (API)
+* (recommended) By leveraging the `{{#is_renotify}}` block in the original message
+
+The original notification message is always included therefore you want to leverage the `{{#is_renotify}}` block in the following conditions:
+
+1. The escalation message is only there to add some extra details and should not contain the original message details
+2. The escalation message should only be sent for a subset of groups
+
+Learn how to configure your monitors for those use cases in [the example section](#examples).
 
 ### Priority
 
@@ -200,9 +212,11 @@ The following conditional variables are available:
 | `{{^is_alert_to_warning}}` | The monitor does not transition from `ALERT` to `WARNING`          |
 | `{{#is_no_data_recovery}}` | The monitor recovers from `NO DATA`                                |
 | `{{^is_no_data_recovery}}` | The monitor does not recover from `NO DATA`                        |
-| `{{#is_priority 'value'}}`  | The monitor has priority `value`. Value ranges from `P1` to `P5`   |
+| `{{#is_priority 'value'}}` | The monitor has priority `value`. Value ranges from `P1` to `P5`   |
 | `{{#is_unknown}}`          | The monitor is in the unknown state                                |
 | `{{^is_unknown}}`          | The monitor is not in the unknown state                            |
+| `{{#is_renotify}}`         | The monitor is renotifying                                         |
+| `{{^is_renotify}}`         | The monitor is not renotifying.                                    |
 
 #### Examples
 
@@ -312,6 +326,46 @@ To notify your dev team if a triggering host has the name `production`, use the 
   named production. @dev-team@company.com
 {{/is_exact_match}}
 ```
+
+{{% /tab %}}
+{{% tab "is_renotify" %}}
+
+To send an escalation message to a different destination just for the `production` environment:
+
+```text
+{{#is_renotify}}
+{{#is_match "env" "production"}}
+  This is an escalation message sent to @dev-team@company.com
+{{/is_match}}
+{{/is_renotify}}
+```
+
+To send a different escalation message that do not contain the original message details, leverage a combination of `{{^is_renotify}}` and `{{#is_renotify}}` blocks:
+
+```text
+{{^is_renotify}}
+This monitor is alerting and sending a first message @dev-team@company.com
+
+To solve this monitor follow the steps:
+1. Go there
+2. Do this
+{{/is_renotify}}
+
+This part is generic and sent both for the first trigger and the escalation message.
+
+{{#is_renotify}}
+  This is the escalation message @dev-team@company.com
+{{/is_renotify}}
+
+```
+
+On monitor renotification, users will only get the following escalation message:
+
+```
+This part is generic and sent both for the first trigger and the escalation message.
+
+This is the escalation message @dev-team@company.com
+``` 
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -53,17 +53,18 @@ Add tags to your monitor (optional). Monitor tags are different than metric tags
 
 ### Renotify
 
-Enable monitor renotification (optional), which is useful to remind your team a problem is not solved. 
-If enabled, you are given the option to include an escalation message sent any time the monitor remain in the `alert` or `no data` state for the configured time.
-The escalation message can be added in two ways:
+Enable monitor renotification (optional) to remind your team that a problem is not solved. 
+If renotification is enabled, you are given the option to include an escalation message that is sent if the monitor remains in the `alert` or `no data` state for the specified time.
+The escalation message can be added in the following ways:
 
-* In the escalation_message box (UI) or attribute (API)
-* (recommended) By leveraging the `{{#is_renotify}}` block in the original message
+* In the `{{#is_renotify}}` block in the original notification message (recommended).
+* In the *escalation_message* field in the app.
+* With the `escalation_message` attribute in the API.
 
-The original notification message is always included therefore you want to leverage the `{{#is_renotify}}` block in the following conditions:
+If you use the `{{#is_renotify}}` block, keep in mind that the original notification message is also included in the renotification, so:
 
-1. The escalation message is only there to add some extra details and should not contain the original message details
-2. The escalation message should only be sent for a subset of groups
+1. Include only extra details in the `{{#is_renotify}}` block and don't repeat the original message details.
+2. Send the escalation message to a subset of groups.
 
 Learn how to configure your monitors for those use cases in [the example section](#examples).
 
@@ -340,7 +341,7 @@ To send an escalation message to a different destination just for the `productio
 {{/is_renotify}}
 ```
 
-To send a different escalation message that do not contain the original message details, leverage a combination of `{{^is_renotify}}` and `{{#is_renotify}}` blocks:
+To send a different escalation message that does not contain the original message details, use a combination of `{{^is_renotify}}` and `{{#is_renotify}}` blocks:
 
 ```text
 {{^is_renotify}}
@@ -359,7 +360,7 @@ This part is generic and sent both for the first trigger and the escalation mess
 
 ```
 
-On monitor renotification, users will only get the following escalation message:
+On monitor renotification, users will get the following escalation message:
 
 ```
 This part is generic and sent both for the first trigger and the escalation message.


### PR DESCRIPTION
### What does this PR do?
Add instructions for the is_renotify block for monitors

### Motivation
Support for the is_renotify block has been added

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/monitor-renotify/monitors/notifications/?tab=is_renotify#examples

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
