### PR TITLE
re-upload Windows installation docs for NPM

### DIFF
--- a/content/en/network_monitoring/performance/_index.md
+++ b/content/en/network_monitoring/performance/_index.md
@@ -32,7 +32,7 @@ Datadog Network Performance Monitoring (NPM) is designed to give you visibility 
 * Identify outages of cloud provider regions and third-party tools
 * Troubleshoot client-side and server-side DNS server issues
 
-NPM makes it simple to monitor complex networks with built in support for containerized environments that are orchestrated and [instrumented with Istio service mesh][4].
+NPM makes it simple to monitor complex networks with built in support for Linux and [Windows OS][3] as well as containerized environments that are orchestrated and [instrumented with Istio service mesh][4].
 
 {{< whatsnext desc="This section includes the following topics:">}}
     {{< nextlink href="network_monitoring/performance/setup" >}}<u>Setup</u>: Configure the Agent to collect network data.{{< /nextlink >}}
@@ -46,4 +46,5 @@ NPM makes it simple to monitor complex networks with built in support for contai
 
 [1]: https://app.datadoghq.com/network
 [2]: https://app.datadoghq.com/network/map
-[3]: https://www.datadoghq.com/blog/monitor-istio-with-npm/
+[3]: https://www.datadoghq.com/blog/npm-windows-support/
+[4]: https://www.datadoghq.com/blog/monitor-istio-with-npm/

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -43,6 +43,10 @@ Data collection is done using eBPF, so Datadog minimally requires platforms that
 
 **Note:** There is an exception to the 4.4.0+ kernel requirement for [CentOS/RHEL 7.6+][2]. The [DNS Resolution][3] feature is not supported on CentOS/RHEL 7.6.
 
+#### Windows OS
+
+Data collection is done using a device driver, and support is available as of Datadog agent version 7.27.1, for Windows versions 2012 and up.
+
 #### macOS
 
 Datadog Network Performance Monitoring does not currently support macOS platforms.
@@ -162,10 +166,42 @@ If you need to use Network Performance Monitoring on other systems with SELinux 
 
 If these utilities do not exist in your distribution, follow the same procedure but using the utilities provided by your distribution instead.
 
+### Windows systems
 
-[1]: /infrastructure/process
+[1]: /infrastructure/process/?tab=linuxwindows#installation
 [2]: /agent/guide/agent-commands/#restart-the-agent
 [3]: https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/selinux/system_probe_policy.te
+{{% /tab %}}
+{{% tab "Agent (Windows)" %}}
+Data collection for Windows relies on a filter driver for collecting network data.
+
+To enable network performance monitoring for Windows hosts:
+
+1. Install the [Datadog Agent][1] (version 7.27.1 or above) with the network driver component enabled.
+
+   During installation pass `ADDLOCAL="MainApplication,NPM"` to the `msiexec` command, or select "Network Performance Monitoring" when running the agent installation through the GUI.
+
+1. Edit `C:\ProgramData\Datadog\system-probe.yaml` to set the enabled flag to `true`:
+
+    ```yaml
+    network_config:
+        enabled: true
+    ```
+3. [Restart the Agent][2].
+
+    For PowerShell (`powershell.exe`):
+    ```shell
+    restart-service -f datadogagent
+    ```
+    For Command Prompt (`cmd.exe`):
+    ```shell
+    net /y stop datadogagent && net start datadogagent
+    ```
+**Note**: NPM currently monitors Windows hosts only, and not Windows containers. DNS metric collection is not supported for Windows systems.
+
+[1]: /agent/basic_agent_usage/windows/?tab=commandline
+[2]: /agent/guide/agent-commands/#restart-the-agent
+
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds Windows install docs back to NPM public docs. 

### Motivation
We've shipped a mitigation w/the 7.27.1 point release to ensure installing the system probe for Windows is safe and reliable.

### Preview
https://docs-staging.datadoghq.com/yael/windows_npm/content/en/network_monitoring/performance/setup.md
https://docs-staging.datadoghq.com/yael/windows_npm/content/en/network_monitoring/performance/_index.md

### Additional Notes
This is a time-sensitive change - please merge ASAP!

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
