### PR TITLE
Add `HASH` in `startUrl` environment variables

### DIFF
--- a/content/en/synthetics/ci.md
+++ b/content/en/synthetics/ci.md
@@ -587,11 +587,15 @@ You can configure on which url your test starts by providing a `startUrl` to you
 
 `URL`
 : Test's original starting URL <br>
-**Example**: `https://www.example.org:81/path/to/something?abc=123`
+**Example**: `https://www.example.org:81/path/to/something?abc=123#target`
 
 `DOMAIN`
 : Test's domain name<br>
 **Example**: `example.org`
+
+`HASH`
+: Test's hash<br>
+**Example**: `#target`
 
 `HOST`
 : Test's host<br>
@@ -625,10 +629,10 @@ You can configure on which url your test starts by providing a `startUrl` to you
 : Test's sub domain<br>
 **Example**: `www`
 
-For instance, if your test's starting URL is `https://www.example.org:81/path/to/something?abc=123`, it can be written as:
+For instance, if your test's starting URL is `https://www.example.org:81/path/to/something?abc=123#target`, it can be written as:
 
-* `{{PROTOCOL}}//{{SUBDOMAIN}}.{{DOMAIN}}:{{PORT}}{{PATHNAME}}{{PARAMS}}`
-* `{{PROTOCOL}}//{{HOST}}{{PATHNAME}}{{PARAMS}}`
+* `{{PROTOCOL}}//{{SUBDOMAIN}}.{{DOMAIN}}:{{PORT}}{{PATHNAME}}{{PARAMS}}{{HASH}}`
+* `{{PROTOCOL}}//{{HOST}}{{PATHNAME}}{{PARAMS}}{{HASH}}`
 * `{{URL}}`
 
 ### Running tests


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add the documentation about the `HASH` environment variable in the `startUrl` override in synthetics CI.

### Motivation
<!-- What inspired you to submit this pull request?-->
The lack of documentation around this feature I just implemented.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/etnbrd/SW-1103/add-hash/synthetics/ci

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
