### PR TITLE
update golang path

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ before_script:
   - "[ -d local/bin ] && find local/bin/ -type f -exec cp {} /usr/local/bin \\;"  # load scripts
   - "[ -d local/etc ] && find local/etc/ -type f -exec cp {} /etc \\;"  # load configs
   - "[ -f /usr/local/bin/helpers.sh ] && source /usr/local/bin/helpers.sh"  # source helpers so they are available in the container
-
+  - "[ -f /etc/profile ] && source /etc/profile" # for golang on path
 
 cache: &cache
   key:


### PR DESCRIPTION
### What does this PR do?

Small update to make sure go is in the $PATH

### Motivation

Without it hugo will say `Error: failed to download modules: exec: "go": executable file not found in $PATH` when attempting to use the modules features

### Preview

Shouldn't effect preview, its setup changes for future usage
https://docs-staging.datadoghq.com/david.jones/path-update/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
