### PR TITLE
Fix backslash scaping for Bean Regexes FAQ

### DIFF
--- a/content/en/integrations/faq/how-to-use-bean-regexes-to-filter-your-jmx-metrics-and-supply-additional-tags.md
+++ b/content/en/integrations/faq/how-to-use-bean-regexes-to-filter-your-jmx-metrics-and-supply-additional-tags.md
@@ -37,7 +37,7 @@ instances:
       - include:
           domain: domain.example.com
           bean_regex:
-            - "domain.example.com:name=my.metric.name.*(?:\.env\.)([a-z]+)(?:.*\.region\.)([a-z-]+[0-9])(?:.*\.method\.)([A-Z]+)(?:.*\.status\.)([0-9]+)(?:.*)"
+            - "domain.example.com:name=my.metric.name.*(?:\\.env\\.)([a-z]+)(?:.*\\.region\\.)([a-z-]+[0-9])(?:.*\\.method\\.)([A-Z]+)(?:.*\\.status\\.)([0-9]+)(?:.*)"
           attribute:
             attribute1:
               metric_type: gauge


### PR DESCRIPTION
This PR fixes the backslash scaping for the double-quoted YAML string in the "How to use Bean Regexes to filter your JMX metrics and supply additional tags" FAQ.

Relates to #10419.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
