### PR TITLE
(DOCS-1985) Add note about tags and Japanese characters

### DIFF
--- a/content/en/getting_started/tagging/_index.md
+++ b/content/en/getting_started/tagging/_index.md
@@ -59,7 +59,7 @@ Below are Datadog's tagging requirements:
 
     **Note**: A tag cannot end with a colon, for example `tag:`
 
-2. Tags can be **up to 200 characters** long and support Unicode.
+2. Tags can be **up to 200 characters** long and support Unicode (which includes most character sets, including languages such as Japanese).
 3. Tags are converted to lowercase. Therefore, `CamelCase` tags are not recommended. Authentication (crawler) based integrations convert camel case tags to underscores, for example `TestTag` --> `test_tag`. **Note**: `host` and `device` tags are excluded from this conversion.
 4. A tag can be in the format `value` or `<KEY>:<VALUE>`. For optimal functionality, **we recommend constructing tags in the `<KEY>:<VALUE>` format.** Commonly used tag keys are `env`, `instance`, and `name`. The key always precedes the first colon of the global tag definition, for example:
 


### PR DESCRIPTION

### What does this PR do?
specifically mentions Japanese as an example of Unicode characters supported in tags

### Motivation
DOCS-1985

### Preview
https://docs-staging.datadoghq.com/kari/ja_tags/getting_started/tagging/using_tags/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
