### PR TITLE
Fixing invalid SNMPv2 YAML example

### DIFF
--- a/content/en/network_monitoring/devices/setup.md
+++ b/content/en/network_monitoring/devices/setup.md
@@ -42,7 +42,7 @@ To monitor individual devices:
     init_config:
       loader: core
     instances:
-      - ip_address: "1.2.3.4"
+    - ip_address: "1.2.3.4"
       community_string: “sample-string”
       tags:
         - "key1:val1"


### PR DESCRIPTION
My customer used the example and had an invalid YAML error. Upon checking the documentation our YAML example for SNMPv2 is invalid. There shouldn't be extra spaces before the line:
- ip_address: x.x.x.x

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes invalid YAML example

### Motivation
<!-- What inspired you to submit this pull request?-->
Working on the following ticket https://datadog.zendesk.com/agent/tickets/484604, and noticed the mistake.


### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
