### PR TITLE
use master image tag again

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ cache: &cache
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:david.jones_img-update
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
   tags:
     - "runner:main"
     - "size:2xlarge"


### PR DESCRIPTION
### What does this PR do?

Set docs back to using the master tag image

### Motivation

After confirming changes to images work after a period of time we should switch back to master 
(which has those same changes merged in)

### Preview

Shouldn't have any impact
https://docs-staging.datadoghq.com/david.jones/img-reset/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
