### PR TITLE
[DOCS-1721] Update example to something not deprecated

### DIFF
--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -319,7 +319,7 @@ Set an application’s version in traces and logs, for example: `1.2.3`, `6c44da
 
 The table below specifies the default service names for each integration. Change the service names with `DD_SERVICE_MAPPING`.
 
-Use the name when setting integration-specific configuration such as, `DD_TRACE_<INTEGRATION>_ANALYTICS_ENABLED`, for example: Laravel is `DD_TRACE_LARAVEL_ANALYTICS_ENABLED`.
+Use the name when setting integration-specific configuration such as, `DD_TRACE_<INTEGRATION>_ENABLED`, for example: Laravel is `DD_TRACE_LARAVEL_ENABLED`.
 
 | Integration       | Service Name      |
 |-------------------|-------------------|


### PR DESCRIPTION

### What does this PR do?
Updates trivial example so that it cites an setting that isn't a deprecated setting

### Motivation
DOCS-1721

### Preview
https://docs-staging.datadoghq.com/kari/docs-1721/tracing/setup_overview/setup/php/?tab=containers#integration-names

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
