### PR TITLE
[DOCS-1607] Add notes about DD_SITE env var to APM Agent setup

### DIFF
--- a/content/en/agent/amazon_ecs/apm.md
+++ b/content/en/agent/amazon_ecs/apm.md
@@ -17,43 +17,56 @@ After following the [Amazon ECS agent installation instructions][1], enable trac
 1. Set the following parameters in the task definition for the `gcr.io/datadoghq/agent` container. Set the `portMappings` host / container port to `8126` with protocol `tcp`:
 
     {{< code-block lang="json" >}}
-    containerDefinitions": [
-    {
-      "name": "datadog-agent",
-      "image": "gcr.io/datadoghq/agent:latest",
-      "cpu": 100,
-      "memory": 256,
-      "essential": true,
-      "portMappings": [
-        {
-          "hostPort": 8126,
-          "protocol": "tcp",
-          "containerPort": 8126
-        }
-      ],
+containerDefinitions": [
+  {
+    "name": "datadog-agent",
+    "image": "gcr.io/datadoghq/agent:latest",
+    "cpu": 100,
+    "memory": 256,
+    "essential": true,
+    "portMappings": [
+      {
+        "hostPort": 8126,
+        "protocol": "tcp",
+        "containerPort": 8126
+      }
+    ],
+    ...
+  {{< /code-block >}}
+
+    {{< site-region region="us3,eu,gov" >}} 
+  To ensure the Agent sends data to the right Datadog location, set the following environment variable, where `<DATADOG_SITE>` is {{< region-param key="dd_site" code="true" >}}:
+
+  ```json
+  "environment": [
+       ...
+     {
+       "name": "DD_SITE",
+       "value": "<DATADOG_SITE>"
+     },
+     ...
+     ]
+   ...
+  ```
+  {{< /site-region >}}
+  For **Agent v7.17 or lower**, add the following environment variables:
+   ```json
+   "environment": [
+        ...
+      {
+        "name": "DD_APM_ENABLED",
+        "value": "true"
+      },
+      {
+        "name": "DD_APM_NON_LOCAL_TRAFFIC",
+        "value": "true"
+      },
       ...
-    {{< /code-block >}}
+      ]
+   ...
+   ```
 
-    For **Agent v7.17 or lower**, add the following environment variables:
-
-    {{< code-block lang="json" >}}
-    ...
-          "environment": [
-            ...
-          {
-            "name": "DD_APM_ENABLED",
-            "value": "true"
-          },
-          {
-            "name": "DD_APM_NON_LOCAL_TRAFFIC",
-            "value": "true"
-          },
-          ...
-          ]
-    ...
-    {{< /code-block >}}
-
-    [See all environment variables available for Agent trace collection][1].
+   [See all environment variables available for Agent trace collection][1].
 
 2. Assign the private IP address for each underlying instance your containers are running in your application container to the `DD_AGENT_HOST` environment variable. This allows your application traces to be shipped to the Agent. 
 

--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -39,6 +39,7 @@ For example, the following command allows the Agent to receive traces from your 
 {{< tabs >}}
 {{% tab "Linux" %}}
 
+{{< site-region region="us" >}} 
 ```shell
 docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /proc/:/host/proc/:ro \
@@ -48,16 +49,42 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -e DD_APM_ENABLED=true \
               gcr.io/datadoghq/agent:latest
 ```
+{{< /site-region >}}
+{{< site-region region="us3,eu,gov" >}} 
+```shell
+docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
+              -v /proc/:/host/proc/:ro \
+              -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+              -p 127.0.0.1:8126:8126/tcp \
+              -e DD_API_KEY=<DATADOG_API_KEY> \
+              -e DD_APM_ENABLED=true \
+              -e DD_SITE=<DATADOG_SITE> \
+              gcr.io/datadoghq/agent:latest
+```
+Where `<DATADOG_SITE>` is {{< region-param key="dd_site" code="true" >}}, so that the Agent sends data to the right Datadog location.
+{{< /site-region >}}
 
 {{% /tab %}}
 {{% tab "Windows" %}}
 
+{{< site-region region="us" >}} 
 ```shell
 docker run -d -p 127.0.0.1:8126:8126/tcp \
               -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
               gcr.io/datadoghq/agent:latest
 ```
+{{< /site-region >}}
+{{< site-region region="us3,eu,gov" >}} 
+```shell
+docker run -d -p 127.0.0.1:8126:8126/tcp \
+              -e DD_API_KEY=<DATADOG_API_KEY> \
+              -e DD_APM_ENABLED=true \
+              -e DD_SITE=<DATADOG_SITE> \
+              gcr.io/datadoghq/agent:latest
+```
+Where `<DATADOG_SITE>` is {{< region-param key="dd_site" code="true" >}}, so that the Agent sends data to the right Datadog location.
+{{< /site-region >}}
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -103,7 +130,7 @@ Then start the Agent and the application container, connected to the network pre
 
 {{< tabs >}}
 {{% tab "Standard" %}}
-
+{{< site-region region="us" >}} 
 ```bash
 # Datadog Agent
 docker run -d --name datadog-agent \
@@ -115,7 +142,27 @@ docker run -d --name datadog-agent \
               -e DD_APM_ENABLED=true \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
               gcr.io/datadoghq/agent:latest
+# Application
+docker run -d --name app \
+              --network <NETWORK_NAME> \
+              -e DD_AGENT_HOST=datadog-agent \
+              company/app:latest
+```
+{{< /site-region >}}
+{{< site-region region="us3,eu,gov" >}}
 
+```bash
+# Datadog Agent
+docker run -d --name datadog-agent \
+              --network <NETWORK_NAME> \
+              -v /var/run/docker.sock:/var/run/docker.sock:ro \
+              -v /proc/:/host/proc/:ro \
+              -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+              -e DD_API_KEY=<DATADOG_API_KEY> \
+              -e DD_APM_ENABLED=true \
+              -e DD_SITE=<DATADOG_SITE> \
+              -e DD_APM_NON_LOCAL_TRAFFIC=true \
+              gcr.io/datadoghq/agent:latest
 # Application
 docker run -d --name app \
               --network <NETWORK_NAME> \
@@ -123,8 +170,11 @@ docker run -d --name app \
               company/app:latest
 ```
 
+Where `<DATADOG_SITE>` is {{< region-param key="dd_site" code="true" >}}, so that the Agent sends data to the right Datadog location.
+{{< /site-region >}}
 {{% /tab %}}
 {{% tab "Windows" %}}
+{{< site-region region="us" >}} 
 
 ```bash
 # Datadog Agent
@@ -134,14 +184,32 @@ docker run -d --name datadog-agent \
               -e DD_APM_ENABLED=true \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
               gcr.io/datadoghq/agent:latest
-
 # Application
 docker run -d --name app \
               --network "<NETWORK_NAME>" \
               -e DD_AGENT_HOST=datadog-agent \
               company/app:latest
 ```
+{{< /site-region >}}
+{{< site-region region="us3,eu,gov" >}} 
+```bash
+# Datadog Agent
+docker run -d --name datadog-agent \
+              --network "<NETWORK_NAME>" \
+              -e DD_API_KEY=<DATADOG_API_KEY> \
+              -e DD_APM_ENABLED=true \
+              -e DD_SITE=<DATADOG_SITE> \
+              -e DD_APM_NON_LOCAL_TRAFFIC=true \
+              gcr.io/datadoghq/agent:latest
+# Application
+docker run -d --name app \
+              --network "<NETWORK_NAME>" \
+              -e DD_AGENT_HOST=datadog-agent \
+              company/app:latest
+```
+Where `<DATADOG_SITE>` is {{< region-param key="dd_site" code="true" >}}, so that the Agent sends data to the right Datadog location.
 
+{{< /site-region >}}
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/agent/kubernetes/apm.md
+++ b/content/en/agent/kubernetes/apm.md
@@ -46,8 +46,12 @@ To enable trace collection with your Agent, follow the instructions below:
     ```
 
  - Set your operating system. Add `targetSystem: linux` or `targetSystem: windows` to the top of your `values.yaml`.
+ - Set the API key: `apiKey: <DATADOG_API_KEY>`
+{{< site-region region="us3,eu,gov" >}} 
+ - Set your site so that the Agent sends data to the right Datadog location: `site: `{{< region-param key="dd_site" code="true" >}}
+{{< /site-region >}}
 
- - Then, upgrade your Datadog Helm chart using the following command: `helm upgrade -f values.yaml <RELEASE NAME> datadog/datadog`. Don't forget to set the API key in the YAML file. If you did not set your operating system in `values.yaml`, add `--set targetSystem=linux` or `--set targetSystem=windows` to this command.
+ - Then, upgrade your Datadog Helm chart using the following command: `helm upgrade -f values.yaml <RELEASE NAME> datadog/datadog`. If you did not set your operating system in `values.yaml`, add `--set targetSystem=linux` or `--set targetSystem=windows` to this command.
 
 [1]: /agent/kubernetes/?tab=helm
 {{% /tab %}}
@@ -68,6 +72,10 @@ To enable APM trace collection, open the DaemonSet configuration file and edit t
      # (...)
     ```
 
+{{< site-region region="us3,eu,gov" >}} 
+- Ensure the Agent sends data to the correct Datadog location by setting `site: `{{< region-param key="dd_site" code="true" >}}
+{{< /site-region >}}
+
 - **If using an old agent version (7.17 or lower)**, in addition to the steps above, set the `DD_APM_NON_LOCAL_TRAFFIC` and `DD_APM_ENABLED` variable to `true` in your *env* section of the `datadog.yaml` trace Agent manifest:
 
     ```yaml
@@ -85,7 +93,7 @@ To enable APM trace collection, open the DaemonSet configuration file and edit t
 {{% tab "Operator" %}}
 
 Update your `datadog-agent.yaml` manifest with:
-
+{{< site-region region="us" >}} 
 ```
 agent:
   image:
@@ -94,6 +102,19 @@ agent:
     enabled: true
     hostPort: 8126
 ```
+{{< /site-region >}}
+{{< site-region region="us3,eu,gov" >}} 
+```
+agent:
+  image:
+    name: "gcr.io/datadoghq/agent:latest"
+  apm:
+    enabled: true
+    hostPort: 8126
+site: <DATADOG_SITE>
+```
+Where `<DATADOG_SITE>` is {{< region-param key="dd_site" code="true" >}}, so that the Agent sends data to the right Datadog location.
+{{< /site-region >}}
 
 See the sample [manifest with APM and metrics collection enabled][1] for a complete example.
 
@@ -103,7 +124,7 @@ Then apply the new configuration:
 $ kubectl apply -n $DD_NAMESPACE -f datadog-agent.yaml
 ```
 
-[1]: https://github.com/DataDog/datadog-operator/blob/master/examples/datadog-agent-apm.yaml
+[1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-apm.yaml
 {{% /tab %}}
 {{< /tabs >}}
    **Note**: On minikube, you may receive an `Unable to detect the kubelet URL automatically` error. In this case, set `DD_KUBELET_TLS_VERIFY=false`.

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -324,7 +324,7 @@ For more details on custom instrumentation and custom tagging, see [.NET Custom 
     
 {{< site-region region="us3,eu,gov" >}} 
 
-4. Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
+4. Set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
 
 {{< /site-region >}}
 

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -321,7 +321,12 @@ For more details on custom instrumentation and custom tagging, see [.NET Custom 
 
     - `DD_AGENT_HOST`
     - `DD_TRACE_AGENT_PORT`
+    
+{{< site-region region="us3,eu,gov" >}} 
 
+4. Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
+
+{{< /site-region >}}
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -126,7 +126,7 @@ example.exe
 Install and configure the Datadog Agent to receive traces from your instrumented application. By default the Datadog Agent is enabled in your `datadog.yaml` file under `apm_enabled: true` and listens for trace traffic at `localhost:8126`. For containerized environments, follow the in-app [Quickstart instructions][2] to enable trace collection within the Datadog Agent.
 {{< site-region region="us3,eu,gov" >}} 
 
-Ensure you set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} so that the Agent sends data to the right Datadog location.
+Ensure you set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" code="true" >}} so that the Agent sends data to the right Datadog location.
 
 {{< /site-region >}}
 

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -124,6 +124,11 @@ example.exe
 ### Configure the Datadog Agent for APM
 
 Install and configure the Datadog Agent to receive traces from your instrumented application. By default the Datadog Agent is enabled in your `datadog.yaml` file under `apm_enabled: true` and listens for trace traffic at `localhost:8126`. For containerized environments, follow the in-app [Quickstart instructions][2] to enable trace collection within the Datadog Agent.
+{{< site-region region="us3,eu,gov" >}} 
+
+Ensure you set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} so that the Agent sends data to the right Datadog location.
+
+{{< /site-region >}}
 
 ## Custom instrumentation
 

--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -100,28 +100,33 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 
 3. After having instrumented your application, the tracing client sends traces to `localhost:8126` by default.  If this is not the correct host and port change it by setting the below env variables:
 
-`DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
+    `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
 
-You can also set a custom hostname and port in code:
+    You can also set a custom hostname and port in code:
 
-```go
-package main
+    ```go
+    package main
 
-import (
-    "net"
+    import (
+        "net"
 
-    "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-)
-
-func main() {
-    addr := net.JoinHostPort(
-        "custom-hostname",
-        "1234",
+        "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
     )
-    tracer.Start(tracer.WithAgentAddr(addr))
-    defer tracer.Stop()
-}
-```
+
+    func main() {
+        addr := net.JoinHostPort(
+            "custom-hostname",
+            "1234",
+        )
+        tracer.Start(tracer.WithAgentAddr(addr))
+        defer tracer.Stop()
+    }
+    ```
+{{< site-region region="us3,eu,gov" >}} 
+
+4. Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
+
+{{< /site-region >}}
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}

--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -124,7 +124,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
     ```
 {{< site-region region="us3,eu,gov" >}} 
 
-4. Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
+4. Set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
 
 {{< /site-region >}}
 

--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -69,21 +69,25 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 
 3. After having instrumented your application, the tracing client sends traces to `localhost:8126` by default.  If this is not the correct host and port, change it by setting the below env variables:
 
-`DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
+    `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
 
-```bash
-java -javaagent:<DD-JAVA-AGENT-PATH>.jar -jar <YOUR_APPLICATION_PATH>.jar
-```
+    ```bash
+    java -javaagent:<DD-JAVA-AGENT-PATH>.jar -jar <YOUR_APPLICATION_PATH>.jar
+    ```
 
-You can also use system properties:
+    You can also use system properties:
 
-```bash
-java -javaagent:<DD-JAVA-AGENT-PATH>.jar \
-     -Ddd.agent.host=$DD_AGENT_HOST \
-     -Ddd.agent.port=$DD_TRACE_AGENT_PORT \
-     -jar <YOUR_APPLICATION_PATH>.jar
-```
+    ```bash
+    java -javaagent:<DD-JAVA-AGENT-PATH>.jar \
+        -Ddd.agent.host=$DD_AGENT_HOST \
+        -Ddd.agent.port=$DD_TRACE_AGENT_PORT \
+        -jar <YOUR_APPLICATION_PATH>.jar
+    ```
+{{< site-region region="us3,eu,gov" >}} 
 
+4. Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
+
+{{< /site-region >}}
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}

--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -85,7 +85,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
     ```
 {{< site-region region="us3,eu,gov" >}} 
 
-4. Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
+4. Set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
 
 {{< /site-region >}}
 

--- a/content/en/tracing/setup_overview/setup/nodejs.md
+++ b/content/en/tracing/setup_overview/setup/nodejs.md
@@ -124,7 +124,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
     
 {{< site-region region="us3,eu,gov" >}} 
 
-4. Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
+4. Set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
 
 {{< /site-region >}}
 

--- a/content/en/tracing/setup_overview/setup/nodejs.md
+++ b/content/en/tracing/setup_overview/setup/nodejs.md
@@ -110,18 +110,23 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 
 3. After having instrumented your application, the tracing client sends traces to `localhost:8126` by default.  If this is not the correct host and port change it by setting the below env variables:
 
-`DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
+    `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
 
-```sh
-DD_AGENT_HOST=<HOSTNAME> DD_TRACE_AGENT_PORT=<PORT> node server
-```
+    ```sh
+    DD_AGENT_HOST=<HOSTNAME> DD_TRACE_AGENT_PORT=<PORT> node server
+    ```
 
-To use a different protocol such as UDS, specify the entire URL as a single ENV variable `DD_TRACE_AGENT_URL`.
+    To use a different protocol such as UDS, specify the entire URL as a single ENV variable `DD_TRACE_AGENT_URL`.
 
-```sh
-DD_TRACE_AGENT_URL=unix:<SOCKET_PATH> node server
-```
+    ```sh
+    DD_TRACE_AGENT_URL=unix:<SOCKET_PATH> node server
+    ```
+    
+{{< site-region region="us3,eu,gov" >}} 
 
+4. Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
+
+{{< /site-region >}}
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -58,9 +58,14 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 
 3. After having instrumented your application, the tracing client sends traces to `localhost:8126` by default.  If this is not the correct host and port change it by setting the below env variables:
 
-`DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
+    `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
 
-See [environment variable configuration](#environment-variable-configuration) for more information on how to set these variables.
+    See [environment variable configuration](#environment-variable-configuration) for more information on how to set these variables.
+{{< site-region region="us3,eu,gov" >}} 
+
+4. Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
+
+{{< /site-region >}}
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -63,7 +63,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
     See [environment variable configuration](#environment-variable-configuration) for more information on how to set these variables.
 {{< site-region region="us3,eu,gov" >}} 
 
-4. Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
+4. Set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
 
 {{< /site-region >}}
 

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -74,20 +74,24 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 
 3. After having instrumented your application, the tracing client sends traces to `localhost:8126` by default.  If this is not the correct host and port change it by setting the below env variables:
 
-`DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
+    `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
 
-You can also set the hostname and port in code:
+    You can also set the hostname and port in code:
 
-```python
-import os
-from ddtrace import tracer
+    ```python
+    import os
+    from ddtrace import tracer
 
-tracer.configure(
-    hostname="custom-hostname",
-    port="1234",
-)
-```
+    tracer.configure(
+        hostname="custom-hostname",
+        port="1234",
+    )
+    ```
+{{< site-region region="us3,eu,gov" >}} 
 
+4. Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
+
+{{< /site-region >}}
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -89,7 +89,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
     ```
 {{< site-region region="us3,eu,gov" >}} 
 
-4. Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
+4. Set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
 
 {{< /site-region >}}
 


### PR DESCRIPTION

### What does this PR do?
For pages in APM setup for Containers and in Containers Agent APM setup, adds a note for non-US locations to set the DD_SITE env variable

### Motivation
DOCS-1607

### Preview
To test: The new additions should show up for US3, EU, and GOV sites, but not US site.

https://docs-staging.datadoghq.com/kari/docs-1607-ddsite-apm/tracing/setup_overview/setup/java/?tab=containers#configure-the-datadog-agent-for-apm
https://docs-staging.datadoghq.com/kari/docs-1607-ddsite-apm/tracing/setup_overview/setup/python/?tab=containers#configure-the-datadog-agent-for-apm
https://docs-staging.datadoghq.com/kari/docs-1607-ddsite-apm/tracing/setup_overview/setup/go/?tab=containers#configure-the-datadog-agent-for-apm
https://docs-staging.datadoghq.com/kari/docs-1607-ddsite-apm/tracing/setup_overview/setup/nodejs/?tab=containers#configure-the-datadog-agent-for-apm
https://docs-staging.datadoghq.com/kari/docs-1607-ddsite-apm/tracing/setup_overview/setup/php/?tab=containers#configure-the-datadog-agent-for-apm
https://docs-staging.datadoghq.com/kari/docs-1607-ddsite-apm/tracing/setup_overview/setup/dotnet-core/?tab=containers#configure-the-datadog-agent-for-apm
https://docs-staging.datadoghq.com/kari/docs-1607-ddsite-apm/tracing/setup_overview/setup/dotnet-framework/?tab=containers#configure-the-datadog-agent-for-apm
https://docs-staging.datadoghq.com/kari/docs-1607-ddsite-apm/agent/docker/apm/
https://docs-staging.datadoghq.com/kari/docs-1607-ddsite-apm/agent/kubernetes/apm/
https://docs-staging.datadoghq.com/kari/docs-1607-ddsite-apm/agent/amazon_ecs/apm

### Additional Notes
Still to be done (outside `documentation` repo): same updates for ElasticBeanstalk and ECS Fargate APM/Agent setup.

if you change any spacing in the Amazon ECS page BE VERY CAREFUL. I had to mess around A LOT to get the indentation correct in step 1 without breaking anything.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
