### PR TITLE
update logo referencing in security platform

### DIFF
--- a/layouts/security_rules/list.html
+++ b/layouts/security_rules/list.html
@@ -33,8 +33,9 @@
             <div class="js-group js-group-{{ $i }}">
                 <div class="js-group-header mb-1 active">
                     <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2 py-1">
-                        {{ range first 1 $v.Pages }}
-                            {{ $int_logo := partial "integrations-logo.html" (dict "context" $dot "basename" .Params.source "variant" "avatar") }}
+                        {{ range last 1 $v.Pages }}
+                            {{ $basename := .Params.integration_id | default .Params.source }}
+                            {{ $int_logo := partial "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "avatar") }}
                             {{ if $int_logo }}
                                 <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}" />
                             {{ else }}
@@ -54,7 +55,7 @@
                 <div class="group-{{ .Key }} mb-2 ml-4 d-none">
                     {{ range $v.Pages }}
                         <a class="mb-1 font-semibold mix js-single-rule {{ range $i, $e := .Params.rule_category }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" href="{{.Permalink}}" data-name="{{ lower .Title }} {{ .File.TranslationBaseName }}">
-                            {{ $basename := (.Params.scope | default .Params.source) }}
+                            {{ $basename := .Params.integration_id | default .Params.source }}
                             {{ if in .Params.scope "." }}
                                 <!-- e.g gcp.project use source -->
                                 {{ $basename = .Params.source }}

--- a/layouts/security_rules/single.html
+++ b/layouts/security_rules/single.html
@@ -6,7 +6,7 @@
 	{{ partial "translate_status_banner/translate_status_banner.html" . }}
 
 	<div class="rule-specification row align-items-center mb-3">
-    {{ $basename := (.Params.scope | default .Params.source) }}
+    {{ $basename := .Params.integration_id | default .Params.source }}
     {{ if in .Params.scope "." }}
         <!-- e.g gcp.project use source -->
         {{ $basename = .Params.source }}

--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -69,7 +69,8 @@ def security_rules(content, content_dir):
                             f"/security_monitoring/default_rules/{data.get('defaultRuleId', '').strip()}",
                             f"/security_monitoring/default_rules/{p.stem}"
                         ],
-                        "rule_category": []
+                        "rule_category": [],
+                        "integration_id": ""
                     }
 
                     # we need to get the path relative to the repo root for comparisons
@@ -107,6 +108,12 @@ def security_rules(content, content_dir):
                         page_data["source"] = page_data["source"].lower()
                     if page_data.get("scope", None):
                         page_data["scope"] = page_data["scope"].lower()
+
+                    # integration id
+                    page_data["integration_id"] = page_data.get("scope", None) or page_data.get("source", "")
+                    cloud = page_data.get("cloud", None)
+                    if cloud and cloud == 'aws':
+                        page_data["integration_id"] = "amazon-{}".format(page_data["integration_id"])
 
                     front_matter = yaml.dump(page_data, default_flow_style=False).strip()
                     output_content = TEMPLATE.format(front_matter=front_matter, content=message.strip())
@@ -157,7 +164,8 @@ def compliance_rules(content, content_dir):
                         "type": "security_rules",
                         "disable_edit": True,
                         "aliases": [f"{json_data.get('defaultRuleId', '').strip()}"],
-                        "source": f"{json_data.get('framework', {}).get('name', '').replace('cis-','')}"
+                        "source": f"{json_data.get('framework', {}).get('name', '').replace('cis-','')}",
+                        "integration_id": ""
                     }
 
                     for tag in json_data.get('tags', []):
@@ -169,6 +177,12 @@ def compliance_rules(content, content_dir):
                         page_data["source"] = page_data["source"].lower()
                     if page_data.get("scope", None):
                         page_data["scope"] = page_data["scope"].lower()
+
+                    # integration id
+                    page_data["integration_id"] = page_data.get("scope", None) or page_data.get("source", "")
+                    cloud = page_data.get("cloud", None)
+                    if cloud and cloud == 'aws':
+                        page_data["integration_id"] = "amazon-{}".format(page_data["integration_id"])
 
                     front_matter = yaml.dump(page_data, default_flow_style=False).strip()
                     output_content = TEMPLATE.format(front_matter=front_matter, content=message.strip())


### PR DESCRIPTION
### What does this PR do?

For security and compliance rules lets build an "integration_id" for easier referencing of logos.
We also check for the existence of `cloud` to be more specific in referencing images

### Motivation

Discussion in `#websites` around elasticsearch

### Preview

Check the logos here look good
https://docs-staging.datadoghq.com/david.jones/logo-update/security_platform/default_rules/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
