### PR TITLE
Update permissions synonyms

### DIFF
--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -256,7 +256,7 @@
             ["gcp", "google cloud platform"],
             ["aws", "amazon web service"],
             ["RUM", "rum", "real user monitoring"],
-            ["Role Permissions", "permissions"]
+            ["permissions", "Role Permissions"]
         ]
     },
     "only_content_level": true,


### PR DESCRIPTION
### What does this PR do?
Previously added Algolia synonyms were not populating the role permissions page. Updated ordering and it seems to have fixed the problem

### Additional Notes
For testing: search for `permissions` on the home page and make sure it populates the `Role Permissions` page. Test on a few additional pages as well in different sections.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
