### PR TITLE
[WEB-1418] Brian.deutsch/js errors

### DIFF
--- a/src/scripts/components/algolia.js
+++ b/src/scripts/components/algolia.js
@@ -32,6 +32,7 @@ const { algoliaConfig } = getConfig();
 let algoliaTimer;
 
 const isApiPage = () => document.body.classList.value.includes('api');
+const alogliaApiDocsearchInput = document.getElementById('search-input-api');
 
 const handleSearchPageRedirect = () => {
     const docsearchInput = document.querySelector('.docssearch-input.ds-input');
@@ -41,18 +42,26 @@ const handleSearchPageRedirect = () => {
     }
 }
 
-const appendHomeLinkToAutocompleteWidget = (autocompleteHeaderElement) => {
+const appendHomeLinkToAutocompleteWidget = () => {
+    const headers = document.querySelectorAll('.algolia-autocomplete .algolia-docsearch-suggestion--category-header');
+    const autocompleteHeaderElement = headers[0];
     const searchPageLink = document.createElement('a');
+
     searchPageLink.className = "font-regular text-underline pl-2 js-api-search";
     searchPageLink.innerText = 'Click here to search the full docs';
     searchPageLink.href = `${baseUrl}/search/`;
 
-    autocompleteHeaderElement.appendChild(searchPageLink);
+    if (alogliaApiDocsearchInput && alogliaApiDocsearchInput.value !== '') {
+        searchPageLink.href += `?s=${alogliaApiDocsearchInput.value}`;
+    }
+
+    if (autocompleteHeaderElement) {
+        autocompleteHeaderElement.appendChild(searchPageLink)
+    }
 }
 
 const enhanceApiResultStyles = () => {
     const headers = document.querySelectorAll('.algolia-autocomplete .algolia-docsearch-suggestion--category-header');
-    appendHomeLinkToAutocompleteWidget(headers[0]);
 
     headers.forEach(header => {
         if (header.textContent.toLowerCase().includes('api')) {
@@ -145,9 +154,11 @@ searchDesktop.autocomplete.on('keyup', function(e) {
 
     if (isApiPage()) {
         const searchLink = document.querySelector('.js-api-search');
-        const searchInput = document.querySelector('.docssearch-input.ds-input');
+        const searchInput = document.getElementById('search-input-api');
 
-        if (searchLink && searchInput) {
+        // The search query's first input character is handled by appendHomeLinkToAutocompleteWidget()
+        // This is because it must be handled during algolia's autocomplete:shown function so we have access to algolia's autocomplete elements.
+        if (searchLink && searchInput && searchInput.length > 1) {
             searchLink.href += !searchLink.href.includes('?') ? `?s=${searchInput.value}` : searchInput.value;
         }
     }
@@ -162,6 +173,7 @@ searchDesktop.autocomplete.on('autocomplete:shown', function() {
     if (isApiPage()) {
         enhanceApiResultStyles();
         setApiEndpointAsSubcategory();
+        appendHomeLinkToAutocompleteWidget();
     }
 })
 

--- a/src/scripts/components/algolia.js
+++ b/src/scripts/components/algolia.js
@@ -38,7 +38,7 @@ const handleSearchPageRedirect = () => {
     const docsearchInput = document.querySelector('.docssearch-input.ds-input');
 
     if (docsearchInput.value !== '') {
-        window.location = `${baseUrl}/search?s=${docsearchInput.value}`;
+        window.location = `${baseUrl}/search/?s=${docsearchInput.value}`;
     }
 }
 

--- a/src/scripts/components/algolia.js
+++ b/src/scripts/components/algolia.js
@@ -236,5 +236,6 @@ searchMobile.autocomplete.on('autocomplete:shown', function() {
     if (isApiPage()) {
         enhanceApiResultStyles();
         setApiEndpointAsSubcategory();
+        appendHomeLinkToAutocompleteWidget();
     }
 })


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Fixes bug with appending search query string to `Click here to search full docs` link on API page algolia autocomplete widget
- Fixes bug with appending search query string when users click `Search` button from homepage.

### Motivation
Failed synthetics test: failed synthetics test: https://dd-corpsite.datadoghq.com/synthetics/details/ycq-nxu-nkx/result/8418860546946627471?index=4

JS error: https://dd-corpsite.datadoghq.com/rum/error-tracking?end=1621274308489&eventSrc=rum&fingerprint=2E1078725B06A122B7E24FB614A31A19&fingerprint_version=2&paused=false&query=%40service%3Adocs&start=1621187908489&eventId=AQAAAXl6p_aycKvcCgAAAABBWGw2cF9lMkFBRHFpaERYLXFMZWpRQVU

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/js-errors/
- Type a string into the search input and click `Search`
- User should be redirected to search page with appropriate search query parameter

https://docs-staging.datadoghq.com/brian.deutsch/js-errors/api
- Type one letter into the search input on the left-hand side.
- Hover over the `Click here to search the full docs` link.   Verify the one letter you typed is being appended to the `s` query parameter properly.
- Type a full term into the search input.   Verify that clicking the link results in being redirected to the search page with the search query appended properly.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
