### PR TITLE
[WEB-1403] Configure Vale to lint modified files when PR is opened

### DIFF
--- a/.github/styles/Datadog/headings.yml
+++ b/.github/styles/Datadog/headings.yml
@@ -1,7 +1,7 @@
 extends: capitalization
 message: "'%s' should use sentence-style capitalization."
 link: "https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#headers"
-level: warning
+level: suggestion
 scope: heading
 match: $sentence
 exceptions:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,15 @@
+name: Linting
+on: [pull_request]
+
+jobs:
+  prose:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Vale
+      uses: errata-ai/vale-action@v1.4.0
+      with:
+        onlyAnnotateModifiedLines: true
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### What does this PR do?
Configures Vale to lint modified md/html files when PR is opened.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1403

### Preview
n/a

Vale is configured to run as a Github Action when a new PR is opened.  The linter should check only modified md and html files, and automatically create an annotation directly in the PR if any issues were uncovered.   [I have a test PR here](https://github.com/DataDog/documentation/pull/10583/files) showing a suggestion to update the content of a heading that was linted by Vale.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
