### PR TITLE
Clarify java tracer system property order

### DIFF
--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -225,7 +225,7 @@ All configuration options below have system property and environment variable eq
 If the same key type is set for both, the system property configuration takes priority.
 System properties can be set as JVM flags.
 
-Note: When using the java tracer’s system properties, make sure that they are listed before `-jar` so they get read in as JVM options.
+Note: When using the Java tracer’s system properties, make sure that they are listed before `-jar` so they get read in as JVM options.
 
 
 `dd.service`

--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -225,6 +225,7 @@ All configuration options below have system property and environment variable eq
 If the same key type is set for both, the system property configuration takes priority.
 System properties can be set as JVM flags.
 
+Note: When using the java tracer’s system properties, make sure that they are listed before `-jar` so they get read in as JVM options.
 
 
 `dd.service`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Clarifies that when using the java tracer with system properties, the system properties need to be listed before `-jar`. If you swap this order and list them after `-jar`, they don't take effect.

### Motivation
<!-- What inspired you to submit this pull request?-->

To explain the correct order of system properties.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/java-apm-configuration-order/tracing/setup_overview/setup/java/?tab=containers#follow-the-in-app-documentation-recommended

### Additional Notes
<!-- Anything else we should know when reviewing?-->

@andrewsouthard1 should confirm the wording.
cc @mcculls who explained this to me and for any feedback.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
