### PR TITLE
Updating "Runtime Security" to "Workload Security"

### DIFF
--- a/content/en/security_platform/default_rules/_index.md
+++ b/content/en/security_platform/default_rules/_index.md
@@ -12,6 +12,6 @@ disable_sidebar: true
 
 Datadog provides out-of-the-box (OOTB) detection rules to flag attacker techniques and potential misconfigurations so that you can immediately take steps to improve your security posture. Datadog continuously develops new default detection rules, which are automatically imported into your account.
 
-Filter by **Logs Detection** to see the Security monitoring rules, **Runtime Agent** to see Cloud Security Workload rules, or **Cloud Configuration** to see the Cloud Security Posture rules.
+Filter by **Logs Detection** to see the Security monitoring rules, **Workload Security** to see Cloud Security Workload rules, or **Cloud Configuration** to see the Cloud Security Posture rules.
 
 [1]: ../detection_rules

--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -84,7 +84,7 @@ def security_rules(content, content_dir):
                         if 'compliance' in relative_path:
                             page_data['rule_category'].append('Infrastructure Configuration')
                         else:
-                            page_data['rule_category'].append('Runtime Agent')
+                            page_data['rule_category'].append('Workload Security')
 
                     tags = data.get('tags', [])
                     if tags:


### PR DESCRIPTION
### What does this PR do?
New product name.

https://docs-staging.datadoghq.com/kaylyn/runtime-agent/security_platform/default_rules/ - button and text should now say  "Workload Security"

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
