### PR TITLE
Fix redisdb integration name in file autodiscovery example

### DIFF
--- a/content/en/agent/docker/integrations.md
+++ b/content/en/agent/docker/integrations.md
@@ -226,8 +226,8 @@ This looks like a minimal [Redis integration configuration][1], but notice the `
 
 If your Redis requires an additional `password` when accessing its stats endpoint:
 
-1. Create the folders `conf.d/` and `conf.d/redis.d` on your host.
-2. Add the custom auto-configuration below to `conf.d/redis.d/conf.yaml` on your host.
+1. Create the folders `conf.d/` and `conf.d/redisdb.d` on your host.
+2. Add the custom auto-configuration below to `conf.d/redisdb.d/conf.yaml` on your host.
 3. Mount the host `conf.d/` folder to the containerized Agent `conf.d/` folder.
 
 ```yaml


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes the integration name for the [redisdb check](https://github.com/DataDog/integrations-core/tree/master/redisdb) in the file configuration example.

### Motivation
Following the current instructions will result in a check loading error because `redis` isn't a valid check name:

```
  Loading Errors
  ==============
    redis
    -----
      Core Check Loader:
        Check redis not found in Catalog
        
      JMX Check Loader:
        check is not a jmx check, or unable to determine if it's so
        
      Python Check Loader:
        unable to find a subclass of the base check in module 'redis': cannot find a subclass
```

### Preview
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/caroline.kim/fix-redisdb-file-conf-example/agent/docker/integrations/?tab=file#datadog-redis-integration

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
