### PR TITLE
DOCS-2033 Remove client config info from AWS PrivateLink guide

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -95,149 +95,19 @@ The overall process consists of configuring an internal endpoint in your VPC tha
 10. Wait for the status to move from _Pending_ to _Available_. This can take up to 10 minutes.
     {{< img src="agent/guide/private_link/vpc_status.png" alt="VPC status" style="width:60%;" >}}
 
-Once it shows _Available_, the AWS PrivateLink is ready to be used. The next step is to update your Agent configurations with the new target endpoint for your Datadog Agents, Lambda forwarder, and/or other clients shipping data to Datadog.
+Once it shows _Available_, the AWS PrivateLink is ready to be used. 
 
-## Client configuration
-
-Select the tab below to see how to send your metrics and logs to Datadog using this new VPC endpoint, or which new host URL you would need to use for Datadog API:
-
-{{< tabs >}}
-{{% tab "Metrics" %}}
-
-_Available for Agent 6.0+_
-
-To forward your metrics to Datadog using this new VPC endpoint, configure `pvtlink.agent.datadoghq.com` as your new metric destination:
-
-1. Update the `dd_url` parameter in the [Agent `datadog.yaml` configuration file][1]:
-
-    ```yaml
-    dd_url: https://pvtlink.agent.datadoghq.com
-    ```
-
-2. [Restart your Agent][2] to send metrics to Datadog through AWS PrivateLink.
-
-**Note**: If you are using the container Agent, set the environment variable instead: `DD_DD_URL="https://pvtlink.agent.datadoghq.com"`. Configure this environment variable on _both_ the Cluster Agent & Node Agent if using the Cluster Agent to monitor a Kubernetes environment.
-
-
-[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
-[2]: /agent/guide/agent-commands/#restart-the-agent
-{{% /tab %}}
-{{% tab "Logs" %}}
-
-_Available for Agent 6.14+_
-
-To forward your logs to Datadog using this new VPC endpoint, configure `pvtlink.logs.datadoghq.com` as your new log destination:
-
-**Using the Datadog Agent**:
-
-1. Add the following to the [Agent `datadog.yaml` configuration file][1]:
-
-    ```yaml
-    logs_config:
-        use_http: true
-        logs_dd_url: pvtlink.logs.datadoghq.com:443
-    ```
-
-    - The `use_http` variable forces the Datadog Agent to send logs over HTTPS. This configuration is required when sending logs to Datadog via AWS PrivateLink. More information about this is available in the [Agent log collection documentation][2].
-    - The `logs_dd_url` variable is used to send logs to the VPC endpoint.
-
-2. [Restart your Agent][3] to send logs to Datadog through AWS PrivateLink.
-
-**Note**: if you are using the container Agent, set the following environment variables instead:
-
-- `DD_LOGS_CONFIG_USE_HTTP=true`
-- `DD_LOGS_CONFIG_LOGS_DD_URL="pvtlink.logs.datadoghq.com:443"`
-
-**Using the Lambda or a custom forwarder**:
-
-Add `DD_URL: api-pvtlink.logs.datadoghq.com` in your [Datadog Lambda function][4] environment variable to use the private link when forwarding AWS Service Logs to Datadog.
-
-By default, the forwarder's API key is stored in Secrets Manager. The Secrets Manager endpoint needs to be added to the VPC. You can follow the instructions [here for adding AWS services to a VPC][5].
-
-When installing the forwarder with the CloudFormation template, enable 'DdUsePrivateLink' and set at least one subnet ID and security group.
-
-[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
-[2]: /agent/logs/?tab=tailexistingfiles#send-logs-over-https
-[3]: /agent/guide/agent-commands/#restart-the-agent
-[4]: /integrations/amazon_web_services/#set-up-the-datadog-lambda-function
-[5]: https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#create-interface-endpoint
-{{% /tab %}}
-{{% tab "API" %}}
-
-To send data to the Datadog API or consume data from it through this new endpoint, replace your API call host signature `api.datadoghq.com/api/` with `pvtlink.api.datadoghq.com/api/`.
-
-{{% /tab %}}
-{{% tab "Processes" %}}
-
-To forward your processes metrics to Datadog using this new VPC endpoint, configure `pvtlink.process.datadoghq.com` as your new processes data destination:
-
-1. Update the `process_dd_url` in the `process_config:` section of the [Agent `datadog.yaml` configuration file][1]:
-
-    ```yaml
-    process_dd_url: https://pvtlink.process.datadoghq.com
-    ```
-
-2. [Restart your Agent][2] to send processes data to Datadog through AWS PrivateLink.
-
-**Note**: If you are using the container Agent, set the environment variable instead: `DD_PROCESS_AGENT_URL="https://pvtlink.process.datadoghq.com"`. Configure this environment variable on _both_ the Cluster Agent & Node Agent if using the Cluster Agent to monitor a Kubernetes environment.
-
-
-[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
-[2]: /agent/guide/agent-commands/#restart-the-agent
-{{% /tab %}}
-{{% tab "Traces" %}}
-
-To forward your trace metrics to Datadog using this new VPC endpoint, configure `trace-pvtlink.agent.datadoghq.com` as your new trace destination:
-
-1. Update the `apm_dd_url` parameter in the `apm_config` section of the [Agent `datadog.yaml` configuration file][1]:
-
-    ```yaml
-    apm_dd_url: https://trace-pvtlink.agent.datadoghq.com
-    ```
-
-2. [Restart your Agent][2] to send traces to Datadog through AWS PrivateLink.
-
-**Note**: If you are using the container Agent, set the environment variable instead: `DD_APM_DD_URL="https://trace-pvtlink.agent.datadoghq.com"`. Configure this environment variable on _both_ the Cluster Agent & Node Agent if using the Cluster Agent to monitor a Kubernetes environment.
-
-
-[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
-[2]: /agent/guide/agent-commands/#restart-the-agent
-{{% /tab %}}
-{{% tab "Kubernetes Resources" %}}
-
-To forward your Kubernetes resources to Datadog using this new VPC endpoint, configure `orchestrator-pvtlink.datadoghq.com` as your new orchestrator data destination:
-
-1. Update the `dd_url` parameter in the [Agent `datadog.yaml` configuration file][1]:
-
-    ```yaml
-    dd_url: orchestrator-pvtlink.datadoghq.com
-    ```
-
-   For the container Agent, set the following environment variable instead:
-
-   ```
-   DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL="orchestrator-pvtlink.datadoghq.com"
-   ```
-
-   Set this for the process Agent as well. If you are using the Cluster Agent to monitor a Kubernetes environment, also configure this environment variable for the Cluster Agent and the node Agent.
-
-2. [Restart your Agent][2] to send Kubernetes resources to Datadog through AWS PrivateLink.
-
-
-[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
-[2]: /agent/guide/agent-commands/#restart-the-agent
-{{% /tab %}}
-{{< /tabs >}}
+[Restart your Agents][3] to send data to Datadog through AWS PrivateLink.
 
 ## Advanced usage
 
 ### Inter-region peering
 
-To route traffic to Datadog’s PrivateLink offering in `us-east-1` from other regions, use inter-region [Amazon VPC peering][3]. 
+To route traffic to Datadog’s PrivateLink offering in `us-east-1` from other regions, use inter-region [Amazon VPC peering][4]. 
 
 Inter-region VPC peering enables you to establish connections between VPCs across different AWS regions. This allows VPC resources in different regions to communicate with each other using private IP addresses.
 
-For more information, see the [Amazon VPC peering documentation][3].
+For more information, see the [Amazon VPC peering documentation][4].
 
 ## Further Reading
 
@@ -245,4 +115,5 @@ For more information, see the [Amazon VPC peering documentation][3].
 
 [1]: https://aws.amazon.com/privatelink/
 [2]: /help/
-[3]: https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html
+[3]: /agent/guide/agent-commands/#restart-the-agent
+[4]: https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html

--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -95,19 +95,32 @@ The overall process consists of configuring an internal endpoint in your VPC tha
 10. Wait for the status to move from _Pending_ to _Available_. This can take up to 10 minutes.
     {{< img src="agent/guide/private_link/vpc_status.png" alt="VPC status" style="width:60%;" >}}
 
-Once it shows _Available_, the AWS PrivateLink is ready to be used. 
+    Once it shows _Available_, the AWS PrivateLink is ready to be used. 
+11. If you are collecting logs data, ensure your Agent is configured to send logs over HTTPS. If it's not already there, add the following to the [Agent `datadog.yaml` configuration file][3]:
 
-[Restart your Agents][3] to send data to Datadog through AWS PrivateLink.
+    ```yaml
+    logs_config:
+        use_http: true
+    ```
+
+    If you are using the container Agent, set the following environment variable instead:
+
+    ```
+    DD_LOGS_CONFIG_USE_HTTP=true
+    ```
+
+    This configuration is required when sending logs to Datadog via AWS PrivateLink. More information about this is available in the [Agent log collection documentation][4].
+12. [Restart your Agent][5] to send data to Datadog through AWS PrivateLink.
 
 ## Advanced usage
 
 ### Inter-region peering
 
-To route traffic to Datadog’s PrivateLink offering in `us-east-1` from other regions, use inter-region [Amazon VPC peering][4]. 
+To route traffic to Datadog’s PrivateLink offering in `us-east-1` from other regions, use inter-region [Amazon VPC peering][6]. 
 
 Inter-region VPC peering enables you to establish connections between VPCs across different AWS regions. This allows VPC resources in different regions to communicate with each other using private IP addresses.
 
-For more information, see the [Amazon VPC peering documentation][4].
+For more information, see the [Amazon VPC peering documentation][6].
 
 ## Further Reading
 
@@ -115,5 +128,7 @@ For more information, see the [Amazon VPC peering documentation][4].
 
 [1]: https://aws.amazon.com/privatelink/
 [2]: /help/
-[3]: /agent/guide/agent-commands/#restart-the-agent
-[4]: https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html
+[3]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
+[4]: /agent/logs/?tab=tailexistingfiles#send-logs-over-https
+[5]: /agent/guide/agent-commands/#restart-the-agent
+[6]: https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html


### PR DESCRIPTION
### What does this PR do?
Private link forwarder now uses standard endpoints, so less agent config is required. Removed previous client configuration section (left in details about logs over http)

### Motivation
DOCS-2033

### Preview

https://docs-staging.datadoghq.com/kari/docs-2033-privatelink/agent/guide/private-link/?tab=metrics

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
