### PR TITLE
Document changes in APT key management

### DIFF
--- a/content/en/agent/faq/agent-downgrade-major.md
+++ b/content/en/agent/faq/agent-downgrade-major.md
@@ -66,23 +66,31 @@ This guide assumes you upgraded to the Agent v6 using the [upgrade guide][1]. If
 
 **Debian Flavored Systems**:
 
-1. Set up apt so it can download through https
+1. Set up apt so it can download through https and install `curl` and `gnupg`
 
     ```shell
     sudo apt-get update
-    sudo apt-get install apt-transport-https
+    sudo apt-get install apt-transport-https curl gnupg
     ```
 
 2. Remove Beta Repo and Ensure the stable repo is present:
 
     ```shell
     sudo rm /etc/apt/sources.list.d/datadog-beta.list
-    [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 D75CEA17048B9ACBF186794B32637D44F14F620E
+    [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
+    sudo touch /usr/share/keyrings/datadog-archive-keyring.gpg
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
     ```
 
-3. Update apt and downgrade the Agent:
+3. If running Ubuntu 14 or earlier or Debian 8 or earlier, copy the keyring to `/etc/apt/trusted.gpg.d`:
+
+   ```shell
+   sudo cp /usr/share/keyrings/datadog-archive-keyring.gpg /etc/apt/trusted.gpg.d
+   ```
+
+4. Update apt and downgrade the Agent:
 
     ```shell
     sudo apt-get update
@@ -90,13 +98,13 @@ This guide assumes you upgraded to the Agent v6 using the [upgrade guide][1]. If
     sudo apt-get install datadog-agent
     ```
 
-4. Back-sync configurations and AutoDiscovery templates (optional)
+5. Back-sync configurations and AutoDiscovery templates (optional)
 
     If you have made any changes to your configurations or templates, you might want to sync these back for agent 5.
 
     **Note**: if you have made any changes to your configurations to support new agent6-only options, these will not work anymore with Agent version 5.
 
-5. Back-sync custom checks (optional):
+6. Back-sync custom checks (optional):
 
     If you made any changes or added any new custom checks while testing Agent 6 you might want to enable them back on Agent 5. Note that you only need to copy back    checks you changed.
 
@@ -104,7 +112,7 @@ This guide assumes you upgraded to the Agent v6 using the [upgrade guide][1]. If
     sudo -u dd-agent -- cp /etc/datadog-agent/checks.d/<CHECK>.py /etc/dd-agent/checks.d/
     ```
 
-6. Restart the agent
+7. Restart the agent
 
     ```shell
     # Systemd
@@ -113,7 +121,7 @@ This guide assumes you upgraded to the Agent v6 using the [upgrade guide][1]. If
     sudo /etc/init.d/datadog-agent restart
     ```
 
-7. Clean out `/etc/datadog-agent` (optional):
+8. Clean out `/etc/datadog-agent` (optional):
 
     ```shell
     sudo -u dd-agent -- rm -rf /etc/datadog-agent/

--- a/content/en/agent/faq/agent-downgrade-major.md
+++ b/content/en/agent/faq/agent-downgrade-major.md
@@ -79,6 +79,7 @@ This guide assumes you upgraded to the Agent v6 using the [upgrade guide][1]. If
     sudo rm /etc/apt/sources.list.d/datadog-beta.list
     [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
     sudo touch /usr/share/keyrings/datadog-archive-keyring.gpg
+
     curl https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
     curl https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
     curl https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch

--- a/content/en/agent/iot/_index.md
+++ b/content/en/agent/iot/_index.md
@@ -72,6 +72,7 @@ To manually install the IoT Agent on Debian-based operating systems, run the fol
     ```bash
     sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable 7' > /etc/apt/sources.list.d/datadog.list"
     sudo touch /usr/share/keyrings/datadog-archive-keyring.gpg
+
     curl https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
     curl https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
     curl https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch

--- a/content/en/agent/iot/_index.md
+++ b/content/en/agent/iot/_index.md
@@ -62,36 +62,44 @@ DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" DD_AGE
 
 To manually install the IoT Agent on Debian-based operating systems, run the following commands:
 
-1. Update `apt` and install `apt-transport-https` to download through HTTPS:
+1. Update `apt` and install `apt-transport-https` to download through HTTPS and `curl` and `gnupg` to obtain the signing keys:
     ```bash
     sudo apt-get update
-    sudo apt-get install apt-transport-https
+    sudo apt-get install apt-transport-https curl gnupg
     ```
 
 2. Set up the Datadog deb repo on your system and import Datadog's apt keys:
     ```bash
-    sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 7' > /etc/apt/sources.list.d/datadog.list"
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 D75CEA17048B9ACBF186794B32637D44F14F620E
+    sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable 7' > /etc/apt/sources.list.d/datadog.list"
+    sudo touch /usr/share/keyrings/datadog-archive-keyring.gpg
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
     ```
 
-3. Update `apt` and install the IoT Agent:
+3. If running Ubuntu 14 or earlier or Debian 8 or earlier, copy the keyring to `/etc/apt/trusted.gpg.d`:
+
+   ```shell
+   sudo cp /usr/share/keyrings/datadog-archive-keyring.gpg /etc/apt/trusted.gpg.d
+   ```
+
+4. Update `apt` and install the IoT Agent:
     ```bash
     sudo apt-get update
     sudo apt-get install datadog-iot-agent
     ```
 
-4. Copy the example config and plug in your API key:
+5. Copy the example config and plug in your API key:
     ```bash
     DD_API_KEY=<YOUR_DD_API_KEY> ; sudo sh -c "sed 's/api_key:.*/api_key:$DD_API_KEY/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
     ```
 
-5. Set your Datadog site to {{< region-param key="dd_site" code="true" >}}. Defaults to `datadoghq.com`.
+6. Set your Datadog site to {{< region-param key="dd_site" code="true" >}}. Defaults to `datadoghq.com`.
     ```bash
     sudo sh -c "sed 's/# site:.*/site: <YOUR_DD_SITE>/' /etc/datadog-agent/datadog.yaml > /etc/datadog-agent/datadog.yaml.new && mv /etc/datadog-agent/datadog.yaml.new /etc/datadog-agent/datadog.yaml
     ```
 
-6. Start the IoT Agent:
+7. Start the IoT Agent:
     ```bash
     sudo systemctl restart datadog-agent.service
     ```

--- a/content/en/agent/versions/upgrade_to_agent_v6.md
+++ b/content/en/agent/versions/upgrade_to_agent_v6.md
@@ -183,6 +183,7 @@ Find below the manual upgrade instructions for:
     ```shell
     sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
     sudo touch /usr/share/keyrings/datadog-archive-keyring.gpg
+
     curl https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
     curl https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
     curl https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
@@ -312,6 +313,7 @@ Find below the manual upgrade instructions for:
     ```shell
     sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
     sudo touch /usr/share/keyrings/datadog-archive-keyring.gpg
+
     curl https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
     curl https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
     curl https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch

--- a/content/en/agent/versions/upgrade_to_agent_v6.md
+++ b/content/en/agent/versions/upgrade_to_agent_v6.md
@@ -173,38 +173,44 @@ Find below the manual upgrade instructions for:
 
 ### Debian
 
-1. Enable HTTPS support for APT:
+1. Enable HTTPS support for APT, install `curl` and `gnupg`:
     ```
     sudo apt-get update
-    sudo apt-get install apt-transport-https
+    sudo apt-get install apt-transport-https curl gnupg
     ```
 
 2. Set up the Datadog API repo on your system and import Datadog's APT keys:
     ```shell
-    sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 D75CEA17048B9ACBF186794B32637D44F14F620E
+    sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
+    sudo touch /usr/share/keyrings/datadog-archive-keyring.gpg
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
     ```
 
-    Note: You might need to install `dirmngr` to import Datadog's APT keys.
+3. If running Debian 8 or earlier, copy the keyring to `/etc/apt/trusted.gpg.d`:
 
-3. Update your local APT cache and install the Agent:
+   ```shell
+   sudo cp /usr/share/keyrings/datadog-archive-keyring.gpg /etc/apt/trusted.gpg.d
+   ```
+
+4. Update your local APT cache and install the Agent:
     ```
     sudo apt-get update
     sudo apt-get install datadog-agent
     ```
 
-4. Copy the example configuration into place and plug in your API key:
+5. Copy the example configuration into place and plug in your API key:
     ```shell
     sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
     ```
 
-5. Transition your Agent configuration paths and formats from Agent v5 to Agent v6, with the `import` command. The command parses an existing v5 `datadog.conf` and converts the configuration options to the new v6 `datadog.yaml` format. It also copies configuration files for checks that are currently enabled:
+6. Transition your Agent configuration paths and formats from Agent v5 to Agent v6, with the `import` command. The command parses an existing v5 `datadog.conf` and converts the configuration options to the new v6 `datadog.yaml` format. It also copies configuration files for checks that are currently enabled:
     ```
     sudo -u dd-agent -- datadog-agent import /etc/dd-agent/ /etc/datadog-agent/
     ```
 
-6. Start the Agent:
+7. Start the Agent:
     ```
     sudo service datadog-agent start
     ```
@@ -296,38 +302,44 @@ Find below the manual upgrade instructions for:
 
 ### Ubuntu
 
-1. Enable HTTPS support for APT:
+1. Enable HTTPS support for APT, install `curl` and `gnupg`:
     ```
     sudo apt-get update
-    sudo apt-get install apt-transport-https
+    sudo apt-get install apt-transport-https curl gnupg
     ```
 
 2. Set up the Datadog API repo on your system and import Datadog's APT keys:
     ```shell
-    sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
-    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 D75CEA17048B9ACBF186794B32637D44F14F620E
+    sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable 6' > /etc/apt/sources.list.d/datadog.list"
+    sudo touch /usr/share/keyrings/datadog-archive-keyring.gpg
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
     ```
 
-    Note: You might need to install `dirmngr` to import Datadog's APT keys.
+3. If running Ubuntu 14 or earlier, copy the keyring to `/etc/apt/trusted.gpg.d`:
 
-3. Update your local APT cache and install the Agent:
+   ```shell
+   sudo cp /usr/share/keyrings/datadog-archive-keyring.gpg /etc/apt/trusted.gpg.d
+   ```
+
+4. Update your local APT cache and install the Agent:
     ```
     sudo apt-get update
     sudo apt-get install datadog-agent
     ```
 
-4. Copy the example configuration into place and plug in your API key:
+5. Copy the example configuration into place and plug in your API key:
     ```shell
     sudo sh -c "sed 's/api_key:.*/api_key: <YOUR_API_KEY>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
     ```
 
-5. Transition your Agent configuration paths and formats from Agent v5 to Agent v6, with the `import` command. The command parses an existing v5 `datadog.conf` and converts the configuration options to the new v6 `datadog.yaml` format. It also copies configuration files for checks that are currently enabled.:
+6. Transition your Agent configuration paths and formats from Agent v5 to Agent v6, with the `import` command. The command parses an existing v5 `datadog.conf` and converts the configuration options to the new v6 `datadog.yaml` format. It also copies configuration files for checks that are currently enabled.:
     ```
     sudo -u dd-agent -- datadog-agent import /etc/dd-agent/ /etc/datadog-agent/
     ```
 
-6. Start the Agent:
+7. Start the Agent:
 
     * Ubuntu 16.04 or higher:
     ```


### PR DESCRIPTION
### What does this PR do?
* By default, get keys from keys.datadoghq.com, not Ubuntu keyserver
* Always add the DATADOG_APT_KEY_CURRENT.public key (contains key used to sign current repodata)
* Add 'signed-by' option to all sources list lines
* On Debian >= 9 and Ubuntu >= 16, only add keys to /usr/share/keyrings/datadog-archive-keyring.gpg
* On older systems, also add the same keyring to /etc/apt/trusted.gpg.d

### Motivation
Changes in APT key management that are being implemented to all management tools, e.g. [our ansible role](https://github.com/DataDog/ansible-datadog/commit/90f2d41d28ef6194820a86741b8dfb07b2891059).

### Preview
https://docs-staging.datadoghq.com/slavek.kabrda/apt-key-changes/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
