### PR TITLE
Remove pre configuration in python/ruby SDK installation

### DIFF
--- a/content/en/api/latest/_index.md
+++ b/content/en/api/latest/_index.md
@@ -121,7 +121,7 @@ import datadog
 {{< programming-lang lang="python-beta" >}}
 #### Installation
 ```console
-pip3 install datadog-api-client --pre
+pip3 install datadog-api-client
 ```
 #### Usage
 ```python
@@ -143,7 +143,7 @@ require 'dogapi'
 {{< programming-lang lang="ruby-beta" >}}
 #### Installation
 ```sh
-gem install datadog_api_client -v {{< sdk-version "datadog-api-client-ruby" >}} --pre
+gem install datadog_api_client -v {{< sdk-version "datadog-api-client-ruby" >}}
 ```
 #### Usage
 ```ruby


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Small change to installation instructions.

### Motivation
<!-- What inspired you to submit this pull request?-->

Python and Ruby SDKs have 1.0 releases.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.