### PR TITLE
adding security monitoring template variables docs

### DIFF
--- a/content/en/security_platform/security_monitoring/log_detection_rules.md
+++ b/content/en/security_platform/security_monitoring/log_detection_rules.md
@@ -169,7 +169,7 @@ Set a maximum duration to keep updating a signal if new values are detected with
 
 ## Say What's Happening
 
-The notification box has the same Markdown and preview features as those of [monitor notifications][1]. In addition to the features, you can reference the tags associated with the signal and the event attributes. The attributes can be seen on a signal in the “event attributes” tab and you can access the attributes with the following syntax: {{@attribute}}. You can access inner keys of the event attributes by using JSON dot notation (e.g. {{@attribute.inner_key}}).
+The notification box has the same Markdown and preview features as those of [monitor notifications][1]. In addition to the features, you can reference the tags associated with the signal and the event attributes. The attributes can be seen on a signal in the “event attributes” tab, and you can access the attributes with the following syntax: {{@attribute}}. You can access inner keys of the event attributes by using JSON dot notation (for example, {{@attribute.inner_key}}).
 
 This JSON object is an example of event attributes which may be associated with a security signal:
 
@@ -192,21 +192,29 @@ This JSON object is an example of event attributes which may be associated with 
 
 ```
 
-You could use the following in the “say what’s happening” section
+You could use the following in the “say what’s happening” section:
 
 ```
 {{@usr.id}} just logged in without MFA from {@network.client.ip}.
 ```
 
-And this would be rendered as the following
+And this would be rendered as the following:
 
 ```
 user@domain.com just logged in without MFA from 1.2.3.4.
 ```
 
-You can use if-else logic to see if an attribute exists with the notation `{{#if @network.client.ip}}The attribute IP attribute exists.{{/if}}`.
+You can use if-else logic to see if an attribute exists with the notation:
 
-You can use if-else logic to see if an attribute matches a value. `{{#is_exact_match "@network.client.ip" "1.2.3.4"}}The ip matched.{{/is_exact_match}}`
+```
+{{#if @network.client.ip}}The attribute IP attribute exists.{{/if}}
+```
+
+You can use if-else logic to see if an attribute matches a value:
+
+```
+{{#is_exact_match "@network.client.ip" "1.2.3.4"}}The ip matched.{{/is_exact_match}}
+```
 
 You can read more about template variables [here][1].
 

--- a/content/en/security_platform/security_monitoring/log_detection_rules.md
+++ b/content/en/security_platform/security_monitoring/log_detection_rules.md
@@ -169,7 +169,46 @@ Set a maximum duration to keep updating a signal if new values are detected with
 
 ## Say What's Happening
 
-The notification box has the same Markdown and preview features as those of [monitor notifications][1].
+The notification box has the same Markdown and preview features as those of [monitor notifications][1]. In addition to the features, you can reference the tags associated with the signal and the event attributes. The attributes can be seen on a signal in the “event attributes” tab and you can access the attributes with the following syntax: {{@attribute}}. You can access inner keys of the event attributes by using JSON dot notation (e.g. {{@attribute.inner_key}}).
+
+This JSON object is an example of event attributes which may be associated with a security signal:
+
+```json
+{
+  "network": {
+    "client": {
+      "ip": "1.2.3.4"
+    }
+  },
+  "usr": {
+    "id": "user@domain.com"
+  },
+  "evt": {
+    "category": "authentication",
+    "outcome": "success"
+  },
+  "used_mfa": "false"
+}
+
+```
+
+You could use the following in the “say what’s happening” section
+
+```
+{{@usr.id}} just logged in without MFA from {@network.client.ip}.
+```
+
+And this would be rendered as the following
+
+```
+user@domain.com just logged in without MFA from 1.2.3.4.
+```
+
+You can use if-else logic to see if an attribute exists with the notation `{{#if @network.client.ip}}The attribute IP attribute exists.{{/if}}`.
+
+You can use if-else logic to see if an attribute matches a value. `{{#is_exact_match "@network.client.ip" "1.2.3.4"}}The ip matched.{{/is_exact_match}}`
+
+You can read more about template variables [here][1].
 
 The **Rule name** section allows you to configure the rule name that appears in the rules list view, as well as the title of the Security Signal.
 

--- a/content/en/security_platform/security_monitoring/log_detection_rules.md
+++ b/content/en/security_platform/security_monitoring/log_detection_rules.md
@@ -169,7 +169,7 @@ Set a maximum duration to keep updating a signal if new values are detected with
 
 ## Say What's Happening
 
-The notification box has the same Markdown and preview features as those of [monitor notifications][1]. In addition to the features, you can reference the tags associated with the signal and the event attributes. The attributes can be seen on a signal in the “event attributes” tab, and you can access the attributes with the following syntax: {{@attribute}}. You can access inner keys of the event attributes by using JSON dot notation (for example, {{@attribute.inner_key}}).
+The notification box has the same Markdown and preview features as those of [monitor notifications][1]. In addition to the features, you can reference the tags associated with the signal and the event attributes. The attributes can be seen on a signal in the “event attributes” tab, and you can access the attributes with the following syntax: `{{@attribute}}`. You can access inner keys of the event attributes by using JSON dot notation (for example, `{{@attribute.inner_key}}`).
 
 This JSON object is an example of event attributes which may be associated with a security signal:
 


### PR DESCRIPTION
### What does this PR do?
Adds documentation for template variables which are now supported in Security Monitoring. 

### Motivation
New feature :) 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/justin.massey/template-variables/security_platform/security_monitoring/log_detection_rules/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
