### PR TITLE
Update _index.md

### DIFF
--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -172,7 +172,7 @@ Send custom metrics with [the StatsD protocol][17]:
 | `DD_DOGSTATSD_SOCKET`            | Path to the unix socket to listen to. Must be in a `rw` mounted volume.                                                                                    |
 | `DD_DOGSTATSD_ORIGIN_DETECTION`  | Enable container detection and tagging for unix socket metrics.                                                                                            |
 | `DD_DOGSTATSD_TAGS`              | Additional tags to append to all metrics, events, and service checks received by this DogStatsD server, for example: `"env:golden group:retrievers"`. |
-
+| `DD_DOGSTATSD_DISABLE`           | Disables sending custom metrics from the dogstatsd library.                                                                                                |
 Learn more about [DogStatsD over Unix Domain Sockets][18].
 
 ### Tagging


### PR DESCRIPTION
### What does this PR do?
- Adds missing documentation for the DD_DOGSTATSD_DISABLE environment variable.

### Motivation
- I got "connection errors" (even though it's a udp socket?) when I disabled the dogstatsd port in development.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
