### PR TITLE
add doc updates for api rate limiting

### DIFF
--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -14,7 +14,6 @@ Rate limits can be increased from the defaults by [contacting the Datadog suppor
 Regarding the API rate limit policy:
 
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
-- The rate limit for a single IP is `12000` per hour.
 - The rate limit for metric **retrieval** is `100` per hour per organization.
 - The rate limit for event submission is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
 - The rate limit for the [Query a Timeseries API][4] call is `1600` per hour per organization. This can be extended on demand.

--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -7,8 +7,6 @@ type: api
 
 All of the API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
 
-For rate-limited API endpoints, Datadog returns headers to show how close you are to your limit. If you exceed your limit, review these headers to determine when you can try again.
-
 If you are rate limited, you will see a 429 in the response code. Datadog recommends to either wait the time designated by the `X-RateLimit-Limit` before making calls again, or you should switch to making calls at a frequency slightly longer than the `X-RateLimit-Limit` / `X-RateLimit-Period`.
 
 Rate limits can be increased from the defaults by [contacting the Datadog support team][1].

--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -9,6 +9,8 @@ All of the API endpoints are rate limited. Once you exceed a certain number of r
 
 For rate-limited API endpoints, Datadog returns headers to show how close you are to your limit. If you exceed your limit, review these headers to determine when you can try again.
 
+If you are rate limited, you will see a 429 in the response code. Datadog recommends to either wait the time designated by the `X-RateLimit-Limit` before making calls again, or you should switch to making calls at a frequency slightly longer than the `X-RateLimit-Limit` / `X-RateLimit-Period`.
+
 Rate limits can be increased from the defaults by [contacting the Datadog support team][1].
 
 Regarding the API rate limit policy:

--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -5,7 +5,7 @@ type: api
 
 {{< h2 >}}Rate Limits{{< /h2 >}}
 
-Some of the API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
+All of the API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
 
 For rate-limited API endpoints, Datadog returns headers to show how close you are to your limit. If you exceed your limit, review these headers to determine when you can try again.
 
@@ -14,6 +14,7 @@ Rate limits can be increased from the defaults by [contacting the Datadog suppor
 Regarding the API rate limit policy:
 
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
+- The rate limit for a single IP is `12000` per hour.
 - The rate limit for metric **retrieval** is `100` per hour per organization.
 - The rate limit for event submission is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
 - The rate limit for the [Query a Timeseries API][4] call is `1600` per hour per organization. This can be extended on demand.

--- a/content/en/api/v1/rate-limits/_index.md
+++ b/content/en/api/v1/rate-limits/_index.md
@@ -14,7 +14,6 @@ Rate limits can be increased from the defaults by [contacting the Datadog suppor
 Regarding the API rate limit policy:
 
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
-- The rate limit for a single IP is `12000` per hour.
 - The rate limit for metric **retrieval** is `100` per hour per organization.
 - The rate limit for event submission is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
 - The rate limit for the [Query a Timeseries API][4] call is `1600` per hour per organization. This can be extended on demand.

--- a/content/en/api/v1/rate-limits/_index.md
+++ b/content/en/api/v1/rate-limits/_index.md
@@ -7,7 +7,7 @@ type: api
 
 All of the API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
 
-For rate-limited API endpoints, Datadog returns headers to show how close you are to your limit. If you exceed your limit, review these headers to determine when you can try again.
+If you are rate limited, you will see a 429 in the response code. Datadog recommends to either wait the time designated by the `X-RateLimit-Limit` before making calls again, or you should switch to making calls at a frequency slightly longer than the `X-RateLimit-Limit` / `X-RateLimit-Period`.
 
 Rate limits can be increased from the defaults by [contacting the Datadog support team][1].
 

--- a/content/en/api/v1/rate-limits/_index.md
+++ b/content/en/api/v1/rate-limits/_index.md
@@ -5,7 +5,7 @@ type: api
 
 {{< h2 >}}Rate Limits{{< /h2 >}}
 
-Some of the API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
+All of the API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
 
 For rate-limited API endpoints, Datadog returns headers to show how close you are to your limit. If you exceed your limit, review these headers to determine when you can try again.
 
@@ -14,6 +14,7 @@ Rate limits can be increased from the defaults by [contacting the Datadog suppor
 Regarding the API rate limit policy:
 
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
+- The rate limit for a single IP is `12000` per hour.
 - The rate limit for metric **retrieval** is `100` per hour per organization.
 - The rate limit for event submission is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
 - The rate limit for the [Query a Timeseries API][4] call is `1600` per hour per organization. This can be extended on demand.

--- a/content/en/api/v2/rate-limits/_index.md
+++ b/content/en/api/v2/rate-limits/_index.md
@@ -5,7 +5,7 @@ type: api
 
 {{< h2 >}}Rate Limits{{< /h2 >}}
 
-Some of the API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
+All of the API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
 
 For rate-limited API endpoints, Datadog returns headers to show how close you are to your limit. If you exceed your limit, review these headers to determine when you can try again.
 

--- a/content/en/api/v2/rate-limits/_index.md
+++ b/content/en/api/v2/rate-limits/_index.md
@@ -7,7 +7,7 @@ type: api
 
 All of the API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
 
-For rate-limited API endpoints, Datadog returns headers to show how close you are to your limit. If you exceed your limit, review these headers to determine when you can try again.
+If you are rate limited, you will see a 429 in the response code. Datadog recommends to either wait the time designated by the `X-RateLimit-Limit` before making calls again, or you should switch to making calls at a frequency slightly longer than the `X-RateLimit-Limit` / `X-RateLimit-Period`.
 
 Rate limits can be increased from the defaults by [contacting the Datadog support team][1].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
API Rate limiting is now enabled for all routes as we have enabled global ip rate limiting by default. It is set to 12000 reqs/min. 

### Motivation
Docs need an update

### Preview
Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ry-add-updates-to-rate-limiting/api/latest/rate-limits/

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
