### PR TITLE
DOCS-2033 Update AWS PrivateLink Service Names

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -40,14 +40,14 @@ The overall process consists of configuring an internal endpoint in your VPC tha
 
 | Datadog Metric Service Name                                |
 | ---------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-056576c12b36056ca`  |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-0d560852f6f1e27ac`  |
 
 {{% /tab %}}
 {{% tab "Logs" %}}
 
 | Forwarder | Datadog Logs Service Name |
 | --------- | ------------------------- |
-| Datadog Agent | `com.amazonaws.vpce.us-east-1.vpce-svc-0a2aef8496ee043bf` |
+| Datadog Agent | `com.amazonaws.vpce.us-east-1.vpce-svc-025a56b9187ac1f63` |
 | Lambda or custom forwarder | `com.amazonaws.vpce.us-east-1.vpce-svc-06394d10ccaf6fb97` |
 
 {{% /tab %}}
@@ -55,28 +55,28 @@ The overall process consists of configuring an internal endpoint in your VPC tha
 
 | Datadog API Service Name                                  |
 | --------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-02a4a57bc703929a0` |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-064ea718f8d0ead77` |
 
 {{% /tab %}}
 {{% tab "Processes" %}}
 
 | Datadog Process Monitoring Service Name                   |
 | --------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-05316fe237f6d8ddd` |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-0ed1f789ac6b0bde1` |
 
 {{% /tab %}}
 {{% tab "Traces" %}}
 
 | Datadog Trace Service Name                                |
 | --------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-07672d13af0033c24` |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-0355bb1880dfa09c2` |
 
 {{% /tab %}}
 {{% tab "Kubernetes Resources" %}}
 
 | Datadog Kubernetes Explorer Service Name                  |
 | --------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-0b03d6756bf6c2ec3` |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-0ad5fb9e71f85fe99` |
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
the agent any longer, but didn't update the documentation to show the new
PrivateLink Service IDs that don't require agent configuration.

This PR updates the service IDs so that the documentation and the service IDs
are in line.


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/rtdean/fix-privatelink-service-names/agent/guide/private-link/
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.