### PR TITLE
[WEB-1434] Remove duplicate breadcrumb on API pages

### DIFF
--- a/layouts/partials/api/api-toolbar.html
+++ b/layouts/partials/api/api-toolbar.html
@@ -3,8 +3,6 @@
 
 <div class="api-toolbar pt-2 mb-lg-1 d-lg-flex justify-content-between">
     <div id="breadcrumbs">
-        <a class="text-uppercase text-gray-darkish" href="{{ .Page.Parent.RelPermalink }}">{{ .Page.Parent.Title }}</a>&nbsp;>&nbsp;
-
         {{ if .Page.Parent }}
             <a class="text-uppercase text-gray-darkish" href="{{ .Page.Parent.RelPermalink }}">{{ .Page.Parent.Title }}</a>
             &nbsp;>&nbsp;

--- a/layouts/partials/api/api-toolbar.html
+++ b/layouts/partials/api/api-toolbar.html
@@ -3,8 +3,8 @@
 
 <div class="api-toolbar pt-2 mb-lg-1 d-lg-flex justify-content-between">
     <div id="breadcrumbs">
-        {{ if .Page.Parent }}
-            <a class="text-uppercase text-gray-darkish" href="{{ .Page.Parent.RelPermalink }}">{{ .Page.Parent.Title }}</a>
+        {{ with .Page.Parent }}
+            <a class="text-uppercase text-gray-darkish" href="{{ .RelPermalink }}">{{ .Title }}</a>
             &nbsp;>&nbsp;
         {{ end }}
 


### PR DESCRIPTION
### What does this PR do?
Removes duplicate breadcrumb on API pages

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1434

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/dupe-breadcrumb/api/latest/

- There are no longer two duplicate `API Reference` breadcrumbs on API pages.

### Additional Notes

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
