### PR TITLE
Fixed outdated text on Metrics Explorer page

### DIFF
--- a/content/en/metrics/explorer.md
+++ b/content/en/metrics/explorer.md
@@ -59,7 +59,7 @@ Export all graphs to a new or existing timeboard with the buttons at the bottom 
 
 ### Snapshot
 
-Create a snapshot of an individual graph by clicking the camera icon on the top right of a graph.
+Create a snapshot of an individual graph by using the share icon in the upper right. Clicking on the icon brings up a dropdown menu with the **Send snaphot...** option.
 
 ## Further reading
 

--- a/content/en/metrics/explorer.md
+++ b/content/en/metrics/explorer.md
@@ -59,7 +59,7 @@ Export all graphs to a new or existing timeboard with the buttons at the bottom 
 
 ### Snapshot
 
-Create a snapshot of an individual graph by using the share icon in the upper right. Clicking on the icon brings up a dropdown menu with the **Send snaphot...** option.
+Create a snapshot of an individual graph by using the share icon in the upper right. Clicking on the icon displays a dropdown menu with the **Send snaphot...** option.
 
 ## Further reading
 


### PR DESCRIPTION
My first PR!

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updated the text to match the new UI.

### Motivation
<!-- What inspired you to submit this pull request?-->
My hiring test.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/quickfix/metrics/explorer

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
