### PR TITLE
Remove stickyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
         "popper.js": "1.16.1",
         "safe-json-stringify": "^1.2.0",
         "slugify": "^1.4.6",
-        "stickyfilljs": "2.1.0",
         "tiny-async-pool": "^1.0.4",
         "translate": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/translate-v1.0.37.tgz",
         "traverse": "0.6.6",

--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -1,4 +1,3 @@
-import Stickyfill from 'stickyfilljs';
 import { initializeIntegrations } from './components/integrations';
 import { initializeSecurityRules } from './components/security-rules';
 import { updateTOC, buildTOCMap, onScroll, closeMobileTOC } from './components/table-of-contents';
@@ -67,13 +66,7 @@ $(document).ready(function () {
         });
     }
     
-
     updateMainContentAnchors();
-
-
-    // sticky polyfill trigger
-    const elements = document.querySelectorAll('.sticky');
-    Stickyfill.add(elements);
 
     // add targer-blank to external links
     const newLinks = document.getElementsByTagName('a');

--- a/yarn.lock
+++ b/yarn.lock
@@ -11327,11 +11327,6 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
-stickyfilljs@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/stickyfilljs/-/stickyfilljs-2.1.0.tgz#46dabb599d8275d185bdb97db597f86a2e3afa7b"
-  integrity sha512-LkG0BXArL5HbW2O09IAXfnBQfpScgGqJuUDUrI3Ire5YKjRz/EhakIZEJogHwgXeQ4qnTicM9sK9uYfWN11qKg==
-
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"


### PR DESCRIPTION
### What does this PR do?
Remove `Stickyfill.js` library

### Motivation
a) [The library is no longer maintained](https://github.com/wilddeer/stickyfill)
b) [All modern browsers have implemented `position: sticky`](https://caniuse.com/?search=position%3Asticky)
c) reduce JS bloat / general maintenance 

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/remove-stickyfill/

- Elements with sticky such as the left side navs and site/lang selectors continue to look and function properly
- No related JS errors in console

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
