### PR TITLE
[WEB-1123] Preconnect to Hotjar

### DIFF
--- a/layouts/partials/prefetch.html
+++ b/layouts/partials/prefetch.html
@@ -1,1 +1,2 @@
 <link rel="dns-prefetch preconnect" href="https://datadog-docs.imgix.net" />
+<link rel="dns-prefetch preconnect" href="https://static.hotjar.com">


### PR DESCRIPTION
### What does this PR do?
Browser resource hint - preconnect to Hotjar

### Motivation
Core Web Vitals reports show Docs pages with slow First Input Delay metric. I ran several Lighthouse tests over the last week and have randomly seen results where Hotjar scripts are blocking the main thread for a long period of time. (See this screen cap: [https://a.cl.ly/12uAXpLZ](https://a.cl.ly/12uAXpLZ)).  Preconnecting to Hotjar could potentially help alleviate this.

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/preconnect-hotjar/

- Not much to test here. In the document `<head>` should be a `<link rel='dns-prefetch preconnect'>` element pointing to Hotjar.  I ran 7-8 lighthouse tests on various pages in the preview and didn't notice any terrible TBT issues or diagnostic results about reducing the impact of 3rd party scripts.

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
