### PR TITLE
Security table of contents update

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1848,7 +1848,7 @@ main:
     identifier: cws_workload_security_rules
     weight: 303
   - name: OOTB Rules
-    url: security_platform/default_rules#cat-runtime-agent
+    url: security_platform/default_rules#cat-workload-security
     parent: cloud_workload_security
     identifier: cws_workload_default_rules
     weight: 304


### PR DESCRIPTION
### What does this PR do?

Missed updating the toc when I updated the product name

When you click on OOTB Rules under Cloud Workload security in the nav, it should go here:
https://docs-staging.datadoghq.com/kaylyn/security-toc-1/default_rules#cat-workload-security

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
