### PR TITLE
Add ephemeral_storage_allocatable and ephemeral_storage_capacity metr…

### DIFF
--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -183,6 +183,9 @@ datadog:
 `kubernetes_state.node.pods_allocatable`
 : The allocatable memory of a node that is available for scheduling. Tags:`node` `resource` `unit`.
 
+`kubernetes_state.node.ephemeral_storage_allocatable`
+: The allocatable ephemeral-storage of a node that is available for scheduling. Tags:`node` `resource` `unit`.
+
 `kubernetes_state.node.cpu_capacity`
 : The CPU capacity of a node. Tags:`node` `resource` `unit`.
 
@@ -191,6 +194,9 @@ datadog:
 
 `kubernetes_state.node.pods_capacity`
 : The pods capacity of a node. Tags:`node` `resource` `unit`.
+
+`kubernetes_state.node.ephemeral_storage_capacity`
+: The ephemeral-storage capacity of a node. Tags:`node` `resource` `unit`.
 
 `kubernetes_state.node.by_condition`
 : The condition of a cluster node. Tags:`condition` `node` `status`.


### PR DESCRIPTION
### What does this PR do?
Add new metrics to Kubernetes State Metrics Core check. 
* ```kubernetes_state.node.ephemeral_storage_allocatable```
* ```kubernetes_state.node.ephemeral_storage_capacity```

### Motivation
Update the new metrics add to the ksm core check.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
