### PR TITLE
Modified documentation for usage of get_correlation_ids()

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/python.md
+++ b/content/en/tracing/connect_logs_and_traces/python.md
@@ -58,18 +58,18 @@ hello()
 
 ### Without Standard Library Logging
 
-If you are not using the standard library `logging` module, you can use the `ddtrace.helpers.get_correlation_ids()` to inject tracer information into your logs.
+If you are not using the standard library `logging` module, you can use the helper method `ddtrace.tracer.get_correlation_ids()` to inject tracer information into your logs.
 As an illustration of this approach, the following example defines a function as a *processor* in `structlog` to add tracer fields to the log output:
 
 ``` python
 import ddtrace
-from ddtrace.helpers import get_correlation_ids
+from ddtrace import tracer
 
 import structlog
 
 def tracer_injection(logger, log_method, event_dict):
     # get correlation ids from current tracer context
-    trace_id, span_id = get_correlation_ids()
+    trace_id, span_id = tracer.get_correlation_ids()
 
     # add ids to structlog event dictionary
     event_dict['dd.trace_id'] = trace_id or 0


### PR DESCRIPTION
### What does this PR do?
Update the python integrations doc in logs_and_traces to the match the correct usage for the recently updated `get_correlation_ids()` helper function [PR](https://github.com/DataDog/dd-trace-py/pull/2488/files)


### Motivation
JIRA issue

### Preview
https://docs-staging.datadoghq.com/yunkim/apm_python_logs_and_traces/tracing/connect_logs_and_traces/python/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
