### PR TITLE
go profiler: Improve Search Profiles page

### DIFF
--- a/content/en/tracing/profiler/search_profiles.md
+++ b/content/en/tracing/profiler/search_profiles.md
@@ -137,10 +137,10 @@ CPU Time
 : Shows the time each function spent running on the CPU. Off-CPU time such as waiting for Networking, Channels, Mutexes and Sleep is not captured in this profile, see Mutex and Block profile.
 
 Allocations
-: Shows the amount of heap memory allocated by each function since the start of the application, including allocations which were subsequently freed. Go calls this `alloc_space`. This is useful for investigating garbage collection load.
+: Shows the number of objects allocated in heap memory by each function since the start of the application, including allocations which were subsequently freed. This is useful for investigating garbage collection load.
 
 Allocated Memory
-: Shows the number of objects allocated in heap memory by each function since the start of the application, including allocations which were subsequently freed. This is useful for investigating garbage collection load.
+: Shows the amount of heap memory allocated by each function since the start of the application, including allocations which were subsequently freed. Go calls this `alloc_space`. This is useful for investigating garbage collection load.
 
 Heap Live Objects
 : Shows the number of objects allocated in heap memory by each function, and which objects remained allocated since the start of the application and lived since the last garbage collection. This is useful for investigating the overall memory usage of your service.

--- a/content/en/tracing/profiler/search_profiles.md
+++ b/content/en/tracing/profiler/search_profiles.md
@@ -133,20 +133,20 @@ Exceptions
 Once enabled, the following profile types are collected:
 
 
-CPU
+CPU Time
 : Shows the time each function spent running on the CPU.
 
-Allocation
+Allocations
 : Shows the amount of heap memory allocated by each function since the start of the application, including allocations which were subsequently freed. Go calls this `alloc_space`. This is useful for investigating garbage collection load.
 
-Allocation Count
+Allocated Memory
 : Shows the number of objects allocated in heap memory by each function since the start of the application, including allocations which were subsequently freed. This is useful for investigating garbage collection load.
 
-Heap
-: Shows the amount of heap memory allocated by each function that remained allocated since the start of the application and lived since the last garbage collection. Go calls this `inuse_space`. This is useful for investigating the overall memory usage of your service.
-
-Heap Count
+Heap Live Objects
 : Shows the number of objects allocated in heap memory by each function, and which objects remained allocated since the start of the application and lived since the last garbage collection. This is useful for investigating the overall memory usage of your service.
+
+Heap Live Size
+: Shows the amount of heap memory allocated by each function that remained allocated since the start of the application and lived since the last garbage collection. Go calls this `inuse_space`. This is useful for investigating the overall memory usage of your service.
 
 {{< /programming-lang >}}
 {{< programming-lang lang="ruby" >}}

--- a/content/en/tracing/profiler/search_profiles.md
+++ b/content/en/tracing/profiler/search_profiles.md
@@ -148,6 +148,17 @@ Heap Live Objects
 Heap Live Size
 : Shows the amount of heap memory allocated by each function that remained allocated since the start of the application and lived since the last garbage collection. Go calls this `inuse_space`. This is useful for investigating the overall memory usage of your service.
 
+Mutex
+: Shows the time functions have been waiting on mutexes since the start of the application. The stack traces in this profile point the `Unlock()` operation that allowed another goroutine blocked on the mutex to proceed. Short mutex contentions using spinlocks are not captured by this profile, but can be seen in the CPU profile.
+
+Block
+: Shows the time functions have been waiting on mutexes and channel operations since the start of the application. Sleep, GC, Network and Syscall operations are not captured by this profile. Blocking operations are only captured after they become unblocked, so this profile cannot be used to debug applications that appear to be stuck. For mutex contentions, the stack traces in this profile point to blocked `Lock()` operations. This will tell you where your program is getting blocked, while the mutex profile tells you what part of your program is causing the contention. See our [Block Profiling in Go][1] research for more in-depth information.
+
+Goroutines
+: Shows a snapshot of the number of goroutines currently executing the same functions (On CPU as well as waiting Off-CPU). An increasing number of goroutines between snapshots can indicate that the program is leaking goroutines. In most healthy applications this profile is dominated by worker pools and shows the number of goroutines they utilize. Applications that are extremely latency sensitive and utilize a large number of goroutines (> 10.000) should be aware that enabling this profile requires O(N) stop-the-world pauses. The pauses occur only once every profiling period (default 60s) and normally last for `~1µsec` per goroutine. Typical applications with a p99 latency SLO of `~100ms` can generally ignore this warning. See our [Goroutine Profiling in Go][2] research for more in-depth information.
+
+[1]: https://github.com/DataDog/go-profiler-notes/blob/main/block.md
+[2]: https://github.com/DataDog/go-profiler-notes/blob/main/goroutine.md
 {{< /programming-lang >}}
 {{< programming-lang lang="ruby" >}}
 

--- a/content/en/tracing/profiler/search_profiles.md
+++ b/content/en/tracing/profiler/search_profiles.md
@@ -134,7 +134,7 @@ Once enabled, the following profile types are collected:
 
 
 CPU Time
-: Shows the time each function spent running on the CPU.
+: Shows the time each function spent running on the CPU. Off-CPU time such as waiting for Networking, Channels, Mutexes and Sleep is not captured in this profile, see Mutex and Block profile.
 
 Allocations
 : Shows the amount of heap memory allocated by each function since the start of the application, including allocations which were subsequently freed. Go calls this `alloc_space`. This is useful for investigating garbage collection load.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Improves the [Search Profiles](https://docs.datadoghq.com/tracing/profiler/search_profiles) documentation for Go.

- Adds 3 missing profile types (Block/Mutex/Goroutines)
- Slightly expands the CPU Time docs
- Aligns the profile type names to match the names currently used in the UI.

### Motivation
<!-- What inspired you to submit this pull request?-->

Better docs -> happy users 😃 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/felix.geisendoerfer/go-profiler-types/tracing/profiler/search_profiles/?code-lang=go

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
