### PR TITLE
Add monitor notification local time variable

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -138,15 +138,15 @@ Template variables that return numerical values support operations and functions
 
 #### Local time
 
-Use the `local_time` function to transform a date into its local time:`{{local_time 'time_variable' 'timezone'}}`.
-For example, to show the last triggered time of the monitor in the Tokyo timezone in your notification, include the following in the notification message:
+Use the `local_time` function to transform a date into its local time: `{{local_time 'time_variable' 'timezone'}}`.
+For example, to show the last triggered time of the monitor in the Tokyo time zone in your notification, include the following in the notification message:
 
 ```
 {{local_time 'last_triggered_at' 'Asia/Tokyo'}}
 ```
 
-The result are displayed in the ISO8601 format: yyyy-MM-dd HH:mm:ss±HH:mm. Example `2021-05-31 23:43:27+09:00`. 
-Check the [TZ database name][15] column to see the list of available timezones values.
+The result is displayed in the ISO 8601 format: `yyyy-MM-dd HH:mm:ss±HH:mm`, for example `2021-05-31 23:43:27+09:00`. 
+Refer to the [list of tz database time zones][15], particularly the TZ database name column, to see the list of available time zone values.
 
 ### Tag variables
 

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -136,6 +136,18 @@ Use template variables to customize your monitor notifications. The built-in var
 
 Template variables that return numerical values support operations and functions, which allow you to perform mathematical operations or formatting changes to the value. For full details, see [Template Variable Evaluation][13].
 
+#### Local time
+
+Use the `local_time` function to transform a date into its local time:`{{local_time 'time_variable' 'timezone'}}`.
+For example, to show the last triggered time of the monitor in the Tokyo timezone in your notification, include the following in the notification message:
+
+```
+{{local_time 'last_triggered_at' 'Asia/Tokyo'}}
+```
+
+The result are displayed in the ISO8601 format: yyyy-MM-dd HH:mm:ss±HH:mm. Example `2021-05-31 23:43:27+09:00`. 
+Check the [TZ database name][15] column to see the list of available timezones values.
+
 ### Tag variables
 
 Tag variables can be used in multi-alert monitors based on the tags selected in the multi-alert group box. This works for any tag following the `key:value` syntax.
@@ -524,3 +536,4 @@ If `host.name` matches `<HOST_NAME>`, the template outputs:
 [12]: /events/
 [13]: /monitors/guide/template-variable-evaluation/
 [14]: /monitors/faq/what-are-recovery-thresholds/
+[15]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add instruction for the `local_time` function

### Motivation
This function was recently added

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/monitor-notification-local-timezone/monitors/notifications/?tab=is_alert#evaluation

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
