### PR TITLE
Fix typo in catalina_opts on tomcat/windows

### DIFF
--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -155,7 +155,7 @@ CATALINA_OPTS="$CATALINA_OPTS -javaagent:/path/to/dd-java-agent.jar"
 Or on Windows, `setenv.bat`:
 
 ```text
-set CATALINA_OPTS_OPTS=%CATALINA_OPTS_OPTS% -javaagent:"c:\path\to\dd-java-agent.jar"
+set CATALINA_OPTS=%CATALINA_OPTS% -javaagent:"c:\path\to\dd-java-agent.jar"
 ```
 If a `setenv` file does not exist, create it in the `./bin` directory of the Tomcat project folder.
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
replace CATALINA_OPTS_OPTS=%CATALINA_OPTS_OPTS% with CATALINA_OPTS=%CATALINA_OPTS%

### Motivation
<!-- What inspired you to submit this pull request?-->
CATALINA_OPTS_OPTS=%CATALINA_OPTS_OPTS% should be CATALINA_OPTS=%CATALINA_OPTS%

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
