### PR TITLE
update clipboard export docs

### DIFF
--- a/content/en/monitors/incident_management/datadog_clipboard.md
+++ b/content/en/monitors/incident_management/datadog_clipboard.md
@@ -46,7 +46,9 @@ The Clipboard holds a maximum of 20 signals. Remove signals by deleting them ind
 
 ## Exporting
 
-Items on the Clipboard can be exported to dashboards, notebooks, or incidents. `Shift + Click` to select multiple items. In the export menu, choose a new export destination, or search through existing dashboards, notebooks, and incidents. Only [supported graphs][1] can be exported to Notebooks.
+Items on the Clipboard can be exported to Dashboards, Notebooks, or Incidents using keyboard shortcuts or the export menu. To copy an individual signal, hover over it and use `Cmd/Ctrl + C` to copy, and paste it into a dashboard or notebook with `Cmd/Ctrl + V`. To copy multiple signals, use  `Shift + Click` to select graphs and links, and use `Cmd/Ctrl + C` to copy them.
+
+Alternatively, export your selection to a new or existing dashboard, notebook, or incident using the export menu. Only [supported graphs][1] can be exported to Notebooks.
 
 {{< img src="monitors/incidents/exporting.png" alt="Export from the Clipboard"  style="width:80%;">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- updates the export section of Datadog Clipboard docs

### Motivation
<!-- What inspired you to submit this pull request?-->
- new feature: `cmd+c` support
- multi-signal copy support

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/stephanieniu/clipboard/monitors/incident_management/datadog_clipboard/#exporting

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
