### PR TITLE
DOCS-1575 - adding docker deprecation guide

### DIFF
--- a/content/en/agent/guide/_index.md
+++ b/content/en/agent/guide/_index.md
@@ -25,6 +25,7 @@ private: true
     {{< nextlink href="agent/guide/ad_identifiers" >}}Apply an Autodiscovery configuration file template to a given container with the ad_identifers parameter.{{< /nextlink >}}
     {{< nextlink href="agent/guide/operator-advanced" >}}Advanced setup for Datadog Operator.{{< /nextlink >}}
     {{< nextlink href="/agent/guide/container-images-for-docker-environments" >}}Container Images for Docker Environments{{< /nextlink >}}
+    {{< nextlink href="/agent/guide/docker-deprecation" >}}Deprecating Docker in Kubernetes{{< /nextlink >}}
 {{< /whatsnext >}}
 <br>
 {{< whatsnext desc="Agent 5 Guides:" >}}

--- a/content/en/agent/guide/docker-deprecation.md
+++ b/content/en/agent/guide/docker-deprecation.md
@@ -9,13 +9,13 @@ Kubernetes is deprecating Docker as a runtime starting after version 1.20, and s
 
 - GKE 1.19 [deprecated Docker and uses containerd by default, on new nodes][2].
 
-If you are running a version of Kubernetes where Docker has been deprecated, the Docker socket is no longer present, and the Docker check does not work. This means that you will have to enable either the [containerd][3] or the [CRI-O][4] check depending on the container runtime you are using. The container metrics collected from the new container runtime replace the Docker metrics.
+If you are running a version of Kubernetes where Docker has been deprecated, the Docker socket is no longer present, and the Docker check does not work. This means that you must enable either the [containerd][3] or the [CRI-O][4] check depending on the container runtime you are using. The container metrics collected from the new container runtime replace the Docker metrics.
 
-With version 7.27+ of the Datadog Agent, the Agent automatically detects the environment you are running, and you do not to make any configuration changes.
+With version 7.27+ of the Datadog Agent, the Agent automatically detects the environment you are running, and you do not need to make any configuration changes.
 
-**If you are using Agent < v7.26, then you will need to specify your container runtime socket path:**
+**If you are using Agent < v7.26, you must specify your container runtime socket path:**
 
-Note that you may need to update your existing monitors, dashboards and SLOs because metrics names will change—for example, from `docker.*` to `containerd.*`.
+**Note**: You may need to update your existing monitors, dashboards, and SLOs because metrics names will change—for example, from `docker.*` to `containerd.*`.
 
 {{< tabs >}}
 {{% tab "Helm" %}}
@@ -33,7 +33,7 @@ criSocketPath:  /var/run/containerd/containerd.sock
 
 Remove any references to the Docker socket, as well as any Docker socket volume mounts.
 
-Use the environment variable `DD_CRI_SOCKET_PATH` to point to your container runtime socket path. This should be set on all Agent containers if using dedicated containers:
+Use the environment variable `DD_CRI_SOCKET_PATH` to point to your container runtime socket path. Set on all Agent containers if using dedicated containers:
 
 ```
 env:
@@ -41,7 +41,7 @@ env:
     value: /var/run/containerd/containerd.sock
 ```
 
-You will also have to mount the socket from your host to the Agent container:
+Mount the socket from your host to the Agent container:
 
 ```
 volumeMounts:

--- a/content/en/agent/guide/docker-deprecation.md
+++ b/content/en/agent/guide/docker-deprecation.md
@@ -1,0 +1,64 @@
+---
+title: Docker Deprecation
+kind: documentation
+further_reading:
+- link: "/agent/autodiscovery/"
+  tag: "Documentation"
+  text: "Autodiscovery"
+---
+
+Kubernetes is deprecating Docker as a runtime starting after version 1.20, and some cloud providers have deprecated Docker in their images. 
+
+- AKS 1.19 [deprecated Docker and uses containerd by default][1].
+
+- GKE 1.19 [deprecated Docker and uses containerd by default, on new nodes][2].
+
+If you are running a version of Kubernetes where Docker has been deprecated, the Docker socket is no longer present, and the Docker check does not work. This means that you will have to enable either the [containerd][3] or the [CRI-O][4] check depending on the container runtime you are using. The container metrics collected from the new container runtime replace the Docker metrics.
+
+With version 7.27+ of the Datadog Agent, the Agent automatically detects the environment you are running, and you do not to make any configuration changes.
+
+**If you are using Agent < v7.26, then you will need to specify your container runtime socket path:**
+
+{{< tabs >}}
+{{% tab "Helm" %}}
+Set the path to your container runtime socket with the `criSocketPath` parameter in the [Helm chart][1].
+
+[1]: https://github.com/DataDog/helm-charts/blob/d8817b4401b75b1a064481da989c451633249ea9/charts/datadog/values.yaml#L262-L263
+{{% /tab %}}
+{{% tab "DaemonSet" %}}
+
+Remove any references to the Docker socket, as well as any Docker socket volume mounts.
+
+Use the environment variable `DD_CRI_SOCKET_PATH` to point to your container runtime socket path. This should be set on all Agent containers if using dedicated containers:
+
+```
+env:
+  - name: DD_CRI_SOCKET_PATH
+    value: /var/run/containerd/containerd.sock
+```
+
+You will also have to mount the socket from your host to the Agent container:
+
+```
+volumeMounts:
+  - name: containerdsocket
+    mountPath: /var/run/containerd/containerd.sock
+  - mountPath: /host/var/run
+    name: var-run
+    readOnly: true
+volumes:
+  - hostPath:
+      path: /var/run/containerd/containerd.sock
+    name: containerdsocket
+  - hostPath:
+      path: /var/run
+    name: var-run
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+[1]: https://github.com/Azure/AKS/releases/tag/2020-11-16
+[2]: https://cloud.google.com/kubernetes-engine/docs/release-notes#december_8_2020
+[3]: /integrations/containerd/
+[4]: /integrations/crio/

--- a/content/en/agent/guide/docker-deprecation.md
+++ b/content/en/agent/guide/docker-deprecation.md
@@ -21,6 +21,12 @@ Note that you may need to update your existing monitors, dashboards and SLOs bec
 {{% tab "Helm" %}}
 Set the path to your container runtime socket with the `criSocketPath` parameter in the [Helm chart][1].
 
+For example:
+
+```
+criSocketPath:  /var/run/containerd/containerd.sock
+```
+
 [1]: https://github.com/DataDog/helm-charts/blob/d8817b4401b75b1a064481da989c451633249ea9/charts/datadog/values.yaml#L262-L263
 {{% /tab %}}
 {{% tab "DaemonSet" %}}

--- a/content/en/agent/guide/docker-deprecation.md
+++ b/content/en/agent/guide/docker-deprecation.md
@@ -19,6 +19,8 @@ With version 7.27+ of the Datadog Agent, the Agent automatically detects the env
 
 **If you are using Agent < v7.26, then you will need to specify your container runtime socket path:**
 
+Note that you may need to update your existing monitors, dashboards and SLOs because metrics names will change—for example, from `docker.*` to `containerd.*`.
+
 {{< tabs >}}
 {{% tab "Helm" %}}
 Set the path to your container runtime socket with the `criSocketPath` parameter in the [Helm chart][1].

--- a/content/en/agent/guide/docker-deprecation.md
+++ b/content/en/agent/guide/docker-deprecation.md
@@ -1,10 +1,6 @@
 ---
-title: Docker Deprecation
+title: Docker Deprecation in Kubernetes
 kind: documentation
-further_reading:
-- link: "/agent/autodiscovery/"
-  tag: "Documentation"
-  text: "Autodiscovery"
 ---
 
 Kubernetes is deprecating Docker as a runtime starting after version 1.20, and some cloud providers have deprecated Docker in their images. 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
adds a guide about docker being deprecated as a runtime in kubernetes

### Motivation
docker is gettin deprecated in kubernetes

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/cswatt/docker-deprecation/agent/guide/docker-deprecation

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
