### PR TITLE
Caroline.kim/ecs fargate flare instructions

### DIFF
--- a/content/en/agent/troubleshooting/send_a_flare.md
+++ b/content/en/agent/troubleshooting/send_a_flare.md
@@ -54,7 +54,7 @@ To get a flare from each container, run the following commands:
 ### Agent
 
 ```bash
-kubectl exec -it <agent-pod-name> -c agent -- agent flare <case-id>
+kubectl exec -it <AGENT_POD_NAME> -c agent -- agent flare <CASE_ID>
 ```
 
 ### Process Agent
@@ -81,6 +81,7 @@ kubectl logs <AGENT_POD_NAME> -c system-probe > system-probe.log
 [2]: /agent/basic_agent_usage/windows/#agent-v6
 [3]: /agent/faq/heroku-troubleshooting/#send-a-flare
 [4]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/CHANGELOG.md
+[5]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
@@ -111,6 +112,20 @@ kubectl logs <AGENT_POD_NAME> -c system-probe > system-probe.log
 
 {{% /tab %}}
 {{< /tabs >}}
+
+## ECS Fargate
+
+When using ECS Fargate platform v1.4.0, ECS tasks and services can be configured to allow access to running Linux containers by enabling [Amazon ECS Exec][5]. Once configured, run the following command to send a flare:
+
+```bash
+aws ecs execute-command --cluster <CLUSTER_NAME> \
+    --task <TASK_ID> \
+    --container datadog-agent \
+    --interactive \
+    --command "agent flare <CASE_ID>"
+```
+
+**Note:** ECS Exec can only be enabled for new tasks. Existing tasks need to be recreated in order to use ECS Exec.
 
 ## Manual submission
 

--- a/content/en/agent/troubleshooting/send_a_flare.md
+++ b/content/en/agent/troubleshooting/send_a_flare.md
@@ -77,6 +77,20 @@ The system-probe container cannot send a flare so get container logs instead:
 kubectl logs <AGENT_POD_NAME> -c system-probe > system-probe.log
 ```
 
+## ECS Fargate
+
+When using ECS Fargate platform v1.4.0, ECS tasks and services can be configured to allow access to running Linux containers by enabling [Amazon ECS Exec][5]. Once configured, run the following command to send a flare:
+
+```bash
+aws ecs execute-command --cluster <CLUSTER_NAME> \
+    --task <TASK_ID> \
+    --container datadog-agent \
+    --interactive \
+    --command "agent flare <CASE_ID>"
+```
+
+**Note:** ECS Exec can only be enabled for new tasks. Existing tasks need to be recreated in order to use ECS Exec.
+
 [1]: /agent/basic_agent_usage/#gui
 [2]: /agent/basic_agent_usage/windows/#agent-v6
 [3]: /agent/faq/heroku-troubleshooting/#send-a-flare
@@ -112,20 +126,6 @@ kubectl logs <AGENT_POD_NAME> -c system-probe > system-probe.log
 
 {{% /tab %}}
 {{< /tabs >}}
-
-## ECS Fargate
-
-When using ECS Fargate platform v1.4.0, ECS tasks and services can be configured to allow access to running Linux containers by enabling [Amazon ECS Exec][5]. Once configured, run the following command to send a flare:
-
-```bash
-aws ecs execute-command --cluster <CLUSTER_NAME> \
-    --task <TASK_ID> \
-    --container datadog-agent \
-    --interactive \
-    --command "agent flare <CASE_ID>"
-```
-
-**Note:** ECS Exec can only be enabled for new tasks. Existing tasks need to be recreated in order to use ECS Exec.
 
 ## Manual submission
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds instructions to send a flare on ECS Fargate 1.4.0 using ECS Exec

### Motivation
With AWS' release of ECS Exec, users can easily send flares from ECS Fargate

### Preview

https://docs-staging.datadoghq.com/caroline.kim/ecs-fargate-flare-instructions/agent/troubleshooting/send_a_flare/?tab=agentv6v7

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
