### PR TITLE
Event rate limit update

### DIFF
--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -15,7 +15,8 @@ Regarding the API rate limit policy:
 
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
 - The rate limit for metric **retrieval** is `100` per hour per organization.
-- The rate limit for event submission is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
+- The rate limit for event submission is `500'000` events per hour per organization.
+- The rate limit for event aggregation is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
 - The rate limit for the [Query a Timeseries API][4] call is `1600` per hour per organization. This can be extended on demand.
 - The rate limit for the [Log Query API][5] call is `300` per hour per organization. This can be extended on demand.
 - The rate limit for the [Graph a Snapshot API][6] call is `60` per hour per organization. This can be extended on demand.

--- a/content/en/api/v1/rate-limits/_index.md
+++ b/content/en/api/v1/rate-limits/_index.md
@@ -15,7 +15,8 @@ Regarding the API rate limit policy:
 
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
 - The rate limit for metric **retrieval** is `100` per hour per organization.
-- The rate limit for event submission is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
+- The rate limit for event submission is `500'000` events per hour per organization.
+- The rate limit for event aggregation is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
 - The rate limit for the [Query a Timeseries API][4] call is `1600` per hour per organization. This can be extended on demand.
 - The rate limit for the [Log Query API][5] call is `300` per hour per organization. This can be extended on demand.
 - The rate limit for the [Graph a Snapshot API][6] call is `60` per hour per organization. This can be extended on demand.

--- a/content/en/api/v2/rate-limits/_index.md
+++ b/content/en/api/v2/rate-limits/_index.md
@@ -15,7 +15,8 @@ Regarding the API rate limit policy:
 
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
 - The rate limit for metric **retrieval** is `100` per hour per organization.
-- The rate limit for event submission is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
+- The rate limit for event submission is `500'000` events per hour per organization.
+- The rate limit for event aggregation is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
 - The rate limit for the [Query a Timeseries API][4] call is `1600` per hour per organization. This can be extended on demand.
 - The rate limit for the [Log Query API][5] call is `300` per hour per organization. This can be extended on demand.
 - The rate limit for the [Graph a Snapshot API][6] call is `60` per hour per organization. This can be extended on demand.


### PR DESCRIPTION
### What does this PR do?

Clarified rate limit in public documentation as current version described only the maximum number of events that can be grouped in the event stream using the "aggregate related events" feature.
The rate limit of 500'000 events per hour is a "soft limit": it triggers the stringer process, and customer will be contacted.
We will likely remove this limit later when event migration is done

https://docs-staging.datadoghq.com/sguyon/ratelimitupdate/api/latest/rate-limits/