### PR TITLE
Update credit card mask sequence

### DIFF
--- a/content/en/agent/faq/commonly-used-log-processing-rules.md
+++ b/content/en/agent/faq/commonly-used-log-processing-rules.md
@@ -84,7 +84,7 @@ Redact credit card numbers for Visa, Mastercard, American Express, Diner's Club,
   pattern: (?:4[0-9]{12}(?:[0-9]{3})?|[25][1-7][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})
 ```
 
-The above rule may cause interference when connecting logs and traces as trace id's can match the above format. If connecting logs and traces and you wish to use the above regular expression, consider the below.
+The above rule may cause interference when connecting logs and traces as trace IDs can match the above format. If connecting logs and traces and you wish to use the above regular expression, consider the below example:
 
 ```yaml
 - type: mask_sequences

--- a/content/en/agent/faq/commonly-used-log-processing-rules.md
+++ b/content/en/agent/faq/commonly-used-log-processing-rules.md
@@ -84,6 +84,15 @@ Redact credit card numbers for Visa, Mastercard, American Express, Diner's Club,
   pattern: (?:4[0-9]{12}(?:[0-9]{3})?|[25][1-7][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})
 ```
 
+The above rule may cause interference when connecting logs and traces as trace id's can match the above format. If connecting logs and traces and you wish to use the above regular expression, consider the below.
+
+```yaml
+- type: mask_sequences
+  name: visa_mc_amex_diners_discover_jcb_credit_card
+  replace_placeholder: "[CREDIT CARD REDACTED]"
+  pattern: \b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|6(?:011|5[0-9]{2})[0-9]{12}|(?:2131|1800|35\d{3})\d{11})\b
+```
+
 ## Postal codes
 
 Redact postal codes (US).


### PR DESCRIPTION
This stems from a ticket/escalation where this rule caused issues. The proposed solution came from here and worked in the related tickets: https://datadoghq.atlassian.net/browse/LOGSS-4523?focusedCommentId=410150

In saying that, this hasn't been extensively tested so I'm not sure if it would need approval from the logs/apm team.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates the mask sequences section of the below article.

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadog.zendesk.com/agent/tickets/495224

### Preview
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/agent/faq/commonly-used-log-processing-rules/#credit-card-numbers

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
