### PR TITLE
[WEB-1306] Update Links to Alerts Product Page

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -84,7 +84,7 @@ main_left:
   - identifier: alerts
     name: Alerts
     pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/alert.svg' alt='alert icon'>"
-    url: "https://www.datadoghq.com/product/platform/alerts/"
+    url: "https://www.datadoghq.com/product/alerts/"
     weight: 14
     parent: product
   - identifier: api
@@ -2528,7 +2528,7 @@ footer_product:
     url: "https://www.datadoghq.com/product/serverless-monitoring/"
     weight: 140
   - name: Alerts
-    url: "https://www.datadoghq.com/product/platform/alerts/"
+    url: "https://www.datadoghq.com/product/alerts/"
     weight: 145
   - name: API
     url: "https://docs.datadoghq.com/api/"
@@ -2541,7 +2541,7 @@ footer_product_two:
     url: "https://www.datadoghq.com/product/serverless-monitoring/"
     weight: 140
   - name: Alerts
-    url: "https://www.datadoghq.com/product/platform/alerts/"
+    url: "https://www.datadoghq.com/product/alerts/"
     weight: 145
   - name: API
     url: "https://docs.datadoghq.com/api/"

--- a/config/_default/menus/menus.fr.yaml
+++ b/config/_default/menus/menus.fr.yaml
@@ -84,7 +84,7 @@ main_left:
   - identifier: alerts
     name: Alerts
     pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/alert.svg' alt='alert icon'>"
-    url: "https://www.datadoghq.com/product/platform/alerts/"
+    url: "https://www.datadoghq.com/product/alerts/"
     weight: 14
     parent: product
   - identifier: api
@@ -3952,7 +3952,7 @@ footer_product:
     url: "https://www.datadoghq.com/product/serverless-monitoring/"
     weight: 140
   - name: Alertes
-    url: "https://www.datadoghq.com/product/platform/alerts/"
+    url: "https://www.datadoghq.com/product/alerts/"
     weight: 145
   - name: API
     url: api
@@ -3965,7 +3965,7 @@ footer_product_two:
     url: "https://www.datadoghq.com/product/serverless-monitoring/"
     weight: 140
   - name: Alertes
-    url: "https://www.datadoghq.com/product/platform/alerts/"
+    url: "https://www.datadoghq.com/product/alerts/"
     weight: 145
   - name: API
     url: api

--- a/config/_default/menus/menus.ja.yaml
+++ b/config/_default/menus/menus.ja.yaml
@@ -84,7 +84,7 @@ main_left:
   - identifier: alerts
     name: Alerts
     pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/alert.svg' alt='alert icon'>"
-    url: "https://www.datadoghq.com/product/platform/alerts/"
+    url: "https://www.datadoghq.com/product/alerts/"
     weight: 14
     parent: product
   - identifier: api
@@ -2415,7 +2415,7 @@ footer_product:
     url: "https://www.datadoghq.com/product/serverless-monitoring/"
     weight: 140
   - name: アラート
-    url: "https://www.datadoghq.com/product/platform/alerts/"
+    url: "https://www.datadoghq.com/product/alerts/"
     weight: 145
   - name: API
     url: "https://docs.datadoghq.com/api/"
@@ -2428,7 +2428,7 @@ footer_product_two:
     url: "https://www.datadoghq.com/product/serverless-monitoring/"
     weight: 140
   - name: アラート
-    url: "https://www.datadoghq.com/product/platform/alerts/"
+    url: "https://www.datadoghq.com/product/alerts/"
     weight: 145
   - name: API
     url: "https://docs.datadoghq.com/api/"

--- a/data/partials/footer.fr.yaml
+++ b/data/partials/footer.fr.yaml
@@ -35,7 +35,7 @@ col1:
     link: 'https://www.datadoghq.com/product/serverless-monitoring/'
     title: Informatique sans serveur
   - name: alerts
-    link: 'https://www.datadoghq.com/product/platform/alerts/'
+    link: 'https://www.datadoghq.com/product/alerts/'
     title: Alertes
 col2:
   - name: pricing

--- a/data/partials/footer.ja.yaml
+++ b/data/partials/footer.ja.yaml
@@ -35,7 +35,7 @@ col1:
     link: 'https://www.datadoghq.com/product/serverless-monitoring/'
     title: サーバーレス
   - name: alerts
-    link: 'https://www.datadoghq.com/product/platform/alerts/'
+    link: 'https://www.datadoghq.com/product/alerts/'
     title: アラート
 col2:
   - name: pricing

--- a/data/partials/header.fr.yaml
+++ b/data/partials/header.fr.yaml
@@ -48,7 +48,7 @@ left:
         title: Informatique sans serveur
         pre: '<img class=''menu-icon mr-1'' src=''https://imgix.datadoghq.com/img/navbar/menu/serverless.svg'' alt=''icône sans serveur''>'
       - name: product_alerts
-        link: 'https://www.datadoghq.com/product/platform/alerts/'
+        link: 'https://www.datadoghq.com/product/alerts/'
         title: Alertes
         pre: '<img class=''menu-icon mr-1'' src=''https://imgix.datadoghq.com/img/navbar/menu/alert.svg'' alt=''icône alerte''>'
       - name: product_api

--- a/data/partials/header.ja.yaml
+++ b/data/partials/header.ja.yaml
@@ -48,7 +48,7 @@ left:
         title: サーバーレス
         pre: '<img class=''menu-icon mr-1'' src=''https://imgix.datadoghq.com/img/navbar/menu/serverless.svg'' alt=''サーバーレスアイコン''>'
       - name: product_alerts
-        link: 'https://www.datadoghq.com/product/platform/alerts/'
+        link: 'https://www.datadoghq.com/product/alerts/'
         title: アラート
         pre: '<img class=''menu-icon mr-1'' src=''https://imgix.datadoghq.com/img/navbar/menu/alert.svg'' alt=''アラートアイコン''>'
       - name: product_api


### PR DESCRIPTION
### What does this PR do?
Update nav link to corpsite Alerts page.

### Motivation
Alerts page has move to product/alerts from product/platform/alerts
https://datadoghq.atlassian.net/browse/WEB-1306

### Preview
https://docs-staging.datadoghq.com/davidweid/alerts-nav-update/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
