### PR TITLE
add steps for enabling runtime metrics without ddtrace-run

### DIFF
--- a/content/en/tracing/runtime_metrics/python.md
+++ b/content/en/tracing/runtime_metrics/python.md
@@ -23,7 +23,14 @@ This feature is currently in private beta. <a href="https://docs.datadoghq.com/h
 
 ## Automatic configuration
 
-Runtime metrics collection can be enabled with the `DD_RUNTIME_METRICS_ENABLED=true` environment parameter when running with `ddtrace-run`:
+Runtime metrics collection can be enabled with the `DD_RUNTIME_METRICS_ENABLED=true` environment parameter when running with `ddtrace-run`.
+
+If you are not using `ddtrace-run`, you can enable runtime metrics collection in code:
+
+```python
+from ddtrace.runtime import RuntimeMetrics
+RuntimeMetrics.enable()
+```
 
 Runtime metrics can be viewed in correlation with your Python services. See the [Service page][1] in Datadog.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

We had only described how to enable runtime metrics with ddtrace-run. This PR includes steps for enabling in code.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/python-runtime-metrics-manual/tracing/runtime_metrics/python/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
