### PR TITLE
Fix links on Profiler language tiles

### DIFF
--- a/content/en/tracing/profiler/connect_traces_and_profiles.md
+++ b/content/en/tracing/profiler/connect_traces_and_profiles.md
@@ -39,7 +39,7 @@ Requires:
 - OpenJDK 8u282 or greater
 
 
-[1]: /tracing/profiler/enabling
+[1]: /tracing/profiler/enabling/?code-lang=java
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}
 
@@ -48,7 +48,7 @@ Code Hotspots identification is enabled by default when you [turn on profiling f
 Requires tracing library version 0.44.0 or greater.
 
 
-[1]: /tracing/profiler/enabling
+[1]: /tracing/profiler/enabling/?code-lang=python
 {{< /programming-lang >}}
 {{< programming-lang lang="ruby" >}}
 
@@ -57,7 +57,7 @@ Code Hotspots identification is enabled by default when you [turn on profiling f
 Requires tracing library version 0.49.0 or greater.
 
 
-[1]: /tracing/profiler/getting_started
+[1]: /tracing/profiler/enabling/?code-lang=ruby
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 

--- a/layouts/partials/profiling/profiling-languages.html
+++ b/layouts/partials/profiling/profiling-languages.html
@@ -2,22 +2,22 @@
 <div class="profiling-languages">
   <div class="container cards-dd">
     <div class="card-deck">
-      <a class="card" href="/tracing/profiler/getting_started/?code-lang=java">
+      <a class="card" href="/tracing/profiler/enabling/?code-lang=java">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
         </div>
       </a>
-      <a class="card" href="/tracing/profiler/getting_started/?code-lang=python">
+      <a class="card" href="/tracing/profiler/enabling/?code-lang=python">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
         </div>
       </a>
-      <a class="card" href="/tracing/profiler/getting_started/?code-lang=go">
+      <a class="card" href="/tracing/profiler/enabling/?code-lang=go">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/golang.png" "class" "img-fluid" "alt" "Go" "width" "400") }}
         </div>
       </a>
-      <a class="card" href="/tracing/profiler/getting_started/?code-lang=ruby">
+      <a class="card" href="/tracing/profiler/enabling/?code-lang=ruby">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
         </div>


### PR DESCRIPTION
### What does this PR do?
Fixes links to new "enabling" page on profiler index tiles (and one other link)

### Motivation
Report in profiler-docs Slack channel

### Preview
https://docs-staging.datadoghq.com/kari/profile-langs/tracing/profiler/  <-- tiles should take you to the language you selected.


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
