### PR TITLE
Clarify that Log facet variables need "@"

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -182,7 +182,7 @@ Log monitors can use facets as variables if the monitor is grouped by the facets
 For example, if your log monitor is grouped by the `facet`, the variable is:
 
 ```text
-{{ facet.name }}
+{{ @facet.name }}
 ```
 **Example**: To include the information in a multi alert log monitor group by `@machine_id`: 
 


### PR DESCRIPTION
Log facet variables need "@" in order to work, but the documentation says `{{ facet.name }}`, which can cause confusion. I've added the `@` in order to clarify that log facet variables need `@` (i.e., `{{ @facet.name }}`).

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
