### PR TITLE
[apm]: update ruby version compatibility

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/ruby.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/ruby.md
@@ -30,10 +30,10 @@ The Ruby Datadog Trace library is open source - view the [Github repository][1] 
 |       |                            | 2.3     | Full                                 | Latest              |
 |       |                            | 2.2     | Full                                 | Latest              |
 |       |                            | 2.1     | Full                                 | Latest              |
-|       |                            | 2.0     | Full                                 | Latest              |
+|       |                            | 2.0     | Maintenance (until June 7th, 2021)   | < 0.50.0            |
 |       |                            | 1.9.3   | Maintenance (until August 6th, 2020) | < 0.27.0            |
 |       |                            | 1.9.1   | Maintenance (until August 6th, 2020) | < 0.27.0            |
-| JRuby | https://www.jruby.org      | 9.2     | Full                                | Latest              |
+| JRuby | https://www.jruby.org      | 9.2     | Full                                 | Latest              |
 
 **Supported web servers**:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

It does so much. Mostly it makes a minor change to apm ruby min version requirements.

### Motivation
<!-- What inspired you to submit this pull request?-->

We no longer support Ruby 2.0 in dd-trace-rb, so we should update our docs to reflect this.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ericmustin/update_ruby_version_compatibility/tracing/setup_overview/compatibility_requirements/ruby

### Additional Notes
<!-- Anything else we should know when reviewing?-->

No not really, thanks for reviewing!

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
