### PR TITLE
CI: Use realistic custom tags for Jenkins setup

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -100,11 +100,11 @@ The Datadog plugin adds a `datadog` step that allows adding custom tags to your 
 In declarative pipelines, add the step to a top-level option block:
 
 ```groovy
-def DD_TEST = "bar"
+def DD_TYPE = "release"
 pipeline {
     agent any
     options {
-        datadog(tags: ["foo:bar", "bar:${DD_TEST}", "${DD_TEST}:value"])
+        datadog(tags: ["team:backend", "type:${DD_TYPE}", "${DD_TYPE}:canary"])
     }
     stages {
         stage('Example') {
@@ -119,7 +119,7 @@ pipeline {
 In scripted pipelines, wrap the relevant section with the `datadog` step:
 
 ```groovy
-datadog(tags: ["foo:bar", "bar:baz"]){
+datadog(tags: ["team:backend", "release:canary"]){
     node {
         stage('Example') {
             echo "Hello world."


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR modifies the Jenkins setup to use realistic custom tags.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/drodriguezhdez/improve_jenkins_docs

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
