### PR TITLE
[agent] Document the ability to use vector

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2572,6 +2572,11 @@ main:
     pre: nav_help
     identifier: help_top_level
     weight: 240000
+  - name: Aggregating Agents
+    url: agent/vector_aggregation/
+    parent: agent
+    identifier: vector_aggregation
+    weight: 13
 footer_product:
   - name: Features
     url: 'https://www.datadoghq.com/product/'

--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -106,7 +106,7 @@ transforms:
     inputs:
       - datadog_logs # It's the name of the preconfigured Datadog source
     source: |
-      .ddtags = add_datadog_tags!(.ddtags, ["sender:vector"])
+      .ddtags = .ddtags + ",sender:vector"
 
 sinks:
   to_datadog:

--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -24,7 +24,7 @@ process data before sending them to Datadog. Vector capability includes:
 * Log deduplication to avoid duplicated log to be send
 * Transforming logs using the [Vector Remap Language][2]
 
-** Note **: Only logs aggregation is supported, support for other data type (metrics, processes, traces, etc.)
+**Note**: Only logs aggregation is supported, support for other data type (metrics, processes, traces, etc.)
 is scheduled for later.
 
 ## Configuration

--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -46,6 +46,7 @@ Only the logs data type is currently supported. Update the following values in t
 logs_config:
   logs_dd_url: "<VECTOR_HOST>:<VECTOR_PORT>"
   logs_no_ssl: true # If TLS/SSL is not enabled on the vector side
+  use_http: true # Vector `datadog_logs` source only supports HTTP
 ```
 
 Where `VECTOR_HOST` is the hostname of the system running Vector and `VECTOR_PORT` is the TCP port on which

--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -1,0 +1,100 @@
+---
+title: Aggregating multiple agents using Vector
+kind: documentation
+further_reading:
+- link: "/logs/"
+  tag: "Documentation"
+  text: "Collect your logs"
+- link: "/agent/proxy/"
+  tag: "Documentation"
+  text: "Configure the Agent to use a proxy"
+
+---
+
+## Overview 
+
+The Datadog agent can be used along with [Vector][1], in this scenario Agents will send data
+to Vector that will aggregate data from multiple incoming Agent:
+
+`Agents ---> Vector ---> Datadog`
+
+This scenario differs from using a [proxy][/agent/proxy] in the extend that Vector is able to
+process data before sending them to Datadog. Vector capability includes:
+* Log sampling
+* Log deduplication to avoid duplicated log to be send
+* Transforming logs using the [Vector Remap Language][2]
+
+** Note **: Only logs aggregation is supported, support for other data type (metrics, processes, traces, etc.)
+is scheduled for later.
+
+## Configuration
+
+### Agent configuration
+To send logs to vector the Agent configuration file, `datadog.yaml` should be update to send data to Vector.
+As only logs data type are currently supported, you need to update the following values in your `datadog.yaml`:
+```yaml
+logs_config:
+  logs_dd_url: "<VECTOR_HOST>:<VECTOR_PORT>"
+  logs_no_ssl: true # If TLS/SSL is not enabled on the vector side
+```
+
+### Vector configuration
+To receive logs from Datadog Agent Vector should be configured with a [datadog_logs source][3].
+To send logs to Datadog, Vector should be configured with at least one [datadog_logs sink][4].
+
+Please check the official [Vector documentation][5] for all available configuration parameters and
+all transforms that can be applied to logs while they are processed by Vector.
+
+Sample configuration that simply add a tag to every log using the Vector Remap Language:
+```yaml
+sources:
+  datadog_agents:
+    type: datadog_logs
+    address: "[::]:8080"
+
+transforms:
+  add_tags:
+    type: remap
+    inputs:
+      - datadog_agents
+    source: |
+      .ddtags = add_datadog_tags!(.ddtags, ["sender:vector"])
+
+sinks:
+  to_datadog:
+    type: datadog_logs
+    inputs:
+       - add_tags
+    default_api_key: "${DATADOG_API_KEY_ENV_VAR}"
+    compression: gzip
+    encoding:
+      codec: json
+    healthcheck:
+      enabled: true
+```
+
+### Using Kubernetes
+Using the official Datadog chart the following values need to be updated:
+```yaml
+agents:
+  useConfigMap: true
+  agents.customAgentConfig:
+    logs_dd_url: "<VECTOR_HOST>:<VECTOR_PORT>"
+    logs_no_ssl: true # If TLS/SSL is not enabled on the vector side
+```
+
+Vector provide an [offical chart for aggregating data][6] that comes with a Datadog
+logs source preconfigured, a Datadog sinks need to be added in order to ship back
+logs to Datadog.
+
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://vector.dev/
+[2]: https://vector.dev/docs/reference/configuration/transforms/remap/
+[3]: https://vector.dev/docs/reference/configuration/sources/datadog_logs/
+[4]: https://vector.dev/docs/reference/configuration/sinks/datadog_logs/
+[5]: https://vector.dev/docs/reference/configuration/
+[6]: https://github.com/timberio/vector/tree/master/distribution/helm/vector-aggregator

--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -8,6 +8,9 @@ further_reading:
 - link: "/agent/proxy/"
   tag: "Documentation"
   text: "Configure the Agent to use a proxy"
+- link: "https://vector.dev/docs/"
+  tag: "Documentation"
+  text: "Vector documentation"
 
 ---
 
@@ -31,7 +34,7 @@ it to Datadog and other destinations. Vector capabilities include, among others:
 
 **Note**: Vector can also directly collect logs from alternative sources. If doing so, it is likely that 
 third party logs won't come with proper tagging. A convenient way to [add tags][8], source or service
-values is to use the [Vector Remap Language][3].
+values is to use the [Vector Remap Language][9].
 
 ## Configuration
 
@@ -46,10 +49,10 @@ logs_config:
 ```
 
 ### Vector configuration
-To receive logs from Datadog Agent, configure Vector with a [datadog_logs source][9].
-To send logs to Datadog, Vector should be configured with at least one [datadog_logs sink][10].
+To receive logs from Datadog Agent, configure Vector with a [datadog_logs source][10].
+To send logs to Datadog, Vector should be configured with at least one [datadog_logs sink][11].
 
-See the official [Vector documentation][11] for all available configuration parameters and
+See the official [Vector documentation][12] for all available configuration parameters and
 all transforms that can be applied to logs while they are processed by Vector.
 
 Here is a configuration example that adds a tag to every log using the Vector Remap Language:
@@ -90,11 +93,11 @@ agents:
     logs_no_ssl: true # If TLS/SSL is not enabled on the vector side
 ```
 
-For additional details about the Datadog Helm chart, see [the Kubernetes documentation][12].
+For additional details about the Datadog Helm chart, see [the Kubernetes documentation][13].
 
-Vector provides an [official chart for aggregating data][13] that comes with a Datadog
+Vector provides an [official chart for aggregating data][14] that comes with a Datadog
 logs source preconfigured. For more information about installing Vector using Helm,
-see to the [official Vector documentation][14].
+see to the [official Vector documentation][15].
 
 To ultimately send logs to Datadog, a `datadog_logs` sink need to be added to the Vector
 configuration. Vector's chart supports adding additional sinks in the `values.yaml` file.
@@ -128,7 +131,7 @@ sinks:
 
 Logs sent to Vector can benefit from the full capabilities of Vector, including [Vector Remap Language][3] for fast and safe log transformations.
 When received by Vector, logs sent by the Datadog Agent are structured using the expected schema. When
-submitting logs directly to the Datadog API, please refer to the [API documentation][15]
+submitting logs directly to the Datadog API, please refer to the [API documentation][16]
 for a complete schema description.
 
 Logs collected by Vector from other sources can be [fully enriched][8]. VRL can be used to adjust those logs
@@ -146,10 +149,11 @@ to fill relevant fields according to the expected schema.
 [6]: https://vector.dev/docs/reference/configuration/transforms/log_to_metric/
 [7]: https://vector.dev/docs/reference/configuration/transforms/route/
 [8]: /getting_started/tagging
-[9]: https://vector.dev/docs/reference/configuration/sources/datadog_logs/
-[10]: https://vector.dev/docs/reference/configuration/sinks/datadog_logs/
-[11]: https://vector.dev/docs/reference/configuration/
-[12]: /agent/kubernetes/?tab=helm
-[13]: https://github.com/timberio/vector/tree/master/distribution/helm/vector-aggregator
-[14]: https://vector.dev/docs/setup/installation/package-managers/helm/
-[15]: api/latest/logs/#send-logs
+[9]: https://vector.dev/docs/reference/vrl/
+[10]: https://vector.dev/docs/reference/configuration/sources/datadog_logs/
+[11]: https://vector.dev/docs/reference/configuration/sinks/datadog_logs/
+[12]: https://vector.dev/docs/reference/configuration/
+[13]: /agent/kubernetes/?tab=helm
+[14]: https://github.com/timberio/vector/tree/master/distribution/helm/vector-aggregator
+[15]: https://vector.dev/docs/setup/installation/package-managers/helm/
+[16]: api/latest/logs/#send-logs

--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -18,18 +18,18 @@ to Vector that will aggregate data from multiple incoming Agent:
 
 `Agents ---> Vector ---> Datadog`
 
-This scenario differs from using a <a href="/agent/proxy">proxy</a> in the extend that Vector is able to
+This scenario differs from using a [proxy][2] in the extend that Vector is able to
 process data before sending them to Datadog. Vector capabilities include, among others:
 * Log sampling
 * Log deduplication to avoid duplicated log to be send
-* Transforming logs using the [Vector Remap Language][2]
+* Transforming logs using the [Vector Remap Language][3]
 
 
 **Note**: Only logs aggregation is supported, support for other data type (metrics, processes, traces, etc.)
-is scheduled for later.
+will be available later.
 
 **Note**: Vector can also directly collect logs from alternative sources, if doing so it is likely that those 
-third party logs won't come with proper tagging. A convenient way of <a href="/getting_started/tagging/">adding tags</a>, source or service values is to do so using the [Vector Remap Language][2].
+third party logs won't come with proper tagging. A convenient way of [adding tags][4], source or service values is to do so using the [Vector Remap Language][3].
 
 ## Configuration
 
@@ -43,10 +43,10 @@ logs_config:
 ```
 
 ### Vector configuration
-To receive logs from Datadog Agent Vector should be configured with a [datadog_logs source][3].
-To send logs to Datadog, Vector should be configured with at least one [datadog_logs sink][4].
+To receive logs from Datadog Agent Vector should be configured with a [datadog_logs source][5].
+To send logs to Datadog, Vector should be configured with at least one [datadog_logs sink][6].
 
-Please check the official [Vector documentation][5] for all available configuration parameters and
+Please check the official [Vector documentation][7] for all available configuration parameters and
 all transforms that can be applied to logs while they are processed by Vector.
 
 Sample configuration that simply add a tag to every log using the Vector Remap Language:
@@ -87,11 +87,11 @@ agents:
     logs_no_ssl: true # If TLS/SSL is not enabled on the vector side
 ```
 
-For additional details about the Datadog chart, please check <a href="/agent/kubernetes/?tab=helm">this page</a>.
+For additional details about the Datadog chart, please check [this page][8].
 
-Vector provide an [offical chart for aggregating data][6] that comes with a Datadog
+Vector provide an [offical chart for aggregating data][9] that comes with a Datadog
 logs source preconfigured. For more information about installing Vector using Helm
-please refer to the [official Vector documentation][7].
+please refer to the [official Vector documentation][10].
 
 To ultimately sent logs to Datadog, a `datadog_logs` sinks need to be added to the Vector
 configuration. The Vector's chart easily support adding additional sinks in its `values.yaml` file.
@@ -121,14 +121,29 @@ sinks:
       enabled: true
 ```
 
+## Manipulating Datadog Logs with Vector
+
+Logs sent to Vector can benefit from the full capabilities of Vector, including [VRL][3] manipulation.
+When received by Vector, logs sent by a Datadog Agent are structured using the expected schema when
+submitting logs directly to the Datadog API, please refer to the [API documention][11]
+for a complete schema description.
+
+Logs collected by Vector from other sources can be fully enriched according to
+[Datadog recommandation][4], VRL can be used to adjust those logs to fill relevant
+fields according to the expected schema. 
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://vector.dev/
-[2]: https://vector.dev/docs/reference/configuration/transforms/remap/
-[3]: https://vector.dev/docs/reference/configuration/sources/datadog_logs/
-[4]: https://vector.dev/docs/reference/configuration/sinks/datadog_logs/
-[5]: https://vector.dev/docs/reference/configuration/
-[6]: https://github.com/timberio/vector/tree/master/distribution/helm/vector-aggregator
-[7]: https://vector.dev/docs/setup/installation/package-managers/helm/
+[2]: /agent/proxy
+[3]: https://vector.dev/docs/reference/configuration/transforms/remap/
+[4]: /getting_started/tagging
+[5]: https://vector.dev/docs/reference/configuration/sources/datadog_logs/
+[6]: https://vector.dev/docs/reference/configuration/sinks/datadog_logs/
+[7]: https://vector.dev/docs/reference/configuration/
+[8]: /agent/kubernetes/?tab=helm
+[9]: https://github.com/timberio/vector/tree/master/distribution/helm/vector-aggregator
+[10]: https://vector.dev/docs/setup/installation/package-managers/helm/
+[11]: api/latest/logs/#send-logs

--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -16,13 +16,13 @@ further_reading:
 
 ## Overview 
 
-The Datadog Agent can be used along with [Vector][1]. In this scenario Agents will send data
-to Vector which will aggregate data from multiple upstream Agents:
+The Datadog Agent can be used along with [Vector][1]. In this scenario Agents send data
+to Vector, which aggregates data from multiple upstream Agents:
 
-`Agents ---> Vector ---> Datadog`
+`Agents -> Vector -> Datadog`
 
 This scenario differs from using a [proxy][2] since Vector is able to process data before sending
-it to Datadog and other destinations. Vector capabilities include, among others:
+it to Datadog and other destinations. Vector capabilities include:
 
 * [Log parsing, structuring, and enrichment][3]
 * Cost reduction through [sampling][4]
@@ -30,34 +30,33 @@ it to Datadog and other destinations. Vector capabilities include, among others:
 * [Deriving metrics from logs][6] for cost effective analysis
 * [Routing to multiple destinations][7]
 
-**Note**: Only logs aggregation is currently supported.
+**Notes**:
 
-**Note**: Vector can also directly collect logs from alternative sources. If doing so, it is likely that 
-third party logs won't come with proper tagging. A convenient way to [add tags][8], source or service
-values is to use the [Vector Remap Language][9].
+- Only logs aggregation is supported.
+- Vector can directly collect logs from alternative sources. When doing so, third party logs may not include proper tagging. A convenient way to [add tags][8], source or service values is to use the [Vector Remap Language][9].
 
 ## Configuration
 
 ### Agent configuration
 To send logs to Vector, update the Agent configuration file, `datadog.yaml`.
-Only the logs data type is currently supported. Update the following values in the `datadog.yaml` file:
+Only the logs data type is supported. Update the following values in the `datadog.yaml` file:
 
 ```yaml
 logs_config:
   logs_dd_url: "<VECTOR_HOST>:<VECTOR_PORT>"
-  logs_no_ssl: true # If TLS/SSL is not enabled on the vector side
+  logs_no_ssl: true # If TLS/SSL is not enabled on the Vector side
   use_http: true # Vector `datadog_logs` source only supports HTTP
 ```
 
 Where `VECTOR_HOST` is the hostname of the system running Vector and `VECTOR_PORT` is the TCP port on which
-the Vector `datadog_logs` source will be listening.
+the Vector `datadog_logs` source is listening.
 
 ### Vector configuration
 To receive logs from Datadog Agent, configure Vector with a [datadog_logs source][10].
-To send logs to Datadog, Vector should be configured with at least one [datadog_logs sink][11].
+To send logs to Datadog, Vector must be configured with at least one [datadog_logs sink][11].
 
 See the official [Vector documentation][12] for all available configuration parameters and
-all transforms that can be applied to logs while they are processed by Vector.
+transforms that can be applied to logs while they are processed by Vector.
 
 Here is a configuration example that adds a tag to every log using the Vector Remap Language:
 
@@ -65,7 +64,7 @@ Here is a configuration example that adds a tag to every log using the Vector Re
 sources:
   datadog_agents:
     type: datadog_logs
-    address: "[::]:8080" # The <VECTOR_PORT> mentionned above should be set to the port value used here
+    address: "[::]:8080" # The <VECTOR_PORT> mentioned above should be set to the port value used here
 
 transforms:
   add_tags:
@@ -87,9 +86,9 @@ sinks:
 
 ### Using Kubernetes
 
-Using the official Datadog chart the configuration settings [described above](#agent-configuration) can be added 
-to the `agents.customAgentConfig` value (Note that `agent.useConfigMap` shall also be set to `true`
-for `agents.customAgentConfig` to be taken into account).
+Using the official Datadog chart the [Agent configuration settings](#agent-configuration) described above can be added 
+to the `agents.customAgentConfig` value. **Note**: `agent.useConfigMap` must be set to `true`
+for `agents.customAgentConfig` to be taken into account.
 
 For additional details about the Datadog Helm chart, see [the Kubernetes documentation][13].
 
@@ -97,16 +96,16 @@ Vector provides an [official chart for aggregating data][14] that comes with a D
 logs source preconfigured. For more information about installing Vector using Helm,
 see to the [official Vector documentation][15].
 
-To ultimately send logs to Datadog, a `datadog_logs` sink need to be added to the Vector
+To send logs to Datadog, a `datadog_logs` sink need to be added to the Vector
 configuration. Vector's chart can hold any valid Vector configuration in the `values.yaml` file using the
-`customConfig` field. In order to enable a `datadog_logs` the same kind of configuration that the one 
-described [above](#vector-configuration) can be directlyt included as-is in the Vector chart configuration.
+`customConfig` field. To enable `datadog_logs` the same kind of configuration as 
+described under [Vector configuration](#vector-configuration) can be directly included as-is in the Vector chart configuration.
 
 ## Manipulating Datadog logs with Vector
 
-Logs sent to Vector can benefit from the full capabilities of Vector, including [Vector Remap Language][3] for fast and safe log transformations.
+Logs sent to Vector can benefit from the full capabilities of Vector, including [Vector Remap Language][3] for log transformations.
 When received by Vector, logs sent by the Datadog Agent are structured using the expected schema. When
-submitting logs directly to the Datadog API, please refer to the [API documentation][16]
+submitting logs directly to the Datadog API, see the [API documentation][16]
 for a complete schema description.
 
 Logs collected by Vector from other sources can be [fully enriched][8]. VRL can be used to adjust those logs

--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -18,14 +18,18 @@ to Vector that will aggregate data from multiple incoming Agent:
 
 `Agents ---> Vector ---> Datadog`
 
-This scenario differs from using a [proxy][/agent/proxy] in the extend that Vector is able to
-process data before sending them to Datadog. Vector capability includes:
+This scenario differs from using a <a href="/agent/proxy">proxy</a> in the extend that Vector is able to
+process data before sending them to Datadog. Vector capabilities include, among others:
 * Log sampling
 * Log deduplication to avoid duplicated log to be send
 * Transforming logs using the [Vector Remap Language][2]
 
+
 **Note**: Only logs aggregation is supported, support for other data type (metrics, processes, traces, etc.)
 is scheduled for later.
+
+**Note**: Vector can also directly collect logs from alternative sources, if doing so it is likely that those 
+third party logs won't come with proper tagging. A convenient way of <a href="/getting_started/tagging/">adding tags</a>, source or service values is to do so using the [Vector Remap Language][2].
 
 ## Configuration
 
@@ -83,10 +87,39 @@ agents:
     logs_no_ssl: true # If TLS/SSL is not enabled on the vector side
 ```
 
-Vector provide an [offical chart for aggregating data][6] that comes with a Datadog
-logs source preconfigured, a Datadog sinks need to be added in order to ship back
-logs to Datadog.
+For additional details about the Datadog chart, please check <a href="/agent/kubernetes/?tab=helm">this page</a>.
 
+Vector provide an [offical chart for aggregating data][6] that comes with a Datadog
+logs source preconfigured. For more information about installing Vector using Helm
+please refer to the [official Vector documentation][7].
+
+To ultimately sent logs to Datadog, a `datadog_logs` sinks need to be added to the Vector
+configuration. The Vector's chart easily support adding additional sinks in its `values.yaml` file.
+
+A sample `datadog_logs` sinks would consist in the following additions, it includes a `remap` transform
+that simply adds a Datadog tag to recognize logs forwarded by Vector:
+
+```yaml
+transforms:
+  add_tags:
+    type: remap
+    inputs:
+      - datadog_logs # It's the name of the preconfigured Datadog source
+    source: |
+      .ddtags = add_datadog_tags!(.ddtags, ["sender:vector"])
+
+sinks:
+  to_datadog:
+    type: datadog_logs
+    inputs:
+       - add_tags
+    default_api_key: "${DATADOG_API_KEY_ENV_VAR}"
+    compression: gzip
+    encoding:
+      codec: json
+    healthcheck:
+      enabled: true
+```
 
 ## Further Reading
 
@@ -98,3 +131,4 @@ logs to Datadog.
 [4]: https://vector.dev/docs/reference/configuration/sinks/datadog_logs/
 [5]: https://vector.dev/docs/reference/configuration/
 [6]: https://github.com/timberio/vector/tree/master/distribution/helm/vector-aggregator
+[7]: https://vector.dev/docs/setup/installation/package-managers/helm/

--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -20,7 +20,6 @@ to Vector which will aggregate data from multiple upstream Agents:
 
 This scenario differs from using a [proxy][2] since Vector is able to process data before sending
 it to Datadog and other destinations. Vector capabilities include, among others:
-others:
 
 * [Log parsing, structuring, and enrichment][3]
 * Cost reduction through [sampling][4]
@@ -39,6 +38,7 @@ values is to use the [Vector Remap Language][3].
 ### Agent configuration
 To send logs to Vector, update the Agent configuration file, `datadog.yaml`.
 Only the logs data type is currently supported. Update the following values in the `datadog.yaml` file:
+
 ```yaml
 logs_config:
   logs_dd_url: "<VECTOR_HOST>:<VECTOR_PORT>"
@@ -53,6 +53,7 @@ See the official [Vector documentation][11] for all available configuration para
 all transforms that can be applied to logs while they are processed by Vector.
 
 Here is a configuration example that adds a tag to every log using the Vector Remap Language:
+
 ```yaml
 sources:
   datadog_agents:
@@ -73,11 +74,8 @@ sinks:
     inputs:
        - add_tags
     default_api_key: "${DATADOG_API_KEY_ENV_VAR}"
-    compression: gzip
     encoding:
       codec: json
-    healthcheck:
-      enabled: true
 ```
 
 ### Using Kubernetes
@@ -98,7 +96,7 @@ Vector provides an [official chart for aggregating data][13] that comes with a D
 logs source preconfigured. For more information about installing Vector using Helm,
 see to the [official Vector documentation][14].
 
-To ultimately sent logs to Datadog, a `datadog_logs` sink need to be added to the Vector
+To ultimately send logs to Datadog, a `datadog_logs` sink need to be added to the Vector
 configuration. Vector's chart supports adding additional sinks in the `values.yaml` file.
 
 A sample `datadog_logs` sink should ideally include a `remap` transform
@@ -109,7 +107,7 @@ transforms:
   add_tags:
     type: remap
     inputs:
-      - datadog_logs # It's the name of the preconfigured Datadog source
+      - datadog_logs # The name of the preconfigured Datadog source
     source: |
       .ddtags = .ddtags + ",sender:vector"
 
@@ -128,10 +126,10 @@ sinks:
 
 ## Manipulating Datadog logs with Vector
 
-Logs sent to Vector can benefit from the full capabilities of Vector, including [VRL][3] manipulation.
+Logs sent to Vector can benefit from the full capabilities of Vector, including [Vector Remap Language][3] for fast and safe log transformations.
 When received by Vector, logs sent by the Datadog Agent are structured using the expected schema. When
 submitting logs directly to the Datadog API, please refer to the [API documentation][15]
-for a complete schema descriptions.
+for a complete schema description.
 
 Logs collected by Vector from other sources can be [fully enriched][8]. VRL can be used to adjust those logs
 to fill relevant fields according to the expected schema. 


### PR DESCRIPTION
### What does this PR do?
Describe how to use vector to aggregate/transform logs from a fleet of agents

### Motivation
Show how to use Vector for additional feature around log processing.

### Preview
https://docs-staging.datadoghq.com/prognant/vector_aggregator/agent/vector_aggregation/

### Additional Notes
Should not be merged before timberio/vector#8168

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
