### PR TITLE
Change the example from executionRule skipped to blocking

### DIFF
--- a/content/en/synthetics/ci.md
+++ b/content/en/synthetics/ci.md
@@ -435,7 +435,7 @@ In the global configuration file, you can configure the following options:
         "headers": { "<NEW_HEADER>": "<NEW_VALUE>" },
             "locations": ["aws:us-west-1"],
         "retry": { "count": 2, "interval": 300 },
-        "executionRule": "skipped",
+        "executionRule": "blocking",
         "startUrl": "{{URL}}?static_hash={{STATIC_HASH}}",
         "variables": { "titleVariable": "new value" },
         "pollingTimeout": 180000


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Changing the example from "executionRule": "skipped" to "executionRule": "blocking". 

### Motivation
<!-- What inspired you to submit this pull request?-->

Using "executionRule": "skipped" as a default results to an unintuitive error "Internal Error:No tests to trigger" even when they have properly defined tests.

ZD tickets #343216 #506941 

### Preview
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/synthetics/ci/?tab=npm#setup-the-client

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
