### PR TITLE
[DOCS-2129] Update python.md

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/python.md
+++ b/content/en/tracing/connect_logs_and_traces/python.md
@@ -72,8 +72,8 @@ def tracer_injection(logger, log_method, event_dict):
     trace_id, span_id = get_correlation_ids()
 
     # add ids to structlog event dictionary
-    event_dict['dd.trace_id'] = trace_id or 0
-    event_dict['dd.span_id'] = span_id or 0
+    event_dict['dd.trace_id'] = str(trace_id or 0)
+    event_dict['dd.span_id'] = str(span_id or 0)
 
     # add the env, service, and version configured for the tracer
     event_dict['dd.env'] = ddtrace.config.env or ""


### PR DESCRIPTION
Match how https://github.com/DataDog/dd-trace-py casts trace_id & spand_id as strings

This also protects again issues where a forwarding library may have trouble with large integers (as is happening with the datadog fluent bit forwarding plugin - which is currently rounding down any integers > the largest signed integer to 9223372036854775807)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
