### PR TITLE
[WEB-1123] Codetabs Cumulative Layout Shift fix

### DIFF
--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -510,7 +510,7 @@ h5 {
 
 /* codetabs inside content */
 .code-tabs {
-    min-height: 350px;
+    min-height: 200px;
 
     & > ul {
         list-style-type: none;


### PR DESCRIPTION
### What does this PR do?
Add some `min-height` to code tabs to prevent layout shift on page load, which has been flagged by Google Search Console.

### Motivation
- https://datadoghq.atlassian.net/browse/WEB-1123
- Warnings in Google Search Console

### Preview
- https://docs-staging.datadoghq.com/brian.deutsch/cls-fix/agent/faq/how-do-i-uninstall-the-agent/:   running Lighthouse (Desktop) reflects an improved Cumulative Layout Shift score from yellow/red to green when compared to live.

Check some other pages with Codetabs.    Styles should still look good, tabs should remain functional, no CLS issues.

- https://docs-staging.datadoghq.com/brian.deutsch/cls-fix/monitors/downtimes/
- https://docs-staging.datadoghq.com/brian.deutsch/cls-fix/agent/amazon_ecs/?tab=webui
- https://docs-staging.datadoghq.com/brian.deutsch/cls-fix/account_management/rbac/

### Additional Notes
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
