### PR TITLE
CI docs cleanup: better tables and codeblocks

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -18,17 +18,22 @@ If you are a GitLab.com user and you want to early-adopt this integration, [open
 If you manage your own GitLab installation and your version is recent enough, you can enable the feature flag yourself by executing the following commands that use GitLab's [Rails Runner][4] depending on your installation type:
 
 For Omnibus installations:
-```
+
+{{< code-block lang="shell" >}}
 sudo gitlab-rails runner "Feature.enable(:datadog_ci_integration)"
-```
+{{< /code-block >}}
+
 For installations from source:
-```
+
+{{< code-block lang="shell" >}}
 sudo -u git -H bundle exec rails runner -e production "Feature.enable(:datadog_ci_integration)"
-```
+{{< /code-block >}}
+
 For [Kubernetes deployments][5]:
-```
+
+{{< code-block lang="shell" >}}
 kubectl exec -it <task-runner-pod-name> -- /srv/gitlab/bin/rails runner "Feature.enable(:datadog_ci_integration)"
-```
+{{< /code-block >}}
 
 Once the feature flag is enabled, configure the integration on a per project basis by going to **Settings > Integrations > Datadog** for each project you want to instrument. Mark it as active and paste a valid [API key][6].
 

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -27,10 +27,10 @@ Install and enable the [Datadog Jenkins plugin][2] v2.1.1 or newer:
 
 When the configuration is correct, the Jenkins log shows lines similar to this after the restart:
 
-```
+{{< code-block lang="text" >}}
 INFO    datadog.trace.core.CoreTracer#<init>: New instance: DDTracer-62fcf62{ ... }
 INFO    datadog.trace.core.StatusLogger#logStatus: DATADOG TRACER CONFIGURATION { ... }
-```
+{{< /code-block >}}
 
 **Note**: Enabling the collection of traces using the Jenkins plugin is incompatible with running the Java APM tracer as a Java agent when launching Jenkins.
 
@@ -43,13 +43,13 @@ Enable log collection in the Agent:
 
 2. Create a file at `/etc/datadog-agent/conf.d/jenkins.d/conf.yaml` (for Linux; [check here for other operating systems][4]) with the following contents. Make sure that `service` matches the `traceServiceName` provided earlier:
 
-```yaml
+{{< code-block lang="yaml" >}}
 logs:
   - type: tcp
     port: 10518
     service: my-jenkins-instance
     source: jenkins
-```
+{{< /code-block >}}
 
 3. [Restart the Agent][5] for the changes to take effect.
 
@@ -63,10 +63,10 @@ Configure the Jenkins plugin to send job logs to the Agent:
 
 2.  Add or modify the following lines:
 
-```xml
+{{< code-block lang="xml" >}}
 <targetLogCollectionPort>10518</targetLogCollectionPort>
 <collectBuildLogs>true</collectBuildLogs>
-```
+{{< /code-block >}}
 
 3. Restart Jenkins for the changes to take effect.
 
@@ -79,7 +79,7 @@ To report pipeline results, attach the default branch name (for example, `main`)
 
 If this happens, set the default branch manually using the `DD_GIT_DEFAULT_BRANCH` environment variable in your build. For example:
 
-```groovy
+{{< code-block lang="groovy" >}}
 pipeline {
     agent any
     environment {
@@ -90,7 +90,7 @@ pipeline {
         ...
     }
 }
-```
+{{< /code-block >}}
 ## Customization
 
 ### Setting custom tags for your pipelines
@@ -99,7 +99,7 @@ The Datadog plugin adds a `datadog` step that allows adding custom tags to your 
 
 In declarative pipelines, add the step to a top-level option block:
 
-```groovy
+{{< code-block lang="groovy" >}}
 def DD_TYPE = "release"
 pipeline {
     agent any
@@ -114,11 +114,11 @@ pipeline {
         }
     }
 }
-```
+{{< /code-block >}}
 
 In scripted pipelines, wrap the relevant section with the `datadog` step:
 
-```groovy
+{{< code-block lang="groovy" >}}
 datadog(tags: ["team:backend", "release:canary"]){
     node {
         stage('Example') {
@@ -126,7 +126,7 @@ datadog(tags: ["team:backend", "release:canary"]){
         }
     }
 }
-```
+{{< /code-block >}}
 
 ### Setting global custom tags
 
@@ -135,16 +135,14 @@ You can configure the Jenkins Plugin to send custom tags in all pipeline traces:
 1. Open the file `$JENKINS_HOME\org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration.xml`.
 2. Add or modify the following lines:
 
-    ```xml
+    {{< code-block lang="xml" >}}
     <globalTags>global_tag:global_value,global_tag2:${SOME_ENVVAR},${OTHER_ENVVAR}:global_tagvalue</globalTags>
     <globalJobTags>(.*?)_job_(*?)_release:someValue</globalJobTags>
-    ```
+    {{< /code-block >}}
 
-    Global tags (`globalTags`)
-    : A comma-separated list of tags to apply to all metrics, traces, events, and service checks. Tags can include environment variables that are defined in the Jenkins controller instance.
+    **Global tags** (`globalTags`): A comma-separated list of tags to apply to all metrics, traces, events, and service checks. Tags can include environment variables that are defined in the Jenkins controller instance.
 
-    Global job tags (`globalJobTags`)
-    : A comma-separated list of regex to match a job and a list of tags to apply to that job. Tags can include environment variables that are defined in the Jenkins controller instance. Tags can reference match groups in the regex using the `$` symbol.
+    **Global job tags** (`globalJobTags`): A comma-separated list of regex to match a job and a list of tags to apply to that job. Tags can include environment variables that are defined in the Jenkins controller instance. Tags can reference match groups in the regex using the `$` symbol.
 
 3. Restart Jenkins for the changes to take effect.
 

--- a/content/en/continuous_integration/setup_tests/agent.md
+++ b/content/en/continuous_integration/setup_tests/agent.md
@@ -30,10 +30,10 @@ If your CI provider runs your tests in a container (such as on-prem CI providers
 
 To enable APM and disable the monitoring of the container, set the following environment variable on the Agent container:
 
-```
+{{< code-block lang="text" >}}
 DD_INSIDE_CI=true
 DD_HOSTNAME=none
-```
+{{< /code-block >}}
 
 This allows the tracer to send test results to port `8126` of the Agent container.
 
@@ -42,8 +42,7 @@ This allows the tracer to send test results to port `8126` of the Agent containe
 
 Regardless of which CI provider you use, if tests are run using Docker Compose, the Agent can be run as one service:
 
-```yaml
-# docker-compose.yml
+{{< code-block lang="yaml" filename="docker-compose.yml" >}}
 version: '3'
 services:
   datadog-agent:
@@ -59,12 +58,11 @@ services:
     build: .
     environment:
       - DD_AGENT_HOST=datadog-agent
-```
+{{< /code-block >}}
 
 Alternatively, share the same network namespace between the Agent container and the tests container:
 
-```yaml
-# docker-compose.yml
+{{< code-block lang="yaml" filename="docker-compose.yml" >}}
 version: '3'
 services:
   datadog-agent:
@@ -77,15 +75,15 @@ services:
   tests:
     build: .
     network_mode: "service:datadog-agent"
-```
+{{< /code-block >}}
 
 In this case, no `DD_AGENT_HOST` is required because it is `localhost` by default.
 
 Then, run your tests by providing your [Datadog API key][3] in the `DD_API_KEY` environment variable:
 
-```bash
+{{< code-block lang="bash" >}}
 DD_API_KEY=<MY_API_KEY> docker-compose up --build --abort-on-container-exit tests
-```
+{{< /code-block >}}
 
 **Note:** In this case, also pass along all the required CI provider environment variables so build information can be attached to each test result, as described in [Tests in containers][4].
 
@@ -97,8 +95,7 @@ The following sections provide CI provider-specific instructions to run and conf
 
 To run the Agent in Azure Pipelines, define the Agent container in the [`resources` section][5] and link it with the job declaring it as a [`service` container][6]:
 
-```yaml
-# azure-pipeline.yml
+{{< code-block lang="yaml" filename="azure-pipeline.yml" >}}
 variables:
   ddApiKey: $(DD_API_KEY)
 
@@ -119,7 +116,7 @@ jobs:
       dd_agent: dd_agent
     steps:
       - script: make test
-```
+{{< /code-block >}}
 
 Add your [Datadog API key][3] to your [project environment variables][7] with the key `DD_API_KEY`.
 
@@ -128,8 +125,7 @@ Add your [Datadog API key][3] to your [project environment variables][7] with th
 
 To run the Agent in GitLab, define the Agent container under [`services`][8]:
 
-```yaml
-# .gitlab-ci.yml
+{{< code-block lang="yaml" filename=".gitlab-ci.yml" >}}
 variables:
   DD_AGENT_HOST: "datadog-agent"
   DD_HOSTNAME: "none"
@@ -141,7 +137,7 @@ test:
     - name: datadog/agent:latest
   script:
     - make test
-```
+{{< /code-block >}}
 
 Add your [Datadog API key][3] to your [project environment variables][9] with the key `DD_API_KEY`.
 
@@ -150,7 +146,7 @@ Add your [Datadog API key][3] to your [project environment variables][9] with th
 
 To run the Agent in GitHub Actions, define the Agent container under [`services`][10]:
 
-```yaml
+{{< code-block lang="yaml" >}}
 jobs:
   test:
     services:
@@ -164,7 +160,7 @@ jobs:
           DD_INSIDE_CI: "true"
     steps:
       - run: make test
-```
+{{< /code-block >}}
 
 Add your [Datadog API key][3] to your [project secrets][11] with the key `DD_API_KEY`.
 
@@ -175,8 +171,7 @@ To run the Agent in CircleCI, launch the agent container before running tests by
 
 For example:
 
-```yaml
-# .circleci/config.yml
+{{< code-block lang="yaml" filename=".circleci/config.yml" >}}
 version: 2.1
 
 orbs:
@@ -196,7 +191,7 @@ workflows:
   test:
     jobs:
       - test
-```
+{{< /code-block >}}
 
 Add your [Datadog API key][3] to your [project environment variables][13] with the key `DD_API_KEY`.
 

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -41,23 +41,23 @@ Supported CI providers:
 
 To install the `dd-trace` command globally on the machine, run:
 
-```
+{{< code-block lang="bash" >}}
 dotnet tool install -g dd-trace
-```
+{{< /code-block >}}
 
 Or, if you have a previous version of the tool, update it by running:
 
-```
+{{< code-block lang="bash" >}}
 dotnet tool update -g dd-trace
-```
+{{< /code-block >}}
 
 ## Instrumenting your tests
 
 To instrument your test suite, prefix your test command with `dd-trace`. For example:
 
-```
+{{< code-block lang="bash" >}}
 dd-trace dotnet test
-```
+{{< /code-block >}}
 
 All tests are instrumented automatically.
 
@@ -65,28 +65,44 @@ All tests are instrumented automatically.
 
 You can change the default configuration of the CLI by using command line arguments or environment variables. For a full list of configuration settings, run:
 
-```
+{{< code-block lang="bash" >}}
 dd-trace --help
-```
+{{< /code-block >}}
 
-The following table shows the default values for key configuration settings:
+The following list shows the default values for key configuration settings:
 
 
-| CLI option                     | Environment variable          | Default value            | Description                                                             |
-|--------------------------------|--------------------------------|-------------------------|-------------------------------------------------------------------------|
-| `--set-ci`                     |                                | `false`                 | Sets up the clr profiler environment variables for all the CI pipeline. |
-| `--dd-env`                     | `DD_ENV`                       | `(empty)`               | Environment name for unified service tagging.                       |
-| `--dd-service`                 | `DD_SERVICE`                   | `(ProcessName)`         | Service name for unified service tagging.                           |
-| `--dd-version`                 | `DD_VERSION`                   | `(empty)`               | Version for unified service tagging.                                |
-| `--agent-url`                  | `DD_TRACE_AGENT_URL`           | `http://localhost:8126` | Datadog trace agent URL.                                                |
+`--set-ci`
+: Sets up the clr profiler environment variables for all the CI pipeline. <br/>
+**Default**: `false`
+
+`--dd-env`
+: Environment name for unified service tagging.<br/>
+**Environment variable**: `DD_ENV`<br/>
+**Default**: `(empty)`
+
+`--dd-service`
+: Service name for unified service tagging. <br/>
+**Environment variable**: `DD_SERVICE`<br/>
+**Default**: `(ProcessName)` 
+
+`--dd-version` 
+: Version for unified service tagging. <br/>
+**Environment variable**: `DD_VERSION`<br/>
+**Default**: `(empty)`
+
+`--agent-url` 
+: Datadog trace agent URL. <br/>
+**Environment variable**: `DD_TRACE_AGENT_URL`<br/>
+**Default**: `http://localhost:8126`
 
 Additionally, all [Datadog Tracer configuration][2] options can be used during test phase. 
 
 For example, to run a test suite with a custom agent URL and a custom service name:
 
-```
+{{< code-block lang="bash" >}}
 dd-trace --agent-url=http://agent:8126 --dd-service=my-app dotnet test
-```
+{{< /code-block >}}
 
 ### Passing parameters to the application
 
@@ -94,17 +110,17 @@ If the application expects command line arguments, use a `--` separator before t
 
 The following example shows how to instrument the command `dotnet test --framework netcoreapp3.1` with `ci` as environment:
 
-```
+{{< code-block lang="bash" >}}
 dd-trace --dd-env=ci -- dotnet test --framework netcoreapp3.1
-```
+{{< /code-block >}}
 
 ### Instrumenting MsTest V2 framework
 
 Support for MsTest V2 framework is disabled by default, as it relies on an experimental method of instrumentation (some third-party libraries' instrumentation might be missing). To enable it, set the following environment variable before running the `dd-trace dotnet test` command:
 
-```
+{{< code-block lang="bash" >}}
 DD_TRACE_CALLTARGET_ENABLED=true
-```
+{{< /code-block >}}
 
 ## Further reading
 

--- a/content/en/continuous_integration/setup_tests/java.md
+++ b/content/en/continuous_integration/setup_tests/java.md
@@ -39,7 +39,7 @@ Supported CI providers:
 
 Add a new Maven profile in your root `pom.xml` configuring the Datadog Java tracer dependency and the `javaagent` arg property, replacing `$VERSION` with the latest version of the tracer accessible from the [Maven Repository][2]: 
 
-```xml
+{{< code-block lang="xml" >}}
 <profile>
   <id>ci-app</id>
   <activation>
@@ -59,13 +59,13 @@ Add a new Maven profile in your root `pom.xml` configuring the Datadog Java trac
     </dependency>  
   </dependencies> 
 </profile>
-```
+{{< /code-block >}}
 
 ### Using Gradle
 
 Add the `ddTracerAgent` entry to the `configurations` task block, and add the Datadog Java tracer dependency, replacing `$VERSION` with the latest version of the tracer available in the [Maven Repository][2].
 
-```groovy
+{{< code-block lang="groovy" >}}
 configurations {
     ddTracerAgent
 }
@@ -73,7 +73,7 @@ configurations {
 dependencies {
     ddTracerAgent "com.datadoghq:dd-java-agent:$VERSION"
 }
-```
+{{< /code-block >}}
 
 ## Instrumenting your tests
 
@@ -81,7 +81,7 @@ dependencies {
 
 Configure the [Maven Surefire Plugin][3] and/or the [Maven Failsafe Plugin][4] to use Datadog Java agent (use `-Ddd.integration.testng.enabled=true` if your testing framework is TestNG rather than JUnit):
 
-```xml
+{{< code-block lang="xml" >}}
 <plugin>
   <groupId>org.apache.maven.plugins</groupId>
   <artifactId>maven-surefire-plugin</artifactId>
@@ -105,62 +105,93 @@ Configure the [Maven Surefire Plugin][3] and/or the [Maven Failsafe Plugin][4] t
       </execution>
   </executions>
 </plugin>
-```
+{{< /code-block >}}
 
 Run your tests using the `ci-app` profile, for example:
-```
+
+{{< code-block lang="bash" >}}
 mvn clean verify -P ci-app
-```
+{{< /code-block >}}
+
 ### Using Gradle
 
 Configure the `test` Gradle task by adding to the `jvmArgs` attribute the `-javaagent` argument targeting the Datadog Java tracer based on the `configurations.ddTracerAgent` property (use `-Ddd.integration.testng.enabled=true` if your testing framework is TestNG rather than JUnit):
 
-```groovy
+{{< code-block lang="groovy" >}}
 test {
     jvmArgs = ["-javaagent:${configurations.ddTracerAgent.asPath}", "-Ddd.prioritization.type=ENSURE_TRACE", "-Ddd.jmxfetch.enabled=false", "-Ddd.integrations.enabled=false", "-Ddd.integration.junit.enabled=true"]
 }
-```
+{{< /code-block >}}
 
 Run your tests as you normally do, for example:
 
-```
+{{< code-block lang="bash" >}}
 ./gradlew cleanTest test --rerun-tasks
-```
+{{< /code-block >}}
 
 **Important:** As Gradle builds can be customizable programmatically, you may need to adapt these steps to your specific build configuration.
 
 ## Configuration options
 
-All configuration options below have system property and environment variable equivalents. If the same key type is set for both, the system property configuration takes priority. System properties can be set as JVM flags.
+The following system properties set configuration options and have environment variable equivalents. If the same key type is set for both, the system property configuration takes priority. System properties can be set as JVM flags.
 
-| System property                 | Environment variable            | Default | Description                                             |
-|---------------------------------|---------------------------------|---------|---------------------------------------------------------|
-| `dd.integration.junit.enabled`  | `DD_INTEGRATION_JUNIT_ENABLED`  | `false` | When `true`, tests based on JUnit runners are reported. |
-| `dd.integration.testng.enabled` | `DD_INTEGRATION_TESTNG_ENABLED` | `false` | When `true`, tests based on TestNG are reported.        |
+`dd.integration.junit.enabled`
+: When `true`, tests based on JUnit runners are reported.<br/>
+**Environment variable**: `DD_INTEGRATION_JUNIT_ENABLED`<br/>
+**Default**: `false`
+
+`dd.integration.testng.enabled`
+: When `true`, tests based on TestNG are reported.<br/>
+**Environment variable**: `DD_INTEGRATION_TESTNG_ENABLED`<br/>
+**Default**: `false`
 
 Additionally, set the tracer prioritization type to `EnsureTrace` to avoid dropping test spans.
 
-| System property          | Environment variable            | Default | Description                                                       |
-|--------------------------|--------------------------|------------|-------------------------------------------------------------------|
-| `dd.prioritization.type` | `DD_PRIORITIZATION_TYPE` | `FAST_LANE` | Set to `ENSURE_TRACE` to avoid dropping tests spans by the tracer. |
+`dd.prioritization.type`
+: Set to `ENSURE_TRACE` to avoid dropping tests spans by the tracer.<br/>
+**Environment variable**: `DD_PRIORITIZATION_TYPE`<br/>
+**Default**: `FAST_LANE`
 
 All [Datadog tracer configuration][5] options can be used during the test phase.
 
 ### Recommended configuration
 
-To improve the Datadog Java Agent startup, follow these recommended configuration settings:
+To improve the Datadog Java Agent startup, follow these configuration settings:
 
-| System property          | Environment variable            | Default | Recommendation                                                         |
-|--------------------------------|--------------------------------|--------------------|------------------------------------------------------------------------|
-| `dd.service`                   | `DD_SERVICE`                   | `unnamed-java-app` | The name of the Test Service that will appear in the CI Tests tab.  |
-| `dd.agent.host`                | `DD_AGENT_HOST`                | `localhost`        | Make sure this property targets the Datadog Agent host.                |
-| `dd.trace.agent.port`          | `DD_TRACE_AGENT_PORT`          | `8126`             | Make sure this property targets the Datadog Agent port.                |
-| `dd.integrations.enabled`      | `DD_INTEGRATIONS_ENABLED`      | `true`             | `false`                                                                |
-| `dd.integration.junit.enabled` | `DD_INTEGRATION_JUNIT_ENABLED` | `false`            | `true`                                                                 |
-| `dd.prioritization.type`       | `DD_PRIORITIZATION_TYPE`       | `FAST_LANE`        | `ENSURE_TRACE`                                                         |
-| `dd.jmxfetch.enabled`          | `DD_JMXFETCH_ENABLED`          | `true`             | `false`                                                                |
+System property: `dd.service`
+: **Environment variable**: `DD_SERVICE`<br/>
+**Default**: `unnamed-java-app`</br>
+**Set to**: The name of the Test Service that will appear in the CI Tests tab.
 
-Change the `dd.integration` property or variable from `junit` to `testng` to correspond to your test integration.
+System property: `dd.agent.host`
+: **Environment variable**: `DD_AGENT_HOST`<br/>
+**Default**: `localhost`</br>
+**Set to**: The Datadog Agent host.
+
+System property: `dd.trace.agent.port`
+: **Environment variable**: `DD_TRACE_AGENT_PORT`<br/>
+**Default**: `8126`</br>
+**Set to**: The Datadog Agent port.
+
+System property: `dd.integrations.enabled`
+: **Environment variable**: `DD_INTEGRATIONS_ENABLED`<br/>
+**Default**: `true`</br>
+**Recommendation**: `false`
+
+System property: `dd.integration.junit.enabled` or `dd.integration.testng.enabled`
+: **Environment variable**: `DD_INTEGRATION_JUNIT_ENABLED` or `DD_INTEGRATION_TESTNG_ENABLED`<br/>
+**Default**: `false`</br>
+**Recommendation**: `true`
+
+System property: `dd.prioritization.type`
+: **Environment variable**: `DD_PRIORITIZATION_TYPE`<br/>
+**Default**: `FAST_LANE`</br>
+**Recommendation**: `ENSURE_TRACE`
+
+System property: `dd.jmxfetch.enabled`
+: **Environment variable**: `DD_JMXFETCH_ENABLED`<br/>
+**Default**: `true`</br>
+**Recommendation**: `false`
 
 **Important:** You may want to enable more integrations if you have integration tests. To enable a specific integration, use the [Datadog Tracer Compatibility][6] table to create your custom setup for your integration tests.
 

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -37,9 +37,9 @@ Supported CI providers:
 
 To install the [JavaScript tracer][3], run:
 
-```bash
+{{< code-block lang="bash" >}}
 yarn add --dev dd-trace
-```
+{{< /code-block >}}
 
 For more information, see the [JavaScript tracer installation docs][4].
 
@@ -49,51 +49,50 @@ For more information, see the [JavaScript tracer installation docs][4].
 
 1. Install the `jest-circus` test runner:
 
-    ```bash
-    yarn add --dev jest-circus
-    ```
+    {{< code-block lang="bash" >}}
+yarn add --dev jest-circus
+{{< /code-block >}}
 
 2. Configure a custom [testEnvironment][5] and [testRunner][6] in your `jest.config.js` or however you are configuring [jest][7]:
 
-    ```javascript
-    // jest.config.js
-    module.exports = {
-      // ...
-      testRunner: 'jest-circus/runner',
-      // It may be another route. It refers to the file below.
-      testEnvironment: '<rootDir>/testEnvironment.js',
-      // ...
-    }
-    ```
+    {{< code-block lang="javascript" filename="jest.config.js" >}}
+module.exports = {
+  // ...
+  testRunner: 'jest-circus/runner',
+  // It may be another route. It refers to the file below.
+  testEnvironment: '<rootDir>/testEnvironment.js',
+  // ...
+}
+{{< /code-block >}}
 
     And in `testEnvironment.js`:
 
-    ```javascript
-    require('dd-trace').init({
-      service: 'ui-tests' // The name of the Test Service that will appear in the CI Tests tab.
-    })
-    // jest-environment-jsdom is an option too
-    module.exports = require('jest-environment-node') 
-    ``` 
+    {{< code-block lang="javascript" filename="testEnvironment.js" >}}
+require('dd-trace').init({
+  service: 'ui-tests' // The name of the Test Service that will appear in the CI Tests tab.
+})
+// jest-environment-jsdom is an option too
+module.exports = require('jest-environment-node') 
+{{< /code-block >}}
 
 **Note**: The default configuration should work for most cases, but depending on the volume and speed of your tests, the tracer or the Agent might drop some of the spans. Alleviate this by increasing the `flushInterval` (a value in milliseconds) when initializing the tracer:
 
-```javascript
+{{< code-block lang="javascript" >}}
 require('dd-trace').init({
   flushInterval: 300000
 })
-```
+{{< /code-block >}}
 
 ### Mocha instrumentation
 
 Add `--require dd-trace/init` to however you normally run your `mocha` tests, for example in your your `package.json`:
 
-```javascript
+{{< code-block lang="javascript" >}}
 // package.json
 'scripts': {
   'test': 'mocha --require dd-trace/init'
 },
-```
+{{< /code-block >}}
 
 ## Disabling instrumentation in local development
 
@@ -103,23 +102,23 @@ If you want to disable the testing instrumentation for local development (where 
 
 When initializing the tracer, check whether you are in CI:
 
-```javascript
+{{< code-block lang="javascript" >}}
 require('dd-trace').init({
   enabled: !!process.env.CI // the environment variable to use depends on the CI provider
 })
-```
+{{< /code-block >}}
 
 ### Mocha
 
 Use different test scripts for CI and local development:
 
-```javascript
+{{< code-block lang="javascript" >}}
 // package.json
 'scripts': {
   'test': 'mocha',
   'test:ci': 'mocha --require dd-trace/init'
 },
-```
+{{< /code-block >}}
 
 ## Configuration settings
 

--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -27,25 +27,25 @@ Supported CI providers:
 
 Install the `@datadog/datadog-ci` CLI:
 
-```bash
+{{< code-block lang="bash" >}}
 yarn global add @datadog/datadog-ci
-```
+{{< /code-block >}}
 
 ## Uploading test reports
 
 To upload your JUnit XML test reports to Datadog:
 
-```bash
+{{< code-block lang="bash" >}}
 datadog-ci junit upload [--service] [--tags] [--max-concurrency] [--dry-run] <paths>
-```
+{{< /code-block >}}
 
 For example:
 
-```bash
+{{< code-block lang="bash" >}}
 datadog-ci junit upload --service my-service \
   --tags key1:value1 --tags key2:value2 \
   unit-tests/junit-reports acceptance-tests/junit-reports e2e-tests/single-report.xml
-```
+{{< /code-block >}}
 
 `--service`
 : The name of the service you're uploading JUnit XML reports for.<br>

--- a/content/en/continuous_integration/setup_tests/python.md
+++ b/content/en/continuous_integration/setup_tests/python.md
@@ -30,9 +30,9 @@ Supported CI providers:
 
 Install the Python tracer by running:
 
-```bash
+{{< code-block lang="bash" >}}
 pip install ddtrace
-```
+{{< /code-block >}}
 
 For more information, see the [Python tracer installation documentation][2].
 
@@ -40,23 +40,28 @@ For more information, see the [Python tracer installation documentation][2].
 
 To enable instrumentation of `pytest` tests, add the `--ddtrace` option when running `pytest`:
 
-```bash
+{{< code-block lang="bash" >}}
 pytest --ddtrace
-```
+{{< /code-block >}}
 
 You can also add the following configuration to any file used to configure `pytest` (such as `pytest.ini` or `setup.cfg`):
 
-```ini
+{{< code-block lang="ini" >}}
 [pytest]
 ddtrace = 1
-```
+{{< /code-block >}}
 
 ## Configuration parameters
 
-| Parameter  | Environment variable  | Default | Description       |
-|------------|-----------------------|---------|-------------------|
-| `ddtrace.config.pytest["service"]` | `DD_PYTEST_SERVICE` | `"pytest"` | The service name reported by default for pytest traces. |
-| `ddtrace.config.pytest["operation_name"]` | `DD_PYTEST_OPERATION_NAME` | `"pytest.test"` | The operation name reported by default for pytest traces. |
+`ddtrace.config.pytest["service"]` 
+: The service name reported by default for pytest traces.<br/>
+**Environment variable**: `DD_PYTEST_SERVICE`<br/>
+**Default**: `"pytest"`
+
+`ddtrace.config.pytest["operation_name"]`
+: The operation name reported by default for pytest traces.<br/>
+**Environment variable**: `DD_PYTEST_OPERATION_NAME`<br/>
+**Default**: `"pytest.test"`
 
 ## Further reading
 

--- a/content/en/continuous_integration/setup_tests/ruby.md
+++ b/content/en/continuous_integration/setup_tests/ruby.md
@@ -33,11 +33,11 @@ To install the Ruby tracer:
 
 1. Add the `ddtrace` gem to your `Gemfile` using the specified branch:
 
-    ```ruby
-    gem 'ddtrace', 
-        :git => "git://github.com/DataDog/dd-trace-rb.git", 
-        :branch => "feature/test_mode"
-    ```
+    {{< code-block lang="ruby" >}}
+gem 'ddtrace', 
+    :git => "git://github.com/DataDog/dd-trace-rb.git", 
+    :branch => "feature/test_mode"
+{{< /code-block >}}
 2. Install the gem by running `bundle install`
 
 See the [Ruby tracer installation docs][2] for more details.
@@ -48,7 +48,7 @@ The Cucumber integration traces executions of scenarios and steps when using the
 
 To activate your integration:
 
-```ruby
+{{< code-block lang="ruby" >}}
 require 'cucumber'
 require 'datadog/ci'
 
@@ -68,7 +68,7 @@ Around do |scenario, block|
   end
   block.call
 end
-```
+{{< /code-block >}}
 
 Where `options` is an optional `Hash` that accepts the following parameters:
 
@@ -88,7 +88,7 @@ The RSpec integration traces all executions of example groups and examples when 
 
 To activate your integration, add this to the `spec_helper.rb` file:
 
-```ruby
+{{< code-block lang="ruby" >}}
 require 'rspec'
 require 'datadog/ci'
 
@@ -97,7 +97,7 @@ Datadog.configure do |c|
   c.ci_mode.enabled = true
   c.use :rspec, options
 end
-```
+{{< /code-block >}}
 
 Where `options` is an optional `Hash` that accepts the following parameters:
 


### PR DESCRIPTION
### What does this PR do?
leftover from beta release this week: clean up tables formatting and codeblock markdown

### Motivation
good hygiene 

### Preview

https://docs-staging.datadoghq.com/kari/ci-cleanup/continuous-integration/continuous_integration/setup_pipelines/gitlab/
https://docs-staging.datadoghq.com/kari/ci-cleanup/continuous-integration/continuous_integration/setup_pipelines/jenkins/
https://docs-staging.datadoghq.com/kari/ci-cleanup/continuous-integration/continuous_integration/setup_tests/agent/
https://docs-staging.datadoghq.com/kari/ci-cleanup/continuous-integration/continuous_integration/setup_tests/dotnet/
https://docs-staging.datadoghq.com/kari/ci-cleanup/continuous-integration/continuous_integration/setup_tests/java/
https://docs-staging.datadoghq.com/kari/ci-cleanup/continuous-integration/continuous_integration/setup_tests/javascript/
https://docs-staging.datadoghq.com/kari/ci-cleanup/continuous-integration/continuous_integration/setup_tests/junit_upload/
https://docs-staging.datadoghq.com/kari/ci-cleanup/continuous-integration/continuous_integration/setup_tests/python/
https://docs-staging.datadoghq.com/kari/ci-cleanup/continuous-integration/continuous_integration/setup_tests/ruby/

### Additional Notes
 
no content changes, just formatting

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
