### PR TITLE
[agent] Add FAQ on how to run the macOS Agent as a system service

### DIFF
--- a/content/en/agent/faq/_index.md
+++ b/content/en/agent/faq/_index.md
@@ -14,6 +14,7 @@ aliases:
     {{< nextlink href="agent/faq/how-datadog-agent-determines-the-hostname" >}}How does Datadog determine the Agent hostname?{{< /nextlink >}}
     {{< nextlink href="agent/faq/how-do-i-install-the-agent-on-a-server-with-limited-internet-connectivity" >}}How do I install the Agent on a server with limited internet connectivity?{{< /nextlink >}}
     {{< nextlink href="agent/faq/how-do-i-uninstall-the-agent" >}}How do I uninstall the Agent?{{< /nextlink >}}
+    {{< nextlink href="agent/faq/macos-agent-run-as-system-service" >}}How do I set up the Agent to run as a system service on MacOS?{{< /nextlink >}}
     {{< nextlink href="agent/faq/error-restarting-agent-already-listening-on-a-configured-port" >}}Error Restarting Agent: Already Listening on a Configured Port{{< /nextlink >}}
     {{< nextlink href="agent/faq/how-is-the-system-mem-used-metric-calculated" >}}How is the 'system.mem.used' metric calculated?{{< /nextlink >}}
     {{< nextlink href="agent/faq/why-should-i-install-the-agent-on-my-cloud-instances" >}}Why should I install the Datadog Agent on my cloud instances?{{< /nextlink >}}

--- a/content/en/agent/faq/_index.md
+++ b/content/en/agent/faq/_index.md
@@ -14,7 +14,7 @@ aliases:
     {{< nextlink href="agent/faq/how-datadog-agent-determines-the-hostname" >}}How does Datadog determine the Agent hostname?{{< /nextlink >}}
     {{< nextlink href="agent/faq/how-do-i-install-the-agent-on-a-server-with-limited-internet-connectivity" >}}How do I install the Agent on a server with limited internet connectivity?{{< /nextlink >}}
     {{< nextlink href="agent/faq/how-do-i-uninstall-the-agent" >}}How do I uninstall the Agent?{{< /nextlink >}}
-    {{< nextlink href="agent/faq/macos-agent-run-as-system-service" >}}How do I set up the Agent to run as a system service on MacOS?{{< /nextlink >}}
+    {{< nextlink href="agent/faq/macos-agent-run-as-system-service" >}}How do I set up the Agent to run as a system service on macOS?{{< /nextlink >}}
     {{< nextlink href="agent/faq/error-restarting-agent-already-listening-on-a-configured-port" >}}Error Restarting Agent: Already Listening on a Configured Port{{< /nextlink >}}
     {{< nextlink href="agent/faq/how-is-the-system-mem-used-metric-calculated" >}}How is the 'system.mem.used' metric calculated?{{< /nextlink >}}
     {{< nextlink href="agent/faq/why-should-i-install-the-agent-on-my-cloud-instances" >}}Why should I install the Datadog Agent on my cloud instances?{{< /nextlink >}}

--- a/content/en/agent/faq/macos-agent-run-as-system-service.md
+++ b/content/en/agent/faq/macos-agent-run-as-system-service.md
@@ -1,0 +1,66 @@
+---
+title: How do I set up the Agent to run as a system service on MacOS?
+kind: faq
+further_reading:
+- link: "/agent/"
+  tag: "Documentation"
+  text: "Learn more about the Datadog Agent"
+---
+
+On MacOS, the Datadog Agent is installed as a user service (for the user that runs the install instructions). This allows the Datadog Agent GUI application to work (while logged in to the MacOS GUI as the user that performed the install), but the main drawback is that the Agent only runs when the user that performed the install is logged in using the MacOS GUI.
+
+Because of this, by default the Datadog Agent doesn't run in cases where no GUI access to the MacOS host is available. Additional steps are therefore required when installing & running the MacOS Datadog Agent with no GUI access.
+
+## Install
+
+1. Connect to the host and [follow the Agent installation instructions][1] to install the MacOS Datadog Agent.
+
+2. As the user that ran the install, execute the following bash script:
+
+```sh
+#!/bin/bash
+
+echo "Moving the Datadog Agent service for the $USER user to a system service"
+# Move the per-user service definition installed by the Agent to a system service
+sudo mv /Users/$USER/Library/LaunchAgents/com.datadoghq.agent.plist /Library/LaunchDaemons/com.datadoghq.agent.plist
+
+echo "Setting the Datadog Agent service to run as the $USER user"
+# By default, system services run as root.
+# This plist file modification is needed to make the Agent not run as root, but as the current user.
+sudo plutil -insert UserName -string "$USER" /Library/LaunchDaemons/com.datadoghq.agent.plist
+
+echo "Setting permissions on the Datadog Agent service file"
+# Put the correct permissions on the plist file.
+# Otherwise launchctl will refuse running commands for this service.
+sudo chown root:staff /Library/LaunchDaemons/com.datadoghq.agent.plist
+
+echo "Enabling the Datadog Agent service"
+# Enable the service: makes sure it runs on reboot
+sudo launchctl enable system/com.datadoghq.agent
+
+echo "Loading & launching the Datadog Agent service"
+# Load the service: this starts the Agent
+sudo launchctl load /Library/LaunchDaemons/com.datadoghq.agent.plist
+```
+
+This script reconfigures the Datadog Agent service to run as a launch daemon, with the following properties:
+- the service is automatically started when the host starts
+- the Agent processes run as the user that ran the above script (to avoid running as root)
+- the Datadog Agent GUI application won't be available.
+
+
+## Operations
+
+To operate the Datadog Agent service once the following script is executed, run (as the `root` user, or with `sudo`):
+
+- `launchctl list com.datadoghq.agent` to print the service status.
+
+- `launchctl stop com.datadoghq.agent` to stop the Agent.
+
+- `launchctl start com.datadoghq.agent` to start the Agent.
+
+- `launchctl disable system/com.datadoghq.agent` to disable the Agent (ie. the above list / start / stop commands won’t work, and the service won’t be started when the host reboots). 
+
+- `launchctl enable system/com.datadoghq.agent` then `launchctl load /Library/LaunchDaemons/com.datadoghq.agent.plist` to enable the Agent.
+
+[1]: https://app.datadoghq.com/account/settings#agent

--- a/content/en/agent/faq/macos-agent-run-as-system-service.md
+++ b/content/en/agent/faq/macos-agent-run-as-system-service.md
@@ -1,5 +1,5 @@
 ---
-title: How do I set up the Agent to run as a system service on MacOS?
+title: How do I set up the Agent to run as a system service on macOS?
 kind: faq
 further_reading:
 - link: "/agent/"
@@ -7,13 +7,13 @@ further_reading:
   text: "Learn more about the Datadog Agent"
 ---
 
-On MacOS, the Datadog Agent is installed as a user service (for the user that runs the install instructions). This allows the Datadog Agent GUI system tray application to work (while logged in to the MacOS GUI as the user that performed the install), but the main drawback is that the Agent only runs when the user that performed the install is logged in using the MacOS GUI.
+On macOS, the Datadog Agent is installed as a user service (for the user that runs the install instructions). This allows the Datadog Agent GUI system tray application to work (while logged in to the macOS GUI as the user that performed the install), but the main drawback is that the Agent only runs when the user that performed the install is logged in using the macOS GUI.
 
-Because of this, by default the Datadog Agent doesn't run in cases where no GUI access to the MacOS host is available. Additional steps are therefore required when installing & running the MacOS Datadog Agent with no GUI access.
+Because of this, by default the Datadog Agent doesn't run in cases where no GUI access to the macOS host is available. Additional steps are therefore required when installing & running the macOS Datadog Agent with no GUI access.
 
 ## Install
 
-1. Connect to the host and [follow the Agent installation instructions][1] to install the MacOS Datadog Agent.
+1. Connect to the host and [follow the Agent installation instructions][1] to install the macOS Datadog Agent.
 
 2. As the user that ran the install, execute the following bash script:
 

--- a/content/en/agent/faq/macos-agent-run-as-system-service.md
+++ b/content/en/agent/faq/macos-agent-run-as-system-service.md
@@ -7,9 +7,9 @@ further_reading:
   text: "Learn more about the Datadog Agent"
 ---
 
-On macOS, the Datadog Agent is installed as a user service (for the user that runs the install instructions). This allows the Datadog Agent GUI system tray application to work (while logged in to the macOS GUI as the user that performed the install), but the main drawback is that the Agent only runs when the user that performed the install is logged in using the macOS GUI.
+On macOS, the Datadog Agent is installed as a user service for the user that runs the install instructions. This allows the Datadog Agent GUI system tray application to work, if you're logged in to the macOS GUI as the user that performed the install. The main drawback is that the Agent runs only when the user that performed the install is logged in using the macOS GUI.
 
-Because of this, by default the Datadog Agent doesn't run in cases where no GUI access to the macOS host is available. Additional steps are therefore required when installing & running the macOS Datadog Agent with no GUI access.
+Because of this, by default the Datadog Agent doesn't run in cases where no GUI access to the macOS host is available. Additional steps are therefore required when installing and running the macOS Datadog Agent with no GUI access.
 
 ## Install
 
@@ -17,7 +17,7 @@ Because of this, by default the Datadog Agent doesn't run in cases where no GUI 
 
 2. As the user that ran the install, execute the following bash script:
 
-```sh
+    ```sh
 #!/bin/bash
 
 echo "Moving the Datadog Agent service for the $USER user to a system service"
@@ -44,14 +44,14 @@ sudo launchctl load /Library/LaunchDaemons/com.datadoghq.agent.plist
 ```
 
 This script reconfigures the Datadog Agent service to run as a launch daemon, with the following properties:
-- the service is automatically started when the host starts
-- the Agent processes run as the user that ran the above script (to avoid running as root)
-- the Datadog Agent GUI system tray application won't be available.
+- The service is automatically started when the host starts.
+- The Agent processes run as the user that ran the above script (to avoid running as root).
+- The Datadog Agent GUI system tray application is not available.
 
 
 ## Operations
 
-The Datadog Agent service is managed with `launchctl`. After the above installation instructions have been run you can manage the Agent service with the following commands:
+The Datadog Agent service is managed with `launchctl`. After the above installation instructions have been run, manage the Agent service with the following commands:
 
 | Description                   | Command                                                                                                                   |
 |-------------------------------|---------------------------------------------------------------------------------------------------------------------------|
@@ -62,6 +62,6 @@ The Datadog Agent service is managed with `launchctl`. After the above installat
 | Enable Agent service          | `sudo launchctl enable system/com.datadoghq.agent && sudo launchctl load /Library/LaunchDaemons/com.datadoghq.agent.plist`|
 
 
-Disabling the Agent prevents the list / start / stop commands from working, and prevents the Agent service from being started on reboot. 
+Disabling the Agent prevents the `list`, `start`, and `stop` commands from working, and prevents the Agent service from being started on reboot. 
 
 [1]: https://app.datadoghq.com/account/settings#agent/mac

--- a/content/en/agent/faq/macos-agent-run-as-system-service.md
+++ b/content/en/agent/faq/macos-agent-run-as-system-service.md
@@ -51,16 +51,17 @@ This script reconfigures the Datadog Agent service to run as a launch daemon, wi
 
 ## Operations
 
-To operate the Datadog Agent service once the following script is executed, run (as the `root` user, or with `sudo`):
+The Datadog Agent service is managed with `launchctl`. After the above installation instructions have been run you can manage the Agent service with the following commands:
 
-- `launchctl list com.datadoghq.agent` to print the service status.
+| Description                   | Command                                                                                                                   |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| Start Agent service           | `sudo launchctl start com.datadoghq.agent`                                                                                |
+| Stop Agent running service    | `sudo launchctl stop com.datadoghq.agent`                                                                                 |
+| Status of Agent service       | `sudo launchctl list com.datadoghq.agent`                                                                                 |
+| Disable Agent service         | `sudo launchctl disable system/com.datadoghq.agent`                                                                       |
+| Enable Agent service          | `sudo launchctl enable system/com.datadoghq.agent && sudo launchctl load /Library/LaunchDaemons/com.datadoghq.agent.plist`|
 
-- `launchctl stop com.datadoghq.agent` to stop the Agent.
 
-- `launchctl start com.datadoghq.agent` to start the Agent.
+Disabling the Agent prevents the list / start / stop commands from working, and prevents the Agent service from being started on reboot. 
 
-- `launchctl disable system/com.datadoghq.agent` to disable the Agent (ie. the above list / start / stop commands won’t work, and the service won’t be started when the host reboots). 
-
-- `launchctl enable system/com.datadoghq.agent` then `launchctl load /Library/LaunchDaemons/com.datadoghq.agent.plist` to enable the Agent.
-
-[1]: https://app.datadoghq.com/account/settings#agent
+[1]: https://app.datadoghq.com/account/settings#agent/mac

--- a/content/en/agent/faq/macos-agent-run-as-system-service.md
+++ b/content/en/agent/faq/macos-agent-run-as-system-service.md
@@ -7,7 +7,7 @@ further_reading:
   text: "Learn more about the Datadog Agent"
 ---
 
-On MacOS, the Datadog Agent is installed as a user service (for the user that runs the install instructions). This allows the Datadog Agent GUI application to work (while logged in to the MacOS GUI as the user that performed the install), but the main drawback is that the Agent only runs when the user that performed the install is logged in using the MacOS GUI.
+On MacOS, the Datadog Agent is installed as a user service (for the user that runs the install instructions). This allows the Datadog Agent GUI system tray application to work (while logged in to the MacOS GUI as the user that performed the install), but the main drawback is that the Agent only runs when the user that performed the install is logged in using the MacOS GUI.
 
 Because of this, by default the Datadog Agent doesn't run in cases where no GUI access to the MacOS host is available. Additional steps are therefore required when installing & running the MacOS Datadog Agent with no GUI access.
 
@@ -46,7 +46,7 @@ sudo launchctl load /Library/LaunchDaemons/com.datadoghq.agent.plist
 This script reconfigures the Datadog Agent service to run as a launch daemon, with the following properties:
 - the service is automatically started when the host starts
 - the Agent processes run as the user that ran the above script (to avoid running as root)
-- the Datadog Agent GUI application won't be available.
+- the Datadog Agent GUI system tray application won't be available.
 
 
 ## Operations

--- a/content/en/agent/faq/macos-agent-run-as-system-service.md
+++ b/content/en/agent/faq/macos-agent-run-as-system-service.md
@@ -18,30 +18,30 @@ Because of this, by default the Datadog Agent doesn't run in cases where no GUI 
 2. As the user that ran the install, execute the following bash script:
 
     ```sh
-#!/bin/bash
+    #!/bin/bash
 
-echo "Moving the Datadog Agent service for the $USER user to a system service"
-# Move the per-user service definition installed by the Agent to a system service
-sudo mv /Users/$USER/Library/LaunchAgents/com.datadoghq.agent.plist /Library/LaunchDaemons/com.datadoghq.agent.plist
+    echo "Moving the Datadog Agent service for the $USER user to a system service"
+    # Move the per-user service definition installed by the Agent to a system service
+    sudo mv /Users/$USER/Library/LaunchAgents/com.datadoghq.agent.plist /Library/LaunchDaemons/com.datadoghq.agent.plist
 
-echo "Setting the Datadog Agent service to run as the $USER user"
-# By default, system services run as root.
-# This plist file modification is needed to make the Agent not run as root, but as the current user.
-sudo plutil -insert UserName -string "$USER" /Library/LaunchDaemons/com.datadoghq.agent.plist
+    echo "Setting the Datadog Agent service to run as the $USER user"
+    # By default, system services run as root.
+    # This plist file modification is needed to make the Agent not run as root, but as the current user.
+    sudo plutil -insert UserName -string "$USER" /Library/LaunchDaemons/com.datadoghq.agent.plist
 
-echo "Setting permissions on the Datadog Agent service file"
-# Put the correct permissions on the plist file.
-# Otherwise launchctl will refuse running commands for this service.
-sudo chown root:staff /Library/LaunchDaemons/com.datadoghq.agent.plist
+    echo "Setting permissions on the Datadog Agent service file"
+    # Put the correct permissions on the plist file.
+    # Otherwise launchctl will refuse running commands for this service.
+    sudo chown root:staff /Library/LaunchDaemons/com.datadoghq.agent.plist
 
-echo "Enabling the Datadog Agent service"
-# Enable the service: makes sure it runs on reboot
-sudo launchctl enable system/com.datadoghq.agent
+    echo "Enabling the Datadog Agent service"
+    # Enable the service: makes sure it runs on reboot
+    sudo launchctl enable system/com.datadoghq.agent
 
-echo "Loading & launching the Datadog Agent service"
-# Load the service: this starts the Agent
-sudo launchctl load /Library/LaunchDaemons/com.datadoghq.agent.plist
-```
+    echo "Loading & launching the Datadog Agent service"
+    # Load the service: this starts the Agent
+    sudo launchctl load /Library/LaunchDaemons/com.datadoghq.agent.plist
+    ```
 
 This script reconfigures the Datadog Agent service to run as a launch daemon, with the following properties:
 - The service is automatically started when the host starts.


### PR DESCRIPTION
### What does this PR do?

Adds an FAQ page about additional steps to make the MacOS Agent work in environments where GUI access is not available.

### Motivation

Provide easy-to-access docs to teams trying to set up MacOS Agents on hosts without GUI access (eg. production servers where only SSH access is available.

### Preview

[FAQ list page](https://docs-staging.datadoghq.com/kylian.serrania/macos-system-service-faq/agent/faq/)
[FAQ page](https://docs-staging.datadoghq.com/kylian.serrania/macos-system-service-faq/agent/faq/macos-agent-run-as-system-service/)

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
