### PR TITLE
adding_note_for_32_bit

### DIFF
--- a/content/en/developers/metrics/_index.md
+++ b/content/en/developers/metrics/_index.md
@@ -33,7 +33,7 @@ A Datadog custom metric has the properties below. Refer to the [Metrics Introduc
 | Property         | Description                                                                                                                                                  |
 |------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `<METRIC_NAME>`  | The [name of your metric](#naming-custom-metrics).                                                                                                                  |
-| `<METRIC_VALUE>` | The value of your metric.                                                                                                                                    |
+| `<METRIC_VALUE>` | The value of your metric. **Note**: Metric values must be 32 bit.                                                                                                                                 |
 | `<TIMESTAMP>`    | The timestamp associated with the metric value. **Note**: Metric timestamps cannot be more than ten minutes in the future or more than one hour in the past. |
 | `<TAGS>`         | The set of tags associated with your metric.                                                                                                                 |
 | `<METRIC_TYPE>`  | The type of your metric. See the [metric type documentation][8].                                                                                             |

--- a/content/en/developers/metrics/_index.md
+++ b/content/en/developers/metrics/_index.md
@@ -33,7 +33,7 @@ A Datadog custom metric has the properties below. Refer to the [Metrics Introduc
 | Property         | Description                                                                                                                                                  |
 |------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `<METRIC_NAME>`  | The [name of your metric](#naming-custom-metrics).                                                                                                                  |
-| `<METRIC_VALUE>` | The value of your metric. **Note**: Metric values must be 32 bit.                                                                                                                                 |
+| `<METRIC_VALUE>` | The value of your metric. **Note**: Metric values must be 32-bit.                                                                                                                                 |
 | `<TIMESTAMP>`    | The timestamp associated with the metric value. **Note**: Metric timestamps cannot be more than ten minutes in the future or more than one hour in the past. |
 | `<TAGS>`         | The set of tags associated with your metric.                                                                                                                 |
 | `<METRIC_TYPE>`  | The type of your metric. See the [metric type documentation][8].                                                                                             |


### PR DESCRIPTION
Our storage backend will convert values to 32 bit. Sometimes this means large values will be converted to their 32 bit counterpart. We should specify this.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add a note in main metric docs for what we expect in a metric value payload

### Motivation
https://datadoghq.atlassian.net/browse/METS-3199

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mikepcarlos-docs/developers/metrics/#custom-metrics-properties

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
