### PR TITLE
Update Password Reset docs to include EU endpoint

### DIFF
--- a/content/en/account_management/faq/help-my-password-email-never-came-through.md
+++ b/content/en/account_management/faq/help-my-password-email-never-came-through.md
@@ -13,9 +13,11 @@ Confirm this from the team page as shown here:
 
 {{< img src="account_management/faq/handle_image.png" alt="handle image"  >}}
 
-Enter your email address in the password reset link:
+Enter your email address in the password reset link for your region:
 
-`https://app.datadoghq.com/account/forgot_password`
+Datadog US Region: `https://app.datadoghq.com/account/forgot_password`
+Datadog EU Region: `https://app.datadoghq.eu/account/forgot_password`
+
 
 If you have confirmed your email address is correct and you still have not received your password reset email, check your spam and filtered emails.  
 

--- a/content/en/account_management/faq/help-my-password-email-never-came-through.md
+++ b/content/en/account_management/faq/help-my-password-email-never-came-through.md
@@ -15,8 +15,14 @@ Confirm this from the team page as shown here:
 
 Enter your email address in the password reset link for your region:
 
+
+{{< site-region region="us" >}}
 Datadog US Region: `https://app.datadoghq.com/account/forgot_password`
+{{< /site-region >}}
+
+{{< site-region region="eu" >}}
 Datadog EU Region: `https://app.datadoghq.eu/account/forgot_password`
+{{< /site-region >}}
 
 
 If you have confirmed your email address is correct and you still have not received your password reset email, check your spam and filtered emails.  


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This PR updates the password reset docs to include the link where customers in the EU need to go to reset their passwords

### Motivation

frequent support tickets from using the wrong endpoint link

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alexandrafren/reset-passwords-eu-link/account_management/faq/help-my-password-email-never-came-through/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
