### PR TITLE
[WEB-1491] - catch dt dd tags

### DIFF
--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -193,7 +193,7 @@
             },
             "lvl1": ".main h1",
             "lvl2": ".main h2",
-            "text": ".main p, table tbody tr td, code-tabs table tbody tr td, pre code",
+            "text": ".main p, table tbody tr td, code-tabs table tbody tr td, dl dt, dl dd, pre code",
             "language": {
                 "selector": "/html/@lang",
                 "type": "xpath",
@@ -210,7 +210,7 @@
             "lvl2": ".main h2",
             "lvl3": ".main h3",
             "lvl4": ".main h4",
-            "text": ".main p, .main ul > li, table tbody tr td, code-tabs table tbody tr td, pre code",
+            "text": ".main p, .main ul > li, table tbody tr td, code-tabs table tbody tr td, dl dt, dl dd, pre code",
             "language": {
                 "selector": "/html/@lang",
                 "type": "xpath",
@@ -227,7 +227,7 @@
             "lvl2": ".main h2",
             "lvl3": ".main h3",
             "lvl4": ".main h4",
-            "text": ".main p, .main ul > li, table tbody tr, code-tabs table tbody tr td, pre code",
+            "text": ".main p, .main ul > li, table tbody tr, code-tabs table tbody tr td, dl dt, dl dd, pre code",
             "language": {
                 "selector": "/html/@lang",
                 "type": "xpath",

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -193,7 +193,7 @@
             },
             "lvl1": ".main h1",
             "lvl2": ".main h2",
-            "text": ".main p, table tbody tr td, code-tabs table tbody tr td, pre code",
+            "text": ".main p, table tbody tr td, code-tabs table tbody tr td, dl dt, dl dd, pre code",
             "language": {
                 "selector": "/html/@lang",
                 "type": "xpath",
@@ -210,7 +210,7 @@
             "lvl2": ".main h2",
             "lvl3": ".main h3",
             "lvl4": ".main h4",
-            "text": ".main p, .main ul > li, table tbody tr td, code-tabs table tbody tr td, pre code",
+            "text": ".main p, .main ul > li, table tbody tr td, code-tabs table tbody tr td, dl dt, dl dd, pre code",
             "language": {
                 "selector": "/html/@lang",
                 "type": "xpath",
@@ -227,7 +227,7 @@
             "lvl2": ".main h2",
             "lvl3": ".main h3",
             "lvl4": ".main h4",
-            "text": ".main p, .main ul > li, table tbody tr, code-tabs table tbody tr td, pre code",
+            "text": ".main p, .main ul > li, table tbody tr, code-tabs table tbody tr td, dl dt, dl dd, pre code",
             "language": {
                 "selector": "/html/@lang",
                 "type": "xpath",


### PR DESCRIPTION
### What does this PR do?

updates algolia to also index dt, dd data

### Motivation

https://datadoghq.atlassian.net/browse/WEB-1491

### Preview

1. visit https://docs-staging.datadoghq.com/david.jones/table-def/
2. in the search enter datadog.trace_agent.cpu_percent
3. You should see results

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
