### PR TITLE
updating to remove helm stable line, closes #10834

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -50,10 +50,9 @@ To install the chart with a custom release name, `<RELEASE_NAME>` (e.g. `datadog
 
 1. [Install Helm][1].
 2. Download the [Datadog `values.yaml` configuration file][2].
-3. If this is a fresh install, add the Helm Datadog repo and the Helm stable repo (for Kube State Metrics chart):
+3. If this is a fresh install, add the Helm Datadog repo:
     ```bash
     helm repo add datadog https://helm.datadoghq.com
-    helm repo add stable https://charts.helm.sh/stable
     helm repo update
     ```
 4. Retrieve your Datadog API key from your [Agent installation instructions][3] and run:


### PR DESCRIPTION
### What does this PR do?
Updating to remove helm stable line, since now everything lives in https://github.com/DataDog/helm-charts now. It looks like we captured all of the updated links, but we forgot to update the code example. Closes #10834. 


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
