### PR TITLE
[rum] Fix broken link for SPA view attributes

### DIFF
--- a/content/en/real_user_monitoring/browser/data_collected.md
+++ b/content/en/real_user_monitoring/browser/data_collected.md
@@ -59,7 +59,7 @@ RUM action, error, resource and long task events contain information about the a
 | Attribute name                 | Type   | Description                                                                                                    |
 |--------------------------------|--------|----------------------------------------------------------------------------------------------------------------|
 | `view.id`                      | string | Randomly generated ID for each page view.                                                                      |
-| `view.loading_type`                     | string | The type of page load: `initial_load` or `route_change`. For more information, see the [single page applications support docs](#single-page-applications).|
+| `view.loading_type`                     | string | The type of page load: `initial_load` or `route_change`. For more information, see the [single page applications support docs](?tab=view#single-page-applications).|
 | `view.referrer`                | string | The URL of the previous web page from which a link to the currently requested page was followed.               |
 | `view.url`                     | string | The view URL.                                                                                                  |
 | `view.url_hash`                     | string | The hash part of the URL.|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

- Add URL parameter to SPA docs link so that the correct tab is opened. (Without this, if someone does not have the `view` tab open, the link won't work.)

### Motivation

- Using the docs + clicking a link that had no effect . (Was using this page to figure out how to add Datadog Rum to a plug-in for Storybook). 

### Preview
<!-- Impacted pages preview links-->

- https://docs.datadoghq.com/real_user_monitoring/browser/data_collected/?tab=session#view-attributes
- https://docs-staging.datadoghq.com/hydrosquall/update-rum-spa-docs/real_user_monitoring/browser/data_collected/?tab=session#view-attributes

### Additional Notes
 
- N/A

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
