### PR TITLE
Adding default polling timeout

### DIFF
--- a/content/en/synthetics/ci.md
+++ b/content/en/synthetics/ci.md
@@ -540,7 +540,9 @@ Variables to replace in the test. This object should contain, as keys, the name 
 
 `pollingTimeout`
 : **Type**: integer<br>
-Duration after which `datadog-ci` should stop polling for test results (in milliseconds). Test results finishing after this duration are considered failed test results at the CI level. Defaults to 120000 ms.
+The duration in milliseconds after which `datadog-ci` stops polling for test results. The default is 120,000 ms. 
+
+At the CI level, test results completed after this duration are considered failed.
 
 **Note**: Tests' overrides take precedence over global overrides.
 

--- a/content/en/synthetics/ci.md
+++ b/content/en/synthetics/ci.md
@@ -542,7 +542,6 @@ Variables to replace in the test. This object should contain, as keys, the name 
 : **Type**: integer<br>
 The duration in milliseconds after which `datadog-ci` stops polling for test results. The default is 120,000 ms. At the CI level, test results completed after this duration are considered failed.
 
-
 **Note**: Tests' overrides take precedence over global overrides.
 
 **Example advanced test configuration file**:

--- a/content/en/synthetics/ci.md
+++ b/content/en/synthetics/ci.md
@@ -540,7 +540,7 @@ Variables to replace in the test. This object should contain, as keys, the name 
 
 `pollingTimeout`
 : **Type**: integer<br>
-The duration in milliseconds after which `datadog-ci` stops polling for test results. The default is 120,000 ms. 
+The duration in milliseconds after which `datadog-ci` stops polling for test results. The default is 120,000 ms. At the CI level, test results completed after this duration are considered failed.
 
 
 **Note**: Tests' overrides take precedence over global overrides.

--- a/content/en/synthetics/ci.md
+++ b/content/en/synthetics/ci.md
@@ -540,7 +540,7 @@ Variables to replace in the test. This object should contain, as keys, the name 
 
 `pollingTimeout`
 : **Type**: integer<br>
-Duration after which `datadog-ci` should stop polling for test results (in milliseconds). Test results finishing after this duration are considered failed test results at the CI level.
+Duration after which `datadog-ci` should stop polling for test results (in milliseconds). Test results finishing after this duration are considered failed test results at the CI level. Defaults to 120000 ms.
 
 **Note**: Tests' overrides take precedence over global overrides.
 

--- a/content/en/synthetics/ci.md
+++ b/content/en/synthetics/ci.md
@@ -542,7 +542,6 @@ Variables to replace in the test. This object should contain, as keys, the name 
 : **Type**: integer<br>
 The duration in milliseconds after which `datadog-ci` stops polling for test results. The default is 120,000 ms. 
 
-At the CI level, test results completed after this duration are considered failed.
 
 **Note**: Tests' overrides take precedence over global overrides.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds the default for the pollingTimeout parameter

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
