### PR TITLE
DOCS-2135 Deemphasize ruby in CI docs

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1671,21 +1671,16 @@ main:
     parent: setup_tests
     identifier: ci_python
     weight: 106
-  - name: Ruby
-    url: continuous_integration/setup_tests/ruby/
-    parent: setup_tests
-    identifier: ci_ruby
-    weight: 107
   - name: Swift
     url: continuous_integration/setup_tests/swift/
     parent: setup_tests
     identifier: ci_swift
-    weight: 108
+    weight: 107
   - name: JUnit Report Uploads
     url: continuous_integration/setup_tests/junit_upload/
     parent: setup_tests
     identifier: ci_junit
-    weight: 109
+    weight: 108
   - name: Tracing Pipelines
     url: continuous_integration/setup_pipelines/
     parent: ci

--- a/content/en/continuous_integration/setup_tests/_index.md
+++ b/content/en/continuous_integration/setup_tests/_index.md
@@ -14,7 +14,6 @@ To gather test suite results, performance, and reliability data, first set up th
     {{< nextlink href="continuous_integration/setup_tests/java" >}}Java{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_tests/javascript" >}}JavaScript{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_tests/python" >}}Python{{< /nextlink >}}
-    {{< nextlink href="continuous_integration/setup_tests/ruby" >}}Ruby{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_tests/swift" >}}Swift{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_tests/junit_upload" >}}Uploading JUnit test report files to Datadog{{< /nextlink >}}
 {{< /whatsnext >}}


### PR DESCRIPTION
### What does this PR do?
Removes ruby from sidebar and index page

### Motivation
Conversation with PM, DOCS-2135

### Preview
https://docs-staging.datadoghq.com/kari/docs-2135/continuous_integration/setup_tests/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
