### PR TITLE
Display estimated usage for Analyzed Logs (security)

### DIFF
--- a/content/en/account_management/billing/usage_metrics.md
+++ b/content/en/account_management/billing/usage_metrics.md
@@ -20,20 +20,21 @@ Datadog calculates your current estimated usage in near real-time. Estimated usa
 
 Estimated usage metrics are generally available for the following usage types:
 
-| Usage Type           | Metric                                   |
-|----------------------|------------------------------------------|
-| Infrastructure Hosts | `datadog.estimated_usage.hosts`          |
-| Containers           | `datadog.estimated_usage.containers`     |
-| Custom Metrics       | `datadog.estimated_usage.metrics.custom` |
-| Logs Ingested Bytes  | `datadog.estimated_usage.logs.ingested_bytes`          |
-| Logs Ingested Events | `datadog.estimated_usage.logs.ingested_events`   |
-| APM Hosts            | `datadog.estimated_usage.apm_hosts`      |
-| APM Indexed Spans   | `datadog.estimated_usage.apm.indexed_spans` |
-| APM Ingested Bytes   | `datadog.estimated_usage.apm.ingested_bytes` |
-| APM Ingested Spans   | `datadog.estimated_usage.apm.ingested_spans` |
-| Serverless Lambda Functions | `datadog.estimated_usage.serverless.aws_lambda_functions` |
-| API test runs        | `datadog.estimated_usage.synthetics.api_test_runs` |
-| Browser test runs    | `datadog.estimated_usage.synthetics.browser_test_runs`|
+| Usage Type                    | Metric                                   |
+|-------------------------------|------------------------------------------|
+| Infrastructure Hosts          | `datadog.estimated_usage.hosts`          |
+| Containers                    | `datadog.estimated_usage.containers`     |
+| Custom Metrics                | `datadog.estimated_usage.metrics.custom` |
+| Logs Ingested Bytes           | `datadog.estimated_usage.logs.ingested_bytes`          |
+| Logs Ingested Events          | `datadog.estimated_usage.logs.ingested_events`   |
+| Analyzed Logs (security)      | `datadog.estimated_usage.security_monitoring.analyzed_bytes`   |
+| APM Hosts                     | `datadog.estimated_usage.apm_hosts`      |
+| APM Indexed Spans             | `datadog.estimated_usage.apm.indexed_spans` |
+| APM Ingested Bytes            | `datadog.estimated_usage.apm.ingested_bytes` |
+| APM Ingested Spans            | `datadog.estimated_usage.apm.ingested_spans` |
+| Serverless Lambda Functions   | `datadog.estimated_usage.serverless.aws_lambda_functions` |
+| API test runs                 | `datadog.estimated_usage.synthetics.api_test_runs` |
+| Browser test runs             | `datadog.estimated_usage.synthetics.browser_test_runs`|
 
 Log-based usage metrics must be manually enabled from the [Generate Metrics][1] page.
 


### PR DESCRIPTION
### What does this PR do?
Update the Usage Metrics page to include estimated usage for Security Monitoring: `datadog.estimated_usage.security_monitoring.analyzed_bytes`

### Motivation
Customer question

### Preview
https://docs-staging.datadoghq.com/marc.tremsal/security-monitoring-usage-metric/account_management/billing/usage_metrics/#types-of-usage

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
