### PR TITLE
Add priority override instructions

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -71,6 +71,21 @@ Learn how to configure your monitors for those use cases in [the example section
 ### Priority
 
 Add a priority (optional) associated with your monitors. Values range from P1 through P5, with P1 being the highest priority and the P5 being the lowest.
+To override the monitor priority in the notification message, use `{{override_priority 'Pi'}}` where `Pi` is between P1 and P5. 
+
+Example: different priority for `alert` and `warning` notifications:
+
+```
+{{#is_alert}}
+{{override_priority 'P1'}}
+ ...
+{{/is_alert}}
+
+{{#is_warning}}
+{{override_priority 'P4'}}
+...
+{{/is_warning}}
+```
 
 ## Notify your team
 

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -73,7 +73,7 @@ Learn how to configure your monitors for those use cases in [the example section
 Add a priority (optional) associated with your monitors. Values range from P1 through P5, with P1 being the highest priority and the P5 being the lowest.
 To override the monitor priority in the notification message, use `{{override_priority 'Pi'}}` where `Pi` is between P1 and P5. 
 
-Example: different priority for `alert` and `warning` notifications:
+For example, you can set different priorities for `alert` and `warning` notifications:
 
 ```
 {{#is_alert}}


### PR DESCRIPTION
### What does this PR do?
Add instruction on how to override the priority for a monitor notification.

### Motivation
Feature was just released.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/monitor-priority-override/monitors/notifications/?tab=is_alert#priority

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
