### PR TITLE
[ci-app] Add instructions to enable CI Visibility in Jenkins

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -35,6 +35,33 @@ INFO    datadog.trace.core.StatusLogger#logStatus: DATADOG TRACER CONFIGURATION 
 **Note**: Enabling the collection of traces using the Jenkins plugin is incompatible with running the Java APM tracer as a Java agent when launching Jenkins.
 
 
+## Enabling CI Visibility on the plugin
+
+While in beta, the UI to activate CI Visibility is hidden and needs to be manually configured following these steps:
+
+1. Open the file: `$JENKINS_HOME\org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration.xml`
+
+2. Add or modify the following lines:
+
+{{< code-block lang="xml" >}}
+<reportWith>DSD</reportWith>
+<targetHost>localhost</targetHost>
+<targetPort>8125</targetPort>
+<targetTraceCollectionPort>8126</targetTraceCollectionPort>
+<traceServiceName>my-jenkins-instance</traceServiceName>
+<collectBuildTraces>true</collectBuildTraces>
+{{< /code-block >}}
+
+3. Restart Jenkins for the changes to take effect.
+
+If the configuration is correct, you should be able to see the following lines in the Jenkins log after restarting it:
+
+{{< code-block lang="text" >}}
+INFO    datadog.trace.core.CoreTracer#<init>: New instance: DDTracer-62fcf62{ ... }
+INFO    datadog.trace.core.StatusLogger#logStatus: DATADOG TRACER CONFIGURATION { ... }
+{{< /code-block >}}
+
+
 ## Enable job log collection on the Agent
 
 Enable log collection in the Agent:

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -48,7 +48,7 @@ While in beta, the UI to activate CI Visibility is hidden and needs to be manual
 <targetHost>localhost</targetHost>
 <targetPort>8125</targetPort>
 <targetTraceCollectionPort>8126</targetTraceCollectionPort>
-<traceServiceName>my-jenkins-instance</traceServiceName>
+<traceServiceName>jenkins</traceServiceName>
 <collectBuildTraces>true</collectBuildTraces>
 {{< /code-block >}}
 

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -54,7 +54,7 @@ While in beta, the UI to activate CI Visibility is hidden and needs to be manual
 
 3. Restart Jenkins for the changes to take effect.
 
-If the configuration is correct, you should be able to see the following lines in the Jenkins log after restarting it:
+If the configuration is correct, your Jenkins log should contain the following lines after restarting:
 
 {{< code-block lang="text" >}}
 INFO    datadog.trace.core.CoreTracer#<init>: New instance: DDTracer-62fcf62{ ... }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds a missing section to the CI Visibility Jenkins instructions that explain how to enable CI visibility on the plugin.

### Motivation
<!-- What inspired you to submit this pull request?-->

Customers won't be able to properly configure the Jenkins plugin for CI visibility without this section.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fermayo/ciapp-fix-jenkins-docs/continuous_integration/setup_pipelines/jenkins/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

We are actively working on enabling the UI for configuring the Jenkins plugin, so these instructions will be greatly simplified very soon.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
