### PR TITLE
[apm] add warning on otel collector docs about v0.28

### DIFF
--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -23,6 +23,10 @@ Datadog supports a variety of open standards, including [OpenTelemetry][1] and [
 
 ## OpenTelemetry collector Datadog exporter
 
+<div class="alert alert-warning">
+The Datadog exporter version v0.28.0 (the current latest version at time of writing) has reports of an <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3786">unintended issue</a> that may cause Traces exported to Datadog to not be retained past 15 minutes. This may cause unexpected behavior in the Datadog UI. The current recommended version of the Datadog Exporter is <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.27.0">v0.27.0</a>. Please <a href="https://docs.datadoghq.com/help/">Reach out to support</a> if it doesn't work as you expect.
+</div>
+
 The OpenTelemetry Collector is a vendor-agnostic separate agent process for collecting and exporting telemetry data emitted by many processes. Datadog has [an exporter available within the OpenTelemetry Collector][3] to receive traces and metrics data from the OpenTelemetry SDKs, and to forward the data on to Datadog (without the Datadog Agent). It works with all supported languages, and you can [connect those OpenTelemetry trace data with application logs](#connect-opentelemetry-traces-and-logs).
 
 You can [deploy the OpenTelemetry Collector using any of the supported methods][4], and configure it by adding a `datadog` exporter to your [OpenTelemetry configuration YAML file][5] along with your [Datadog API key][6]:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds a warning to opentelemetry onboarding documentation with warning to users about v0.28.0, which has user reports of emitting spans that are not retained by the backend.

### Motivation
<!-- What inspired you to submit this pull request?-->

Prevent users from bad onboarding experience

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ericmustin/add_otel_collector_version_note/tracing/setup_overview/open_standards/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

cc @andrewsouthard1 lmk what you think of language here

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
