### PR TITLE
Export environment variables in Ruby example

### DIFF
--- a/content/en/tracing/profiler/enabling.md
+++ b/content/en/tracing/profiler/enabling.md
@@ -282,10 +282,10 @@ The Datadog Profiler requires MRI Ruby 2.1+. **Wall time profiling is available 
 3. You can auto-enable the profiler with environment variables:
 
     ```shell
-    DD_PROFILING_ENABLED=true
-    DD_ENV=prod
-    DD_SERVICE=my-web-app
-    DD_VERSION=1.0.3
+    export DD_PROFILING_ENABLED=true
+    export DD_ENV=prod
+    export DD_SERVICE=my-web-app
+    export DD_VERSION=1.0.3
     ```
 
     or in code:


### PR DESCRIPTION
This was suggested by a colleague, the environment variables by themselves cannot just be copy-pasted to the shell without `export`.

It also seems harmless for those who don't need an export: then can always remove it.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add `export` in front of every environment variable in the Ruby example.

### Motivation
Suggestion from a colleague.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ivoanjo-patch-1/content/en/tracing/profiler/enabling.md (Not sure I added the link correctly -- does not seem to be working)

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
