### PR TITLE
Remove extra 'detection' word

### DIFF
--- a/content/en/security_platform/security_monitoring/log_detection_rules.md
+++ b/content/en/security_platform/security_monitoring/log_detection_rules.md
@@ -21,7 +21,7 @@ aliases:
 
 ## Overview
 
-To create a new log detection detection rule in Datadog, hover over **Security**, select **Security Rules**, and select the **New Rule** button in the top right corner of the page.
+To create a new log detection rule in Datadog, hover over **Security**, select **Security Rules**, and select the **New Rule** button in the top right corner of the page.
 
 ## Rule Type
 


### PR DESCRIPTION
There was extra 'detection' word in the first line of this doc.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Remove extra 'detection' word in the overview section of this doc.

### Motivation
Sentence correction.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/morsalin2171-patch-1/security_platform/security_monitoring/log_detection_rules/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
