### PR TITLE
[WEB-1504] - make nav links to api non async

### DIFF
--- a/layouts/partials/nav/main-menu.html
+++ b/layouts/partials/nav/main-menu.html
@@ -20,7 +20,7 @@
     {{ $currentPage := . }}
     {{ range .Site.Menus.main }}
         {{ if .HasChildren }}
-            <li class="nav-top-level {{ if (not (in $excludeAsyc .Identifier)) }} js-load {{ end }}
+            <li class="nav-top-level {{ if (not (or (in $excludeAsyc .Identifier) (in .URL "api/"))) }} js-load {{ end }}
             {{ if $currentPage.HasMenuCurrent "main" . }}active{{ end }}">
                 {{ $url_without_anchor = (index (split .URL "#") 0) }}
                 <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
@@ -28,7 +28,7 @@
                 </a>
                 <ul class="list-unstyled sub-menu">
                     {{ range .Children }}
-                        <li class="{{ if (not (in $excludeAsyc .Identifier )) }} js-load {{- end -}} {{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }}">
+                        <li class="{{ if (not (or (in $excludeAsyc .Identifier ) (in .URL "api/"))) }} js-load {{- end -}} {{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }}">
                             {{ $url_without_anchor = (index (split .URL "#") 0) }}
                             <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
                                 {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>
@@ -36,7 +36,7 @@
                         {{ if .HasChildren }}
                             <ul class="list-unstyled sub-menu">
                             {{ range .Children }}
-                                <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (in $excludeAsyc .Identifier)) }} js-load {{- end -}}" >
+                                <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (or (in $excludeAsyc .Identifier) (in .URL "api/"))) }} js-load {{- end -}}" >
                                     {{ $url_without_anchor = (index (split .URL "#") 0) }}
                                     <a href="{{ .URL | relLangURL }}" data-type="{{- with site.GetPage .URL -}}{{- .Type -}}{{- end -}}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
                                         {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>
@@ -45,7 +45,7 @@
                                     {{ if .HasChildren }}
                                         <ul class="list-unstyled sub-menu d-none">
                                         {{ range .Children }}
-                                            <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (in $excludeAsyc .Identifier)) }} js-load {{- end -}}" >
+                                            <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (or (in $excludeAsyc .Identifier) (in .URL "api/"))) }} js-load {{- end -}}" >
                                                 {{ $url_without_anchor = (index (split .URL "#") 0) }}
                                                 <a data-name="{{- delimit (last 1 (split (strings.TrimSuffix "/" .URL) "/")) "" -}}" href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
                                                     {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>
@@ -63,7 +63,7 @@
                 </ul>
             </li>
         {{ else }}
-            <li class="nav-top-level {{ if (not (in $excludeAsyc .Identifier)) }} js-load {{ end }}">
+            <li class="nav-top-level {{ if (not (or (in $excludeAsyc .Identifier) (in .URL "api/"))) }} js-load {{ end }}">
                 <a href="{{ .URL | absLangURL }}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
                     {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>
                 </a>


### PR DESCRIPTION
### What does this PR do?

For api links in the main nav we should avoid async loading as its a different layout/structure.

### Motivation

https://datadoghq.atlassian.net/browse/WEB-1504

### Preview

https://docs-staging.datadoghq.com/david.jones/nav-async/developers/service_checks/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
