### PR TITLE
Split profiler troubleshooting into per-language sections, and add Ruby-specific questions

### DIFF
--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -6,12 +6,19 @@ further_reading:
       tag: 'Documentation'
       text: 'APM Troubleshooting'
 ---
+
+{{< programming-lang-wrapper langs="java,ruby" >}}
+{{< programming-lang lang="java" >}}
+
 ## Missing profiles in the profile search page
 
 If you've configured the profiler and don't see profiles in the profile search page, turn on [debug mode][1] and [open a support ticket][2] with debug files and the following information:
 
-- Operating system type and version (for example, Linux Ubuntu 14.04.3)
+- Operating system type and version (for example, Linux Ubuntu 20.04)
 - Runtime type, version, and vendor (for example, Java OpenJDK 11 AdoptOpenJDK)
+
+[1]: /tracing/troubleshooting/#tracer-debug-logs
+[2]: /help/
 
 ## Reduce overhead from default setup
 
@@ -28,7 +35,7 @@ java -javaagent:dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.profiling.jfr
 
 ## Increase profiler information granularity
 
-If you want more granularity in your profiling data, you can specify `comprehensive` configuration. Note that this approach will increase your profiler overhead at the cost of further granularity. Comprehensive configuration has the following changes compared to the default:
+If you want more granularity in your profiling data, you can specify the `comprehensive` configuration. Note that this approach will increase your profiler overhead at the cost of further granularity. Comprehensive configuration has the following changes compared to the default:
 
 - Reduces sampling threshold to 10ms for `ThreadSleep`, `ThreadPark`, and `JavaMonitorWait` events compared to 100ms default
 - Enables `ObjectAllocationInNewTLAB`, `ObjectAllocationOutsideTLAB`, `ExceptionSample`, `ExceptionCount` events
@@ -90,7 +97,7 @@ The following OpenJDK 8 vendors are supported for Continuous Profiling because t
 | RedHat                      | u262                                                           |
 | Amazon (Corretto)           | u262                                                           |
 | Bell-Soft (Liberica)        | u262                                                           |
-| All vendors upstream builds             | u272                                                           |
+| All vendors upstream builds | u272                                                           |
 
 If your vendor is not on the list, [open a support ticket][2], we can let you know if we're planning to support it or if we already offer beta support.
 
@@ -121,5 +128,21 @@ Override templates let you specify profiling properties to override. However, th
 
 {{< partial name="whats-next/whats-next.html" >}}
 
+{{< /programming-lang >}}
+{{< programming-lang lang="ruby" >}}
+
+## Missing profiles in the profile search page
+
+If you've configured the profiler and don't see profiles in the profile search page, turn on [debug mode][1] and [open a support ticket][2] with debug files and the following information:
+
+- Operating system type and version (for example, Linux Ubuntu 20.04)
+- Runtime type, version, and vendor (for example, Ruby 2.7.3)
+
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+{{< /programming-lang >}}

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -186,6 +186,7 @@ Without this flag, profiles for short-lived Resque jobs will be unavailable.
 [2]: /help/
 
 {{< /programming-lang >}}
+{{< /programming-lang >}}
 
 ## Further Reading
 

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -124,10 +124,6 @@ Override templates let you specify profiling properties to override. However, th
     java -javaagent:/path/to/dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.logs.injection=true -Ddd.trace.sample.rate=1 -Ddd.profiling.jfr-template-override-file=</path/to/override.jfp> -jar path/to/your/app.jar
     {{< /code-block >}}
 
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
-
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}
 
@@ -141,10 +137,6 @@ If you've configured the profiler and don't see profiles in the profile search p
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/
 
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
-
 {{< /programming-lang >}}
 {{< programming-lang lang="go" >}}
 
@@ -157,10 +149,6 @@ If you've configured the profiler and don't see profiles in the profile search p
 
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/
-
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
 
 {{< /programming-lang >}}
 {{< programming-lang lang="ruby" >}}
@@ -197,8 +185,8 @@ Without this flag, profiles for short-lived Resque jobs will be unavailable.
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/
 
+{{< /programming-lang >}}
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-
-{{< /programming-lang >}}

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -7,7 +7,7 @@ further_reading:
       text: 'APM Troubleshooting'
 ---
 
-{{< programming-lang-wrapper langs="java,ruby" >}}
+{{< programming-lang-wrapper langs="java,python,go,ruby" >}}
 {{< programming-lang lang="java" >}}
 
 ## Missing profiles in the profile search page
@@ -123,6 +123,40 @@ Override templates let you specify profiling properties to override. However, th
     {{< code-block lang="text" filename="example-template.jfp" >}}
     java -javaagent:/path/to/dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.logs.injection=true -Ddd.trace.sample.rate=1 -Ddd.profiling.jfr-template-override-file=</path/to/override.jfp> -jar path/to/your/app.jar
     {{< /code-block >}}
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+{{< /programming-lang >}}
+{{< programming-lang lang="python" >}}
+
+## Missing profiles in the profile search page
+
+If you've configured the profiler and don't see profiles in the profile search page, turn on [debug mode][1] and [open a support ticket][2] with debug files and the following information:
+
+- Operating system type and version (for example, Linux Ubuntu 20.04)
+- Runtime type, version, and vendor (for example, Python 3.9.5)
+
+[1]: /tracing/troubleshooting/#tracer-debug-logs
+[2]: /help/
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+{{< /programming-lang >}}
+{{< programming-lang lang="go" >}}
+
+## Missing profiles in the profile search page
+
+If you've configured the profiler and don't see profiles in the profile search page, turn on [debug mode][1] and [open a support ticket][2] with debug files and the following information:
+
+- Operating system type and version (for example, Linux Ubuntu 20.04)
+- Runtime type, version, and vendor (for example, Go 1.16.5)
+
+[1]: /tracing/troubleshooting/#tracer-debug-logs
+[2]: /help/
 
 ## Further Reading
 

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -141,6 +141,28 @@ If you've configured the profiler and don't see profiles in the profile search p
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/
 
+## Application triggers "stack level too deep (SystemStackError)" errors
+
+The profiler instruments the Ruby VM to track thread creation.
+This instrumentation is compatible with most other Ruby gems that also instrument thread creation, with a few exceptions.
+
+If you're using any of the below gems:
+
+* `rollbar`: Ensure you're using version 3.1.2 or newer.
+* `logging`: Disable `logging`'s thread context inheritance by setting the `LOGGING_INHERIT_CONTEXT` environment
+  variable to `false`.
+
+If you're still experiencing `SystemStackError` errors after following the above instructions,
+[open a support ticket](/help/) taking care to include the full backtrace leading to the error.
+
+## Missing profiles for Resque jobs
+
+When profiling [Resque](https://github.com/resque/resque) jobs, you should set the `RUN_AT_EXIT_HOOKS` environment
+variable to `1`, as described in the
+[Resque documentation](https://github.com/resque/resque/blob/v2.0.0/docs/HOOKS.md#worker-hooks).
+
+Without this flag, profiles for short-lived Resque jobs will be unavailable.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -172,9 +172,6 @@ If you've configured the profiler and don't see profiles in the profile search p
 - Operating system type and version (for example, Linux Ubuntu 20.04)
 - Runtime type, version, and vendor (for example, Ruby 2.7.3)
 
-[1]: /tracing/troubleshooting/#tracer-debug-logs
-[2]: /help/
-
 ## Application triggers "stack level too deep (SystemStackError)" errors
 
 The profiler instruments the Ruby VM to track thread creation.
@@ -187,7 +184,7 @@ If you're using any of the below gems:
   variable to `false`.
 
 If you're still experiencing `SystemStackError` errors after following the above instructions,
-[open a support ticket](/help/) taking care to include the full backtrace leading to the error.
+[open a support ticket][2] taking care to include the full backtrace leading to the error.
 
 ## Missing profiles for Resque jobs
 
@@ -196,6 +193,9 @@ variable to `1`, as described in the
 [Resque documentation](https://github.com/resque/resque/blob/v2.0.0/docs/HOOKS.md#worker-hooks).
 
 Without this flag, profiles for short-lived Resque jobs will be unavailable.
+
+[1]: /tracing/troubleshooting/#tracer-debug-logs
+[2]: /help/
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
* Split existing profiler troubleshooting page into per-language sections (one for each currently-supported language/runtime)
  * Note that the previous page, while it did not state it, was almost all Java-specific, and that is the reason why that content was moved under Java
* Document two Ruby-specific troubleshooting questions

### Motivation
Customer ran into one of the Ruby questions, and we decided to document it; the page refactor was needed to avoid mixing Java and Ruby content in the same page.

(The other Ruby question was already documented elsewhere, but made sense to mention here as well)

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ivoanjo/ruby-profiler-troubleshooting/tracing/profiler/profiler_troubleshooting/

### Additional Notes
I ended up copy/pasting the "Further Reading" segment on every page, as the site generator didn't seem to be very happy with having a footer that was outside `{{< /programming-lang >}}`.

This is my first big change to the docs, so please keep an eye out for noob mistakes :)
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
