### PR TITLE
Adding examples to documentation downtime

### DIFF
--- a/content/en/monitors/downtimes.md
+++ b/content/en/monitors/downtimes.md
@@ -21,7 +21,7 @@ Schedule downtimes for system shutdowns, off-line maintenance, or upgrades witho
 To schedule a [monitor downtime][1] in Datadog use the main navigation: _Monitors –> Manage Downtime_. Then, click the **Schedule Downtime** button in the upper right.
 
 ### Choose what to silence
-
+Test
 {{< tabs >}}
 {{% tab "By Monitor Name" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Making a test PR for practice.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/cynthia/downtime-examples/monitors/downtimes/?tab=bymonitorname#pagetitle

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
