### PR TITLE
skip the bump version action on forks

### DIFF
--- a/.github/workflows/bump_versions.yml
+++ b/.github/workflows/bump_versions.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   sdk-versions:
+    # Don't trigger on schedule event when in a fork
+    if: github.repository == 'DataDog/documentation'
     runs-on: ubuntu-latest
     steps:
       - id: set-versions


### PR DESCRIPTION
### What does this PR do?

This PR only runs the gh job for bumping versions when the repo is the datadog docs not on forks.
The reason being users with forks were receiving lots of failure email notifications.

### Motivation

slack

### Preview

Shouldn't impact the site
https://docs-staging.datadoghq.com/david.jones/skip-action-forks/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
