### PR TITLE
Add Helm instructions and cleanup Daemonset approach

### DIFF
--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -164,7 +164,7 @@ After redeploying your `Daemonset` with these configurations in place, the Datad
 [1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent
 [2]: /agent/kubernetes/?tab=daemonset
 [3]: /agent/faq/rbac-for-dca-running-on-aks-with-helm/
-[4]: /agent/cluster_agent/setup/?tab=daemonset#configure-the-datadog-agen
+[4]: /agent/cluster_agent/setup/?tab=daemonset#configure-the-datadog-agent
 [5]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-services.yaml
 [6]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/secret-api-key.yaml
 [7]: https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/manifests/cluster-agent/secret-application-key.yaml

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -21,6 +21,27 @@ further_reading:
 
 To set up the Datadog Cluster Agent on your Kubernetes cluster, follow these steps:
 
+{{< tabs >}}
+{{% tab "Helm" %}}
+
+To enable the Cluster Agent collection with Helm, update your [datadog-values.yaml][1] file with the following Cluster Agent configuration, then upgrade your Datadog Helm chart:
+
+  ```yaml
+  clusterAgent:
+    # clusterAgent.enabled -- Set this to false to disable Datadog Cluster Agent
+    enabled: true
+  ```
+
+This will automatically update the necessary RBAC files for the Cluster Agent and Datadog Agent, as well utilize the same API Key between both Agents.
+
+This will also automatically generate a random token in a `Secret` shared between both the Cluster Agent and the Datadog Agent. You can manually set this by specifying a token in the  `clusterAgent.token` configuration or by specifying an existing `Secret` name containing a `token` value through the `clusterAgent.tokenExistingSecret` configuration.
+
+When set manually this token must be 32 alphanumeric characters.
+
+[1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
+{{% /tab %}}
+{{% tab "Daemonset" %}}
+
 1. [Set up the Datadog Cluster Agent](#configure-the-datadog-cluster-agent).
 2. [Configure your Agent to communicate with the Datadog Cluster Agent](#configure-the-datadog-agent)
 
@@ -45,153 +66,121 @@ If you are using Azure Kubernetes Service (AKS), you may require extra permissio
 
 ### Secure Cluster Agent to Agent communication
 
-Use one of the following options to secure communication between the Datadog Agent and the Datadog Cluster Agent.
+The Datadog Agent and Cluster Agent require a token to secure their communication. So it is recommended to save this token in a `Secret` that both the Cluster Agent and Agent can reference into their Environment Variable `DD_CLUSTER_AGENT_AUTH_TOKEN`. As this will help maintain consistency and avoid the token being readable in the `PodSpec`.
 
-* Create a secret and access it with an environment variable.
-* Set a token in an environment variable.
-* Use a ConfigMap to manage your secrets.
+To create this token run this one line command to generate a `Secret` named `datadog-cluster-agent` with a `token` set. Replace the `<TOKEN>` with 32 alphanumeric characters.
+  ```shell
+  kubectl create secret generic datadog-cluster-agent --from-literal=token='<TOKEN>' --namespace="default"
+  ```
+**Note:** This creates a `Secret` in the default namespace. If you are in a custom namespace, update the namespace parameter of the command before running it.
 
-Setting the value without a secret results in the token being readable in the `PodSpec`.
+The default `cluster-agent-deployment.yaml` provided for the Cluster Agent is already configured to refer to this `Secret` with the Environment Variable configuration:
+  ```yaml
+  - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: datadog-cluster-agent
+        key: token
+  ```
 
-{{< tabs >}}
-{{% tab "Secret" %}}
-
-1. Run the following command to create a secret token. Your token must be at least 32 characters long.
-
-    ```shell
-    echo -n '<ThirtyX2XcharactersXlongXtoken>' | base64
-    ```
-
-2. Run this one line command:
-
-    ```shell
-    kubectl create secret generic datadog-cluster-agent --from-literal=token='<ThirtyX2XcharactersXlongXtoken>'
-    ```
-
-    Alternatively, modify the value of the secret in the `agent-secret.yaml` file located in the [manifest/cluster-agent directory][1] or create it with:
-
-    `kubectl create -f Dockerfiles/manifests/cluster-agent/agent-secret.yaml`
-
-3. Refer to this secret with the environment variable `DD_CLUSTER_AGENT_AUTH_TOKEN` in the manifests of the Cluster Agent. See [Create the Cluster Agent and its service][2] and [Configure the Datadog Cluster Agent][3].
-
-[1]: https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/cluster-agent/agent-secret.yaml
-[2]: /agent/cluster_agent/setup/?tab=secret#create-the-cluster-agent-and-its-service
-[3]: /agent/cluster_agent/setup/?tab=secret#configure-the-datadog-agent
-{{% /tab %}}
-{{% tab "Environment Variable" %}}
-
-1. Run the following command to create a secret token. Your token must be at least 32 characters long.
-
-    ```shell
-    echo -n '<ThirtyX2XcharactersXlongXtoken>' | base64
-    ```
-
-2. Refer to this secret with the environment variable `DD_CLUSTER_AGENT_AUTH_TOKEN` in the manifests of the Cluster Agent and the node-based Agent.
-
-    ```yaml
-              - name: DD_CLUSTER_AGENT_AUTH_TOKEN
-                value: "<ThirtyX2XcharactersXlongXtoken>"
-    ```
-
-{{% /tab %}}
-{{% tab "ConfigMap" %}}
-
-1. Run the following command to create a secret token. Your token must be at least 32 characters long.
-
-    ```shell
-    echo -n '<ThirtyX2XcharactersXlongXtoken>' | base64
-    ```
-
-2. Create your `datadog-cluster.yaml` with the variables of your choice within the `datadog.yaml` file and create the ConfigMap accordingly:
-
-    ```shell
-    kubectl create configmap dca-yaml --from-file datadog-cluster.yaml
-    ```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-**Note**: This needs to be set in the manifest of the Cluster Agent **and** the node agent.
+You'll need to configure this Environment Variable in an identical way when [Configuring the Datadog Agent][4].
 
 ### Create the Cluster Agent and its service
 
 1. Download the following manifests:
 
-  * [`agent-services.yaml`: The Cluster Agent Service manifest][4]
-  * [`secrets.yaml`: The secret holding the Datadog API key][5]
-  * [`cluster-agent-deployment.yaml`: Cluster Agent manifest][6]
-  * [`install_info-configmap.yaml`: Install Info Configmap][7]
+    * [`agent-services.yaml`: The Cluster Agent Service manifest][5]
+    * [`secrets.yaml`: The secret holding the Datadog API key][6]
+    * [`secret-application-key.yaml`: The secret holding the Datadog Application Key][7]
+    * [`cluster-agent-deployment.yaml`: Cluster Agent manifest][8]
+    * [`install_info-configmap.yaml`: Install Info Configmap][9]
 
-2. In the `secrets.yaml` manifest, replace `PUT_YOUR_BASE64_ENCODED_API_KEY_HERE` with [your Datadog API key][8] encoded in base64:
+2. In the `secrets.yaml` manifest, replace `PUT_YOUR_BASE64_ENCODED_API_KEY_HERE` with [your Datadog API key][10] encoded in base64. To get the base64 version of your Api Key you can run:
 
     ```shell
     echo -n '<Your API key>' | base64
     ```
+3. In the `secrets-application-key.yaml` manifest, replace `PUT_YOUR_BASE64_ENCODED_APP_KEY_HERE` with [your Datadog Application key][11] encoded in base64.
+4. The `cluster-agent-deployment.yaml` manifest will refer to the token created previously in the `Secret` `datadog-cluster-agent` by *default*. If you are storing this token in an *alternative* way you will need to configure your Environment Variable `DD_CLUSTER_AGENT_AUTH_TOKEN` accordingly.
+5. Deploy these resources for the Cluster Agent Deployment to use:
+    ```shell
+    kubectl apply -f agent-services.yaml
+    kubectl apply -f secrets.yaml
+    kubectl apply -f secret-application-key.yaml
+    kubectl apply -f install_info-configmap.yaml
+    ```
+6. Finally, deploy the Datadog Cluster Agent:
+    ```shell
+    kubectl apply -f cluster-agent-deployment.yaml
+    ```
 
-3. In the `cluster-agent-deployment.yaml` manifest, set the token from [Secure Cluster-Agent-to-Agent Communication][11]. The format depends on how you set up your secret; instructions can be found in the manifest directly.
-4. Run: `kubectl apply -f agent-services.yaml`
-5. Run: `kubectl apply -f secrets.yaml`
-6. Run: `kubectl apply -f install_info-configmap.yaml`
-6. Finally, deploy the Datadog Cluster Agent: `kubectl apply -f cluster-agent-deployment.yaml`
-
-**Note**: In your Datadog Cluster Agent, set `<DD_SITE>` to your Datadog site: {{< region-param key="dd_site" code="true" >}}. The default value is `datadoghq.com`
+**Note**: In your Datadog Cluster Agent, set the Environment Variable `DD_SITE` to your Datadog site: {{< region-param key="dd_site" code="true" >}}. It defaults to the `US` site `datadoghq.com`
 
 ### Verification
 
 At this point, you should see:
 
 ```shell
--> kubectl get deploy
+$ kubectl get deploy
 
 NAME                    DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 datadog-cluster-agent   1         1         1            1           1d
 
--> kubectl get secret
+$ kubectl get secret
 
-NAME                         TYPE                                  DATA      AGE
-datadog-agent-cluster-agent  Opaque                                1         1d
+NAME                    TYPE                                  DATA      AGE
+datadog-cluster-agent   Opaque                                1         1d
 
--> kubectl get pods -l app=datadog-cluster-agent
+$ kubectl get pods -l app=datadog-cluster-agent
 
 datadog-cluster-agent-8568545574-x9tc9   1/1       Running   0          2h
 
--> kubectl get service -l app=datadog-cluster-agent
+$ kubectl get service -l app=datadog-cluster-agent
 
 NAME                    TYPE           CLUSTER-IP       EXTERNAL-IP        PORT(S)          AGE
 datadog-cluster-agent   ClusterIP      10.100.202.234   none               5005/TCP         1d
 ```
 
-**Note**: If you already have the Datadog Agent running, you may need to apply the [agent-rbac.yaml manifest][12] before the Cluster Agent can start running.
+**Note**: If you already have the Datadog Agent running, you may need to apply the [Agent's rbac.yaml manifest][12] before the Cluster Agent can start running.
 
 ## Configure the Datadog Agent
 
-After having set up the Datadog Cluster Agent, configure your Datadog Agent to communicate with the Datadog Cluster Agent.
+After having set up the Datadog Cluster Agent, modify your Datadog Agent configuration to communicate with the Datadog Cluster Agent. You can reference the provided [daemonset.yaml manifest][13] for a full example.
 
-### Setup
+In your existing `Daemonset` [manifest file][2] set the Environment Variable `DD_CLUSTER_AGENT_ENABLED` to `true`. As well as set the `DD_CLUSTER_AGENT_AUTH_TOKEN` using the same syntax used in [Secure Cluster-Agent-to-Agent Communication][14].
 
-#### Set RBAC permissions for node-based Agents
+  ```yaml
+  - name: DD_CLUSTER_AGENT_ENABLED
+    value: "true"
+  - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: datadog-cluster-agent
+        key: token
+  ```
 
-1. Download the the [agent-rbac.yaml manifest][9]. **Note**: When using the Cluster Agent, your node Agents are not able to interact with the Kubernetes API server—only the Cluster Agent is able to do so.
+After redeploying your `Daemonset` with these configurations in place the Datadog Agent should be able to communicate with the Cluster Agent.
 
-2. Run: `kubectl apply -f agent-rbac.yaml`
-
-#### Enable the Datadog Agent
-
-1. Download the [daemonset.yaml manifest][10].
-
-3. In the `daemonset.yaml` manifest, replace `<DD_SITE>` with your Datadog site: `{{< region-param key="dd_site">}}`. Defaults to `datadoghq.com`.
-
-4. In the `daemonset.yaml` manifest, set the token from [Secure Cluster-Agent-to-Agent Communication][11]. The format depends on how you set up your secret; instructions can be found in the manifest directly.
-
-5. In the `daemonset.yaml` manifest, check that the environment variable `DD_CLUSTER_AGENT_ENABLED` is set to `true`.
-
-6. (Optional) If your cluster encompasses a single environment, you can also set `<DD_ENV>` in the `agent.yaml`.
-
-7. Create the DaemonSet with this command: `kubectl apply -f daemonset.yaml`
+[1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent
+[2]: /agent/kubernetes/?tab=daemonset
+[3]: /agent/faq/rbac-for-dca-running-on-aks-with-helm/
+[4]: /agent/cluster_agent/setup/?tab=daemonset#configure-the-datadog-agen
+[5]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-services.yaml
+[6]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/secret-api-key.yaml
+[7]: https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/manifests/cluster-agent/secret-application-key.yaml
+[8]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-deployment.yaml
+[9]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/install_info-configmap.yaml
+[10]: https://app.datadoghq.com/account/settings#api
+[11]: https://app.datadoghq.com/access/application-keys
+[12]: /agent/cluster_agent/setup/?tab=daemonset#configure-rbac-permissions
+[13]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/daemonset.yaml
+[14]: /agent/cluster_agent/setup/?tab=daemonset#secure-cluster-agent-to-agent-communication
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Verification
 
-Run:
+You can verify your Datadog Agent pods and Cluster Agent pods are running by executing the command:
 
 ```shell
 kubectl get pods | grep agent
@@ -209,6 +198,20 @@ datadog-agent-rdgwz                      1/1       Running   0          2h
 datadog-agent-x5wk5                      1/1       Running   0          2h
 [...]
 datadog-cluster-agent-8568545574-x9tc9   1/1       Running   0          2h
+```
+
+You can additionally verify the Datadog Agent has successfully connected to the Cluster Agent with the [Agent status output][1].
+
+```shell
+kubectl exec -it <AGENT_POD_NAME> agent status
+[...]
+=====================
+Datadog Cluster Agent
+=====================
+
+  - Datadog Cluster Agent endpoint detected: https://10.104.246.194:5005
+  Successfully connected to the Datadog Cluster Agent.
+  - Running: 1.11.0+commit.4eadd95
 ```
 
 Kubernetes events are beginning to flow into your Datadog account, and relevant metrics collected by your Agents are tagged with their corresponding cluster level metadata.
@@ -241,15 +244,4 @@ clusterAgent:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent
-[2]: /agent/kubernetes/
-[3]: /agent/faq/rbac-for-dca-running-on-aks-with-helm/
-[4]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/agent-services.yaml
-[5]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/secret-api-key.yaml
-[6]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-deployment.yaml
-[7]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/install_info-configmap.yaml
-[8]: https://app.datadoghq.com/account/settings#api
-[9]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml
-[10]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/daemonset.yaml
-[11]: /agent/cluster_agent/setup/?tab=secret#secure-cluster-agent-to-agent-communication
-[12]: /agent/cluster_agent/setup/?tab=secret#configure-rbac-permissions
+[1]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6v7#agent-information

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -32,9 +32,9 @@ To enable the Cluster Agent collection with Helm, update your [datadog-values.ya
     enabled: true
   ```
 
-This will automatically update the necessary RBAC files for the Cluster Agent and Datadog Agent, as well utilize the same API Key between both Agents.
+This automatically updates the necessary RBAC files for the Cluster Agent and Datadog Agent. Both Agents use the same API key.
 
-This will also automatically generate a random token in a `Secret` shared between both the Cluster Agent and the Datadog Agent. You can manually set this by specifying a token in the  `clusterAgent.token` configuration or by specifying an existing `Secret` name containing a `token` value through the `clusterAgent.tokenExistingSecret` configuration.
+This also automatically generates a random token in a `Secret` shared between both the Cluster Agent and the Datadog Agent. You can manually set this by specifying a token in the `clusterAgent.token` configuration. You can also manually set this by specifying an existing `Secret` name containing a `token` value through the `clusterAgent.tokenExistingSecret` configuration.
 
 When set manually this token must be 32 alphanumeric characters.
 
@@ -66,7 +66,7 @@ If you are using Azure Kubernetes Service (AKS), you may require extra permissio
 
 ### Secure Cluster Agent to Agent communication
 
-The Datadog Agent and Cluster Agent require a token to secure their communication. So it is recommended to save this token in a `Secret` that both the Cluster Agent and Agent can reference into their Environment Variable `DD_CLUSTER_AGENT_AUTH_TOKEN`. As this will help maintain consistency and avoid the token being readable in the `PodSpec`.
+The Datadog Agent and Cluster Agent require a token to secure their communication. It is recommended that you save this token in a `Secret` that both the Datadog Agent and Cluster Agent can reference in the environment variable `DD_CLUSTER_AGENT_AUTH_TOKEN`. This helps to maintain consistency and to avoid the token being readable in the `PodSpec`.
 
 To create this token run this one line command to generate a `Secret` named `datadog-cluster-agent` with a `token` set. Replace the `<TOKEN>` with 32 alphanumeric characters.
   ```shell
@@ -74,7 +74,7 @@ To create this token run this one line command to generate a `Secret` named `dat
   ```
 **Note:** This creates a `Secret` in the default namespace. If you are in a custom namespace, update the namespace parameter of the command before running it.
 
-The default `cluster-agent-deployment.yaml` provided for the Cluster Agent is already configured to refer to this `Secret` with the Environment Variable configuration:
+The default `cluster-agent-deployment.yaml` provided for the Cluster Agent is already configured to refer to this `Secret` with the environment variable configuration:
   ```yaml
   - name: DD_CLUSTER_AGENT_AUTH_TOKEN
     valueFrom:
@@ -83,7 +83,7 @@ The default `cluster-agent-deployment.yaml` provided for the Cluster Agent is al
         key: token
   ```
 
-You'll need to configure this Environment Variable in an identical way when [Configuring the Datadog Agent][4].
+This environment variable must be configured (using the same setup) when [Configuring the Datadog Agent][4].
 
 ### Create the Cluster Agent and its service
 
@@ -95,13 +95,13 @@ You'll need to configure this Environment Variable in an identical way when [Con
     * [`cluster-agent-deployment.yaml`: Cluster Agent manifest][8]
     * [`install_info-configmap.yaml`: Install Info Configmap][9]
 
-2. In the `secrets.yaml` manifest, replace `PUT_YOUR_BASE64_ENCODED_API_KEY_HERE` with [your Datadog API key][10] encoded in base64. To get the base64 version of your Api Key you can run:
+2. In the `secrets.yaml` manifest, replace `PUT_YOUR_BASE64_ENCODED_API_KEY_HERE` with [your Datadog API key][10] encoded in base64. To get the base64 version of your API key, you can run:
 
     ```shell
     echo -n '<Your API key>' | base64
     ```
 3. In the `secrets-application-key.yaml` manifest, replace `PUT_YOUR_BASE64_ENCODED_APP_KEY_HERE` with [your Datadog Application key][11] encoded in base64.
-4. The `cluster-agent-deployment.yaml` manifest will refer to the token created previously in the `Secret` `datadog-cluster-agent` by *default*. If you are storing this token in an *alternative* way you will need to configure your Environment Variable `DD_CLUSTER_AGENT_AUTH_TOKEN` accordingly.
+4. The `cluster-agent-deployment.yaml` manifest will refers to the token created previously in the `Secret` `datadog-cluster-agent` by *default*. If you are storing this token in an *alternative* way, configure your `DD_CLUSTER_AGENT_AUTH_TOKEN` environment variable accordingly.
 5. Deploy these resources for the Cluster Agent Deployment to use:
     ```shell
     kubectl apply -f agent-services.yaml
@@ -114,7 +114,7 @@ You'll need to configure this Environment Variable in an identical way when [Con
     kubectl apply -f cluster-agent-deployment.yaml
     ```
 
-**Note**: In your Datadog Cluster Agent, set the Environment Variable `DD_SITE` to your Datadog site: {{< region-param key="dd_site" code="true" >}}. It defaults to the `US` site `datadoghq.com`
+**Note**: In your Datadog Cluster Agent, set the environment variable `DD_SITE` to your Datadog site: {{< region-param key="dd_site" code="true" >}}. It defaults to the `US` site `datadoghq.com`
 
 ### Verification
 
@@ -147,7 +147,7 @@ datadog-cluster-agent   ClusterIP      10.100.202.234   none               5005/
 
 After having set up the Datadog Cluster Agent, modify your Datadog Agent configuration to communicate with the Datadog Cluster Agent. You can reference the provided [daemonset.yaml manifest][13] for a full example.
 
-In your existing `Daemonset` [manifest file][2] set the Environment Variable `DD_CLUSTER_AGENT_ENABLED` to `true`. As well as set the `DD_CLUSTER_AGENT_AUTH_TOKEN` using the same syntax used in [Secure Cluster-Agent-to-Agent Communication][14].
+In your existing `Daemonset` [manifest file][2] set the environment variable `DD_CLUSTER_AGENT_ENABLED` to `true`. Then, set the `DD_CLUSTER_AGENT_AUTH_TOKEN` using the same syntax used in [Secure Cluster-Agent-to-Agent Communication][14].
 
   ```yaml
   - name: DD_CLUSTER_AGENT_ENABLED
@@ -159,7 +159,7 @@ In your existing `Daemonset` [manifest file][2] set the Environment Variable `DD
         key: token
   ```
 
-After redeploying your `Daemonset` with these configurations in place the Datadog Agent should be able to communicate with the Cluster Agent.
+After redeploying your `Daemonset` with these configurations in place, the Datadog Agent is able to communicate with the Cluster Agent.
 
 [1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent
 [2]: /agent/kubernetes/?tab=daemonset


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add Helm instructions to the Cluster Agent setup, in this case following the patterns with the other docs by having Tabs for Helm / Daemonset. 

Cleanup the Daemonset approach to simplify some of the setup steps and account for any missing portions. Namely:
- Cleanup Token deployment and reference portion
- Clarify creating API Key
- Give instructions for APP Key (as it is currently required in the sample Deployment)
- Simplify Node Agent steps
- Couple markdown fixes for formatting
- Give `status` output example for final verification (outside the Daemonset tab as it is the same for Helm)

### Motivation
<!-- What inspired you to submit this pull request?-->
Current instructions do not provide the steps for helm, and while they are simple it is good to have that included. Additionally the cleanup steps for the Daemonset approach to simplify the steps needed to get this deployed.

### Preview
<!-- Impacted pages preview links-->
Original: 
 - https://docs.datadoghq.com/agent/cluster_agent/setup/?tab=secret#configure-the-datadog-cluster-agent

New Version:
 - https://docs-staging.datadoghq.com/jack.davenport/cluster_agent_helm_and_cleanup/agent/cluster_agent/setup/?tab=helm


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
