### PR TITLE
Add vsphere duplicated hosts troubleshooting

### DIFF
--- a/content/en/integrations/faq/_index.md
+++ b/content/en/integrations/faq/_index.md
@@ -129,17 +129,21 @@ aliases:
 
 * [Can I limit the number of VMs that are pulled in via the VMWare integration?][52]
 
+## VSphere
+
+* [Troubleshooting duplicated hosts with vSphere][53]
+
 ## Webhooks
 
-* [How to make a Trello Card using Webhooks][53]
+* [How to make a Trello Card using Webhooks][54]
 
 ## Windows
 
-* [How to add event log files to the `Win32_NTLogEvent` WMI class][54]
-* [Collect Custom Windows Performance Counters over WMI][55]
-* [Windows Status Based Check][56]
-* [How to monitor events from the Windows Event Logs][57]
-* [How to retrieve WMI metrics][58]
+* [How to add event log files to the `Win32_NTLogEvent` WMI class][55]
+* [Collect Custom Windows Performance Counters over WMI][56]
+* [Windows Status Based Check][57]
+* [How to monitor events from the Windows Event Logs][58]
+* [How to retrieve WMI metrics][59]
 
 [1]: /integrations/faq/aws-integration-and-cloudwatch-faq/
 [2]: /integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration/
@@ -193,9 +197,10 @@ aliases:
 [50]: https://github.com/DataDog/Miscellany/tree/master/custom_check_shell
 [51]: /integrations/faq/how-to-collect-metrics-from-custom-vertica-queries/
 [52]: /integrations/faq/can-i-limit-the-number-of-vms-that-are-pulled-in-via-the-vmware-integration/
-[53]: /integrations/faq/how-to-make-trello-card-using-webhooks/
-[54]: /integrations/faq/how-to-add-event-log-files-to-the-win32-ntlogevent-wmi-class/
-[55]: /integrations/faq/collect-custom-windows-performance-counters-over-wmi/
-[56]: /integrations/faq/windows-status-based-check/
-[57]: /integrations/faq/how-to-monitor-events-from-the-windows-event-logs/
-[58]: /integrations/faq/how-to-retrieve-wmi-metrics/
+[53]: /integrations/faq/troubleshooting-duplicated-hosts-with-vsphere/
+[54]: /integrations/faq/how-to-make-trello-card-using-webhooks/
+[55]: /integrations/faq/how-to-add-event-log-files-to-the-win32-ntlogevent-wmi-class/
+[56]: /integrations/faq/collect-custom-windows-performance-counters-over-wmi/
+[57]: /integrations/faq/windows-status-based-check/
+[58]: /integrations/faq/how-to-monitor-events-from-the-windows-event-logs/
+[59]: /integrations/faq/how-to-retrieve-wmi-metrics/

--- a/content/en/integrations/faq/troubleshooting-duplicated-hosts-with-vsphere.md
+++ b/content/en/integrations/faq/troubleshooting-duplicated-hosts-with-vsphere.md
@@ -5,18 +5,19 @@ kind: faq
 
 ## Duplicated hosts issue context
 
-[vSphere integration][1] is configured to crawl into the different resources of a vCenter, such as VMs or ESXi. It flags the VMs and ESXi as separate hosts, and they appear in the instracture list view of the Datadog web UI under a name `<vsphere-hostname>`.  
-Inside a vCenter, a guest VM can be running an agent. This agent submits metrics and is attaching a `<guest-hostname>` metadata to them. A host appear in the infrastructure list under `<guest-hostname>`.
-Depending on the vSphere integration configuration, and the guest agent configuration, `<vsphere-hostname>` and `<guest-hostname>` can be different, so a single VM appears twice in the infrastructure list. For example, `<vsphere-hostname>` can be a Fully Qualified Domain Name (FQDN) and `<guest-hostname>` a Short Name.
+The [vSphere integration][1] is configured to crawl into the different resources of a vCenter, such as VMs or ESXi. The integration flags the VMs and ESXi as separate hosts, and they appear in your [Infrastructure List][4] as `<vsphere-hostname>`.  
+Inside a vCenter, a guest VM can run an Agent. This Agent submits metrics and attaches `<guest-hostname>` metadata to them. A host appears in the Infrastructure List as `<guest-hostname>`.
+Depending on the vSphere integration configuration and the guest Agent configuration, `<vsphere-hostname>` and `<guest-hostname>` can be different. For example, `<vsphere-hostname>` can be a Fully Qualified Domain Name (FQDN) and `<guest-hostname>` a Short Name. In this case, a single VM can appear twice in the Infrastructure List.
 
 ## Workaround
 
 * In the vSphere integration configuration file, set [`use_guest_hostname: true`][2] for the vSphere integration to use the guest hostname instead of the VM name given by the vCenter.
-* If the previous step is not enough: in the guest VM agent configuration `datadog.yaml`, change the value of [`hostname_fqdn`][3].
-* If the previous steps are not enough: manually set a host alias between `vsphere-hostname` and `guest-hostname`.
+* If the previous step does not resolve the issue, change the value of [`hostname_fqdn`][3] in the guest VM Agent configuration `datadog.yaml`.
+* If the previous steps do not resolve the issue, manually set a host alias between `vsphere-hostname` and `guest-hostname`.
 
-Note: The old host in the infrastrure list takes time before disappearing.
+Note: The old host in the Infrastructure List takes time before disappearing.
 
 [1]: https://docs.datadoghq.com/integrations/vsphere/
 [2]: https://github.com/DataDog/integrations-core/blob/21a90b00f603b00250c4baa6534e47ee5529ed3c/vsphere/datadog_checks/vsphere/data/conf.yaml.example#L301-L308
 [3]: https://github.com/DataDog/datadog-agent/blob/6ba10dc8cd0c1aa89adcebe6b5941571caf25d50/pkg/config/config_template.yaml#L56-L61
+[4]: https://app.datadoghq.com/infrastructure

--- a/content/en/integrations/faq/troubleshooting-duplicated-hosts-with-vsphere.md
+++ b/content/en/integrations/faq/troubleshooting-duplicated-hosts-with-vsphere.md
@@ -1,0 +1,22 @@
+---
+title: Troubleshooting duplicated hosts with vSphere
+kind: faq
+---
+
+## Duplicated hosts issue context
+
+[vSphere integration][1] is configured to crawl into the different resources of a vCenter, such as VMs or ESXi. It flags the VMs and ESXi as separate hosts, and they appear in the instracture list view of the Datadog web UI under a name `<vsphere-hostname>`.  
+Inside a vCenter, a guest VM can be running an agent. This agent submits metrics and is attaching a `<guest-hostname>` metadata to them. A host appear in the infrastructure list under `<guest-hostname>`.
+Depending on the vSphere integration configuration, and the guest agent configuration, `<vsphere-hostname>` and `<guest-hostname>` can be different, so a single VM appears twice in the infrastructure list. For example, `<vsphere-hostname>` can be a Fully Qualified Domain Name (FQDN) and `<guest-hostname>` a Short Name.
+
+## Workaround
+
+* In the vSphere integration configuration file, set [`use_guest_hostname: true`][2] for the vSphere integration to use the guest hostname instead of the VM name given by the vCenter.
+* If the previous step is not enough: in the guest VM agent configuration `datadog.yaml`, change the value of [`hostname_fqdn`][3].
+* If the previous steps are not enough: manually set a host alias between `vsphere-hostname` and `guest-hostname`.
+
+Note: The old host in the infrastrure list takes time before disappearing.
+
+[1]: https://docs.datadoghq.com/integrations/vsphere/
+[2]: https://github.com/DataDog/integrations-core/blob/21a90b00f603b00250c4baa6534e47ee5529ed3c/vsphere/datadog_checks/vsphere/data/conf.yaml.example#L301-L308
+[3]: https://github.com/DataDog/datadog-agent/blob/6ba10dc8cd0c1aa89adcebe6b5941571caf25d50/pkg/config/config_template.yaml#L56-L61


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Sometimes when using vSphere integration, a host can appear twice in the infrastructure list. This page explains how to fix it, even though it depends a lot on the customer environment.

### Motivation
<!-- What inspired you to submit this pull request?-->
Should reduce the number of support case about it.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/paul/vsphere-hosts-duplicate/integrations/faq

### Additional Notes
<!-- Anything else we should know when reviewing?-->
This page will be linked in the vsphere readme

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
