### PR TITLE
[WEB-1512] evaluate_missing_metrics job fixes

### DIFF
--- a/local/bin/py/missing_metrics.py
+++ b/local/bin/py/missing_metrics.py
@@ -107,7 +107,7 @@ def post_dd_metrics(metrics, keys):
       'app_key': keys.corpappkey
   }
   initialize(**options)
-  api.Metric.send(metrics)
+  api.Metric.send(metrics, compress_payload=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

In the `evaluate_missing_metrics` job send the metrics to the api with compression enabled to reduce 413 payload to large errors.

### Motivation

https://datadoghq.atlassian.net/browse/WEB-1512

### Preview

https://docs-staging.datadoghq.com/david.jones/missing-metric/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
