### PR TITLE
Add names of supported source code management tools

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/browser_errors.md
+++ b/content/en/real_user_monitoring/error_tracking/browser_errors.md
@@ -24,7 +24,7 @@ Error Tracking processes errors collected from the browser by the RUM SDK: whene
 
 ## Link errors with your source code
 
-In addition to sending source maps, the new version of the [Datadog CLI][6] reports Git information such as the commit hash, the repository URL, and the list of tracked file paths in the Git repository. Using this information, Error Tracking and RUM can correlate an error with the source code, and you can pivot from a stack trace frame to the related source code in your source code management tool. 
+In addition to sending source maps, the new version of the [Datadog CLI][6] reports Git information such as the commit hash, the repository URL, and the list of tracked file paths in the code repository. Using this information, Error Tracking and RUM can correlate an error with the source code, and you can pivot from any stack trace frame to the related line of code in [GitHub][https://github.com/], [GitLab][https://about.gitlab.com/], [Bitbucket][https://bitbucket.org/product/] or other source code management tools, no matter whether they are self-hosted or not. 
 
 {{< img src="real_user_monitoring/error_tracking/link_to_git_js_example.gif" alt="Link from a stack frame to the source code"  >}}
 

--- a/content/en/real_user_monitoring/error_tracking/browser_errors.md
+++ b/content/en/real_user_monitoring/error_tracking/browser_errors.md
@@ -24,7 +24,7 @@ Error Tracking processes errors collected from the browser by the RUM SDK: whene
 
 ## Link errors with your source code
 
-In addition to sending source maps, the new version of the [Datadog CLI][6] reports Git information such as the commit hash, the repository URL, and the list of tracked file paths in the code repository. Using this information, Error Tracking and RUM can correlate an error with the source code, and you can pivot from any stack trace frame to the related line of code in [GitHub][https://github.com/], [GitLab][https://about.gitlab.com/], [Bitbucket][https://bitbucket.org/product/] or other source code management tools, no matter whether they are self-hosted or not. 
+In addition to sending source maps, the new version of the [Datadog CLI][6] reports Git information such as the commit hash, the repository URL, and the list of tracked file paths in the code repository. Using this information, Error Tracking and RUM can correlate an error with the source code, and you can pivot from any stack trace frame to the related line of code in [GitHub][7], [GitLab][8], [Bitbucket][9] or other source code management tools, no matter whether they are self-hosted or not. 
 
 {{< img src="real_user_monitoring/error_tracking/link_to_git_js_example.gif" alt="Link from a stack frame to the source code"  >}}
 
@@ -40,3 +40,6 @@ In addition to sending source maps, the new version of the [Datadog CLI][6] repo
 [4]: /real_user_monitoring/browser/#initialization-parameters
 [5]: /real_user_monitoring/guide/upload-javascript-source-maps
 [6]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command
+[7]: https://github.com
+[8]: https://about.gitlab.com
+[9]: https://bitbucket.org/product

--- a/content/en/real_user_monitoring/error_tracking/browser_errors.md
+++ b/content/en/real_user_monitoring/error_tracking/browser_errors.md
@@ -24,7 +24,7 @@ Error Tracking processes errors collected from the browser by the RUM SDK: whene
 
 ## Link errors with your source code
 
-In addition to sending source maps, the new version of the [Datadog CLI][6] reports Git information such as the commit hash, the repository URL, and the list of tracked file paths in the code repository. Using this information, Error Tracking and RUM can correlate an error with the source code, and you can pivot from any stack trace frame to the related line of code in [GitHub][7], [GitLab][8], [Bitbucket][9] or other source code management tools, no matter whether they are self-hosted or not. 
+In addition to sending source maps, the new version of the [Datadog CLI][6] reports Git information such as the commit hash, the repository URL, and the list of tracked file paths in the code repository. Using this information, Error Tracking and RUM can correlate an error with the source code, and you can pivot from any stack trace frame to the related line of code in [GitHub][7], [GitLab][8], [Bitbucket][9] or other source code management tools. 
 
 {{< img src="real_user_monitoring/error_tracking/link_to_git_js_example.gif" alt="Link from a stack frame to the source code"  >}}
 

--- a/content/en/real_user_monitoring/error_tracking/browser_errors.md
+++ b/content/en/real_user_monitoring/error_tracking/browser_errors.md
@@ -24,7 +24,7 @@ Error Tracking processes errors collected from the browser by the RUM SDK: whene
 
 ## Link errors with your source code
 
-In addition to sending source maps, the new version of the [Datadog CLI][6] reports Git information such as the commit hash, the repository URL, and the list of tracked file paths in the code repository. Using this information, Error Tracking and RUM can correlate an error with the source code, and you can pivot from any stack trace frame to the related line of code in [GitHub][7], [GitLab][8], [Bitbucket][9] or other source code management tools. 
+In addition to sending source maps, the new version of the [Datadog CLI][6] reports Git information such as the commit hash, the repository URL, and the list of tracked file paths in the code repository. Using this information, Error Tracking and RUM can correlate an error with the source code, and you can pivot from any stack trace frame to the related line of code in [GitHub][7], [GitLab][8] and [Bitbucket][9]. 
 
 {{< img src="real_user_monitoring/error_tracking/link_to_git_js_example.gif" alt="Link from a stack frame to the source code"  >}}
 


### PR DESCRIPTION
### What does this PR do?
Add names of supported source code management tools

### Motivation
Clarify which source code management tools are supported

### Preview
https://docs-staging.datadoghq.com/maxime.matheron/linktogit-js-add-scm-names/real_user_monitoring/error_tracking/browser_errors/#link-errors-with-your-source-code

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
