### PR TITLE
Mention DD_PROFILING_HEAP_ENABLED to enable heap profilingon Python

### DIFF
--- a/content/en/tracing/profiler/enabling.md
+++ b/content/en/tracing/profiler/enabling.md
@@ -166,6 +166,7 @@ You can configure the profiler using the following environment variables:
 | Environment Variable    | Keyword Argument to `Profiler` | Type                       | Description                                                         |
 | ------------------------|------------------------------- | -------------------------- | --------------------------------------------------------------------|
 | `DD_PROFILING_ENABLED`  |                                | Boolean                    | Set to `true` to enable profiler.                                   |
+| `DD_PROFILING_HEAP_ENABLED` |                            | Boolean                    | Set to `true` to enable memory heap profiling. (ddtrace 0.50+)      |
 | `DD_SERVICE`            | `service`                      | String                     | The Datadog [service][4] name.                                      |
 | `DD_ENV`                | `env`                          | String                     | The Datadog [environment][5] name, for example, `production`.       |
 | `DD_VERSION`            | `version`                      | String                     | The version of your application.                                    |


### PR DESCRIPTION
### What does this PR do?

Mention DD_PROFILING_HEAP_ENABLED to enable heap profilingon Python

### Motivation
<!-- What inspired you to submit this pull request?-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
