### PR TITLE
Add template variable format for event tags with periods

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -194,6 +194,12 @@ For example, if your tag is `dot.key.test:five` and your monitor is grouped by `
 {{[dot.key.test].name}}
 ```
 
+If the tag is on an event and you're using an event monitor, use:
+
+```text
+{{ event.tags.[dot.key.test] }}
+```
+
 #### Log facet variables
 
 Log monitors can use facets as variables if the monitor is grouped by the facets.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds an example for formatting template variables that involve event tags with periods 

### Motivation
<!-- What inspired you to submit this pull request?-->

Customer reached out about it on a ticket

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/anthony/event-tags-period/monitors/notifications/?tab=is_alert#tag-key-with-period

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
