### PR TITLE
Update documentation for EC2 tags collection

### DIFF
--- a/content/en/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration.md
+++ b/content/en/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration.md
@@ -29,13 +29,13 @@ To pull custom AWS tags for an EC2 instance through the Datadog Agent without us
 {{% /tab %}}
 {{% tab "Docker" %}}
 
-1. Make sure an IAM role is assigned to the EC2 **instance**, using the [AWS documentation][1]. Create one if necessary.
+1. Make sure an IAM role is assigned to the agent task, using the [AWS documentation][1]. Create one if necessary.
 2. Attach a policy to the IAM role that includes the permission `ec2:DescribeTags`.
 3. Start the Datadog Agent container with the environment variable `DD_COLLECT_EC2_TAGS=true`.
 
-**Note**: With ECS, permissions are usually tied to the task, but the Datadog Agent requires permissions to be associated with the EC2 **instance** profile.
+**Note**: for backwards compatibility, Agent will also try using EC2 instance role if ECS task role is unavailable or has insufficient permissions.
 
-[1]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+[1]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration.md
+++ b/content/en/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration.md
@@ -33,7 +33,7 @@ To pull custom AWS tags for an EC2 instance through the Datadog Agent without us
 2. Attach a policy to the IAM role that includes the permission `ec2:DescribeTags`.
 3. Start the Datadog Agent container with the environment variable `DD_COLLECT_EC2_TAGS=true`.
 
-**Note**: for backwards compatibility, Agent will also try using EC2 instance role if ECS task role is unavailable or has insufficient permissions.
+**Note**: For backwards compatibility, the Agent will also try using the EC2 instance role if the ECS task role is unavailable or has insufficient permissions.
 
 [1]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
 {{% /tab %}}


### PR DESCRIPTION


### What does this PR do?

Update documentation for EC2 tags collection.

### Motivation

Agent is now able to use permissions assigned to it via a task role.

### Preview

https://docs-staging.datadoghq.com/vickenty/ecs-tags/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration/?tab=docker

### Additional Notes

Do not merge before agent 7.29 is released.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
