### PR TITLE
[Agent] add OOTB container tags lists

### DIFF
--- a/content/en/agent/docker/tag.md
+++ b/content/en/agent/docker/tag.md
@@ -21,31 +21,31 @@ If you are running the Agent as a binary on a host, configure your tag extractio
 
 ### Out of the box tagging
 
-The Agent can autodiscover and attach tags to all data emitted by containers. The list of tags attached automaticaly depends on the agent [cardinality configuration][1].
+The Agent can autodiscover and attach tags to all data emitted by containers. The list of tags attached depends on the Agent [cardinality configuration][1].
 
-| Tag               | Cardinality  | Requirement                                    |
-|-------------------|--------------|------------------------------------------------|
-| container_name    | high         | n/a                                            |
-| container_id      | high         | n/a                                            |
-| rancher_container | high         | rancher environment                            |
-| mesos_task        | orchestrator | mesos environment                              |
-| docker_image      | low          | n/a                                            |
-| image_name        | low          | n/a                                            |
-| short_image       | low          | n/a                                            |
-| image_tag         | low          | n/a                                            |
-| swarm_service     | low          | swarm environment                              |
-| swarm_namespace   | low          | swarm environment                              |
-| rancher_stack     | low          | rancher environment                            |
-| rancher_service   | low          | rancher environment                            |
-| env               | low          | [unified service tagging][2] enabled           |
-| version           | low          | [unified service tagging][2] enabled           |
-| service           | low          | [unified service tagging][2] enabled           |
-| marathon_app      | low          | marathon environment                           |
-| chronos_job       | low          | mesos environment                              |
-| chronos_job_owner | low          | mesos environment                              |
-| nomad_task        | low          | nomad environment                              |
-| nomad_job         | low          | nomad environment                              |
-| nomad_group       | low          | nomad environment                              |
+| Tag                 | Cardinality  | Requirement                          |
+|---------------------|--------------|--------------------------------------|
+| `container_name`    | High         | N/A                                  |
+| `container_id`      | High         | N/A                                  |
+| `rancher_container` | High         | Rancher environment                  |
+| `mesos_task`        | Orchestrator | Mesos environment                    |
+| `docker_image`      | Low          | N/A                                  |
+| `image_name`        | Low          | N/A                                  |
+| `short_image`       | Low          | N/A                                  |
+| `image_tag`         | Low          | N/A                                  |
+| `swarm_service`     | Low          | Swarm environment                    |
+| `swarm_namespace`   | Low          | Swarm environment                    |
+| `rancher_stack`     | Low          | Rancher environment                  |
+| `rancher_service`   | Low          | Rancher environment                  |
+| `env`               | Low          | [Unified service tagging][2] enabled |
+| `version`           | Low          | [Unified service tagging][2] enabled |
+| `service`           | Low          | [Unified service tagging][2] enabled |
+| `marathon_app`      | Low          | Marathon environment                 |
+| `chronos_job`       | Low          | Mesos environment                    |
+| `chronos_job_owner` | Low          | Mesos environment                    |
+| `nomad_task`        | Low          | Nomad environment                    |
+| `nomad_job`         | Low          | Nomad environment                    |
+| `nomad_group`       | Low          | Nomad environment                    |
 
 
 ### Unified service tagging

--- a/content/en/agent/docker/tag.md
+++ b/content/en/agent/docker/tag.md
@@ -19,9 +19,38 @@ The Datadog Agent can create and assign tags to all metrics, traces, and logs em
 
 If you are running the Agent as a binary on a host, configure your tag extractions with the [Agent](?tab=agent) tab instructions. If you are running the Agent as a container, configure your tag extraction with the [Containerized Agent](?tab=containerizedagent) tab instructions.
 
+### Out of the box tagging
+
+The Agent can autodiscover and attach tags to all data emitted by containers. The list of tags attached automaticaly depends on the agent [cardinality configuration][1].
+
+| Tag               | Cardinality  | Requirement                                    |
+|-------------------|--------------|------------------------------------------------|
+| container_name    | high         | n/a                                            |
+| container_id      | high         | n/a                                            |
+| rancher_container | high         | rancher environment                            |
+| mesos_task        | orchestrator | mesos environment                              |
+| docker_image      | low          | n/a                                            |
+| image_name        | low          | n/a                                            |
+| short_image       | low          | n/a                                            |
+| image_tag         | low          | n/a                                            |
+| swarm_service     | low          | swarm environment                              |
+| swarm_namespace   | low          | swarm environment                              |
+| rancher_stack     | low          | rancher environment                            |
+| rancher_service   | low          | rancher environment                            |
+| env               | low          | container label or container envvar must exist |
+| version           | low          | container label or container envvar must exist |
+| service           | low          | container label or container envvar must exist |
+| marathon_app      | low          | marathon environment                           |
+| chronos_job       | low          | mesos environment                              |
+| chronos_job_owner | low          | mesos environment                              |
+| nomad_task        | low          | nomad environment                              |
+| nomad_job         | low          | nomad environment                              |
+| nomad_group       | low          | nomad environment                              |
+
+
 ### Unified service tagging
 
-As a best practice in containerized environments, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][1] documentation.
+As a best practice in containerized environments, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][2] documentation.
 
 ## Extract labels as tags
 
@@ -68,7 +97,7 @@ docker_labels_as_tags:
 
 ## Extract environment variables as tags
 
-Datadog automatically collects common tags from [Docker, Kubernetes, ECS, Swarm, Mesos, Nomad, and Rancher][2]. To extract even more tags, use the following options:
+Datadog automatically collects common tags from [Docker, Kubernetes, ECS, Swarm, Mesos, Nomad, and Rancher][3]. To extract even more tags, use the following options:
 
 | Environment Variable               | Description                                    |
 |------------------------------------|------------------------------------------------|
@@ -120,6 +149,8 @@ docker_env_as_tags:
   ENVIRONMENT: env
 ```
 
+
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -127,5 +158,6 @@ docker_env_as_tags:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /getting_started/tagging/unified_service_tagging
-[2]: /agent/docker/?tab=standard#tagging
+[1]: /agent/docker/tag/#extract-environment-variables-as-tags
+[2]: /getting_started/tagging/unified_service_tagging
+[3]: /agent/docker/?tab=standard#tagging

--- a/content/en/agent/docker/tag.md
+++ b/content/en/agent/docker/tag.md
@@ -37,9 +37,9 @@ The Agent can autodiscover and attach tags to all data emitted by containers. Th
 | swarm_namespace   | low          | swarm environment                              |
 | rancher_stack     | low          | rancher environment                            |
 | rancher_service   | low          | rancher environment                            |
-| env               | low          | container label or container envvar must exist |
-| version           | low          | container label or container envvar must exist |
-| service           | low          | container label or container envvar must exist |
+| env               | low          | [unified service tagging][2] enabled           |
+| version           | low          | [unified service tagging][2] enabled           |
+| service           | low          | [unified service tagging][2] enabled           |
 | marathon_app      | low          | marathon environment                           |
 | chronos_job       | low          | mesos environment                              |
 | chronos_job_owner | low          | mesos environment                              |

--- a/content/en/agent/kubernetes/tag.md
+++ b/content/en/agent/kubernetes/tag.md
@@ -21,50 +21,50 @@ If you are running the Agent as a binary on a host, configure your tag extractio
 
 ## Out of the box tags
 
-The Agent can autodiscover and attach tags to all data emitted by the entire pods or an individual container within this pod. The list of tags attached automaticaly depends on the agent [cardinality configuration][1].
+The Agent can autodiscover and attach tags to all data emitted by the entire pods or an individual container within this pod. The list of tags attached automatically depends on the agent [cardinality configuration][1].
 
-| Tag                         | Cardinality  | Source                                                                  | Requirement                                         |
-|-----------------------------|--------------|-------------------------------------------------------------------------|-----------------------------------------------------|
-| container_id                | high         | pod status                                                              | n/a                                                 |
-| display_container_name      | high         | pod status                                                              | n/a                                                 |
-| pod_name                    | orchestrator | pod metadata                                                            | n/a                                                 |
-| oshift_deployment           | orchestrator | pod annotation `openshift.io/deployment.name`                           | openshift environment and pod annotation must exist |
-| kube_ownerref_name          | orchestrator | pod ownerref                                                            | pod must have an owner                              |
-| kube_job                    | orchestrator | pod ownerref                                                            | pod must be attached to a job                       |
-| kube_replica_set            | orchestrator | pod ownerref                                                            | pod must be attached to a replicaset                |
-| kube_service                | orchestrator | kubernetes service discovery                                            | pod is behind a kubernetes service                  |
-| kube_daemon_set             | low          | pod ownerref                                                            | pod must be attached to a daemonset                 |
-| kube_container_name         | low          | pod status                                                              | n/a                                                 |
-| kube_namespace              | low          | pod metadata                                                            | n/a                                                 |
-| kube_app_name               | low          | pod label `app.kubernetes.io/name`                                      | pod label must exist                                |
-| kube_app_instance           | low          | pod label `app.kubernetes.io/instance`                                  | pod label must exist                                |
-| kube_app_version            | low          | pod label `app.kubernetes.io/version`                                   | pod label must exist                                |
-| kube_app_component          | low          | pod label `app.kubernetes.io/component`                                 | pod label must exist                                |
-| kube_app_part_of            | low          | pod label `app.kubernetes.io/part-of`                                   | pod label must exist                                |
-| kube_app_managed_by         | low          | pod label `app.kubernetes.io/managed-by`                                | pod label must exist                                |
-| env                         | low          | pod label `tags.datadoghq.com/env` or container envvar `DD_ENV`         | [unified service tagging][2] enabled                |
-| version                     | low          | pod label `tags.datadoghq.com/version` or container envvar `DD_VERSION` | [unified service tagging][2] enabled                |
-| service                     | low          | pod label `tags.datadoghq.com/service` or container envvar `DD_SERVICE` | [unified service tagging][2] enabled                |
-| pod_phase                   | low          | pod status                                                              | n/a                                                 |
-| oshift_deployment_config    | low          | pod annotation `openshift.io/deployment-config.name`                    | openshift environment and pod annotation must exist |
-| kube_ownerref_kind          | low          | pod ownerref                                                            | pod must have an owner                              |
-| kube_deployment             | low          | pod ownerref                                                            | pod must be attached to a deployment                |
-| kube_replication_controller | low          | pod ownerref                                                            | pod must be attached to a replication controller    |
-| kube_stateful_set           | low          | pod ownerref                                                            | pod must be attached to a statefulset               |
-| persistentvolumeclaim       | low          | pod spec                                                                | a pvc must be attached to the pod                   |
-| kube_cronjob                | low          | pod ownerref                                                            | pod must be attached to a cronjob                   |
-| image_name                  | low          | pod spec                                                                | n/a                                                 |
-| short_image                 | low          | pod spec                                                                | n/a                                                 |
-| image_tag                   | low          | pod spec                                                                | n/a                                                 |
+| Tag                           | Cardinality  | Source                                                                  | Requirement                                         |
+|-------------------------------|--------------|-------------------------------------------------------------------------|-----------------------------------------------------|
+| `container_id`                | High         | Pod status                                                              | N/A                                                 |
+| `display_container_name`      | High         | Pod status                                                              | N/A                                                 |
+| `pod_name`                    | Orchestrator | Pod metadata                                                            | N/A                                                 |
+| `oshift_deployment`           | Orchestrator | Pod annotation `openshift.io/deployment.name`                           | OpenShift environment and pod annotation must exist |
+| `kube_ownerref_name`          | Orchestrator | Pod ownerref                                                            | Pod must have an owner                              |
+| `kube_job`                    | Orchestrator | Pod ownerref                                                            | Pod must be attached to a job                       |
+| `kube_replica_set`            | Orchestrator | Pod ownerref                                                            | Pod must be attached to a replica set               |
+| `kube_service`                | Orchestrator | kubernetes service discovery                                            | Pod is behind a Kubernetes service                  |
+| `kube_daemon_set`             | Low          | Pod ownerref                                                            | Pod must be attached to a DaemonSet                 |
+| `kube_container_name`         | Low          | Pod status                                                              | N/A                                                 |
+| `kube_namespace`              | Low          | Pod metadata                                                            | N/A                                                 |
+| `kube_app_name`               | Low          | Pod label `app.kubernetes.io/name`                                      | Pod label must exist                                |
+| `kube_app_instance`           | Low          | Pod label `app.kubernetes.io/instance`                                  | Pod label must exist                                |
+| `kube_app_version`            | Low          | Pod label `app.kubernetes.io/version`                                   | Pod label must exist                                |
+| `kube_app_component`          | Low          | Pod label `app.kubernetes.io/component`                                 | Pod label must exist                                |
+| `kube_app_part_of`            | Low          | Pod label `app.kubernetes.io/part-of`                                   | Pod label must exist                                |
+| `kube_app_managed_by`         | Low          | Pod label `app.kubernetes.io/managed-by`                                | Pod label must exist                                |
+| `env`                         | Low          | Pod label `tags.datadoghq.com/env` or container envvar `DD_ENV`         | [Unified service tagging][2] enabled                |
+| `version`                     | Low          | Pod label `tags.datadoghq.com/version` or container envvar `DD_VERSION` | [Unified service tagging][2] enabled                |
+| `service`                     | Low          | Pod label `tags.datadoghq.com/service` or container envvar `DD_SERVICE` | [Unified service tagging][2] enabled                |
+| `pod_phase`                   | Low          | Pod status                                                              | N/A                                                 |
+| `oshift_deployment_config`    | Low          | Pod annotation `openshift.io/deployment-config.name`                    | OpenShift environment and pod annotation must exist |
+| `kube_ownerref_kind`          | Low          | Pod ownerref                                                            | Pod must have an owner                              |
+| `kube_deployment`             | Low          | Pod ownerref                                                            | Pod must be attached to a deployment                |
+| `kube_replication_controller` | Low          | Pod ownerref                                                            | Pod must be attached to a replication controller    |
+| `kube_stateful_set`           | Low          | Pod ownerref                                                            | Pod must be attached to a statefulset               |
+| `persistentvolumeclaim`       | Low          | Pod spec                                                                | A pvc must be attached to the pod                   |
+| `kube_cronjob`                | Low          | Pod ownerref                                                            | Pod must be attached to a cronjob                   |
+| `image_name`                  | Low          | Pod spec                                                                | N/A                                                 |
+| `short_image`                 | Low          | Pod spec                                                                | N/A                                                 |
+| `image_tag`                   | Low          | Pod spec                                                                | N/A                                                 |
 
 ### Host tag
 
-The agent can also attach kubernetes environement information as "host tags".
+The agent can also attach kubernetes environment information as "host tags".
 
-| Tag               | Cardinality | Source                                                         | Requirement                                                    |
-|-------------------|-------------|----------------------------------------------------------------|----------------------------------------------------------------|
-| kube_cluster_name | low         | `DD_CLUSTER_NAME` envvar or cloud provider integration         | `DD_CLUSTER_NAME` envvar or cloud provider integration enabled |
-| kube_node_role    | low         | node label `node-role.kubernetes.io/<role>` | Node label must exist                |
+| Tag                 | Cardinality | Source                                                 | Requirement                                                    |
+|---------------------|-------------|--------------------------------------------------------|----------------------------------------------------------------|
+| `kube_cluster_name` | Low         | `DD_CLUSTER_NAME` envvar or cloud provider integration | `DD_CLUSTER_NAME` envvar or cloud provider integration enabled |
+| `kube_node_role`    | Low         | Node label `node-role.kubernetes.io/<role>`            | Node label must exist                                          |
 
 
 ## Tag Autodiscovery
@@ -197,7 +197,6 @@ kubernetes_pod_labels_as_tags:
 **Note**: Custom metrics may impact billing. See the [custom metrics billing page][3] for more information.
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
-[2]: /account_management/billing/custom_metrics
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/agent/kubernetes/tag.md
+++ b/content/en/agent/kubernetes/tag.md
@@ -42,9 +42,9 @@ The Agent can autodiscover and attach tags to all data emitted by the entire pod
 | kube_app_component          | low          | pod label `app.kubernetes.io/component`                                 | pod label must exist                                |
 | kube_app_part_of            | low          | pod label `app.kubernetes.io/part-of`                                   | pod label must exist                                |
 | kube_app_managed_by         | low          | pod label `app.kubernetes.io/managed-by`                                | pod label must exist                                |
-| env                         | low          | pod label `tags.datadoghq.com/env` or container envvar `DD_ENV`         | pod label or container envvar must exist            |
-| version                     | low          | pod label `tags.datadoghq.com/version` or container envvar `DD_VERSION` | pod label or container envvar must exist            |
-| service                     | low          | pod label `tags.datadoghq.com/service` or container envvar `DD_SERVICE` | `pod label or container envvar must exist           |
+| env                         | low          | pod label `tags.datadoghq.com/env` or container envvar `DD_ENV`         | [unified service tagging][2] enabled                |
+| version                     | low          | pod label `tags.datadoghq.com/version` or container envvar `DD_VERSION` | [unified service tagging][2] enabled                |
+| service                     | low          | pod label `tags.datadoghq.com/service` or container envvar `DD_SERVICE` | [unified service tagging][2] enabled                |
 | pod_phase                   | low          | pod status                                                              | n/a                                                 |
 | oshift_deployment_config    | low          | pod annotation `openshift.io/deployment-config.name`                    | openshift environment and pod annotation must exist |
 | kube_ownerref_kind          | low          | pod ownerref                                                            | pod must have an owner                              |
@@ -61,9 +61,9 @@ The Agent can autodiscover and attach tags to all data emitted by the entire pod
 
 The agent can also attach kubernetes environement information as "host tags".
 
-| Tag               | Cardinality | Source                                      | Requirement                          |
-|-------------------|-------------|---------------------------------------------|--------------------------------------|
-| kube_cluster_name | low         | `DD_CLUSTER_NAME` envvar                    | `DD_CLUSTER_NAME` envvar must be set |
+| Tag               | Cardinality | Source                                                         | Requirement                                                    |
+|-------------------|-------------|----------------------------------------------------------------|----------------------------------------------------------------|
+| kube_cluster_name | low         | `DD_CLUSTER_NAME` envvar or cloud provider integration         | `DD_CLUSTER_NAME` envvar or cloud provider integration enabled |
 | kube_node_role    | low         | node label `node-role.kubernetes.io/<role>` | Node label must exist                |
 
 

--- a/content/en/agent/kubernetes/tag.md
+++ b/content/en/agent/kubernetes/tag.md
@@ -32,7 +32,7 @@ The Agent can autodiscover and attach tags to all data emitted by the entire pod
 | `kube_ownerref_name`          | Orchestrator | Pod ownerref                                                            | Pod must have an owner                              |
 | `kube_job`                    | Orchestrator | Pod ownerref                                                            | Pod must be attached to a job                       |
 | `kube_replica_set`            | Orchestrator | Pod ownerref                                                            | Pod must be attached to a replica set               |
-| `kube_service`                | Orchestrator | kubernetes service discovery                                            | Pod is behind a Kubernetes service                  |
+| `kube_service`                | Orchestrator | Kubernetes service discovery                                            | Pod is behind a Kubernetes service                  |
 | `kube_daemon_set`             | Low          | Pod ownerref                                                            | Pod must be attached to a DaemonSet                 |
 | `kube_container_name`         | Low          | Pod status                                                              | N/A                                                 |
 | `kube_namespace`              | Low          | Pod metadata                                                            | N/A                                                 |
@@ -51,7 +51,7 @@ The Agent can autodiscover and attach tags to all data emitted by the entire pod
 | `kube_deployment`             | Low          | Pod ownerref                                                            | Pod must be attached to a deployment                |
 | `kube_replication_controller` | Low          | Pod ownerref                                                            | Pod must be attached to a replication controller    |
 | `kube_stateful_set`           | Low          | Pod ownerref                                                            | Pod must be attached to a statefulset               |
-| `persistentvolumeclaim`       | Low          | Pod spec                                                                | A pvc must be attached to the pod                   |
+| `persistentvolumeclaim`       | Low          | Pod spec                                                                | A PVC must be attached to the pod                   |
 | `kube_cronjob`                | Low          | Pod ownerref                                                            | Pod must be attached to a cronjob                   |
 | `image_name`                  | Low          | Pod spec                                                                | N/A                                                 |
 | `short_image`                 | Low          | Pod spec                                                                | N/A                                                 |
@@ -59,7 +59,7 @@ The Agent can autodiscover and attach tags to all data emitted by the entire pod
 
 ### Host tag
 
-The agent can also attach kubernetes environment information as "host tags".
+The Agent can attach Kubernetes environment information as "host tags".
 
 | Tag                 | Cardinality | Source                                                 | Requirement                                                    |
 |---------------------|-------------|--------------------------------------------------------|----------------------------------------------------------------|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add "Out of the box tags documentation" for `docker` and `kubernetes` intergations.

### Motivation

provide to use a complete list of tags added the by different container integrations.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/clamoriniere/ootb-container-tags/agent/docker/tag/?tab=containerizedagent
https://docs-staging.datadoghq.com/clamoriniere/ootb-container-tags/agent/kubernetes/tag/?tab=containerizedagent

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
