### PR TITLE
opentracing cpp version depending of envoy version

### DIFF
--- a/content/en/tracing/setup_overview/proxy_setup/_index.md
+++ b/content/en/tracing/setup_overview/proxy_setup/_index.md
@@ -222,13 +222,16 @@ The available [environment variables][2] depend on the version of the C++ tracer
 
 | Envoy Version | C++ Tracer Version |
 |---------------|--------------------|
+| v1.18 | v1.2.1 |
+| v1.17 | v1.1.5 |
+| v1.16 | v1.1.5 |
+| v1.15 | v1.1.5 |
 | v1.14 | v1.1.3 |
 | v1.13 | v1.1.1 |
 | v1.12 | v1.1.1 |
 | v1.11 | v0.4.2 |
 | v1.10 | v0.4.2 |
 | v1.9 | v0.3.6 |
-
 
 [1]: https://github.com/DataDog/dd-opentracing-cpp/tree/master/examples/envoy-tracing
 [2]: /tracing/setup/cpp/#environment-variables


### PR DESCRIPTION
### What does this PR do?
add dd opentracing cpp version depending of envoy version for envoy 1.15, 1.16, 1.17 and 1.18
you can find the info in https://github.com/envoyproxy/envoy/blob/main/bazel/repository_locations.bzl

### Motivation
notice that this doc needs to be updated

### Preview

https://docs-staging.datadoghq.com/cécile/addcppversionenvoy/tracing/setup_overview/proxy_setup/?tab=envoy#environment-variables

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
