### PR TITLE
Add a note regarding the Datadog Agent service account

### DIFF
--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -17,6 +17,9 @@ The account gains the following rights during installation:
 * It has remote login disabled
 * It has network login disabled
 
+**Note**: The installer doesn't add the account it creates to the `Users` groups by default.
+If you encounter permission issues running the Datadog Agent service, make sure the account under which the service runs is in the `Users` group.
+
 **Note**: Since the account is modified during installation to restrict its privileges, including login privileges, make sure it is not a 'real' user account but an account solely dedicated to run the Datadog Agent.
 
 ## Installation

--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -18,7 +18,6 @@ The account gains the following rights during installation:
 * It has network login disabled
 
 **Note**: The installer doesn't add the account it creates to the `Users` groups by default. On most systems this is fine.
-If you encounter permission issues running the Datadog Agent service, make sure the account under which the service runs is in the `Users` group.
 
 **Note**: Since the account is modified during installation to restrict its privileges, including login privileges, make sure it is not a 'real' user account but an account solely dedicated to run the Datadog Agent.
 

--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -17,7 +17,7 @@ The account gains the following rights during installation:
 * It has remote login disabled
 * It has network login disabled
 
-**Note**: The installer doesn't add the account it creates to the `Users` groups by default.
+**Note**: The installer doesn't add the account it creates to the `Users` groups by default. On most systems this is fine.
 If you encounter permission issues running the Datadog Agent service, make sure the account under which the service runs is in the `Users` group.
 
 **Note**: Since the account is modified during installation to restrict its privileges, including login privileges, make sure it is not a 'real' user account but an account solely dedicated to run the Datadog Agent.

--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -6,20 +6,22 @@ kind: faq
 Starting with release `6.11.0`, the Core and APM/Trace components of the Windows Agent run under a dedicated user account, instead of running under the `LOCAL_SYSTEM` account, as was the case on prior versions. If enabled, the Live Process component still runs under the `LOCAL_SYSTEM` account.
 
 The Agent installer creates a new account by default (`ddagentuser`) but it can also use a user-supplied account.
-The account gains the following rights during installation:
+The is assigned to the following groups during installation:
 
-* It can start and stop the APM and Process Agent
 * It becomes a member of the “Performance Monitor Users” group
   * Necessary to access WMI information
   * Necessary to access Windows performance counter data
 * It becomes a member of the “Event Log Readers” group
-* It has local login disabled
-* It has remote login disabled
-* It has network login disabled
 
 **Note**: The installer doesn't add the account it creates to the `Users` groups by default. In rare cases, you may encounter permission issues. If so, manually add the created user to the `Users` group.
 
-**Note**: Since the account is modified during installation to restrict its privileges, including login privileges, make sure it is not a 'real' user account but an account solely dedicated to run the Datadog Agent.
+Additionally the following security policies are applied to the account during installation:
+* Deny access to this computer from the network
+* Deny log on locally
+* Deny log on through Remote Desktop Services
+* Log on as a service
+
+**Important**: Since the account is modified during installation to restrict its privileges, including login privileges, make sure it is not a 'real' user account but an account solely dedicated to run the Datadog Agent.
 
 ## Installation
 

--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -6,7 +6,7 @@ kind: faq
 Starting with release `6.11.0`, the Core and APM/Trace components of the Windows Agent run under a dedicated user account, instead of running under the `LOCAL_SYSTEM` account, as was the case on prior versions. If enabled, the Live Process component still runs under the `LOCAL_SYSTEM` account.
 
 The Agent installer creates a new account by default (`ddagentuser`) but it can also use a user-supplied account.
-The is assigned to the following groups during installation:
+The account is assigned to the following groups during installation:
 
 * It becomes a member of the “Performance Monitor Users” group
   * Necessary to access WMI information

--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -17,7 +17,7 @@ The account gains the following rights during installation:
 * It has remote login disabled
 * It has network login disabled
 
-**Note**: The installer doesn't add the account it creates to the `Users` groups by default. On most systems this is fine.
+**Note**: The installer doesn't add the account it creates to the `Users` groups by default. In rare cases, you may encounter permission issues. If so, manually add the created user to the `Users` group.
 
 **Note**: Since the account is modified during installation to restrict its privileges, including login privileges, make sure it is not a 'real' user account but an account solely dedicated to run the Datadog Agent.
 


### PR DESCRIPTION
### What does this PR do?
This PR clarifies that the Datadog Agent service account should also be in the `Users` group.
Also clarify the security policies applied to the account by sourcing their exact terms from the Windows Security Policy menu.

### Motivation
A support case revealed that in some cases the Datadog Agent service account was not in the `Users` group, and it caused permission issues.
Additionally we often face questions about the exact security policies applied to the account under which the Agent runs.

### Preview
https://docs-staging.datadoghq.com/julien.lebot/clarify_users_group/agent/faq/windows-agent-ddagent-user/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
