### PR TITLE
Fixed is_match example.

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -334,7 +334,7 @@ The `is_match` condition also supports matching multiple strings:
 To send a different notification if the tag doesn't contain `db`, use the negation of the condition as follows:
 
 ```text
-{{^#is_match "role.name" "db"}}
+{{^is_match "role.name" "db"}}
   This displays if the role tag doesn't contain `db`.
   @slack-example
 {{/is_match}}

--- a/content/fr/monitors/notifications.md
+++ b/content/fr/monitors/notifications.md
@@ -269,7 +269,7 @@ La condition `is_match` prend également en charge plusieurs chaînes :
 Pour envoyer une autre notification lorsque le tag ne contient pas `db`, utilisez la négation de la condition tel que suit :
 
 ```text
-{{^#is_match "role.name" "db"}}
+{{^is_match "role.name" "db"}}
   Cela s'affiche si le tag du rôle ne contient pas `db`.
   @slack-example
 {{/is_match}}

--- a/content/ja/monitors/notifications.md
+++ b/content/ja/monitors/notifications.md
@@ -269,7 +269,7 @@ This alert was triggered on {{ @machine_id.name }}
 タグに `db` が含まれない場合に異なる通知を送信するには、以下のように条件の否認を使用します。
 
 ```text
-{{^#is_match "role.name" "db"}}
+{{^is_match "role.name" "db"}}
   ロールタグに `db` が含まれない場合に表示されます。
   @slack-example
 {{/is_match}}


### PR DESCRIPTION
The is_match example was wrong, fixed it.

### What does this PR do?
The is_match example was wrong, fixed it.
If the context does not match, it should be written as `{{^is_match}}`, but the example is `{{^#is_match}}`.


### Motivation


### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->


### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
