### PR TITLE
[WEB-1487] Nav Titles Indent when 2 Lines

### DIFF
--- a/assets/styles/components/_sidenav.scss
+++ b/assets/styles/components/_sidenav.scss
@@ -123,7 +123,7 @@ body > header.scrolled ~ .container .sidenav .sticky {
 
     .nav-top-level {
       & > a span {
-        margin-left: 5px;
+        margin-left: 10px;
       }
       
     }
@@ -172,7 +172,7 @@ body > header.scrolled ~ .container .sidenav .sticky {
           font-weight: 600;
           padding: 3px 0 0 2px;
           margin-right: 10px;
-          display:block;
+          display:flex;
           border:1px solid transparent;
           &:hover {
             background:transparent;


### PR DESCRIPTION
### What does this PR do?
Updates sidenav styles. Sidenav title links indent when greater than 1 line to differentiate from the next title.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1487

### Preview
https://docs-staging.datadoghq.com/davidweid/sidebar-nav-indents/agent/

- Smallest screen size width with sidebar nav visible: 992px
- Long sidenav titles "APM & Distributed Tracing" and "Account Management" wrap to 2 lines on smaller screens. When wrapping, text on both lines should be aligned / indented.
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.