### PR TITLE
Replaced deprecated API usage with manual alternative

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/python.md
+++ b/content/en/tracing/connect_logs_and_traces/python.md
@@ -58,7 +58,12 @@ hello()
 
 ### No standard library logging
 
-If you are not using the standard library `logging` module, you can use the `ddtrace.helpers.get_correlation_ids()` to inject tracer information into your logs.
+If you are not using the standard library `logging` module, you can use the following code snippet to inject tracer information into your logs:
+
+```python
+span = tracer.get_current_span()
+correlation_ids = (span.trace_id, span.span.id)
+```
 As an illustration of this approach, the following example defines a function as a *processor* in `structlog` to add tracer fields to the log output:
 
 ``` python
@@ -69,7 +74,8 @@ import structlog
 
 def tracer_injection(logger, log_method, event_dict):
     # get correlation ids from current tracer context
-    trace_id, span_id = get_correlation_ids()
+    span = tracer.get_current_span()
+    trace_id, span_id = (span.trace_id, span.span.id)
 
     # add ids to structlog event dictionary
     event_dict['dd.trace_id'] = str(trace_id or 0)


### PR DESCRIPTION
### What does this PR do?
This PR replaces the usage of a deprecated `get_correlation_ids()` helper function with a manual alternative for users.

### Motivation
Until the dd-trace-py [PR](https://github.com/DataDog/dd-trace-py/pull/2488) for a replacement API is merged, the corps docs should provide an alternative manual replacement for the now deprecated `get_correlation_ids()` helper as made by this PR.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/yunkim/logs-and-traces/tracing/connect_logs_and_traces/python/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
