### PR TITLE
Redo PR 10763 - Update documentation for FFQ in logs

### DIFF
--- a/content/en/logs/explorer/_index.md
+++ b/content/en/logs/explorer/_index.md
@@ -46,14 +46,16 @@ The search filter consists of a timerange and a search query mixing `key:value` 
 [Indexed Logs][4] support both full-text search and `key:value` search queries.
 
 {{< site-region region="gov,us3" >}}
+**Note**: `key:value` queries require that you [declare a facet][1] beforehand.
 
-**Note**: `key:value` queries require that you [declare a facet][5] beforehand.
+[5]: /logs/explorer/facets/
 
 {{< /site-region >}}
 
 {{< site-region region="us,eu" >}}
+**Note**: `key:value` queries **do not** require that you [declare a facet][1] beforehand.
 
-**Note**: `key:value` queries **do not** require that you [declare a facet][5] beforehand.
+[5]: /logs/explorer/facets/
 
 {{< /site-region >}}
 ## Aggregate and measure

--- a/content/en/logs/explorer/_index.md
+++ b/content/en/logs/explorer/_index.md
@@ -48,14 +48,14 @@ The search filter consists of a timerange and a search query mixing `key:value` 
 {{< site-region region="gov,us3" >}}
 **Note**: `key:value` queries require that you [declare a facet][1] beforehand.
 
-[5]: /logs/explorer/facets/
+[1]: /logs/explorer/facets/
 
 {{< /site-region >}}
 
 {{< site-region region="us,eu" >}}
 **Note**: `key:value` queries **do not** require that you [declare a facet][1] beforehand.
 
-[5]: /logs/explorer/facets/
+[1]: /logs/explorer/facets/
 
 {{< /site-region >}}
 ## Aggregate and measure

--- a/content/en/logs/explorer/_index.md
+++ b/content/en/logs/explorer/_index.md
@@ -47,6 +47,7 @@ The search filter consists of a timerange and a search query mixing `key:value` 
 
 {{< site-region region="gov,us3" >}}
 **Note**: `key:value` queries require that you [declare a facet][1] beforehand.
+<p></p>
 
 [1]: /logs/explorer/facets/
 
@@ -54,6 +55,7 @@ The search filter consists of a timerange and a search query mixing `key:value` 
 
 {{< site-region region="us,eu" >}}
 **Note**: `key:value` queries **do not** require that you [declare a facet][1] beforehand.
+<p></p>
 
 [1]: /logs/explorer/facets/
 

--- a/content/en/logs/explorer/_index.md
+++ b/content/en/logs/explorer/_index.md
@@ -45,7 +45,7 @@ The search filter consists of a timerange and a search query mixing `key:value` 
 
 [Indexed Logs][4] support both full-text search and `key:value` search queries.
 
-**Note**: `key:value` queries require that you [declare a facet][5] beforehand.
+**Note**: `key:value` queries **do not** require that you [declare a facet][5] beforehand.
 
 ## Aggregate and measure
 
@@ -118,13 +118,13 @@ Lists displaying individual logs and lists displaying aggregates of logs have sl
 For a list of individual logs, choose which information of interest to display as columns. **Manage the columns** of the table using either:
 
 - The **table**, with interactions available in the first row. This is the preferred method to **sort**, **rearrange**, or **remove** columns.
-- The **facet panel** the the left, or the _log side panel_ on the right. This is the preferred option to **add** a column for a field.
+- The **facet panel** on the left, or the _log side panel_ on the right. This is the preferred option to **add** a column for a field.
 
 With the **Options** button, control the **number of lines** displayed in the table per log event.
 
 {{< img src="logs/explorer/table_controls.gif" alt="configure display table"  style="width:80%;">}}
 
-The default **sort** for logs in the list visualization is by timestamp, with the most recent logs on top. This is the fastest and therefore recommended sorting method for general purposes. Surface logs with lowest or highest value for a measure first, or sort your logs lexicographically for the unique value of facet, ordering a column according to that facet. Note that sorting your table according to a specific field requires that you [declare a facet][5] beforehand.
+The default **sort** for logs in the list visualization is by timestamp, with the most recent logs on top. This is the fastest and therefore recommended sorting method for general purposes. Surface logs with lowest or highest value for a measure first, or sort your logs lexicographically for the unique value of facet, ordering a column according to that facet. Note that, although any attributes or tags can be added as a column, sorting your table according to a specific field requires that you [declare a facet][5] beforehand.
 
 The configuration of the log table is stored alongside other elements of your troubleshooting context in [Saved Views][1]
 

--- a/content/en/logs/explorer/_index.md
+++ b/content/en/logs/explorer/_index.md
@@ -45,8 +45,17 @@ The search filter consists of a timerange and a search query mixing `key:value` 
 
 [Indexed Logs][4] support both full-text search and `key:value` search queries.
 
+{{< site-region region="gov,us3" >}}
+
+**Note**: `key:value` queries require that you [declare a facet][5] beforehand.
+
+{{< /site-region >}}
+
+{{< site-region region="us,eu" >}}
+
 **Note**: `key:value` queries **do not** require that you [declare a facet][5] beforehand.
 
+{{< /site-region >}}
 ## Aggregate and measure
 
 Logs can be valuable as individual events, but sometimes valuable information lives in a subset of events. In order to expose this information, aggregate your logs.
@@ -124,7 +133,13 @@ With the **Options** button, control the **number of lines** displayed in the ta
 
 {{< img src="logs/explorer/table_controls.gif" alt="configure display table"  style="width:80%;">}}
 
+{{< site-region region="gov,us3" >}}
+The default **sort** for logs in the list visualization is by timestamp, with the most recent logs on top. This is the fastest and therefore recommended sorting method for general purposes. Surface logs with lowest or highest value for a measure first, or sort your logs lexicographically for the unique value of facet, ordering a column according to that facet. Note that sorting your table according to a specific field requires that you [declare a facet][5] beforehand.
+{{< /site-region >}}
+
+{{< site-region region="us,eu" >}}
 The default **sort** for logs in the list visualization is by timestamp, with the most recent logs on top. This is the fastest and therefore recommended sorting method for general purposes. Surface logs with lowest or highest value for a measure first, or sort your logs lexicographically for the unique value of facet, ordering a column according to that facet. Note that, although any attributes or tags can be added as a column, sorting your table according to a specific field requires that you [declare a facet][5] beforehand.
+{{< /site-region >}}
 
 The configuration of the log table is stored alongside other elements of your troubleshooting context in [Saved Views][1]
 

--- a/content/en/logs/explorer/facets.md
+++ b/content/en/logs/explorer/facets.md
@@ -260,6 +260,7 @@ This is the best option if you onboard logs flowing from new sources. Rather tha
 [4]: /monitors/monitor_types/log/
 [5]: /dashboards/widgets/
 [6]: /notebooks/
+[15]: /logs/log_configuration/rehydrating
 [16]: /integrations/nginx/
 [17]: /logs/processing/processors/?tab=ui#geoip-parser
 [18]: /integrations/kong/

--- a/content/en/logs/explorer/facets.md
+++ b/content/en/logs/explorer/facets.md
@@ -33,19 +33,35 @@ Facets also allow you to manipulate your logs in your [log monitors][4], log wid
 
 {{< site-region region="gov,us3" >}}
 
-**Note**: You do not need facets to support [log processing][7], [livetail search][8], [archive][9] forwarding, rehydration, or [metric generation][10] from logs. You also do not need facets for routing logs through to [Pipelines][11] and [Indexes][12] with filters, or excluding or sampling logs from indexes with [exclusion filters][13]. 
+**Note**: You do not need facets to support [log processing][1], [livetail search][2], [archive][3] forwarding, rehydration, or [metric generation][4] from logs. You also do not need facets for routing logs through to [Pipelines][5] and [Indexes][6] with filters, or excluding or sampling logs from indexes with [exclusion filters][7]. 
 
 In all these contexts, autocomplete capabilities rely on existing facets, but any input matching incoming logs would work.
 
+[1]: /logs/processing/processors/
+[2]: /logs/live_tail/
+[3]: /logs/archives/
+[4]: /logs/logs_to_metrics/
+[5]: /logs/processing/pipelines/
+[6]: /logs/indexes/#indexes-filters
+[7]: /logs/indexes/#exclusion-filters
 
 {{< /site-region >}}
 
 {{< site-region region="us,eu" >}}
 
-**Note**: You do not need facets to support [log processing][7], [livetail search][8], [log explorer search][14], [metric generation][10] from logs, [archive][9] forwarding, or [rehydration][15]. You also do not need facets for routing logs through to [Pipelines][11] and [Indexes][12] with filters, or excluding or sampling logs from indexes with [exclusion filters][13]. 
+**Note**: You do not need facets to support [log processing][1], [livetail search][2], [log explorer search][8], [metric generation][4] from logs, [archive][3] forwarding, or [rehydration][9]. You also do not need facets for routing logs through to [Pipelines][5] and [Indexes][6] with filters, or excluding or sampling logs from indexes with [exclusion filters][7]. 
 
 In all these contexts, autocomplete capabilities rely on existing facets, but any input matching incoming logs would work.
 
+[1]: /logs/processing/processors/
+[2]: /logs/live_tail/
+[3]: /logs/archives/
+[4]: /logs/logs_to_metrics/
+[5]: /logs/processing/pipelines/
+[6]: /logs/indexes/#indexes-filters
+[7]: /logs/indexes/#exclusion-filters
+[8]: /logs/processing/attributes_naming_convention/#standard-attribute-list
+[9]: /logs/archives/rehydrating/
 
 {{< /site-region >}}
 
@@ -55,23 +71,22 @@ In all these contexts, autocomplete capabilities rely on existing facets, but an
 
 Use qualitative facets when you need:
 
-- To **get relative insights** for values. For instance, create a facet on `http.network.client.geoip.country.iso_code` to see the top countries most impacted per number of 5XX errors on your [NGINX][16] web access logs, enriched with the Datadog [GeoIP Processor][17].
+- To **get relative insights** for values. For instance, create a facet on `http.network.client.geoip.country.iso_code` to see the top countries most impacted per number of 5XX errors on your [NGINX][16] web access logs, enriched with the Datadog [GeoIP Processor][17].<br/><br/>
 
 - To **count unique values**. For instance, create a facet on `user.email` from your [Kong][18] logs to know how many users connect every day to your website.
 
 {{< site-region region="gov,us3" >}}
+- To **filter** your logs against specific value(s). For instance, create a facet on an `environment` [tag][1] to scope troubleshooting down to development, staging, or production environments.
 
-- To **filter** your logs against specific value(s). For instance, create a facet on an `environment` [tag][19] to scope troubleshooting down to development, staging, or production environments.
-
+[1]: /getting_started/tagging/assigning_tags/
 
 {{< /site-region >}}
-
 {{< site-region region="us,eu" >}}
-
-- To frequently **filter** your logs against particular values. For instance, create a facet on an `environment` [tag][19] to scope troubleshooting down to development, staging, or production environments.
+- To frequently **filter** your logs against particular values. For instance, create a facet on an `environment` [tag][1] to scope troubleshooting down to development, staging, or production environments.
 
 **Note**: Although it is not required to create facets to filter on attribute values, defining them on attributes that you often use during investigations can help reduce your time to resolution.
 
+[1]: /getting_started/tagging/assigning_tags/
 
 {{< /site-region >}}
 
@@ -245,19 +260,9 @@ This is the best option if you onboard logs flowing from new sources. Rather tha
 [4]: /monitors/monitor_types/log/
 [5]: /dashboards/widgets/
 [6]: /notebooks/
-[7]: /logs/processing/processors/
-[8]: /logs/live_tail/
-[9]: /logs/archives/
-[10]: /logs/logs_to_metrics/
-[11]: /logs/processing/pipelines/
-[12]: /logs/indexes/#indexes-filters
-[13]: /logs/indexes/#exclusion-filters
-[14]: /logs/processing/attributes_naming_convention/#standard-attribute-list
-[15]: /logs/archives/rehydrating/
 [16]: /integrations/nginx/
 [17]: /logs/processing/processors/?tab=ui#geoip-parser
 [18]: /integrations/kong/
-[19]: /getting_started/tagging/assigning_tags/
 [20]: /integrations/varnish/
 [21]: /integrations/ansible/
 [22]: /integrations/python/

--- a/content/en/logs/explorer/facets.md
+++ b/content/en/logs/explorer/facets.md
@@ -32,27 +32,48 @@ Facets are user-defined tags and attributes from your indexed logs. They are mea
 Facets also allow you to manipulate your logs in your [log monitors][4], log widgets in [dashboards][5], and [notebooks][6].
 
 {{< site-region region="gov,us3" >}}
-**Note**: You do not need facets to support [log processing][7], [livetail search][8], [archive][9] forwarding, rehydration, or [metric generation][10] from logs. You also do not need facets for routing logs through to [Pipelines][11] and [Indexes][12] with filters, or excluding or sampling logs from indexes with [exclusion filters][13]. In all these contexts, autocomplete capabilities rely on existing facets, but any input matching incoming logs would work.
+
+**Note**: You do not need facets to support [log processing][7], [livetail search][8], [archive][9] forwarding, rehydration, or [metric generation][10] from logs. You also do not need facets for routing logs through to [Pipelines][11] and [Indexes][12] with filters, or excluding or sampling logs from indexes with [exclusion filters][13]. 
+
+In all these contexts, autocomplete capabilities rely on existing facets, but any input matching incoming logs would work.
+
+
 {{< /site-region >}}
 
 {{< site-region region="us,eu" >}}
-**Note**: You do not need facets to support [log processing][7], [livetail search][8], [log explorer search][14], [metric generation][10] from logs, [archive][9] forwarding, or [rehydration][15]. You also do not need facets for routing logs through to [Pipelines][11] and [Indexes][12] with filters, or excluding or sampling logs from indexes with [exclusion filters][13]. In all these contexts, autocomplete capabilities rely on existing facets, but any input matching incoming logs would work.
+
+**Note**: You do not need facets to support [log processing][7], [livetail search][8], [log explorer search][14], [metric generation][10] from logs, [archive][9] forwarding, or [rehydration][15]. You also do not need facets for routing logs through to [Pipelines][11] and [Indexes][12] with filters, or excluding or sampling logs from indexes with [exclusion filters][13]. 
+
+In all these contexts, autocomplete capabilities rely on existing facets, but any input matching incoming logs would work.
+
+
 {{< /site-region >}}
 
 ### Qualitative facets
+
 #### Dimensions
 
 Use qualitative facets when you need:
 
 - To **get relative insights** for values. For instance, create a facet on `http.network.client.geoip.country.iso_code` to see the top countries most impacted per number of 5XX errors on your [NGINX][16] web access logs, enriched with the Datadog [GeoIP Processor][17].
+
+
 - To **count unique values**. For instance, create a facet on `user.email` from your [Kong][18] logs to know how many users connect every day to your website.
+
 {{< site-region region="gov,us3" >}}
+
 - To **filter** your logs against specific value(s). For instance, create a facet on an `environment` [tag][19] to scope troubleshooting down to development, staging, or production environments.
+
+
 {{< /site-region >}}
+
 {{< site-region region="us,eu" >}}
+
 - To frequently **filter** your logs against particular values. For instance, create a facet on an `environment` [tag][19] to scope troubleshooting down to development, staging, or production environments.
 
 **Note**: Although it is not required to create facets to filter on attribute values, defining them on attributes that you often use during investigations can help reduce your time to resolution.
+
+
 {{< /site-region >}}
 
 #### Types

--- a/content/en/logs/explorer/facets.md
+++ b/content/en/logs/explorer/facets.md
@@ -31,16 +31,29 @@ Facets are user-defined tags and attributes from your indexed logs. They are mea
 
 Facets also allow you to manipulate your logs in your [log monitors][4], log widgets in [dashboards][5], and [notebooks][6].
 
+{{< site-region region="gov,us3" >}}
 **Note**: You do not need facets to support [log processing][7], [livetail search][8], [archive][9] forwarding, rehydration, or [metric generation][10] from logs. You also do not need facets for routing logs through to [Pipelines][11] and [Indexes][12] with filters, or excluding or sampling logs from indexes with [exclusion filters][13]. In all these contexts, autocomplete capabilities rely on existing facets, but any input matching incoming logs would work.
+{{< /site-region >}}
+
+{{< site-region region="us,eu" >}}
+**Note**: You do not need facets to support [log processing][7], [livetail search][8], [log explorer search][14], [metric generation][10] from logs, [archive][9] forwarding, or [rehydration][15]. You also do not need facets for routing logs through to [Pipelines][11] and [Indexes][12] with filters, or excluding or sampling logs from indexes with [exclusion filters][13]. In all these contexts, autocomplete capabilities rely on existing facets, but any input matching incoming logs would work.
+{{< /site-region >}}
 
 ### Qualitative facets
 #### Dimensions
 
 Use qualitative facets when you need:
 
-- To **filter** your logs against specific value(s). For instance, create a facet on an `environment` [tag][14] to scope troubleshooting down to development, staging, or production environments.
-- To **get relative insights** for values. For instance, create a facet on `http.network.client.geoip.country.iso_code` to see the top countries most impacted per number of 5XX errors on your [NGINX][15] web access logs, enriched with the Datadog [GeoIP Processor][16].
-- To **count unique values**. For instance, create a facet on `user.email` from your [Kong][17] logs to know how many users connect every day to your website.
+- To **get relative insights** for values. For instance, create a facet on `http.network.client.geoip.country.iso_code` to see the top countries most impacted per number of 5XX errors on your [NGINX][16] web access logs, enriched with the Datadog [GeoIP Processor][17].
+- To **count unique values**. For instance, create a facet on `user.email` from your [Kong][18] logs to know how many users connect every day to your website.
+{{< site-region region="gov,us3" >}}
+- To **filter** your logs against specific value(s). For instance, create a facet on an `environment` [tag][19] to scope troubleshooting down to development, staging, or production environments.
+{{< /site-region >}}
+{{< site-region region="us,eu" >}}
+- To frequently **filter** your logs against particular values. For instance, create a facet on an `environment` [tag][19] to scope troubleshooting down to development, staging, or production environments.
+
+**Note**: Although it is not required to create facets to filter on attribute values, defining them on attributes that you often use during investigations can help reduce your time to resolution.
+{{< /site-region >}}
 
 #### Types
 
@@ -51,9 +64,9 @@ Qualitative facets can have a string or numerical (integer) type. While assignin
 
 Use measures when you need:
 
-- To **aggregate values** from multiple logs. For instance, create a measure on the size of tiles served by the [Varnish cache][18] of a map server and keep track of the **average** daily throughput, or top-most referrers per **sum** of tile size requested.
-- To **range filter** your logs. For instance, create a measure on the execution time of [Ansible][19] tasks, and see the list of servers having the most runs taking more than 10s.
-- To **sort logs** against that value. For instance, create a measure on the amount of payments performed with your [Python][20] microservice. You can then search all the logs, starting with the one with the highest amount.
+- To **aggregate values** from multiple logs. For instance, create a measure on the size of tiles served by the [Varnish cache][20] of a map server and keep track of the **average** daily throughput, or top-most referrers per **sum** of tile size requested.
+- To **range filter** your logs. For instance, create a measure on the execution time of [Ansible][21] tasks, and see the list of servers having the most runs taking more than 10s.
+- To **sort logs** against that value. For instance, create a measure on the amount of payments performed with your [Python][22] microservice. You can then search all the logs, starting with the one with the highest amount.
 
 #### Types
 
@@ -70,7 +83,7 @@ Measures support units in **time** or **size** for easier handling of orders of 
 
 Unit is a property of the measure itself, not of the field. For example, consider a `duration` measure in nanoseconds: you have logs from `service:A` where `duration:1000` stands for 1000 milliseconds, and other logs from `service:B` where `duration:500` stands for 500 microseconds:
 
-1. Scale duration into nanoseconds for all logs flowing in with the [arithmetic processor][21]. Use a `*1000000` multiplier on logs from `service:A`, and a `*1000` multiplier on logs from `service:B`.
+1. Scale duration into nanoseconds for all logs flowing in with the [arithmetic processor][23]. Use a `*1000000` multiplier on logs from `service:A`, and a `*1000` multiplier on logs from `service:B`.
 2. Use `duration:>20ms` (see [search syntax][1] for reference) to consistently query logs from both services at once, and see an aggregated result of max `1 min`.
 
 ## Facet panel
@@ -105,7 +118,7 @@ Hidden facets have no impact aside from the log explorer (for instance: live tai
 
 #### Hidden facets and teammates
 
-Hiding facets is specific to your own troubleshooting context and won't impact your teammates' view, unless you update a [Saved View][22]. Hidden facets is part of the context saved in a saved view.
+Hiding facets is specific to your own troubleshooting context and won't impact your teammates' view, unless you update a [Saved View][24]. Hidden facets is part of the context saved in a saved view.
 
 ### Group facets
 
@@ -139,11 +152,11 @@ You may wish to keep the non-standard _aliased_ version of the facet if you are 
 
 Most common facets such as `Host`, `Service`, `URL Path`, or `Duration` come out-of-the-box to start troubleshooting right away once your logs are flowing into log indexes.
 
-Facets on [Reserved Attributes][23] and most [Standard Attributes][24] are available by default.
+Facets on [Reserved Attributes][25] and most [Standard Attributes][26] are available by default.
 
 ### Index facet
 
-The index facet is a specific facet that appears only if your organization has [multiple indexes][25], and/or if you have active [historical views][26]. Use this facet if you want to scope down your query to a subset of your indexes.
+The index facet is a specific facet that appears only if your organization has [multiple indexes][27], and/or if you have active [historical views][15]. Use this facet if you want to scope down your query to a subset of your indexes.
 
 {{< img src="logs/explorer/facet/index_facet_.png" alt="Create Facet" style="width:30%;">}}
 
@@ -179,7 +192,7 @@ Autocomplete based on the content in logs of the current views helps you to defi
 
 ### Alias facets
 
-Gathering similar content under a unique facet enables cross-team analytics and eases cross-team troubleshooting—see [Naming Convention][24] for reference.
+Gathering similar content under a unique facet enables cross-team analytics and eases cross-team troubleshooting—see [Naming Convention][26] for reference.
 
 Use aliasing as an option to smoothly realign teams that rely on inconsistent naming conventions. With aliasing, you can have them all using the standard facet emerging for your organization.
 
@@ -192,7 +205,7 @@ When aliasing an _aliased_ facet towards a _standard_ facet:
 - Users can use either aliased and standard facets for troubleshooting. You may prefer the standard one, which eases correlation of content flowing from diverse and possibly heterogeneous sources.
 - Users are nudged to use the standard facet in place of the aliased one.
 
-To alias a facet towards a standard one, select the `Alias to...` action item in the facet menu. Pick the destination facets from all the [standard][27] ones existing for your organization.
+To alias a facet towards a standard one, select the `Alias to...` action item in the facet menu. Pick the destination facets from all the [standard][14] ones existing for your organization.
 
 {{< img src="logs/explorer/facet/alias_modal.png" alt="alias modal" style="width:30%;">}}
 
@@ -219,17 +232,17 @@ This is the best option if you onboard logs flowing from new sources. Rather tha
 [11]: /logs/processing/pipelines/
 [12]: /logs/indexes/#indexes-filters
 [13]: /logs/indexes/#exclusion-filters
-[14]: /getting_started/tagging/assigning_tags/
-[15]: /integrations/nginx/
-[16]: /logs/processing/processors/?tab=ui#geoip-parser
-[17]: /integrations/kong/
-[18]: /integrations/varnish/
-[19]: /integrations/ansible/
-[20]: /integrations/python/
-[21]: /logs/processing/processors/?tab=ui#arithmetic-processor
-[22]: /logs/explorer/saved_views/
-[23]: /logs/processing/attributes_naming_convention/#reserved-attributes
-[24]: /logs/processing/attributes_naming_convention/
-[25]: /logs/indexes/#indexes
-[26]: /logs/archives/rehydrating/
-[27]: /logs/processing/attributes_naming_convention/#standard-attribute-list
+[14]: /logs/processing/attributes_naming_convention/#standard-attribute-list
+[15]: /logs/archives/rehydrating/
+[16]: /integrations/nginx/
+[17]: /logs/processing/processors/?tab=ui#geoip-parser
+[18]: /integrations/kong/
+[19]: /getting_started/tagging/assigning_tags/
+[20]: /integrations/varnish/
+[21]: /integrations/ansible/
+[22]: /integrations/python/
+[23]: /logs/processing/processors/?tab=ui#arithmetic-processor
+[24]: /logs/explorer/saved_views/
+[25]: /logs/processing/attributes_naming_convention/#reserved-attributes
+[26]: /logs/processing/attributes_naming_convention/
+[27]: /logs/indexes/#indexes

--- a/content/en/logs/explorer/facets.md
+++ b/content/en/logs/explorer/facets.md
@@ -57,7 +57,6 @@ Use qualitative facets when you need:
 
 - To **get relative insights** for values. For instance, create a facet on `http.network.client.geoip.country.iso_code` to see the top countries most impacted per number of 5XX errors on your [NGINX][16] web access logs, enriched with the Datadog [GeoIP Processor][17].
 
-
 - To **count unique values**. For instance, create a facet on `user.email` from your [Kong][18] logs to know how many users connect every day to your website.
 
 {{< site-region region="gov,us3" >}}

--- a/content/en/logs/explorer/saved_views.md
+++ b/content/en/logs/explorer/saved_views.md
@@ -13,7 +13,7 @@ further_reading:
 
 ## Overview
 
-Efficient troubleshooting requires your data to be in the proper **scope** to permit exploration, have access to **visualization options** to surface meaningful information, and have relevant **[facets][1]** to enable analysis.
+Efficient troubleshooting requires your data to be in the proper **scope** to permit exploration, have access to **visualization options** to surface meaningful information, and have relevant **[facets][1]** listed to enable analysis.
 
 Troubleshooting is highly contextual, and Saved Views enable you and your teammates to easily switch between different troubleshooting contexts. You can access Saved Views in the upper left corner of the [Log Explorer][2].
 

--- a/content/en/logs/explorer/search_syntax.md
+++ b/content/en/logs/explorer/search_syntax.md
@@ -56,16 +56,20 @@ The following characters are considered special: `+` `-` `=` `&&` `||` `>` `<` `
 
 To search for logs that contain `user=JaneDoe` in the message attribute use the following search:
 
-`user\=JaneDoe`
+```
+user\=JaneDoe
+```
 
 ### Attributes search
 
 {{< site-region region="gov,us3" >}}
-To search on a specific attribute, first [add it as a facet][2] and then add `@` to specify you are searching on a facet.
+To search on a specific attribute, first [add it as a facet][1] and then add `@` to specify you are searching on a facet.
 
-For instance, if your attribute name is **url** and you want to filter on the **url** value *www.datadoghq.com*, enter:
+For instance, if your attribute name is **url** and you want to filter on the **url** value `www.datadoghq.com`, enter:
 
-`@url:www.datadoghq.com`
+```
+@url:www.datadoghq.com
+```
 
 
 **Notes**:
@@ -75,14 +79,18 @@ For instance, if your attribute name is **url** and you want to filter on the **
 2. Searching for a facet value that contains special characters requires escaping or double quotes.
 For example, for a facet `my_facet` with the value `hello:world`, search using: `@my_facet:hello\:world` or `@my_facet:"hello:world"`.
 To match a single special character or space, use the `?` wildcard. For example, for a facet `my_facet` with the value `hello world`, search using: `@my_facet:hello?world`.
-{{< /site-region >}}
 
+[1]: /logs/explorer/facets/
+
+{{< /site-region >}}
 {{< site-region region="us,eu" >}}
 To search on a specific attribute, add `@` to specify you are searching on an attribute.
 
-For instance, if your attribute name is **url** and you want to filter on the **url** value *www.datadoghq.com*, enter:
+For instance, if your attribute name is **url** and you want to filter on the **url** value `www.datadoghq.com`, enter:
 
-`@url:www.datadoghq.com`
+```
+@url:www.datadoghq.com
+```
 
 
 **Notes**:
@@ -116,17 +124,24 @@ To perform a multi-character wildcard search, use the `*` symbol as follows:
 
 {{< site-region region="gov,us3" >}}
 Wildcard searches work within facets with this syntax. This query returns all the services that end with the string `mongo`:
+<p> </p>
 {{< /site-region >}}
 
 {{< site-region region="us,eu" >}}
 Wildcard searches work within attributes and tags (faceted or not) with this syntax. This query returns all the services that end with the string `mongo`:
+<p> </p>
 {{< /site-region >}}
+<p></p>
 
-`service:*mongo`
+```
+service:*mongo
+```
 
 Wildcard searches can also be used to search in the plain text of a log that is not part of a facet. This query returns all the logs that contain the string `NETWORK`:
 
-`*NETWORK*`
+```
+*NETWORK*
+```
 
 However, this search term does not return logs that contain the string `NETWORK` if it is in a facet and not part of the log message.
 
@@ -134,28 +149,40 @@ However, this search term does not return logs that contain the string `NETWORK`
 
 {{< site-region region="gov,us3" >}}
 When searching for a facet value that contains special characters or requires escaping or double quotes, use the `?` wildcard to match a single special character or space. For example, to search for a facet `my_facet` with the value `hello world`: `@my_facet:hello?world`.
+<p> </p>
 {{< /site-region >}}
 
 {{< site-region region="us,eu" >}}
 When searching for an attribute or tag value that contains special characters or requires escaping or double quotes, use the `?` wildcard to match a single special character or space. For example, to search for an attribute `my_attribute` with the value `hello world`: `@my_attribute:hello?world`.
+<p> </p>
 {{< /site-region >}}
 
 ## Numerical values
 
 {{< site-region region="gov,us3" >}}
 Use `<`,`>`, `<=`, or `>=` to perform a search on numerical attributes. For instance, retrieve all logs that have a response time over 100ms with:
+<p> </p>
 {{< /site-region >}}
 
 {{< site-region region="us,eu" >}}
-In order to search on a numerical attribute, first [add it as a facet][2]. You can then use numerical operators (`<`,`>`, `<=`, or `>=`) to perform a search on numerical facets.
+In order to search on a numerical attribute, first [add it as a facet][1]. You can then use numerical operators (`<`,`>`, `<=`, or `>=`) to perform a search on numerical facets.
 For instance, retrieve all logs that have a response time over 100ms with:
-{{< /site-region >}}
+<p> </p>
 
-`@http.response_time:>100`
+[1]: /logs/explorer/facets/
+
+{{< /site-region >}}
+<p></p>
+
+```
+@http.response_time:>100
+```
 
 You can search for numerical attribute within a specific range. For instance, retrieve all your 4xx errors with:
 
-`@http.status_code:[400 TO 499]`
+```
+@http.status_code:[400 TO 499]
+```
 
 ## Tags
 
@@ -179,6 +206,7 @@ In the below example, clicking on the `Peter` value in the facet returns all the
 
 {{< site-region region="us,eu" >}}
 **Note**: Search can also be used on non-faceted array attributes using an equivalent syntax.
+<p> </p>
 {{< /site-region >}}
 
 ## Saved searches
@@ -190,7 +218,6 @@ In the below example, clicking on the `Peter` value in the facet returns all the
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /logs/processing/parsing/?tab=matcher
-[2]: /logs/explorer/facets/
 [3]: /infrastructure/
 [4]: /integrations/#cat-log-collection
 [5]: /getting_started/tagging/#tags-best-practices

--- a/content/en/logs/explorer/search_syntax.md
+++ b/content/en/logs/explorer/search_syntax.md
@@ -6,7 +6,7 @@ aliases:
     - /logs/search
     - /logs/search-syntax
     - /logs/explorer/search/
-    - /logs/search_syntax
+    - /logs/search_syntax/
 further_reading:
 - link: "/logs/explorer/#visualize"
   tag: "Documentation"

--- a/content/en/logs/explorer/search_syntax.md
+++ b/content/en/logs/explorer/search_syntax.md
@@ -6,6 +6,7 @@ aliases:
     - /logs/search
     - /logs/search-syntax
     - /logs/explorer/search/
+    - /logs/search_syntax
 further_reading:
 - link: "/logs/explorer/#visualize"
   tag: "Documentation"

--- a/content/en/logs/explorer/search_syntax.md
+++ b/content/en/logs/explorer/search_syntax.md
@@ -75,7 +75,7 @@ For instance, if your attribute name is **url** and you want to filter on the **
 
 **Notes**:
 
-1. It is **not** required to define a facet to search on attributes and tags.
+1. Facet searches are case sensitive. Use free text search to get case insensitive results. Another option is to use the lowercase filter with your Grok parser while parsing to get case insensitive results during search.
 
 2. Searching for a facet value that contains special characters requires escaping or double quotes.
 For example, for a facet `my_facet` with the value `hello:world`, search using: `@my_facet:hello\:world` or `@my_facet:"hello:world"`.
@@ -129,7 +129,7 @@ Wildcard searches work within facets with this syntax. This query returns all th
 {{< /site-region >}}
 
 {{< site-region region="us,eu" >}}
-Wildcard searches work within attributes and tags (faceted or not) with this syntax. This query returns all the services that end with the string `mongo`:
+Wildcard searches work within tags and attributes (faceted or not) with this syntax. This query returns all the services that end with the string `mongo`:
 <p> </p>
 {{< /site-region >}}
 <p></p>
@@ -160,20 +160,9 @@ When searching for an attribute or tag value that contains special characters or
 
 ## Numerical values
 
-{{< site-region region="gov,us3" >}}
-Use `<`,`>`, `<=`, or `>=` to perform a search on numerical attributes. For instance, retrieve all logs that have a response time over 100ms with:
-<p> </p>
-{{< /site-region >}}
-
-{{< site-region region="us,eu" >}}
-In order to search on a numerical attribute, first [add it as a facet][1]. You can then use numerical operators (`<`,`>`, `<=`, or `>=`) to perform a search on numerical facets.
+In order to search on a numerical attribute, first [add it as a facet][2]. You can then use numerical operators (`<`,`>`, `<=`, or `>=`) to perform a search on numerical facets.
 For instance, retrieve all logs that have a response time over 100ms with:
 <p> </p>
-
-[1]: /logs/explorer/facets/
-
-{{< /site-region >}}
-<p></p>
 
 ```
 @http.response_time:>100
@@ -219,6 +208,7 @@ In the below example, clicking on the `Peter` value in the facet returns all the
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /logs/processing/parsing/?tab=matcher
+[2]: /logs/explorer/facets/
 [3]: /infrastructure/
 [4]: /integrations/#cat-log-collection
 [5]: /getting_started/tagging/#tags-best-practices

--- a/content/en/logs/explorer/search_syntax.md
+++ b/content/en/logs/explorer/search_syntax.md
@@ -6,7 +6,6 @@ aliases:
     - /logs/search
     - /logs/search-syntax
     - /logs/explorer/search/
-    - /logs/search_syntax/
 further_reading:
 - link: "/logs/explorer/#visualize"
   tag: "Documentation"
@@ -59,22 +58,43 @@ To search for logs that contain `user=JaneDoe` in the message attribute use the 
 
 `user\=JaneDoe`
 
-### Facets search
+### Attributes search
 
+{{< site-region region="gov,us3" >}}
 To search on a specific attribute, first [add it as a facet][2] and then add `@` to specify you are searching on a facet.
 
-For instance, if your facet name is **url** and you want to filter on the **url** value *www.datadoghq.com*, enter:
+For instance, if your attribute name is **url** and you want to filter on the **url** value *www.datadoghq.com*, enter:
 
 `@url:www.datadoghq.com`
 
 
 **Notes**:
 
-1. Facet searches are case sensitive. Use free text search to get case insensitive results. Another option is to use the `lowercase` filter with your Grok parser while parsing to get case insensitive results during search.
+1. It is **not** required to define a facet to search on attributes and tags.
 
 2. Searching for a facet value that contains special characters requires escaping or double quotes.
 For example, for a facet `my_facet` with the value `hello:world`, search using: `@my_facet:hello\:world` or `@my_facet:"hello:world"`.
 To match a single special character or space, use the `?` wildcard. For example, for a facet `my_facet` with the value `hello world`, search using: `@my_facet:hello?world`.
+{{< /site-region >}}
+
+{{< site-region region="us,eu" >}}
+To search on a specific attribute, add `@` to specify you are searching on an attribute.
+
+For instance, if your attribute name is **url** and you want to filter on the **url** value *www.datadoghq.com*, enter:
+
+`@url:www.datadoghq.com`
+
+
+**Notes**:
+
+1. It is **not** required to define a facet to search on attributes and tags.
+
+2. Attributes searches are case sensitive. Use free text search to get case insensitive results. Another option is to use the `lowercase` filter with your Grok parser while parsing to get case insensitive results during search.
+
+3. Searching for an attribute value that contains special characters requires escaping or double quotes.
+For example, for an attribute `my_attribute` with the value `hello:world`, search using: `@my_attribute:hello\:world` or `@my_attribute:"hello:world"`.
+To match a single special character or space, use the `?` wildcard. For example, for an attribute `my_attribute` with the value `hello world`, search using: `@my_attribute:hello?world`.
+{{< /site-region >}}
 
 Examples:
 
@@ -94,7 +114,13 @@ To perform a multi-character wildcard search, use the `*` symbol as follows:
 * `web*` matches all log messages starting with `web`
 * `*web` matches all log messages that end with `web`
 
+{{< site-region region="gov,us3" >}}
 Wildcard searches work within facets with this syntax. This query returns all the services that end with the string `mongo`:
+{{< /site-region >}}
+
+{{< site-region region="us,eu" >}}
+Wildcard searches work within attributes and tags (faceted or not) with this syntax. This query returns all the services that end with the string `mongo`:
+{{< /site-region >}}
 
 `service:*mongo`
 
@@ -106,11 +132,24 @@ However, this search term does not return logs that contain the string `NETWORK`
 
 ### Search wildcard
 
+{{< site-region region="gov,us3" >}}
 When searching for a facet value that contains special characters or requires escaping or double quotes, use the `?` wildcard to match a single special character or space. For example, to search for a facet `my_facet` with the value `hello world`: `@my_facet:hello?world`.
+{{< /site-region >}}
+
+{{< site-region region="us,eu" >}}
+When searching for an attribute or tag value that contains special characters or requires escaping or double quotes, use the `?` wildcard to match a single special character or space. For example, to search for an attribute `my_attribute` with the value `hello world`: `@my_attribute:hello?world`.
+{{< /site-region >}}
 
 ## Numerical values
 
+{{< site-region region="gov,us3" >}}
 Use `<`,`>`, `<=`, or `>=` to perform a search on numerical attributes. For instance, retrieve all logs that have a response time over 100ms with:
+{{< /site-region >}}
+
+{{< site-region region="us,eu" >}}
+In order to search on a numerical attribute, first [add it as a facet][2]. You can then use numerical operators (`<`,`>`, `<=`, or `>=`) to perform a search on numerical facets.
+For instance, retrieve all logs that have a response time over 100ms with:
+{{< /site-region >}}
 
 `@http.response_time:>100`
 
@@ -137,6 +176,10 @@ You can add facets on arrays of strings or numbers. All values included in the a
 In the below example, clicking on the `Peter` value in the facet returns all the logs that contains a `users.names` attribute, whose value is either `Peter` or an array that contains `Peter`:
 
 {{< img src="logs/explorer/search/array_search.png" alt="Array and Facets"  style="width:80%;">}}
+
+{{< site-region region="us,eu" >}}
+**Note**: Search can also be used on non-faceted array attributes using an equivalent syntax.
+{{< /site-region >}}
 
 ## Saved searches
 


### PR DESCRIPTION
What does this PR do?
Update Logs documentation for the upcoming general availability of Free form queries.

Motivation
The new feature will enable filtering on non-faceted attributes in logs, removing for some cases the need to define a facet before hand.


### Preview

https://docs-staging.datadoghq.com/kari/ffq_update2/logs/explorer/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
