### PR TITLE
[WEB-1519] - testing collision fallback to integration id instead

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -671,9 +671,10 @@ class Integrations:
             if manifest_json.get("is_public", False):
                 out_name = self.content_integrations_dir + new_file_name
 
-                # if the same integration exists in multiple locations try name md after manifest name entry
+                # if the same integration exists in multiple locations try name md file differently
+                # integration_id.md -> name.md -> original_collision_name.md
                 if exist_collision:
-                    f_name = manifest_json.get("name", new_file_name)
+                    f_name = integration_id or manifest_json.get("name", "") or new_file_name
                     f_name = f_name if f_name.endswith('.md') else f_name + ".md"
                     out_name = self.content_integrations_dir + f_name
                     print("\x1b[33mWARNING\x1b[0m: Collision, duplicate integration {} trying as {}".format(
@@ -735,7 +736,8 @@ class Integrations:
                 fm = fm.replace('!!bool "false"', 'false')
                 fm = fm.replace('!!bool "true"', 'true')
             else:
-                fm = {"kind": "integration"}
+                fm = yaml.safe_dump({"kind": "integration"}, width=150, default_style='"', default_flow_style=False,
+                                    allow_unicode=True).rstrip()
         return template.format(
             front_matter=fm, content=content
         )


### PR DESCRIPTION
### What does this PR do?

Testing out integration collisions falling back to id

### Motivation

https://datadoghq.atlassian.net/browse/WEB-1519

### Preview

https://docs-staging.datadoghq.com/david.jones/test-fallback/integrations/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
