### PR TITLE
Added supported Pytest versions in CIApp description

### DIFF
--- a/content/en/continuous_integration/setup_tests/python.md
+++ b/content/en/continuous_integration/setup_tests/python.md
@@ -11,6 +11,9 @@ further_reading:
 ---
 ## Compatibility
 
+Supported Test Frameworks:
+* Pytest 3.0+
+
 Supported CI providers:
 * Appveyor
 * Azure Pipelines


### PR DESCRIPTION
### What does this PR do?
This PR adds a short description about supported pytest versions in the python continuous integration docs.

### Motivation
This is to ensure the CIApp documentation page is up to date.

### Preview
https://docs-staging.datadoghq.com/yunkim/ci_python/continuous_integration/setup_tests/python/


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
