### PR TITLE
Update for tag variables on single alert monitors

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -171,7 +171,7 @@ Refer to the [list of tz database time zones][14], particularly the TZ database 
 Tag variables can be used in multi-alert monitors based on the tags selected in the multi-alert group box. This works for any tag following the `key:value` syntax.
 For example, if your monitor triggers for each `env`, then the variable `{{env.name}}` is available in your notification message. 
 
-<div class="alert alert-info"><strong>Note</strong>: Tag variables on single alert monitors are not supported. If you want to know the specific tag of the alerted monitor, use a multi-alert monitor instead.</div>
+<div class="alert alert-info"><strong>Note</strong>: Tag variables on single alert monitors are not supported. If you want to know the specific tag value that caused the alert, use a multi-alert monitor instead.</div>
 
 **Notes**: Variable content is escaped by default. To prevent content such as JSON or code from being escaped, use triple braces instead of double braces, for example: `{{{event.text}}}`.
 

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -173,7 +173,7 @@ For example, if your monitor triggers for each `env`, then the variable `{{env.n
 
 <div class="alert alert-info"><strong>Note</strong>: Tag variables on single alert monitors are not supported. If you want to know the specific tag value that caused the alert, use a multi-alert monitor instead.</div>
 
-**Notes**: Variable content is escaped by default. To prevent content such as JSON or code from being escaped, use triple braces instead of double braces, for example: `{{{event.text}}}`.
+Variable content is escaped by default. To prevent content such as JSON or code from being escaped, use triple braces instead of double braces, for example: `{{{event.text}}}`.
 
 #### Multi-alert group by host
 

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -169,7 +169,9 @@ Refer to the [list of tz database time zones][14], particularly the TZ database 
 ### Tag variables
 
 Tag variables can be used in multi-alert monitors based on the tags selected in the multi-alert group box. This works for any tag following the `key:value` syntax.
-For example, if your monitor triggers for each `env`, then the variable `{{env.name}}` is available in your notification message. **Note**: Tag variables on single alert monitors are not supported. If you want to know the specific tag of the alerted monitor, you should use a multi-alert monitor instead. 
+For example, if your monitor triggers for each `env`, then the variable `{{env.name}}` is available in your notification message. 
+
+<div class="alert alert-info"><strong>Note</strong>: Tag variables on single alert monitors are not supported. If you want to know the specific tag of the alerted monitor, use a multi-alert monitor instead.</div>
 
 **Notes**: Variable content is escaped by default. To prevent content such as JSON or code from being escaped, use triple braces instead of double braces, for example: `{{{event.text}}}`.
 

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -169,7 +169,7 @@ Refer to the [list of tz database time zones][14], particularly the TZ database 
 ### Tag variables
 
 Tag variables can be used in multi-alert monitors based on the tags selected in the multi-alert group box. This works for any tag following the `key:value` syntax.
-For example, if your monitor triggers for each `env`, then the variable `{{env.name}}` is available in your notification message.
+For example, if your monitor triggers for each `env`, then the variable `{{env.name}}` is available in your notification message. **Note**: Tag variables on single alert monitors may be blank, especially if the monitor is grouped by the tag in question. If you want to know the specific tag of the alerted monitor, you should use a multi-alert monitor instead. 
 
 **Notes**: Variable content is escaped by default. To prevent content such as JSON or code from being escaped, use triple braces instead of double braces, for example: `{{{event.text}}}`.
 

--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -169,7 +169,7 @@ Refer to the [list of tz database time zones][14], particularly the TZ database 
 ### Tag variables
 
 Tag variables can be used in multi-alert monitors based on the tags selected in the multi-alert group box. This works for any tag following the `key:value` syntax.
-For example, if your monitor triggers for each `env`, then the variable `{{env.name}}` is available in your notification message. **Note**: Tag variables on single alert monitors may be blank, especially if the monitor is grouped by the tag in question. If you want to know the specific tag of the alerted monitor, you should use a multi-alert monitor instead. 
+For example, if your monitor triggers for each `env`, then the variable `{{env.name}}` is available in your notification message. **Note**: Tag variables on single alert monitors are not supported. If you want to know the specific tag of the alerted monitor, you should use a multi-alert monitor instead. 
 
 **Notes**: Variable content is escaped by default. To prevent content such as JSON or code from being escaped, use triple braces instead of double braces, for example: `{{{event.text}}}`.
 


### PR DESCRIPTION
Added a note to clarify that single alert monitors cannot use multi-alert tags. This is because the client in this ticket (https://datadog.zendesk.com/agent/tickets/517170) did not understand why his single-alert monitor had blank tags, and became upset at what he felt were unclear instructions.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
See description above

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadog.zendesk.com/agent/tickets/517170

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wenzstev/added-note-for-single-alert-monitors/monitors/notifications/?tab=is_alert#tag-variables

### Additional Notes
<!-- Anything else we should know when reviewing?-->
This is my first time doing this so please let me know if anything should be done differently!

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
