### PR TITLE
[ci-app] Bump version of Python tracer to 0.50.0rc4

### DIFF
--- a/content/en/continuous_integration/setup_tests/python.md
+++ b/content/en/continuous_integration/setup_tests/python.md
@@ -34,7 +34,7 @@ Supported CI providers:
 Install the Python tracer by running:
 
 {{< code-block lang="bash" >}}
-pip install "ddtrace>=0.50.0rc2"
+pip install "ddtrace>=0.50.0rc4"
 {{< /code-block >}}
 
 For more information, see the [Python tracer installation documentation][2].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Bumps the version of the Python tracer in the CI Visibility docs

### Motivation
<!-- What inspired you to submit this pull request?-->

This new version comes with new features that we want users to try out as part of the ongoing private beta.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fermayo/ciapp-bump-python-version/continuous_integration/setup_tests/python/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
