### PR TITLE
Improve serverless custom installation doc

### DIFF
--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -166,9 +166,7 @@ More information and additional parameters can be found in the [Datadog CDK NPM 
 {{% /tab %}}
 {{% tab "Datadog CLI" %}}
 
-<div class="alert alert-warning">This service is in public beta. If you have any feedback, contact <a href="/help">Datadog support</a>.</div>
-
-Use the Datadog CLI to set up instrumentation on your Lambda functions in your CI/CD pipelines. The CLI command automatically adds the Datadog Lambda Library to your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog.
+Use the Datadog CLI to set up instrumentation on your Lambda functions in your CI/CD pipelines or from your local command-line interface. The CLI command automatically adds the Datadog Lambda library and extension to your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog.
 
 ### Install
 
@@ -261,9 +259,11 @@ Replace `<TAG>` with either a specific version number (for example, `7`) or with
 {{% /tab %}}
 {{% tab "Custom" %}}
 
-### Install
+<div class="alert alert-warning">If you are not using any of the supported serverless application development tool, such as the serverless framework, we strongly recommend that you set up the Datadog instrumentation using the <a href="/?tab=datadogcli">Datadog CLI</a> instead.</div>
 
-The Datadog Lambda Library can be imported as a layer or JavaScript package.
+### Install the Datadog Lambda library
+
+The Datadog Lambda Library can be either imported as a layer **OR** JavaScript package.
 
 The minor version of the `datadog-lambda-js` package always matches the layer version. E.g., datadog-lambda-js v0.5.0 matches the content of layer version 5.
 

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -259,11 +259,11 @@ Replace `<TAG>` with either a specific version number (for example, `7`) or with
 {{% /tab %}}
 {{% tab "Custom" %}}
 
-<div class="alert alert-warning">If you are not using any of the supported serverless application development tool, such as the serverless framework, we strongly recommend that you set up the Datadog instrumentation using the <a href="/?tab=datadogcli">Datadog CLI</a> instead.</div>
+<div class="alert alert-warning">If you are not using any of the recommended serverless development tools, such as the Serverless Framework, we strongly encourage you instrument your serverless applications with the <a href="/?tab=datadogcli">Datadog CLI</a>.</div>
 
 ### Install the Datadog Lambda library
 
-The Datadog Lambda Library can be either imported as a layer **OR** JavaScript package.
+The Datadog Lambda Library can be imported either as a layer **OR** as a JavaScript package.
 
 The minor version of the `datadog-lambda-js` package always matches the layer version. E.g., datadog-lambda-js v0.5.0 matches the content of layer version 5.
 

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -259,11 +259,11 @@ Replace `<TAG>` with either a specific version number (for example, `7`) or with
 {{% /tab %}}
 {{% tab "Custom" %}}
 
-<div class="alert alert-warning">If you are not using any of the recommended serverless development tools, such as the Serverless Framework, we strongly encourage you instrument your serverless applications with the <a href="/?tab=datadogcli">Datadog CLI</a>.</div>
+<div class="alert alert-info">If you are not using a serverless development tool that we support, such as the Serverless Framework or AWS CDK, we strongly encourage you instrument your serverless applications with the <a href="/?tab=datadogcli">Datadog CLI</a>.</div>
 
 ### Install the Datadog Lambda library
 
-The Datadog Lambda Library can be imported either as a layer **OR** as a JavaScript package.
+The Datadog Lambda Library can be imported either as a layer _OR_ as a JavaScript package.
 
 The minor version of the `datadog-lambda-js` package always matches the layer version. E.g., datadog-lambda-js v0.5.0 matches the content of layer version 5.
 

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -259,7 +259,7 @@ Replace `<TAG>` with either a specific version number (for example, `7`) or with
 {{% /tab %}}
 {{% tab "Custom" %}}
 
-<div class="alert alert-info">If you are not using a serverless development tool that we support, such as the Serverless Framework or AWS CDK, we strongly encourage you instrument your serverless applications with the <a href="/?tab=datadogcli">Datadog CLI</a>.</div>
+<div class="alert alert-info">If you are not using a serverless development tool that Datadog supports, such as the Serverless Framework or AWS CDK, we strongly encourage you instrument your serverless applications with the <a href="./?tab=datadogcli#configuration">Datadog CLI</a>.</div>
 
 ### Install the Datadog Lambda library
 

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -369,11 +369,11 @@ Replace `<TAG>` with either a specific version number (for example, `7`) or with
 {{% /tab %}}
 {{% tab "Custom" %}}
 
-<div class="alert alert-warning">If you are not using any of the supported serverless application development tool, such as the serverless framework, we strongly recommend that you set up the Datadog instrumentation using the <a href="/?tab=datadogcli">Datadog CLI</a> instead.</div>
+<div class="alert alert-warning">If you are not using any of the recommended serverless development tools, such as the Serverless Framework, we strongly encourage you instrument your serverless applications with the <a href="/?tab=datadogcli">Datadog CLI</a>.</div>
 
 ### Install the Datadog Lambda library
 
-You can either install the Datadog Lambda library as a layer (recommended) **OR** Python package.
+The Datadog Lambda Library can be imported either as a layer (recommended) **OR** as a Python package.
 
 The minor version of the `datadog-lambda` package always matches the layer version. E.g., datadog-lambda v0.5.0 matches the content of layer version 5.
 

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -369,7 +369,7 @@ Replace `<TAG>` with either a specific version number (for example, `7`) or with
 {{% /tab %}}
 {{% tab "Custom" %}}
 
-<div class="alert alert-info">If you are not using a serverless development tool that we support, such as the Serverless Framework or AWS CDK, we strongly encourage you instrument your serverless applications with the <a href="/?tab=datadogcli">Datadog CLI</a>.</div>
+<div class="alert alert-info">If you are not using a serverless development tool that Datadog supports, such as the Serverless Framework or AWS CDK, we strongly encourage you instrument your serverless applications with the <a href="./?tab=datadogcli#configuration">Datadog CLI</a>.</div>
 
 ### Install the Datadog Lambda library
 

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -369,11 +369,11 @@ Replace `<TAG>` with either a specific version number (for example, `7`) or with
 {{% /tab %}}
 {{% tab "Custom" %}}
 
-<div class="alert alert-warning">If you are not using any of the recommended serverless development tools, such as the Serverless Framework, we strongly encourage you instrument your serverless applications with the <a href="/?tab=datadogcli">Datadog CLI</a>.</div>
+<div class="alert alert-info">If you are not using a serverless development tool that we support, such as the Serverless Framework or AWS CDK, we strongly encourage you instrument your serverless applications with the <a href="/?tab=datadogcli">Datadog CLI</a>.</div>
 
 ### Install the Datadog Lambda library
 
-The Datadog Lambda Library can be imported either as a layer (recommended) **OR** as a Python package.
+The Datadog Lambda Library can be imported either as a layer (recommended) _OR_ as a Python package.
 
 The minor version of the `datadog-lambda` package always matches the layer version. E.g., datadog-lambda v0.5.0 matches the content of layer version 5.
 

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -291,9 +291,7 @@ For example:
 {{% /tab %}}
 {{% tab "Datadog CLI" %}}
 
-<div class="alert alert-warning">This service is in public beta. If you have any feedback, contact <a href="/help">Datadog support</a>.</div>
-
-Use the Datadog CLI to set up instrumentation on your Lambda functions in your CI/CD pipelines. The CLI command automatically adds the Datadog Lambda Library to your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog.
+Use the Datadog CLI to set up instrumentation on your Lambda functions in your CI/CD pipelines or from your local command-line interface. The CLI command automatically adds the Datadog Lambda library and extension to your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog.
 
 ### Install
 
@@ -371,9 +369,11 @@ Replace `<TAG>` with either a specific version number (for example, `7`) or with
 {{% /tab %}}
 {{% tab "Custom" %}}
 
-### Install
+<div class="alert alert-warning">If you are not using any of the supported serverless application development tool, such as the serverless framework, we strongly recommend that you set up the Datadog instrumentation using the <a href="/?tab=datadogcli">Datadog CLI</a> instead.</div>
 
-You can either install the Datadog Lambda library as a layer (recommended) or Python package.
+### Install the Datadog Lambda library
+
+You can either install the Datadog Lambda library as a layer (recommended) **OR** Python package.
 
 The minor version of the `datadog-lambda` package always matches the layer version. E.g., datadog-lambda v0.5.0 matches the content of layer version 5.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

- Take Datadog CLI installation method out of beta (and a minor update to the description)
- Recommend users to use the Datadog CLI instead of following the custom installation steps

### Motivation

Most of customers following the custom installation steps did not realize that they could have used the Datadog CLI to automate the required configuration changes. Like custom installation, the Datadog CLI should be able to set up instrumentation for any Python or Node.js Lambda function as long as they are deployed from an environment where a command-line interface exists.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->

- https://docs-staging.datadoghq.com/tian.chu/improve-serverless-custom-installation/serverless/installation/python/?tab=custom
- https://docs-staging.datadoghq.com/tian.chu/improve-serverless-custom-installation/serverless/installation/nodejs/?tab=custom

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
