### PR TITLE
(DOCS-2183) Remove link from faq index

### DIFF
--- a/content/en/dashboards/faq/_index.md
+++ b/content/en/dashboards/faq/_index.md
@@ -27,7 +27,6 @@ aliases:
     {{< nextlink href="dashboards/faq/how-does-datadog-render-graphs-my-graph-doesn-t-show-the-values-i-m-expecting" >}}How does Datadog render graphs? My graph doesn't show the values I'm expecting.{{< /nextlink >}}
     {{< nextlink href="dashboards/faq/what-is-the-granularity-of-my-graphs-am-i-seeing-raw-data-or-aggregates-on-my-graph" >}}What is the granularity of my graphs? Am I seeing raw data or aggregates on my graph?{{< /nextlink >}}
     {{< nextlink href="dashboards/faq/how-can-i-graph-host-uptime-percentage" >}}How can I graph host uptime percentage?{{< /nextlink >}}
-    {{< nextlink href="dashboards/faq/inconsistent-sum-aggregation-between-different-time-windows-on-graph" >}}Inconsistent sum aggregation between different time windows on graph{{< /nextlink >}}
     {{< nextlink href="dashboards/faq/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs" >}}Why does zooming out a timeframe also smooth out my graphs?{{< /nextlink >}}
     {{< nextlink href="dashboards/faq/why-is-a-counter-metric-being-displayed-as-a-decimal-value" >}}Why is a counter metric being displayed as a decimal value?{{< /nextlink >}}
     {{< nextlink href="dashboards/faq/the-same-color-is-used-twice-in-my-graph" >}}The same color is used twice in my graph!{{< /nextlink >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes a link to a removed FAQ page

### Motivation
Customer trying to click link gets the redirect, we should've removed this link when the FAQ was removed.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
