### PR TITLE
Fixes for Serverless Docs

### DIFF
--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -31,7 +31,7 @@ If not already configured, install the [AWS integration][1]. This allows Datadog
 
 {{< img src="serverless/serverless_monitoring_installation_instructions.png" alt="Instrument AWS Serverless Applications"  style="width:100%;">}}
 
-If you previously set up Datadog Serverless using the Datadog Forwarder or your Lambda functions are deployed to AWS GovCloud, see the [installation instructions here][2].
+If you previously set up Datadog Serverless using the Datadog Forwarder, see the [installation instructions here][2].
 
 ## Configuration
 
@@ -58,7 +58,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
         addExtension: true
         apiKey: # Your Datadog API Key goes here.
     ```
-    Find your Datadog API key on the [API Management page][3]. For additional settings, see the [plugin documentation][1].
+    Find your Datadog API key from the [API Management page][3]. For additional settings, see the [plugin documentation][1].
 
 
 [1]: https://docs.datadoghq.com/serverless/serverless_integrations/plugin
@@ -92,13 +92,18 @@ Transform:
   - Name: DatadogServerless
     Parameters:
       stackName: !Ref "AWS::StackName"
+      apiKey: <DATADOG_API_KEY>
       nodeLayerVersion: "<LAYER_VERSION>"
       extensionLayerVersion: "<EXTENSION_VERSION>"
       service: "<SERVICE>" # Optional
       env: "<ENV>" # Optional
 ```
 
-Replace `<SERVICE>` and `<ENV>` with appropriate values, `<LAYER_VERSION>` with the [desired version][4] of Datadog Lambda Library, and `<EXTENSION_VERSION>` with the [desired version][5] of the Datadog Lambda Extension.
+To fill in the placeholders:
+- Replace `<DATADOG_API_KEY>` with your Datadog API key from the [API Management page][6]. 
+- Replace `<LAYER_VERSION>` with the desired version of the Datadog Lambda layer (see the [latest releases][4]).
+- Replace `<EXTENSION_VERSION>` with the desired version of the Datadog Lambda Extension (see the [latest releases][5]).
+- Replace `<SERVICE>` and `<ENV>` with appropriate values.
 
 More information and additional parameters can be found in the [macro documentation][1].
 
@@ -108,6 +113,7 @@ More information and additional parameters can be found in the [macro documentat
 [3]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
 [4]: https://github.com/DataDog/datadog-lambda-js/releases
 [5]: https://gallery.ecr.aws/datadog/lambda-extension
+[6]: https://app.datadoghq.com/account/settings#api
 {{% /tab %}}
 {{% tab "AWS CDK" %}}
 
@@ -151,7 +157,7 @@ class CdkStack extends cdk.Stack {
 
 To fill in the placeholders:
 
-- Replace `<DATADOG_API_KEY>` with your Datadog API key on the [API Management page][3]. 
+- Replace `<DATADOG_API_KEY>` with your Datadog API key from the [API Management page][3]. 
 - Replace `<SERVICE>` and `<ENV>` with appropriate values.
 - Replace `<LAYER_VERSION>` with the desired version of the Datadog Lambda layer (see the [latest releases][2]).
 - Replace `<EXTENSION_VERSION>` with the desired version of the Datadog Lambda Extension (see the [latest releases][4]).
@@ -251,7 +257,7 @@ Replace `<TAG>` with either a specific version number (for example, `7`) or with
   - Set `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
   - Set `DD_TRACE_ENABLED` to `true`.
   - Set `DD_FLUSH_TO_LOG` to `true`.
-  - Set `DD_API_KEY` with your Datadog API key on the [API Management page][2]. 
+  - Set `DD_API_KEY` with your Datadog API key from the [API Management page][2]. 
 3. Optionally add `service` and `env` tags with appropriate values to your function.
 
 [1]: https://gallery.ecr.aws/datadog/lambda-extension
@@ -347,7 +353,7 @@ Follow these steps to configure the function:
 1. Set your function's handler to `/opt/nodejs/node_modules/datadog-lambda-js/handler.handler` if using the layer, or `node_modules/datadog-lambda-js/dist/handler.handler` if using the package.
 2. Set the environment variable `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
 3. Set the environment variable `DD_TRACE_ENABLED` to `true`.
-4. Set the environment variable `DD_API_KEY` to your Datadog API key on the [API Management page][5]. 
+4. Set the environment variable `DD_API_KEY` to your Datadog API key from the [API Management page][5]. 
 5. Optionally add a `service` and `env` tag with appropriate values to your function.
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -58,7 +58,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
         addExtension: true
         apiKey: # Your Datadog API Key goes here.
     ```
-    Find your Datadog API key from the [API Management page][3]. For additional settings, see the [plugin documentation][1].
+    Find your Datadog API key on the [API Management page][3]. For additional settings, see the [plugin documentation][1].
 
 
 [1]: https://docs.datadoghq.com/serverless/serverless_integrations/plugin

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -297,6 +297,8 @@ For example:
 {{% /tab %}}
 {{% tab "Datadog CLI" %}}
 
+Use the Datadog CLI to set up instrumentation on your Lambda functions in your CI/CD pipelines or from your local command-line interface. The CLI command automatically adds the Datadog Lambda library and extension to your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog.
+
 ### Install
 
 Install the Datadog CLI with NPM or Yarn:

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -31,7 +31,7 @@ If not already configured, install the [AWS integration][1]. This allows Datadog
 
 {{< img src="serverless/serverless_monitoring_installation_instructions.png" alt="Instrument AWS Serverless Applications"  style="width:100%;">}}
 
-If your Python Lambda functions are written in [Python 3.6 or less][2], you previously set up Datadog Serverless using the Datadog Forwarder or your Lambda functions are not deployed to the `us-east-1`, `eu-west-1` or `eu-south-1` regions, see the [installation instructions here][3].
+If your Python Lambda functions are written in [Python 3.6 or less][2] or you previously set up Datadog Serverless using the Datadog Forwarder, see the [installation instructions here][3].
 
 ## Configuration
 

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -31,7 +31,7 @@ If not already configured, install the [AWS integration][1]. This allows Datadog
 
 {{< img src="serverless/serverless_monitoring_installation_instructions.png" alt="Instrument AWS Serverless Applications"  style="width:100%;">}}
 
-If your Python Lambda functions are written in [Python 3.6 or less][2], you previously set up Datadog Serverless using the Datadog Forwarder or your Lambda functions are deployed to AWS GovCloud, see the [installation instructions here][3].
+If your Python Lambda functions are written in [Python 3.6 or less][2], you previously set up Datadog Serverless using the Datadog Forwarder or your Lambda functions are not deployed to the `us-east-1`, `eu-west-1` or `eu-south-1` regions, see the [installation instructions here][3].
 
 ## Configuration
 
@@ -92,13 +92,18 @@ Transform:
   - Name: DatadogServerless
     Parameters:
       stackName: !Ref "AWS::StackName"
+      apiKey: <DATADOG_API_KEY>
       nodeLayerVersion: "<LAYER_VERSION>"
       extensionLayerVersion: "<EXTENSION_VERSION>"
       service: "<SERVICE>" # Optional
       env: "<ENV>" # Optional
 ```
 
-Replace `<SERVICE>` and `<ENV>` with appropriate values, `<LAYER_VERSION>` with the [desired version][4] of Datadog Lambda Library, and `<EXTENSION_VERSION>` with the [desired version][5] of the Datadog Lambda Extension.
+To fill in the placeholders:
+- Replace `<DATADOG_API_KEY>` with your Datadog API key from the [API Management page][6]. 
+- Replace `<LAYER_VERSION>` with the desired version of the Datadog Lambda layer (see the [latest releases][4]).
+- Replace `<EXTENSION_VERSION>` with the desired version of the Datadog Lambda Extension (see the [latest releases][5]).
+- Replace `<SERVICE>` and `<ENV>` with appropriate values.
 
 More information and additional parameters can be found in the [macro documentation][1].
 
@@ -108,6 +113,7 @@ More information and additional parameters can be found in the [macro documentat
 [3]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
 [4]: https://github.com/DataDog/datadog-lambda-python/releases
 [5]: https://gallery.ecr.aws/datadog/lambda-extension
+[6]: https://app.datadoghq.com/account/settings#api
 {{% /tab %}}
 {{% tab "AWS CDK" %}}
 
@@ -125,7 +131,7 @@ pip install datadog-cdk-constructs
 
 ### Instrument the function
 
-Import the `datadog-cdk-construct` module in your AWS CDK app and add the following configurations:
+Import the `datadog-cdk-construct` module in your AWS CDK app and add the following configuration:
 
 ```python
 from datadog_cdk_constructs import Datadog
@@ -133,7 +139,7 @@ from datadog_cdk_constructs import Datadog
 datadog = Datadog(self, "Datadog",
     python_layer_version=<LAYER_VERSION>,
     extension_layer_version=<EXTENSION_LAYER_VERSION>,
-    dd_api_key=<DATADOG_API_KEY>,
+    api_key=<DATADOG_API_KEY>,
     service=<SERVICE>, # Optional
     env=<ENV>, # Optional
 )
@@ -290,8 +296,6 @@ For example:
 [4]: https://aws.github.io/chalice/topics/middleware.html?highlight=handler#registering-middleware
 {{% /tab %}}
 {{% tab "Datadog CLI" %}}
-
-Use the Datadog CLI to set up instrumentation on your Lambda functions in your CI/CD pipelines or from your local command-line interface. The CLI command automatically adds the Datadog Lambda library and extension to your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog.
 
 ### Install
 


### PR DESCRIPTION
### What does this PR do?
Update docs to fix a few issues related to Serverless installation:
- The Datadog Lambda Extension can now be used in all AWS regions, including GovCloud. (The exceptions are the mainland China regions, but I don't think our docs really apply there at all).
- Include an API key when setting up the CloudFormation Macro. This is required when adding the Lambda Extension.
- Correct the parameter that sets the API key when using the CDK Construct Library in Python from `dd_api_key` to `api_key`.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
