### PR TITLE
Fixing the accidental revert of #10923

### DIFF
--- a/content/en/agent/docker/tag.md
+++ b/content/en/agent/docker/tag.md
@@ -19,9 +19,38 @@ The Datadog Agent can create and assign tags to all metrics, traces, and logs em
 
 If you are running the Agent as a binary on a host, configure your tag extractions with the [Agent](?tab=agent) tab instructions. If you are running the Agent as a container, configure your tag extraction with the [Containerized Agent](?tab=containerizedagent) tab instructions.
 
+### Out of the box tagging
+
+The Agent can autodiscover and attach tags to all data emitted by containers. The list of tags attached depends on the Agent [cardinality configuration][1].
+
+| Tag                 | Cardinality  | Requirement                          |
+|---------------------|--------------|--------------------------------------|
+| `container_name`    | High         | N/A                                  |
+| `container_id`      | High         | N/A                                  |
+| `rancher_container` | High         | Rancher environment                  |
+| `mesos_task`        | Orchestrator | Mesos environment                    |
+| `docker_image`      | Low          | N/A                                  |
+| `image_name`        | Low          | N/A                                  |
+| `short_image`       | Low          | N/A                                  |
+| `image_tag`         | Low          | N/A                                  |
+| `swarm_service`     | Low          | Swarm environment                    |
+| `swarm_namespace`   | Low          | Swarm environment                    |
+| `rancher_stack`     | Low          | Rancher environment                  |
+| `rancher_service`   | Low          | Rancher environment                  |
+| `env`               | Low          | [Unified service tagging][2] enabled |
+| `version`           | Low          | [Unified service tagging][2] enabled |
+| `service`           | Low          | [Unified service tagging][2] enabled |
+| `marathon_app`      | Low          | Marathon environment                 |
+| `chronos_job`       | Low          | Mesos environment                    |
+| `chronos_job_owner` | Low          | Mesos environment                    |
+| `nomad_task`        | Low          | Nomad environment                    |
+| `nomad_job`         | Low          | Nomad environment                    |
+| `nomad_group`       | Low          | Nomad environment                    |
+
+
 ### Unified service tagging
 
-As a best practice in containerized environments, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][1] documentation.
+As a best practice in containerized environments, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][2] documentation.
 
 ## Extract labels as tags
 
@@ -68,7 +97,7 @@ docker_labels_as_tags:
 
 ## Extract environment variables as tags
 
-Datadog automatically collects common tags from [Docker, Kubernetes, ECS, Swarm, Mesos, Nomad, and Rancher][2]. To extract even more tags, use the following options:
+Datadog automatically collects common tags from [Docker, Kubernetes, ECS, Swarm, Mesos, Nomad, and Rancher][3]. To extract even more tags, use the following options:
 
 | Environment Variable               | Description                                    |
 |------------------------------------|------------------------------------------------|
@@ -120,6 +149,7 @@ docker_env_as_tags:
   ENVIRONMENT: env
 ```
 
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -127,5 +157,6 @@ docker_env_as_tags:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /getting_started/tagging/unified_service_tagging
-[2]: /agent/docker/?tab=standard#tagging
+[1]: /agent/docker/tag/#extract-environment-variables-as-tags
+[2]: /getting_started/tagging/unified_service_tagging
+[3]: /agent/docker/?tab=standard#tagging

--- a/content/en/agent/kubernetes/tag.md
+++ b/content/en/agent/kubernetes/tag.md
@@ -19,11 +19,59 @@ The Agent can create and assign tags to all metrics, traces, and logs emitted by
 
 If you are running the Agent as a binary on a host, configure your tag extractions with the [Agent](?tab=agent) tab instructions. If you are running the Agent as a container in your Kubernetes cluster, configure your tag extraction with the [Containerized Agent](?tab=containerizedagent) tab instructions.
 
+## Out of the box tags
+
+The Agent can autodiscover and attach tags to all data emitted by the entire pods or an individual container within this pod. The list of tags attached automatically depends on the agent [cardinality configuration][1].
+
+| Tag                           | Cardinality  | Source                                                                  | Requirement                                         |
+|-------------------------------|--------------|-------------------------------------------------------------------------|-----------------------------------------------------|
+| `container_id`                | High         | Pod status                                                              | N/A                                                 |
+| `display_container_name`      | High         | Pod status                                                              | N/A                                                 |
+| `pod_name`                    | Orchestrator | Pod metadata                                                            | N/A                                                 |
+| `oshift_deployment`           | Orchestrator | Pod annotation `openshift.io/deployment.name`                           | OpenShift environment and pod annotation must exist |
+| `kube_ownerref_name`          | Orchestrator | Pod ownerref                                                            | Pod must have an owner                              |
+| `kube_job`                    | Orchestrator | Pod ownerref                                                            | Pod must be attached to a job                       |
+| `kube_replica_set`            | Orchestrator | Pod ownerref                                                            | Pod must be attached to a replica set               |
+| `kube_service`                | Orchestrator | Kubernetes service discovery                                            | Pod is behind a Kubernetes service                  |
+| `kube_daemon_set`             | Low          | Pod ownerref                                                            | Pod must be attached to a DaemonSet                 |
+| `kube_container_name`         | Low          | Pod status                                                              | N/A                                                 |
+| `kube_namespace`              | Low          | Pod metadata                                                            | N/A                                                 |
+| `kube_app_name`               | Low          | Pod label `app.kubernetes.io/name`                                      | Pod label must exist                                |
+| `kube_app_instance`           | Low          | Pod label `app.kubernetes.io/instance`                                  | Pod label must exist                                |
+| `kube_app_version`            | Low          | Pod label `app.kubernetes.io/version`                                   | Pod label must exist                                |
+| `kube_app_component`          | Low          | Pod label `app.kubernetes.io/component`                                 | Pod label must exist                                |
+| `kube_app_part_of`            | Low          | Pod label `app.kubernetes.io/part-of`                                   | Pod label must exist                                |
+| `kube_app_managed_by`         | Low          | Pod label `app.kubernetes.io/managed-by`                                | Pod label must exist                                |
+| `env`                         | Low          | Pod label `tags.datadoghq.com/env` or container envvar `DD_ENV`         | [Unified service tagging][2] enabled                |
+| `version`                     | Low          | Pod label `tags.datadoghq.com/version` or container envvar `DD_VERSION` | [Unified service tagging][2] enabled                |
+| `service`                     | Low          | Pod label `tags.datadoghq.com/service` or container envvar `DD_SERVICE` | [Unified service tagging][2] enabled                |
+| `pod_phase`                   | Low          | Pod status                                                              | N/A                                                 |
+| `oshift_deployment_config`    | Low          | Pod annotation `openshift.io/deployment-config.name`                    | OpenShift environment and pod annotation must exist |
+| `kube_ownerref_kind`          | Low          | Pod ownerref                                                            | Pod must have an owner                              |
+| `kube_deployment`             | Low          | Pod ownerref                                                            | Pod must be attached to a deployment                |
+| `kube_replication_controller` | Low          | Pod ownerref                                                            | Pod must be attached to a replication controller    |
+| `kube_stateful_set`           | Low          | Pod ownerref                                                            | Pod must be attached to a statefulset               |
+| `persistentvolumeclaim`       | Low          | Pod spec                                                                | A PVC must be attached to the pod                   |
+| `kube_cronjob`                | Low          | Pod ownerref                                                            | Pod must be attached to a cronjob                   |
+| `image_name`                  | Low          | Pod spec                                                                | N/A                                                 |
+| `short_image`                 | Low          | Pod spec                                                                | N/A                                                 |
+| `image_tag`                   | Low          | Pod spec                                                                | N/A                                                 |
+
+### Host tag
+
+The Agent can attach Kubernetes environment information as "host tags".
+
+| Tag                 | Cardinality | Source                                                 | Requirement                                                    |
+|---------------------|-------------|--------------------------------------------------------|----------------------------------------------------------------|
+| `kube_cluster_name` | Low         | `DD_CLUSTER_NAME` envvar or cloud provider integration | `DD_CLUSTER_NAME` envvar or cloud provider integration enabled |
+| `kube_node_role`    | Low         | Node label `node-role.kubernetes.io/<role>`            | Node label must exist                                          |
+
+
 ## Tag Autodiscovery
 
 Starting with Agent v6.10+, the Agent can autodiscover tags from Pod annotations. It allows the Agent to associate tags to all data emitted by the entire pods or an individual container within this pod.
 
-As a best practice in containerized environments, Datadog recommends using unified service tagging to help unify tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][1] documentation.
+As a best practice in containerized environments, Datadog recommends using unified service tagging to help unify tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][2] documentation.
 
 To apply a `<TAG_KEY>:<TAG_VALUE>` tag to all data emitted by a given pod and collected by the Agent use the following annotation on your pod:
 
@@ -39,7 +87,7 @@ annotations:
   ad.datadoghq.com/<CONTAINER_IDENTIFIER>.tags: '{"<TAG_KEY>": "<TAG_VALUE>","<TAG_KEY_1>": "<TAG_VALUE_1>"}'
 ```
 
-Starting with Agent v7.17+, the Agent can Autodiscover tags from Docker labels. This process allows the Agent to associate custom tags to all data emitted by a container, without [modifying the Agent `datadog.yaml` file][2].
+Starting with Agent v7.17+, the Agent can Autodiscover tags from Docker labels. This process allows the Agent to associate custom tags to all data emitted by a container, without [modifying the Agent `datadog.yaml` file][3].
 
 ```yaml
 com.datadoghq.ad.tags: '["<TAG_KEY>:TAG_VALUE", "<TAG_KEY_1>:<TAG_VALUE_1>"]'
@@ -146,10 +194,9 @@ kubernetes_pod_labels_as_tags:
   *: <PREFIX>_%%label%%
 ```
 
-**Note**: Custom metrics may impact billing. See the [custom metrics billing page][2] for more information.
+**Note**: Custom metrics may impact billing. See the [custom metrics billing page][3] for more information.
 
 [1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
-[2]: /account_management/billing/custom_metrics
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -206,5 +253,6 @@ kubernetes_pod_annotations_as_tags:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /getting_started/tagging/unified_service_tagging
-[2]: /agent/kubernetes/tag/?tab=agent#extract-labels-as-tags
+[1]: /agent/docker/tag/#extract-environment-variables-as-tags
+[2]: /getting_started/tagging/unified_service_tagging
+[3]: /agent/kubernetes/tag/?tab=agent#extract-labels-as-tags


### PR DESCRIPTION
### What does this PR do?
#10923 got overwritten

- https://docs-staging.datadoghq.com/kaylyn/tags-updated/agent/docker/tag/
- https://docs-staging.datadoghq.com/kaylyn/tags-updated/agent/kubernetes/tag/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
