### PR TITLE
Make installation instructions for Swift a bit clearer.

### DIFF
--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -33,7 +33,11 @@ Supported CI providers:
 * TravisCI
 * Bitrise
 
-## Installing the Swift testing SDK using SPM
+## Installing the Swift testing SDK 
+
+There are two ways of installing the testing framework:
+
+### Using Swift Package Manager
 
 1. Add `dd-sdk-swift-testing` package to your project. It is located at [`https://github.com/DataDog/dd-sdk-swift-testing`][1].
 
@@ -41,9 +45,9 @@ Supported CI providers:
 
 3. If you run UITests, also link the app running the tests with this library.
 
-## Binary linking
+### Adding the framework to your project
 
-1. Download and decompress `DatadogSDKTesting.zip` from the release page. 
+1. Download and decompress `DatadogSDKTesting.zip` from the release page: [`https://github.com/DataDog/dd-sdk-swift-testing/releases`][2]. 
 
 2. Copy and link your test targets with the resulting XCFramework.
 

--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -47,7 +47,7 @@ There are two ways of installing the testing framework:
 
 ### Adding the framework to your project
 
-1. Download and decompress `DatadogSDKTesting.zip` from the release page: [`https://github.com/DataDog/dd-sdk-swift-testing/releases`][2]. 
+1. Download and decompress `DatadogSDKTesting.zip` from the [release page][2]. 
 
 2. Copy and link your test targets with the resulting XCFramework.
 
@@ -378,3 +378,4 @@ You can also disable or enable specific auto-instrumentation in some of the test
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/dd-sdk-swift-testing
+[2]: https://github.com/DataDog/dd-sdk-swift-testing/releases


### PR DESCRIPTION
### What does this PR do?
Try to make clear that there are two different options for installing the testing SDK for Swift

### Motivation
I found out that they were looking like two mandatory steps but only one of them is needed

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nachoBonafonte/CI-app-improve-Swift-installation-instruction

### Additional Notes

---

### Reviewer checklist
- [X] Review the changed files.
- [X] Review the URLs listed in the [Preview](#preview) section.
- [X] Check images for PII
- [X] Review any mentions of "Contact Datadog support" for internal support documentation.
