### PR TITLE
[WEB-1499] - update code language tabs

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -10,25 +10,25 @@ imgix:
 code_languages:
   'py':
     extension: py
-    name: python
+    name: python-legacy
     syntax: python
     command: python
     example_file: example.py
   'pybeta':
     extension: py
-    name: python-beta
+    name: python
     syntax: python
     command: python3
     example_file: example.py
   'rb':
     extension: rb
-    name: ruby
+    name: ruby-legacy
     syntax: ruby
     command: rb
     example_file: example.rb
   'rbbeta':
     extension: rbbeta
-    name: ruby-beta
+    name: ruby
     syntax: ruby
     command: rb
     example_file: example.rb

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -68,10 +68,10 @@ code_language_ids:
     cpp: 'C++'
     php: PHP
     nodejs: NodeJS
-    python: Python [legacy]
-    python-beta: Python
-    ruby: Ruby [legacy]
-    ruby-beta: Ruby
+    python-legacy: Python [legacy]
+    python: Python
+    ruby-legacy: Ruby [legacy]
+    ruby: Ruby
     go: Go
     typescript: Typescript
     ".NET": ".NET"

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -68,10 +68,10 @@ code_language_ids:
     cpp: 'C++'
     php: PHP
     nodejs: NodeJS
-    python: Python
-    python-beta: Python [beta]
-    ruby: Ruby
-    ruby-beta: Ruby [beta]
+    python: Python [legacy]
+    python-beta: Python
+    ruby: Ruby [legacy]
+    ruby-beta: Ruby
     go: Go
     typescript: Typescript
     ".NET": ".NET"

--- a/content/en/api/latest/_index.md
+++ b/content/en/api/latest/_index.md
@@ -28,7 +28,7 @@ To try out the API [![Run in Postman][3]](https://app.getpostman.com/run-collect
 
 By default, the Datadog API Docs show examples in cURL. Select one of our official [client libraries][6] languages in each endpoint to see code examples from that library. To install each library:
 
-{{< programming-lang-wrapper langs="java,python,python-beta,ruby,ruby-beta,go,typescript" >}}
+{{< programming-lang-wrapper langs="java,python-legacy,python,ruby-legacy,ruby,go,typescript" >}}
 
 {{< programming-lang lang="java" >}}
 #### Installation
@@ -107,7 +107,7 @@ Execute example by running `gradle run` command.
 
 {{< /programming-lang >}}
 
-{{< programming-lang lang="python" >}}
+{{< programming-lang lang="python-legacy" >}}
 #### Installation
 ```sh
 pip install datadog
@@ -118,7 +118,7 @@ import datadog
 ```
 {{< /programming-lang >}}
 
-{{< programming-lang lang="python-beta" >}}
+{{< programming-lang lang="python" >}}
 #### Installation
 ```console
 pip3 install datadog-api-client
@@ -129,7 +129,7 @@ import datadog_api_client
 ```
 {{< /programming-lang >}}
 
-{{< programming-lang lang="ruby" >}}
+{{< programming-lang lang="ruby-legacy" >}}
 #### Installation
 ```sh
 gem install dogapi
@@ -140,7 +140,7 @@ require 'dogapi'
 ```
 {{< /programming-lang >}}
 
-{{< programming-lang lang="ruby-beta" >}}
+{{< programming-lang lang="ruby" >}}
 #### Installation
 ```sh
 gem install datadog_api_client -v {{< sdk-version "datadog-api-client-ruby" >}}

--- a/layouts/partials/code-lang-tabs.html
+++ b/layouts/partials/code-lang-tabs.html
@@ -4,11 +4,11 @@
 <ul class="nav nav-tabs border-none code-lang-list-container">
     {{ $count := 0}}
 
-    {{ range .codeLangs }}
+    {{ range sort .codeLangs "value" "asc" }}
         <li class="nav-item" style="margin-bottom: 6px;">
             <a class="nav-link mr-1 js-code-example-link" data-code-lang-trigger="{{ . }}" href="#">{{ index $.context.Site.Params.code_language_ids . }}</a>
         </li>
         {{ $count = add $count 1 }}
     {{ end}}
 
-</ul>  
+</ul>


### PR DESCRIPTION
### What does this PR do?
Update the code language tabs so that

| Before        | After           | 
| ------------- |-------------| 
| `Python`      | `Python [legacy]` | 
| `Python [beta]`      | `Python`      |
| `Ruby` | `Ruby [legacy]`      | 
| `Ruby [beta]` | `Ruby`       | 

### Motivation

https://datadoghq.atlassian.net/browse/WEB-1499

### Preview

View code examples and check the python/ruby is legacy
https://docs-staging.datadoghq.com/david.jones/code-tabs-legacy/api/latest/
https://docs-staging.datadoghq.com/david.jones/code-tabs-legacy/api/latest/dashboards/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
