### PR TITLE
Update serverless custom metrics doc

### DIFF
--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -8,82 +8,43 @@ kind: documentation
 There are a few different ways to submit custom metrics to Datadog from a Lambda function. 
 
 - **Creating custom metrics from logs or traces**: If your Lambda functions are already sending trace or log data to Datadog, and the data you want to query is captured in an existing log or trace, you can [generate custom metrics from logs and traces](#creating-custom-metrics-from-logs-or-traces) without re-deploying or making any changes to your application code.
-- **Submitting custom metrics synchronously**: If you want to generate custom metrics from a non-performance-critical Lambda function written in Python, Node.js or Golang and you are not interested in collecting traces, you can use Datadog Lambda Library to [submit custom metrics synchronously](#enabling-synchronous-custom-metrics).
-- **Submitting custom metrics asynchronously**: If you want to generate custom metrics from a performance-critical Lambda function, Datadog encourage you to use Datadog Lambda Library to [submit custom metrics asynchronously](#enabling-asynchronous-custom-metrics).
+- **Submitting custom metrics using the Datadog Lambda Extension**: If you want to submit custom metrics directly from your Lambda function, Datadog recommends using the [Datadog Lambda Extension](#with-the-datadog-lambda-extension). Check whether the Datadog Lambda Extension is supported for the runtime of your Lambda function [here][1]. The Datadog Lambda Extension does _NOT_ support metrics with timestamps that are from the past.  
+- **Submitting custom metrics using the Datadog Forwarder Lambda**: If you want to submit custom metrics from a runtime that is not yet supported by the Datadog Lambda Extension, you can use the [Datadog Forwarder Lambda](#with-the-datadog-forwarder). The Datadog Forwarder Lambda supports metrics with timestamps from the past 15 mins.
 - **(Deprecated) Submitting custom metrics from CloudWatch logs**: The method to submit custom metrics by printing a log formatted as `MONITORING|<UNIX_EPOCH_TIMESTAMP>|<METRIC_VALUE>|<METRIC_TYPE>|<METRIC_NAME>|#<TAG_LIST>` has been [deprecated](#deprecated-cloudwatch-logs), and you should migrate to one of the solutions above.
-- **(Not recommended) Using a third-party library**: Most of [third-party libraries](#third-party-libraries) do not submit metrics as distributions and can lead to under-counted results.
+- **(Not recommended) Using a third-party library**: Most [third-party libraries](#third-party-libraries) do not submit metrics as distributions and can lead to under-counted results.
 
 ### Understanding distribution metrics
 
-Custom metrics submitted from Lambda functions are aggregated as [distributions][1], as they are designed to instrument applications, independent of the underlying hosts. You can query the metrics using aggregation `avg`, `sum`, `max`, `min`, `count`. You can also enable percentile aggregations (p50, p75, p90, p95, p99) and [manage tags][2] for aggregation on the metric summary page.
-
-Certain submission methods allow you submit metrics with timestamps from the past, up-to 20 mins old.
+Custom metrics submitted from Lambda functions are aggregated as [distributions][2], because they are designed to instrument applications, independent of the underlying hosts. You can query the metrics using aggregations: `avg`, `sum`, `max`, `min`, `count`. You can also enable percentile aggregations (p50, p75, p90, p95, p99), and [manage tags][3] for aggregation on the metric summary page.
 
 ## Creating custom metrics from logs or traces
 
-With log-based metrics, you can record a count of logs that match a query or summarize a numeric value contained in a log, such as request duration. Log-based metrics are a cost-efficient way to summarize log data from the entire ingest stream. Learn more about creating log-based metrics [here][3]. 
+With log-based metrics, you can record a count of logs that match a query or summarize a numeric value contained in a log, such as request duration. Log-based metrics are a cost-efficient way to summarize log data from the entire ingest stream. Learn more about creating log-based metrics [here][4]. 
 
-You can also generate metrics from 100% of ingested spans, regardless of whether they are indexed by a retention filter. Learn more about creating span-based metrics [here][4].
-
-## Enabling synchronous custom metrics
-
-If you want to generate custom metrics from a Lambda function that is written in Python, Node.js or Golang and is performance-critical, you can use Datadog Lambda Library to submit custom metrics synchronously to Datadog API at the end your Lambda invocation.
-
-1. Follow the general [serverless installation instructions][5] to install the Datadog Lambda Library and configure your Lambda function. Note, you do _NOT_ need to add the Datadog Lambda Extension or Forwarder.
-1. Ensure the environment variable `DD_FLUSH_TO_LOG` is set to `false`, which instructs the Datadog Lambda Library to send metrics synchronously to the Datadog API.
-1. Ensure the environment variable `DD_TRACE_ENABLED` is set to `false`, which instructs the Datadog Lambda Library to NOT generate traces for the Lambda function.
-1. Ensure the environment variable `DD_API_KEY` (or an equivalent one when encrypted) is set with a valid Datadog API key.
-1. Import and use the helper function from the Datadog Lambda Library, such as `lambda_metric` or `sendDistributionMetric`, to submit your custom metrics following the [sample code](#custom-metrics-sample-code).
-### Running in a VPC
-
-The Datadog Lambda Library requires [access to the public internet][6] to submit custom metrics **synchronously**. If your Lambda function is associated with a VPC, ensure that your function can reach the public internet.
-
-## Enabling asynchronous custom metrics
-
-If you want to generate custom metrics from a performance-critical Lambda function, Datadog encourage you to use Datadog Lambda Library to submit custom metrics asynchronously. The Datadog Lambda Library can either
-
-- Publishes your custom metrics to the [Datadog Lambda Extension][7], which will submit your custom metrics directly to Datadog without impacting your function latency. This solution is easier to set up, but it currently only work for the popular runtimes, and does not support submitting metrics with timestamps from the past.
-- Emits your custom metrics as specially-formatted log which the [Datadog Forwarder][8] parses and submits to Datadog. This solution works for any runtime and metrics with timestamps from the past.
-
-### With the Datadog Lambda Extension
+You can also generate metrics from 100% of ingested spans, regardless of whether they are indexed by a retention filter. Learn more about creating span-based metrics [here][5].
+## With the Datadog Lambda Extension
 
 {{< img src="serverless/serverless_custom_metrics.png" alt="Collecting Custom Metrics from AWS Lambda" >}}
 
-1. Follow the general [serverless installation instructions][5] to configure your Lambda function and install the Datadog Lambda Library and Extension.
+Datadog recommends using [Datadog Lambda Extension][1] to submit custom metrics from a supported Lambda runtime.
+
+1. Follow the general [serverless installation instructions][6] to configure your Lambda function and install the Datadog Lambda Library and Extension.
 1. If you are not interested in collecting traces from the Lambda function, set the environment variable `DD_TRACE_ENABLED` to `false`.
-1. If you are not interested in collecting logs from the Lambda function, set the environment variable `DD_LOGS_ENABLED` to `false`.
+1. If you are not interested in collecting logs from the Lambda function, set the environment variable `DD_SERVERLESS_LOGS_ENABLED` to `false`.
 1. Import and use the helper function from the Datadog Lambda Library, such as `lambda_metric` or `sendDistributionMetric`, to submit your custom metrics following the [sample code](#custom-metrics-sample-code).
+
+If your Lambda function is associated with a VPC, ensure that your function can reach Datadog API endpoints either through the public internet, [PrivateLink][7] or a [proxy][8].
 
 ### With the Datadog Forwarder
 
-You can emit metrics to CloudWatch logs using the Datadog Lambda Library.
+Datadog recommends using [Datadog Forwarder Lambda][9] to submit custom metrics from a Lambda runtime that is not yet supported by the Datadog Lambda Extension.
 
-1. Follow the general [serverless installation instructions][5] (certain runtimes default to using the Extension, and see [here][9] for the Forwarder-based installation guides) to configure your Lambda function, install the Datadog Lambda Library and the Datadog Forwarder Lambda function, and subscribe the Forwarder to your function's log group. For Lambda runtimes not listed in the installation guide, refer to the next section for solutions.
+1. Follow the general [serverless installation instructions][6] to configure your Lambda function, install the Datadog Lambda Library and the Datadog Forwarder Lambda function, and subscribe the Forwarder to your function's log group.
 1. If you are not interested in collecting traces from the Lambda function, set the environment variable `DD_TRACE_ENABLED` to `false` on your own Lambda function.
 1. If you are not interested in collecting logs from the Lambda function, update the Forwarder's CloudFormation stack parameter `DdForwardLog` to `false`.
 1. Import and use the helper function from the Datadog Lambda Library, such as `lambda_metric` or `sendDistributionMetric`, to submit your custom metrics following the [sample code](#custom-metrics-sample-code).
 
-You can also emit metrics to CloudWatch logs in the following json format on your own from any Lambda runtime without installing the Datadog Lambda Library.
-
-```json
-{
-    "m": "Metric name",
-    "v": "Metric value",
-    "e": "Unix timestamp (seconds)",
-    "t": "Array of tags"
-}
-```
-
-For example:
-
-```json
-{
-    "m": "coffee_house.order_value",
-    "v": 12.45,
-    "e": 1572273854,
-    "t": ["product:latte", "order:online"]
-}
-```
+If the Datadog Lambda Library is not available for your runtime, you can print metrics to CloudWatch logs in the expected JSON format on your own. Select the "Other" tab from [sample code](#custom-metrics-sample-code) section.
 
 ## Custom metrics sample code
 
@@ -228,13 +189,15 @@ For example:
 
 ## Third-party libraries
 
-There are a number of open source libraries that make it easy to submit custom metrics to Datadog. However, many have not been updated to use [Distribution metrics][1], which are optimized for Lambda. Distribution metrics allow for server-side aggregations independent of a host, and give you flexible aggregations and tagging.
+There are a number of open source libraries that make it easy to submit custom metrics to Datadog. However, many have not been updated to use [Distribution metrics][2], which are optimized for Lambda. Distribution metrics allow for server-side aggregations independent of a host, and give you flexible aggregations and tagging.
 
 When evaluating third-party metrics libraries for AWS Lambda, ensure they support Distribution metrics.
 
 ## [DEPRECATED] CloudWatch logs
 
-**This method of submitting custom metrics is no longer supported, and is disabled for all new customers.** The recommended way to submit custom metrics from Lambda is with a [Datadog Lambda Library][5].
+**This method of submitting custom metrics is no longer supported, and is disabled for all new customers. Migrate to one of the recommended solutions.**.
+
+**Note**: If you are migrating to one of the recommended solutions, you'll need to start instrumenting your custom metrics under **new metric names** when submitting them to Datadog. The same metric name cannot simultaneously exist as both distribution and non-distribution metric types.
 
 This requires the following AWS permissions in your [Datadog IAM policy][0].
 
@@ -244,7 +207,7 @@ This requires the following AWS permissions in your [Datadog IAM policy][0].
 | `logs:DescribeLogStreams` | List available log streams for a group.                     |
 | `logs:FilterLogEvents`    | Fetch specific log events for a stream to generate metrics. |
 
-**[DEPRECATED]** To send custom metrics to Datadog from your Lambda logs, print a log line using the following format:
+To send custom metrics to Datadog from your Lambda logs, print a log line using the following format:
 
 ```text
 MONITORING|<UNIX_EPOCH_TIMESTAMP>|<METRIC_VALUE>|<METRIC_TYPE>|<METRIC_NAME>|#<TAG_LIST>
@@ -261,15 +224,13 @@ Where:
 
 **Note**: The sum for each timestamp is used for counts and the last value for a given timestamp is used for gauges. It is not recommended to print a log statement every time you increment a metric, as this increases the time it takes to parse your logs. Continually update the value of the metric in your code, and print one log statement for that metric before the function finishes.
 
-**Note**: If you are migrating to one of the recommended solutions, you'll need to start instrumenting your custom metrics under **new metric names** when submitting them to Datadog. The same metric name cannot simultaneously exist as both distribution and non-distribution metric types.
-
-[1]: /metrics/distributions/
-[2]: /metrics/distributions/#customize-tagging
-[3]: /logs/logs_to_metrics/
-[4]: /tracing/generate_metrics/
-[5]: /serverless/installation/
-[6]: https://aws.amazon.com/premiumsupport/knowledge-center/internet-access-lambda-function
-[7]: /serverless/libraries_integrations/extension/
-[8]: /serverless/forwarder/
-[9]: /serverless/guide/
+[1]: /serverless/libraries_integrations/extension/
+[2]: /metrics/distributions/
+[3]: /metrics/distributions/#customize-tagging
+[4]: /logs/logs_to_metrics/
+[5]: /tracing/generate_metrics/
+[6]: /serverless/installation/
+[7]: /agent/guide/private-link/
+[8]: /agent/proxy/
+[9]: /serverless/forwarder/
 [10]: /developers/metrics/

--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -35,7 +35,7 @@ Datadog recommends using the [Datadog Lambda Extension][1] to submit custom metr
 
 If your Lambda function is associated with a VPC, ensure that your function can reach Datadog API endpoints either through the public internet, [PrivateLink][7] or a [proxy][8].
 
-### With the Datadog Forwarder
+## With the Datadog Forwarder
 
 Datadog recommends using the [Datadog Forwarder Lambda][9] to submit custom metrics from Lambda runtimes that are not yet supported by the Datadog Lambda Extension.
 

--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -8,8 +8,8 @@ kind: documentation
 There are a few different ways to submit custom metrics to Datadog from a Lambda function. 
 
 - **Creating custom metrics from logs or traces**: If your Lambda functions are already sending trace or log data to Datadog, and the data you want to query is captured in an existing log or trace, you can [generate custom metrics from logs and traces](#creating-custom-metrics-from-logs-or-traces) without re-deploying or making any changes to your application code.
-- **Submitting custom metrics using the Datadog Lambda Extension**: If you want to submit custom metrics directly from your Lambda function, Datadog recommends using the [Datadog Lambda Extension](#with-the-datadog-lambda-extension). Check whether the Datadog Lambda Extension is supported for the runtime of your Lambda function [here][1]. The Datadog Lambda Extension does _NOT_ support metrics with timestamps that are from the past.  
-- **Submitting custom metrics using the Datadog Forwarder Lambda**: If you want to submit custom metrics from a runtime that is not yet supported by the Datadog Lambda Extension, you can use the [Datadog Forwarder Lambda](#with-the-datadog-forwarder). The Datadog Forwarder Lambda supports metrics with timestamps from the past 15 mins.
+- **Submitting custom metrics using the Datadog Lambda Extension**: If you want to submit custom metrics directly from your Lambda function, Datadog recommends using the [Datadog Lambda Extension](#with-the-datadog-lambda-extension). Check whether the Datadog Lambda Extension is supported for the runtime of your Lambda function [here][1].  
+- **Submitting custom metrics using the Datadog Forwarder Lambda**: If you want to submit custom metrics from a runtime that is not yet supported by the Datadog Lambda Extension, you can use the [Datadog Forwarder Lambda](#with-the-datadog-forwarder).
 - **(Deprecated) Submitting custom metrics from CloudWatch logs**: The method to submit custom metrics by printing a log formatted as `MONITORING|<UNIX_EPOCH_TIMESTAMP>|<METRIC_VALUE>|<METRIC_TYPE>|<METRIC_NAME>|#<TAG_LIST>` has been [deprecated](#deprecated-cloudwatch-logs), and you should migrate to one of the solutions above.
 - **(Not recommended) Using a third-party library**: Most [third-party libraries](#third-party-libraries) do not submit metrics as distributions and can lead to under-counted results.
 
@@ -26,29 +26,27 @@ You can also generate metrics from 100% of ingested spans, regardless of whether
 
 {{< img src="serverless/serverless_custom_metrics.png" alt="Collecting Custom Metrics from AWS Lambda" >}}
 
-Datadog recommends using [Datadog Lambda Extension][1] to submit custom metrics from a supported Lambda runtime.
+Datadog recommends using the [Datadog Lambda Extension][1] to submit custom metrics from supported Lambda runtimes.
 
 1. Follow the general [serverless installation instructions][6] to configure your Lambda function and install the Datadog Lambda Library and Extension.
-1. If you are not interested in collecting traces from the Lambda function, set the environment variable `DD_TRACE_ENABLED` to `false`.
-1. If you are not interested in collecting logs from the Lambda function, set the environment variable `DD_SERVERLESS_LOGS_ENABLED` to `false`.
+1. If you are not interested in collecting traces from your Lambda function, set the environment variable `DD_TRACE_ENABLED` to `false`.
+1. If you are not interested in collecting logs from your Lambda function, set the environment variable `DD_SERVERLESS_LOGS_ENABLED` to `false`.
 1. Import and use the helper function from the Datadog Lambda Library, such as `lambda_metric` or `sendDistributionMetric`, to submit your custom metrics following the [sample code](#custom-metrics-sample-code).
 
 If your Lambda function is associated with a VPC, ensure that your function can reach Datadog API endpoints either through the public internet, [PrivateLink][7] or a [proxy][8].
 
 ### With the Datadog Forwarder
 
-Datadog recommends using [Datadog Forwarder Lambda][9] to submit custom metrics from a Lambda runtime that is not yet supported by the Datadog Lambda Extension.
+Datadog recommends using the [Datadog Forwarder Lambda][9] to submit custom metrics from Lambda runtimes that are not yet supported by the Datadog Lambda Extension.
 
 1. Follow the general [serverless installation instructions][6] to configure your Lambda function, install the Datadog Lambda Library and the Datadog Forwarder Lambda function, and subscribe the Forwarder to your function's log group.
-1. If you are not interested in collecting traces from the Lambda function, set the environment variable `DD_TRACE_ENABLED` to `false` on your own Lambda function.
-1. If you are not interested in collecting logs from the Lambda function, update the Forwarder's CloudFormation stack parameter `DdForwardLog` to `false`.
+1. If you are not interested in collecting traces from your Lambda function, set the environment variable `DD_TRACE_ENABLED` to `false` on your own Lambda function.
+1. If you are not interested in collecting logs from your Lambda function, set the Forwarder's CloudFormation stack parameter `DdForwardLog` to `false`.
 1. Import and use the helper function from the Datadog Lambda Library, such as `lambda_metric` or `sendDistributionMetric`, to submit your custom metrics following the [sample code](#custom-metrics-sample-code).
 
-If the Datadog Lambda Library is not available for your runtime, you can print metrics to CloudWatch logs in the expected JSON format on your own. Select the "Other" tab from [sample code](#custom-metrics-sample-code) section.
+If the Datadog Lambda Library is not available for your runtime, you can print metrics to CloudWatch logs in the expected JSON format on your own. Select the "Other" tab from the [sample code](#custom-metrics-sample-code) section.
 
 ## Custom metrics sample code
-
-Refer to the following sample code for both synchronous and asynchronous custom metric submissions. 
 
 **Note:** The arguments to the custom metrics reporting methods have the following requirements:
 

--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -8,14 +8,14 @@ kind: documentation
 There are a few different ways to submit custom metrics to Datadog from a Lambda function. 
 
 - **Creating custom metrics from logs or traces**: If your Lambda functions are already sending trace or log data to Datadog, and the data you want to query is captured in an existing log or trace, you can [generate custom metrics from logs and traces](#creating-custom-metrics-from-logs-or-traces) without re-deploying or making any changes to your application code.
-- **Submitting custom metrics using the Datadog Lambda Extension**: If you want to submit custom metrics directly from your Lambda function, Datadog recommends using the [Datadog Lambda Extension](#with-the-datadog-lambda-extension). Check whether the Datadog Lambda Extension is supported for the runtime of your Lambda function [here][1].  
+- **Submitting custom metrics using the Datadog Lambda Extension**: If you want to submit custom metrics directly from your Lambda function, Datadog recommends using the [Datadog Lambda Extension](#with-the-datadog-lambda-extension). [Check whether the Datadog Lambda Extension is supported][1] in your Lambda function runtime.  
 - **Submitting custom metrics using the Datadog Forwarder Lambda**: If you want to submit custom metrics from a runtime that is not yet supported by the Datadog Lambda Extension, you can use the [Datadog Forwarder Lambda](#with-the-datadog-forwarder).
 - **(Deprecated) Submitting custom metrics from CloudWatch logs**: The method to submit custom metrics by printing a log formatted as `MONITORING|<UNIX_EPOCH_TIMESTAMP>|<METRIC_VALUE>|<METRIC_TYPE>|<METRIC_NAME>|#<TAG_LIST>` has been [deprecated](#deprecated-cloudwatch-logs), and you should migrate to one of the solutions above.
 - **(Not recommended) Using a third-party library**: Most [third-party libraries](#third-party-libraries) do not submit metrics as distributions and can lead to under-counted results.
 
 ### Understanding distribution metrics
 
-Custom metrics submitted from Lambda functions are aggregated as [distributions][2], because they are designed to instrument applications, independent of the underlying hosts. You can query the metrics using aggregations: `avg`, `sum`, `max`, `min`, `count`. You can also enable percentile aggregations (p50, p75, p90, p95, p99), and [manage tags][3] for aggregation on the metric summary page.
+Custom metrics submitted from Lambda functions are aggregated as [distributions][2], because they are designed to instrument applications, independent of the underlying hosts. You can query the metrics using aggregations: `avg`, `sum`, `max`, `min`, `count`. You can also enable percentile aggregations (p50, p75, p90, p95, p99), and [manage tags][3] for aggregation on the Metric Summary page.
 
 ## Creating custom metrics from logs or traces
 
@@ -33,7 +33,7 @@ Datadog recommends using the [Datadog Lambda Extension][1] to submit custom metr
 1. If you are not interested in collecting logs from your Lambda function, set the environment variable `DD_SERVERLESS_LOGS_ENABLED` to `false`.
 1. Import and use the helper function from the Datadog Lambda Library, such as `lambda_metric` or `sendDistributionMetric`, to submit your custom metrics following the [sample code](#custom-metrics-sample-code).
 
-If your Lambda function is associated with a VPC, ensure that your function can reach Datadog API endpoints either through the public internet, [PrivateLink][7] or a [proxy][8].
+If your Lambda function is running in a VPC, ensure that your function can reach Datadog API endpoints either through the public internet, [PrivateLink][7] or a [proxy][8].
 
 ## With the Datadog Forwarder
 

--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -3,56 +3,95 @@ title: Custom Metrics
 kind: documentation
 ---
 
-If your Lambda functions are sending trace or log data to Datadog, and the data you want to query is captured in an existing log or trace, you can [generate custom metrics from logs and traces](#creating-custom-metrics-from-logs-or-traces) without re-deploying or making any changes to your application code. If you want to send new data not captured in an existing log or trace, you can [send custom metrics using the Datadog Lambda Library](#sending-custom-metrics-from-the-datadog-lambda-library).
+## Overview
+
+There are a few different ways to submit custom metrics to Datadog from a Lambda function. 
+
+- **Creating custom metrics from logs or traces**: If your Lambda functions are already sending trace or log data to Datadog, and the data you want to query is captured in an existing log or trace, you can [generate custom metrics from logs and traces](#creating-custom-metrics-from-logs-or-traces) without re-deploying or making any changes to your application code.
+- **Submitting custom metrics synchronously**: If you want to generate custom metrics from a non-performance-critical Lambda function written in Python, Node.js or Golang and you are not interested in collecting traces, you can use Datadog Lambda Library to [submit custom metrics synchronously](#enabling-synchronous-custom-metrics).
+- **Submitting custom metrics asynchronously**: If you want to generate custom metrics from a performance-critical Lambda function, Datadog encourage you to use Datadog Lambda Library to [submit custom metrics asynchronously](#enabling-asynchronous-custom-metrics).
+- **(Deprecated) Submitting custom metrics from CloudWatch logs**: The method to submit custom metrics by printing a log formatted as `MONITORING|<UNIX_EPOCH_TIMESTAMP>|<METRIC_VALUE>|<METRIC_TYPE>|<METRIC_NAME>|#<TAG_LIST>` has been [deprecated](#deprecated-cloudwatch-logs), and you should migrate to one of the solutions above.
+- **(Not recommended) Using a third-party library**: Most of [third-party libraries](#third-party-libraries) do not submit metrics as distributions and can lead to under-counted results.
+
+### Understanding distribution metrics
+
+Custom metrics submitted from Lambda functions are aggregated as [distributions][1], as they are designed to instrument applications, independent of the underlying hosts. You can query the metrics using aggregation `avg`, `sum`, `max`, `min`, `count`. You can also enable percentile aggregations (p50, p75, p90, p95, p99) and [manage tags][2] for aggregation on the metric summary page.
+
+Certain submission methods allow you submit metrics with timestamps from the past, up-to 20 mins old.
 
 ## Creating custom metrics from logs or traces
 
-With log-based metrics, you can record a count of logs that match a query or summarize a numeric value contained in a log, such as request duration. Log-based metrics are a cost-efficient way to summarize log data from the entire ingest stream. Learn more about creating log-based metrics [here][1]. 
+With log-based metrics, you can record a count of logs that match a query or summarize a numeric value contained in a log, such as request duration. Log-based metrics are a cost-efficient way to summarize log data from the entire ingest stream. Learn more about creating log-based metrics [here][3]. 
 
-You can also generate metrics from 100% of ingested spans, regardless of whether they are indexed by a retention filter. Learn more about creating span-based metrics [here][2].
+You can also generate metrics from 100% of ingested spans, regardless of whether they are indexed by a retention filter. Learn more about creating span-based metrics [here][4].
 
-## Sending custom metrics from the Datadog Lambda library
+## Enabling synchronous custom metrics
+
+If you want to generate custom metrics from a Lambda function that is written in Python, Node.js or Golang and is performance-critical, you can use Datadog Lambda Library to submit custom metrics synchronously to Datadog API at the end your Lambda invocation.
+
+1. Follow the general [serverless installation instructions][5] to install the Datadog Lambda Library and configure your Lambda function. Note, you do _NOT_ need to add the Datadog Lambda Extension or Forwarder.
+1. Ensure the environment variable `DD_FLUSH_TO_LOG` is set to `false`, which instructs the Datadog Lambda Library to send metrics synchronously to the Datadog API.
+1. Ensure the environment variable `DD_TRACE_ENABLED` is set to `false`, which instructs the Datadog Lambda Library to NOT generate traces for the Lambda function.
+1. Ensure the environment variable `DD_API_KEY` (or an equivalent one when encrypted) is set with a valid Datadog API key.
+1. Import and use the helper function from the Datadog Lambda Library, such as `lambda_metric` or `sendDistributionMetric`, to submit your custom metrics following the [sample code](#custom-metrics-sample-code).
+### Running in a VPC
+
+The Datadog Lambda Library requires [access to the public internet][6] to submit custom metrics **synchronously**. If your Lambda function is associated with a VPC, ensure that your function can reach the public internet.
+
+## Enabling asynchronous custom metrics
+
+If you want to generate custom metrics from a performance-critical Lambda function, Datadog encourage you to use Datadog Lambda Library to submit custom metrics asynchronously. The Datadog Lambda Library can either
+
+- Publishes your custom metrics to the [Datadog Lambda Extension][7], which will submit your custom metrics directly to Datadog without impacting your function latency. This solution is easier to set up, but it currently only work for the popular runtimes, and does not support submitting metrics with timestamps from the past.
+- Emits your custom metrics as specially-formatted log which the [Datadog Forwarder][8] parses and submits to Datadog. This solution works for any runtime and metrics with timestamps from the past.
+
+### With the Datadog Lambda Extension
 
 {{< img src="serverless/serverless_custom_metrics.png" alt="Collecting Custom Metrics from AWS Lambda" >}}
 
-Install the Datadog Lambda Library to collect and send custom metrics. Metrics sent from the Datadog Lambda Library are automatically aggregated into [distributions][3], so you can graph the `avg`, `sum`, `max`, `min`, and `count`. You can also calculate aggregations over a set of tags for the 50th, 75th, 95th, and 99th percentile values on the [Distribution Metrics][3] page.
+1. Follow the general [serverless installation instructions][5] to configure your Lambda function and install the Datadog Lambda Library and Extension.
+1. If you are not interested in collecting traces from the Lambda function, set the environment variable `DD_TRACE_ENABLED` to `false`.
+1. If you are not interested in collecting logs from the Lambda function, set the environment variable `DD_LOGS_ENABLED` to `false`.
+1. Import and use the helper function from the Datadog Lambda Library, such as `lambda_metric` or `sendDistributionMetric`, to submit your custom metrics following the [sample code](#custom-metrics-sample-code).
 
-Distribution metrics are designed to instrument logical objects, like services, independent of the underlying hosts. So, they are well-suited for serverless infrastructure because they aggregate metrics server-side instead of locally with an Agent.
+### With the Datadog Forwarder
 
-### Synchronous vs. asynchronous custom metrics
+You can emit metrics to CloudWatch logs using the Datadog Lambda Library.
 
-The Datadog Lambda Library supports submitting custom metrics in Lambda, both synchronously and asynchronously.
+1. Follow the general [serverless installation instructions][5] (certain runtimes default to using the Extension, and see [here][9] for the Forwarder-based installation guides) to configure your Lambda function, install the Datadog Lambda Library and the Datadog Forwarder Lambda function, and subscribe the Forwarder to your function's log group. For Lambda runtimes not listed in the installation guide, refer to the next section for solutions.
+1. If you are not interested in collecting traces from the Lambda function, set the environment variable `DD_TRACE_ENABLED` to `false` on your own Lambda function.
+1. If you are not interested in collecting logs from the Lambda function, update the Forwarder's CloudFormation stack parameter `DdForwardLog` to `false`.
+1. Import and use the helper function from the Datadog Lambda Library, such as `lambda_metric` or `sendDistributionMetric`, to submit your custom metrics following the [sample code](#custom-metrics-sample-code).
 
-**Synchronous**: The default behavior. This method submits your custom metrics to Datadog via HTTP periodically (every 10 seconds) and at the end of your Lambda invocation. If the invocation lasts for less than 10 seconds, your custom metrics are submitted at the end of the invocation.
+You can also emit metrics to CloudWatch logs in the following json format on your own from any Lambda runtime without installing the Datadog Lambda Library.
 
-**Asynchronous (recommended)**: It's possible to submit your custom metrics with zero latency overhead **and** have them appear in Datadog in near-real-time. To accomplish this, the Lambda Library either:
-- Publishes your custom metrics to the [Datadog Lambda Extension][4], which will submit your custom metrics directly to Datadog without impacting your function latency.
-- Emits your custom metrics as specially-formatted log which the [Datadog Forwarder][5] parses and submits to Datadog. Logging in AWS Lambda is 100% asynchronous, so this method ensures there is zero latency overhead to your function.
+```json
+{
+    "m": "Metric name",
+    "v": "Metric value",
+    "e": "Unix timestamp (seconds)",
+    "t": "Array of tags"
+}
+```
 
-### Enabling asynchronous custom metrics
+For example:
 
-#### With the Datadog Lambda Extension
+```json
+{
+    "m": "coffee_house.order_value",
+    "v": 12.45,
+    "e": 1572273854,
+    "t": ["product:latte", "order:online"]
+}
+```
 
-Datadog recommends using the Datadog Lambda Extension if your you are using Node.js or Python Lambda runtimes.
+## Custom metrics sample code
 
-1. Set the environment variable `DD_FLUSH_TO_LOG` to `True` on your Lambda function.
-2. Add the [Datadog Lambda Extension][4] to your function either as a Lambda Layer or as a container image.
-3. Add the environment variable `DD_API_KEY` or `DD_KMS_API_KEY` to your Lambda function, and set the value to your Datadog API key on the [API Management page][12]. 
-
-#### With the Datadog Forwarder
-
-1. Set the environment variable `DD_FLUSH_TO_LOG` to `True` on your Lambda function.
-2. Update your [Datadog Forwarder][5] to at least version 1.4.0.
-
-If you are not using Datadog Logs, you can still use asynchronous custom metric submission. Set the environment variable `DD_FORWARD_LOG` to `False` on the [Datadog log collection AWS Lambda function][5]. This intelligently forwards only custom metrics to Datadog, and not regular logs.
-
-### Custom metrics sample code
-
-In your function code, you must import the necessary methods from the Lambda Library and add a wrapper around your function handler. You do not need to wrap your helper functions. 
+Refer to the following sample code for both synchronous and asynchronous custom metric submissions. 
 
 **Note:** The arguments to the custom metrics reporting methods have the following requirements:
 
-- `<METRIC_NAME>` uniquely identifies your metric and adheres to the [metric naming policy][6].
+- `<METRIC_NAME>` uniquely identifies your metric and adheres to the [metric naming policy][10].
 - `<METRIC_VALUE>` MUST be a number (i.e. integer or float).
 - `<TAG_LIST>` is optional and formatted, for example: `['owner:Datadog', 'env:demo', 'cooltag']`.
 
@@ -61,10 +100,7 @@ In your function code, you must import the necessary methods from the Lambda Lib
 
 ```python
 from datadog_lambda.metric import lambda_metric
-from datadog_lambda.wrapper import datadog_lambda_wrapper
 
-# You only need to wrap your function handler (Not helper functions). 
-@datadog_lambda_wrapper
 def lambda_handler(event, context):
     lambda_metric(
         "coffee_house.order_value",             # Metric name
@@ -76,28 +112,20 @@ def lambda_handler(event, context):
 {{< programming-lang lang="nodeJS" >}}
 
 ```javascript
-const { datadog, sendDistributionMetric } = require('datadog-lambda-js');
+const { sendDistributionMetric } = require('datadog-lambda-js');
 
 async function myHandler(event, context) {
     sendDistributionMetric(
         'coffee_house.order_value', // Metric name
         12.45, // Metric value
-        'product:latte',
-        'order:online' // Associated tags
+        'product:latte', // First tag
+        'order:online' // Second tag
     );
     return {
         statusCode: 200,
         body: 'hello, dog!'
     };
 }
-// You only need to wrap your function handler (Not helper functions).
-module.exports.myHandler = datadog(myHandler);
-
-/* OR with manual configuration options
-module.exports.myHandler = datadog(myHandler, {
-    apiKey: "my-api-key"
-});
-*/
 ```
 {{< /programming-lang >}}
 {{< programming-lang lang="go" >}}
@@ -160,7 +188,7 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
 
         Map<String,String> myTags = new HashMap<String, String>();
             myTags.put("product", "latte");
-            myTags.put("order","online");
+            myTags.put("order", "online");
         
         dd.metric(
             "coffee_house.order_value", // Metric name
@@ -173,10 +201,7 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
 {{< /programming-lang >}}
 {{< programming-lang lang="other" >}}
 
-Emitting [asynchronous custom metrics](#synchronous-vs-asynchronous-custom-metrics) is possible for any language or custom runtime. It works by printing a special JSON-formatted string in your Lambda function that the [Datadog Forwarder][1] identifies and submits to Datadog. To use this:
-
-1. [Enable asynchronous cusstom metrics](#enabling-asynchronous-custom-metrics)
-2. Write a reusable function that logs your custom metrics in the following format:
+Write a reusable function that logs your custom metrics in the following format:
 
 ```json
 {
@@ -198,43 +223,20 @@ For example:
 }
 ```
 
-**Note:** These custom metrics are submitted as [distributions](#custom-metrics). If you were previously submitting custom metrics another way, [consult the documentation on the implications of upgrading to distributions](#understanding-distribution-metrics).
-
-[1]: /serverless/forwarder/
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 
-### Tagging custom metrics
+## Third-party libraries
 
-You should tag your custom metrics when submitting them with the [Datadog Lambda Library][7]. Use the [Distribution Metrics][3] page to [customize the set of tags][8] applied to your custom metrics.
-
-To add Lambda resource tags to your custom metrics, set the parameter `DdFetchLambdaTags` to `true` on the Datadog forwarder CloudFormation stack.
-
-### Understanding distribution metrics
-
-With distribution metrics, you select the aggregation when graphing or querying it instead of specifying it at submission time.
-
-If you previously submitted custom metrics from Lambda without using one of the Datadog Lambda Libraries, you'll need to start instrumenting your custom metrics under **new metric names** when submitting them to Datadog. The same metric name cannot simultaneously exist as both distribution and non-distribution metric types.
-
-To enable percentile aggregations for your distribution metrics, consult the [Distribution Metrics][8] page.
-
-## Other submission methods
-
-### Running in a VPC
-
-The Datadog Lambda Library requires [access to the public internet][9] to submit custom metrics **synchronously**. If your Lambda function is associated with a VPC, ensure that it is instead submitting custom metrics **asynchronously** or that your function can reach the public internet.
-
-### Third-party libraries
-
-There are a number of open source libraries that make it easy to submit custom metrics to Datadog. However, many have not been updated to use [Distribution metrics][3], which are optimized for Lambda. Distribution metrics allow for server-side aggregations independent of a host or locally-running [agent][10]. In a serverless environment where there is no agent, Distribution metrics give you flexible aggregations and tagging.
+There are a number of open source libraries that make it easy to submit custom metrics to Datadog. However, many have not been updated to use [Distribution metrics][1], which are optimized for Lambda. Distribution metrics allow for server-side aggregations independent of a host, and give you flexible aggregations and tagging.
 
 When evaluating third-party metrics libraries for AWS Lambda, ensure they support Distribution metrics.
 
-### [DEPRECATED] CloudWatch logs
+## [DEPRECATED] CloudWatch logs
 
-**This method of submitting custom metrics is no longer supported, and is disabled for all new customers.** The recommended way to submit custom metrics from Lambda is with a [Datadog Lambda Library][7].
+**This method of submitting custom metrics is no longer supported, and is disabled for all new customers.** The recommended way to submit custom metrics from Lambda is with a [Datadog Lambda Library][5].
 
-This requires the following AWS permissions in your [Datadog IAM policy][11].
+This requires the following AWS permissions in your [Datadog IAM policy][0].
 
 | AWS Permission            | Description                                                 |
 | ------------------------- | ----------------------------------------------------------- |
@@ -254,19 +256,20 @@ Where:
 - `<UNIX_EPOCH_TIMESTAMP>` is in seconds, not milliseconds.
 - `<METRIC_VALUE>` MUST be a number (i.e. integer or float).
 - `<METRIC_TYPE>` is `count`, `gauge`, `histogram`, or `check`.
-- `<METRIC_NAME>` uniquely identifies your metric and adheres to the [metric naming policy][6].
+- `<METRIC_NAME>` uniquely identifies your metric and adheres to the [metric naming policy][10].
 - `<TAG_LIST>` is optional, comma separated, and must be preceded by `#`. The tag `function_name:<name_of_the_function>` is automatically applied to custom metrics.
 
 **Note**: The sum for each timestamp is used for counts and the last value for a given timestamp is used for gauges. It is not recommended to print a log statement every time you increment a metric, as this increases the time it takes to parse your logs. Continually update the value of the metric in your code, and print one log statement for that metric before the function finishes.
 
-[1]: /logs/logs_to_metrics/
-[2]: /tracing/generate_metrics/
-[3]: https://docs.datadoghq.com/metrics/distributions/
-[4]: /serverless/libraries_integrations/extension
-[5]: /serverless/forwarder/
-[6]: /developers/metrics/
-[7]: /serverless/installation/
-[8]: /metrics/distributions/#customize-tagging
-[9]: https://aws.amazon.com/premiumsupport/knowledge-center/internet-access-lambda-function
-[10]: /agent/
-[11]: https://docs.datadoghq.com/integrations/amazon_web_services/#installation
+**Note**: If you are migrating to one of the recommended solutions, you'll need to start instrumenting your custom metrics under **new metric names** when submitting them to Datadog. The same metric name cannot simultaneously exist as both distribution and non-distribution metric types.
+
+[1]: /metrics/distributions/
+[2]: /metrics/distributions/#customize-tagging
+[3]: /logs/logs_to_metrics/
+[4]: /tracing/generate_metrics/
+[5]: /serverless/installation/
+[6]: https://aws.amazon.com/premiumsupport/knowledge-center/internet-access-lambda-function
+[7]: /serverless/libraries_integrations/extension/
+[8]: /serverless/forwarder/
+[9]: /serverless/guide/
+[10]: /developers/metrics/

--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -11,7 +11,7 @@ There are a few different ways to submit custom metrics to Datadog from a Lambda
 - **Submitting custom metrics using the Datadog Lambda Extension**: If you want to submit custom metrics directly from your Lambda function, Datadog recommends using the [Datadog Lambda Extension](#with-the-datadog-lambda-extension). [Check whether the Datadog Lambda Extension is supported][1] in your Lambda function runtime.  
 - **Submitting custom metrics using the Datadog Forwarder Lambda**: If you want to submit custom metrics from a runtime that is not yet supported by the Datadog Lambda Extension, you can use the [Datadog Forwarder Lambda](#with-the-datadog-forwarder).
 - **(Deprecated) Submitting custom metrics from CloudWatch logs**: The method to submit custom metrics by printing a log formatted as `MONITORING|<UNIX_EPOCH_TIMESTAMP>|<METRIC_VALUE>|<METRIC_TYPE>|<METRIC_NAME>|#<TAG_LIST>` has been [deprecated](#deprecated-cloudwatch-logs), and you should migrate to one of the solutions above.
-- **(Not recommended) Using a third-party library**: Most [third-party libraries](#third-party-libraries) do not submit metrics as distributions and can lead to under-counted results.
+- **(Not recommended) Using a third-party library**: Most third-party libraries do not submit metrics as distributions and can lead to under-counted results.
 
 ### Understanding distribution metrics
 
@@ -184,12 +184,6 @@ For example:
 
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
-
-## Third-party libraries
-
-There are a number of open source libraries that make it easy to submit custom metrics to Datadog. However, many have not been updated to use [Distribution metrics][2], which are optimized for Lambda. Distribution metrics allow for server-side aggregations independent of a host, and give you flexible aggregations and tagging.
-
-When evaluating third-party metrics libraries for AWS Lambda, ensure they support Distribution metrics.
 
 ## [DEPRECATED] CloudWatch logs
 

--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -51,7 +51,7 @@ If the Datadog Lambda Library is not available for your runtime, you can print m
 **Note:** The arguments to the custom metrics reporting methods have the following requirements:
 
 - `<METRIC_NAME>` uniquely identifies your metric and adheres to the [metric naming policy][10].
-- `<METRIC_VALUE>` MUST be a number (i.e. integer or float).
+- `<METRIC_VALUE>` MUST be a number (that is, integer or float).
 - `<TAG_LIST>` is optional and formatted, for example: `['owner:Datadog', 'env:demo', 'cooltag']`.
 
 {{< programming-lang-wrapper langs="python,nodeJS,go,ruby,java,other" >}}
@@ -209,7 +209,7 @@ Where:
 
 - `MONITORING` signals to the Datadog integration that it should collect this log entry.
 - `<UNIX_EPOCH_TIMESTAMP>` is in seconds, not milliseconds.
-- `<METRIC_VALUE>` MUST be a number (i.e. integer or float).
+- `<METRIC_VALUE>` MUST be a number (that is, integer or float).
 - `<METRIC_TYPE>` is `count`, `gauge`, `histogram`, or `check`.
 - `<METRIC_NAME>` uniquely identifies your metric and adheres to the [metric naming policy][10].
 - `<TAG_LIST>` is optional, comma separated, and must be preceded by `#`. The tag `function_name:<name_of_the_function>` is automatically applied to custom metrics.

--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -193,7 +193,7 @@ When evaluating third-party metrics libraries for AWS Lambda, ensure they suppor
 
 ## [DEPRECATED] CloudWatch logs
 
-**This method of submitting custom metrics is no longer supported, and is disabled for all new customers. Migrate to one of the recommended solutions.**.
+**This method of submitting custom metrics is no longer supported, and is disabled for all new customers. Migrate to one of the recommended solutions.**
 
 **Note**: If you are migrating to one of the recommended solutions, you'll need to start instrumenting your custom metrics under **new metric names** when submitting them to Datadog. The same metric name cannot simultaneously exist as both distribution and non-distribution metric types.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the custom metrics doc:

1. Summarize all the possible solutions with high-level differences to help customers pick the right one.
2. Remove the outdated installation instructions and link readers to the general installation instructions instead (with hopes that they may get updated more frequently).
3. Update the outdated sample code.

### Motivation

The custom metrics doc is quite out of date due to recent improvements/changes on serverless instrumentation. Customers get confused when reading this page, and I can easily spot many things that are no longer accurate or relevant.

### Preview

https://docs-staging.datadoghq.com/tian.chu/serverless-custom-metrics/serverless/custom_metrics/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
