### PR TITLE
disable halting build on duplicate ref link

### DIFF
--- a/local/bin/py/build/actions/format_link.py
+++ b/local/bin/py/build/actions/format_link.py
@@ -83,7 +83,9 @@ def check_references(all_references):
             duplicated_reference_index, duplicated_reference_val = duplicated_reference
             print('Duplicated reference: [{}]: {}'.format(
                 duplicated_reference_index, duplicated_reference_val))
-        raise AssertionError
+        # having a duplicate index => value doesn't actually break hugo or the page
+        # lets just print and skip halting the build
+        # raise AssertionError
 
     return all_references_deduped
 


### PR DESCRIPTION
### What does this PR do?

This PR disables halting the build for integrations that have duplicate ref links e.g 

```
[6]: https://www.google.com
[7]: https://www.thesamelink.com
[7]: https://www.thesamelink.com
[8]: /somethingelse
```

and instead just prints the warning with the duplicate removed

### Motivation

The build has broken a few times due to duplicate ref links which doesn't actually cause a bad experience for the user.

### Preview

https://docs-staging.datadoghq.com/david.jones/duplicate-ref-noskip/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
