### PR TITLE
[rum] add cors warning for apm<>rum link

### DIFF
--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -138,6 +138,8 @@ Datadog uses the distributed tracing protocol and sets up the following HTTP hea
 `x-datadog-sampled: 1`
 : Generated from the Real User Monitoring SDK. Indicates this request is selected for sampling.
 
+**Note**: These HTTP headers are not CORS-safelisted, so you need to [configure Access-Control-Allow-Headers][17] on your server. The server must also accept [preflight requests][18] (OPTIONS requests).
+
 ## How are APM quotas affected?
 
 The `x-datadog-origin: rum` header specifies to the APM backend that the traces are generated from Real User Monitoring. The generated traces consequently do not impact Indexed Span counts.
@@ -164,3 +166,5 @@ These traces are retained [just like your classical APM traces][16].
 [14]: /tracing/setup_overview/setup/dotnet-core/
 [15]: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.18.2
 [16]: /tracing/trace_retention_and_ingestion/
+[17]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+[18]: https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* Add note below HTTP headers injected by RUM relative to CORS and preflight requests.

### Motivation
<!-- What inspired you to submit this pull request?-->
* Suggestion from customer on public slack.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/apm-rum-cors/real_user_monitoring/connect_rum_and_traces/?tab=browserrum#how-are-rum-resources-linked-to-traces

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
