### PR TITLE
Fix minimum Windows version for NPM

### DIFF
--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -45,7 +45,7 @@ Data collection is done using eBPF, so Datadog minimally requires platforms that
 
 #### Windows OS
 
-Data collection is done using a device driver, and support is available as of Datadog agent version 7.27.1, for Windows versions 2012 and up.
+Data collection is done using a device driver, and support is available as of Datadog agent version 7.27.1, for Windows versions 2012 R2 and up.
 
 #### macOS
 


### PR DESCRIPTION
### What does this PR do?

Fixes the minimum required version of Windows for NPM.

### Motivation

Support case which installed NPM on Windows Server 2012 R1.

### Preview

https://docs-staging.datadoghq.com/bryce.kahle/fix-npm-windows-version/network_monitoring/performance/setup/#windows-os

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
