### PR TITLE
Fix DogStatsD Event header lengths.

### DIFF
--- a/content/en/developers/dogstatsd/datagram_shell.md
+++ b/content/en/developers/dogstatsd/datagram_shell.md
@@ -16,7 +16,7 @@ further_reading:
       text: 'DogStatsD source code'
 ---
 
-This section specifies the raw datagram format for metrics, events, and service checks that DogStatsD accepts. This isn't required reading if you're using any of [the DogStatsD client libraries][1]; however, if you want to write your own library, or use the shell to send metrics, then read on.
+This section specifies the raw datagram format for metrics, events, and service checks that DogStatsD accepts. The raw datagrams are encoded in UTF-8. This isn't required reading if you're using any of [the DogStatsD client libraries][1]; however, if you want to write your own library, or use the shell to send metrics, then read on.
 
 {{< tabs >}}
 {{% tab "Metrics" %}}
@@ -47,13 +47,15 @@ Here are some example datagrams:
 {{% /tab %}}
 {{% tab "Events" %}}
 
-`_e{<TITLE>.length,<TEXT>.length}:<TITLE>|<TEXT>|d:<TIMESTAMP>|h:<HOSTNAME>|p:<PRIORITY>|t:<ALERT_TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>`
+`_e{<TITLE_UTF8_LENGTH>,<TEXT_UTF8_LENGTH>}:<TITLE>|<TEXT>|d:<TIMESTAMP>|h:<HOSTNAME>|p:<PRIORITY>|t:<ALERT_TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>`
 
 | Parameter                            | Required | Description                                                                                                            |
 | ------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `_e`                                 | Yes      | The datagram must begin with `_e`.                                                                                     |
 | `<TITLE>`                            | Yes      | The event title.                                                                                                       |
 | `<TEXT>`                             | Yes      | The event text. Insert line breaks with: `\\n`.                                                                        |
+| `<TITLE_UTF8_LENGTH>`                | Yes      | The length of the UTF-8-encoded <TITLE>                                                                                |
+| `<TEXT_UTF8_LENGTH>`                 | Yes      | The length of the UTF-8-encoded <TEXT>                                                                                 |
 | `d:<TIMESTAMP>`                      | No       | Add a timestamp to the event. The default is the current Unix epoch timestamp.                                         |
 | `h:<HOSTNAME>`                       | No       | Add a hostname to the event. No default.                                                                               |
 | `k:<AGGREGATION_KEY>`                | No       | Add an aggregation key to group the event with others that have the same key. No default.                              |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR fixes the DogStatsD documentation about the Event header length for text and title.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
