### PR TITLE
[kubernetes control plane] Add additional sections about managed services

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -582,16 +582,21 @@ main:
     parent: agent_kubernetes
     identifier: agent_kubernetes_tag
     weight: 305
+  - name: Control plane monitoring
+    url: agent/kubernetes/control_plane/
+    parent: agent_kubernetes
+    identifier: agent_kubernetes_control_plane
+    weight: 306
   - name: Data collected
     url: agent/kubernetes/data_collected/
     parent: agent_kubernetes
     identifier: agent_kubernetes_data_collected
-    weight: 306
+    weight: 307
   - name: Operator configuration
     url: agent/kubernetes/operator_configuration
     parent: agent_kubernetes
     identifier: agent_kubernetes_operator_configuration
-    weight: 307
+    weight: 308
   - name: IoT
     url: agent/iot/
     parent: agent

--- a/content/en/agent/kubernetes/control_plane.md
+++ b/content/en/agent/kubernetes/control_plane.md
@@ -310,7 +310,7 @@ scheduler:
 
 ## Kubernetes on Amazon EKS {#EKS}
 
-On Elastic Kubernetes Service (EKS), AWS exposes API server metrics on a [single endpoint][5]. This allows the Datadog Agent to obtain API server metrics using endpoint checks as described in the [Kubernetes API server metrics check documentation][6]. To configure the check, add the following annotations to the `default/kubernetes` service:
+On Amazon Elastic Kubernetes Service (EKS), [API server metrics are exposed][5]. This allows the Datadog Agent to obtain API server metrics using endpoint checks as described in the [Kubernetes API server metrics check documentation][6]. To configure the check, add the following annotations to the `default/kubernetes` service:
 
 ```yaml
 annotations:
@@ -331,5 +331,5 @@ On other managed services, such as Azure Kubernetes Service (AKS) and Google Kub
 [2]: https://docs.datadoghq.com/integrations/etcd/?tab=containerized
 [3]: https://docs.datadoghq.com/integrations/kube_controller_manager/
 [4]: https://docs.datadoghq.com/integrations/kube_scheduler/
-[5]: https://aws.github.io/aws-eks-best-practices/reliability/docs/controlplane/#monitor-control-plane-metrics
+[5]: https://aws.github.io/aws-eks-best-practices/reliability/docs/controlplane.html#monitor-control-plane-metrics
 [6]: https://docs.datadoghq.com/integrations/kube_apiserver_metrics/

--- a/content/en/agent/kubernetes/control_plane.md
+++ b/content/en/agent/kubernetes/control_plane.md
@@ -26,7 +26,7 @@ further_reading:
 
 This section aims to document specificities and to provide good base configurations for monitoring the Kubernetes Control Plane. You can then customize these configurations to add any Datadog feature.
 
-With Datadog integrations for the [API Server][1], [ETCD][2], [Controller Manager][3], and [Scheduler][4], you can collect key metrics from all four components of the Kubernetes Control Plane.
+With Datadog integrations for the [API server][1], [Etcd][2], [Controller Manager][3], and [Scheduler][4], you can collect key metrics from all four components of the Kubernetes Control Plane.
 
 * [Kubernetes with Kubeadm](#Kubeadm)
 * [Kubernetes on Amazon EKS](#EKS)
@@ -36,13 +36,13 @@ With Datadog integrations for the [API Server][1], [ETCD][2], [Controller Manage
 
 The following configurations are tested on Kubernetes `v1.18+`.
 
-### API Server
+### API server
 
-The API Server integration is automatically configured. The Datadog Agent discovers it automatically.
+The API server integration is automatically configured. The Datadog Agent discovers it automatically.
 
-### ETCD
+### Etcd
 
-By providing read access to the ETCD certificates located on the host, the Datadog Agent check can communicate with ETCD and start collecting ETCD metrics.
+By providing read access to the Etcd certificates located on the host, the Datadog Agent check can communicate with Etcd and start collecting Etcd metrics.
 
 {{< tabs >}}
 {{% tab "Helm" %}}
@@ -308,9 +308,9 @@ scheduler:
     bind-address: 0.0.0.0
 ```
 
-## Kubernetes on Amazon Elastic Kubernetes Service {#EKS}
+## Kubernetes on Amazon EKS {#EKS}
 
-On EKS, AWS exposes API Server metrics via [a single endpoint][5]. This allows the Datadog Agent to obtain API Server metrics using endpoint checks as described in the [Kubernetes API Server metrics check documentation][6]. To conigure the check, add the following annotations to the `default/kubernetes` service:
+On Elastic Kubernetes Service (EKS), AWS exposes API server metrics on a [single endpoint][5]. This allows the Datadog Agent to obtain API server metrics using endpoint checks as described in the [Kubernetes API server metrics check documentation][6]. To configure the check, add the following annotations to the `default/kubernetes` service:
 
 ```yaml
 annotations:
@@ -322,9 +322,9 @@ annotations:
 
 Other control plane components are not exposed in EKS and cannot be monitored.
 
-## Kubernetes on Managed Services (Azure Kubernetes Service, Google Kubernetes Engine) {#ManagedServices}
+## Kubernetes on managed services (AKS, GKE) {#ManagedServices}
 
-On most Managed Services the user cannot access the control plane components. As a result, it is not possible to run the `kube_apiserver`, `kube_controller_manager`, `kube_scheduler`, and `etcd` checks in these environments.
+On other managed services, such as Azure Kubernetes Service (AKS) and Google Kubernetes Engine (GKE), the user cannot access the control plane components. As a result, it is not possible to run the `kube_apiserver`, `kube_controller_manager`, `kube_scheduler`, and `etcd` checks in these environments.
 
 
 [1]: https://docs.datadoghq.com/integrations/kube_apiserver_metrics/

--- a/content/en/agent/kubernetes/control_plane.md
+++ b/content/en/agent/kubernetes/control_plane.md
@@ -29,7 +29,7 @@ This section aims to document specificities and to provide good base configurati
 With Datadog integrations for the [API Server][1], [ETCD][2], [Controller Manager][3], and [Scheduler][4], you can collect key metrics from all four components of the Kubernetes Control Plane.
 
 * [Kubernetes with Kubeadm](#Kubeadm)
-* [Kubernetes on EKS](#EKS)
+* [Kubernetes on Amazon EKS](#EKS)
 * [Kubernetes on Managed Services (AKS, GKE)](#ManagedServices)
 
 ## Kubernetes with Kubeadm {#Kubeadm}
@@ -308,7 +308,7 @@ scheduler:
     bind-address: 0.0.0.0
 ```
 
-## Kubernetes on EKS {#EKS}
+## Kubernetes on Amazon Elastic Kubernetes Service {#EKS}
 
 On EKS, AWS exposes API Server metrics via [a single endpoint][5]. This allows the Datadog Agent to obtain API Server metrics using endpoint checks as described in the [Kubernetes API Server metrics check documentation][6]. To conigure the check, add the following annotations to the `default/kubernetes` service:
 
@@ -322,7 +322,7 @@ annotations:
 
 Other control plane components are not exposed in EKS and cannot be monitored.
 
-## Kubernetes on Managed Services (AKS, GKE) {#ManagedServices}
+## Kubernetes on Managed Services (Azure Kubernetes Service, Google Kubernetes Engine) {#ManagedServices}
 
 On most Managed Services the user cannot access the control plane components. As a result, it is not possible to run the `kube_apiserver`, `kube_controller_manager`, `kube_scheduler`, and `etcd` checks in these environments.
 

--- a/content/en/agent/kubernetes/control_plane.md
+++ b/content/en/agent/kubernetes/control_plane.md
@@ -29,6 +29,8 @@ This section aims to document specificities and to provide good base configurati
 With Datadog integrations for the [API Server][1], [ETCD][2], [Controller Manager][3], and [Scheduler][4], you can collect key metrics from all four components of the Kubernetes Control Plane.
 
 * [Kubernetes with Kubeadm](#Kubeadm)
+* [Kubernetes on EKS](#EKS)
+* [Kubernetes on Managed Services (AKS, GKE)](#ManagedServices)
 
 ## Kubernetes with Kubeadm {#Kubeadm}
 
@@ -306,7 +308,28 @@ scheduler:
     bind-address: 0.0.0.0
 ```
 
+## Kubernetes on EKS {#EKS}
+
+On EKS, AWS exposes API Server metrics via [a single endpoint][5]. This allows the Datadog Agent to obtain API Server metrics using endpoint checks as described in the [Kubernetes API Server metrics check documentation][6]. To conigure the check, add the following annotations to the `default/kubernetes` service:
+
+```yaml
+annotations:
+  ad.datadoghq.com/endpoints.check_names: '["kube_apiserver_metrics"]'
+  ad.datadoghq.com/endpoints.init_configs: '[{}]'
+  ad.datadoghq.com/endpoints.instances:
+    '[{ "prometheus_url": "https://%%host%%:%%port%%/metrics", "bearer_token_auth": "true" }]'
+```
+
+Other control plane components are not exposed in EKS and cannot be monitored.
+
+## Kubernetes on Managed Services (AKS, GKE) {#ManagedServices}
+
+On most Managed Services, the user cannot reliably access control plane components to monitor them. As a result, it is not possible to run the `kube_controller_manager`, `kube_scheduler`, `etcd`, and `kube_apiserver` checks on the Datadog Agent in these environments. 
+
+
 [1]: https://docs.datadoghq.com/integrations/kube_apiserver_metrics/
 [2]: https://docs.datadoghq.com/integrations/etcd/?tab=containerized
 [3]: https://docs.datadoghq.com/integrations/kube_controller_manager/
 [4]: https://docs.datadoghq.com/integrations/kube_scheduler/
+[5]: https://aws.github.io/aws-eks-best-practices/reliability/docs/controlplane/#monitor-control-plane-metrics
+[6]: https://docs.datadoghq.com/integrations/kube_apiserver_metrics/

--- a/content/en/agent/kubernetes/control_plane.md
+++ b/content/en/agent/kubernetes/control_plane.md
@@ -324,7 +324,7 @@ Other control plane components are not exposed in EKS and cannot be monitored.
 
 ## Kubernetes on Managed Services (AKS, GKE) {#ManagedServices}
 
-On most Managed Services, the user cannot reliably access control plane components to monitor them. As a result, it is not possible to run the `kube_controller_manager`, `kube_scheduler`, `etcd`, and `kube_apiserver` checks on the Datadog Agent in these environments. 
+On most Managed Services the user cannot access the control plane components. As a result, it is not possible to run the `kube_apiserver`, `kube_controller_manager`, `kube_scheduler`, and `etcd` checks in these environments.
 
 
 [1]: https://docs.datadoghq.com/integrations/kube_apiserver_metrics/


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add additional sections to Kubernetes Control Plane monitoring docs regarding EKS and other Managed Services

### Motivation
Better user information

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/celene/k8s_control_plane/agent/kubernetes/control_plane

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
