### PR TITLE
Added note to not use reserved tags as host level tags

### DIFF
--- a/content/en/tracing/guide/setting_primary_tags_to_scope.md
+++ b/content/en/tracing/guide/setting_primary_tags_to_scope.md
@@ -76,11 +76,13 @@ Note:
 
 * Only organization administrators have access to this page.
 * Changes may take up to two hours to be reflected in the UI.
+* There are some tags that the tracer always adds to spans: `resource`, `name`, and `service`. To avoid potentially confusing UI behavior never add these as host level tags. 
 
 If you change a previously set primary tag, be aware of the following:
 
 * Historical APM data aggregated by the previously set tag is no longer accessible.
 * Any APM monitors scoped to the previous tag display a status of _No Data_.
+
 
 ### Data by primary tag
 

--- a/content/en/tracing/guide/setting_primary_tags_to_scope.md
+++ b/content/en/tracing/guide/setting_primary_tags_to_scope.md
@@ -76,7 +76,7 @@ Note:
 
 * Only organization administrators have access to this page.
 * Changes may take up to two hours to be reflected in the UI.
-* There are some tags that the tracer always adds to spans: `resource`, `name`, and `service`. To avoid potentially confusing UI behavior never add these as host level tags. 
+* The tracer always adds `resource`, `name`, and `service` tags to spans. Datadog recommends never adding these as host level tags to avoid confusion.
 
 If you change a previously set primary tag, be aware of the following:
 


### PR DESCRIPTION
### What does this PR do?
Added note to not use reserved tags as host level tags

### Motivation
A customer was adding resource as a host level tag which led to difficult to troubleshoot UI behavior. 


### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
