### PR TITLE
Add Agent ECS-Anywhere support doc

### DIFF
--- a/content/en/agent/amazon_ecs/_index.md
+++ b/content/en/agent/amazon_ecs/_index.md
@@ -66,7 +66,13 @@ Configure the task using either the [AWS CLI tools][12] or using the Amazon Web 
 
 1. For Linux containers, download [datadog-agent-ecs.json][1] ([datadog-agent-ecs1.json][2] if you are using an original Amazon Linux 1 AMI). For Windows, download [datadog-agent-ecs-win.json][3].
 2. Edit `datadog-agent-ecs.json` and set `<YOUR_DATADOG_API_KEY>` with the [Datadog API key][4] for your account.
-3. Optionally - Add an Agent health check.
+3. Optionally - Add the following to you ECS task definition to deploy on an ["ECS-Anywhere" cluster][5].
+
+    ```json
+    "requiresCompatibilities": ["EXTERNAL"]
+    ```
+
+4. Optionally - Add an Agent health check.
 
     Add the following to your ECS task definition to create an Agent health check:
 
@@ -80,12 +86,12 @@ Configure the task using either the [AWS CLI tools][12] or using the Amazon Web 
     }
     ```
 
-4. Optionally - If you are in Datadog EU site, edit `datadog-agent-ecs.json` and set `DD_SITE` to `DD_SITE:datadoghq.eu`.
-5. Optionally - See [log collection][5] to activate log collection.
-6. Optionally - See [process collection](#process-collection) to activate process collection.
-7. Optionally - See [trace collection (APM)][6] to activate trace collection.
-8. Optionally - See [network performance monitoring (NPM)](#network-performance-monitoring-collection) to activate network collection
-9. Execute the following command:
+5. Optionally - If you are in Datadog EU site, edit `datadog-agent-ecs.json` and set `DD_SITE` to `DD_SITE:datadoghq.eu`.
+6. Optionally - See [log collection][6] to activate log collection.
+7. Optionally - See [process collection](#process-collection) to activate process collection.
+8. Optionally - See [trace collection (APM)][7] to activate trace collection.
+9. Optionally - See [network performance monitoring (NPM)](#network-performance-monitoring-collection) to activate network collection
+10. Execute the following command:
 
 ```bash
 aws ecs register-task-definition --cli-input-json <path to datadog-agent-ecs.json>
@@ -95,14 +101,16 @@ aws ecs register-task-definition --cli-input-json <path to datadog-agent-ecs.jso
 [2]: /resources/json/datadog-agent-ecs1.json
 [3]: /resources/json/datadog-agent-ecs-win.json
 [4]: https://app.datadoghq.com/account/settings#api
-[5]: /agent/amazon_ecs/logs/
-[6]: /agent/amazon_ecs/apm/
+[5]: https://www.datadoghq.com/blog/amazon-ecs-anywhere-monitoring/
+[6]: /agent/amazon_ecs/logs/
+[7]: /agent/amazon_ecs/apm/
 {{% /tab %}}
 {{% tab "Web UI" %}}
 
 1. Log in to your AWS Console and navigate to the EC2 Container Service section.
 2. Click on the cluster you wish to add Datadog to.
 3. Click on **Task Definitions** on the left side and click the button **Create new Task Definition**.
+   Select "External" on the launch type step if you plan to deploy the agent task on an "ECS-Anywhere" cluster.
 4. Enter a **Task Definition Name**, such as `datadog-agent-task`.
 5. Click on the **Add volume** link.
 6. For **Name** enter `docker_sock`. For **Source Path**, enter `/var/run/docker.sock` on Linux or `\\.\pipe\docker_engine` on Windows. Click **Add**.

--- a/content/en/agent/amazon_ecs/_index.md
+++ b/content/en/agent/amazon_ecs/_index.md
@@ -66,7 +66,7 @@ Configure the task using either the [AWS CLI tools][12] or using the Amazon Web 
 
 1. For Linux containers, download [datadog-agent-ecs.json][1] ([datadog-agent-ecs1.json][2] if you are using an original Amazon Linux 1 AMI). For Windows, download [datadog-agent-ecs-win.json][3].
 2. Edit `datadog-agent-ecs.json` and set `<YOUR_DATADOG_API_KEY>` with the [Datadog API key][4] for your account.
-3. Optionally - Add the following to you ECS task definition to deploy on an ["ECS-Anywhere" cluster][5].
+3. Optionally - Add the following to your ECS task definition to deploy on an [ECS Anywhere cluster][5].
 
     ```json
     "requiresCompatibilities": ["EXTERNAL"]
@@ -110,7 +110,7 @@ aws ecs register-task-definition --cli-input-json <path to datadog-agent-ecs.jso
 1. Log in to your AWS Console and navigate to the EC2 Container Service section.
 2. Click on the cluster you wish to add Datadog to.
 3. Click on **Task Definitions** on the left side and click the button **Create new Task Definition**.
-   Select "External" on the launch type step if you plan to deploy the agent task on an "ECS-Anywhere" cluster.
+   Select "External" on the launch type step if you plan to deploy the agent task on an ECS Anywhere cluster.
 4. Enter a **Task Definition Name**, such as `datadog-agent-task`.
 5. Click on the **Add volume** link.
 6. For **Name** enter `docker_sock`. For **Source Path**, enter `/var/run/docker.sock` on Linux or `\\.\pipe\docker_engine` on Windows. Click **Add**.


### PR DESCRIPTION
### What does this PR do?

Add Agent ECS-Anywhere support doc, the information are extracted from the https://www.datadoghq.com/blog/amazon-ecs-anywhere-monitoring/ blogpost.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/clamoriniere/aws-ecs-anywhere/agent/amazon_ecs/?tab=awscli

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
