### PR TITLE
Fixed incorrect API usage in Python tracer logging docs.

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/python.md
+++ b/content/en/tracing/connect_logs_and_traces/python.md
@@ -61,8 +61,8 @@ hello()
 If you are not using the standard library `logging` module, you can use the following code snippet to inject tracer information into your logs:
 
 ```python
-span = tracer.get_current_span()
-correlation_ids = (span.trace_id, span.span.id)
+span = tracer.current_span()
+correlation_ids = (span.trace_id, span.span.id) if span else (None, None)
 ```
 As an illustration of this approach, the following example defines a function as a *processor* in `structlog` to add tracer fields to the log output:
 

--- a/content/en/tracing/connect_logs_and_traces/python.md
+++ b/content/en/tracing/connect_logs_and_traces/python.md
@@ -74,8 +74,8 @@ import structlog
 
 def tracer_injection(logger, log_method, event_dict):
     # get correlation ids from current tracer context
-    span = tracer.get_current_span()
-    trace_id, span_id = (span.trace_id, span.span.id)
+    span = tracer.current_span()
+    trace_id, span_id = (span.trace_id, span.span.id) if span else (None, None)
 
     # add ids to structlog event dictionary
     event_dict['dd.trace_id'] = str(trace_id or 0)


### PR DESCRIPTION
### What does this PR do?
This fixes #10944 which introduced an incorrect API usage in the Python tracer logging docs.

### Motivation
#10944 introduced an incorrect API reference to `tracer.get_current_span()` which has now been corrected to `tracer.current_span()`.

### Preview
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/yunkim/python-logs-and-traces-fix/tracing/connect_logs_and_traces/python/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
