### PR TITLE
[RUM] document `actionNameAttribute` usage

### DIFF
--- a/content/en/real_user_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/browser/tracking_user_actions.md
@@ -20,7 +20,7 @@ further_reading:
 ---
 
 
-Real User Monitoring (RUM) Browser SDK automatically detects user interactions performed during a user journey. 
+Real User Monitoring (RUM) Browser SDK automatically detects user interactions performed during a user journey.
 
 The automatic collection of user actions provides insights into user behavior, without having to manually instrument every single click in your application. It helps you achieve the following objectives:
 * Understand the performance of key interactions (for example, a click on the "Add to cart" button)
@@ -75,6 +75,22 @@ The RUM library uses various strategies to get a name for click actions. If you 
   Enter a valid email address
 </div>
 ```
+
+Starting with [version 2.16.0][3], with the `actionNameAttribute` initialization parameter, you can specify your own attribute that will be used to name the action. For example:
+
+```html
+<script>
+  DD_RUM.init({
+    ...
+    trackInteractions: true,
+    actionNameAttribute: 'data-custom-name',
+  ...
+  })
+</script>
+
+<a class="btn btn-default" href="#" role="button" data-custom-name="Login button">Try it out!</a>
+```
+
 ## Custom actions
 
 Custom actions are user actions declared and sent manually by using the `addAction` API. They are used to send information relative to an event occurring during a user journey. In the following example, the RUM SDK collects a visitor's cart data when they hit the checkout button. The number of items within the cart, the list of items, and how much the cart is worth overall are collected.
@@ -145,3 +161,4 @@ window.DD_RUM &&
 
 [1]: /real_user_monitoring/browser/modifying_data_and_context/
 [2]: /real_user_monitoring/browser/data_collected/#default-attributes
+[3]: https://github.com/DataDog/browser-sdk/blob/main/CHANGELOG.md#v2160

--- a/content/en/real_user_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/browser/tracking_user_actions.md
@@ -76,7 +76,7 @@ The RUM library uses various strategies to get a name for click actions. If you 
 </div>
 ```
 
-Starting with [version 2.16.0][3], with the `actionNameAttribute` initialization parameter, you can specify your own attribute that will be used to name the action. For example:
+Starting with [version 2.16.0][3], with the `actionNameAttribute` initialization parameter, you can specify your own attribute that is used to name the action. For example:
 
 ```html
 <script>

--- a/content/en/real_user_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/browser/tracking_user_actions.md
@@ -91,6 +91,8 @@ Starting with [version 2.16.0][3], with the `actionNameAttribute` initialization
 <a class="btn btn-default" href="#" role="button" data-custom-name="Login button">Try it out!</a>
 ```
 
+**Note**: `data-dd-action-name` is favored when both attributes are present on an element.
+
 ## Custom actions
 
 Custom actions are user actions declared and sent manually by using the `addAction` API. They are used to send information relative to an event occurring during a user journey. In the following example, the RUM SDK collects a visitor's cart data when they hit the checkout button. The number of items within the cart, the list of items, and how much the cart is worth overall are collected.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

document `actionNameAttribute` usage
cf [feature](https://github.com/DataDog/browser-sdk/pull/919), [doc initialization parameter](https://github.com/DataDog/browser-sdk/pull/923)

### Motivation

help customer discover this new capability

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bcaudan/custom-action-attribute/real_user_monitoring/browser/tracking_user_actions/?tab=npm#declaring-a-name-for-click-actions



---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
