### PR TITLE
Add instructions to enable the Allocation Profiler

### DIFF
--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -46,6 +46,21 @@ To use the comprehensive configuration ensure you have `dd-trace-java` version `
 java -javaagent:dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.profiling.jfr-template-override-file=comprehensive -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
 ```
 
+## Enabling the allocation profiler
+
+The allocation profiler is turned off by default because it can overwhelm the profiler in allocation-heavy applications.
+
+To enable the allocation profiler, start your application with the `-Ddd.profiling.allocation.enabled=true` JVM setting or the `DD_PROFILING_ALLOCATION_ENABLED=true` environment variable.
+
+Alternatively, you can enable the following events in your `jfp` [override template file](#creating-and-using-a-jfr-template-override-file):
+
+```
+jdk.ObjectAllocationInNewTLAB#enabled=true
+jdk.ObjectAllocationOutsideTLAB#enabled=true
+```
+
+[Learn how to use override templates.](#creating-and-using-a-jfr-template-override-file)
+
 ## Removing sensitive information from profiles
 
 If your system properties contain sensitive information such as user names or passwords, turn off the system property event by creating a `jfp` [override template file](#creating-and-using-a-jfr-template-override-file) with `jdk.InitialSystemProperty` disabled:
@@ -58,19 +73,18 @@ jdk.InitialSystemProperty#enabled=false
 
 ## Large allocation events overwhelming the profiler
 
-To turn off allocation profiling, disable the following events in your `jfp` [override template file](#large-allocation-events-overwhelming-the-profiler):
+To turn off allocation profiling, disable the following events in your `jfp` [override template file](#creating-and-using-a-jfr-template-override-file):
 
 ```
 jdk.ObjectAllocationInNewTLAB#enabled=false
 jdk.ObjectAllocationOutsideTLAB#enabled=false
-jdk.OldObjectSample#enabled=false
 ```
 
 [Learn how to use override templates.](#creating-and-using-a-jfr-template-override-file)
 
 ## Memory leak detection slowing down garbage collector
 
-To turn off memory leak detection, disable the following event in your `jfp` [override template file](#large-allocation-events-overwhelming-the-profiler):
+To turn off memory leak detection, disable the following event in your `jfp` [override template file](#creating-and-using-a-jfr-template-override-file):
 
 ```
 jdk.OldObjectSample#enabled=false


### PR DESCRIPTION
Because the allocation profiler can overwhelm the profiler in
allocation-heavy applications. To guarantee an optimal experience, we
want to make it opt-in.

We are adding a message in the web ui pointing to this section of the
documentation.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add documentation section on enabling the Allocation Profiler.

### Motivation
<!-- What inspired you to submit this pull request?-->

We are making the Allocation Profiler opt-in in the Java Profiler.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
