### PR TITLE
Clarify .NET client settings vs agent settings

### DIFF
--- a/content/en/tracing/setup_overview/custom_instrumentation/dotnet.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/dotnet.md
@@ -75,7 +75,7 @@ public class ShoppingCartController : Controller
 
 ### Adding tags globally to all spans
 
-Use the `DD_TAGS` environment variable (at the agent level) to set tags across all generated spans for an application. This can be useful for grouping stats for your applications, data centers, regions, etc. within the Datadog UI. For example:
+Use the `DD_TAGS` environment variable (at the Agent level) to set tags across all generated spans for an application. This can be useful for grouping stats for your applications, data centers, regions, etc. within the Datadog UI. For example:
 
 ```ini
 DD_TAGS=datacenter:njc,key2:value2

--- a/content/en/tracing/setup_overview/custom_instrumentation/dotnet.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/dotnet.md
@@ -75,7 +75,7 @@ public class ShoppingCartController : Controller
 
 ### Adding tags globally to all spans
 
-Use the `DD_TAGS` environment variable to set tags across all generated spans for an application. This can be useful for grouping stats for your applications, data centers, regions, etc. within the Datadog UI. For example:
+Use the `DD_TAGS` environment variable (at the agent level) to set tags across all generated spans for an application. This can be useful for grouping stats for your applications, data centers, regions, etc. within the Datadog UI. For example:
 
 ```ini
 DD_TAGS=datacenter:njc,key2:value2


### PR DESCRIPTION
The line in question (in fact across all client library documentation) is nebulous. The way this is worded makes it seem like `DD_TAGS` is a client level parameter rather than configured at the agent level

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
