### PR TITLE
DOCS-2099 Update retention and analytics info around intelligent retention filters

### DIFF
--- a/content/en/tracing/trace_retention_and_ingestion/_index.md
+++ b/content/en/tracing/trace_retention_and_ingestion/_index.md
@@ -53,12 +53,14 @@ For more information, refer to the [Usage Metrics][1] documentation, or see the 
 
 Intelligent retention is always active for your services, and it keeps a proportion of traces to help you monitor the health of your applications. All [top level spans][4] are indexed for the traces kept by the intelligent retention filter.
 
-Intelligent Retention retains:
+For 30 days, intelligent retention retains:
 
  - A representative selection of errors, ensuring error diversity (for example, response code 400s, 500s).
  - High Latency in the different quartiles `p75`, `p90`, `p95`.
  - All Resources with any traffic will have associated Traces in the past for any time window selection.
  - True maximum duration trace for each time window.
+
+**Note**: Because intelligent retention is not indiscriminate when choosing what spans to retain, spans that are retained only by the intelligent filter are _not_ included in trace analytics. Trace analytics is available only for spans retained by [custom retention filters](#create-your-own-retention-filter).
 
 If there are specific tags, facets, or groups of traces that you want to investigate _in detail_, meaning you want to retain more than what Intelligent Retention retains, then [create your own retention filter](#create-your-own-retention-filter). For example, you might want to keep more than a representative selection of errors from your production environment. To ensure _all_ production errors are retained and available for search and analytics for 15 days, create a 100 percent retention filter scoped to `env:prod` and `status:error`. As discussed below, this may have an impact on your bill.
 

--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -19,9 +19,11 @@ The Datadog app shows a **Live** indicator next to the time selector whenever yo
 
 {{< img src="tracing/live_search/LiveSearch.png" alt="Live Search Indicator" >}}
 
-All ingested traces are passed through custom [retention filters][3] that you can create to determine which spans to index, along with the default [intelligent retention filter][4] that retains a diverse set of traces.
+All ingested traces are passed through [custom retention filters][3] that you can create to determine which spans to index, along with the default [intelligent retention filter][4] that retains a diverse set of traces.
 
-Once indexed, traces are available for use in Search and Analytics, and they are retained for 15 days.
+Once indexed through a custom retention filter, traces are available for use in Search and Analytics, and they are retained for 15 days.
+
+When indexed through the intelligent retention filter, traces are available for use in Search (not Analytics, unless a custom filter has also retained them), and they are retained for 30 days.
 
 The Datadog app shows a 'Retained traces' indicator beside the time selector whenever you search [indexed spans][5]:
 
@@ -129,7 +131,7 @@ Retained Analytics is available from the same page as Live Analytics.  To switch
 
 {{< img src="tracing/live_search/HistoricalAnalytics2.gif" alt="Historical Analytics" >}}
 
-All spans indexed by retention filters or legacy App Analytics filters are available to be searched when using trace analytics. These spans are kept by Datadog for 15 days after being indexed by a retention filter.
+All spans indexed by _custom_ retention filters (not the intelligent retention filter) or legacy App Analytics filters are available to be searched when using trace analytics. These spans are kept by Datadog for 15 days after being indexed by a retention filter.
 
 **Note:** As of October 20, 2020 Tracing without Limits replaced App Analytics as a more flexible way to ingest 100% of your traces and retain the ones important to your business.
 

--- a/content/en/tracing/trace_search_and_analytics/_index.md
+++ b/content/en/tracing/trace_search_and_analytics/_index.md
@@ -23,7 +23,7 @@ All ingested traces are passed through [custom retention filters][3] that you ca
 
 Once indexed through a custom retention filter, traces are available for use in Search and Analytics, and they are retained for 15 days.
 
-When indexed through the intelligent retention filter, traces are available for use in Search (not Analytics, unless a custom filter has also retained them), and they are retained for 30 days.
+When indexed through the intelligent retention filter, traces are available for use in Search (not Analytics), and they are retained for 30 days.
 
 The Datadog app shows a 'Retained traces' indicator beside the time selector whenever you search [indexed spans][5]:
 
@@ -131,9 +131,7 @@ Retained Analytics is available from the same page as Live Analytics.  To switch
 
 {{< img src="tracing/live_search/HistoricalAnalytics2.gif" alt="Historical Analytics" >}}
 
-All spans indexed by _custom_ retention filters (not the intelligent retention filter) or legacy App Analytics filters are available to be searched when using trace analytics. These spans are kept by Datadog for 15 days after being indexed by a retention filter.
-
-**Note:** As of October 20, 2020 Tracing without Limits replaced App Analytics as a more flexible way to ingest 100% of your traces and retain the ones important to your business.
+All spans indexed by _custom_ retention filters (not the intelligent retention filter) are available to be searched when using trace analytics. These spans are kept by Datadog for 15 days after being indexed by a retention filter.
 
 You can customize what spans are retained and at what retention rates. By default, [Datadog Intelligent Retention][4] will be applied which automatically retains traces with error and latency diversity as well as low-throughput resources. To learn more about the default span retention filter and how to create your own additional filters, see the [Retention Filters][3] documentation. Go to the [Retention Filters][8] page within the Datadog app to create or modify your own filters.
 


### PR DESCRIPTION
### What does this PR do?

Makes explicit a couple points: spans retained by intelligent retention filters only aren't available for trace analytics, are retained for 30 days.

### Motivation

DOCS-2099

### Preview

https://docs-staging.datadoghq.com/kari/docs-2099-retention/tracing/trace_search_and_analytics/
https://docs-staging.datadoghq.com/kari/docs-2099-retention/tracing/trace_retention_and_ingestion/#datadog-intelligent-retention-filter

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
