### PR TITLE
Sending events and logs to Datadog with Amazon EventBridge API Destinations

### DIFF
--- a/content/en/logs/guide/_index.md
+++ b/content/en/logs/guide/_index.md
@@ -15,6 +15,7 @@ private: true
 
 {{< whatsnext desc="Log Collection" >}}
     {{< nextlink href="/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination/" >}}Send AWS services logs with the Datadog Kinesis Firehose Destination{{< /nextlink >}}
+    {{< nextlink href="/logs/guide/sending-events-and-logs-to-datadog-with-amazon-eventbridge-api-destinations/" >}}Sending Events and Logs to Datadog with Amazon EventBridge API Destinations{{< /nextlink >}}
     {{< nextlink href="/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/" >}}Send AWS services logs with the Datadog Lambda function{{< /nextlink >}}
     {{< nextlink href="logs/guide/collect-heroku-logs" >}}Collect Heroku Logs{{< /nextlink >}}
     {{< nextlink href="logs/guide/log-collection-troubleshooting-guide" >}}Log Collection Troubleshooting Guide{{< /nextlink >}}

--- a/content/en/logs/guide/sending-events-and-logs-to-datadog-with-amazon-eventbridge-api-destinations.md
+++ b/content/en/logs/guide/sending-events-and-logs-to-datadog-with-amazon-eventbridge-api-destinations.md
@@ -16,16 +16,16 @@ Before you begin, you need a [Datadog account][2], with [an API key][3], and you
 ### Configuration
 
 1. Follow the steps in the [Amazon Create an API destination docs][5] to add Datadog as an API destination.
-    - Use API key Authorization, with `DD-API-KEY` as your key name and your [Datadog API key][3] as the value.
-    - For your destination endpoint, input `https://http-intake.logs.datadoghq.com/v1/input` for logs or `https://api.datadoghq.com/api/v1/events` for events, and set `POST` as the HTTP method. For more information about the differences between logs and events, see the [logs section][6], and the [events section][7] of the [Categories of Data docs page][8].
+    - Use API key authorization, with `DD-API-KEY` as your key name and your [Datadog API key][3] as the value.
+    - For your destination endpoint, use `https://http-intake.logs.datadoghq.com/v1/input` for logs or `https://api.datadoghq.com/api/v1/events` for events, and set `POST` as the HTTP method. For more information about the differences between logs and events, see the [logs section][6], and the [events section][7] of the [Categories of Data docs page][8].
 2. Once you've set up the destination, you can now follow the Amazon instructions to [create an EventBridge rule][9], where you set Datadog as your destination.
-3. Once you've set up the rule with Datadog as the destination, trigger an event by posting an event to EventBridge. For more information about pushing events to EventBridge from Datadog, see the [EventBridge integration docs][1]. For example, to trigger a test event by [uploading the objects to an S3 bucket][10] in your account, use this AWS CloudShell cmd:
+3. Once you've set up the rule with Datadog as the destination, trigger an event by posting an event to EventBridge. For more information about pushing events to EventBridge from Datadog, see the [EventBridge integration docs][1]. For example, to trigger a test event by [uploading the objects to an S3 bucket][10] in your account, use this AWS CloudShell command:
 
     ```bash
     echo "test" > testfile.txt
     aws s3 cp testfile.txt s3://YOUR_BUCKET_NAME
     ```
-4. Once events and logs are sending, after about five minutes, you start seeing the data in the Datadog [logs console][11] or [events stream][12], depending on which endpoint you are sending them.
+4. Once events and logs are sending, after about five minutes, the data is available in the Datadog [logs console][11] or [events stream][12], depending on which endpoint you are sending them to.
 
 ## Further Reading
 

--- a/content/en/logs/guide/sending-events-and-logs-to-datadog-with-amazon-eventbridge-api-destinations.md
+++ b/content/en/logs/guide/sending-events-and-logs-to-datadog-with-amazon-eventbridge-api-destinations.md
@@ -1,5 +1,5 @@
 ---
-title: Sending events and logs to Datadog with Amazon EventBridge API Destinations
+title: Sending Events and Logs to Datadog with Amazon EventBridge API Destinations
 kind: guide
 further_reading:
 - link: "https://aws.amazon.com/blogs/compute/using-api-destinations-with-amazon-eventbridge/#sending-aws-events-to-datadog"
@@ -16,7 +16,7 @@ Before you begin, you need a [Datadog account][1], with [an API key][2], and you
 ### Configuration
 
 1. Follow the steps in the [Amazon Create an API destination docs][4] to add Datadog as an API destination.
-    - Use API key Authorization, with `DD-API-KEY` as your key name and your Datadog API key as the value.
+    - Use API key Authorization, with `DD-API-KEY` as your key name and your [Datadog API key][2] as the value.
     - For your destination endpoint, input `https://http-intake.logs.datadoghq.com/v1/input` for logs or `https://api.datadoghq.com/api/v1/events` for events, and set `POST` as the HTTP method. For more information about the differences between logs and events, see the [logs section][5], and the [events section][6] of the [Categories of Data docs page][7].
 2. Once you've set up the destination, you can now follow the Amazon instructions to [create an EventBridge rule][8], where you set Datadog as your destination.
 3. Once you've set up the rule with Datadog as the destination, [upload the objects to an S3 bucket][9] in your account to trigger an event. To trigger a test event, use this AWS CloudShell cmd:

--- a/content/en/logs/guide/sending-events-and-logs-to-datadog-with-amazon-eventbridge-api-destinations.md
+++ b/content/en/logs/guide/sending-events-and-logs-to-datadog-with-amazon-eventbridge-api-destinations.md
@@ -7,39 +7,40 @@ further_reading:
   text: "AWS Blog with example API destination use cases"
 ---
 
-Amazon EventBridge is a serverless event bus that enables you to build event-driven applications. EventBridge can integrate with your AWS services, but the API destinations feature lets you push and pull data from outside of AWS using APIs. This guide gives steps for sending your events and logs from EventBridge to Datadog. You can configure EventBridge to send events or logs.
+Amazon EventBridge is a serverless event bus that enables you to build event-driven applications. EventBridge can integrate with your AWS services, but the API destinations feature lets you push and pull data from outside of AWS using APIs. This guide gives steps for sending your events and logs from EventBridge to Datadog. For more information about pushing your events from Datadog to EventBridge, [see the EventBridge integration docs][1].
 
 ## Setup
 
-Before you begin, you need a [Datadog account][1], with [an API key][2], and you need access to [Amazon Eventbridge API destinations][3].
+Before you begin, you need a [Datadog account][2], with [an API key][3], and you need access to [Amazon Eventbridge API destinations][4].
 
 ### Configuration
 
-1. Follow the steps in the [Amazon Create an API destination docs][4] to add Datadog as an API destination.
-    - Use API key Authorization, with `DD-API-KEY` as your key name and your [Datadog API key][2] as the value.
-    - For your destination endpoint, input `https://http-intake.logs.datadoghq.com/v1/input` for logs or `https://api.datadoghq.com/api/v1/events` for events, and set `POST` as the HTTP method. For more information about the differences between logs and events, see the [logs section][5], and the [events section][6] of the [Categories of Data docs page][7].
-2. Once you've set up the destination, you can now follow the Amazon instructions to [create an EventBridge rule][8], where you set Datadog as your destination.
-3. Once you've set up the rule with Datadog as the destination, [upload the objects to an S3 bucket][9] in your account to trigger an event. To trigger a test event, use this AWS CloudShell cmd:
+1. Follow the steps in the [Amazon Create an API destination docs][5] to add Datadog as an API destination.
+    - Use API key Authorization, with `DD-API-KEY` as your key name and your [Datadog API key][3] as the value.
+    - For your destination endpoint, input `https://http-intake.logs.datadoghq.com/v1/input` for logs or `https://api.datadoghq.com/api/v1/events` for events, and set `POST` as the HTTP method. For more information about the differences between logs and events, see the [logs section][6], and the [events section][7] of the [Categories of Data docs page][8].
+2. Once you've set up the destination, you can now follow the Amazon instructions to [create an EventBridge rule][9], where you set Datadog as your destination.
+3. Once you've set up the rule with Datadog as the destination, trigger an event by posting an event to EventBridge. For more information about pushing events to EventBridge from Datadog, see the [EventBridge integration docs][1]. For example, to trigger a test event by [uploading the objects to an S3 bucket][10] in your account, use this AWS CloudShell cmd:
 
     ```bash
     echo "test" > testfile.txt
     aws s3 cp testfile.txt s3://YOUR_BUCKET_NAME
     ```
-4. Once events and logs are sending, after about five minutes, you will start seeing the data in the Datadog [logs console][10] or [events stream][11], depending on which endpoint you are sending them.
+4. Once events and logs are sending, after about five minutes, you start seeing the data in the Datadog [logs console][11] or [events stream][12], depending on which endpoint you are sending them.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: https://www.datadoghq.com/free-datadog-trial/
-[2]: /account_management/api-app-keys/#api-keys
-[3]: https://aws.amazon.com/eventbridge/
-[4]: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-api-destinations.html#eb-api-destination-create
-[5]: /security/#logs
-[6]: /security/#events-and-comments
-[7]: /security/
-[8]: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rules.html
-[9]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html
-[10]: https://app.datadoghq.com/logs
-[11]: https://app.datadoghq.com/event/stream
+[1]: /integrations/amazon_event_bridge/
+[2]: https://www.datadoghq.com/free-datadog-trial/
+[3]: /account_management/api-app-keys/#api-keys
+[4]: https://aws.amazon.com/eventbridge/
+[5]: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-api-destinations.html#eb-api-destination-create
+[6]: /security/#logs
+[7]: /security/#events-and-comments
+[8]: /security/
+[9]: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rules.html
+[10]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html
+[11]: https://app.datadoghq.com/logs
+[12]: https://app.datadoghq.com/event/stream

--- a/content/en/logs/guide/sending-events-and-logs-to-datadog-with-amazon-eventbridge-api-destinations.md
+++ b/content/en/logs/guide/sending-events-and-logs-to-datadog-with-amazon-eventbridge-api-destinations.md
@@ -1,0 +1,45 @@
+---
+title: Sending events and logs to Datadog with Amazon EventBridge API Destinations
+kind: guide
+further_reading:
+- link: "https://aws.amazon.com/blogs/compute/using-api-destinations-with-amazon-eventbridge/#sending-aws-events-to-datadog"
+  tag: "Blog"
+  text: "AWS Blog with example API destination use cases"
+---
+
+Amazon EventBridge is a serverless event bus that enables you to build event-driven applications. EventBridge can integrate with your AWS services, but the API destinations feature lets you push and pull data from outside of AWS using APIs. This guide gives steps for sending your events and logs from EventBridge to Datadog. You can configure EventBridge to send events or logs.
+
+## Setup
+
+Before you begin, you need a [Datadog account][1], with [an API key][2], and you need access to [Amazon Eventbridge API destinations][3].
+
+### Configuration
+
+1. Follow the steps in the [Amazon Create an API destination docs][4] to add Datadog as an API destination.
+    - Use API key Authorization, with `DD-API-KEY` as your key name and your Datadog API key as the value.
+    - For your destination endpoint, input `https://http-intake.logs.datadoghq.com/v1/input` for logs or `https://api.datadoghq.com/api/v1/events` for events, and set `POST` as the HTTP method. For more information about the differences between logs and events, see the [logs section][5], and the [events section][6] of the [Categories of Data docs page][7].
+2. Once you've set up the destination, you can now follow the Amazon instructions to [create an EventBridge rule][8], where you set Datadog as your destination.
+3. Once you've set up the rule with Datadog as the destination, [upload the objects to an S3 bucket][9] in your account to trigger an event. To trigger a test event, use this AWS CloudShell cmd:
+
+    ```bash
+    echo "test" > testfile.txt
+    aws s3 cp testfile.txt s3://YOUR_BUCKET_NAME
+    ```
+4. Once events and logs are sending, after about five minutes, you will start seeing the data in the Datadog [logs console][10] or [events stream][11], depending on which endpoint you are sending them.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+
+[1]: https://www.datadoghq.com/free-datadog-trial/
+[2]: /account_management/api-app-keys/#api-keys
+[3]: https://aws.amazon.com/eventbridge/
+[4]: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-api-destinations.html#eb-api-destination-create
+[5]: /security/#logs
+[6]: /security/#events-and-comments
+[7]: /security/
+[8]: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rules.html
+[9]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html
+[10]: https://app.datadoghq.com/logs
+[11]: https://app.datadoghq.com/event/stream


### PR DESCRIPTION
## What does this PR do?
Adds a guide around the new(ish) Datadog support in Eventbridge destinations

https://docs-staging.datadoghq.com/kaylyn/eventbridge/logs/guide/sending-events-and-logs-to-datadog-with-amazon-eventbridge-api-destinations/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
