### PR TITLE
Fix Composite Monitor examples

### DIFF
--- a/content/en/monitors/monitor_types/composite.md
+++ b/content/en/monitors/monitor_types/composite.md
@@ -104,11 +104,11 @@ Datadog computes `A && B && C` in the way you would expect, but which monitor st
 | `Ok`      | False                |1 (Least severe)   |
 | `Skipped` | False                |1                  |
 
-The Boolean operators used (`&&`, `||`, `!`) operate on the alert-worthiness of the composite monitor status. 
+The Boolean operators used (`&&`, `||`, `!`) operate on the alert-worthiness of the composite monitor status.
 
-If `A && B` is alert-worthy, the result is the **least** severe status between A and B. 
+If `A && B` is alert-worthy, the result is the **least** severe status between A and B.
 
-If `A || B` is alert-worthy, the result is the **most** severe status between A and B. 
+If `A || B` is alert-worthy, the result is the **most** severe status between A and B.
 
 
 If `A` is `No Data`, `!A` is `No Data`
@@ -123,11 +123,17 @@ Consider a composite monitor that uses three individual monitors (`A`, `B`, `C`)
 | Monitor A   | Monitor B   | Monitor C   | Composite status | Alert triggered? |
 |-------------|-------------|-------------|------------------|------------------|
 | Unknown (T) | Warn (T)    | Unknown (T) | Warn (T)         | {{< X >}}        |
-| Skipped (F) | Ok (F)      | Unknown (T) | Ok (F)           |                  |
-| Alert (T)   | Warn (T)    | Unknown (T) | Alert (T)        | {{< X >}}        |
-| Skipped (F) | No Data (F) | Unknown (T) | Skipped (F)      |                  |
+| Alert (T)   | Warn (T)    | Unknown (T) | Warn (T)         | {{< X >}}        |
+| OK (F)      | No Data (T) | Alert (T)   | OK (F)           |                  |
 
-Two of the four scenarios trigger an alert, even though not all of the individual monitors have the most severe status (`Alert`).
+Now consider a composite monitor that uses two individual monitors (`A`, `B`) and a trigger condition `A || B`. The following table shows the resulting status of the composite monitor given different statuses for its individual monitors (alert-worthiness is indicated with T or F):
+
+| Monitor A   | Monitor B   | Composite status                               | Alert triggered? |
+|-------------|-------------|------------------------------------------------|------------------|
+| Alert (T)   | Warn (T)    | Alert (T)                                      | {{< X >}}        |
+| Warn (T)    | Ok (F)      | Warn (T)                                       | {{< X >}}        |
+| OK (F)      | No Data (T) | No Data (T) _(if Notify No Data is enabled)_   | {{< X >}}        |
+| OK (F)      | No Data (F) | OK (F)      _(if Notify No Data is disabled)_  |                  |
 
 ### Number of alerts
 

--- a/content/en/monitors/monitor_types/composite.md
+++ b/content/en/monitors/monitor_types/composite.md
@@ -149,7 +149,7 @@ Here's an example cycle for the composite monitor `A && B && C`:
 
 | Source | Monitor A | Monitor B | Monitor C | Composite status | Alert triggered? |
 |--------|-----------|-----------|-----------|------------------|------------------|
-| web04  | Unknown   | Warn      | Alert     | Alert            | {{< X >}}        |
+| web04  | Unknown   | Warn      | Alert     | Warn             | {{< X >}}        |
 | web05  | Ok        | Ok        | Alert     | Ok               |                  |
 
 ### Common reporting sources


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixing some erroneous examples of Composite Monitor behavior. 

### Motivation
Misleading for users as the composite behavior just changed.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/antoine.dussault/composite_monitor_new/monitors/monitor_types/composite/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
