### PR TITLE
[WEB-1478] Improves Docsearch results for RBAC page

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,6 +193,7 @@ index_algolia_preview:
     <<: *cache
     policy: pull
   environment: "preview"
+  timeout: 1h 30m
   script:
     - |-
         echo APPLICATION_ID=$(get_secret 'ci.documentation.algolia_docsearch_application_id') > .env
@@ -318,6 +319,7 @@ index_algolia:
     <<: *cache
     policy: pull
   environment: "live"
+  timeout: 1h 30m
   script:
     - |-
       echo APPLICATION_ID=$(get_secret 'ci.documentation.algolia_docsearch_application_id') > .env

--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -54,6 +54,15 @@
             "page_rank": 10
         },
         {
+            "url": "https://docs.datadoghq.com(?P<localisation>.*?)/account_management/rbac/permissions",
+            "selectors_key": "docs",
+            "variables": {
+                "localisation": ["", "/fr", "/ja"]
+            },
+            "tags": ["rbac_permissions"],
+            "page_rank": 110
+        },
+        {
             "url": "https://docs.datadoghq.com(?P<localisation>.*?)/getting_started/",
             "selectors_key": "getting_started",
             "variables": {

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -60,7 +60,7 @@
                 "localisation": ["", "/fr", "/ja"]
             },
             "tags": ["docs"],
-            "page_rank": 15
+            "page_rank": 110
         },
         {
             "url": "https://docs.datadoghq.com(?P<localisation>.*?)/getting_started/",

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -56,7 +56,9 @@
         {
             "url": "https://docs.datadoghq.com(?P<localisation>.*?)/account_management/rbac/permissions",
             "selectors_key": "docs",
-            "localisation": ["", "/fr", "/ja"],
+            "variables": {
+                "localisation": ["", "/fr", "/ja"]
+            },
             "tags": ["docs"],
             "page_rank": 15
         },

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -59,7 +59,7 @@
             "variables": {
                 "localisation": ["", "/fr", "/ja"]
             },
-            "tags": ["docs"],
+            "tags": ["rbac_permissions"],
             "page_rank": 110
         },
         {

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -54,6 +54,13 @@
             "page_rank": 10
         },
         {
+            "url": "https://docs.datadoghq.com(?P<localisation>.*?)/account_management/rbac/permissions",
+            "selectors_key": "docs",
+            "localisation": ["", "/fr", "/ja"],
+            "tags": ["docs"],
+            "page_rank": 15
+        },
+        {
             "url": "https://docs.datadoghq.com(?P<localisation>.*?)/getting_started/",
             "selectors_key": "getting_started",
             "variables": {

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -256,7 +256,7 @@
             ["gcp", "google cloud platform"],
             ["aws", "amazon web service"],
             ["RUM", "rum", "real user monitoring"],
-            ["Role Permissions", "permissions"]
+            ["Role Permissions", "permissions", "Datadog Role Permissions", "RBAC"]
         ]
     },
     "only_content_level": true,


### PR DESCRIPTION
### What does this PR do?
Increase page rank for the RBAC page, so that search strings like `permissions`, `role permissions`, and `RBAC` will surface this first in the result set.  Also increases the timeout for this job in Gitlab to be 1h 30m, as the size of the index in Algolia is increasing we are coming close to the 1h timeout threshold.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1478

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/rbac-algolia/

- Searches (from non-API pages) for `RBAC`, `permission(s)`, `role permissions` should all have the RBAC page (https://docs.datadoghq.com/account_management/rbac/permissions/) as the first result.

### Additional Notes
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
