### PR TITLE
[DOCS-2053] Mention section of config file

### DIFF
--- a/content/en/tracing/setup_overview/setup/cpp.md
+++ b/content/en/tracing/setup_overview/setup/cpp.md
@@ -178,7 +178,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 {{< tabs >}}
 {{% tab "Containers" %}}
 
-1. Set `apm_non_local_traffic: true` in your main [`datadog.yaml` configuration file][1]
+1. Set `apm_non_local_traffic: true` in the `apm_config` section of your main [`datadog.yaml` configuration file][1].
 
 2. See the specific setup instructions to ensure that the Agent is configured to receive traces in a containerized environment:
 

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -310,7 +310,7 @@ For more details on custom instrumentation and custom tagging, see [.NET Custom 
 
 {{% tab "Containers" %}}
 
-1. If the Agent is running on a different host or container, set `apm_non_local_traffic: true` in your main [`datadog.yaml` configuration file][1]
+1. If the Agent is running on a different host or container, set `apm_non_local_traffic: true` in the `apm_config` section of your main [`datadog.yaml` configuration file][1].
 
 2. See the specific setup instructions to ensure that the Agent is configured to receive traces in a containerized environment:
 

--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -91,7 +91,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 {{< tabs >}}
 {{% tab "Containers" %}}
 
-1. Set `apm_non_local_traffic: true` in your main [`datadog.yaml` configuration file][1]
+1. Set `apm_non_local_traffic: true` in the `apm_config` section of your main [`datadog.yaml` configuration file][1].
 
 2. See the specific setup instructions to ensure that the Agent is configured to receive traces in a containerized environment:
 

--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -73,7 +73,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 {{< tabs >}}
 {{% tab "Containers" %}}
 
-1. Set `apm_non_local_traffic: true` in your main [`datadog.yaml` configuration file][1]
+1. Set `apm_non_local_traffic: true` in the `apm_config` section of your main [`datadog.yaml` configuration file][1].
 
 2. See the specific setup instructions to ensure that the Agent is configured to receive traces in a containerized environment:
 

--- a/content/en/tracing/setup_overview/setup/nodejs.md
+++ b/content/en/tracing/setup_overview/setup/nodejs.md
@@ -101,7 +101,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 {{< tabs >}}
 {{% tab "Containers" %}}
 
-1. Set `apm_non_local_traffic: true` in your main [`datadog.yaml` configuration file][1]
+1. Set `apm_non_local_traffic: true` in the `apm_config` section of your main [`datadog.yaml` configuration file][1].
 
 2. See the specific setup instructions to ensure that the Agent is configured to receive traces in a containerized environment:
 

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -49,7 +49,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 {{< tabs >}}
 {{% tab "Containers" %}}
 
-1. Set `apm_non_local_traffic: true` in your main [`datadog.yaml` configuration file][1]
+1. Set `apm_non_local_traffic: true` in the `apm_config` section of your main [`datadog.yaml` configuration file][1].
 
 2. See the specific setup instructions to ensure that the Agent is configured to receive traces in a containerized environment:
 

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -65,7 +65,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 {{< tabs >}}
 {{% tab "Containers" %}}
 
-1. Set `apm_non_local_traffic: true` in your main [`datadog.yaml` configuration file][1]
+1. Set `apm_non_local_traffic: true` in the `apm_config` section of your main [`datadog.yaml` configuration file][1].
 
 2. See the specific setup instructions to ensure that the Agent is configured to receive traces in a containerized environment:
 


### PR DESCRIPTION

### What does this PR do?
Updates APM setup instructions for containers to specify where in the config yaml file the apm_non_local_traffic setting is.

### Motivation
DOCS-2053

### Preview

https://docs-staging.datadoghq.com/kari/docs-2053-nonlocaltraffickey/tracing/setup_overview/setup/php?tab=containers (and most of the other languages, too)

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
