### PR TITLE
[CIAPP-2205] Add Git metadata troubleshooting section

### DIFF
--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -3,30 +3,30 @@ title: Troubleshooting CI Visibility
 kind: documentation
 ---
 
-### I instrumented my Jenkins instance but I don't see any data in Datadog
+### Your Jenkins instance is instrumented, but Datadog isn't showing any data
 
 1. Make sure that at least one pipeline has finished executing. Pipeline execution information is only sent after the pipeline has finished.
-2. Make sure the Datadog Agent host is properly configured and it's reachable by the Datadog Plugin. You can test connectivity by clicking on the **Check connectivity with the Datadog Agent** button on the plugin configuration UI.
+2. Make sure the Datadog Agent host is properly configured and it's reachable by the Datadog Plugin. You can test connectivity by clicking on the **Check connectivity with the Datadog Agent** button on the Jenkins plugin configuration UI.
 3. If you still don't see any results, [contact Support][3] and we'll help you troubleshoot.
 
-### I instrumented my tests but I don't see any data in Datadog
+### Your tests are instrumented, but Datadog isn't showing any data
 
-1. Check the _Compatibility_ section of the page of the language you are instrumenting, and make sure the testing framework you are using is supported.
-2. Check if you see any test results in the [Test Runs][4] section. If you do see results there, but not in the [Tests][5] section, Git information  might be missing. If this is this case, read the next section to troubleshoot it.
-3. For all languages (except [Swift][7]), make sure the Datadog Agent is running in the host where tests are run (accessible at `localhost:8126`), or if accessible on another hostname and/or port, make sure you run your tests with the appropriate agent hostname set in the `DD_AGENT_HOST` and the appropriate port in `DD_TRACE_AGENT_PORT` environment variables. You can activate [debug mode][8] in the tracer to check if it's being able to connect to the agent.
-4. If you still don't see any results, [contact Support][3] and we'll help you troubleshoot.
+1. Go to the [Setup Tracing on CI Tests][9] page for the language you're instrumenting and check the _Compatibility_ section. Make sure the testing framework you are using is supported.
+2. Check if you see any test results in the [Test Runs][4] section. If you do see results there, but not in the [Tests][5] section, Git information is missing. See [Data appears in Test Runs but not Tests](#data-appears-in-test-runs-but-not-tests) to troubleshoot it.
+3. For languages other than Swift, make sure the Datadog Agent is running on the host where tests are run (accessible at `localhost:8126`), or if accessible on another hostname or port, make sure you run your tests with the appropriate Agent hostname set in the `DD_AGENT_HOST` and the appropriate port in `DD_TRACE_AGENT_PORT` environment variables. You can activate [debug mode][8] in the tracer to check if it's able to connect to the Agent.
+4. If you still don't see any results, [contact Support][3] for troubleshooting help.
 
-### I see my tests in the "Test Runs" tab, but not in the "Tests" tab
+### Data appears in Test Runs but not Tests
 
-This is most probably due to missing Git metadata (repository, commit and/or branch). To confirm this is the case, open a test execution on the [Test Runs][4] section, and check that there is no `git.repository_url`, `git.commit.sha` or `git.branch`. If these tags are not populated, nothing will show on the [Tests][5] section.
+If you can see test results data in the **Test Runs** tab, but not the **Tests** tab, Git metadata (repository, commit and/or branch) is probably missing. To confirm this is the case, open a test execution in the [Test Runs][4] section, and check that there is no `git.repository_url`, `git.commit.sha`, or `git.branch`. If these tags are not populated, nothing will show on the [Tests][5] section.
 
 1. Tracers will first try to fetch Git metadata using the local `.git` folder by executing `git` commands. This is the preferred approach, as it will populate all Git metadata fields, including commit message, author and committer information.
 2. If the `.git` folder is not present, or the `git` binary is not installed, tracers will fallback to use the environment variables set by the CI provider (as listed in the [Running tests inside a container][6] section) to collect Git information. This will populate, at least, repository, commit hash and branch information.
 3. If no CI provider environment variables are found, tests results will be sent with no Git metadata.
 
-### I have another issue not described here
+### Need further help?
 
-If that's the case, please [contact Support][3] and we'll help you troubleshoot your issue.
+If you have another issue, or the above solutions don't work, [contact Support][3] for troubleshooting help.
 
 
 [1]: https://app.datadoghq.com/ci/pipeline-executions
@@ -35,5 +35,5 @@ If that's the case, please [contact Support][3] and we'll help you troubleshoot 
 [4]: https://app.datadoghq.com/ci/test-runs
 [5]: https://app.datadoghq.com/ci/test-services
 [6]: /continuous_integration/setup_tests/containers/
-[7]: /continuous_integration/setup_tests/swift/
 [8]: /tracing/troubleshooting/tracer_debug_logs
+[9]: /continuous_integration/setup_tests/

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -3,21 +3,18 @@ title: Troubleshooting CI Visibility
 kind: documentation
 ---
 
-### I instrumented my CI provider but I don't see any data in Datadog
+### I instrumented my Jenkins instance but I don't see any data in Datadog
 
-1. Make sure that at least one pipeline has finished executing. Pipeline execution information is only sent after it has finished.
-2. Check if you see any results in the [Pipeline Executions][1] section. In the [Pipelines][2] section, only pipelines that contain git information and that were executed in the default branch will be shown.
-3. If instrumenting Jenkins, make sure the Datadog Agent is reachable by the Datadog Plugin.
-4. If you still don't see any results, [contact Support][3] and we'll help you troubleshoot.
-
+1. Make sure that at least one pipeline has finished executing. Pipeline execution information is only sent after the pipeline has finished.
+2. Make sure the Datadog Agent host is properly configured and it's reachable by the Datadog Plugin. You can test connectivity by clicking on the **Check connectivity with the Datadog Agent** button on the plugin configuration UI.
+3. If you still don't see any results, [contact Support][3] and we'll help you troubleshoot.
 
 ### I instrumented my tests but I don't see any data in Datadog
 
-1. Check if you see any results in the [Test Runs][4] section. In the [Tests][5] section, only tests that contain git information will be shown.
-2. If you are executing your tests in a container, make sure you are forwarding the required CI provider environment variables to them. Check out the [Running tests inside a container][6] section for more information.
-3. For all languages except Swift, make sure the Datadog Agent is running in the host where tests are run (accessible at `localhost:8126`), or if accessible on another hostname and/or port, make sure you run your tests with the appropriate hostname set in the `DD_AGENT_HOST` and the appropriate port in `DD_AGENT_PORT` environment variables.
+1. Check the _Compatibility_ section of the page of the language you are instrumenting, and make sure the testing framework you are using is supported.
+2. Check if you see any test results in the [Test Runs][4] section. If you do see results there, but not in the [Tests][5] section, Git information  might be missing. If this is this case, read the next section to troubleshoot it.
+3. For all languages (except [Swift][7]), make sure the Datadog Agent is running in the host where tests are run (accessible at `localhost:8126`), or if accessible on another hostname and/or port, make sure you run your tests with the appropriate agent hostname set in the `DD_AGENT_HOST` and the appropriate port in `DD_TRACE_AGENT_PORT` environment variables. You can activate [debug mode][8] in the tracer to check if it's being able to connect to the agent.
 4. If you still don't see any results, [contact Support][3] and we'll help you troubleshoot.
-
 
 ### I see my tests in the "Test Runs" tab, but not in the "Tests" tab
 
@@ -27,6 +24,10 @@ This is most probably due to missing Git metadata (repository, commit and/or bra
 2. If the `.git` folder is not present, or the `git` binary is not installed, tracers will fallback to use the environment variables set by the CI provider (as listed in the [Running tests inside a container][6] section) to collect Git information. This will populate, at least, repository, commit hash and branch information.
 3. If no CI provider environment variables are found, tests results will be sent with no Git metadata.
 
+### I have another issue not described here
+
+If that's the case, please [contact Support][3] and we'll help you troubleshoot your issue.
+
 
 [1]: https://app.datadoghq.com/ci/pipeline-executions
 [2]: https://app.datadoghq.com/ci/pipelines
@@ -34,3 +35,5 @@ This is most probably due to missing Git metadata (repository, commit and/or bra
 [4]: https://app.datadoghq.com/ci/test-runs
 [5]: https://app.datadoghq.com/ci/test-services
 [6]: /continuous_integration/setup_tests/containers/
+[7]: /continuous_integration/setup_tests/swift/
+[8]: /tracing/troubleshooting/tracer_debug_logs

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -7,7 +7,7 @@ kind: documentation
 
 1. Make sure that at least one pipeline has finished executing. Pipeline execution information is only sent after it has finished.
 2. Check if you see any results in the [Pipeline Executions][1] section. In the [Pipelines][2] section, only pipelines that contain git information and that were executed in the default branch will be shown.
-3. If instrumenting Jenkins, make sure the Datadog Agent is running in the master host and available at its default location (`localhost:8126`).
+3. If instrumenting Jenkins, make sure the Datadog Agent is reachable by the Datadog Plugin.
 4. If you still don't see any results, [contact Support][3] and we'll help you troubleshoot.
 
 
@@ -17,6 +17,15 @@ kind: documentation
 2. If you are executing your tests in a container, make sure you are forwarding the required CI provider environment variables to them. Check out the [Running tests inside a container][6] section for more information.
 3. For all languages except Swift, make sure the Datadog Agent is running in the host where tests are run (accessible at `localhost:8126`), or if accessible on another hostname and/or port, make sure you run your tests with the appropriate hostname set in the `DD_AGENT_HOST` and the appropriate port in `DD_AGENT_PORT` environment variables.
 4. If you still don't see any results, [contact Support][3] and we'll help you troubleshoot.
+
+
+### I see my tests in the "Test Runs" tab, but not in the "Tests" tab
+
+This is most probably due to missing Git metadata (repository, commit and/or branch). To confirm this is the case, open a test execution on the [Test Runs][4] section, and check that there is no `git.repository_url`, `git.commit.sha` or `git.branch`. If these tags are not populated, nothing will show on the [Tests][5] section.
+
+1. Tracers will first try to fetch Git metadata using the local `.git` folder by executing `git` commands. This is the preferred approach, as it will populate all Git metadata fields, including commit message, author and committer information.
+2. If the `.git` folder is not present, or the `git` binary is not installed, tracers will fallback to use the environment variables set by the CI provider (as listed in the [Running tests inside a container][6] section) to collect Git information. This will populate, at least, repository, commit hash and branch information.
+3. If no CI provider environment variables are found, tests results will be sent with no Git metadata.
 
 
 [1]: https://app.datadoghq.com/ci/pipeline-executions

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -20,8 +20,8 @@ kind: documentation
 
 If you can see test results data in the **Test Runs** tab, but not the **Tests** tab, Git metadata (repository, commit and/or branch) is probably missing. To confirm this is the case, open a test execution in the [Test Runs][4] section, and check that there is no `git.repository_url`, `git.commit.sha`, or `git.branch`. If these tags are not populated, nothing will show on the [Tests][5] section.
 
-1. Tracers will first try to fetch Git metadata using the local `.git` folder by executing `git` commands. This is the preferred approach, as it will populate all Git metadata fields, including commit message, author and committer information.
-2. If the `.git` folder is not present, or the `git` binary is not installed, tracers will fallback to use the environment variables set by the CI provider (as listed in the [Running tests inside a container][6] section) to collect Git information. This will populate, at least, repository, commit hash and branch information.
+1. Tracers will first try to fetch Git metadata using the local `.git` folder by executing `git` commands. This is the preferred approach, as it will populate all Git metadata fields, including commit message, author and committer information. Ensure the `.git` folder is present and the `git` binary is installed and in `$PATH`.
+2. If the `.git` folder is not present, or the `git` binary is not installed, tracers will fallback to use the environment variables set by the CI provider to collect Git information. See the [Running tests inside a container][6] page for a list of environment variables that the tracer will attempt to read for each supported CI provider. This will populate, at least, repository, commit hash and branch information.
 3. If no CI provider environment variables are found, tests results will be sent with no Git metadata.
 
 ### Need further help?

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -7,7 +7,7 @@ kind: documentation
 
 1. Make sure that at least one pipeline has finished executing. Pipeline execution information is only sent after the pipeline has finished.
 2. Make sure the Datadog Agent host is properly configured and it's reachable by the Datadog Plugin. You can test connectivity by clicking on the **Check connectivity with the Datadog Agent** button on the Jenkins plugin configuration UI.
-3. If you still don't see any results, [contact Support][3] and we'll help you troubleshoot.
+3. If you still don't see any results, [contact Support][3] for troubleshooting help.
 
 ### Your tests are instrumented, but Datadog isn't showing any data
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds a new section to the Troubleshooting page of CI Visibility about missing Git metadata.

### Motivation
<!-- What inspired you to submit this pull request?-->

Increasing number of private beta customers having problems with this topic

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fermayo/ciapp-add-git-troubleshooting/continuous_integration/troubleshooting/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
