### PR TITLE
[DOCS-2146] cloud workload security - change overwrite to append

### DIFF
--- a/content/en/security_platform/cloud_workload_security/getting_started.md
+++ b/content/en/security_platform/cloud_workload_security/getting_started.md
@@ -91,8 +91,8 @@ By default Runtime Security is disabled. To enable it, both the datadog.yaml and
 
 {{< code-block lang="bash" filename="debian-runtime-security.sh" >}}
 
-echo "runtime_security_config.enabled: true" > /etc/datadog-agent/security-agent.yaml
-echo "runtime_security_config.enabled: true" > /etc/datadog-agent/system-probe.yaml
+echo "runtime_security_config.enabled: true" >> /etc/datadog-agent/security-agent.yaml
+echo "runtime_security_config.enabled: true" >> /etc/datadog-agent/system-probe.yaml
 
 systemctl restart datadog-agent
 
@@ -108,8 +108,8 @@ For a package-based deployment, the Datadog package has to be deployed: run `yum
 
 {{< code-block lang="bash" filename="fedora-centos-runtime-security.sh" >}}
 
-echo "runtime_security_config.enabled: true" > /etc/datadog-agent/security-agent.yaml
-echo "runtime_security_config.enabled: true" > /etc/datadog-agent/system-probe.yaml
+echo "runtime_security_config.enabled: true" >> /etc/datadog-agent/security-agent.yaml
+echo "runtime_security_config.enabled: true" >> /etc/datadog-agent/system-probe.yaml
 
 systemctl restart datadog-agent
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
changes the overwrite `>` to append `>>`

### Motivation
some people already have stuff in their security-agent.yaml or system-probe.yaml

### Preview

https://docs-staging.datadoghq.com/cswatt/overwrite-append/security_platform/cloud_workload_security/getting_started/?tab=debian

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
