### PR TITLE
[DOCS-2180] add note on k8s secrets

### DIFF
--- a/content/en/agent/guide/secrets-management.md
+++ b/content/en/agent/guide/secrets-management.md
@@ -260,6 +260,7 @@ DD_SECRET_BACKEND_ARGUMENTS=/etc/secret-volume
 DD_SECRET_BACKEND_COMMAND=/readsecret.sh
 DD_SECRET_BACKEND_ARGUMENTS=/etc/secret-volume
 ```
+The Datadog Cluster Agent also uses a different secret helper command. Instead of `agent secret`, as used in the Node Agent, the Cluster Agent uses `cluster-agent secret-helper`.
 
 Following the linked example, the password field is stored in the `/etc/secret-volume/password` file, and accessible through the `ENC[password]` token.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
adds a thing that says the cluster agent secret helper command is different

### Motivation
support request

### Preview

https://docs-staging.datadoghq.com/cswatt/k8s-secret-note/agent/guide/secrets-management/?tab=linux#kubernetes-secrets

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
