### PR TITLE
[DOCS-1626] Add info about nginx log trace correlation config

### DIFF
--- a/content/en/tracing/setup_overview/proxy_setup/_index.md
+++ b/content/en/tracing/setup_overview/proxy_setup/_index.md
@@ -293,6 +293,8 @@ The `http` block enables the OpenTracing module and loads the Datadog tracer:
     opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/nginx/dd-config.json;
 ```
 
+The `log_format with_trace_id` block is for correlating logs and traces. See the [example NGINX config][5] file for the complete format. The `$opentracing_context_x_datadog_trace_id` value captures the trace ID, and `$opentracing_context_x_datadog_parent_id` captures the span ID. 
+
 The `location` block within the server where tracing is desired should add the following:
 
 ```nginx


### PR DESCRIPTION
### What does this PR do?
Adds a description of two config settings for NGINX proxy log-trace correlation setup. 

### Motivation
Community request/DOCS-1626

### Preview

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/docs-1626-nginx-config/tracing/setup_overview/proxy_setup/?tab=nginx

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
