### PR TITLE
[public-docs] Fixing broken link

### DIFF
--- a/content/en/integrations/faq/how-do-i-monitor-my-aws-billing-details.md
+++ b/content/en/integrations/faq/how-do-i-monitor-my-aws-billing-details.md
@@ -27,5 +27,5 @@ For more robust cost monitoring across a number of cloud services in addition to
 
 [1]: /integrations/amazon_web_services/
 [2]: http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html#turning_on_billing_metrics
-[3]: https://www.cloudhealthtech.com/partners/technology-partners/datadog
+[3]: /integrations/cloudhealth/
 [4]: https://www.datadoghq.com/blog/monitor-cloudhealth-assets-datadog


### PR DESCRIPTION
This link is no longer valid: https://www.cloudhealthtech.com/partners/technology-partners/datadog
So can be replaced with DD integrations CloudHealth instead.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes broken link to https://www.cloudhealthtech.com/partners/technology-partners/datadog
Now pointing to https://docs.datadoghq.com/integrations/cloudhealth/

### Motivation
<!-- What inspired you to submit this pull request?-->
I hate broken links

### Preview
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/integrations/faq/how-do-i-monitor-my-aws-billing-details/#pagetitle

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jcayetano-patch-1/integrations/faq/how-do-i-monitor-my-aws-billing-details/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
