### PR TITLE
Link documentation on enabling allocation profiler in enabling the profiler

### DIFF
--- a/content/en/tracing/profiler/enabling.md
+++ b/content/en/tracing/profiler/enabling.md
@@ -68,6 +68,9 @@ The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler lib
 | `DD_VERSION`                                     | String        | The version of your service.                             |
 | `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api, team:intake`.  |
 
+## Enabling the allocation profiler
+
+In versions 0.84.0+ of the tracer, the allocation profiler is disabled by default. To enable it, see [Enabling the allocation profiler][8]
 
 [1]: https://docs.oracle.com/javacomponents/jmc-5-4/jfr-runtime-guide/about.htm
 [2]: /tracing/profiler/profiler_troubleshooting/#java-8-support
@@ -76,6 +79,7 @@ The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler lib
 [5]: https://app.datadoghq.com/profiling
 [6]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
 [7]: /tracing/guide/setting_primary_tags_to_scope/#environment
+[8]: (/tracing/profiler/profiler_troubleshooting/#enabling-the-allocation-profiler)
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

As we are disabling the allocation profiler by default in Java, we want
to make it as clear as possible for users on how to enable it back.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
