### PR TITLE
update docs to include ddtrace-run --status command

### DIFF
--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -117,6 +117,8 @@ For other environments, please refer to the [Integrations][5] documentation for 
 {{% /tab %}}
 {{< /tabs >}}
 
+Once you've finished setup and are running the tracer with your application, you can run `ddtrace-run --status` to check that configurations are working as expected.
+
 For more advanced usage, configuration, and fine-grain control, see Datadog's [API documentation][3].
 
 ## Configuration


### PR DESCRIPTION
**DO NOT MERGE,** as this feature is not yet released.

The ddtrace-run --status command output helpful information for customers so they can see if their settings are working and that there are not connection issues between the tracer and trace-agent.

### What does this PR do?
Let's customer's know about a new flag that will inform them about their setup and configuration, as well as make suggestions in case certain settings have not yet been set, e.g service, env, version

### Motivation
Customer's often have issues figuring out how to setup tracing in the beginning. the --status flag should help them with this.

