### PR TITLE
Remove link to aws go sdk

### DIFF
--- a/content/en/network_monitoring/performance/guide/aws_supported_services.md
+++ b/content/en/network_monitoring/performance/guide/aws_supported_services.md
@@ -11,13 +11,10 @@ further_reading:
     text: 'Network Device Monitoring'
 ---
 
-Datadog Network Performance Monitoring (NPM) automatically detects S3, RDS, Kinesis, ELB, Elasticache, and other AWS services listed in the [aws-sdk-go repo][1]:
+Datadog Network Performance Monitoring (NPM) automatically detects S3, RDS, Kinesis, ELB, Elasticache, and other AWS services listed below:
 
 {{< get-npm-integrations "aws" >}}
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-
-
-[1]: https://github.com/aws/aws-sdk-go/blob/main/aws/endpoints/defaults.go


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Remove link to aws go sdk.

### Motivation
There is no need to link to go sdk code; it is an implementation detail.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hasan.mahmood/remove-aws-sdk-link/network_monitoring/performance/guide/aws_supported_services/

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
