### PR TITLE
Remove unused imports from python logging example

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/python.md
+++ b/content/en/tracing/connect_logs_and_traces/python.md
@@ -68,7 +68,6 @@ As an illustration of this approach, the following example defines a function as
 
 ``` python
 import ddtrace
-from ddtrace.helpers import get_correlation_ids
 
 import structlog
 


### PR DESCRIPTION
### What does this PR do?
Removes unused imports from the python logging example

### Motivation
Jira escalation - https://datadoghq.atlassian.net/browse/APMS-5809?focusedCommentId=437665

### Preview
https://docs-staging.datadoghq.com/bowen.brooks/remove-python-unused-imports/tracing/connect_logs_and_traces/python#no-standard-library-logging

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
