### PR TITLE
DOCS-2185 Service checks automation

### DIFF
--- a/content/en/agent/docker/data_collected.md
+++ b/content/en/agent/docker/data_collected.md
@@ -26,12 +26,4 @@ The Docker Agent produces the following events:
 
 ## Service checks
 
-- **docker.service_up**:
-    Returns `CRITICAL` if the Agent is unable to collect the list of containers from the Docker daemon, otherwise returns `OK`.
-
-- **docker.container_health**:
-    This Service Check is only available for Agent v5. It returns `CRITICAL` if a container is unhealthy, `UNKNOWN` if the health is unknown, and `OK` otherwise.
-
-- **docker.exit**:
-    Returns `CRITICAL` if a container exited with a non-zero exit code, otherwise returns `OK`.
-
+{{< get-service-checks-from-git "docker" >}}

--- a/content/en/agent/kubernetes/data_collected.md
+++ b/content/en/agent/kubernetes/data_collected.md
@@ -85,34 +85,13 @@ As the 5.17.0 release, Datadog Agent now supports built in [leader election opti
 
 ## Service checks
 
-The Kubernetes check includes the following service checks:
+### Kubelet
 
-`kubernetes.kubelet.check`
-: If `CRITICAL`, either `kubernetes.kubelet.check.ping` or `kubernetes.kubelet.check.syncloop` is in `CRITICAL` or `NO DATA` state.
+{{< get-service-checks-from-git "kubelet" >}}
 
-`kubernetes.kubelet.check.ping`
-: If `CRITICAL` or `NO DATA`, Kubelet's API isn't available
+### Kubernetes state
 
-`kubernetes.kubelet.check.syncloop`
-: If `CRITICAL` or `NO DATA`, Kubelet's sync loop that updates containers isn't working.
-
-`kubernetes_state.node.ready`
-: Returns `CRITICAL` if a cluster node is not ready. Returns `OK` otherwise.
-
-`kubernetes_state.node.out_of_disk`
-: Returns `CRITICAL` if a cluster node is out of disk space. Returns `OK` otherwise.
-
-`kubernetes_state.node.disk_pressure`
-: Returns `CRITICAL` if a cluster node is in a disk pressure state. Returns `OK` otherwise.
-
-`kubernetes_state.node.memory_pressure`
-: Returns `CRITICAL` if a cluster node is in a memory pressure state. Returns `OK` otherwise.
-
-`kubernetes_state.node.network_unavailable`
-: Returns `CRITICAL` if a cluster node is in a network unavailable state. Returns `OK` otherwise.
-
-`kubernetes_state.cronjob.on_schedule_check`
-: Returns `CRITICAL` if a cron job scheduled time is in the past. Returns `OK` otherwise.
+{{< get-service-checks-from-git "kubernetes_state" >}}
 
 ## Further Reading
 

--- a/content/en/integrations/system.md
+++ b/content/en/integrations/system.md
@@ -104,7 +104,7 @@ The System Core check does not include any events.
 
 #### Service checks
 
-The System Core check does not include any service checks.
+{{< get-service-checks-from-git "system_core" >}}
 
 ## System Swap
 

--- a/content/en/network_monitoring/devices/data.md
+++ b/content/en/network_monitoring/devices/data.md
@@ -17,5 +17,4 @@ Network Device Monitoring does not include any events.
 
 ## Service checks
 
-**snmp.can_check**:<br>
-Returns `CRITICAL` if the Agent cannot collect SNMP metrics, otherwise returns `OK`.
+{{< get-service-checks-from-git "snmp" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add service checks automation for integrations in the docs repo

### Motivation
OKR

### Preview
- https://docs-staging.datadoghq.com/ruth/docs-2185/integrations/system/#service-checks-1
- https://docs-staging.datadoghq.com/ruth/docs-2185/agent/docker/data_collected/
- https://docs-staging.datadoghq.com/ruth/docs-2185/agent/kubernetes/data_collected/
- https://docs-staging.datadoghq.com/ruth/docs-2185/network_monitoring/devices/data/


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
