### PR TITLE
Fix Error Budget Alert TF Syntax

### DIFF
--- a/content/en/monitors/service_level_objectives/error_budget.md
+++ b/content/en/monitors/service_level_objectives/error_budget.md
@@ -51,7 +51,7 @@ resource "datadog_monitor" "metric-based-slo" {
     EOT
 
     message = "Example monitor message"
-    thresholds = {
+    monitor_thresholds = {
       critical = 75
     }
     tags = ["foo:bar", "baz"]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes a line in the TF example for error budget alerts

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer pointed it out

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/markazerdd/fix_slo_alerts_tf/monitors/service_level_objectives/error_budget/#api-and-terraform

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
