### PR TITLE
[CIAPP] Re-add Ruby instructions

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1728,16 +1728,21 @@ main:
     parent: setup_tests
     identifier: ci_python
     weight: 106
+  - name: Ruby
+    url: continuous_integration/setup_tests/ruby/
+    parent: setup_tests
+    identifier: ci_ruby
+    weight: 107
   - name: Swift
     url: continuous_integration/setup_tests/swift/
     parent: setup_tests
     identifier: ci_swift
-    weight: 107
+    weight: 108
   - name: JUnit Report Uploads
     url: continuous_integration/setup_tests/junit_upload/
     parent: setup_tests
     identifier: ci_junit
-    weight: 108
+    weight: 109
   - name: Tracing Pipelines
     url: continuous_integration/setup_pipelines/
     parent: ci

--- a/content/en/continuous_integration/setup_tests/_index.md
+++ b/content/en/continuous_integration/setup_tests/_index.md
@@ -14,6 +14,7 @@ To gather test suite results, performance, and reliability data, first set up th
     {{< nextlink href="continuous_integration/setup_tests/java" >}}Java{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_tests/javascript" >}}JavaScript{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_tests/python" >}}Python{{< /nextlink >}}
+    {{< nextlink href="continuous_integration/setup_tests/ruby" >}}Ruby{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_tests/swift" >}}Swift{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_tests/junit_upload" >}}Uploading JUnit test report files to Datadog{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/continuous_integration/setup_tests/ruby.md
+++ b/content/en/continuous_integration/setup_tests/ruby.md
@@ -30,11 +30,10 @@ To install the Ruby tracer:
 
 1. Add the `ddtrace` gem to your `Gemfile`:
 
-
     {{< code-block lang="ruby" filename="Gemfile" >}}
-    source 'https://rubygems.org'
-    gem 'ddtrace', ">=0.51.0"
-    {{< /code-block >}}
+source 'https://rubygems.org'
+gem 'ddtrace', ">=0.51.0"
+{{< /code-block >}}
 
 2. Install the gem by running `bundle install`
 
@@ -49,7 +48,7 @@ The Cucumber integration traces executions of scenarios and steps when using the
 
 To activate your integration, add the following code to your application:
 
-{{< code-block lang="ruby" >}}
+```ruby
 require 'cucumber'
 require 'datadog/ci'
 
@@ -58,13 +57,13 @@ Datadog.configure do |c|
   c.service = 'my-ruby-app'  # Name of the service or library under test
   c.use :cucumber
 end
-{{< /code-block >}}
+```
 
 Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:
 
-{{< code-block lang="bash" >}}
+```bash
 DD_ENV=ci bundle exec rake cucumber
-{{< /code-block >}}
+```
 
 {{% /tab %}}
 {{% tab "RSpec" %}}
@@ -73,7 +72,7 @@ The RSpec integration traces all executions of example groups and examples when 
 
 To activate your integration, add this to the `spec_helper.rb` file:
 
-{{< code-block lang="ruby" filename="spec_helper.rb" >}}
+```ruby
 require 'rspec'
 require 'datadog/ci'
 
@@ -82,13 +81,13 @@ Datadog.configure do |c|
   c.service = 'my-ruby-app'  # Name of the service or library under test
   c.use :rspec
 end
-{{< /code-block >}}
+```
 
 Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:
 
-{{< code-block lang="bash" >}}
+```bash
 DD_ENV=ci bundle exec rake spec
-{{< /code-block >}}
+```
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Reverts the change done in https://github.com/DataDog/documentation/pull/10847

### Motivation
<!-- What inspired you to submit this pull request?-->

Latest version of Ruby tracer is feature complete and ready to be used by beta customers

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fermayo/ciapp-readd-ruby/continuous_integration/setup_tests/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
