### PR TITLE
Fix formatting issue in Events table

### DIFF
--- a/content/en/developers/dogstatsd/datagram_shell.md
+++ b/content/en/developers/dogstatsd/datagram_shell.md
@@ -54,8 +54,8 @@ Here are some example datagrams:
 | `_e`                                 | Yes      | The datagram must begin with `_e`.                                                                                     |
 | `<TITLE>`                            | Yes      | The event title.                                                                                                       |
 | `<TEXT>`                             | Yes      | The event text. Insert line breaks with: `\\n`.                                                                        |
-| `<TITLE_UTF8_LENGTH>`                | Yes      | The length of the UTF-8-encoded <TITLE>                                                                                |
-| `<TEXT_UTF8_LENGTH>`                 | Yes      | The length of the UTF-8-encoded <TEXT>                                                                                 |
+| `<TITLE_UTF8_LENGTH>`                | Yes      | The length of the UTF-8-encoded `<TITLE>`                                                                              |
+| `<TEXT_UTF8_LENGTH>`                 | Yes      | The length of the UTF-8-encoded `<TEXT>`                                                                               |
 | `d:<TIMESTAMP>`                      | No       | Add a timestamp to the event. The default is the current Unix epoch timestamp.                                         |
 | `h:<HOSTNAME>`                       | No       | Add a hostname to the event. No default.                                                                               |
 | `k:<AGGREGATION_KEY>`                | No       | Add an aggregation key to group the event with others that have the same key. No default.                              |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Wrap the `<TITLE>` and `<TEXT>` portions in the event table with backticks `

### Motivation
<!-- What inspired you to submit this pull request?-->
Page wasn't loading correctly.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.
Replace the branch name and add the complete path: -->
Preview Page:
https://docs-staging.datadoghq.com/jack.davenport/dogstatsd_formatting_fix/developers/dogstatsd/datagram_shell?tab=metrics

Current Page:
https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#send-metrics-using-dogstatsd-and-the-shell

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
