### PR TITLE
Fixed typo and added import for clarity.

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/python.md
+++ b/content/en/tracing/connect_logs_and_traces/python.md
@@ -61,6 +61,8 @@ hello()
 If you are not using the standard library `logging` module, you can use the following code snippet to inject tracer information into your logs:
 
 ```python
+from ddtrace import tracer
+
 span = tracer.current_span()
 correlation_ids = (span.trace_id, span.span.id) if span else (None, None)
 ```
@@ -68,13 +70,14 @@ As an illustration of this approach, the following example defines a function as
 
 ``` python
 import ddtrace
+from ddtrace import tracer
 
 import structlog
 
 def tracer_injection(logger, log_method, event_dict):
     # get correlation ids from current tracer context
     span = tracer.current_span()
-    trace_id, span_id = (span.trace_id, span.span.id) if span else (None, None)
+    trace_id, span_id = (span.trace_id, span.span_id) if span else (None, None)
 
     # add ids to structlog event dictionary
     event_dict['dd.trace_id'] = str(trace_id or 0)


### PR DESCRIPTION
### What does this PR do?
Fixes typo and adds clarity to logging step in the python docs.

### Motivation
A customer [issue](https://github.com/DataDog/documentation/issues/11067) pointing out a typo and undefined variable in the current python documentation regarding non-standard library logging. 

### Preview
https://docs-staging.datadoghq.com/yunkim/python-logs-and-traces/tracing/connect_logs_and_traces/python/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
