### PR TITLE
api build improvement

### DIFF
--- a/content/en/api/v1/_index.md
+++ b/content/en/api/v1/_index.md
@@ -6,4 +6,5 @@ cascade:
   _build:
     render: false
     list: true
+    publishResources: false
 ---

--- a/content/en/api/v1/_index.md
+++ b/content/en/api/v1/_index.md
@@ -1,0 +1,9 @@
+---
+title: Api V1
+_build:
+  render: false
+cascade:
+  _build:
+    render: false
+    list: true
+---

--- a/content/en/api/v2/_index.md
+++ b/content/en/api/v2/_index.md
@@ -6,4 +6,5 @@ cascade:
   _build:
     render: false
     list: true
+    publishResources: false
 ---

--- a/content/en/api/v2/_index.md
+++ b/content/en/api/v2/_index.md
@@ -1,0 +1,9 @@
+---
+title: Api V2
+_build:
+  render: false
+cascade:
+  _build:
+    render: false
+    list: true
+---


### PR DESCRIPTION
### What does this PR do?

We use the v1/v2 api content to build out `/latest/`. Currently we still render and deploy these pages even though redirects take over.

This PR is a performance improvement in that it will no longer render/deploy the v1/v2 html or assets but the data is still available to generate `/latest/` 

### Motivation

Discovering new features in hugo

### Preview

Test api pages
- code tabs are there and working
- switching between v1 and v2 endpoints still works
https://docs-staging.datadoghq.com/david.jones/api-render-settings/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
