### PR TITLE
[CIAPP] Update Ruby and Javascript instructions to disable autoinstrumentation

### DIFF
--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -81,7 +81,7 @@ All tests will be automatically instrumented.
 {{% /tab %}}
 {{< /tabs >}}
 
-### Additional configuration settings
+### Configuration settings
 
 You can change the default configuration of the CLI by using command line arguments or environment variables. For a full list of configuration settings, run:
 
@@ -104,7 +104,7 @@ The following list shows the default values for key configuration settings:
 **Examples**: `local`, `ci`
 
 `--agent-url`
-: Datadog Agent URL for traces.<br/>
+: Datadog Agent URL for trace collection in the form `http://hostname:port`.<br/>
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
 **Default**: `http://localhost:8126`
 

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -81,7 +81,7 @@ All tests will be automatically instrumented.
 {{% /tab %}}
 {{< /tabs >}}
 
-### Configuration settings
+## Configuration settings
 
 You can change the default configuration of the CLI by using command line arguments or environment variables. For a full list of configuration settings, run:
 

--- a/content/en/continuous_integration/setup_tests/java.md
+++ b/content/en/continuous_integration/setup_tests/java.md
@@ -143,7 +143,7 @@ DD_ENV=ci ./gradlew cleanTest test -Pdd-civisibility --rerun-tasks
 {{% /tab %}}
 {{< /tabs >}}
 
-## Additional configuration settings
+## Configuration settings
 
 The following system properties set configuration options and have environment variable equivalents. If the same key type is set for both, the system property configuration takes priority. System properties can be set as JVM flags.
 
@@ -159,20 +159,10 @@ The following system properties set configuration options and have environment v
 **Default**: `none`<br/>
 **Examples**: `local`, `ci`
 
-`dd.trace.enabled`
-: Setting this to `false` completely disables the instrumentation.<br/>
-**Environment variable**: `DD_TRACE_ENABLED`<br/>
-**Default**: `true`
-
-`dd.agent.host`
-: The Datadog Agent hostname.<br/>
-**Environment variable**: `DD_AGENT_HOST`<br/>
-**Default**: `localhost`
-
-`dd.trace.agent.port`
-: The Datadog Agent trace collection port.<br/>
-**Environment variable**: `DD_TRACE_AGENT_PORT`<br/>
-**Default**: `8126`
+`dd.trace.agent.url`
+: Datadog Agent URL for trace collection in the form `http://hostname:port`.<br/>
+**Environment variable**: `DD_TRACE_AGENT_URL`<br/>
+**Default**: `http://localhost:8126`
 
 All other [Datadog Tracer configuration][2] options can also be used.
 

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -105,7 +105,7 @@ DD_ENV=ci npm test
 {{% /tab %}}
 {{< /tabs >}}
 
-## Additional configuration settings
+## Configuration settings
 
 The following is a list of the most important configuration settings that can be used with the tracer. They can be either passed in on its `init()` function, or as environment variables:
 
@@ -121,20 +121,10 @@ The following is a list of the most important configuration settings that can be
 **Default**: `none`<br/>
 **Examples**: `local`, `ci`
 
-`enabled`
-: Setting this to `false` completely disables the instrumentation.<br/>
-**Environment variable**: `DD_TRACE_ENABLED`<br/>
-**Default**: `true`
-
-`hostname`
-: The Datadog Agent hostname.<br/>
-**Environment variable**: `DD_TRACE_AGENT_HOSTNAME`<br/>
-**Default**: `localhost`
-
-`port`
-: The Datadog Agent trace collection port.<br/>
-**Environment variable**: `DD_TRACE_AGENT_PORT`<br/>
-**Default**: `8126`
+`url`
+: Datadog Agent URL for trace collection in the form `http://hostname:port`.<br/>
+**Environment variable**: `DD_TRACE_AGENT_URL`<br/>
+**Default**: `http://localhost:8126`
 
 All other [Datadog Tracer configuration][5] options can also be used.
 

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -40,19 +40,19 @@ For more information, see the [JavaScript tracer installation docs][4].
 
 1. Install the `jest-circus` test runner:
 
-    {{< code-block lang="bash" >}}
+```bash
 yarn add --dev jest-circus
-{{< /code-block >}}
+```
 
 **Important**: The installed version of `jest-circus` and `jest` must be the same. For example, if you're using `jest@25.5.4`, run:
 
-    {{< code-block lang="bash" >}}
+```bash
 yarn add --dev jest-circus@25.5.4
-{{< /code-block >}}
+```
 
 2. Configure a custom [testEnvironment][1] and [testRunner][2] in your `jest.config.js` or however you are configuring `jest`:
 
-    {{< code-block lang="javascript" filename="jest.config.js" >}}
+```javascript
 module.exports = {
   // ...
   testRunner: 'jest-circus/runner',
@@ -60,27 +60,33 @@ module.exports = {
   testEnvironment: '<rootDir>/testEnvironment.js',
   // ...
 }
-{{< /code-block >}}
+```
 
 And in `testEnvironment.js`:
 
-    {{< code-block lang="javascript" filename="testEnvironment.js" >}}
+```javascript
 require('dd-trace').init({
-  service: 'my-ui-app',  // Name of the service or library under test
-  flushInterval: 300000  // To guarantee test span delivery
+  // Only activates test instrumentation on CI
+  enabled: process.env.DD_ENV === 'ci',
+
+  // Name of the service or library under test
+  service: 'my-ui-app',
+
+  // To guarantee test span delivery
+  flushInterval: 300000
 })
 
 // jest-environment-jsdom is an option too
 module.exports = require('jest-environment-node')
-{{< /code-block >}}
+```
 
 <div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-node</code> and <code>jest-environment-jsdom</code> are installed together with <code>jest</code>, so they do not normally appear in your <code>package.json</code>. If you've extracted any of these libraries in your <code>package.json</code>, make sure the installed version is the same as the one of <code>jest</code>.</div>
 
 Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:
 
-{{< code-block lang="bash" >}}
+```bash
 DD_ENV=ci npm test
-{{< /code-block >}}
+```
 
 
 [1]: https://jestjs.io/docs/en/configuration#testenvironment-string
@@ -88,19 +94,31 @@ DD_ENV=ci npm test
 {{% /tab %}}
 {{% tab "Mocha" %}}
 
-Add `--require dd-trace/init` to however you normally run your `mocha` tests, for example in your `package.json`:
+Create a file in your project (for example, `init-tracer.js`) with the following contents:
 
-{{< code-block lang="javascript" filename="package.json" >}}
+```javascript
+require('dd-trace').init({
+  // Only activates test instrumentation on CI
+  enabled: process.env.DD_ENV === 'ci',
+
+  // Name of the service or library under test
+  service: 'my-ui-app'
+})
+```
+
+Add `--require ./init-tracer` to however you normally run your `mocha` tests, for example in your `package.json`:
+
+```javascript
 'scripts': {
-  'test': 'DD_SERVICE=my-ui-app mocha --require dd-trace/init'
+  'test': 'mocha --require ./init-tracer'
 },
-{{< /code-block >}}
+```
 
 Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:
 
-{{< code-block lang="bash" >}}
+```bash
 DD_ENV=ci npm test
-{{< /code-block >}}
+```
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -106,7 +106,7 @@ require('dd-trace').init({
 })
 ```
 
-Add `--require init-tracer` to however you normally run your `mocha` tests, for example in your `package.json`:
+Add `--require init-tracer` to the run command for your `mocha` tests, for example in your `package.json`:
 
 ```javascript
 'scripts': {

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -106,11 +106,11 @@ require('dd-trace').init({
 })
 ```
 
-Add `--require ./init-tracer` to however you normally run your `mocha` tests, for example in your `package.json`:
+Add `--require init-tracer` to however you normally run your `mocha` tests, for example in your `package.json`:
 
 ```javascript
 'scripts': {
-  'test': 'mocha --require ./init-tracer'
+  'test': 'mocha --require init-tracer'
 },
 ```
 

--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -40,7 +40,7 @@ DD_ENV=ci DATADOG_API_KEY=<api_key> datadog-ci junit upload \
   unit-tests/junit-reports e2e-tests/single-report.xml
 {{< /code-block >}}
 
-## Additional configuration settings
+## Configuration settings
 
 This is the full list of options available when using the `datadog-ci junit upload` command:
 

--- a/content/en/continuous_integration/setup_tests/python.md
+++ b/content/en/continuous_integration/setup_tests/python.md
@@ -40,7 +40,7 @@ To enable instrumentation of `pytest` tests, add the `--ddtrace` option when run
 DD_SERVICE=my-python-app DD_ENV=ci pytest --ddtrace
 {{< /code-block >}}
 
-## Additional configuration settings
+## Configuration settings
 
 The following is a list of the most important configuration settings that can be used with the tracer, either in code or using environment variables:
 
@@ -56,17 +56,11 @@ The following is a list of the most important configuration settings that can be
 **Default**: `none`<br/>
 **Examples**: `local`, `ci`
 
-The following configuration settings can be passed in as parameters to `tracer.configure()`, or using environment variables:
+The following environment variable can be used to configure the location of the Datadog Agent:
 
-`hostname`
-: The Datadog Agent hostname.<br/>
-**Environment variable**: `DD_AGENT_HOST`<br/>
-**Default**: `localhost`
-
-`port`
-: The Datadog Agent trace collection port.<br/>
-**Environment variable**: `DD_TRACE_AGENT_PORT`<br/>
-**Default**: `8126`
+`DD_TRACE_AGENT_URL`
+: Datadog Agent URL for trace collection in the form `http://hostname:port`.<br/>
+**Default**: `http://localhost:8126`
 
 All other [Datadog Tracer configuration][3] options can also be used.
 

--- a/content/en/continuous_integration/setup_tests/ruby.md
+++ b/content/en/continuous_integration/setup_tests/ruby.md
@@ -59,7 +59,7 @@ Datadog.configure do |c|
   # Configures the tracer to ensure results delivery
   c.ci_mode.enabled = true
 
-  # Name of the service or library under test
+  # The name of the service or library under test
   c.service = 'my-ruby-app'
 
   # Enables the Cucumber instrumentation
@@ -91,7 +91,7 @@ Datadog.configure do |c|
   # Configures the tracer to ensure results delivery
   c.ci_mode.enabled = true
 
-  # Name of the service or library under test
+  # The name of the service or library under test
   c.service = 'my-ruby-app'
 
   # Enables the RSpec instrumentation

--- a/content/en/continuous_integration/setup_tests/ruby.md
+++ b/content/en/continuous_integration/setup_tests/ruby.md
@@ -53,8 +53,16 @@ require 'cucumber'
 require 'datadog/ci'
 
 Datadog.configure do |c|
+  # Only activates test instrumentation on CI
+  c.tracer.enabled = (ENV["DD_ENV"] == "ci")
+
+  # Configures the tracer to ensure results delivery
   c.ci_mode.enabled = true
-  c.service = 'my-ruby-app'  # Name of the service or library under test
+
+  # Name of the service or library under test
+  c.service = 'my-ruby-app'
+
+  # Enables the Cucumber instrumentation
   c.use :cucumber
 end
 ```
@@ -77,8 +85,16 @@ require 'rspec'
 require 'datadog/ci'
 
 Datadog.configure do |c|
+  # Only activates test instrumentation on CI
+  c.tracer.enabled = (ENV["DD_ENV"] == "ci")
+
+  # Configures the tracer to ensure results delivery
   c.ci_mode.enabled = true
-  c.service = 'my-ruby-app'  # Name of the service or library under test
+
+  # Name of the service or library under test
+  c.service = 'my-ruby-app'
+
+  # Enables the RSpec instrumentation
   c.use :rspec
 end
 ```

--- a/content/en/continuous_integration/setup_tests/ruby.md
+++ b/content/en/continuous_integration/setup_tests/ruby.md
@@ -92,7 +92,7 @@ DD_ENV=ci bundle exec rake spec
 {{% /tab %}}
 {{< /tabs >}}
 
-## Additional configuration settings
+## Configuration settings
 
 The following is a list of the most important configuration settings that can be used with the tracer, either in code by using a `Datadog.configure` block, or using environment variables:
 
@@ -108,20 +108,11 @@ The following is a list of the most important configuration settings that can be
 **Default**: `none`<br/>
 **Examples**: `local`, `ci`
 
-`tracer.enabled`
-: Setting this to `false` completely disables the instrumentation.<br/>
-**Environment variable**: `DD_TRACE_ENABLED`<br/>
-**Default**: `true`
+The following environment variable can be used to configure the location of the Datadog Agent:
 
-`tracer.hostname`
-: The Datadog Agent hostname.<br/>
-**Environment variable**: `DD_AGENT_HOST`<br/>
-**Default**: `localhost`
-
-`tracer.port`
-: The Datadog Agent trace collection port.<br/>
-**Environment variable**: `DD_TRACE_AGENT_PORT`<br/>
-**Default**: `8126`
+`DD_TRACE_AGENT_URL`
+: Datadog Agent URL for trace collection in the form `http://hostname:port`.<br/>
+**Default**: `http://localhost:8126`
 
 All other [Datadog Tracer configuration][3] options can also be used.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* Updates the instructions for JS and Ruby to disable test instrumentation by default, and activate it only via `DD_ENV`
* Removes mentions of `DD_TRACE_ENABLED` on all languages
* Replaces agent `hostname` and `port` config with `DD_TRACE_AGENT_URL` in all languages

### Motivation
<!-- What inspired you to submit this pull request?-->

We don't want developers that run test locally to activate the test instrumentation by default. This is already the case for .NET, Java, Python and Swift, but not for JS and Ruby

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fermayo/ciapp-add-manual-activation/continuous_integration/setup_tests/javascript/
https://docs-staging.datadoghq.com/fermayo/ciapp-add-manual-activation/continuous_integration/setup_tests/ruby/
https://docs-staging.datadoghq.com/fermayo/ciapp-add-manual-activation/continuous_integration/setup_tests/python/
https://docs-staging.datadoghq.com/fermayo/ciapp-add-manual-activation/continuous_integration/setup_tests/java/


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
