### PR TITLE
[CIAPP] No need to have special flags for MsTest anymore

### DIFF
--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -27,7 +27,7 @@ Supported test frameworks:
 
 ## Installing the .NET tracer
 
-To install (or update if already installed) the `dd-trace` command globally on the machine, run:
+To install or update the `dd-trace` command globally on the machine, run:
 
 {{< code-block lang="bash" >}}
 dotnet tool update -g dd-trace
@@ -41,7 +41,7 @@ To instrument your test suite, prefix your test command with `dd-trace`, providi
 dd-trace --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
 {{< /code-block >}}
 
-All tests will be automatically instrumented.
+All tests are automatically instrumented.
 
 ### Additional configuration settings
 

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -27,16 +27,13 @@ Supported test frameworks:
 
 ## Installing the .NET tracer
 
-To install the `dd-trace` command globally on the machine, run:
+To install (or update if already installed) the `dd-trace` command globally on the machine, run:
 
 {{< code-block lang="bash" >}}
-dotnet tool install -g dd-trace
+dotnet tool update -g dd-trace
 {{< /code-block >}}
 
 ## Instrumenting tests
-
-{{< tabs >}}
-{{% tab "xUnit and NUnit" %}}
 
 To instrument your test suite, prefix your test command with `dd-trace`, providing the name of the service or library under test as the `--dd-service` parameter, and the environment where tests are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) as the `--dd-env` parameter. For example:
 
@@ -45,41 +42,6 @@ dd-trace --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
 {{< /code-block >}}
 
 All tests will be automatically instrumented.
-
-{{% /tab %}}
-{{% tab "MsTest V2" %}}
-
-To instrument your test suite, prefix your test command with `dd-trace`, providing the name of the service or library under test as the `--dd-service` parameter, and the environment where tests are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) as the `--dd-env` parameter.
-
-Also, configure the tracer to use call target instrumentation by setting `DD_TRACE_CALLTARGET_ENABLED=true`, which is not the default value.
-
-For example:
-
-* In Bash:
-{{< code-block lang="bash" >}}
-DD_TRACE_CALLTARGET_ENABLED=true dd-trace \
-  dd-trace --dd-service=my-dotnet-app --dd-env=ci -- \
-  dotnet test
-{{< /code-block >}}
-
-* In CMD:
-{{< code-block lang="bash" >}}
-SET DD_TRACE_CALLTARGET_ENABLED=true && ^
-dd-trace --dd-service=my-dotnet-app --dd-env=ci -- ^
-dotnet test
-{{< /code-block >}}
-
-* In PowerShell:
-{{< code-block lang="powershell" >}}
-$env:DD_TRACE_CALLTARGET_ENABLED="true"; `
-  dd-trace --dd-service=my-dotnet-app --dd-env=ci -- `
-  dotnet test
-{{< /code-block >}}
-
-All tests will be automatically instrumented.
-
-{{% /tab %}}
-{{< /tabs >}}
 
 ### Additional configuration settings
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Removes special instructions for MsTest V2 as the latest version of the tracer does not need them

### Motivation
<!-- What inspired you to submit this pull request?-->

New version of the .NET tracer

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fermayo/ciapp-update-dotnet-docs/continuous_integration/setup_tests/dotnet/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
