### PR TITLE
Fix User-Agent for Synthetics tests

### DIFF
--- a/content/en/synthetics/guide/identify_synthetics_bots.md
+++ b/content/en/synthetics/guide/identify_synthetics_bots.md
@@ -46,12 +46,12 @@ A `user-agent` header is added to all requests performed by Synthetic tests.
 {{< tabs >}}
 {{% tab "Single and multistep API tests" %}}
 
-For single and multistep API tests, the `user-agent` header is `Datadog/Synthetics`.
+For single and multistep API tests, the `user-agent` header is `DatadogSynthetics`.
 
 {{% /tab %}}
 {{% tab "Browser tests" %}}
 
-For browser tests, the value of the `user-agent` header varies depending on the browser and device executing the test. The `user-agent` value always ends with `Datadog/Synthetics` to allow you to identify Synthetic tests.
+For browser tests, the value of the `user-agent` header varies depending on the browser and device executing the test. The `user-agent` value always ends with `DatadogSynthetics` to allow you to identify Synthetic tests.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR fixes the UA string added by Synthetic tests

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
