### PR TITLE
Correct second instance of span.span.id

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/python.md
+++ b/content/en/tracing/connect_logs_and_traces/python.md
@@ -64,7 +64,7 @@ If you are not using the standard library `logging` module, you can use the foll
 from ddtrace import tracer
 
 span = tracer.current_span()
-correlation_ids = (span.trace_id, span.span.id) if span else (None, None)
+correlation_ids = (span.trace_id, span.span_id) if span else (None, None)
 ```
 As an illustration of this approach, the following example defines a function as a *processor* in `structlog` to add tracer fields to the log output:
 


### PR DESCRIPTION
Modified from PR 11095 correcting span.span.id to span.span_id

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
