### PR TITLE
Documentation - Correct Grammar typo

### DIFF
--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -88,7 +88,7 @@ For a full list of available parameters for instances, including `namespace` and
 
 1. [Launch the Datadog Agent][10].
 
-2. Use [this Prometheus DaemonSet `prometheus.yaml`][11] to launch a Prometheus pod already with the Autodiscovery configuration in it:
+2. Use the [Prometheus DaemonSet `prometheus.yaml`][11] to launch a Prometheus pod with the Autodiscovery configuration in it:
 
     Autodiscovery configuration:
 

--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -88,7 +88,7 @@ For a full list of available parameters for instances, including `namespace` and
 
 1. [Launch the Datadog Agent][10].
 
-2. Use [this Prometheus DaemonSet `prometheus.yaml`][11] to launch a Prometheus pod with already the Autodiscovery configuration in it:
+2. Use [this Prometheus DaemonSet `prometheus.yaml`][11] to launch a Prometheus pod already with the Autodiscovery configuration in it:
 
     Autodiscovery configuration:
 


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Reversed order of wording.
Prior to change:
-> Use this Prometheus DaemonSet prometheus.yaml to launch a Prometheus pod with already the Autodiscovery configuration in it:
After change:
-> -> Use this Prometheus DaemonSet prometheus.yaml to launch a Prometheus pod already with the Autodiscovery configuration in it:

### Motivation
To make the sentence less confusing

### Preview
N/A

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
https://docs.datadoghq.com/agent/kubernetes/prometheus/#simple-metric-collection
-> Number 2. in list

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
