### PR TITLE
underline specific to alert

### DIFF
--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -274,7 +274,7 @@ details {
     &.nav-tabs {
         .nav-item {
             z-index: 1;
-            
+
             &:before {
                 content: none;
             }
@@ -391,7 +391,7 @@ h5 {
     & p a,
     & ol li a,
     & ul li a,
-    & div > a {
+    & .alert a {
         color: #4a4a4a;
         border-bottom: 1px solid $gray-600;
         &:hover {
@@ -960,5 +960,5 @@ dl {
         width: 100%;
     }
 }
-  
-  
+
+


### PR DESCRIPTION
### What does this PR do?

Switch back to the specific .alert underline instead of the generic selector

### Motivation

https://github.com/DataDog/documentation/pull/11085 causing integrations to have a underline

### Preview

no black lines on tiles here
https://docs-staging.datadoghq.com/david.jones/underline-fix/integrations/

alert boxes have underlined links
https://docs-staging.datadoghq.com/david.jones/underline-fix/logs/log_configuration/pipelines/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
