### PR TITLE
Standardizing Italics in RUM Docs

### DIFF
--- a/content/en/real_user_monitoring/_index.md
+++ b/content/en/real_user_monitoring/_index.md
@@ -30,7 +30,7 @@ further_reading:
 
 ## What is Real User Monitoring?
 
-Datadog's Real User Monitoring (RUM) gives you end-to-end visibility into the real-time activity and experience of individual users. It is designed to solve 4 types of use cases for web and mobile applications:
+Datadog's *Real User Monitoring (RUM)* gives you end-to-end visibility into the real-time activity and experience of individual users. It is designed to solve 4 types of use cases for web and mobile applications:
 
 * **Performance**: Track the performance of web pages, mobile application screens, user actions, network requests, and your front-end code.
 * **Error Management**: Monitor the ongoing bugs and issues and track them over time and versions.


### PR DESCRIPTION
### What does this PR do?

Italics are used to introduce product names and features in product landing pages (the parent page in the TOC). Child pages underneath the parent page do not use italics to discuss product names and features.

### Motivation
<!-- What inspired you to submit this pull request?-->

Writing Style in Docs4Docs

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/rum-doc-improvements/real_user_monitoring

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
