### PR TITLE
[CIAPP] Add section to fix CI Visibility option in Jenkins troubleshooting

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -205,6 +205,15 @@ If the Datadog Plugin section does not appear in Jenkins configuration section, 
 3. Check that the `Enabled` checkbox is marked.
 4. If you enable the plugin here, restart your Jenkins instance using the `/safeRestart` URL path.
 
+### The CI Visibility option does not appear in the Datadog Plugin section.
+
+If the CI Visibility option does not appear in the Datadog Plugin section, make sure that the correct version is installed and restart the Jenkins instance. To do so:
+
+1. In your Jenkins instance web interface, go to **Manage Jenkins > Manage Plugins**.
+2. Search for `Datadog Plugin` in the **Installed** tab.
+3. Check that the installed version is correct.
+4. Restart your Jenkins instance using the `/safeRestart` URL path.
+
 ### The Plugin Tracer failed to initialized due to APM Java Tracer is used to instrument Jenkins
 
 If this error message appears in the **Jenkins Log**, make sure that you are not using the APM Java Tracer to instrument your Jenkins instance.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

This PR adds a section in the Jenkins troubleshooting section to indicates how to solve the case when the user updated the plugin but CI Visibility section is not appearing.

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/drodriguezhdez/ciapp_troubleshooting_jenkins/continuous_integration/setup_pipelines/jenkins/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
