### PR TITLE
Point to keys.datadoghq.com instead of keyserver.ubuntu.com

### DIFF
--- a/content/en/security/agent.md
+++ b/content/en/security/agent.md
@@ -77,8 +77,8 @@ For more information, see the [Secrets Management][20] documentation.
 [1]: /security/
 [2]: /agent/
 [3]: /api/
-[4]: https://keyserver.ubuntu.com/pks/lookup?op=hget&search=d1402d39517b9f8888abfc98d6936dab
-[5]: https://keyserver.ubuntu.com/pks/lookup?op=hget&search=3e8510ce571008616b42bd67916e83f8
+[4]: https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public
+[5]: https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
 [6]: https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
 [7]: https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
 [8]: https://keys.datadoghq.com/DATADOG_RPM_KEY.public


### PR DESCRIPTION
### What does this PR do?

Points URLs of APT keys to the now preferred keys.datadoghq.com instead of keyserver.unbuntu.com.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
