### PR TITLE
Bump Node Lambda Library layer version from 56 -> 59.

### DIFF
--- a/layouts/shortcodes/latest-lambda-layer-version.html
+++ b/layouts/shortcodes/latest-lambda-layer-version.html
@@ -11,7 +11,7 @@
 
 <!-- Node Layer -->
 {{- if eq (.Get "layer") "node" -}}
-    56
+    59
 {{- end -}}
 
 <!-- Ruby Layer -->


### PR DESCRIPTION
Bump the latest version of the Node Lambda Library from 56 to 59.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
