### PR TITLE
Remove serverless-product team as codeowner of latest-lambda-layer-version

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,4 +15,4 @@ package.json              @DataDog/corpweb @DataDog/documentation
 # Serverless
 
 /content/en/serverless/                                 @DataDog/serverless-product @DataDog/documentation
-/layouts/shortcodes/latest-lambda-layer-version.html    @DataDog/serverless-product
+/layouts/shortcodes/latest-lambda-layer-version.html    @DataDog/documentation


### PR DESCRIPTION
### What does this PR do?
Change the CODEOWNER of `/layouts/shortcodes/latest-lambda-layer-version.html` from `@DataDog/serverless-product` to `@DataDog/documentation`. 

### Motivation
We will be frequently updating this file with the latest version numbers of our Lambda Libraries. The Serverless product team doesn't need to sign off on the changes. (This has been confirmed by @Hesperide)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
