### PR TITLE
tagged websites-modules

### DIFF
--- a/config/_default/params.en.yaml
+++ b/config/_default/params.en.yaml
@@ -6,6 +6,6 @@ disclaimer: "This page is not yet available in English, we are working on its tr
 announcement_banner:
   desktop_message: "2021 State of Serverless Report"
   mobile_message: "2021 State of Serverless Report"
-  link: "https://www.datadoghq.com/state-of-serverless/?utm_source=Advertisement&utm_medium=Advertisement&utm_campaign=Organic-TopBannerServerlessReport"
+  external_link: "https://www.datadoghq.com/state-of-serverless/?utm_source=Advertisement&utm_medium=Advertisement&utm_campaign=Organic-TopBannerServerlessReport"
 exclude: []
 translate_status_banner: "This translation isn't up to date, for the latest english version click here"

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.0.0 // indirect
+require github.com/DataDog/websites-modules v1.0.1 // indirect
 
 // replace github.com/DataDog/websites-modules => /Users/brian.deutsch/dd/websites-modules

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v0.0.0-20210608134641-202ae42200c1 // indirect
+require github.com/DataDog/websites-modules v1.0.0 // indirect
 
 // replace github.com/DataDog/websites-modules => /Users/brian.deutsch/dd/websites-modules

--- a/go.sum
+++ b/go.sum
@@ -1,1 +1,2 @@
-github.com/DataDog/websites-modules v0.0.0-20210608134641-202ae42200c1/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.0.0 h1:HlvFbaJhIJN6AC0DGqvgwsovB+wGLe/0Hcs0/ZjtrLo=
+github.com/DataDog/websites-modules v1.0.0/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/DataDog/websites-modules v1.0.0 h1:HlvFbaJhIJN6AC0DGqvgwsovB+wGLe/0Hcs0/ZjtrLo=
 github.com/DataDog/websites-modules v1.0.0/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.0.1 h1:jWpjiSBOjDJLv8+Z86/6xc3QTvsL9qspjuppy750wmM=
+github.com/DataDog/websites-modules v1.0.1/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/DataDog/websites-modules v1.0.0 h1:HlvFbaJhIJN6AC0DGqvgwsovB+wGLe/0Hcs0/ZjtrLo=
-github.com/DataDog/websites-modules v1.0.0/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
 github.com/DataDog/websites-modules v1.0.1 h1:jWpjiSBOjDJLv8+Z86/6xc3QTvsL9qspjuppy750wmM=
 github.com/DataDog/websites-modules v1.0.1/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=


### PR DESCRIPTION
### What does this PR do?

This PR switches to using tagged releases from websites-modules to avoid local go.sum changes.

### Motivation

Confusion over go sum changes that are picked up locally and whether they should be committed or not.

### Preview

- Announcement banner link should be formatted correctly
- No console errors
- Everything should look the same
https://docs-staging.datadoghq.com/david.jones/tagged-modules/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
