### PR TITLE
Add documentation on enabling the Java Heap Profiler

### DIFF
--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -71,7 +71,7 @@ Alternatively, you can enable the following events in your `jfp` [override templ
 jdk.OldObjectSample#enabled=true
 ```
 
-There is no support for reference chains at this time. Please [open a support ticket][2] if it's something you are interested in.
+[Contact Support][2] if you have feedback or feature requests for the Java heap profiler.
 
 [Learn how to use override templates.](#creating-and-using-a-jfr-template-override-file)
 

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -71,8 +71,6 @@ Alternatively, you can enable the following events in your `jfp` [override templ
 jdk.OldObjectSample#enabled=true
 ```
 
-[Contact Support][2] if you have feedback or feature requests for the Java heap profiler.
-
 [Learn how to use override templates.](#creating-and-using-a-jfr-template-override-file)
 
 ## Removing sensitive information from profiles

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -61,6 +61,20 @@ jdk.ObjectAllocationOutsideTLAB#enabled=true
 
 [Learn how to use override templates.](#creating-and-using-a-jfr-template-override-file)
 
+## Enabling the heap profiler
+
+To enable the heap profiler, start your application with the `-Ddd.profiling.heap.enabled=true` JVM setting or the `DD_PROFILING_HEAP_ENABLED=true` environment variable.
+
+Alternatively, you can enable the following events in your `jfp` [override template file](#creating-and-using-a-jfr-template-override-file):
+
+```
+jdk.OldObjectSample#enabled=true
+```
+
+There is no support for reference chains at this time. Please [open a support ticket][2] if it's something you are interested in.
+
+[Learn how to use override templates.](#creating-and-using-a-jfr-template-override-file)
+
 ## Removing sensitive information from profiles
 
 If your system properties contain sensitive information such as user names or passwords, turn off the system property event by creating a `jfp` [override template file](#creating-and-using-a-jfr-template-override-file) with `jdk.InitialSystemProperty` disabled:

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -62,7 +62,7 @@ jdk.ObjectAllocationOutsideTLAB#enabled=true
 [Learn how to use override templates.](#creating-and-using-a-jfr-template-override-file)
 
 ## Enabling the heap profiler
-
+<div class="alert alert-info">The Java heap profiler feature is in beta.</div>
 To enable the heap profiler, start your application with the `-Ddd.profiling.heap.enabled=true` JVM setting or the `DD_PROFILING_HEAP_ENABLED=true` environment variable.
 
 Alternatively, you can enable the following events in your `jfp` [override template file](#creating-and-using-a-jfr-template-override-file):


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add instructions on enabling the Java Heap Profiler.

### Motivation
<!-- What inspired you to submit this pull request?-->

We want to release the Java Heap Profiler in Beta. We need to guide customers to instructions on how to do so.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/luhenry/heap-profiler/tracing/profiler/profiler_troubleshooting

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
