### PR TITLE
Fix DatadogAgent samples in Kubernetes doc

### DIFF
--- a/content/en/agent/kubernetes/distributions.md
+++ b/content/en/agent/kubernetes/distributions.md
@@ -76,7 +76,7 @@ spec:
       enabled: false
     process:
       enabled: true
-      processCollection: false
+      processCollectionEnabled: false
     log:
       enabled: false
     systemProbe:
@@ -139,9 +139,8 @@ spec:
     config:
       kubelet:
         host:
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
+          fieldRef:
+            fieldPath: spec.nodeName
         hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
         # tlsVerify: false # If Kubelet integration fails with provided configuration
   agent:
@@ -151,7 +150,7 @@ spec:
       enabled: false
     process:
       enabled: true
-      processCollection: false
+      processCollectionEnabled: false
     log:
       enabled: false
     systemProbe:
@@ -299,7 +298,7 @@ spec:
       enabled: false
     process:
       enabled: true
-      processCollection: false
+      processCollectionEnabled: false
     log:
       enabled: false
     systemProbe:
@@ -388,7 +387,7 @@ spec:
       enabled: false
     process:
       enabled: true
-      processCollection: false
+      processCollectionEnabled: false
     log:
       enabled: false
     systemProbe:


### PR DESCRIPTION
### What does this PR do?
Fix some incorrect `DatadogAgent` samples in the Kubernetes distribution docs.

### Motivation
Customer report

### Preview

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/vboulineau/fix-distrib/agent/kubernetes/distributions

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
