### PR TITLE
Update PHP tracer docs to include valgrind and strace info

### DIFF
--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -451,20 +451,20 @@ If no core dump was generated, check the following configurations and change the
 1. Ensure you have a suitable `ulimit` set in your system. You can set it to unlimited: `ulimit -c unlimited`.
 1. If your application runs in a Docker container, changes to `/proc/sys/*` have to be done to the host machine. Contact your system administrator to know the options available to you. If you are able to, try recreating the issue in your testing or staging environments.
 
-### Valgrind trace
+### Obtaining a Valgrind trace
 
 To gain more details about the crash, run the application with Valgrind. Unlike core dumps, this approach always works in an unprivileged container.
 
 Install Valgrind with your package manager. Run the application with Valgrind enough to generate a few requests (not generally in production).
 
 For a CLI application, run:
-{{< code-block lang=shell>}}
+{{< code-block lang=shell >}}
 USE_ZEND_ALLOC=0 valgrind -- php path/to/script.php
 {{< /code-block >}}
 When running `php-fpm` run:
 {{< code-block lang="shell" >}}
- USE_ZEND_ALLOC=0 valgrind --trace-children=yes -- php-fpm -F --fpm-config <CONFIG_FILE_PATH> <MORE_OPTIONS>
- {{< /code-block >}}
+USE_ZEND_ALLOC=0 valgrind --trace-children=yes -- php-fpm -F --fpm-config <CONFIG_FILE_PATH> <MORE_OPTIONS>
+{{< /code-block >}}
 When using Apache, run:
 {{< code-block lang="shell" >}}
 (. /etc/apache2/envvars; USE_ZEND_ALLOC=0 valgrind --trace-children=yes -- apache2 -X)`

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -431,7 +431,7 @@ To remove the PHP tracer:
 
 ## Troubleshooting an application crash
 
-In the unusual event of an application crash caused by the PHP tracer, typically because of a segmentation fault, the best thing to do is obtain a core dump and contact Datadog support.
+In the unusual event of an application crash caused by the PHP tracer, typically because of a segmentation fault, the best thing to do is obtain a core dump or a Valgrind trace and contact Datadog support.
 
 ### Obtaining a core dump
 
@@ -450,6 +450,46 @@ If no core dump was generated, check the following configurations and change the
 1. Ensure you have a suitable `rlimit_core` in the PHP-FPM pool configuration section. You can set it to unlimited: `rlimit_core = unlimited`.
 1. Ensure you have a suitable `ulimit` set in your system. You can set it to unlimited: `ulimit -c unlimited`.
 1. If your application runs in a Docker container, changes to `/proc/sys/*` have to be done to the host machine. Contact your system administrator to know the options available to you. If you are able to, try recreating the issue in your testing or staging environments.
+
+### Valgrind trace
+
+To gain more details about the crash, run the application with Valgrind. Unlike core dumps, this approach always works in an unprivileged container.
+
+Install Valgrind with your package manager. Run the application with Valgrind enough to generate a few requests (not generally in production).
+
+For a CLI application, run:
+{{< code-block lang=shell>}}
+USE_ZEND_ALLOC=0 valgrind -- php path/to/script.php
+{{< /code-block >}}
+When running `php-fpm` run:
+{{< code-block lang="shell" >}}
+ USE_ZEND_ALLOC=0 valgrind --trace-children=yes -- php-fpm -F --fpm-config <CONFIG_FILE_PATH> <MORE_OPTIONS>
+ {{< /code-block >}}
+When using Apache, run:
+{{< code-block lang="shell" >}}
+(. /etc/apache2/envvars; USE_ZEND_ALLOC=0 valgrind --trace-children=yes -- apache2 -X)`
+{{< /code-block >}}
+
+### Obtaining a strace
+
+Some issues are caused by external factors, so it can be valuable to have a `strace`. 
+
+Install `strace` with your package manager. When generating a `strace` to send to Datadog Support, ensure you use the `-f` option to follow child processes.
+
+For a CLI application, run:
+{{< code-block lang="shell" >}}
+strace -f php path/to/script.php
+{{< /code-block >}}
+
+For `php-fpm`, run:
+{{< code-block lang="shell" >}}
+strace -f php-fpm -F --fpm-config <CONFIG_FILE_PATH> <MORE_OPTIONS>
+{{< /code-block >}}
+
+For Apache, run:
+{{< code-block lang="shell" >}}
+(. /etc/apache2/envvars; strace -f apache2 -X)
+{{< /code-block >}}
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do?

Sometimes customers do not manage to generate a core dump: showing other ways to get info.

### Preview
https://docs-staging.datadoghq.com/bob/valgrind-and-strace-info-for-php-apm/tracing/setup_overview/setup/php/?tab=containers#troubleshooting-an-application-crash


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
