### PR TITLE
Documentation for New Group Delay monitor configuration option 

### DIFF
--- a/content/en/monitors/guide/monitor_api_options.md
+++ b/content/en/monitors/guide/monitor_api_options.md
@@ -16,7 +16,7 @@ kind: guide
   - bewteen **1** and **60**: the first evaluation is ignored
   - between **61** and **120**: the first two evaluations are ignored
 
-- **`new_host_delay`** Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non negative integer. Default: **300**. Using `new_group_delay` instead of `new_host_delay` is recommanded.
+- **`new_host_delay`** Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non negative integer. **Deprecated: Use `new_group_delay` instead**
 
 - **`notify_no_data`** a Boolean indicating whether this monitor notifies when data stops reporting. Default: **false**
 - **`no_data_timeframe`** The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks.  **If omitted, 2x the evaluation timeframe is used for metric alerts, and 24 hours is used for service checks.**

--- a/content/en/monitors/guide/monitor_api_options.md
+++ b/content/en/monitors/guide/monitor_api_options.md
@@ -10,7 +10,7 @@ kind: guide
   - To mute the alert completely: `{'*': None}`
   - To mute `role:db` for a short time: `{'role:db': 1412798116}`
 
-- **`new_group_delay`** Time (in seconds) before starting the evaluation of monitor results, to allow newly created groups to boot and applications or containers to fully start. Should be a non negative integer. Default: **60**. Example : If you are using containerized architecture, setting an evaluation delay prevents your monitor grouped by containers from triggering when a new container is created, which may cause some metrics to spike up in the first minutes.
+- **`new_group_delay`** Time (in seconds) before starting alerting on new groups, to allow newly created applications to fully start. Should be a non negative integer. Default: **60**. Example : If you are using containerized architecture, setting an evaluation delay prevents your monitor grouped by containers from triggering when a new container is created, which may cause some latency or cpu usage to spike up in the first minutes.
 
 - **`new_host_delay`** Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non negative integer. **Deprecated: Use `new_group_delay` instead**
 

--- a/content/en/monitors/guide/monitor_api_options.md
+++ b/content/en/monitors/guide/monitor_api_options.md
@@ -10,7 +10,7 @@ kind: guide
   - To mute the alert completely: `{'*': None}`
   - To mute `role:db` for a short time: `{'role:db': 1412798116}`
 
-- **`new_group_delay`** Time (in seconds) before starting alerting on new groups, to allow newly created applications to fully start. Should be a non negative integer. Default: **60**. Example : If you are using containerized architecture, setting an evaluation delay prevents your monitor grouped by containers from triggering when a new container is created, which may cause some latency or cpu usage to spike up in the first minutes.
+- **`new_group_delay`** Time (in seconds) before starting alerting on new groups, to allow newly created applications or containers to fully start. Should be a non negative integer. Default: **60**. Example : If you are using containerized architecture, setting an evaluation delay prevents your monitor grouped by containers from triggering when a new container is created, which may cause some latency or cpu usage to spike up in the first minutes.
 
 - **`new_host_delay`** Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non negative integer. **Deprecated: Use `new_group_delay` instead**
 

--- a/content/en/monitors/guide/monitor_api_options.md
+++ b/content/en/monitors/guide/monitor_api_options.md
@@ -3,14 +3,21 @@ title: Monitor API Options
 kind: guide
 ---
 
-## Common options 
+## Common options
 
 - **`silenced`** dictionary of scopes to timestamps or `None`. Each scope is muted until the given POSIX timestamp or forever if the value is `None`. Default: **None**. Examples:
 
   - To mute the alert completely: `{'*': None}`
   - To mute `role:db` for a short time: `{'role:db': 1412798116}`
 
-- **`new_host_delay`** Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non negative integer. Default: **300**
+- **`new_group_delay`** Time (in seconds) before starting the evaluation of monitor results, to allow newly created groups to boot and applications to fully start. Should be a non negative integer. Default: **60**. Examples :
+
+  - equal to **0**: no evaluation is ignored
+  - bewteen **1** and **60**: the first evaluation is ignored
+  - between **61** and **120**: the first two evaluations are ignored
+
+- **`new_host_delay`** Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non negative integer. Default: **300**. Using `new_group_delay` instead of `new_host_delay` is recommanded.
+
 - **`notify_no_data`** a Boolean indicating whether this monitor notifies when data stops reporting. Default: **false**
 - **`no_data_timeframe`** The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks.  **If omitted, 2x the evaluation timeframe is used for metric alerts, and 24 hours is used for service checks.**
 - **`timeout_h`** the number of hours of the monitor not reporting data before it automatically resolves from a triggered state. Default: **None**.
@@ -63,7 +70,7 @@ Example: `{'ok': 1, 'critical': 1, 'warning': 1}`
 
 - **`aggregation`** a dictionary of `type`, `metric` and `groupeBy`:
   - `type`  3 types are supported: `count`, `cardinality` and `avg`
-  - `metric`:  for `cardinality` name of the facet. For `avg` name of the metric. for `count`just put `count` as metric  
+  - `metric`:  for `cardinality` name of the facet. For `avg` name of the metric. for `count`just put `count` as metric
   - `groupeBy` name of the facet on which you want to group by.
 
 Example: `{"metric": "count","type": "count","groupBy": "core_service"}`

--- a/content/en/monitors/guide/monitor_api_options.md
+++ b/content/en/monitors/guide/monitor_api_options.md
@@ -10,11 +10,7 @@ kind: guide
   - To mute the alert completely: `{'*': None}`
   - To mute `role:db` for a short time: `{'role:db': 1412798116}`
 
-- **`new_group_delay`** Time (in seconds) before starting the evaluation of monitor results, to allow newly created groups to boot and applications to fully start. Should be a non negative integer. Default: **60**. Examples :
-
-  - equal to **0**: no evaluation is ignored
-  - bewteen **1** and **60**: the first evaluation is ignored
-  - between **61** and **120**: the first two evaluations are ignored
+- **`new_group_delay`** Time (in seconds) before starting the evaluation of monitor results, to allow newly created groups to boot and applications or containers to fully start. Should be a non negative integer. Default: **60**. Example : If you are using containerized architecture, setting an evaluation delay will prevent your monitor grouped by containers from triggering when a new container is created, which may cause some metrics to spike up in the first minutes.
 
 - **`new_host_delay`** Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non negative integer. **Deprecated: Use `new_group_delay` instead**
 

--- a/content/en/monitors/guide/monitor_api_options.md
+++ b/content/en/monitors/guide/monitor_api_options.md
@@ -10,7 +10,7 @@ kind: guide
   - To mute the alert completely: `{'*': None}`
   - To mute `role:db` for a short time: `{'role:db': 1412798116}`
 
-- **`new_group_delay`** Time (in seconds) before starting the evaluation of monitor results, to allow newly created groups to boot and applications or containers to fully start. Should be a non negative integer. Default: **60**. Example : If you are using containerized architecture, setting an evaluation delay will prevent your monitor grouped by containers from triggering when a new container is created, which may cause some metrics to spike up in the first minutes.
+- **`new_group_delay`** Time (in seconds) before starting the evaluation of monitor results, to allow newly created groups to boot and applications or containers to fully start. Should be a non negative integer. Default: **60**. Example : If you are using containerized architecture, setting an evaluation delay prevents your monitor grouped by containers from triggering when a new container is created, which may cause some metrics to spike up in the first minutes.
 
 - **`new_host_delay`** Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non negative integer. **Deprecated: Use `new_group_delay` instead**
 

--- a/content/en/monitors/guide/monitor_api_options.md
+++ b/content/en/monitors/guide/monitor_api_options.md
@@ -10,7 +10,7 @@ kind: guide
   - To mute the alert completely: `{'*': None}`
   - To mute `role:db` for a short time: `{'role:db': 1412798116}`
 
-- **`new_group_delay`** Time (in seconds) before starting alerting on new groups, to allow newly created applications or containers to fully start. Should be a non negative integer. Default: **60**. Example : If you are using containerized architecture, setting an evaluation delay prevents your monitor grouped by containers from triggering when a new container is created, which may cause some latency or cpu usage to spike up in the first minutes.
+- **`new_group_delay`** Time (in seconds) before starting alerting on new groups, to allow newly created applications or containers to fully start. Should be a non negative integer. Default: **60**. Example: If you are using a containerized architecture, setting an evaluation delay prevents your monitor's group-by containers from triggering when a new container is created, which may cause some latency or a spike in CPU usage in the first minutes.
 
 - **`new_host_delay`** Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of monitor results. Should be a non negative integer. **Deprecated: Use `new_group_delay` instead**
 
@@ -66,7 +66,7 @@ Example: `{'ok': 1, 'critical': 1, 'warning': 1}`
 
 - **`aggregation`** a dictionary of `type`, `metric` and `groupeBy`:
   - `type`  3 types are supported: `count`, `cardinality` and `avg`
-  - `metric`:  for `cardinality` name of the facet. For `avg` name of the metric. for `count`just put `count` as metric
+  - `metric`:  For `cardinality`, use the name of the facet. For `avg`, use the name of the metric. For `count`, put `count` as metric.
   - `groupeBy` name of the facet on which you want to group by.
 
 Example: `{"metric": "count","type": "count","groupBy": "core_service"}`

--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -96,7 +96,7 @@ Alerts are grouped automatically based on your selection of the `group by` step 
 
 Simple alerts aggregate over all reporting sources. You receive one alert when the aggregated value meets the set conditions. This works best to monitor a metric from a single host or the sum of a metric across many hosts.
 
-Multi alerts apply the alert to each source according to your group parameters. You receive an alert for each group that meets the set conditions. For example, you could group `system.disk.in_use` by `host` and `device` to receive a separate alert for each host device that is running out of space. 
+Multi alerts apply the alert to each source according to your group parameters. You receive an alert for each group that meets the set conditions. For example, you could group `system.disk.in_use` by `host` and `device` to receive a separate alert for each host device that is running out of space.
 Note that if your metric is only reporting by `host` with no `device` tag, it would not be detected by a monitor group by both `host` and `device`. [Tag Variables][4] are available for every group evaluated in the multi-alert to dynamically fill in notifications with useful context.
 
 ### Set alert conditions
@@ -189,6 +189,13 @@ For a monitor that does not notify on missing data, if a group does not report d
 For some metrics that report periodically, it may make sense for triggered alerts to auto-resolve after a certain time period. For example, if you have a counter that reports only when an error is logged, the alert never resolves because the metric never reports `0` as the number of errors. In this case, set your alert to resolve after a certain time of inactivity on the metric. **Note**: If a monitor auto-resolves and the value of the query does not meet the recovery threshold at the next evaluation, the monitor triggers an alert again.
 
 In most cases this setting is not useful because you only want an alert to resolve once it is actually fixed. So, in general, it makes sense to leave this as `[Never]` so alerts only resolve when the metric is above or below the set threshold.
+
+#### New group delay
+
+Delay the evaluation by `N` seconds for new groups.
+The option is available with multi-alert mode.
+
+The time (in seconds) before starting the evaluation of monitor results, to allow newly created groups to boot and applications to fully start. This should be a non-negative integer. If the delay is set between `1` and `60` seconds and the evaluation frequency is 1 minute, the monitor will skip the first evaluations for newly created groups. If the delay is set between `61` and `120` seconds, the monitor will skip the 2 first evaluations, and so on.
 
 #### Evaluation delay
 

--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -192,11 +192,11 @@ In most cases this setting is not useful because you only want an alert to resol
 
 #### New group delay
 
-Delay the evaluation start by `N` seconds for new groups.
+Delay the evaluation start by `N` seconds for new groups. The time (in seconds) to wait before starting alerting, to allow newly created groups to boot and applications to fully start. This should be a non-negative integer.
+
+For example, if you are using containerized architecture, setting an evaluation delay prevents your monitor group-by containers from triggering due to high resource usage or high latency when a new container is created. The delay is applied to every new group (which has not been seen in the last 24 hours) and defaults to `60` seconds.
+
 The option is available with multi-alert mode.
-
-The time (in seconds) to wait before starting alerting, to allow newly created groups to boot and applications to fully start. This should be a non-negative integer. For example, if you are using containerized architecture, setting an evaluation delay prevents your monitor grouped by containers from triggering due to a high resource usage or a high latency when a new container is created. The delay is applied to every new group - which has not been seen in the last 24 hours - and is set to `60 seconds` by default.
-
 #### Evaluation delay
 
 Delay evaluation by `N` seconds.

--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -195,7 +195,7 @@ In most cases this setting is not useful because you only want an alert to resol
 Delay the evaluation by `N` seconds for new groups.
 The option is available with multi-alert mode.
 
-The time (in seconds) to wait before starting alerting, to allow newly created groups to boot and applications to fully start. This should be a non-negative integer. If you are using containerized architecture, setting an evaluation delay prevents your monitor grouped by containers from triggering due to a high resource usage or a high latency when a new container is created. The delay is applied to every new group - which has not been seen in the last 24 hours - and is set to `60 seconds` by default.
+The time (in seconds) to wait before starting alerting, to allow newly created groups to boot and applications to fully start. This should be a non-negative integer. For example, if you are using containerized architecture, setting an evaluation delay prevents your monitor grouped by containers from triggering due to a high resource usage or a high latency when a new container is created. The delay is applied to every new group - which has not been seen in the last 24 hours - and is set to `60 seconds` by default.
 
 #### Evaluation delay
 

--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -195,7 +195,7 @@ In most cases this setting is not useful because you only want an alert to resol
 Delay the evaluation by `N` seconds for new groups.
 The option is available with multi-alert mode.
 
-The time (in seconds) before starting the evaluation of monitor results, to allow newly created groups to boot and applications to fully start. This should be a non-negative integer. If you are using containerized architecture, setting an evaluation delay will prevent your monitor grouped by containers from triggering when a new container is created, which may cause some metrics to spike up in the first minutes. The option is set to `60` seconds by default.
+The time (in seconds) before starting the evaluation of monitor results, to allow newly created groups to boot and applications to fully start. This should be a non-negative integer. If you are using containerized architecture, setting an evaluation delay prevents your monitor grouped by containers from triggering when a new container is created, which may cause some metrics to spike up in the first minutes. The option is set to `60` seconds by default.
 
 #### Evaluation delay
 

--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -195,7 +195,7 @@ In most cases this setting is not useful because you only want an alert to resol
 Delay the evaluation by `N` seconds for new groups.
 The option is available with multi-alert mode.
 
-The time (in seconds) before starting the evaluation of monitor results, to allow newly created groups to boot and applications to fully start. This should be a non-negative integer. If the delay is set between `1` and `60` seconds and the evaluation frequency is 1 minute, the monitor will skip the first evaluations for newly created groups. If the delay is set between `61` and `120` seconds, the monitor will skip the 2 first evaluations, and so on.
+The time (in seconds) before starting the evaluation of monitor results, to allow newly created groups to boot and applications to fully start. This should be a non-negative integer. If you are using containerized architecture, setting an evaluation delay will prevent your monitor grouped by containers from triggering when a new container is created, which may cause some metrics to spike up in the first minutes. The option is set to `60` seconds by default.
 
 #### Evaluation delay
 

--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -195,7 +195,7 @@ In most cases this setting is not useful because you only want an alert to resol
 Delay the evaluation by `N` seconds for new groups.
 The option is available with multi-alert mode.
 
-The time (in seconds) before starting the evaluation of monitor results, to allow newly created groups to boot and applications to fully start. This should be a non-negative integer. If you are using containerized architecture, setting an evaluation delay prevents your monitor grouped by containers from triggering when a new container is created, which may cause some metrics to spike up in the first minutes. The option is set to `60` seconds by default.
+The time (in seconds) to wait before starting alerting, to allow newly created groups to boot and applications to fully start. This should be a non-negative integer. If you are using containerized architecture, setting an evaluation delay prevents your monitor grouped by containers from triggering due to a high resource usage or a high latency when a new container is created. The delay is applied to every new group - which has not been seen in the last 24 hours - and is set to `60 seconds` by default.
 
 #### Evaluation delay
 

--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -192,7 +192,7 @@ In most cases this setting is not useful because you only want an alert to resol
 
 #### New group delay
 
-Delay the evaluation by `N` seconds for new groups.
+Delay the evaluation start by `N` seconds for new groups.
 The option is available with multi-alert mode.
 
 The time (in seconds) to wait before starting alerting, to allow newly created groups to boot and applications to fully start. This should be a non-negative integer. For example, if you are using containerized architecture, setting an evaluation delay prevents your monitor grouped by containers from triggering due to a high resource usage or a high latency when a new container is created. The delay is applied to every new group - which has not been seen in the last 24 hours - and is set to `60 seconds` by default.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Documentation for new group delay option replacing new host delay (deprecated)

### Motivation
<!-- What inspired you to submit this pull request?-->
Inform users of the changes (both API and UI)

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/antoine.dussault/new_group_delay/monitors/monitor_types/metric/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
