### PR TITLE
[datadogpy] Update statsd client docs to include buffering API changes

### DIFF
--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -66,14 +66,22 @@ func main() {
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}
 
-By using Datadog's official Python library [datadogpy][1], the example below creates a buffered DogStatsD client instance that sends up to 25 metrics in one packet when the block completes:
+By using Datadog's official Python library [datadogpy][1], the example below uses a buffered DogStatsD client that sends metrics in a minimal number of packets. In client versions v0.43.0 and higher, buffering is enabled by default and automatic flushing is performed at packet size limit and every 300ms (configurable).
 
 ```python
 from datadog import DogStatsd
 
-with DogStatsd(host="127.0.0.1", port=8125, max_buffer_size=25) as batch:
-    batch.gauge('example_metric.gauge_1', 123, tags=["environment:dev"])
-    batch.gauge('example_metric.gauge_2', 1001, tags=["environment:dev"])
+dsd = DogStatsd(host="127.0.0.1", port=8125)
+
+# If using client v0.43.0+, buffering is enabled by default with automatic flushing every 300ms.
+dsd.gauge('example_metric.gauge_1', 123, tags=["environment:dev"])
+dsd.gauge('example_metric.gauge_2', 1001, tags=["environment:dev"])
+dsd.flush()  # Optional manual flush
+
+# If using client before v0.43.0, context manager is needed to use buffering
+with dsd:
+    dsd.gauge('example_metric.gauge_1', 123, tags=["environment:dev"])
+    dsd.gauge('example_metric.gauge_2', 1001, tags=["environment:dev"])
 ```
 
 
@@ -303,7 +311,7 @@ See the next section on burst detection to help you detect bursts of metrics fro
 
 ### Enable metrics processing stats and burst detection
 
-DogStatsD has a stats mode in which you will be able to know which metrics are the most processed. 
+DogStatsD has a stats mode in which you will be able to know which metrics are the most processed.
 
 **Note**: Enabling this mode can decrease DogStatsD performance.
 

--- a/content/en/developers/service_checks/dogstatsd_service_checks_submission.md
+++ b/content/en/developers/service_checks/dogstatsd_service_checks_submission.md
@@ -36,7 +36,7 @@ Service check function parameters:
 
 ### Code examples
 
-Choose your language for a service check code example:
+Run the following code to submit a service check via DogStatsD to Datadog. Remember to `flush`/`close` the client when it is no longer needed.
 
 {{< programming-lang-wrapper langs="python,ruby,go,java,.NET,php" >}}
 

--- a/content/en/developers/service_checks/dogstatsd_service_checks_submission.md
+++ b/content/en/developers/service_checks/dogstatsd_service_checks_submission.md
@@ -36,7 +36,7 @@ Service check function parameters:
 
 ### Code examples
 
-Run the following code to submit a service check via DogStatsD to Datadog. Remember to `flush`/`close` the client when it is no longer needed.
+Run the following code to submit a service check through DogStatsD to Datadog. Remember to `flush`/`close` the client when it is no longer needed.
 
 {{< programming-lang-wrapper langs="python,ruby,go,java,.NET,php" >}}
 

--- a/content/en/events/guides/dogstatsd.md
+++ b/content/en/events/guides/dogstatsd.md
@@ -40,7 +40,7 @@ event(<TITLE>, <TEXT>, <TIMESTAMP>, <HOSTNAME>, <AGGREGATION_KEY>, <PRIORITY>, <
 
 ### Examples
 
-View errors and exceptions in Datadog with a DogStatsD event:
+Run the following code to view errors and exceptions in Datadog with a DogStatsD event. Remember to `flush`/`close` the client when it is no longer needed.
 
 {{< programming-lang-wrapper langs="python,ruby,go,java,.NET,php" >}}
 
@@ -57,6 +57,9 @@ options = {
 initialize(**options)
 
 statsd.event('An error occurred', 'Error message', alert_type='error', tags=['env:dev'])
+
+# Optional manual flush (only available in client versions >= 0.43.0)
+statsd.flush()
 ```
 {{< /programming-lang >}}
 

--- a/content/en/metrics/dogstatsd_metrics_submission.md
+++ b/content/en/metrics/dogstatsd_metrics_submission.md
@@ -51,7 +51,7 @@ After you [install DogStatsD][1], the following functions are available for subm
 
 Emit a `COUNT` metric-stored as a `RATE` metric-to Datadog. Learn more about the `COUNT` type in the [metric types][2] documentation.
 
-Run the following code to submit a DogStatsD `COUNT` metric to Datadog. Remember to `close` the client when it is no longer needed.
+Run the following code to submit a DogStatsD `COUNT` metric to Datadog. Remember to `flush`/`close` the client when it is no longer needed.
 
 {{< programming-lang-wrapper langs="python,ruby,go,java,.NET,php" >}}
 
@@ -219,7 +219,7 @@ Since the value is submitted as a `COUNT` it's stored as `RATE` in Datadog. To g
 
 Emit a `GAUGE` metric-stored as a `GAUGE` metric-to Datadog. Learn more about the `GAUGE` type in the [metric types][5] documentation.
 
-Run the following code to submit a DogStatsD `GAUGE` metric to Datadog. Remember to `close` the client when it is no longer needed.
+Run the following code to submit a DogStatsD `GAUGE` metric to Datadog. Remember to `flush`/`close` the client when it is no longer needed.
 
 {{< programming-lang-wrapper langs="python,ruby,go,java,.NET,php" >}}
 
@@ -378,7 +378,7 @@ After running the code above, your metric data is available to graph in Datadog:
 
 Emit a `SET` metric-stored as a `GAUGE` metric-to Datadog.
 
-Run the following code to submit a DogStatsD `SET` metric to Datadog. Remember to `close` the client when it is no longer needed.
+Run the following code to submit a DogStatsD `SET` metric to Datadog. Remember to `flush`/`close` the client when it is no longer needed.
 
 {{< programming-lang-wrapper langs="python,ruby,go,.NET,PHP" >}}
 
@@ -520,7 +520,7 @@ After running the code above, your metrics data is available to graph in Datadog
 The `HISTOGRAM` metric type is specific to DogStatsD. Emit a `HISTOGRAM` metric—stored as a `GAUGE` and `RATE` metric—to Datadog. Learn more about the `HISTOGRAM` type in the [metric types][6] documentation.
 
 
-Run the following code to submit a DogStatsD `HISTOGRAM` metric to Datadog. Remember to `close` the client when it is no longer needed.
+Run the following code to submit a DogStatsD `HISTOGRAM` metric to Datadog. Remember to `flush`/`close` the client when it is no longer needed.
 
 {{< programming-lang-wrapper langs="python,ruby,go,.NET,PHP" >}}
 
@@ -687,7 +687,7 @@ For a `TIMER`, the `HISTOGRAM` [configuration](#configuration) rules apply.
 
 ##### Code examples
 
-Emit a `TIMER` metric—stored as a `GAUGE` and `RATE` metric—to Datadog. Learn more about the `HISTOGRAM` type in the [metric types][6] documentation. Remember to `close` the client when it is no longer needed.
+Emit a `TIMER` metric—stored as a `GAUGE` and `RATE` metric—to Datadog. Learn more about the `HISTOGRAM` type in the [metric types][6] documentation. Remember to `flush`/`close` the client when it is no longer needed.
 
 {{< programming-lang-wrapper langs="python,PHP" >}}
 
@@ -788,7 +788,7 @@ DogStatsD treats `TIMER` as a `HISTOGRAM` metric. Whether you use the `TIMER` or
 
 The `DISTRIBUTION` metric type is specific to DogStatsD. Emit a `DISTRIBUTION` metric-stored as a `DISTRIBUTION` metric-to Datadog. Learn more about the `DISTRIBUTION` type in the [metric types][9] documentation.
 
-Run the following code to submit a DogStatsD `DISTRIBUTION` metric to Datadog. Remember to `close` the client when it is no longer needed.
+Run the following code to submit a DogStatsD `DISTRIBUTION` metric to Datadog. Remember to `flush`/`close` the client when it is no longer needed.
 
 {{< programming-lang-wrapper langs="python,ruby,go,java,.NET,php" >}}
 


### PR DESCRIPTION
### What does this PR do?

Update `datadogpy` `statsd` client examples/docs to include subtle changes to the API now that buffering is enabled by default.

### Motivation

Since `statsd` in `datadogpy` Python library is now buffered by default, some
documentation changes were needed to reflect that change. While majority
of the usage is the same, some sections needed updating to show that `flush`
may be needed to send the data and that buffering is enabled.

Since other buffered-by-default clients may also need flushing of the data, we
now specify to close/flush the clients in more places.

### Preview

Not sure why these don't work but:
- https://docs-staging.datadoghq.com/sgnn7%2Fdatadogpy-statsd-api-changes/content/en/developers/dogstatsd/high_throughput.md 
- https://docs-staging.datadoghq.com/sgnn7%2Fdatadogpy-statsd-api-changes/content/en/developers/service_checks/dogstatsd_service_checks_submission.md
- https://docs-staging.datadoghq.com/sgnn7%2Fdatadogpy-statsd-api-changes/content/en/events/guides/dogstatsd.md 
- https://docs-staging.datadoghq.com/sgnn7%2Fdatadogpy-statsd-api-changes/content/en/metrics/dogstatsd_metrics_submission.md

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
