### PR TITLE
Remove note about arm64 packages on SUSE

### DIFF
--- a/content/en/agent/basic_agent_usage/suse.md
+++ b/content/en/agent/basic_agent_usage/suse.md
@@ -20,7 +20,7 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for SUSE. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
-Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
+Packages are available for 64-bit x86 architectures. For other architectures, use the source install.
 
 **Note**: SUSE 11 SP4 and above are supported.
 


### PR DESCRIPTION
### Motivation
We only have x64 packages.

### Preview
https://docs-staging.datadoghq.com/albertvaka/remove-arm64-suse-1/agent/basic_agent_usage/suse/?tab=agentv6v7

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
