### PR TITLE
[CIAPP] Bump Python tracer version to latest stable

### DIFF
--- a/content/en/continuous_integration/setup_tests/python.md
+++ b/content/en/continuous_integration/setup_tests/python.md
@@ -27,7 +27,7 @@ Supported test frameworks:
 Install the Python tracer by running:
 
 {{< code-block lang="bash" >}}
-pip install "ddtrace>=0.50.0rc4"
+pip install -U ddtrace
 {{< /code-block >}}
 
 For more information, see the [Python tracer installation documentation][2].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Bumps the required Python tracer version to the latest stable.

cc @juan-fernandez @cindyhan0209 @sejmakes 

### Motivation
<!-- What inspired you to submit this pull request?-->

New Python stable version has been released that includes all CI Visibility features.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fermayo/ciapp-bump-python-version/continuous_integration/setup_tests/python/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
