### PR TITLE
Update network.md

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -106,7 +106,9 @@ Add all of the `ip-ranges` to your inclusion list. While only a subset are activ
 
 ## Open ports
 
+<div class="alert alert-warning">
 All outbound traffic is sent over SSL through TCP / UDP.
+</div>
 
 Open the following ports to benefit from all the **Agent** functionalities:
 


### PR DESCRIPTION
### What does this PR do?
Adds the outbound traffic note as a warning as port `443` is typically used for HTTPS, but in this instance outbound traffic is sent over SSL through TCP/UDP.

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/sarina/logs-network-warning/agent/guide/network

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
