### PR TITLE
[WEB-1580] - update push pull folder frontmatter

### DIFF
--- a/layouts/partials/page-edit.html
+++ b/layouts/partials/page-edit.html
@@ -1,7 +1,6 @@
 {{ $ctx := .ctx }}
 {{ $type := .type}}
-{{ $.Scratch.Set "editURL" "" }}
-
+{{ $editLink := "" }}
 {{ if $ctx.Params.dependencies }}
 {{/* Files with dependencies link to corresponding URL */}}
 
@@ -15,11 +14,12 @@
             {{ if in $dep "/blob/" }}
 
                 {{/* Find Replace /blob/ to /edit/ */}}
-                {{ $tmpURL := replace $dep "/blob/" "/edit/" }}
+                {{ $editLink = replace $dep "/blob/" "/edit/" }}
 
-                {{/* Set Scratch */}}
-                {{ $ctx.Scratch.Set "editURL" $tmpURL }}
-                {{ $editLink := $ctx.Scratch.Get "editURL" }}
+                {{/* if url is a directory try map it to the same filename */}}
+                {{ if or (strings.HasSuffix $editLink "/") }}
+                    {{ $editLink = (print $editLink $ctx.File.TranslationBaseName ".md") }}
+                {{ end }}
 
                 {{ with $ctx.File }}
                     {{ partial "page-edit-body.html" (dict "ctx" $ctx "link" $editLink "type" $type) }}
@@ -37,7 +37,7 @@
 {{/* Not in integrations edit existing docs file */}}
 
     {{ with $ctx.File }}
-        {{ $editLink := ( printf "https://github.com/DataDog/documentation/edit/master/content/%s/%s/" $ctx.Page.Lang $ctx.File.Path ) }}
+        {{ $editLink = ( printf "https://github.com/DataDog/documentation/edit/master/content/%s/%s/" $ctx.Page.Lang $ctx.File.Path ) }}
         {{ partial "page-edit-body.html" (dict "ctx" $ctx "link" $editLink "type" $type) }}
     {{ end }}
 

--- a/local/bin/py/build/actions/pull_and_push_folder.py
+++ b/local/bin/py/build/actions/pull_and_push_folder.py
@@ -27,23 +27,28 @@ def pull_and_push_folder(content, content_dir):
     for file_name in chain.from_iterable(glob.iglob(pattern, recursive=True) for pattern in content["globs"]):
         with open(file_name, mode="r+", encoding="utf-8", errors="ignore") as f:
             file_content = f.read()
+            boundary = re.compile(r'^-{3,}$', re.MULTILINE)
+            split = boundary.split(file_content, 2)
+            new_yml = {}
+            txt = file_content
+            if len(split) == 3:
+                _, fm, txt = split
+                new_yml = yaml.load(fm, Loader=yaml.FullLoader)
+            elif len(split) == 1:
+                txt = split[0]
             # if front matter update existing
             if "front_matters" in content["options"]:
-                boundary = re.compile(r'^-{3,}$', re.MULTILINE)
-                split = boundary.split(file_content, 2)
-                new_yml = {}
-                txt = file_content
-                if len(split) == 3:
-                    _, fm, txt = split
-                    new_yml = yaml.load(fm, Loader=yaml.FullLoader)
-                elif len(split) == 1:
-                    txt = split[0]
                 new_yml.update(content["options"]["front_matters"])
-                front_matter = yaml.dump(new_yml, default_flow_style=False).strip()
-                file_content = TEMPLATE.format(front_matter=front_matter, content=txt.strip())
-            # Replacing the master README.md by _index.md to follow Hugo logic
-            if file_name.endswith("README.md"):
-                file_name = "_index.md"
+                # if the dependency ends with a `/` e.g folder then lets try replace with the actual filename
+                new_deps = []
+                for dep in new_yml.get("dependencies", []):
+                    if dep.endswith('/'):
+                        new_deps.append('{}{}'.format(
+                            dep,
+                            basename(file_name)
+                        ))
+                new_yml['dependencies'] = new_deps
+            front_matter = yaml.dump(new_yml, default_flow_style=False).strip()
             # Replacing links that point to the Github folder by link that point to the doc.
             new_link = (
                 content["options"]["dest_dir"] + "\\2"
@@ -58,12 +63,16 @@ def pull_and_push_folder(content, content_dir):
                     ],
                 )
             )
-            file_content = re.sub(
+            txt = re.sub(
                 regex_github_link,
                 new_link,
-                file_content,
+                txt,
                 count=0,
             )
+            file_content = TEMPLATE.format(front_matter=front_matter, content=txt.strip())
+            # Replacing the master README.md by _index.md to follow Hugo logic
+            if file_name.endswith("README.md"):
+                file_name = "_index.md"
         # Writing the new content to the documentation file
         dirp = "{}{}".format(
             content_dir,

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -85,6 +85,8 @@
       options:
         dest_dir: '/developers/integrations/'
         path_to_remove: 'docs/dev/'
+        front_matters:
+          dependencies: [ "https://github.com/DataDog/integrations-core/blob/master/docs/dev/" ]
 
   - repo_name: integrations-extras
     contents:
@@ -529,6 +531,8 @@
       options:
         dest_dir: '/real_user_monitoring/ios/'
         path_to_remove: 'docs/rum_collection/'
+        front_matters:
+          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
 
   - repo_name: dd-sdk-reactnative
     contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -87,7 +87,7 @@
         dest_dir: '/developers/integrations/'
         path_to_remove: 'docs/dev/'
         front_matters:
-          dependencies: [ "https://github.com/DataDog/integrations-core/tree/master/docs/dev/" ]
+          dependencies: [ "https://github.com/DataDog/integrations-core/blob/master/docs/dev/" ]
 
   - repo_name: integrations-extras
     contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -86,6 +86,8 @@
       options:
         dest_dir: '/developers/integrations/'
         path_to_remove: 'docs/dev/'
+        front_matters:
+          dependencies: [ "https://github.com/DataDog/integrations-core/tree/master/docs/dev/" ]
 
   - repo_name: integrations-extras
     contents:
@@ -530,6 +532,8 @@
       options:
         dest_dir: '/real_user_monitoring/ios/'
         path_to_remove: 'docs/rum_collection/'
+        front_matters:
+          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
 
   - repo_name: dd-sdk-reactnative
     contents:


### PR DESCRIPTION
### What does this PR do?

Updates the pulling in of folders to be able to update dependencies frontmatter so that edit links work.
Note that edit links go to the directory instead of direct files in this situation.

### Motivation

https://datadoghq.atlassian.net/browse/WEB-1580

### Preview

https://docs-staging.datadoghq.com/david.jones/edit-links/developers/integrations/new_check_howto/
https://docs-staging.datadoghq.com/david.jones/edit-links/real_user_monitoring/ios/ 

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
