### PR TITLE
[DOCS-2280][rum] document view renaming

### DIFF
--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -29,6 +29,74 @@ There are various ways you can modify the [data collected][1] by RUM, to support
 - Reducing how much RUM data you're collecting, through sampling the data.
 - Providing more context than what the default attributes provide about where the data is coming from.
 
+## Override default RUM view names
+
+The RUM SDK generates a [view event][14] for each new page visited by your users. A view name is computed from the current page URL, with variable alphanumeric ids being removed automatically (for example, "/dashboard/1234" becomes "/dashboard/?").
+
+Starting with [version 2.17.0][15], you may override the default view name with the `trackViewsManually` option:
+
+1. Set up `trackViewsManually` to true when initializing RUM.
+{{< tabs >}}
+{{% tab "NPM" %}}
+
+```javascript
+import { datadogRum } from '@datadog/browser-rum';
+
+datadogRum.init({
+    ...,
+    trackViewsManually: true,
+    ...
+});
+```
+{{% /tab %}}
+{{% tab "CDN async" %}}
+```javascript
+DD_RUM.onReady(function() {
+    DD_RUM.init({
+        ...,
+        trackViewsManually: true,
+        ...
+    })
+})
+```
+{{% /tab %}}
+{{% tab "CDN sync" %}}
+```javascript
+window.DD_RUM &&
+    window.DD_RUM.init({
+        ...,
+        trackViewsManually: true,
+        ...
+    });
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+2. Start views for each new page and define the associated view name. If not provided a name, the view name will default to the page URL path.
+{{< tabs >}}
+{{% tab "NPM" %}}
+```javascript
+datadogRum.startView('checkout')
+```
+
+{{% /tab %}}
+{{% tab "CDN async" %}}
+```javascript
+DD_RUM.onReady(function() {
+    DD_RUM.startView('checkout')
+})
+```
+{{% /tab %}}
+{{% tab "CDN sync" %}}
+
+```javascript
+window.DD_RUM && window.DD_RUM.startView('checkout')
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+**Note**: If you are using React, Angular, Vue or any other frontend framework, we recommend implementing the `startView` logic at the framework router level.
+
 ## Enrich and control RUM data
 
 The RUM SDK captures RUM events and populates their main attributes. The `beforeSend` callback function gives you access to every event collected by the RUM SDK before they are sent to Datadog. Intercepting the RUM events allows you to:
@@ -540,3 +608,5 @@ var context = window.DD_RUM && DD_RUM.getRumGlobalContext();
 [11]: /real_user_monitoring/guide/enrich-and-control-rum-data
 [12]: https://github.com/DataDog/browser-sdk/blob/main/packages/rum-core/src/rumEvent.types.ts
 [13]: /logs/log_configuration/attributes_naming_convention/#user-related-attributes
+[14]: /real_user_monitoring/browser/monitoring_page_performance/
+[15]: https://github.com/DataDog/browser-sdk/blob/main/CHANGELOG.md#v2170

--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -31,9 +31,9 @@ There are various ways you can modify the [data collected][1] by RUM, to support
 
 ## Override default RUM view names
 
-The RUM SDK generates a [view event][14] for each new page visited by your users. A view name is computed from the current page URL, with variable alphanumeric ids being removed automatically (for example, "/dashboard/1234" becomes "/dashboard/?").
+The RUM SDK automatically generates a [view event][14] for each new page visited by your users, or when the page URL is changed (for single page applications). A view name is computed from the current page URL, with variable alphanumeric ids being removed automatically (for example, "/dashboard/1234" becomes "/dashboard/?").
 
-Starting with [version 2.17.0][15], you may override the default view name with the `trackViewsManually` option:
+Starting with [version 2.17.0][15], you may specify your own view names by tracking view events manually with the `trackViewsManually` option:
 
 1. Set up `trackViewsManually` to true when initializing RUM.
 {{< tabs >}}
@@ -72,7 +72,7 @@ window.DD_RUM &&
 {{% /tab %}}
 {{< /tabs >}}
 
-2. Start views for each new page and define the associated view name. If not provided a name, the view name will default to the page URL path.
+2. Start views for each new page, or route change (for single page applications), and define the associated view name. If not provided a name, the view name defaults to the page URL path.
 {{< tabs >}}
 {{% tab "NPM" %}}
 ```javascript

--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -72,7 +72,7 @@ window.DD_RUM &&
 {{% /tab %}}
 {{< /tabs >}}
 
-2. Start views for each new page, or route change (for single page applications), and define the associated view name. If not provided a name, the view name defaults to the page URL path.
+2. You **must** start views for each new page, or route change (for single page applications), and optionally define the associated view name (it defaults to the page URL path). No RUM data gets collected until the view is started.
 {{< tabs >}}
 {{% tab "NPM" %}}
 ```javascript

--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -31,7 +31,7 @@ There are various ways you can modify the [data collected][1] by RUM, to support
 
 ## Override default RUM view names
 
-The RUM SDK automatically generates a [view event][14] for each new page visited by your users, or when the page URL is changed (for single page applications). A view name is computed from the current page URL, with variable alphanumeric ids being removed automatically (for example, "/dashboard/1234" becomes "/dashboard/?").
+The RUM SDK automatically generates a [view event][14] for each new page visited by your users, or when the page URL is changed (for single page applications). A view name is computed from the current page URL, where variable alphanumeric IDs are removed automatically—for example, "/dashboard/1234" becomes "/dashboard/?".
 
 Starting with [version 2.17.0][15], you may specify your own view names by tracking view events manually with the `trackViewsManually` option:
 
@@ -72,7 +72,7 @@ window.DD_RUM &&
 {{% /tab %}}
 {{< /tabs >}}
 
-2. You **must** start views for each new page, or route change (for single page applications), and optionally define the associated view name (it defaults to the page URL path). No RUM data gets collected until the view is started.
+2. You **must** start views for each new page or route change (for single page applications). You can optionally define the associated view name, which defaults to the page URL path. No RUM data is collected until the view is started.
 {{< tabs >}}
 {{% tab "NPM" %}}
 ```javascript
@@ -95,7 +95,7 @@ window.DD_RUM && window.DD_RUM.startView('checkout')
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: If you are using React, Angular, Vue or any other frontend framework, we recommend implementing the `startView` logic at the framework router level.
+**Note**: If you are using React, Angular, Vue or any other frontend framework, Datadog recommends implementing the `startView` logic at the framework router level.
 
 ## Enrich and control RUM data
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* Document `trackViewsManually` + `startView`

### Motivation
<!-- What inspired you to submit this pull request?-->
New feature

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/view-renaming/real_user_monitoring/browser/modifying_data_and_context/?tab=npm

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
