### PR TITLE
[rum] add browser section to split RUM guides by source

### DIFF
--- a/content/en/real_user_monitoring/guide/_index.md
+++ b/content/en/real_user_monitoring/guide/_index.md
@@ -4,9 +4,9 @@ kind: guide
 private: true
 ---
 
-{{< whatsnext desc="" >}}
+{{< whatsnext desc="Browser RUM" >}}
     {{< nextlink href="real_user_monitoring/guide/send-custom-user-actions" >}}Send Custom User Actions{{< /nextlink >}}
     {{< nextlink href="real_user_monitoring/guide/upload-javascript-source-maps" >}}Upload Javascript source maps{{< /nextlink >}}
-    {{< nextlink href="real_user_monitoring/guide/enrich-and-control-rum-data" >}}Enrich and control RUM data{{< /nextlink >}}
+    {{< nextlink href="real_user_monitoring/guide/enrich-and-control-rum-data" >}}Enrich and control browser RUM data{{< /nextlink >}}
 
 {{< /whatsnext >}}

--- a/content/en/real_user_monitoring/guide/enrich-and-control-rum-data.md
+++ b/content/en/real_user_monitoring/guide/enrich-and-control-rum-data.md
@@ -1,5 +1,5 @@
 ---
-title: Enrich and control RUM data with beforeSend
+title: Enrich and control browser RUM data with beforeSend
 kind: guide
 further_reading:
 - link: '/real_user_monitoring/explorer'
@@ -9,7 +9,7 @@ further_reading:
 
 ## Overview
 
-The RUM SDK captures RUM events and populates their main attributes. The `beforeSend` callback function gives you access to every event collected by the RUM SDK before they are sent to Datadog. Intercepting the RUM events allows you to:
+The RUM browser SDK captures RUM events and populates their main attributes. The `beforeSend` callback function gives you access to every event collected by the RUM SDK before they are sent to Datadog. Intercepting the RUM events allows you to:
 * Enrich your RUM events with additional context attributes
 * Modify your RUM events to modify their content, or redact sensitive sequences (see [list of editable properties][1])
 * Discard selected RUM events


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* Add a "Browser" header next to browser-related guides
* Rename one guide to explicitly state that it applies to browser only

### Motivation
<!-- What inspired you to submit this pull request?-->
Internal feedback

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/browser-guide/real_user_monitoring/guide

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
