### PR TITLE
Java tracer support configuration of UST for logs

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/connect_logs_and_traces/_index.md
@@ -12,7 +12,7 @@ The correlation between Datadog APM and Datadog Log Management is improved by th
 
 It is recommended to configure your application's tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best experience for adding `env`, `service`, and `version`. See the [unified service tagging][2] documentation for more details.
 
-**Note**: The Java and PHP Tracers do not support configuration of unified service tagging for logs.
+**Note**: The PHP Tracer does not support configuration of unified service tagging for logs.
 
 Before correlating traces with logs, ensure your logs are either sent as JSON, or [parsed by the proper language level log processor][3]. Your language level logs _must_ be turned into Datadog attributes in order for traces and logs correlation to work.
 


### PR DESCRIPTION
### What does this PR do?
Java tracer support configuration of UST for logs since https://github.com/DataDog/dd-trace-java/pull/1688 (0.59)
Our documentation states that it's not supported so changing this.
 
### Motivation
Having up to date information in our documentation

### Preview

https://docs-staging.datadoghq.com/cecile/updateJAVAUSTforlogsupport/tracing/connect_logs_and_traces/#pagetitle

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
