### PR TITLE
[apm]: update ruby header extraction docs to match actual behavior

### DIFF
--- a/content/en/tracing/setup_overview/custom_instrumentation/ruby.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/ruby.md
@@ -332,7 +332,7 @@ Extraction styles can be configured using:
 
 - Environment Variable: `DD_PROPAGATION_STYLE_EXTRACT=Datadog,B3`
 
-The value of the environment variable is a comma separated list of header styles that are enabled for extraction. By default only Datadog extraction style is enabled.
+The value of the environment variable is a comma separated list of header styles that are enabled for extraction. By default Datadog and B3 extraction style are enabled.
 
 If multiple extraction styles are enabled extraction attempt is done on the order those styles are configured and first successful extracted value is used.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Our documentation for how datadog distributed tracing context propagation header extraction works is incorrect. We extract _both_ Datadog formatted _and_ b3 formatted headers by default, [as seen here](https://github.com/DataDog/dd-trace-rb/blob/461a627641755f4338e1e7dbb93d366d4534d968/lib/ddtrace/configuration/settings.rb#L94-L105).

### Motivation
<!-- What inspired you to submit this pull request?--> Docs were wrong, customers were confused.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/update_ruby_extract_wording/tracing/setup_overview/custom_instrumentation/ruby/?tab=activespan#trace-client-and-agent-configuration

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
