### PR TITLE
[WEB-1582] Code Lang Weight parameter fix

### DIFF
--- a/layouts/multi-code-lang/single.html
+++ b/layouts/multi-code-lang/single.html
@@ -7,7 +7,7 @@
         {{ end }}
     {{ end }}
 
-    {{ partial "code-lang-tabs" (dict "context" . "codeLangs" $codeLangs "sort" false) }}
+    {{ partial "code-lang-tabs" (dict "context" . "codeLangs" $codeLangs) }}
 
     <h1 id="pagetitle">{{ .Title }}</h1>
     {{ partial "translate_status_banner/translate_status_banner.html" . }}

--- a/layouts/multi-code-lang/single.html
+++ b/layouts/multi-code-lang/single.html
@@ -3,17 +3,15 @@
     {{ $codeLangs := slice }}
     {{ range sort .CurrentSection.Pages ".Params.code_lang_weight" }} 
         {{ with .Params.code_lang }}  
-        {{ $codeLangs = $codeLangs | append .  }}
+            {{ $codeLangs = $codeLangs | append .  }}
         {{ end }}
     {{ end }}
 
-    {{ partial "code-lang-tabs" (dict "context" . "codeLangs" $codeLangs ) }}
+    {{ partial "code-lang-tabs" (dict "context" . "codeLangs" $codeLangs "sort" false) }}
 
     <h1 id="pagetitle">{{ .Title }}</h1>
     {{ partial "translate_status_banner/translate_status_banner.html" . }}
 
-    <div>
-        {{ .Content }}
-    </div>
+    <div>{{ .Content }}</div>
 
 {{ end }}

--- a/layouts/partials/code-lang-tabs.html
+++ b/layouts/partials/code-lang-tabs.html
@@ -2,13 +2,20 @@
 {{ $context := .context }}
 
 <ul class="nav nav-tabs border-none code-lang-list-container">
-    {{ $count := 0}}
+    {{ $count := 0 }}
+    {{ $codeLangs := slice }}
 
-    {{ range sort .codeLangs "value" "asc" }}
+    {{ if eq .sort false }}
+        {{ $codeLangs = .codeLangs }}
+    {{ else }}
+        {{ $codeLangs = sort .codeLangs "value" "asc" }}
+    {{ end }}
+
+    {{ range $codeLangs }}
         <li class="nav-item" style="margin-bottom: 6px;">
             <a class="nav-link mr-1 js-code-example-link" data-code-lang-trigger="{{ . }}" href="#">{{ index $.context.Site.Params.code_language_ids . }}</a>
         </li>
-        {{ $count = add $count 1 }}
-    {{ end}}
 
+        {{ $count = add $count 1 }}
+    {{ end }}
 </ul>

--- a/layouts/partials/code-lang-tabs.html
+++ b/layouts/partials/code-lang-tabs.html
@@ -5,10 +5,10 @@
     {{ $count := 0 }}
     {{ $codeLangs := slice }}
 
-    {{ if eq .sort false }}
-        {{ $codeLangs = .codeLangs }}
-    {{ else }}
+    {{ if eq .sort "name" }}
         {{ $codeLangs = sort .codeLangs "value" "asc" }}
+    {{ else }}
+        {{ $codeLangs = .codeLangs }}
     {{ end }}
 
     {{ range $codeLangs }}

--- a/layouts/shortcodes/programming-lang-wrapper.html
+++ b/layouts/shortcodes/programming-lang-wrapper.html
@@ -1,11 +1,11 @@
 {{ $codeLangs := split (.Get "langs") "," }}
+{{ $sort := .Get "sort" }}
 
 {{ if  not (.Get "langs") }}
     {{ errorf "Programming lang wrapper shortcode error: Missing value for param 'langs': %s" .Position }}
 {{ end }}
 
 <div class="programming-lang-wrapper js-code-snippet-wrapper">
-
-    {{ partial "code-lang-tabs" (dict "context" . "codeLangs" $codeLangs ) }}
+    {{ partial "code-lang-tabs" (dict "context" . "codeLangs" $codeLangs "sort" $sort) }}
     {{ .Inner }}
 </div>


### PR DESCRIPTION
### What does this PR do?
Fixes `code-lang-tabs.html` partial so the code language tabs are ordered according to the `code_lang_weight` frontmatter parameter if available, falling back to ordering according to how the languages were written in the source file.   Additionally, this provides for sorting by name in the future by dropping in `sort="name"` into the shortcode.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1582

### Preview
- https://docs-staging.datadoghq.com/brian.deutsch/code-lang-weight-fix/tracing/setup_overview/compatibility_requirements/cpp/ - Lang tabs should be ordered based on the `code_lang_weight` params.  (i.e. https://github.com/DataDog/documentation/blob/master/content/en/tracing/setup_overview/compatibility_requirements/cpp.md).

- https://docs-staging.datadoghq.com/brian.deutsch/code-lang-weight-fix/agent/docker/apm/?tab=linux - Lang tabs should be ordered based on how they are written in the source file (i.e. https://github.com/DataDog/documentation/blob/master/content/en/agent/docker/apm.md scroll down a bit more than halfway to see the `programming-lang-wrapper` shortcode call).

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
