### PR TITLE
[doc] Update/Clarify Auto-resolve functionality

### DIFF
--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -186,6 +186,12 @@ For a monitor that does not notify on missing data, if a group does not report d
 
 `[Never]`, `After 1 hour`, `After 2 hours`, etc. automatically resolve this event from a triggered state.
 
+Auto-resolve works when data is no longer being submitted. Monitors will not auto-resolve from an ALERT or WARN state. In the case that data is still being submitted, the [renotify][1] feature can be utilized to let your team know when an issue is not resolved. 
+
+[1]: /monitors//notifications/?tab=is_alert#renotify
+{{% /tab %}}
+{{% tab "Change" %}}
+
 For some metrics that report periodically, it may make sense for triggered alerts to auto-resolve after a certain time period. For example, if you have a counter that reports only when an error is logged, the alert never resolves because the metric never reports `0` as the number of errors. In this case, set your alert to resolve after a certain time of inactivity on the metric. **Note**: If a monitor auto-resolves and the value of the query does not meet the recovery threshold at the next evaluation, the monitor triggers an alert again.
 
 In most cases this setting is not useful because you only want an alert to resolve once it is actually fixed. So, in general, it makes sense to leave this as `[Never]` so alerts only resolve when the metric is above or below the set threshold.

--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -186,11 +186,7 @@ For a monitor that does not notify on missing data, if a group does not report d
 
 `[Never]`, `After 1 hour`, `After 2 hours`, etc. automatically resolve this event from a triggered state.
 
-Auto-resolve works when data is no longer being submitted. Monitors will not auto-resolve from an ALERT or WARN state. In the case that data is still being submitted, the [renotify][1] feature can be utilized to let your team know when an issue is not resolved. 
-
-[1]: /monitors//notifications/?tab=is_alert#renotify
-{{% /tab %}}
-{{% tab "Change" %}}
+Auto-resolve works when data is no longer being submitted. Monitors do not auto-resolve from an ALERT or WARN state. If data is still being submitted, the [renotify][6] feature can be utilized to let your team know when an issue is not resolved.
 
 For some metrics that report periodically, it may make sense for triggered alerts to auto-resolve after a certain time period. For example, if you have a counter that reports only when an error is logged, the alert never resolves because the metric never reports `0` as the number of errors. In this case, set your alert to resolve after a certain time of inactivity on the metric. **Note**: If a monitor auto-resolves and the value of the query does not meet the recovery threshold at the next evaluation, the monitor triggers an alert again.
 
@@ -206,7 +202,7 @@ The time (in seconds) to delay evaluation. This should be a non-negative integer
 
 ### Notifications
 
-For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][6] page.
+For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][7] page.
 
 ## Further Reading
 
@@ -217,4 +213,5 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 [3]: /dashboards/querying/#advanced-graphing
 [4]: /monitors/notifications/?tab=is_alert#tag-variables
 [5]: /monitors/faq/what-are-recovery-thresholds/
-[6]: /monitors/notifications/
+[6]: /monitors/notifications/#renotify
+[7]: /monitors/notifications/


### PR DESCRIPTION
To document and clarify when auto-resolve works in a monitor definition.

### What does this PR do?
Changes documentation for auto-resolve and clarifies when auto-resolve works, which is when no data is being submitted. Also added a directive to use the renotify feature as an alternative, if data is still being submitted.


### Motivation
Customer confusion: the monitor team recently had two escalations where customers did not understand auto-resolve behavior; we did not explicitly state the conditions in our docs.

### Preview
https://docs-staging.datadoghq.com/dmcdekker-patch-autoresolve/monitors/monitor_types/metric/?tab=threshold#auto-resolve

### Additional Notes
I have not made a doc change that includes a link to another page; apologies if it is incorrect.
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
