### PR TITLE
Add Process Agent environment variable to linux setup

### DIFF
--- a/content/en/agent/amazon_ecs/_index.md
+++ b/content/en/agent/amazon_ecs/_index.md
@@ -192,6 +192,10 @@ To collect processes information for all your containers and send it to Datadog:
         {
           "name": "DD_API_KEY",
           "value": "<YOUR_DATADOG_API_KEY>"
+        },
+        {
+          "name": "DD_PROCESS_AGENT_ENABLED",
+          "value": "true"
         }
       ]
     }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add the environment variable 

```json
        {
          "name": "DD_PROCESS_AGENT_ENABLED",
          "value": "true"
        }
```
To the linux process agent instructions. This is required to enable the "Live Process" portion of the integration. "Live Containers" is enabled by default.

Can see relative Live Process docs here:
- https://docs.datadoghq.com/infrastructure/process/?tab=docker#installation

### Motivation
<!-- What inspired you to submit this pull request?-->
Missing setup step

### Preview
Original:
- https://docs.datadoghq.com/agent/amazon_ecs/?tab=linux#process-collection

Staging:
- https://docs-staging.datadoghq.com/jack.davenport/ecs_process_agent/agent/amazon_ecs/?tab=awscli#process-collection

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
