### PR TITLE
[Identify Synthetic Bots] DatadogSynthetics for single and multistep …

### DIFF
--- a/content/en/synthetics/guide/identify_synthetics_bots.md
+++ b/content/en/synthetics/guide/identify_synthetics_bots.md
@@ -46,7 +46,7 @@ A `user-agent` header is added to all requests performed by Synthetic tests.
 {{< tabs >}}
 {{% tab "Single and multistep API tests" %}}
 
-For single and multistep API tests, the `user-agent` header is `DatadogSynthetics`.
+For single and multistep API tests, the `user-agent` header is `Datadog/Synthetics`.
 
 {{% /tab %}}
 {{% tab "Browser tests" %}}


### PR DESCRIPTION
### What does this PR do?
Change header for user-agent back to Datadog/Synthetics on the Identify Synthetic Bots page

### Motivation
A customer has noticed a typo: 
https://datadog.zendesk.com/agent/tickets/528632 