### PR TITLE
[WEB-1528] [WEB-1595] Update header formatting

### DIFF
--- a/assets/styles/components/_sidenav.scss
+++ b/assets/styles/components/_sidenav.scss
@@ -1,383 +1,375 @@
-$ddpurple:    #632CA6;
+$ddpurple: #632ca6;
 
 body {
-  .sidenav {
-    .sticky {
-      top: 98px;
+    .sidenav {
+        .sticky {
+            top: 98px;
+        }
     }
-  }
 }
 
 .api {
-  .sidenav-api {
-    .sticky {
-      top: 103px !important;
+    .sidenav-api {
+        .sticky {
+            top: 103px !important;
 
-      @include media-breakpoint-up(xl) {
-        top: 98px !important;
-      }
+            @include media-breakpoint-up(xl) {
+                top: 98px !important;
+            }
+        }
     }
-  }
 }
 
 .side {
-  &:before,
-  &:after {
-    content:"";
-    position:absolute;
-    margin-left:-2000px;
-    left:0;
-    top:0;
-    right:0;
-    bottom:0;
-    background:#F8F8F8;
-    z-index:-1;
-    height:100%;
-  }
-  &:after {
-    // background:#F2F2F2;
-    height:50px;
-  }
+    &:before,
+    &:after {
+        content: '';
+        position: absolute;
+        margin-left: -2000px;
+        left: 0;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        background: #f8f8f8;
+        z-index: -1;
+        height: 100%;
+    }
+    &:after {
+        height: 50px;
+    }
 }
 
 .sidenav {
-  background:#F8F8F8;
-  width:100%;
-  position:relative;
-  z-index:2;
-  padding-right:15px;
-  padding-bottom: 50px;
+    background: #f8f8f8;
+    width: 100%;
+    position: relative;
+    z-index: 2;
+    padding-right: 15px;
+    padding-bottom: 50px;
 
-  .sticky {
-    .col {
-      padding-right:0;
-    }
-  }
-
-  &> .row {
-    &:before,
-    &:after {
-      content:"";
-      position:absolute;
-      margin-left:-2000px;
-      left:0;
-      top:0;
-      right: -15px;
-      bottom:0;
-      background:#F8F8F8;
-      z-index:-1;
-    }
-    &:after {
-      // background:#F2F2F2;
-      height:50px;
-    }
-  }
-
-  h4 {
-    padding: 0 0 10px 10px;
-    color:$ddpurple;
-    font-size:24px;
-    font-weight:200;
-    text-transform: capitalize !important;
-
-    &:lang(ja) {
-      font-size: 20px;
-      font-weight: 200;
-      line-height: 37px;
-    }
-  }
-
-  .sidenav-search {
-    margin-left:7px;
-    padding-right: 10px;
-    //margin-right: 30px;
-    .input-group-addon {
-      background:none;
-      border:none;
-      padding:6px 0 0 3px;
-      border-radius:0;
-      position:absolute;
-      left:0;
-    }
-    .form-control:focus {
-      border-color:$ddpurple;
-      padding-left:5px;
-      & ~ .input-group-addon {
-        display:none;
-      }
-    }
-    input {
-      border-top:none;
-      border-left:none;
-      border-right:none;
-      background:transparent;
-      border-radius:0;
-      font-size:18px;
-      padding-bottom:3px;
-      padding-left: 30px;
-      transition: all .1s ease-in;
-    }
-  }
-
-  .sidenav-nav {
-    margin-left:7px;
-    overflow-x: hidden;
-    overflow-y: auto;
-    ul {
-      margin-top:0px;
-      padding-bottom:3px;
-    }
-    & > ul {
-      margin-top:5px;
+    .sticky {
+        .col {
+            padding-right: 0;
+        }
     }
 
-    .nav-top-level {
-      & > a span {
-        margin-left: 10px;
-      }
-      
+    & > .row {
+        &:before,
+        &:after {
+            content: '';
+            position: absolute;
+            margin-left: -2000px;
+            left: 0;
+            top: 0;
+            right: -15px;
+            bottom: 0;
+            background: #f8f8f8;
+            z-index: -1;
+        }
+        &:after {
+            height: 50px;
+        }
     }
 
-    ul li > ul {
-      display: none;
-    }
-    ul li.open > ul {
-      display:block;
-    }
-    > ul > li.open {
-      > a { // Style the first a tag nested in an open list element.
+    h4 {
+        padding: 0 0 10px 10px;
         color: $ddpurple;
-        border: 1px solid transparent;
-      }
-      > a > span { // The nested span in a
-        // border-bottom: 1px solid $ddpurple;
-      }
-      .hover {
-        display: inline-block;
-      }
-      .static {
-        display: none;
-      }
-    }
-    ul li.open > ul,
-    ul li.active > ul {
-      li {
-        padding-left:27px;
-        a {
-          padding:0;
-          padding-bottom: 0px;
-          margin-top:0px;
+        font-size: 24px;
+        font-weight: 200;
+        text-transform: capitalize !important;
+
+        &:lang(ja) {
+            font-size: 20px;
+            font-weight: 200;
+            line-height: 37px;
         }
-      }
     }
-    // First level should get underline no other li nested
-    > ul {
-      > li.open > a > span { 
-        border-bottom: 1px solid $ddpurple;
-      }
-      li {
-        a {
-          color:#000;
-          font-size:18px;
-          font-weight: 600;
-          padding: 3px 0 0 2px;
-          margin-right: 10px;
-          display:flex;
-          border:1px solid transparent;
-          &:hover {
-            background:transparent;
-            color: $ddpurple;
-            border-radius:0px;
-            border:1px solid transparent;
-          }
-          &.active span, &.active a{
-            background:transparent;
-            border-radius:0px;
-            color: $ddpurple;
-            // border:1px solid transparent;
-            // border-bottom: 1px solid $ddpurple;
-          }
-          .hover {
-            display:none;
-          }
 
-          span,
-          img {
-            vertical-align:top;
-          }
-          img {
-            margin-top:4px;
-            &:lang(ja) {
-              margin-top:0px;
+    .sidenav-search {
+        margin-left: 7px;
+        padding-right: 10px;
+        //margin-right: 30px;
+        .input-group-addon {
+            background: none;
+            border: none;
+            padding: 6px 0 0 3px;
+            border-radius: 0;
+            position: absolute;
+            left: 0;
+        }
+        .form-control:focus {
+            border-color: $ddpurple;
+            padding-left: 5px;
+            & ~ .input-group-addon {
+                display: none;
             }
-          }
+        }
+        input {
+            border-top: none;
+            border-left: none;
+            border-right: none;
+            background: transparent;
+            border-radius: 0;
+            font-size: 18px;
+            padding-bottom: 3px;
+            padding-left: 30px;
+            transition: all 0.1s ease-in;
+        }
+    }
 
-          &:lang(ja) {
-            font-style: normal;
-            font-weight: bold;
-            font-size: 15px;
-            line-height: 24px;
-          }
+    .sidenav-nav {
+        margin-left: 7px;
+        overflow-x: hidden;
+        overflow-y: auto;
+        ul {
+            margin-top: 0px;
+            padding-bottom: 3px;
+        }
+        & > ul {
+            margin-top: 5px;
         }
 
-        // 2nd level
-        ul li {
-          a {
-            margin-left:5px;
-            font-weight:200;
-            line-height:24px;
-            &:lang(ja) {
-              font-style: normal;
-              font-weight: 300;
-              font-size: 14px;
-              line-height: 22px;
+        .nav-top-level {
+            & > a div {
+                margin-left: 10px;
             }
-          }
-
-          // 3rd level
-          ul li a {
-            margin-left:5px;
-            font-size:15px;
-            line-height:22px;
-            &:lang(ja) {
-              font-size: 11px;
-              line-height: 22px;
-            }
-          }
         }
-      }
+
+        ul li > ul {
+            display: none;
+        }
+        ul li.open > ul {
+            display: block;
+        }
+        > ul > li.open {
+            > a {
+                // Style the first a tag nested in an open list element.
+                color: $ddpurple;
+                border: 1px solid transparent;
+                margin-bottom: 1px;
+            }
+            .hover {
+                display: inline-block;
+            }
+            .static {
+                display: none;
+            }
+        }
+        ul li.open > ul,
+        ul li.active > ul {
+            li {
+                padding-left: 27px;
+                a {
+                    padding: 0;
+                    padding-bottom: 0px;
+                    margin-top: 0px;
+                }
+            }
+        }
+        // First level should get underline no other li nested
+        > ul {
+            > li.open > a > div > span {
+                border-bottom: 1px solid $ddpurple;
+                padding-bottom: 2px;
+                margin-bottom: 1px;
+            }
+            li {
+                a {
+                    color: #000;
+                    font-size: 18px;
+                    font-weight: 600;
+                    padding: 3px 0 0 2px;
+                    margin-right: 10px;
+                    display: flex;
+                    border: 1px solid transparent;
+                    &:hover {
+                        background: transparent;
+                        color: $ddpurple;
+                        border-radius: 0px;
+                        border: 1px solid transparent;
+                    }
+                    &.active span,
+                    &.active a {
+                        background: transparent;
+                        border-radius: 0px;
+                        color: $ddpurple;
+                    }
+                    .hover {
+                        display: none;
+                    }
+
+                    span,
+                    img {
+                        vertical-align: top;
+                    }
+                    img {
+                        margin-top: 4px;
+                        &:lang(ja) {
+                            margin-top: 0px;
+                        }
+                    }
+
+                    &:lang(ja) {
+                        font-style: normal;
+                        font-weight: bold;
+                        font-size: 15px;
+                        line-height: 24px;
+                    }
+                }
+
+                // 2nd level
+                ul li {
+                    a {
+                        margin-left: 5px;
+                        font-weight: 200;
+                        line-height: 24px;
+                        &:lang(ja) {
+                            font-style: normal;
+                            font-weight: 300;
+                            font-size: 14px;
+                            line-height: 22px;
+                        }
+                    }
+
+                    // 3rd level
+                    ul li a {
+                        margin-left: 5px;
+                        font-size: 15px;
+                        line-height: 22px;
+                        &:lang(ja) {
+                            font-size: 11px;
+                            line-height: 22px;
+                        }
+                    }
+                }
+            }
+        }
     }
-  }
 }
 
 .sidenav-api {
-  .sidenav-nav {
-    overflow-x: hidden;
-    overflow-y: scroll;
-    &::-webkit-scrollbar {
-      appearance: none;
-      width: 7px;
-    }
-    &::-webkit-scrollbar-thumb {
-      border-radius: 4px;
-      background-color: rgba(0, 0, 0, .5);
-      box-shadow: 0 0 1px rgba(255, 255, 255, .5);
-    }
-
-    scrollbar-width: thin;
-    
-    margin:0;
-    ul li.active{
-      > a {
-        background: transparent;
-              color: $ddpurple;
-              border-bottom: 1px solid transparent;
-      }
-      ul {
-        display: block;
-        li {
-          padding-left: 0;
-          &.active {
-            a {
-              background: transparent;
-              color: $ddpurple;
-              border-bottom: 1px solid transparent;
-            }
-          }
-          
+    .sidenav-nav {
+        overflow-x: hidden;
+        overflow-y: scroll;
+        &::-webkit-scrollbar {
+            appearance: none;
+            width: 7px;
         }
-      }
-    } 
-    ul li > ul {
-      //display: block;
-      list-style-type:none;
-      padding-left:20px;
-      li a {
-        font-size: 16px;
-        margin-top: 0px;
-        padding: 0px;
-      }
-    }
-  }
-  ul li a {
-    line-height: 24px;
-    font-size:18px;
-    font-weight:600;
-    color: #000;
-    padding: 6px 0 0 2px;
-    display: block;
-  }
-  ul:first-of-type {
-    margin-left: 3px;
-  }
+        &::-webkit-scrollbar-thumb {
+            border-radius: 4px;
+            background-color: rgba(0, 0, 0, 0.5);
+            box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
+        }
 
-  .toc_scrolled {
-    background:transparent !important;
-    color: $ddpurple !important;
-    border:1px solid transparent !important;
-    span{
-      border-bottom: 1px solid $ddpurple;
+        scrollbar-width: thin;
+
+        margin: 0;
+        ul li.active {
+            > a {
+                background: transparent;
+                color: $ddpurple;
+                border-bottom: 1px solid transparent;
+            }
+            ul {
+                display: block;
+                li {
+                    padding-left: 0;
+                    &.active {
+                        a {
+                            background: transparent;
+                            color: $ddpurple;
+                            border-bottom: 1px solid transparent;
+                        }
+                    }
+                }
+            }
+        }
+        ul li > ul {
+            list-style-type: none;
+            padding-left: 20px;
+            li a {
+                font-size: 16px;
+                margin-top: 0px;
+                padding: 0px;
+            }
+        }
     }
-  }
-  // open adjacent ul to open link
-  .toc_open ~ ul {
-    display:block !important;
-  }
+    ul li a {
+        line-height: 24px;
+        font-size: 18px;
+        font-weight: 600;
+        color: #000;
+        padding: 6px 0 0 2px;
+        display: block;
+    }
+    ul:first-of-type {
+        margin-left: 3px;
+    }
+
+    .toc_scrolled {
+        background: transparent !important;
+        color: $ddpurple !important;
+        border: 1px solid transparent !important;
+        span {
+            border-bottom: 1px solid $ddpurple;
+        }
+    }
+    // open adjacent ul to open link
+    .toc_open ~ ul {
+        display: block !important;
+    }
 }
 
 //@include media-breakpoint-up(xs) { ... }
 @media (min-width: 576px) {
-
-  .sidenav {
-    ul {
-      li {
-        a {
-          &:hover,
-          &.active {
-            color:$ddpurple;
-            & .hover {
-              display:inline-block;
+    .sidenav {
+        ul {
+            li {
+                a {
+                    &:hover,
+                    &.active {
+                        color: $ddpurple;
+                        & .hover {
+                            display: inline-block;
+                        }
+                        & .static {
+                            display: none;
+                        }
+                    }
+                    .hover {
+                        display: none;
+                    }
+                }
             }
-            & .static {
-              display:none;
-            }
-          }
-          .hover {
-            display:none;
-          }
         }
-      }
     }
-  }
-
 }
 
 @media (max-width: 1199px) {
-  .sidenav {
-    ul {
-      li {
-        a {
-          font-size: 17px;
+    .sidenav {
+        ul {
+            li {
+                a {
+                    font-size: 17px;
+                }
+            }
         }
-      }
     }
-  }
 }
-
 
 .fr .sidenav {
-  h4 {
-    font-size:22px;
-  }
+    h4 {
+        font-size: 22px;
+    }
 }
 
 @media (max-width: 1199px) {
-  .fr {
-    .sidenav {
-      h4 {
-        font-size:18px;
-        padding-top: 15px;
-      }
+    .fr {
+        .sidenav {
+            h4 {
+                font-size: 18px;
+                padding-top: 15px;
+            }
+        }
     }
-  }
 }

--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -173,6 +173,10 @@ code {
     font-family: $font-family-monospace;
 }
 
+h2 code {
+    @include font-size($h3-font-size);
+}
+
 code + code.region-param {
     padding: 0 5px 0 0;
     border-top-left-radius: 0;
@@ -960,5 +964,3 @@ dl {
         width: 100%;
     }
 }
-
-

--- a/layouts/partials/nav/main-menu.html
+++ b/layouts/partials/nav/main-menu.html
@@ -24,7 +24,7 @@
             {{ if $currentPage.HasMenuCurrent "main" . }}active{{ end }}">
                 {{ $url_without_anchor = (index (split .URL "#") 0) }}
                 <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
-                    {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>
+                    {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <div><span>{{ .Name }}</span></div>
                 </a>
                 <ul class="list-unstyled sub-menu">
                     {{ range .Children }}
@@ -65,7 +65,7 @@
         {{ else }}
             <li class="nav-top-level {{ if (not (or (in $excludeAsyc .Identifier) (in .URL "api/"))) }} js-load {{ end }}">
                 <a href="{{ .URL | absLangURL }}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
-                    {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>
+                    {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <div><span>{{ .Name }}</span></div>
                 </a>
             </li>
         {{ end }}


### PR DESCRIPTION
### What does this PR do?
- Update style/sizing for `code` blocks within an `h2` tag to be appropriately sized
- Update underlining for first-level headers in the side nav to have the underline under all text, length of text, when header wraps onto 2 lines (between tablet and desktop window size)
- Formats `_sidenav.scss` (actual code changes are just on line 133 & 171)

### Motivation
Better visual consistency.
- https://datadoghq.atlassian.net/browse/WEB-1528
- https://datadoghq.atlassian.net/browse/WEB-1595

### Preview
Code block in header:
- https://docs-staging.datadoghq.com/davidweid/header-formatting/integrations/slack/?tab=slackapplicationus#-mentions-in-slack-from-monitor-alert

Sidebar header wrapping on smaller screen sizes (larger than tablet)
- https://docs-staging.datadoghq.com/davidweid/header-formatting/tracing/
- https://docs-staging.datadoghq.com/davidweid/header-formatting/account_management/
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.