### PR TITLE
Remove references to service and env parameters for CDK Construct

### DIFF
--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -142,19 +142,14 @@ class CdkStack extends cdk.Stack {
     const datadog = new Datadog(this, "Datadog", { 
         nodeLayerVersion: {{< latest-lambda-layer-version layer="node" >}}, 
         extensionLayerVersion: {{< latest-lambda-layer-version layer="extension" >}}, 
-        apiKey: <DATADOG_API_KEY>,
-        service: <SERVICE> // Optional
-        env: <ENV> // Optional 
+        apiKey: <DATADOG_API_KEY>
     });
     datadog.addLambdaFunctions([<LAMBDA_FUNCTIONS>]);    
   }
 }
 ```
 
-To fill in the placeholders:
-
-- Replace `<DATADOG_API_KEY>` with your Datadog API key from the [API Management page][3]. 
-- Replace `<SERVICE>` and `<ENV>` with appropriate values.
+Replace `<DATADOG_API_KEY>` with your Datadog API key from the [API Management page][3]. 
 
 More information and additional parameters can be found in the [Datadog CDK NPM page][1].
 

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -135,17 +135,12 @@ from datadog_cdk_constructs import Datadog
 datadog = Datadog(self, "Datadog",
     python_layer_version={{< latest-lambda-layer-version layer="python" >}},
     extension_layer_version={{< latest-lambda-layer-version layer="extension" >}},
-    api_key=<DATADOG_API_KEY>,
-    service=<SERVICE>, # Optional
-    env=<ENV>, # Optional
+    api_key=<DATADOG_API_KEY>
 )
 datadog.add_lambda_functions([<LAMBDA_FUNCTIONS>])
 ```
 
-To fill in the placeholders:
-
-- Replace `<DATADOG_API_KEY>` with your Datadog API key on the [API Management page][1]. 
-- Replace `<SERVICE>` and `<ENV>` with appropriate values.
+Replace `<DATADOG_API_KEY>` with your Datadog API key on the [API Management page][1]. 
 
 More information and additional parameters can be found on the [Datadog CDK NPM page][2].
 

--- a/content/fr/serverless/installation/nodejs.md
+++ b/content/fr/serverless/installation/nodejs.md
@@ -140,8 +140,6 @@ class CdkStack extends cdk.Stack {
         nodeLayerVersion: <VERSION_COUCHE>, 
         extensionLayerVersion: <VERSION_EXTENSION>, 
         apiKey: <CLÉ_API_DATADOG>,
-        service: <SERVICE> // Facultatif
-        env: <ENV> // Facultatif 
     });
     datadog.addLambdaFunctions([<FONCTIONS_LAMBDA>]);    
   }
@@ -150,8 +148,7 @@ class CdkStack extends cdk.Stack {
 
 Pour remplir les paramètres fictifs, procédez comme suit :
 
-- Remplacez `<DATADOG_API_KEY>` par votre clé d'API Datadog sur la [page de gestion des API][3]. 
-- Remplacez `<SERVICE>` et `<ENV>` par les valeurs appropriées.
+- Remplacez `<DATADOG_API_KEY>` par votre clé d'API Datadog sur la [page de gestion des API][3].
 - Remplacez `<VERSION_COUCHE>` par la version de votre choix de la couche Lambda Datadog (consultez les [dernières versions][2]).
 - Remplacez `<VERSION_EXTENSION>` par la version de votre choix de l'extension Lambda Datadog (consultez les [dernières versions][4]).
 

--- a/content/fr/serverless/installation/python.md
+++ b/content/fr/serverless/installation/python.md
@@ -132,17 +132,14 @@ from datadog_cdk_constructs import Datadog
 datadog = Datadog(self, "Datadog",
     python_layer_version=<VERSION_COUCHE>,
     extension_layer_version=<VERSION_COUCHE_EXTENSION>,
-    dd_api_key=<CLÉ_API_DATADOG>,
-    service=<SERVICE>, # Facultatif
-    env=<ENV>, # Facultatif
+    dd_api_key=<CLÉ_API_DATADOG>
 )
 datadog.add_lambda_functions([<FONCTIONS_LAMBDA>])
 ```
 
 Pour remplir les paramètres fictifs, procédez comme suit :
 
-- Remplacez `<CLÉ_API_DATADOG>` par votre clé d'API Datadog, disponible sur la [page de gestion des API][3]. 
-- Remplacez `<SERVICE>` et `<ENV>` par les valeurs appropriées.
+- Remplacez `<CLÉ_API_DATADOG>` par votre clé d'API Datadog, disponible sur la [page de gestion des API][3].
 - Remplacez `<VERSION_COUCHE>` par la version de votre choix de la couche Lambda Datadog (consultez les [dernières versions][2]).
 - Remplacez `<VERSION_EXTENSION>` par la version de votre choix de l'extension Lambda Datadog (consultez les [dernières versions][4]).
 

--- a/content/ja/serverless/installation/python.md
+++ b/content/ja/serverless/installation/python.md
@@ -132,17 +132,14 @@ from datadog_cdk_constructs import Datadog
 datadog = Datadog(self, "Datadog",
     python_layer_version=<LAYER_VERSION>,
     extension_layer_version=<EXTENSION_LAYER_VERSION>,
-    dd_api_key=<DATADOG_API_KEY>,
-    service=<SERVICE>, # オプション
-    env=<ENV>, # オプション
+    dd_api_key=<DATADOG_API_KEY>
 )
 datadog.add_lambda_functions([<LAMBDA_FUNCTIONS>])
 ```
 
 関数をインスツルメントするには、AWS CDK アプリの `Stack` オブジェクトに `DatadogServerless` 変換と `CfnMapping` を追加します。以下の Python のサンプルコードを参照してください (他の言語での使用方法も同様です)。
 
-- `<DATADOG_API_KEY>` を [API Management ページ][3]の Datadog API キーに置き換えます。 
-- `<SERVICE>` と `<ENV>` を適切な値に置き換えます。
+- `<DATADOG_API_KEY>` を [API Management ページ][3]の Datadog API キーに置き換えます。
 - `<LAYER_VERSION>` を目的のバージョンの Datadog Lambda レイヤーに置き換えます（[最新リリース]を参照ください[2]）。
 - `<EXTENSION_VERSION>` を目的のバージョンの Datadog Lambda 拡張機能に置き換えます（[最新リリース]を参照ください[4]）。
 


### PR DESCRIPTION
### What does this PR do?
Remove references to the `service` and `env` parameters for the CDK Construct Library.

### Motivation
These parameters don't actually exist yet.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
