### PR TITLE
Update Encrypted Agent port details

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -110,7 +110,7 @@ Endpoints that can be used to send logs to Datadog, for SSL-encrypted connection
 
 
 `{{< region-param key="tcp_endpoint" code="true" >}}`
-: **Port**: `{{< region-param key="tcp_endpoint_port" code="true" >}}` <br>
+: **Port**: `{{< region-param key="tcp_endpoint_port_ssl" code="true" >}}` <br>
 Used by the Agent to send logs in protobuf format over an SSL-encrypted TCP connection.
 
 `{{< region-param key="agent_http_endpoint" code="true" >}}`


### PR DESCRIPTION
According to our backend code our agent only uses port 10516; not 10514: https://github.com/DataDog/datadog-agent/blob/main/pkg/logs/config/config.go#L41-L44

`tcp_endpoint_port_ssl` is the variable used to set the value of encrypted ssl port: https://github.com/DataDog/documentation/blob/master/regions.config.js

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
