### PR TITLE
[CIAPP-2379] [DOCS-2294] Document EU1 support

### DIFF
--- a/content/en/continuous_integration/_index.md
+++ b/content/en/continuous_integration/_index.md
@@ -10,10 +10,10 @@ further_reading:
       text: "Start exploring tests data to find and fix problem tests"
 ---
 
-<div class="alert alert-info"><p>CI Visibility is in private beta. There are no billing implications for tracing pipelines and tests during this period. If you want to be added to the private beta, <a href="https://app.datadoghq.com/ci/getting-started">sign up on the CI Visibility in-app Getting Started</a>.</p><p>CI Visibility is available only on <a href="/getting_started/site/">the US1 Datadog site</a> at this time.</p>
+<div class="alert alert-info"><p>CI Visibility is in private beta. There are no billing implications for tracing pipelines and tests during this period. If you want to be added to the private beta, <a href="https://app.datadoghq.com/ci/getting-started">sign up on the CI Visibility in-app Getting Started</a>.</p><p>CI Visibility is available only on <a href="/getting_started/site/">the US1 and EU1 Datadog sites</a> at this time.</p>
 </div>
 
-Datadog Continuous Integration (CI) Visibility brings together information about CI test and pipeline results _plus_ data about CI performance, trends, and reliability, all into one place. Not only does it provide developers with the ability to dig into the reasons for a test or pipeline failure, to monitor trends in test suite execution times, or to see the effect a given commit has on the pipeline, it also gives build engineers visibility into cross-organization CI health and trends in pipeline performance over time. 
+Datadog Continuous Integration (CI) Visibility brings together information about CI test and pipeline results _plus_ data about CI performance, trends, and reliability, all into one place. Not only does it provide developers with the ability to dig into the reasons for a test or pipeline failure, to monitor trends in test suite execution times, or to see the effect a given commit has on the pipeline, it also gives build engineers visibility into cross-organization CI health and trends in pipeline performance over time.
 
 CI Visibility brings CI metrics and data into Datadog dashboards so you can communicate the health of your CI environment and focus your efforts in improving your team's ability to deliver quality code every time.
 
@@ -22,33 +22,33 @@ CI Visibility helps you troubleshoot test failures and broken builds, connecting
 ## Gain insights into your pipelines
 
 The Datadog Pipelines page is useful for developers who keep an eye on the build pipeline for their service. It answers questions such as:
-- Is the pipeline for your service succeeding, especially on the default branch? 
+- Is the pipeline for your service succeeding, especially on the default branch?
 - If not, what's the root cause?
 
 For build engineers, the Pipelines page provides:
-- An overview of the health of the whole build system, with aggregated stats for pipeline runs and branches. 
-- A window to quickly spotting and fixing immediate, urgent issues like broken pipelines to production. 
-- How each pipeline has run, over time, and with what results and trends. 
+- An overview of the health of the whole build system, with aggregated stats for pipeline runs and branches.
+- A window to quickly spotting and fixing immediate, urgent issues like broken pipelines to production.
+- How each pipeline has run, over time, and with what results and trends.
 - The breakdown of where time is spent in each build stage, over time, so you can focus your improvement efforts where it will make the biggest difference.
 
 CI pipeline data is available in [Dashboards][1] and [Notebooks][2], enabling build engineering teams to customize their communication about high-priority work and CI trends over time.
 
 ## Gain insights into your tests
 
-If you're a developer, the Tests and Test Runs pages provide you with two kinds of information about your work: 
+If you're a developer, the Tests and Test Runs pages provide you with two kinds of information about your work:
 
-- Low-level and immediate: 
-    - See what tests are failing and why. 
-    - See your last commit's test results. 
-    - View the wall time of your tests in your feature branch and compare it to the default branch, to identify if you're about to introduce a performance regression. 
+- Low-level and immediate:
+    - See what tests are failing and why.
+    - See your last commit's test results.
+    - View the wall time of your tests in your feature branch and compare it to the default branch, to identify if you're about to introduce a performance regression.
     - Find out if your commit introduces a new flaky test that wasn't flaky before, indicating that your code change is what's making it flaky. This gives you the opportunity to fix the problem before proceeding rather than contributing to the number of flaky tests in your CI.
 
-- High-level accumulation and trends: 
-    - See the effects that changed code, added tests, and increased complexity have on your test suite performance over time. 
+- High-level accumulation and trends:
+    - See the effects that changed code, added tests, and increased complexity have on your test suite performance over time.
     - See which tests have become slower over time and identify the commit that introduced the regression.
     - Take advantage of Datadog's automatic test flakiness detection and tracking, which shows you which tests are becoming more or less unreliable over time.
 
-Test execution data is also available in [Dashboards][1] and [Notebooks][2]. 
+Test execution data is also available in [Dashboards][1] and [Notebooks][2].
 
 ## Ready to start?
 

--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -102,6 +102,7 @@ Fill in the integration configuration settings:
 
 You can test the integration with the **Test settings** button (only available when configuring the integration on a project). After it's successful, click **Save changes** to finish the integration set up.
 
+{{< site-region region="us,eu" >}}
 ## Integrating through webhooks
 
 As an alternative to using the native Datadog integration, you can use [webhooks][3] to send pipeline data to Datadog.
@@ -114,6 +115,8 @@ Go to **Settings > Webhooks** in your repository (or GitLab instance settings), 
 * **Trigger**: Select `Job events` and `Pipeline events`.
 
 To set custom `env` or `service` parameters, add more query parameters in the webhooks URL: `&env=<YOUR_ENV>&service=<YOUR_SERVICE_NAME>`
+
+{{< /site-region >}}
 
 ## Visualize pipeline data in Datadog
 

--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -105,17 +105,29 @@ You can test the integration with the **Test settings** button (only available w
 {{< site-region region="us,eu" >}}
 ## Integrating through webhooks
 
-As an alternative to using the native Datadog integration, you can use [webhooks][3] to send pipeline data to Datadog.
+As an alternative to using the native Datadog integration, you can use [webhooks][1] to send pipeline data to Datadog.
 
 <div class="alert alert-info"><strong>Note</strong>: The native Datadog integration is the recommended approach and the option that is actively under development.</div>
 
 Go to **Settings > Webhooks** in your repository (or GitLab instance settings), and add a new webhook:
-* **URL**: `https://webhooks-http-intake.logs.{{< region-param key="dd_site" >}}/v2/api/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][2].
+{{< site-region region="us" >}}
+* **URL**: `https://webhooks-http-intake.logs.datadoghq.com/v2/api/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
 * **Secret Token**: leave blank
 * **Trigger**: Select `Job events` and `Pipeline events`.
 
+[1]: https://app.datadoghq.com/account/settings#api
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+* **URL**: `https://webhooks-http-intake.logs.datadoghq.eu/v2/api/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
+* **Secret Token**: leave blank
+* **Trigger**: Select `Job events` and `Pipeline events`.
+
+[1]: https://app.datadoghq.com/account/settings#api
+{{< /site-region >}}
+
 To set custom `env` or `service` parameters, add more query parameters in the webhooks URL: `&env=<YOUR_ENV>&service=<YOUR_SERVICE_NAME>`
 
+[1]: https://docs.gitlab.com/ee/user/project/integrations/webhooks.html
 {{< /site-region >}}
 
 ## Visualize pipeline data in Datadog

--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -10,6 +10,7 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
+{{< site-region region="us,eu" >}}
 ## Compatibility
 
 Supported GitLab versions:
@@ -146,3 +147,7 @@ After the integration is successfully configured, the [Pipelines][4] and [Pipeli
 [3]: https://docs.gitlab.com/ee/user/project/integrations/webhooks.html
 [4]: https://app.datadoghq.com/ci/pipelines
 [5]: https://app.datadoghq.com/ci/pipeline-executions
+{{< /site-region >}}
+{{< site-region region="us3,gov" >}}
+The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported at this time.
+{{< /site-region >}}

--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -80,9 +80,9 @@ Fill in the integration configuration settings:
 : Enables the integration.
 
 **Datadog site**
-: Specifies which [Datadog site][1] to send data to. Only `datadoghq.com` is supported.<br/>
+: Specifies which [Datadog site][1] to send data to.<br/>
 **Default**: `datadoghq.com`<br/>
-**Possible values**: `datadoghq.com`
+**Possible values**: `datadoghq.com`, `datadoghq.eu`
 
 **API URL** (optional)
 : Allows overriding the API URL used for sending data directly, only used in advanced scenarios.<br/>
@@ -108,7 +108,7 @@ As an alternative to using the native Datadog integration, you can use [webhooks
 <div class="alert alert-info"><strong>Note</strong>: The native Datadog integration is the recommended approach and the option that is actively under development.</div>
 
 Go to **Settings > Webhooks** in your repository (or GitLab instance settings), and add a new webhook:
-* **URL**: `https://webhooks-http-intake.logs.datadoghq.com/v2/api/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][5].
+* **URL**: `https://webhooks-http-intake.logs.datadoghq.com/v2/api/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][4].
 * **Secret Token**: leave blank
 * **Trigger**: Select `Job events` and `Pipeline events`.
 
@@ -116,7 +116,7 @@ To set custom `env` or `service` parameters, add more query parameters in the we
 
 ## Visualize pipeline data in Datadog
 
-After the integration is successfully configured, the [Pipelines][4] and [Pipeline Executions][5] pages populate with data after the pipelines finish.
+After the integration is successfully configured, the [Pipelines][5] and [Pipeline Executions][4] pages populate with data after the pipelines finish.
 
 **Note**: The Pipelines page shows data for only the default branch of each repository.
 
@@ -128,5 +128,5 @@ After the integration is successfully configured, the [Pipelines][4] and [Pipeli
 [1]: /getting_started/site/
 [2]: https://app.datadoghq.com/account/settings#api
 [3]: https://docs.gitlab.com/ee/user/project/integrations/webhooks.html
-[4]: https://app.datadoghq.com/ci/pipelines
-[5]: https://app.datadoghq.com/ci/pipeline-executions
+[4]: https://app.datadoghq.com/ci/pipeline-executions
+[5]: https://app.datadoghq.com/ci/pipelines

--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -82,6 +82,7 @@ Fill in the integration configuration settings:
 **Datadog site**
 : Specifies which [Datadog site][1] to send data to.<br/>
 **Default**: `datadoghq.com`<br/>
+**Selected site**: {{< region-param key="dd_site" code="true" >}}<br/>
 **Possible values**: `datadoghq.com`, `datadoghq.eu`
 
 **API URL** (optional)
@@ -108,7 +109,7 @@ As an alternative to using the native Datadog integration, you can use [webhooks
 <div class="alert alert-info"><strong>Note</strong>: The native Datadog integration is the recommended approach and the option that is actively under development.</div>
 
 Go to **Settings > Webhooks** in your repository (or GitLab instance settings), and add a new webhook:
-* **URL**: `https://webhooks-http-intake.logs.datadoghq.com/v2/api/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][4].
+* **URL**: `https://webhooks-http-intake.logs.{{< region-param key="dd_site" >}}/v2/api/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][2].
 * **Secret Token**: leave blank
 * **Trigger**: Select `Job events` and `Pipeline events`.
 
@@ -116,7 +117,7 @@ To set custom `env` or `service` parameters, add more query parameters in the we
 
 ## Visualize pipeline data in Datadog
 
-After the integration is successfully configured, the [Pipelines][5] and [Pipeline Executions][4] pages populate with data after the pipelines finish.
+After the integration is successfully configured, the [Pipelines][4] and [Pipeline Executions][5] pages populate with data after the pipelines finish.
 
 **Note**: The Pipelines page shows data for only the default branch of each repository.
 
@@ -128,5 +129,5 @@ After the integration is successfully configured, the [Pipelines][5] and [Pipeli
 [1]: /getting_started/site/
 [2]: https://app.datadoghq.com/account/settings#api
 [3]: https://docs.gitlab.com/ee/user/project/integrations/webhooks.html
-[4]: https://app.datadoghq.com/ci/pipeline-executions
-[5]: https://app.datadoghq.com/ci/pipelines
+[4]: https://app.datadoghq.com/ci/pipelines
+[5]: https://app.datadoghq.com/ci/pipeline-executions

--- a/content/en/continuous_integration/setup_tests/agent.md
+++ b/content/en/continuous_integration/setup_tests/agent.md
@@ -35,11 +35,17 @@ To run the Datadog Agent as a container acting as a simple results forwarder, us
 `DD_API_KEY` (Required)
 : The [Datadog API key][4] used to upload the test results.
 
-`DD_INSIDE_CI=true`
+`DD_INSIDE_CI=true` (Required)
 : Disables the monitoring of the Datadog Agent container, as the underlying host is not accessible.
 
-`DD_HOSTNAME=none`
+`DD_HOSTNAME=none` (Required)
 : Disables the reporting of hostnames associated with tests, as the underlying host cannot be monitored.
+
+`DD_SITE` (Optional)
+: Specifies which [Datadog site][5] to send data to.<br/>
+**Default**: `datadoghq.com`<br/>
+**Possible values**: `datadoghq.com`, `datadoghq.eu`
+
 
 ### CI provider configuration examples
 
@@ -172,7 +178,7 @@ Add your [Datadog API key][2] to your [project environment variables][3] with th
 
 ### Using Docker Compose
 
-Regardless of which CI provider you use, if tests are run using [Docker Compose][5], the Datadog Agent can be run as one service:
+Regardless of which CI provider you use, if tests are run using [Docker Compose][6], the Datadog Agent can be run as one service:
 
 {{< code-block lang="yaml" filename="docker-compose.yml" >}}
 version: '3'
@@ -219,7 +225,7 @@ DD_API_KEY=<YOUR_DD_API_KEY> docker-compose up \
   tests
 {{< /code-block >}}
 
-**Note:** In this case, add all the required CI provider environment variables so build information can be attached to each test result, as described in [Tests in containers][6].
+**Note:** In this case, add all the required CI provider environment variables so build information can be attached to each test result, as described in [Tests in containers][7].
 
 ## Further reading
 
@@ -229,5 +235,6 @@ DD_API_KEY=<YOUR_DD_API_KEY> docker-compose up \
 [2]: https://app.datadoghq.com/account/settings#agent
 [3]: https://docs.datadoghq.com/agent/cluster_agent/admission_controller/
 [4]: https://app.datadoghq.com/account/settings#api
-[5]: https://docs.docker.com/compose/
-[6]: /continuous_integration/setup_tests/containers/
+[5]: /getting_started/site/
+[6]: https://docs.docker.com/compose/
+[7]: /continuous_integration/setup_tests/containers/

--- a/content/en/continuous_integration/setup_tests/agent.md
+++ b/content/en/continuous_integration/setup_tests/agent.md
@@ -11,6 +11,7 @@ further_reading:
 
 ---
 
+{{< site-region region="us,eu" >}}
 To report test results to Datadog, the [Datadog Agent][1] is required.
 
 There are two ways to set up the Agent in a CI environment:
@@ -46,11 +47,17 @@ To run the Datadog Agent as a container acting as a simple results forwarder, us
 **Default**: (autodetected)<br/>
 **Required value**: `none`
 
-`DD_SITE` (Optional)
-: The [Datadog site][5] to upload results to.<br/>
+
+{{< site-region region="eu" >}}
+Additionally, configure the Datadog site to use the currently selected one ({{< region-param key="dd_site_name" >}}):
+
+`DD_SITE` (Required)
+: The [Datadog site][1] to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
-**Selected site**: {{< region-param key="dd_site" code="true" >}}<br/>
-**Possible values**: `datadoghq.com`, `datadoghq.eu`
+**Selected site**: {{< region-param key="dd_site" code="true" >}}
+
+[1]: /getting_started/site/
+{{< /site-region >}}
 
 ### CI provider configuration examples
 
@@ -275,7 +282,7 @@ Add your [Datadog API key][2] to your [project environment variables][3] with th
 
 ### Using Docker Compose
 
-Regardless of which CI provider you use, if tests are run using [Docker Compose][6], the Datadog Agent can be run as one service:
+Regardless of which CI provider you use, if tests are run using [Docker Compose][5], the Datadog Agent can be run as one service:
 
 {{< site-region region="us" >}}
 {{< code-block lang="yaml" filename="docker-compose.yml" >}}
@@ -363,7 +370,7 @@ DD_API_KEY=<YOUR_DD_API_KEY> docker-compose up \
   tests
 {{< /code-block >}}
 
-**Note:** In this case, add all the required CI provider environment variables so build information can be attached to each test result, as described in [Tests in containers][7].
+**Note:** In this case, add all the required CI provider environment variables so build information can be attached to each test result, as described in [Tests in containers][6].
 
 ## Further reading
 
@@ -373,6 +380,9 @@ DD_API_KEY=<YOUR_DD_API_KEY> docker-compose up \
 [2]: https://app.datadoghq.com/account/settings#agent
 [3]: https://docs.datadoghq.com/agent/cluster_agent/admission_controller/
 [4]: https://app.datadoghq.com/account/settings#api
-[5]: /getting_started/site/
-[6]: https://docs.docker.com/compose/
-[7]: /continuous_integration/setup_tests/containers/
+[5]: https://docs.docker.com/compose/
+[6]: /continuous_integration/setup_tests/containers/
+{{< /site-region >}}
+{{< site-region region="us3,gov" >}}
+The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported at this time.
+{{< /site-region >}}

--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -78,16 +78,15 @@ Additionally, the following environment variables are supported:
 **Default**: (none)<br/>
 **Examples**: `local`, `ci`
 
-<!-- TODO: uncomment this once we support any datacenter other than us1
 `DATADOG_SITE`
-: The Datadog site to upload results to.<br/>
+: The [Datadog site][4] to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
-**Possible values**: `datadoghq.com`, `datadoghq.eu` or `us3.datadoghq.com`
--->
+**Possible values**: `datadoghq.com` or `datadoghq.eu`
+
 
 ## Collecting repository and commit metadata
 
-The Datadog CI CLI tries to extract git repository and commit metadata from CI provider environment variables and from the local `.git` directory and attach it to test executions. In order to read this directory, the [`git`][4] binary is required.
+The Datadog CI CLI tries to extract git repository and commit metadata from CI provider environment variables and from the local `.git` directory and attach it to test executions. In order to read this directory, the [`git`][5] binary is required.
 
 ## Further reading
 
@@ -96,4 +95,5 @@ The Datadog CI CLI tries to extract git repository and commit metadata from CI p
 [1]: https://junit.org/junit5/
 [2]: https://www.npmjs.com/package/@datadog/datadog-ci
 [3]: https://app.datadoghq.com/account/settings#api
-[4]: https://git-scm.com/downloads
+[4]: /getting_started/site/
+[5]: https://git-scm.com/downloads

--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -81,6 +81,7 @@ Additionally, the following environment variables are supported:
 `DATADOG_SITE`
 : The [Datadog site][4] to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
+**Selected site**: {{< region-param key="dd_site" code="true" >}}<br/>
 **Possible values**: `datadoghq.com` or `datadoghq.eu`
 
 

--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -10,6 +10,7 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
+{{< site-region region="us,eu" >}}
 JUnit test report files are XML files that contain test execution information, such as test and suite names, pass/fail status, duration, and sometimes error logs. Although it was introduced by the [JUnit][1] testing framework, many other popular frameworks are able to output results using this format.
 
 As an alternative to instrumenting your tests natively using Datadog tracers, which is the recommended option as it provides the most comprehensive test results, you can also upload JUnit XML test reports.
@@ -67,7 +68,7 @@ This is the full list of options available when using the `datadog-ci junit uplo
 Positional arguments
 : The file paths or directories in which the JUnit XML reports are located. If you pass a directory, the CLI will look for all `.xml` files in it.
 
-Additionally, the following environment variables are supported:
+The following environment variables are supported:
 
 `DATADOG_API_KEY` (Required)
 : [Datadog API key][3] used to authenticate the requests.<br/>
@@ -78,16 +79,21 @@ Additionally, the following environment variables are supported:
 **Default**: (none)<br/>
 **Examples**: `local`, `ci`
 
-`DATADOG_SITE`
-: The [Datadog site][4] to upload results to.<br/>
+{{< site-region region="eu" >}}
+Additionally, configure the Datadog site to use the currently selected one ({{< region-param key="dd_site_name" >}}):
+
+`DD_SITE` (Required)
+: The [Datadog site][1] to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
-**Selected site**: {{< region-param key="dd_site" code="true" >}}<br/>
-**Possible values**: `datadoghq.com` or `datadoghq.eu`
+**Selected site**: {{< region-param key="dd_site" code="true" >}}
+
+[1]: /getting_started/site/
+{{< /site-region >}}
 
 
 ## Collecting repository and commit metadata
 
-The Datadog CI CLI tries to extract git repository and commit metadata from CI provider environment variables and from the local `.git` directory and attach it to test executions. In order to read this directory, the [`git`][5] binary is required.
+The Datadog CI CLI tries to extract git repository and commit metadata from CI provider environment variables and from the local `.git` directory and attach it to test executions. In order to read this directory, the [`git`][4] binary is required.
 
 ## Further reading
 
@@ -96,5 +102,8 @@ The Datadog CI CLI tries to extract git repository and commit metadata from CI p
 [1]: https://junit.org/junit5/
 [2]: https://www.npmjs.com/package/@datadog/datadog-ci
 [3]: https://app.datadoghq.com/account/settings#api
-[4]: /getting_started/site/
-[5]: https://git-scm.com/downloads
+[4]: https://git-scm.com/downloads
+{{< /site-region >}}
+{{< site-region region="us3,gov" >}}
+The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported at this time.
+{{< /site-region >}}

--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -101,6 +101,7 @@ Set all these variables in your test target:
 `DD_SITE`
 : The [Datadog site][2] to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
+**Selected site**: {{< region-param key="dd_site" code="true" >}}<br/>
 **Possible values**: `datadoghq.com` or `datadoghq.eu`
 
 ### Collecting Git and build metadata

--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -98,12 +98,10 @@ Set all these variables in your test target:
 **Recommended**: `$(SRCROOT)`<br/>
 **Example**: `/Users/ci/source/MyApp`
 
-<!-- TODO: uncomment this once we support any datacenter other than us1
 `DD_SITE`
-: The Datadog site to upload results to.<br/>
+: The [Datadog site][2] to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
-**Possible values**: `datadoghq.com`, `us3.datadoghq.com`, `datadoghq.eu`
--->
+**Possible values**: `datadoghq.com` or `datadoghq.eu`
 
 ### Collecting Git and build metadata
 
@@ -418,3 +416,4 @@ Additional Git configuration for physical device testing:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/organization-settings/client-tokens
+[2]: /getting_started/site/

--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -10,6 +10,7 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
+{{< site-region region="us,eu" >}}
 ## Compatibility
 
 Supported languages:
@@ -98,11 +99,16 @@ Set all these variables in your test target:
 **Recommended**: `$(SRCROOT)`<br/>
 **Example**: `/Users/ci/source/MyApp`
 
-`DD_SITE`
-: The [Datadog site][2] to upload results to.<br/>
+{{< site-region region="eu" >}}
+Additionally, configure the Datadog site to use the currently selected one ({{< region-param key="dd_site_name" >}}):
+
+`DD_SITE` (Required)
+: The [Datadog site][1] to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
-**Selected site**: {{< region-param key="dd_site" code="true" >}}<br/>
-**Possible values**: `datadoghq.com` or `datadoghq.eu`
+**Selected site**: {{< region-param key="dd_site" code="true" >}}
+
+[1]: /getting_started/site/
+{{< /site-region >}}
 
 ### Collecting Git and build metadata
 
@@ -417,4 +423,7 @@ Additional Git configuration for physical device testing:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/organization-settings/client-tokens
-[2]: /getting_started/site/
+{{< /site-region >}}
+{{< site-region region="us3,gov" >}}
+The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported at this time.
+{{< /site-region >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Documents how to use CI App on EU1.

### Motivation
<!-- What inspired you to submit this pull request?-->

EU1 is now supported by CI App.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fermayo/ciapp-add-eu1/continuous_integration/
https://docs-staging.datadoghq.com/fermayo/ciapp-add-eu1/continuous_integration/setup_tests/agent/
https://docs-staging.datadoghq.com/fermayo/ciapp-add-eu1/continuous_integration/setup_tests/junit_upload/
https://docs-staging.datadoghq.com/fermayo/ciapp-add-eu1/continuous_integration/setup_tests/swift/
https://docs-staging.datadoghq.com/fermayo/ciapp-add-eu1/continuous_integration/setup_pipelines/gitlab/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
