### PR TITLE
Add Mobile App Notes to other pages

### DIFF
--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -38,6 +38,8 @@ further_reading:
 
 A dashboard is Datadog's tool for visually tracking, analyzing, and displaying key performance metrics, which enable you to monitor the health of your infrastructure.
 
+**Note**: View Dashboards on the go with the [Datadog Mobile App][11], available on the [Apple App Store][12] and [Google Play Store][13].
+
 ## New dashboard
 
 To create a dashboard, click on **+New Dashboard** on the [dashboard list page][1], or click **New Dashboard** from the navigation menu. Enter a dashboard name and choose a layout option.
@@ -204,3 +206,6 @@ Click the settings modal for the whole dashboard, and select *Permissions*. Use 
 [8]: /account_management/users/default_roles/
 [9]: /help/
 [10]: /account_management/rbac/
+[11]: /mobile
+[12]: https://apps.apple.com/app/datadog/id1391380318
+[13]: https://play.google.com/store/apps/details?id=com.datadog.app

--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -38,7 +38,7 @@ further_reading:
 
 A dashboard is Datadog's tool for visually tracking, analyzing, and displaying key performance metrics, which enable you to monitor the health of your infrastructure.
 
-**Note**: View Dashboards on the go with the [Datadog Mobile App][11], available on the [Apple App Store][12] and [Google Play Store][13].
+**Note**: View Dashboards with the [Datadog Mobile App][11], available on the [Apple App Store][12] and [Google Play Store][13].
 
 ## New dashboard
 

--- a/content/en/monitors/incident_management/_index.md
+++ b/content/en/monitors/incident_management/_index.md
@@ -23,7 +23,7 @@ In the Datadog paradigm, any of the following are appropriate situations for dec
 
 Incident Management requires no installation. To view your incidents, go to the [Incidents][1] page to see a feed of all ongoing incidents.  You can configure additional fields that appear for all incidents in [Incident Settings][2].
 
-**Note**: Manage and create incidents on the go with the [Datadog Mobile App][13], available on the [Apple App Store][14] and [Google Play Store][15].
+**Note**: Manage and create incidents with the [Datadog Mobile App][13], available on the [Apple App Store][14] and [Google Play Store][15].
 
 ### Creating an incident
 

--- a/content/en/monitors/incident_management/_index.md
+++ b/content/en/monitors/incident_management/_index.md
@@ -23,6 +23,8 @@ In the Datadog paradigm, any of the following are appropriate situations for dec
 
 Incident Management requires no installation. To view your incidents, go to the [Incidents][1] page to see a feed of all ongoing incidents.  You can configure additional fields that appear for all incidents in [Incident Settings][2].
 
+**Note**: Manage and create incidents on the go with the [Datadog Mobile App][13], available on the [Apple App Store][14] and [Google Play Store][15].
+
 ### Creating an incident
 
 #### From a graph
@@ -167,3 +169,6 @@ Work through an example workflow in the [Getting Started with Incident Managemen
 [10]: /integrations/webhooks/
 [11]: /integrations/webhooks/#sending-sms-through-twilio
 [12]: /getting_started/incident_management
+[13]: /mobile
+[14]: https://apps.apple.com/app/datadog/id1391380318
+[15]: https://play.google.com/store/apps/details?id=com.datadog.app


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds links to the mobile app in other areas of the documentation

### Motivation
Increase awareness of the mobile app

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/justin/mobile-app-additions

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
