### PR TITLE
ja tab fix

### DIFF
--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,3 +1,3 @@
-<div data-lang="{{ .Get 0 | lower }}" class="tab-pane fade" role="tabpanel" title="{{ .Get 0 }}">
+<div data-lang="{{ .Get 0 | anchorize }}" class="tab-pane fade" role="tabpanel" title="{{ .Get 0 }}">
   {{ .Inner }}
 </div>

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,3 +1,3 @@
-<div data-lang="{{ .Get 0 | anchorize }}" class="tab-pane fade" role="tabpanel" title="{{ .Get 0 }}">
+<div data-lang="{{ replace (.Get 0 | lower | anchorize) "-" "" }}" class="tab-pane fade" role="tabpanel" title="{{ .Get 0 }}">
   {{ .Inner }}
 </div>

--- a/src/scripts/components/codetabs.js
+++ b/src/scripts/components/codetabs.js
@@ -2,7 +2,7 @@ import { getQueryParameterByName } from '../helpers/browser';
 
 function codeTabs() {
     const tab = getQueryParameterByName('tab');
-    
+
     if ($('.code-tabs').length > 0) {
         // page load set code tab titles
         $('.code-tabs .tab-content')
@@ -13,7 +13,7 @@ function codeTabs() {
                     .find('.nav-tabs-mobile .dropdown-menu');
                 const navTabs = $(this).closest('.code-tabs').find('.nav-tabs');
                 const title = $(this).attr('title');
-                const lang = title.toLowerCase().replace(/\W/g, '');
+                const lang = $(this).data('lang');
                 navTabs.append(
                     `<li><a href="#" data-lang="${lang}">${title}</a></li>`
                 );


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where tabs were not working on the ja version of the site

~Note that this does change the value in the `?tab` part of the url which we might not want to do?~

~e.g~
~previous`?tab=bymonitortags`~
~with this change `?tab=by-monitor-tags`~

### Motivation

reported in slack that tabs on ja monitors downtimes wasn't working

### Preview

Take a look at the tabs on these 2 pages and compare to production
https://docs-staging.datadoghq.com/david.jones/tab-fix/monitors/downtimes/
https://docs-staging.datadoghq.com/david.jones/tab-fix/ja/monitors/downtimes/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
