### PR TITLE
catch parsing errors

### DIFF
--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -35,10 +35,16 @@ def security_rules(content, content_dir):
         data = None
         if file_name.endswith(".json"):
             with open(file_name, mode="r+") as f:
-                data = json.loads(f.read())
+                try:
+                    data = json.loads(f.read())
+                except:
+                    logger.warn(f"Error parsing {file_name}")
         elif file_name.endswith(".yaml"):
             with open(file_name, mode="r+") as f:
-                data = yaml.load(f.read(), Loader=yaml.FullLoader)
+                try:
+                    data = yaml.load(f.read(), Loader=yaml.FullLoader)
+                except:
+                    logger.warn(f"Error parsing {file_name}")
 
         p = Path(f.name)
         message_file_name = p.with_suffix('.md')
@@ -140,7 +146,10 @@ def compliance_rules(content, content_dir):
         if not file_name.endswith(".json"):
             continue
         with open(file_name, mode="r+") as f:
-            json_data = json.loads(f.read())
+            try:
+                json_data = json.loads(f.read())
+            except:
+                logger.warn(f"Error parsing {file_name}")
             p = Path(f.name)
 
             # delete file or skip if staged


### PR DESCRIPTION
### What does this PR do?

catch json and yaml security monitoring parsing errors and log about them while continuing the build.
This is to cover the recent additions of non valid yaml into the security-monitoring repo.

### Motivation

Build was broken

### Preview

https://docs-staging.datadoghq.com/david.jones/sec-mon-parsefix/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
