### PR TITLE
Update Troubleshooting section of App Service Extension Docs

### DIFF
--- a/content/en/serverless/azure_app_services.md
+++ b/content/en/serverless/azure_app_services.md
@@ -127,12 +127,20 @@ Learn more about [custom metrics][16].
 
 ## Troubleshooting
 
-To start troubleshooting your application, try these steps:
+1. If you are missing metrics and metadata in the APM trace panel and service page:
 
-1. Verify you've set `DD_SITE` and `DD_API_KEY` correctly.
-2. Do a full stop and start of your application.
-3. If not resolved, try uninstalling the extension and re-installing (this also ensures you are running the latest version).
-4. Still need help? Contact [Datadog support][17].
+It is likely that you do have the Azure Integration configured to monitor your application. Proper configuration will improve your ability to correlate metrics, traces, and logs in the Datadog platform, and avoid broken or empty screens. To fix this:
+
+a. Ensure you have installed the [Azure integration][8] for the Azure subscription where your application is running.
+b. Ensure that any App Service Plan filtering rules you may have applied include the App Service Plan where the app is running. Tags on the app itself are not used for filtering.
+
+
+2. If APM traces are not appearing in Datadog, try these steps:
+
+a. Verify you've set `DD_SITE` and `DD_API_KEY` correctly.
+b. Do a full stop and start of your application.
+c. If not resolved, try uninstalling the extension and re-installing (this also ensures you are running the latest version).
+d. Still need help? Contact [Datadog support][17].
 
 **Note**: To expedite the process of investigating application errors with the support team, set `DD_TRACE_DEBUG:true` and add the content of the Datadog logs directory (`%AzureAppServiceHomeDirectory%\LogFiles\datadog`) to your email.
 

--- a/content/en/serverless/azure_app_services.md
+++ b/content/en/serverless/azure_app_services.md
@@ -129,7 +129,7 @@ Learn more about [custom metrics][16].
 
 1. If you are missing metrics and metadata in the APM trace panel and service page:
 
-It is likely that you do have the Azure Integration configured to monitor your application. Proper configuration will improve your ability to correlate metrics, traces, and logs in the Datadog platform, and avoid broken or empty screens. To fix this:
+It is likely that you do not have the Azure integration configured to monitor your application. Proper configuration improves your ability to correlate metrics, traces, and logs in the Datadog platform, as well as to avoid broken or empty screens. To fix this:
 
 a. Ensure you have installed the [Azure integration][8] for the Azure subscription where your application is running.
 b. Ensure that any App Service Plan filtering rules you may have applied include the App Service Plan where the app is running. Tags on the app itself are not used for filtering.


### PR DESCRIPTION
### What does this PR do?
This PR updates the troubleshooting section of the App Servrice Extension page to cover situations where customers do not have the azure integration properly configured.

### Motivation
We are adding indications in the UI that this is an issue. We'll direct customers to this page from the in-app notification.

### Preview


Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
