### PR TITLE
Add webinars link to footer navs

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2695,6 +2695,9 @@ footer_product_three:
   - name: Resources
     url: 'https://www.datadoghq.com/resources/'
     weight: 150
+  - name: Webinars
+    url: 'https://www.datadoghq.com/webinars/'
+    weight: 160
   - name: Security
     url: 'https://www.datadoghq.com/security/'
     weight: 180

--- a/config/_default/menus/menus.fr.yaml
+++ b/config/_default/menus/menus.fr.yaml
@@ -3989,6 +3989,9 @@ footer_product_three:
   - name: Ressources
     url: "https://www.datadoghq.com/resources/"
     weight: 150
+  - name: Webinars
+    url: 'https://www.datadoghq.com/webinars/'
+    weight: 160
   - name: Sécurité
     url: "https://www.datadoghq.com/security/"
     weight: 180

--- a/config/_default/menus/menus.ja.yaml
+++ b/config/_default/menus/menus.ja.yaml
@@ -2452,6 +2452,9 @@ footer_product_three:
   - name: リソース
     url: "https://www.datadoghq.com/ja/resources/"
     weight: 150
+  - name: Webinars
+    url: 'https://www.datadoghq.com/ja/webinars/'
+    weight: 160
   - name: セキュリティ
     url: "https://www.datadoghq.com/ja/security/"
     weight: 180


### PR DESCRIPTION
### What does this PR do?
Adds link to webinar hub page to footer navs

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1459

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/footer-nav-update/
https://docs-staging.datadoghq.com/brian.deutsch/footer-nav-update/ja/
https://docs-staging.datadoghq.com/brian.deutsch/footer-nav-update/fr/

There is a link to the Webinars page in the footer nav below Resources

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
