### PR TITLE
HashMap should be of type object rather than string for tags.

### DIFF
--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -128,7 +128,7 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
     public Integer handleRequest(APIGatewayV2ProxyRequestEvent request, Context context){
         DDLambda ddl = new DDLambda(request, context);
 
-        Map<String,String> myTags = new HashMap<String, String>();
+        Map<String,Object> myTags = new HashMap<String, Object>();
             myTags.put("product", "latte");
             myTags.put("order","online");
         


### PR DESCRIPTION
The current hashmap which is defined in the code is a type <string, string> which is not defined in the class of DDLambda.
The custom metric method is breaking due to the type of map as <string, object> in DDLambda
 
  Map<String,Object> myTags = new HashMap<String, Object>();
        myTags.put("product", "coffee");
        myTags.put("product", "coffee");
        ddl.metric(
                "coffee_house.order_value", // Metric name
                12.45,                      // Metric value
                myTags);

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
