### PR TITLE
[CIAPP] Fix webhook URLs in CI Visibility for GitLab

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -112,14 +112,14 @@ As an alternative to using the native Datadog integration, you can use [webhooks
 
 Go to **Settings > Webhooks** in your repository (or GitLab instance settings), and add a new webhook:
 {{< site-region region="us" >}}
-* **URL**: `https://webhooks-http-intake.logs.datadoghq.com/v2/api/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
+* **URL**: `https://webhooks-http-intake.logs.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
 * **Secret Token**: leave blank
 * **Trigger**: Select `Job events` and `Pipeline events`.
 
 [1]: https://app.datadoghq.com/account/settings#api
 {{< /site-region >}}
 {{< site-region region="eu" >}}
-* **URL**: `https://webhooks-http-intake.logs.datadoghq.eu/v2/api/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
+* **URL**: `https://webhooks-http-intake.logs.datadoghq.eu/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
 * **Secret Token**: leave blank
 * **Trigger**: Select `Job events` and `Pipeline events`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/adrian.lopezcalvo%2Fcivisibility-hotfix-webhook-routes

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
