### PR TITLE
Add known caveats for Python/Ruby DogStatsD clients in detailed info docs

### DIFF
--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -312,6 +312,10 @@ options = {
 initialize(**options)
 ```
 
+<div class="alert alert-warning">
+  By default, Python DogStatsD client instances (including the <code>statsd</code> global instance) cannot be shared across processes but are thread-safe. Because of this, the parent process and each child process must create their own instances of the client or the buffering must be explicitly disabled by setting <code>disable_buffering</code> to <code>True</code>. For more information, refer to the <a href="https://datadogpy.readthedocs.io/en/latest/#datadog-dogstatsd">Python client documentation</a>.
+</div>
+
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby" >}}
@@ -323,6 +327,10 @@ require 'datadog/statsd'
 # Create a DogStatsD client instance.
 statsd = Datadog::Statsd.new('localhost', 8125)
 ```
+
+<div class="alert alert-warning">
+  By default, Ruby DogStatsD client instances cannot be shared across processes but are thread-safe. Because of this, the parent process and each child process must create their own instances of the client or the buffering must be explicitly disabled by setting <code>single_thread</code> to <code>true</code>. For more information, refer to the <a href="https://github.com/DataDog/dogstatsd-ruby">Ruby client documentation</a>.
+</div>
 
 {{< /programming-lang >}}
 
@@ -411,7 +419,9 @@ using (var dogStatsdService = new DogStatsdService())
 
 {{< /programming-lang-wrapper >}}
 
-**Note**: If you use DogStatsD with the Container Agent or in Kubernetes, you must instantiate the host to which StatsD metrics are forwarded to with the `$DD_DOGSTATSD_SOCKET` environment variable if using a Unix Domain Socket, or with the `$DD_AGENT_HOST` environment variable if you are using the host port binding method.
+<div class="alert alert-info">
+  If you use DogStatsD with the Container Agent or in Kubernetes, you must instantiate the host to which StatsD metrics are forwarded to with the <code>$DD_DOGSTATSD_SOCKET</code> environment variable if using a Unix Domain Socket, or with the <code>$DD_AGENT_HOST</code> environment variable if you are using the host port binding method.
+</div>
 
 ### Client instantiation parameters
 
@@ -429,21 +439,26 @@ In addition to the required DogStatsD configuration (`url` and `port`), the foll
 | `statsd_constant_tags` | List of strings | `null`      | Tags to apply to all metrics, events, and service checks.                                                      |
 | `statsd_namespace`     | String          | `null`      | Namespace to prefix all metrics, events, and service checks.                                                   |
 
-For more information, see the [DogStatsD module][1] documentation.
+For the full list of optional parameters available for `datadog.initialize()` as well as parameters only available when explicitly instantiating `datadog.dogstatsd.DogStatsd` instances, see the [Python client documentation][1].
 
 
 [1]: https://datadogpy.readthedocs.io/en/latest
 {{< /programming-lang >}}
 {{< programming-lang lang="ruby" >}}
 
-| Parameter     | Type            | Default     | Description                                                                                                    |
-| ------------- | --------------- | ----------- | -------------------------------------------------------------------------------------------------------------- |
-| `host`        | String          | `localhost` | The host of your DogStatsD server.                                                                             |
-| `port`        | Integer         | `8125`      | The port of your DogStatsD server.                                                                             |
-| `socket_path` | String          | `null`      | The path to the DogStatsD Unix domain socket (overrides `host` and `port`, only supported with the Agent v6+). |
-| `tags`        | List of strings | `null`      | Tags to apply to all metrics, events, and service checks.                                                      |
-| `namespace`   | String          | `null`      | Namespace to prefix to all metrics, events, and service checks.                                                |
+| Parameter       | Type            | Default     | Description                                                                                                    |
+| --------------- | --------------- | ----------- | -------------------------------------------------------------------------------------------------------------- |
+| `host`          | String          | `localhost` | The host of your DogStatsD server.                                                                             |
+| `port`          | Integer         | `8125`      | The port of your DogStatsD server.                                                                             |
+| `socket_path`   | String          | `null`      | The path to the DogStatsD Unix domain socket (overrides `host` and `port`, only supported with the Agent v6+). |
+| `tags`          | List of strings | `null`      | Tags to apply to all metrics, events, and service checks.                                                      |
+| `namespace`     | String          | `null`      | Namespace to prefix to all metrics, events, and service checks.                                                |
+| `single_thread` | Boolean         | `false`     | Makes the client send the metrics on the main thread when enabled rather than in a companion thread.           |
 
+For the full list of optional parameters, see the [Ruby client documentation][1].
+
+
+[1]: https://github.com/DataDog/dogstatsd-ruby
 {{< /programming-lang >}}
 {{< programming-lang lang="go" >}}
 

--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -296,7 +296,7 @@ If the packets sent are too small, the Datadog Agent packs several together to p
 The Datadog Agent performs most optimally if the DogStatsD clients send packets the size of the `dogstatsd_buffer_size`. The packets must not be larger than the buffer size, otherwise, the Agent won't be able to load them completely in the buffer and some of metrics will be malformed. Use the corresponding configuration field in your DogStatsD clients.
 
 <div class="alert alert-info">
-  <strong>Note for UDP</strong>: since UDP packets usually go through the Ethernet and IP layer, avoid IP packets fragmentation by limiting the packet size to a value lower than a single Ethernet frame on your network. Most of the time, IPv4 networks are configured with a MTU of 1500 bytes, so in this situation the packet size of sent packets should be limited to 1472.
+  <strong>Note for UDP</strong>: Because UDP packets usually go through the Ethernet and IP layer, you can avoid IP packets fragmentation by limiting the packet size to a value lower than a single Ethernet frame on your network. Most of the time, IPv4 networks are configured with a MTU of 1500 bytes, so in this situation the packet size of sent packets should be limited to 1472.
 </div>
 
 <div class="alert alert-info">

--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -300,7 +300,7 @@ The Datadog Agent performs most optimally if the DogStatsD clients send packets 
 </div>
 
 <div class="alert alert-info">
-  <strong>Note for UDS</strong>: for the best performances, UDS packet should have a size of 8192 bytes.
+  <strong>Note for UDS</strong>: for the best performances, the UDS packet size should be 8192 bytes.
 </div>
 
 ### Limit the maximum memory usage of the Agent

--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -34,7 +34,9 @@ We recommend that you use the latest version of the [official DogStatsD clients]
 
 Some StatsD and DogStatsD clients, by default, send one metric per datagram. This adds considerable overhead on the client, the operating system, and the Agent. If your client supports buffering multiple metrics in one datagram, enabling this option brings noticeable improvements.
 
-If you are using a community-supported DogStatsD client that supports buffering, make sure to configure a max datagram size that does not exceed the Agent-side per-datagram buffer size (8KB by default, configurable on the Agent with `dogstatsd_buffer_size`) and the network/OS max datagram size.
+<div class="alert alert-info">
+  If you are using a community-supported DogStatsD client that supports buffering, make sure to configure a max datagram size that does not exceed the Agent-side per-datagram buffer size (8KB by default, configurable on the Agent with <code>dogstatsd_buffer_size</code>) and the network/OS max datagram size.
+</div>
 
 Here are a few examples for [official DogStatsD supported clients][3]:
 
@@ -84,6 +86,10 @@ with dsd:
     dsd.gauge('example_metric.gauge_2', 1001, tags=["environment:dev"])
 ```
 
+<div class="alert alert-warning">
+  By default, Python DogStatsD client instances (including the <code>statsd</code> global instance) cannot be shared across processes but are thread-safe. Because of this, the parent process and each child process must create their own instances of the client or the buffering must be explicitly disabled by setting <code>disable_buffering</code> to <code>True</code>. For more information, please refer to the <a href="https://datadogpy.readthedocs.io/en/latest/#datadog-dogstatsd">Python client documentation</a>.
+</div>
+
 
 [1]: https://github.com/DataDog/datadogpy
 {{< /programming-lang >}}
@@ -103,8 +109,10 @@ statsd.gauge('example_metric.gauge', 123, tags: ['environment:dev'])
 statsd.flush(sync: true)
 ```
 
+<div class="alert alert-warning">
+  By default, Ruby DogStatsD client instances cannot be shared across processes but are thread-safe. Because of this, the parent process and each child process must create their own instances of the client or the buffering must be explicitly disabled by setting <code>single_thread</code> to <code>true</code>. For more information, please refer to the <a href="https://github.com/DataDog/dogstatsd-ruby">Ruby client documentation</a>.
+</div>
 
-[1]: https://github.com/DataDog/dogstatsd-ruby
 {{< /programming-lang >}}
 {{< programming-lang lang="java" >}}
 
@@ -287,9 +295,13 @@ If the packets sent are too small, the Datadog Agent packs several together to p
 
 The Datadog Agent performs most optimally if the DogStatsD clients send packets the size of the `dogstatsd_buffer_size`. The packets must not be larger than the buffer size, otherwise, the Agent won't be able to load them completely in the buffer and some of metrics will be malformed. Use the corresponding configuration field in your DogStatsD clients.
 
-Note for UDP: since UDP packets usually go through the Ethernet and IP layer, avoid IP packets fragmentation by limiting the packet size to a value lower than a single Ethernet frame on your network. Most of the time, IPv4 networks are configured with a MTU of 1500 bytes, so in this situation the packet size of sent packets should be limited to 1472.
+<div class="alert alert-info">
+  <strong>Note for UDP</strong>: since UDP packets usually go through the Ethernet and IP layer, avoid IP packets fragmentation by limiting the packet size to a value lower than a single Ethernet frame on your network. Most of the time, IPv4 networks are configured with a MTU of 1500 bytes, so in this situation the packet size of sent packets should be limited to 1472.
+</div>
 
-Note for UDS: for the best performances, UDS packet should have a size of 8192 bytes.
+<div class="alert alert-info">
+  <strong>Note for UDS</strong>: for the best performances, UDS packet should have a size of 8192 bytes.
+</div>
 
 ### Limit the maximum memory usage of the Agent
 
@@ -299,7 +311,9 @@ Avoid sending metrics in bursts in your application - this prevents the Datadog 
 
 Another thing to look at to limit the maximum memory usage is to reduce the buffering. The main buffer of the DogStatsD server within the Agent is configurable with the `dogstatsd_queue_size` field (since Datadog Agent 6.1.0), its default value of `1024` induces an approximate maximum memory usage of 768MB.
 
-**Note**: reducing this buffer could increase the number of packet drops.
+<div class="alert alert-warning">
+  <strong>Note</strong>: Reducing the buffer size could increase the number of packet drops.
+</div>
 
 This example decreases the max memory usage of DogStatsD to approximately 384MB:
 
@@ -311,9 +325,11 @@ See the next section on burst detection to help you detect bursts of metrics fro
 
 ### Enable metrics processing stats and burst detection
 
-DogStatsD has a stats mode in which you will be able to know which metrics are the most processed.
+DogStatsD has a stats mode in which you can see which metrics are the most processed.
 
-**Note**: Enabling this mode can decrease DogStatsD performance.
+<div class="alert alert-warning">
+  <strong>Note</strong>: Enabling metrics stats mode can decrease DogStatsD performance.
+</div>
 
 To enable the stats mode, you can either:
 


### PR DESCRIPTION
### What does this PR do?

- Adds important caveat note about multi-processing to Python and Ruby client detailed/high-throughput usage docs
- Improves a few notes/warnings on those pages to real note/warning stylings

### Motivation

Since Python and Ruby have somewhat big caveats for multi-process use,
those needed to be added to the places where detailed and
high-performance usage was described to prevent issues for users.

Incidental to this change a few notes/warnings had their styling
improved in those two pages.

### Preview

_Note: I don't know why but the links don't show the previews_

- https://docs-staging.datadoghq.com/sgnn7/dogstatsd-client-caveats/developers/dogstatsd
- https://docs-staging.datadoghq.com/sgnn7/dogstatsd-client-caveats/developers/dogstatsd/high_throughput

### Additional Notes

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
