### PR TITLE
Brian.deutsch/bump module version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.0.1 // indirect
+require github.com/DataDog/websites-modules v1.2.1 // indirect
 
 // replace github.com/DataDog/websites-modules => /Users/brian.deutsch/dd/websites-modules

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/DataDog/websites-modules v1.0.1 h1:jWpjiSBOjDJLv8+Z86/6xc3QTvsL9qspjuppy750wmM=
 github.com/DataDog/websites-modules v1.0.1/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.2.1 h1:8oOcmjWBnpSmQnWW4NX0NXufuCLT41vEhDXbf/EGitI=
+github.com/DataDog/websites-modules v1.2.1/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=

--- a/yarn.lock
+++ b/yarn.lock
@@ -12045,3 +12045,5 @@ zip-stream@^2.1.2:
     archiver-utils "^2.1.0"
     compress-commons "^2.1.1"
     readable-stream "^3.4.0"
+
+


### PR DESCRIPTION
### What does this PR do?
Bump `websites-modules` to latest tagged version
Force change to `yarn.lock` to refresh Gitlab cache

### Motivation
Build errors

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/bump-module-version/

### Additional Notes
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
