### PR TITLE
[ci-app] Change `DD_SITE` to `DATADOG_SITE` in JUnit XML

### DIFF
--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -82,7 +82,7 @@ The following environment variables are supported:
 {{< site-region region="eu" >}}
 Additionally, configure the Datadog site to use the currently selected one ({{< region-param key="dd_site_name" >}}):
 
-`DD_SITE` (Required)
+`DATADOG_SITE` (Required)
 : The [Datadog site][1] to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
 **Selected site**: {{< region-param key="dd_site" code="true" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
* Change `DD_SITE` to `DATADOG_SITE`.

### Motivation
* `DD_SITE` is not used in `datadog-ci`.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/juan-fernandez/ci-app-update-dd-site/continuous_integration/setup_tests/junit_upload/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
