### PR TITLE
[Chino Nwabueze] sample_rate and is_rate_limit fix

### DIFF
--- a/content/en/api/v1/logs-indexes/examples.json
+++ b/content/en/api/v1/logs-indexes/examples.json
@@ -127,7 +127,7 @@
             {
               "filter": {
                 "query": "*",
-                "sample_rate": 1
+                "sample_rate": 1.0
               },
               "is_enabled": false,
               "name": "payment"
@@ -136,7 +136,6 @@
           "filter": {
             "query": "source:python"
           },
-          "is_rate_limited": false,
           "name": "main",
           "num_retention_days": 15
         },


### PR DESCRIPTION
https://datadog.zendesk.com/agent/tickets/526877

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR makes fixes to both the sample_rate and is_rate_limit parameters. The sample_rate parameter is expected to be a float instead of an integer which is currently present in the JSON example.

Since the JSON example has a daily_limit, is_rate_limit should not be present. is_rate_limited is related with daily_limit. If you have daily_limit value then you need to set is_rate_limited to true or remove the value entirely. If not you get back an error.

### Motivation
https://datadog.zendesk.com/agent/tickets/526877

### Preview
https://docs.datadoghq.com/api/latest/logs-indexes/#create-an-index

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
