### PR TITLE
[CIAPP-2447] Add site env variable to Swift and JUnit XML command snippets in EU

### DIFF
--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -35,11 +35,20 @@ datadog-ci junit upload --service <service_name> <path> [<path> ...]
 
 Specify a valid [Datadog API key][3] in the `DATADOG_API_KEY` environment variable, and the environment where tests were run (for example, `local` when uploading results from a developer workstation, or `ci` when uploading them from a CI provider) in the `DD_ENV` environment variable. For example:
 
+{{< site-region region="us" >}}
 {{< code-block lang="bash" >}}
 DD_ENV=ci DATADOG_API_KEY=<api_key> datadog-ci junit upload \
   --service my-api-service \
   unit-tests/junit-reports e2e-tests/single-report.xml
 {{< /code-block >}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+{{< code-block lang="bash" >}}
+DD_ENV=ci DATADOG_API_KEY=<api_key> DATADOG_SITE=datadoghq.eu datadog-ci junit upload \
+  --service my-api-service \
+  unit-tests/junit-reports e2e-tests/single-report.xml
+{{< /code-block >}}
+{{< /site-region >}}
 
 ## Configuration settings
 

--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -120,6 +120,7 @@ When running tests in a simulator, full Git metadata is collected using the loca
 
 After installation, run your tests as you normally do, for example using the `xcodebuild test` command. Tests, network requests, and application logs are instrumented automatically. Pass your environment variables when running your tests in the CI, for example:
 
+{{< site-region region="us" >}}
 {{< code-block lang="bash" >}}
 DD_TEST_RUNNER=1 DD_ENV=ci xcodebuild \
   -project "MyProject.xcodeproj" \
@@ -127,6 +128,16 @@ DD_TEST_RUNNER=1 DD_ENV=ci xcodebuild \
   -destination "platform=macOS,arch=x86_64" \
   test
 {{< /code-block >}}
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+{{< code-block lang="bash" >}}
+DD_TEST_RUNNER=1 DD_ENV=ci DD_SITE=datadoghq.eu xcodebuild \
+  -project "MyProject.xcodeproj" \
+  -scheme "MyScheme" \
+  -destination "platform=macOS,arch=x86_64" \
+  test
+{{< /code-block >}}
+{{< /site-region >}}
 
 ### UI tests
 


### PR DESCRIPTION
### What does this PR do?

Adds missing Datadog site environment variable to command snippets for Swift and JUnit XML in EU

### Motivation

https://datadoghq.atlassian.net/browse/CIAPP-2447

### Preview

- https://docs-staging.datadoghq.com/ramon/ci-app_site-env-var-in-code-snippets/continuous_integration/setup_tests/swift/?tab=usingswiftpackagemanager#running-tests
- https://docs-staging.datadoghq.com/ramon/ci-app_site-env-var-in-code-snippets/continuous_integration/setup_tests/junit_upload/#uploading-test-reports

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
