### PR TITLE
[doc] Add note re: config actions/errors displayed in event stream

### DIFF
--- a/content/en/integrations/faq/i-ve-set-up-the-jira-integration-now-how-do-i-get-events-and-tickets-created.md
+++ b/content/en/integrations/faq/i-ve-set-up-the-jira-integration-now-how-do-i-get-events-and-tickets-created.md
@@ -30,4 +30,5 @@ All 'Task' issues created in JIRA for the project designated by the key 'TEST2' 
 * Our integration scrapes JIRA about every five minutes, but issue types can vary in the amount of time they take to appear in Datadog. Generally, larger issue types like 'Stories' take longer to pull in than smaller ones like 'Tasks'.
 * You can pull in multiple issue types from one project, or one issue type from multiple projects.
 * The only tags available are those that you define for the Ticket Types on the integration tile.
+* Any integration configuration actions or errors are displayed in the Datadog event stream.
 


### PR DESCRIPTION
### What does this PR do?
Lets the reader know they can check their Datadog event stream for Jira config actions/errors.

### Motivation
Customer suggested.

### Preview
n/a

### Additional Notes
n/a

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
