### PR TITLE
Add tabs for configuration options

### DIFF
--- a/content/en/real_user_monitoring/guide/session-replay-getting-started.md
+++ b/content/en/real_user_monitoring/guide/session-replay-getting-started.md
@@ -26,7 +26,9 @@ To use Session Replay, set up [Datadog RUM Browser Monitoring][1]. Set up the fo
 
 Session Replay is available through a dedicated build of the RUM Browser SDK. To enable Session Replay, change the npm package name or CDN URL, depending on your chosen installation method:
 
-#### npm
+{{< tabs >}}
+{{% tab "npm" %}}
+
 Replace the `@datadog/browser-rum package` with a version >3.0.2 of [`@datadog/browser-rum`][2] When `datadogRum.init()` is called, it also starts the Session Replay recording.
 
 ``` javascript
@@ -46,9 +48,12 @@ datadogRum.init({
 
 DD_RUM.startSessionReplayRecording();
 ```
+{{% /tab %}}
+{{% tab "CDN" %}}
 
-#### CDN
 Replace the Browser SDK URL `https://www.datadoghq-browser-agent.com/datadog-rum.js` with `https://www.datadoghq-browser-agent.com/datadog-rum-v3.js`. When `DD_RUM.init()` is called, it also starts the Session Replay recording.
+
+{{% /tab %}}
 
 *Supported browsers*: The Session Replay recorder supports all the browsers supported by the RUM Browser SDK with the exception of IE11. See the [browser support table][3].
 


### PR DESCRIPTION
### What does this PR do?
Add tabs instead of configuration sections to focus the views

### Preview

https://docs-staging.datadoghq.com/MirandaKapin/SessionReplay_AddTabs/real_user_monitoring/guide/session-replay-getting-started/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
