### PR TITLE
Adding an extra line space between 2 parts

### DIFF
--- a/content/en/monitors/service_level_objectives/_index.md
+++ b/content/en/monitors/service_level_objectives/_index.md
@@ -61,6 +61,7 @@ Setting a 100% target means having an error budget of 0% since error budget is e
 **Note:** The number of decimal places you can specify for your SLOs differs depending on the type of SLO and the time windows you choose. Refer to the links below for more information for each respective SLO type.
 
 [Monitor-based SLOs][5]: Up to two decimal places are allowed for 7-day and 30-day targets, up to three decimal places are allowed for 90-day targets.
+
 [Metric-based SLOs][6]: Up to three decimal places are allowed for all targets.
 
 ## Edit an SLO


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds an extra line between 2 different types of SLOs.

### Motivation
<!-- What inspired you to submit this pull request?-->
Distinguishing between the 2 types of SLOs

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
