### PR TITLE
Remove preview label for Lambda extension

### DIFF
--- a/content/en/serverless/libraries_integrations/library.md
+++ b/content/en/serverless/libraries_integrations/library.md
@@ -4,7 +4,7 @@ kind: documentation
 further_reading:
 - link: "/serverless/libraries_integrations/extension/"
   tag: "Documentation"
-  text: "Datadog Lambda Extension (Preview)"
+  text: "Datadog Lambda Extension"
 - link: "https://github.com/DataDog/datadog-lambda-python/blob/master/README.md"
   tag: "Github"
   text: "Datadog Lambda Library for Python"


### PR DESCRIPTION
### What does this PR do?

Remove the "preview" label for the Datadog Lambda extension

### Motivation

This feature is generally available

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
