### PR TITLE
[WEB-1625] Make sure footer CTA opens modal

### DIFF
--- a/assets/styles/components/_global-modals.scss
+++ b/assets/styles/components/_global-modals.scss
@@ -1,4 +1,7 @@
 #signupModal {
+  #signUpIframe {
+    width: 100%;
+  }
   .modal-content {
     width:542px;
   }

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -27,7 +27,7 @@
         </div>
         <div class="row mb-0 mb-lg-5">
             <div class="col-12 col-lg-3 footer-side">
-                <a href="#" class="mb-2 mb-lg-4 js-cta-footer {{ if .Params.bottom_footer_trigger }} {{ .Params.bottom_footer_trigger }} {{ else }} sign-up-trigger {{ end }} btn btn-white btn-outline btn-block" data-event-category="Signup" data-event-action="Step 1 Footer Initiated" data-event-label="{{ "{{url path}}" }}">
+                <a href="#" class="mb-2 mb-lg-4 js-cta-footer {{ if .Params.bottom_footer_trigger }} {{ .Params.bottom_footer_trigger }} {{ else }} sign-up-trigger {{ end }} btn btn-white btn-outline btn-block" data-event-category="Signup" data-event-action="Step 1 Footer Initiated" data-event-label="{{ "{{url path}}" }}" data-toggle="modal" data-target="#signupModal">
                     {{ if .Params.custom_footer_cta }}
                         {{ .Params.custom_footer_cta }}
                     {{ else }}


### PR DESCRIPTION
### What does this PR do?
Footer CTA should launch signup modal

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1625

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/free-trial-fix/

`Free Trial` CTA in the footer should launch sign up modal

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
