### PR TITLE
[WEB-1623] Updates JSON deploy config to explicitly set Content-Type

### DIFF
--- a/config/live/config.yaml
+++ b/config/live/config.yaml
@@ -35,10 +35,11 @@ deployment:
       - pattern: "^.+\\.(png|jpg|jpeg|gif|mp4|zip|pdf|txt|csv)$"
         cacheControl: "max-age=31536000, no-transform, public"
         gzip: false
-      - pattern: "^.+\\.(html)$"
+      - pattern: "^.+\\.(html|xml)$"
         gzip: true
         contentType: "text/html; charset=utf-8"
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
-      - pattern: "^.+\\.(xml|json)$"
-        gzip: false
+      - pattern: "^.+\\.(json)$"
+        gzip: true
+        contentType: "application/json; charset=utf-8"
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"

--- a/config/live/config.yaml
+++ b/config/live/config.yaml
@@ -39,6 +39,10 @@ deployment:
         gzip: true
         contentType: "text/html; charset=utf-8"
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
+      - pattern: "^.+\\.(xml)$"
+        gzip: true
+        contentType: "text/xml; charset=utf-8"
+        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
       - pattern: "^.+\\.(json)$"
         gzip: true
         contentType: "application/json; charset=utf-8"

--- a/config/live/config.yaml
+++ b/config/live/config.yaml
@@ -40,5 +40,5 @@ deployment:
         contentType: "text/html; charset=utf-8"
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
       - pattern: "^.+\\.(xml|json)$"
-        gzip: true
+        gzip: false
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"

--- a/config/live/config.yaml
+++ b/config/live/config.yaml
@@ -35,15 +35,15 @@ deployment:
       - pattern: "^.+\\.(png|jpg|jpeg|gif|mp4|zip|pdf|txt|csv)$"
         cacheControl: "max-age=31536000, no-transform, public"
         gzip: false
-      - pattern: "^.+\\.(html|xml)$"
+      - pattern: "^.+\\.html$"
         gzip: true
         contentType: "text/html; charset=utf-8"
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
-      - pattern: "^.+\\.(xml)$"
+      - pattern: "^.+\\.xml$"
         gzip: true
         contentType: "text/xml; charset=utf-8"
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
-      - pattern: "^.+\\.(json)$"
+      - pattern: "^.+\\.json$"
         gzip: true
         contentType: "application/json; charset=utf-8"
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"

--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -35,10 +35,15 @@ deployment:
       - pattern: "^.+\\.(png|jpg|jpeg|gif|mp4|zip|pdf|txt|csv)$"
         cacheControl: "max-age=31536000, no-transform, public"
         gzip: false
-      - pattern: "^.+\\.(html)$"
+      - pattern: "^.+\\.html$"
         gzip: true
         contentType: "text/html; charset=utf-8"
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
-      - pattern: "^.+\\.(xml|json)$"
+      - pattern: "^.+\\.xml$"
         gzip: true
+        contentType: "text/xml; charset=utf-8"
+        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
+      - pattern: "^.+\\.json$"
+        gzip: true
+        contentType: "application/json; charset=utf-8"
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"


### PR DESCRIPTION
### What does this PR do?
Explicitly set content-type header for JSON files uploaded on Docs bucket to `application/json`

### Motivation
Files being downloaded/compressed as they are being set with the wrong content-type (`application/x-gzip`)

Fixes issue #11216 

### Preview

Check file downloads such as: 
https://docs-staging.datadoghq.com/nsollecito/disable-gzip-json/resources/json/datadog-agent-ecs.json
https://docs-staging.datadoghq.com/nsollecito/disable-gzip-json/resources/json/dd-agent-ecs.json
https://docs-staging.datadoghq.com/nsollecito/disable-gzip-json/resources/json/datadog_collection.json
https://docs-staging.datadoghq.com/nsollecito/disable-gzip-json/resources/json/APM_monitoring_dashboard.json

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
