### PR TITLE
[Functions - Rate] Small typo fix

### DIFF
--- a/content/fr/dashboards/functions/rate.md
+++ b/content/fr/dashboards/functions/rate.md
@@ -14,7 +14,7 @@ aliases:
 
 | Fonction       | Description                                                | Exemple                        |
 |:---------------|:-----------------------------------------------------------|:-------------------------------|
-| `per_minute()` | Crée un graphique illustrant le taux de variation de la métrique par seconde. | `per_minute(<NOM_MÉTRIQUE>{*})` |
+| `per_minute()` | Crée un graphique illustrant le taux de variation de la métrique par minute. | `per_minute(<NOM_MÉTRIQUE>{*})` |
 
 ## Par heure
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
On the French Rate page, changing the description of the per_minute() function.
Initial statement: "Graph the rate at which the metric is changing per **second**", while it should be "Graph the rate at which the metric is changing per **minute**"

To compare:
- US docs: https://docs.datadoghq.com/dashboards/functions/rate/
- FR docs: https://docs.datadoghq.com/fr/dashboards/functions/rate/?lang_pref=fr

### Motivation
Small typo fix

### Preview

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/victorien-provenzano/small-typo-fix/dashboards/functions/rate/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
