### PR TITLE
remove gitlab size tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,6 @@ cache: &cache
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
   tags:
     - "runner:main"
-    - "size:2xlarge"
   except:
     - tags
   only:
@@ -169,7 +168,7 @@ missing_tms_preview:
   image:
     name: 486234852809.dkr.ecr.us-east-1.amazonaws.com/vale:v4036929-ee9929a-2.9.1
     entrypoint: [ "" ]
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   stage: post-deploy
   cache: {}
   environment: "preview"
@@ -189,7 +188,7 @@ index_algolia_preview:
   image:
     name: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docsearch-scraper:v2978988-4692ed5-0.8
     entrypoint: [""] # force an empty entrypoint (see https://gitlab.com/gitlab-org/gitlab-runner/issues/2692)
-  tags: [ "runner:main","size:2xlarge" ]
+  tags: ["runner:main"]
   stage: post-deploy
   cache:
     <<: *cache
@@ -291,7 +290,7 @@ index_internal_doc:
   only:
     - master
   except: [ tags, schedules ]
-  tags: [ "runner:main", "size:2xlarge" ]
+  tags: ["runner:main"]
   script:
     - INDEXING_SERVICE=https://datadoc.ddbuild.io index-repository hugo https://docs.datadoghq.com/ "Datadog" "Public Documentation" --source_folder=content/en --tags="team:Documentation,source:hugo-website,visibility:public,github-repository:documentation"
 
@@ -315,7 +314,7 @@ index_algolia:
   image:
     name: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docsearch-scraper:v2978988-4692ed5-0.8
     entrypoint: [ "" ] # force an empty entrypoint (see https://gitlab.com/gitlab-org/gitlab-runner/issues/2692)
-  tags: ["runner:main","size:2xlarge"]
+  tags: ["runner:main"]
   stage: post-deploy
   cache:
     <<: *cache


### PR DESCRIPTION
### What does this PR do?

> All `size:large` and `size:2xlarge` tag requirements should be removed by 1st October 2021

This PR is to remove the size tags in the gitlab config per the latest notes above

### Motivation

announcement

### Preview

- It shouldn't change anything on the site https://docs-staging.datadoghq.com/david.jones/gitlab-size/
- Check the build jobs still ran as expected.

### Additional Notes

Its possible build times will change

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
