### PR TITLE
adding_default_rollup_length

### DIFF
--- a/content/en/dashboards/functions/rollup.md
+++ b/content/en/dashboards/functions/rollup.md
@@ -40,16 +40,16 @@ Applying the `moving_rollup()` function to a query allows you to combine points 
 
 ## Rollup interval: enforced vs custom
 
-When graphing, Datadog imposes a limit on the number of points per graph. In order to respect this limit, Datadog rolls up data points automatically with the `avg` method, effectively displaying the average of all data points within a time interval for a given metric. This default time interval will vary depending on how the data is being visualized. Refer to the following chart to reference these default time intervals:
+When graphing, Datadog imposes a limit on the number of points per graph. To respect this limit, Datadog rolls up data points automatically with the `avg` method, effectively displaying the average of all data points within a time interval for a given metric. This default time interval varies depending on how the data is being visualized. Refer to the following chart to reference these default time intervals:
 
 | Timeframe           | Rollup Interval, Line Graph | Rollup Interval, Bar Graph | Rollup Interval, API |
 |---------------------|-----------------------------|----------------------------|----------------------|
-| The Past Hour       | 20s                         | 1m                         | 20s                  |
-| The Past 4 Hours    | 1m                          | 2m                         | 1m                   |
-| The Past Day        | 5m                          | 20m                        | 5m                   |
-| The Past 2 Days     | 10m                         | 30m                        | 10m                  |
-| The Past Week       | 1hr                         | 2hr                        | 1hr                  |
-| The Past Month      | 2hr                         | 12hr                       | 4hr                  |
+| The past hour       | 20s                         | 1m                         | 20s                  |
+| The past four hours    | 1m                          | 2m                         | 1m                   |
+| The past day        | 5m                          | 20m                        | 5m                   |
+| The past two days     | 10m                         | 30m                        | 10m                  |
+| The past week       | 1hr                         | 2hr                        | 1hr                  |
+| The past month      | 2hr                         | 12hr                       | 4hr                  |
 
 A custom `.rollup()` function can be used to enforce the type of time aggregation applied (`avg`, `min`, `max`, `count`, or `sum`) and the time interval to rollup. However, if a custom `.rollup()` function is applied and uses a smaller time interval than the Datadog limit, the Datadog limit is used instead while still using the specified rollup method. For example, if you're requesting `.rollup(20)` for a month-long window, data is returned at a rollup greater than 20 seconds in order to prevent returning more than allotted number of points.
 

--- a/content/en/dashboards/functions/rollup.md
+++ b/content/en/dashboards/functions/rollup.md
@@ -40,9 +40,18 @@ Applying the `moving_rollup()` function to a query allows you to combine points 
 
 ## Rollup interval: enforced vs custom
 
-When graphing, Datadog imposes a limit of 350 points per graph. In order to respect this limit, Datadog rolls up data points automatically with the `avg` method, effectively displaying the average of all data points within a time interval for a given metric.
+When graphing, Datadog imposes a limit on the number of points per graph. In order to respect this limit, Datadog rolls up data points automatically with the `avg` method, effectively displaying the average of all data points within a time interval for a given metric. This default time interval will vary depending on how the data is being visualized. Refer to the following chart to reference these default time intervals:
 
-A custom `.rollup()` function can be used to enforce the type of time aggregation applied (`avg`, `min`, `max`, `count`, or `sum`) and the time interval to rollup. However, if a custom `.rollup()` function is applied and uses a smaller time interval than the Datadog limit, the Datadog limit is used instead while still using the specified rollup method. For example, if you're requesting `.rollup(20)` for a month-long window, data is returned at a rollup greater than 20 seconds in order to prevent returning more than 350 points.
+| Timeframe           | Rollup Interval, Line Graph | Rollup Interval, Bar Graph | Rollup Interval, API |
+|---------------------|-----------------------------|----------------------------|----------------------|
+| The Past Hour       | 20s                         | 1m                         | 20s                  |
+| The Past 4 Hours    | 1m                          | 2m                         | 1m                   |
+| The Past Day        | 5m                          | 20m                        | 5m                   |
+| The Past 2 Days     | 10m                         | 30m                        | 10m                  |
+| The Past Week       | 1hr                         | 2hr                        | 1hr                  |
+| The Past Month      | 2hr                         | 12hr                       | 4hr                  |
+
+A custom `.rollup()` function can be used to enforce the type of time aggregation applied (`avg`, `min`, `max`, `count`, or `sum`) and the time interval to rollup. However, if a custom `.rollup()` function is applied and uses a smaller time interval than the Datadog limit, the Datadog limit is used instead while still using the specified rollup method. For example, if you're requesting `.rollup(20)` for a month-long window, data is returned at a rollup greater than 20 seconds in order to prevent returning more than allotted number of points.
 
 **Note**: Queries for `COUNT` and `RATE` type metrics have the `.as_count()` modifier appended automatically in the UI, which sets the rollup method used to `sum` and disables interpolation. This `.as_count()` is explicitly visible at the end of the query:
 


### PR DESCRIPTION
updating rollup docs to include chart on default rollup length

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
updating rollup docs to include chart on default rollup length
removes mention of 350 points per graph. This is a bit misleading since it's not true. If a bar graph has a larger rollup bucket it will display less points than a line graph.

### Motivation
Transparency 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mikepcarlos-rollup_length/dashboards/functions/rollup/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
