### PR TITLE
Switch top list vale correction

### DIFF
--- a/.github/styles/Datadog/words.yml
+++ b/.github/styles/Datadog/words.yml
@@ -22,7 +22,7 @@ swap:
   'screen board': screenboard
   'time board': timeboard
   'time series': timeseries
-  'top list': toplist
+  'toplist': top list
   'turnkey': turn-key
   'utilize': use
   'via': with|through


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes vale linter recommendation for using "toplist" instead of "top list" (should be the other way around).

### Motivation
https://dd.slack.com/archives/GGHR55PNV/p1627327732254800

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
