### PR TITLE
PrivateLink: update metrics intake Service Name and fix security group description

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -40,14 +40,14 @@ The overall process consists of configuring an internal endpoint in your VPC tha
 
 | Datadog Metric Service Name                                |
 | ---------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-056576c12b36056ca`  |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-0d560852f6f1e27ac`  |
 
 {{% /tab %}}
 {{% tab "Logs" %}}
 
 | Forwarder | Datadog Logs Service Name |
 | --------- | ------------------------- |
-| Datadog Agent | `com.amazonaws.vpce.us-east-1.vpce-svc-0a2aef8496ee043bf` |
+| Datadog Agent | `com.amazonaws.vpce.us-east-1.vpce-svc-025a56b9187ac1f63` |
 | Lambda or custom forwarder | `com.amazonaws.vpce.us-east-1.vpce-svc-06394d10ccaf6fb97` |
 
 {{% /tab %}}
@@ -55,28 +55,28 @@ The overall process consists of configuring an internal endpoint in your VPC tha
 
 | Datadog API Service Name                                  |
 | --------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-02a4a57bc703929a0` |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-064ea718f8d0ead77` |
 
 {{% /tab %}}
 {{% tab "Processes" %}}
 
 | Datadog Process Monitoring Service Name                   |
 | --------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-05316fe237f6d8ddd` |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-0ed1f789ac6b0bde1` |
 
 {{% /tab %}}
 {{% tab "Traces" %}}
 
 | Datadog Trace Service Name                                |
 | --------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-07672d13af0033c24` |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-0355bb1880dfa09c2` |
 
 {{% /tab %}}
 {{% tab "Kubernetes Resources" %}}
 
 | Datadog Kubernetes Explorer Service Name                  |
 | --------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-0b03d6756bf6c2ec3` |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-0ad5fb9e71f85fe99` |
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -40,7 +40,7 @@ The overall process consists of configuring an internal endpoint in your VPC tha
 
 | Datadog Metric Service Name                                |
 | ---------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-0d560852f6f1e27ac`  |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-09a8006e245d1e7b8`  |
 
 {{% /tab %}}
 {{% tab "Logs" %}}
@@ -87,7 +87,7 @@ The overall process consists of configuring an internal endpoint in your VPC tha
    {{< img src="agent/guide/private_link/enabled_dns_private.png" alt="Enable DNS private" style="width:60%;" >}}
 7. Choose the security group of your choice to control what can send traffic to this VPC endpoint.
 
-    **Note**: **If you want to forward logs to Datadog through this VPC endpoint, the security group must accept inbound and outbound traffic on port `443`**.
+    **Note**: **The security group must accept inbound traffic on TCP port `443`**.
 
 8. Hit **Create endpoint** at the bottom of the screen. If successful, you will see this:
    {{< img src="agent/guide/private_link/vpc_endpoint_created.png" alt="VPC endpoint created" style="width:60%;" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

PrivateLink update is necessitated by datadog-agent#8692 (this is the fix for that)

Also, clarified the description of the Security Group settings that need to be present for
traffic to be able to flow over the PrivateLink - namely, ALL PrivateLinks need to be able to
pass tcp/443, not just the logs ones.

### Motivation
<!-- What inspired you to submit this pull request?-->

Have correct PrivateLink documentation on the website

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/rtdean/privatelink-update-servicename-for-metrics/content/en/agent/guide/private-link.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.