### PR TITLE
PrivateLink: Update service name for metrics intake; fix NOTE for Security Groups

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -40,7 +40,7 @@ The overall process consists of configuring an internal endpoint in your VPC tha
 
 | Datadog Metric Service Name                                |
 | ---------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-0d560852f6f1e27ac`  |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-09a8006e245d1e7b8`  |
 
 {{% /tab %}}
 {{% tab "Logs" %}}
@@ -87,7 +87,7 @@ The overall process consists of configuring an internal endpoint in your VPC tha
    {{< img src="agent/guide/private_link/enabled_dns_private.png" alt="Enable DNS private" style="width:60%;" >}}
 7. Choose the security group of your choice to control what can send traffic to this VPC endpoint.
 
-    **Note**: **If you want to forward logs to Datadog through this VPC endpoint, the security group must accept inbound and outbound traffic on port `443`**.
+    **Note**: **The security group must accept inbound traffic on TCP port `443`**.
 
 8. Hit **Create endpoint** at the bottom of the screen. If successful, you will see this:
    {{< img src="agent/guide/private_link/vpc_endpoint_created.png" alt="VPC endpoint created" style="width:60%;" >}}

--- a/content/fr/agent/guide/private-link.md
+++ b/content/fr/agent/guide/private-link.md
@@ -39,7 +39,7 @@ Pour utiliser PrivateLink, vous devez configurer un endpoint interne dans votre 
 
 | Nom de service des métriques Datadog                                |
 | ---------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-056576c12b36056ca`  |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-09a8006e245d1e7b8`  |
 
 {{% /tab %}}
 {{% tab "Logs" %}}

--- a/content/ja/agent/guide/private-link.md
+++ b/content/ja/agent/guide/private-link.md
@@ -39,7 +39,7 @@ Datadog は <b>us-east-1</b>で AWS PrivateLink エンドポイントを公開�
 
 | Datadog メトリクスのサービス名                                |
 | ---------------------------------------------------------- |
-| `com.amazonaws.vpce.us-east-1.vpce-svc-0d560852f6f1e27ac`  |
+| `com.amazonaws.vpce.us-east-1.vpce-svc-09a8006e245d1e7b8`  |
 
 {{% /tab %}}
 {{% tab "Logs" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

In order to fix datadog-agent#8692 we needed to recreate the metrics PrivateLink
endpoint.  This results in a new service ID, so this PR updates the service ID on
the site.

Also, the NOTE: about accepting incoming tcp/443 applies to ALL PrivateLink endpoints,
not just the logs ones.

### Motivation
<!-- What inspired you to submit this pull request?-->

Update the PrivateLink docs to match current config

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/rtdean/privatelink-update-servicename-for-metrics-and-sg-info/agent/guide/private-link/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.