### PR TITLE
Show link to upload teams CSV file

### DIFF
--- a/content/en/monitors/incident_management/_index.md
+++ b/content/en/monitors/incident_management/_index.md
@@ -143,7 +143,7 @@ Assessment fields are the metadata and context that you can define per incident.
     * Datadog overrides APM service names in favor of the manually uploaded list.
     * Note that if the service is an APM service and no metrics are posted in the past seven days, it does not appear in the search results.
     * Further integrate with Datadog products and accurately assess service impact. The Services property field is automatically populated with APM services for customers using Datadog APM
-* **Teams**: Populated from a CSV upload. Any values uploaded via CSV are only available within Incident Management for incident assessment purposes.
+* **Teams**: Defined in the Incident Settings [Property Fields](https://app.datadoghq.com/incidents/settings#Property-Fields). Upload a list of teams from a CSV file. Any values uploaded via CSV are only available within Incident Management for incident assessment purposes.
 
 ## Integrations
 

--- a/content/en/monitors/incident_management/_index.md
+++ b/content/en/monitors/incident_management/_index.md
@@ -143,7 +143,7 @@ Assessment fields are the metadata and context that you can define per incident.
     * Datadog overrides APM service names in favor of the manually uploaded list.
     * Note that if the service is an APM service and no metrics are posted in the past seven days, it does not appear in the search results.
     * Further integrate with Datadog products and accurately assess service impact. The Services property field is automatically populated with APM services for customers using Datadog APM
-* **Teams**: Defined in the Incident Settings [Property Fields](https://app.datadoghq.com/incidents/settings#Property-Fields). Upload a list of teams from a CSV file. Any values uploaded via CSV are only available within Incident Management for incident assessment purposes.
+* **Teams**: Defined under Incident Settings in the [Property Fields][16]. Upload a list of teams from a CSV file. Any values uploaded through CSV are only available within Incident Management for incident assessment purposes.
 
 ## Integrations
 

--- a/content/en/monitors/incident_management/_index.md
+++ b/content/en/monitors/incident_management/_index.md
@@ -172,3 +172,4 @@ Work through an example workflow in the [Getting Started with Incident Managemen
 [13]: /mobile
 [14]: https://apps.apple.com/app/datadog/id1391380318
 [15]: https://play.google.com/store/apps/details?id=com.datadog.app
+[16]: https://app.datadoghq.com/incidents/settings#Property-Fields


### PR DESCRIPTION
Provide a link to show how you add to the list of teams in an incident.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Provide a link to show HOW to add upload a list of of team into DataDog for incident management

### Motivation
I had to find out how to do it in support. It wasn't obvious.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
