### PR TITLE
Add Agent guide for Podman support with docker integration

### DIFF
--- a/content/en/agent/guide/_index.md
+++ b/content/en/agent/guide/_index.md
@@ -27,6 +27,7 @@ private: true
     {{< nextlink href="/agent/guide/container-images-for-docker-environments" >}}Container Images for Docker Environments{{< /nextlink >}}
     {{< nextlink href="/agent/guide/docker-deprecation" >}}Deprecating Docker in Kubernetes{{< /nextlink >}}
     {{< nextlink href="/agent/guide/heroku-ruby" >}}Instrumenting a Ruby on Rails application on Heroku with Datadog{{< /nextlink >}}
+    {{< nextlink href="/agent/guide/podman-support-with-docker-integration" >}}Using the Docker integration with Podman container runtime{{< /nextlink >}}
 {{< /whatsnext >}}
 <br>
 {{< whatsnext desc="Agent 5 Guides:" >}}

--- a/content/en/agent/guide/podman-support-with-docker-integration.md
+++ b/content/en/agent/guide/podman-support-with-docker-integration.md
@@ -1,0 +1,45 @@
+---
+title: Using the Docker integration with Podman container runtime
+kind: documentation
+---
+
+Podman is a daemonless container engine for developing, managing, and running OCI Containers on your Linux System. Read more on [https://podman.io/][1].
+
+Podman is an alternative to Docker as it provides a Docker-compatible CLI interface and socket. This specificity allows to use the Datadog Agent Docker integration with Podman containers.
+
+## Requirements
+
+* Podman version >= 3.2.0
+* Podman configured to expose its communication socket.
+* Datadog Agent version >= 7.30.0
+
+## Agent deployment as a podman container
+
+To deploy the agent as a podman container, the command to run is very similar to the one used for [docker][2].
+
+```
+$ podman run -d --name dd-agent \
+    -v /run/podman/podman.sock:/run/podman/podman.sock:ro \
+    -v /proc/:/host/proc/:ro \
+    -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+    -e DD_API_KEY=<API_KEY> \
+    -e DOCKER_HOST=unix:///run/podman/podman.sock \
+    --privileged \
+    gcr.io/datadoghq/agent:latest
+```
+
+The 2 importants differences are:
+* `-v /run/podman/podman.sock:/run/podman/podman.sock:ro` to mount the Podman socket instead of the docker socket.
+* `-e DOCKER_HOST=unix:///run/podman/podman.sock` to configure the agent communication with the Podman socket.
+
+All the other dockers configuration options should be compatible too.
+
+
+## Know limitations
+
+* Container logs aggregation are not yet supported.
+* The activation of the Podman socket, can be option in some setup, It might need to enable.
+
+
+[1]: https://podman.io/
+[2]: agent/docker

--- a/content/en/agent/guide/podman-support-with-docker-integration.md
+++ b/content/en/agent/guide/podman-support-with-docker-integration.md
@@ -10,12 +10,12 @@ Podman is an alternative to Docker as it provides a Docker-compatible CLI interf
 ## Requirements
 
 * Podman version >= 3.2.0
-* Podman configured to expose its communication socket.
+* Podman configured to expose its communication socket. [2]
 * Datadog Agent version >= 7.30.0
 
 ## Agent deployment as a podman container
 
-To deploy the agent as a podman container, the command to run is very similar to the one used for [docker][2].
+To deploy the agent as a podman container, the command to run is very similar to the one used for [docker][3].
 
 ```
 $ podman run -d --name dd-agent \
@@ -35,11 +35,12 @@ The 2 importants differences are:
 All the other dockers configuration options should be compatible too.
 
 
-## Know limitations
+## Known limitations
 
 * Container logs aggregation are not yet supported.
 * The activation of the Podman socket, can be option in some setup, It might need to enable.
 
 
 [1]: https://podman.io/
-[2]: agent/docker
+[2]: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/assembly_using-the-container-tools-api_using-the-container-tools-cli
+[3]: agent/docker

--- a/content/en/agent/guide/podman-support-with-docker-integration.md
+++ b/content/en/agent/guide/podman-support-with-docker-integration.md
@@ -15,7 +15,7 @@ Podman is an alternative to Docker as it provides a Docker-compatible CLI interf
 
 ## Agent deployment as a podman container
 
-To deploy the Agent as a Podman container, the command to run is very similar to the one used for [docker][3].
+To deploy the Agent as a Podman container, the command to run is very similar to the one used for [Docker][3].
 
 ```
 $ podman run -d --name dd-agent \

--- a/content/en/agent/guide/podman-support-with-docker-integration.md
+++ b/content/en/agent/guide/podman-support-with-docker-integration.md
@@ -5,17 +5,17 @@ kind: documentation
 
 Podman is a daemonless container engine for developing, managing, and running OCI Containers on your Linux System. Read more on [https://podman.io/][1].
 
-Podman is an alternative to Docker as it provides a Docker-compatible CLI interface and socket. This specificity allows to use the Datadog Agent Docker integration with Podman containers.
+Podman is an alternative to Docker as it provides a Docker-compatible CLI interface and socket. This specificity allows you to use the Datadog Agent Docker integration with Podman containers.
 
 ## Requirements
 
 * Podman version >= 3.2.0
-* Podman configured to expose its communication socket. [2]
+* Podman configured to expose its [communication socket][2].
 * Datadog Agent version >= 7.30.0
 
 ## Agent deployment as a podman container
 
-To deploy the agent as a podman container, the command to run is very similar to the one used for [docker][3].
+To deploy the Agent as a Podman container, the command to run is very similar to the one used for [docker][3].
 
 ```
 $ podman run -d --name dd-agent \
@@ -28,17 +28,16 @@ $ podman run -d --name dd-agent \
     gcr.io/datadoghq/agent:latest
 ```
 
-The 2 importants differences are:
-* `-v /run/podman/podman.sock:/run/podman/podman.sock:ro` to mount the Podman socket instead of the docker socket.
-* `-e DOCKER_HOST=unix:///run/podman/podman.sock` to configure the agent communication with the Podman socket.
+The two importants differences are:
+* `-v /run/podman/podman.sock:/run/podman/podman.sock:ro` to mount the Podman socket instead of the Docker socket.
+* `-e DOCKER_HOST=unix:///run/podman/podman.sock` to configure the Agent communication with the Podman socket.
 
-All the other dockers configuration options should be compatible too.
 
 
 ## Known limitations
 
-* Container logs aggregation are not yet supported.
-* The activation of the Podman socket, can be option in some setup, It might need to enable.
+* Container logs aggregation is not supported.
+* The activation of the Podman socket can be optional depending on your setup. It may need to be enabled.
 
 
 [1]: https://podman.io/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add a new "Agent guide" to document how to configure the Datadog Agent with Podman.

### Motivation

Document Podman support.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/clamoriniere/agent-container-podman/agent/guide/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
