### PR TITLE
[WEB-1609] Update mobile ToC headers that contain code blocks

### DIFF
--- a/assets/styles/components/_table-of-contents.scss
+++ b/assets/styles/components/_table-of-contents.scss
@@ -68,7 +68,7 @@ body > header.scrolled ~ .container .mobile-toc-toggle {
 .toc-container {
     display: none;
     padding-top: 95px;
-    
+
     &.mobile-open {
         top: 60px;
         position: sticky;
@@ -281,6 +281,7 @@ body > header.scrolled ~ .container .mobile-toc-toggle {
                         padding: 10px 60px 10px 30px;
                         display: flex;
                         align-items: center;
+                        flex-wrap: wrap;
 
                         &.toc_open {
                             padding: 10px 60px 10px 30px;
@@ -290,6 +291,11 @@ body > header.scrolled ~ .container .mobile-toc-toggle {
                                 position: absolute;
                                 right: 35px;
                                 font-size: 12px;
+                            }
+
+                            code {
+                                margin-top: 5px;
+                                margin-bottom: 5px;
                             }
                         }
                     }


### PR DESCRIPTION
### What does this PR do?
- Updates CSS regarding the `#TableOfContents`
- header text now wraps to handle ToC headers that contain a `code` element

### Motivation
Mobile ToC headers that contain a `code` element appear weird due to the `anchor` container being `display: flex` with no flex-wrap
- https://datadoghq.atlassian.net/browse/WEB-1609

### Preview
https://docs-staging.datadoghq.com/davidweid/toc-code-header-formatting/integrations/slack/?tab=slackapplicationus

### Additional Notes
- ToC appears on screen widths less than 991px
- ToC header has two states, open and closed
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.