### PR TITLE
Minor fixes to CloudSQL doc for Postgres

### DIFF
--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -232,7 +232,7 @@ cluster_check: true  # Make sure to include this flag
 init_config:
 instances:
   - dbm: true
-    host: '<AWS_INSTANCE_ENDPOINT>'
+    host: '<INSTANCE_ADDRESS>'
     port: 5432
     username: datadog
     password: '<PASSWORD>'

--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -46,7 +46,6 @@ Configure the following [parameters][3] in [Database flags][4] and then **restar
 
 | Parameter | Value | Description |
 | --- | --- | --- |
-| `shared_preload_libraries` | `pg_stat_statements` | Required for `postgresql.queries.*` metrics. Enables collection of query metrics via the the [pg_stat_statements][5] extension. |
 | `track_activity_query_size` | `4096` | Required for collection of larger queries. Increases the size of SQL text in `pg_stat_activity` and `pg_stat_statements`. If left at the default value then queries longer than `1024` characters will not be collected. |
 | `pg_stat_statements.track` | `ALL` | Optional. Enables tracking of statements within stored procedures and functions. |
 | `pg_stat_statements.max` | `10000` | Optional. Increases the number of normalized queries tracked in `pg_stat_statements`. This setting is recommended for high-volume databases that see many different types of queries from many different clients. |


### PR DESCRIPTION
About the `shared_preload_libraries`, it's not a valid flag on a Postgres DB and it looks like it's pre-loaded on CloudSQL instances (see some [doc](https://cloud.google.com/sql/docs/postgres/extensions#postgresql-extensions-supported-by-cloud-sql) here). After suspecting this was already loaded, I completed the setup and confirmed query metrics worked fine.

The second fix is removing a reference to `AWS_INSTANCE_ENDPOINT`. I replaced it by a generic `INSTANCE_ADDRESS` which, in my case, was a private IP that was accessible to my kubernetes cluster via a shared network. 