### PR TITLE
Using Lambda Extension for Go

### DIFF
--- a/content/en/serverless/guide/datadog_forwarder_go.md
+++ b/content/en/serverless/guide/datadog_forwarder_go.md
@@ -77,14 +77,14 @@ Follow these steps to instrument the function:
 
 ### Subscribe
 
-Subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces and logs to Datadog.
+Subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces, and logs to Datadog.
 
 1. [Install the Datadog Forwarder if you haven't][3].
 2. [Subscribe the Datadog Forwarder to your function's log groups][5].
 
 ### Tag
 
-Although it's optional, Datadog highly recommends tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][6].
+Although it's optional, Datadog highly recommends tagging your serverless applications with the `env`, `service`, and `version` tags for [unified service tagging][6].
 
 ## Explore
 
@@ -133,7 +133,7 @@ func myHandler(ctx context.Context, event MyEvent) (string, error) {
 }
 ```
 
-For more information on custom metric submission, see [here][8].
+Learn more about [custom metric submission][8].
 
 ## Further Reading
 

--- a/content/en/serverless/guide/datadog_forwarder_go.md
+++ b/content/en/serverless/guide/datadog_forwarder_go.md
@@ -3,7 +3,8 @@ title: Using the Datadog Forwarder - Go
 kind: guide
 ---
 ## Overview
-If you are a new user of Datadog Serverless, Datadog recommends using the [out-of-the-box Lambda functionality][1]. However, if you got set up on Datadog Serverless using the Datadog Forwarder before Lambda offered out-of-the-box functionality, use this guide to maintain your instance.
+
+If you are a new user of Datadog Serverless, Datadog recommends using the [out-of-the-box Lambda functionality][1]. However, if you were set up on Datadog Serverless using the Datadog Forwarder before Lambda offered out-of-the-box functionality, use this guide to maintain your instance.
 
 ## Required setup
 

--- a/content/en/serverless/guide/datadog_forwarder_go.md
+++ b/content/en/serverless/guide/datadog_forwarder_go.md
@@ -1,0 +1,149 @@
+---
+title: Using the Datadog Forwarder - Go
+kind: guide
+---
+
+If you are a new user of Datadog Serverless, Datadog recommends using the [out-of-the-box Lambda functionality][1]. However, if you got set up on Datadog Serverless using the Datadog Forwarder before Lambda offered out-of-the-box functionality, use this guide to maintain your instance.
+
+## Required setup
+
+If not already configured:
+
+- Install the [AWS integration][2]. This allows Datadog to ingest Lambda metrics from AWS. 
+- Install the [Datadog Forwarder Lambda function][3], which is required to ingest AWS Lambda traces, enhanced metrics, custom metrics, and logs. 
+
+After you have installed the [AWS integration][2] and the [Datadog Forwarder][3], follow these steps to instrument your application to send metrics, logs, and traces to Datadog.
+
+## Configuration
+
+### Install
+
+Install the [Datadog Lambda library][4] locally by running the following command:
+
+```
+go get github.com/DataDog/datadog-lambda-go
+```
+
+### Instrument
+
+Follow these steps to instrument the function:
+
+1. Set environment variable `DD_FLUSH_TO_LOG` and `DD_TRACE_ENABLED` to `true`.
+2. Import the required packages in the file declaring your Lambda function handler.
+
+    ```go
+    package main
+
+    import (
+      "github.com/aws/aws-lambda-go/lambda"
+      "github.com/DataDog/datadog-lambda-go"
+      "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+      httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+    )
+    ```
+3. Wrap your Lambda function handler using the wrapper provided by the Datadog Lambda library.
+
+    ```go
+    func main() {
+      // Wrap your lambda handler like this
+      lambda.Start(ddlambda.WrapHandler(myHandler, nil))
+      /* OR with manual configuration options
+      lambda.Start(ddlambda.WrapHandler(myHandler, &ddlambda.Config{
+        BatchInterval: time.Second * 15
+        APIKey: "my-api-key",
+      }))
+      */
+    }
+    ```
+4. Use the included libraries to create additional spans, connect logs and traces, and pass trace context to other services.
+    ```go
+    func myHandler(ctx context.Context, event MyEvent) (string, error) {
+      // Trace an HTTP request
+      req, _ := http.NewRequestWithContext(ctx, "GET", "https://www.datadoghq.com", nil)
+      client := http.Client{}
+      client = *httptrace.WrapClient(&client)
+      client.Do(req)
+
+      // Connect your Lambda logs and traces
+      currentSpan, _ := tracer.SpanFromContext(ctx)
+      log.Printf("my log message %v", currentSpan)
+
+      // Create a custom span
+      s, _ := tracer.StartSpanFromContext(ctx, "child.span")
+      time.Sleep(100 * time.Millisecond)
+      s.Finish()
+    }
+    ```
+
+### Subscribe
+
+Subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces and logs to Datadog.
+
+1. [Install the Datadog Forwarder if you haven't][3].
+2. [Subscribe the Datadog Forwarder to your function's log groups][5].
+
+### Tag
+
+Although it's optional, Datadog highly recommends tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][6].
+
+## Explore
+
+After configuring your function following the steps above, view your metrics, logs, and traces on the [Serverless homepage][7].
+
+## Monitor custom business logic
+
+If you would like to submit a custom metric, see the sample code below:
+
+```go
+package main
+
+import (
+  "github.com/aws/aws-lambda-go/lambda"
+  "github.com/DataDog/datadog-lambda-go"
+)
+
+func main() {
+  // Wrap your handler function
+  lambda.Start(ddlambda.WrapHandler(myHandler, nil))
+}
+
+func myHandler(ctx context.Context, event MyEvent) (string, error) {
+  // Submit a custom metric
+  ddlambda.Metric(
+    "coffee_house.order_value", // Metric name
+    12.45, // Metric value
+    "product:latte", "order:online" // Associated tags
+  )
+
+  // Submit a custom metric with timestamp
+  ddlambda.MetricWithTimestamp(
+    "coffee_house.order_value", // Metric name
+    12.45, // Metric value
+    time.Now(), // Timestamp, must be within last 20 mins
+    "product:latte", "order:online" // Associated tags
+  )
+  
+  req, err := http.NewRequest("GET", "http://example.com/status")
+
+  // Add the datadog distributed tracing headers
+  ddlambda.AddTraceHeaders(ctx, req)
+
+  client := http.Client{}
+  client.Do(req)
+}
+```
+
+For more information on custom metric submission, see [here][8].
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /serverless/installation
+[2]: /integrations/amazon_web_services/
+[3]: /serverless/forwarder/
+[4]: https://github.com/DataDog/datadog-lambda-go
+[5]: /logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
+[6]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
+[7]: https://app.datadoghq.com/functions
+[8]: /serverless/custom_metrics?tab=go

--- a/content/en/serverless/guide/datadog_forwarder_go.md
+++ b/content/en/serverless/guide/datadog_forwarder_go.md
@@ -2,7 +2,7 @@
 title: Using the Datadog Forwarder - Go
 kind: guide
 ---
-
+## Overview
 If you are a new user of Datadog Serverless, Datadog recommends using the [out-of-the-box Lambda functionality][1]. However, if you got set up on Datadog Serverless using the Datadog Forwarder before Lambda offered out-of-the-box functionality, use this guide to maintain your instance.
 
 ## Required setup

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -22,16 +22,13 @@ aliases:
 
 ## Required setup
 
-If not already configured:
+If not already configured, install the [AWS integration][1]. This allows Datadog to ingest Lambda metrics from AWS. After you have installed the [AWS integration][1], follow these steps to instrument your application to send metrics, logs, and traces to Datadog.
 
-- Install the [AWS integration][1]. This allows Datadog to ingest Lambda metrics from AWS. 
-- Install the [Datadog Forwarder Lambda function][2], which is required to ingest AWS Lambda traces, enhanced metrics, custom metrics, and logs. 
-
-After you have installed the [AWS integration][1] and the [Datadog Forwarder][2], follow these steps to instrument your application to send metrics, logs, and traces to Datadog.
+If you previously set up Datadog Serverless using the Datadog Forwarder, see the [installation instructions here][2].
 
 ## Configuration
 
-### Install
+### Install the Datadog Lambda Library
 
 Install the [Datadog Lambda library][3] locally by running the following command:
 
@@ -39,12 +36,30 @@ Install the [Datadog Lambda library][3] locally by running the following command
 go get github.com/DataDog/datadog-lambda-go
 ```
 
+### Install the Datadog Lambda Extension
+
+Add the Datadog Lambda Extension layer for your Lambda function using the ARN in the following format:
+
+{{< site-region region="us,us3,eu" >}}
+```
+arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:<EXTENSION_VERSION>
+```
+{{< /site-region >}}
+{{< site-region region="gov" >}}
+```
+arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-Extension:<EXTENSION_VERSION>
+```
+{{< /site-region >}}
+
+The latest `EXTENSION_VERSION` is {{< latest-lambda-layer-version layer="extension" >}}.
+
 ### Instrument
 
 Follow these steps to instrument the function:
 
+1. Set the environment variable `DD_API_KEY` to your Datadog API key on the [API Management page][4]. 
 1. Set environment variable `DD_FLUSH_TO_LOG` and `DD_TRACE_ENABLED` to `true`.
-2. Import the required packages in the file declaring your Lambda function handler.
+1. Import the required packages in the file declaring your Lambda function handler.
 
     ```go
     package main
@@ -56,7 +71,7 @@ Follow these steps to instrument the function:
       httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
     )
     ```
-3. Wrap your Lambda function handler using the wrapper provided by the Datadog Lambda library.
+1. Wrap your Lambda function handler using the wrapper provided by the Datadog Lambda library.
 
     ```go
     func main() {
@@ -70,7 +85,7 @@ Follow these steps to instrument the function:
       */
     }
     ```
-4. Use the included libraries to create additional spans, connect logs and traces, and pass trace context to other services.
+1. Use the included libraries to create additional spans, connect logs and traces, and pass trace context to other services.
     ```go
     func myHandler(ctx context.Context, event MyEvent) (string, error) {
       // Trace an HTTP request
@@ -89,13 +104,6 @@ Follow these steps to instrument the function:
       s.Finish()
     }
     ```
-
-### Subscribe
-
-Subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces and logs to Datadog.
-
-1. [Install the Datadog Forwarder if you haven't][2].
-2. [Subscribe the Datadog Forwarder to your function's log groups][4].
 
 ### Tag
 
@@ -155,9 +163,9 @@ For more information on custom metric submission, see [here][7].
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /integrations/amazon_web_services/
-[2]: /serverless/forwarder/
+[2]: /serverless/guide/datadog_forwarder_go
 [3]: https://github.com/DataDog/datadog-lambda-go
-[4]: /logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
+[4]: https://app.datadoghq.com/account/settings#api
 [5]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
 [6]: https://app.datadoghq.com/functions
 [7]: /serverless/custom_metrics?tab=go

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -24,11 +24,11 @@ aliases:
 
 If not already configured, install the [AWS integration][1]. This allows Datadog to ingest Lambda metrics from AWS. After you have installed the [AWS integration][1], follow these steps to instrument your application to send metrics, logs, and traces to Datadog.
 
-If you previously set up Datadog Serverless using the Datadog Forwarder, see the [installation instructions here][2].
+If you previously set up Datadog Serverless using the Datadog Forwarder, see the [installation instructions][2].
 
 ## Configuration
 
-### Install the Datadog Lambda Library
+### Install the Datadog Lambda library
 
 Install the [Datadog Lambda library][3] locally by running the following command:
 
@@ -57,7 +57,7 @@ The latest `EXTENSION_VERSION` is {{< latest-lambda-layer-version layer="extensi
 
 Follow these steps to instrument the function:
 
-1. Set the environment variable `DD_API_KEY` to your Datadog API key on the [API Management page][4]. 
+1. Set the environment variable `DD_API_KEY` to your Datadog API key from [API Management][4]. 
 1. Set environment variable `DD_FLUSH_TO_LOG` and `DD_TRACE_ENABLED` to `true`.
 1. Import the required packages in the file declaring your Lambda function handler.
 

--- a/content/en/serverless/libraries_integrations/extension.md
+++ b/content/en/serverless/libraries_integrations/extension.md
@@ -19,7 +19,7 @@ The Datadog Lambda Extension is responsible for:
 - Pushing real-time [enhanced Lambda metrics][1], [custom metrics][2], and [traces][3] from the Datadog Lambda Library to Datadog.
 - Forwarding logs from your Lambda function to Datadog.
 
-The Datadog extension submits custom metrics, enhanced metrics, traces and logs [asynchronously][4]. Submitting Lambda logs with the extension is supported in all Lambda runtimes. Submitting custom metrics, enhanced metrics and traces is supported in Node.js, Python, Go and Java Lambda runtimes.
+The Datadog extension submits custom metrics, enhanced metrics, traces and logs [asynchronously][4]. Submitting Lambda logs with the extension is supported in all Lambda runtimes. Submitting custom metrics, enhanced metrics and traces is supported in Node.js, Python, and Go Lambda runtimes.
 
 ## Installation
 

--- a/content/en/serverless/libraries_integrations/extension.md
+++ b/content/en/serverless/libraries_integrations/extension.md
@@ -19,7 +19,7 @@ The Datadog Lambda Extension is responsible for:
 - Pushing real-time [enhanced Lambda metrics][1], [custom metrics][2], and [traces][3] from the Datadog Lambda Library to Datadog.
 - Forwarding logs from your Lambda function to Datadog.
 
-The Datadog extension submits custom metrics, enhanced metrics, traces and logs [asynchronously][4]. Submitting Lambda logs with the extension is supported in all Lambda runtimes. Submitting custom metrics, enhanced metrics and traces is supported in Node.js, Python, and Go Lambda runtimes.
+The Datadog extension submits custom metrics, enhanced metrics, traces, and logs [asynchronously][4]. Submitting Lambda logs with the extension is supported in all Lambda runtimes. Submitting custom metrics, enhanced metrics and traces is supported in Node.js, Python, and Go Lambda runtimes.
 
 ## Installation
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

- Update the installation instructions for Go to use Lambda Extension.
- Move the forwarder-based installation instructions for Go to a guide (with a link from the new instructions)
- Correct a mistake in the extension doc -- Java is not yet supported.

### Motivation

Datadog Lambda Extension now supports Go.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tian.chu/lambda-extension-for-go/serverless/installation/go

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
