### PR TITLE
Update RUM browser error collection to reflect RUM v3 changes

### DIFF
--- a/content/en/real_user_monitoring/browser/collecting_browser_errors.md
+++ b/content/en/real_user_monitoring/browser/collecting_browser_errors.md
@@ -25,10 +25,9 @@ Front-end errors are collected with Real User Monitoring (RUM). The error messag
 ## Error origins
 Front-end errors are split into four different categories depending on their `error.origin`:
 
-- **network**: XHR or Fetch errors resulting from AJAX requests. Specific attributes to network errors can be found [in the network errors documentation][1].
 - **source**: Unhandled exceptions or unhandled promise rejections (source-code related).
 - **console**: `console.error()` API calls.
-- **custom**: Errors sent with the [RUM `addError` API](#collect-errors-manually) that default to `custom`.
+- **custom**: Errors sent with the [RUM `addError` API](#collect-errors-manually).
 
 ## Error attributes
 
@@ -36,27 +35,10 @@ For information about the default attributes for all RUM event types, see [Data 
 
 | Attribute       | Type   | Description                                                       |
 |-----------------|--------|-------------------------------------------------------------------|
-| `error.source`  | string | Where the error originates from (for example, `console` or `network`).     |
-| `error.type`    | string | The error type (or error code in some cases).                   |
+| `error.source`  | string | Where the error originates from (for example, `console`).         |
+| `error.type`    | string | The error type (or error code in some cases).                     |
 | `error.message` | string | A concise, human-readable, one-line message explaining the event. |
 | `error.stack`   | string | The stack trace or complementary information about the error.     |
-
-### Network errors
-
-Network errors include information about failing HTTP requests. The following facets are collected:
-
-| Attribute                      | Type   | Description                                                                             |
-|--------------------------------|--------|-----------------------------------------------------------------------------------------|
-| `error.resource.status_code`             | number | The response status code.                                                               |
-| `error.resource.method`                | string | The HTTP method (for example `POST`, `GET`).           |
-| `error.resource.url`                     | string | The resource URL.                                                                       |
-| `error.resource.url_host`        | string | The host part of the URL.                                                          |
-| `error.resource.url_path`        | string | The path part of the URL.                                                          |
-| `error.resource.url_query` | object | The query string parts of the URL decomposed as query params key/value attributes. |
-| `error.resource.url_scheme`      | string | The protocol name of the URL (HTTP or HTTPS).                                            |
-| `error.resource.provider.name`      | string | The resource provider name. Default is `unknown`.                                            |
-| `error.resource.provider.domain`      | string | The resource provider domain.                                            |
-| `error.resource.provider.type`      | string | The resource provider type (for example `first-party`, `cdn`, `ad`, `analytics`).                                            |
 
 ### Source errors
 
@@ -73,8 +55,7 @@ Monitor handled exceptions, handled promise rejections and other errors not trac
 {{< code-block lang="javascript" >}}
 addError(
     error: unknown,
-    context?: Context,
-    source: ErrorSource.CUSTOM | ErrorSource.NETWORK | ErrorSource.SOURCE = ErrorSource.CUSTOM
+    context?: Context
 );
 {{< /code-block >}}
 
@@ -95,14 +76,14 @@ datadogRum.addError(error, {
 
 // Send a network error
 fetch('<SOME_URL>').catch(function(error) {
-    datadogRum.addError(error, undefined, 'network');
+    datadogRum.addError(error);
 })
 
 // Send a handled exception error
 try {
     //Some code logic
 } catch (error) {
-    datadogRum.addError(error, undefined, 'source');
+    datadogRum.addError(error);
 }
 ```
 {{% /tab %}}
@@ -121,7 +102,7 @@ DD_RUM.onReady(function() {
 // Send a network error
 fetch('<SOME_URL>').catch(function(error) {
     DD_RUM.onReady(function() {
-        DD_RUM.addError(error, undefined, 'network');
+        DD_RUM.addError(error);
     });
 })
 
@@ -130,7 +111,7 @@ try {
     //Some code logic
 } catch (error) {
     DD_RUM.onReady(function() {
-        DD_RUM.addError(error, undefined, 'source');
+        DD_RUM.addError(error);
     })
 }
 ```
@@ -147,14 +128,14 @@ window.DD_RUM && DD_RUM.addError(error, {
 
 // Send a network error
 fetch('<SOME_URL>').catch(function(error) {
-    window.DD_RUM && DD_RUM.addError(error, undefined, 'network');
+    window.DD_RUM && DD_RUM.addError(error);
 })
 
 // Send a handled exception error
 try {
     //Some code logic
 } catch (error) {
-    window.DD_RUM && DD_RUM.addError(error, undefined, 'source');
+    window.DD_RUM && DD_RUM.addError(error);
 }
 ```
 {{% /tab %}}
@@ -187,7 +168,6 @@ Get visibility into cross-origin scripts by following these two steps:
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: /real_user_monitoring/data_collected/error/#network-errors
 [2]: /real_user_monitoring/browser/data_collected/
 [3]: /real_user_monitoring/browser/modifying_data_and_context/
 [4]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error

--- a/content/en/real_user_monitoring/browser/data_collected.md
+++ b/content/en/real_user_monitoring/browser/data_collected.md
@@ -26,9 +26,9 @@ further_reading:
   text: "Datadog Standard Attributes"
 ---
 
-The RUM SDK generates events that have associated metrics and attributes. Every RUM event has all of the [default attributes](#default-attributes), for example, the URL of the page (`view.url`) and user information such as their device type (`device.type`) and their country (`geo.country`). 
+The RUM SDK generates events that have associated metrics and attributes. Every RUM event has all of the [default attributes](#default-attributes), for example, the URL of the page (`view.url`) and user information such as their device type (`device.type`) and their country (`geo.country`).
 
-There are additional [metrics and attributes that are specific to a given event type](#event-specific-metrics-and-attributes). For example, the metric `view.loading_time` is associated with "view" events and the attribute `resource.method` is associated with "resource" events. 
+There are additional [metrics and attributes that are specific to a given event type](#event-specific-metrics-and-attributes). For example, the metric `view.loading_time` is associated with "view" events and the attribute `resource.method` is associated with "resource" events.
 
 This page provides descriptions of each of the metrics and attributes collected. For guidance on what you can do with this data, see:
 - [Modifying Data and Context][1]
@@ -100,7 +100,7 @@ The following attributes are related to the geolocation of IP addresses:
 | `geo.continent`       | string | Name of the continent (`Europe`, `Australia`, `North America`, `Africa`, `Antartica`, `South America`, `Oceania`).                    |
 | `geo.city`            | string | The name of the city (example `Paris`, `New York`).                                                                                   |
 
-**Note**: By default, Datadog stores the client IP address. If you want to stop collecting IP addresses, [contact Support][8]. This does not impact the collection of geolocation attributes listed above. 
+**Note**: By default, Datadog stores the client IP address. If you want to stop collecting IP addresses, [contact Support][8]. This does not impact the collection of geolocation attributes listed above.
 
 ### User attributes
 
@@ -156,7 +156,7 @@ The following diagram illustrates the RUM event hierarchy:
 | `session.last_view.url_query` | object | The query string parts of the URL decomposed as query params key/value attributes. |
 | `session.last_view.url_scheme` | object | The scheme part of the URL. |
 
-### View timing metrics 
+### View timing metrics
 
 
 | Attribute                       | Type        | Description                                                                                                                                                                                                           |
@@ -224,22 +224,6 @@ Detailed network timing data for the loading of an application’s resources are
 | `error.message` | string | A concise, human-readable, one-line message explaining the event. |
 | `error.stack`   | string | The stack trace or complementary information about the error.     |
 
-#### Network errors
-
-Network errors include information about failing HTTP requests. The following facets are also collected:
-
-| Attribute                      | Type   | Description                                                                             |
-|--------------------------------|--------|-----------------------------------------------------------------------------------------|
-| `error.resource.status_code`             | number | The response status code.                                                               |
-| `error.resource.method`                | string | The HTTP method (for example `POST`, `GET`).           |
-| `error.resource.url`                     | string | The resource URL.                                                                       |
-| `error.resource.url_host`        | string | The host part of the URL.                                                          |
-| `error.resource.url_path`        | string | The path part of the URL.                                                          |
-| `error.resource.url_query` | object | The query string parts of the URL decomposed as query params key/value attributes. |
-| `error.resource.url_scheme`      | string | The protocol name of the URL (HTTP or HTTPS).                                            |
-| `error.resource.provider.name`      | string | The resource provider name. Default is `unknown`.                                            |
-| `error.resource.provider.domain`      | string | The resource provider domain.                                            |
-| `error.resource.provider.type`      | string | The resource provider type (for example `first-party`, `cdn`, `ad`, `analytics`).                                            |
 
 #### Source errors
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Update RUM browser error collection to reflect RUM v3 changes. In particular:

* remove any mentions of network errors
* remove the "source" argument of the `addError` function.

### Motivation

We release the new Browser RUM SDK v3 and those two changes were part of it. See  [deprecation guide](https://docs.google.com/document/d/15yX1e0dqMX9yWyWd5v6zwTxBo6oLBW0C8ojuJuKzOms/edit)

### Preview

https://docs-staging.datadoghq.com/benoit/update-rum-browser-error-doc/en/real_user_monitoring/browser/collecting_browser_errors.md (doesn't seem to work? anyway, you can see it rendered [here](https://github.com/DataDog/documentation/blob/benoit/update-rum-browser-error-doc/content/en/real_user_monitoring/browser/collecting_browser_errors.md))

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
