### PR TITLE
Document which endpoints the install_script.sh accesses

### DIFF
--- a/content/en/agent/faq/how-do-i-install-the-agent-on-a-server-with-limited-internet-connectivity.md
+++ b/content/en/agent/faq/how-do-i-install-the-agent-on-a-server-with-limited-internet-connectivity.md
@@ -10,7 +10,14 @@ further_reading:
   text: "Learn more about Proxy"
 ---
 
-The one-line install command provided in the [Agent install instructions][1] requires outbound HTTPS access to a number of different endpoints to function properly and might not work with servers that have limited internet access.
+The one-line install command provided in the [Agent install instructions][1] requires outbound HTTPS access to a number of different endpoints to function properly and might not work with servers that have limited internet access. Specifially, these are:
+
+* For Debian/Ubuntu systems installation:
+  * https://keys.datadoghq.com - Storage of Datadog public signing keys.
+  * https://apt.datadoghq.com - Datadog APT package repository.
+* For RedHat and SUSE based systems installation:
+  * https://keys.datadoghq.com - Storage of Datadog public signing keys.
+  * https://yum.datadoghq.com - Datadog RPM package repository.
 
 For servers with no direct internet access, the Agent can be configured to route through a proxy, refer to [Agent Proxy Configuration][2]. For servers with limited outbound internet connectivity, the Agent can be installed using the relevant package for the server's OS. The [Agent install instructions][1] contain step-by-step instructions underneath the one-line install commands.
 

--- a/content/en/agent/faq/how-do-i-install-the-agent-on-a-server-with-limited-internet-connectivity.md
+++ b/content/en/agent/faq/how-do-i-install-the-agent-on-a-server-with-limited-internet-connectivity.md
@@ -10,7 +10,7 @@ further_reading:
   text: "Learn more about Proxy"
 ---
 
-The one-line install command provided in the [Agent install instructions][1] requires outbound HTTPS access to a number of different endpoints to function properly and might not work with servers that have limited internet access. Specifically, these are:
+The one-line install command provided in the [Agent install instructions][1] requires outbound HTTPS access to a few different endpoints to function properly and might not work with servers that have limited internet access. Specifically, these are:
 
 * For Debian/Ubuntu systems installation:
   * https://keys.datadoghq.com - Storage of Datadog public signing keys.

--- a/content/en/agent/faq/how-do-i-install-the-agent-on-a-server-with-limited-internet-connectivity.md
+++ b/content/en/agent/faq/how-do-i-install-the-agent-on-a-server-with-limited-internet-connectivity.md
@@ -10,7 +10,7 @@ further_reading:
   text: "Learn more about Proxy"
 ---
 
-The one-line install command provided in the [Agent install instructions][1] requires outbound HTTPS access to a number of different endpoints to function properly and might not work with servers that have limited internet access. Specifially, these are:
+The one-line install command provided in the [Agent install instructions][1] requires outbound HTTPS access to a number of different endpoints to function properly and might not work with servers that have limited internet access. Specifically, these are:
 
 * For Debian/Ubuntu systems installation:
   * https://keys.datadoghq.com - Storage of Datadog public signing keys.


### PR DESCRIPTION
### What does this PR do?

Documents which endpoints the install_script.sh needs to be able to access based on OS used.

### Motivation

Previously we weren't using the keys.datadoghq.com keys storage and when we introduced it, install_script.sh started failing for some existing customers. Let's make sure that doesn't happen for new customers who read the docs.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
