### PR TITLE
Forcing yarn lock update to refresh gitlab cache

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,9 @@
 # yarn lockfile v1
 
 
+
+
+
 "@apidevtools/json-schema-ref-parser@^8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz#9eb749499b3f8d919e90bb141e4b6f67aee4692d"


### PR DESCRIPTION
### What does this PR do?
Forcing `yarn.lock` change so that Gitlab will refresh the cache

### Motivation
https://dd.slack.com/archives/C3CT8QA11/p1628260871025100

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/yarn-lock-change/
Build passed: https://gitlab.ddbuild.io/DataDog/documentation/-/commit/edc65a33c261e49d35dfc95f667b1b2f108c59ac

### Additional Notes
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
