### PR TITLE
Revert gitlab cache key to use to use commit ref slug

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,9 +28,7 @@ before_script:
   - mkdir -p logs
 
 cache: &cache
-  key:
-    files:
-      - yarn.lock
+  key: $CI_COMMIT_REF_SLUG-$CI_PROJECT_DIR
   paths:
     - node_modules/
 


### PR DESCRIPTION
### What does this PR do?
Change the Gitlab cache key to use the CI commit ref slug/feature branch, so Gitlab will create a cache per branch

### Motivation
Gitlab build errors

### Preview
n/a

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
