### PR TITLE
Add Command Line Helm Instructions for Kubernetes Agent Configuration

### DIFF
--- a/content/en/database_monitoring/setup_mysql/aurora.md
+++ b/content/en/database_monitoring/setup_mysql/aurora.md
@@ -217,6 +217,26 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the MySQL configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
+### Command Line with Helm
+Get up and running quickly by executing the following [helm][11] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+```bash
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+
+helm install <RELEASE_NAME> \
+  --set 'datadog.apiKey=<DATADOG_API_KEY>' \
+  --set 'clusterAgent.enabled=true' \
+  --set "clusterAgent.confd.mysql\.yaml=cluster_check: true
+init_config:
+instances:
+  - dbm: true
+    host: <INSTANCE_ADDRESS>
+    port: 3306
+    username: datadog
+    password: <UNIQUEPASSWORD" \
+  datadog/datadog
+```
+
 ### Configure with mounted files
 
 To configure a cluster check with a mounted configuration file, mount the configuration file in the Cluster Agent container on the path `/conf.d/mysql.yaml`:
@@ -304,3 +324,4 @@ If you have installed and configured the integrations and Agent as described and
 [8]: https://app.datadoghq.com/databases
 [9]: /integrations/amazon_rds
 [10]: /database_monitoring/troubleshooting/?tab=mysql
+[11]: https://helm.sh

--- a/content/en/database_monitoring/setup_mysql/aurora.md
+++ b/content/en/database_monitoring/setup_mysql/aurora.md
@@ -217,8 +217,10 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the MySQL configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
-### Command line with helm
-Get up and running quickly by executing the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+### Command line with Helm
+
+Execute the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your Kubernetes cluster. Replace the values to match your account and environment:
+
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update

--- a/content/en/database_monitoring/setup_mysql/aurora.md
+++ b/content/en/database_monitoring/setup_mysql/aurora.md
@@ -218,7 +218,7 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the MySQL configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
 ### Command line with helm
-Get up and running quickly by executing the following [Helm][11] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+Get up and running quickly by executing the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update
@@ -289,11 +289,12 @@ spec:
 
 The Cluster Agent automatically registers this configuration and begin running the MySQL check.
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][3] and declare the password using the `ENC[]` syntax.
+To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][4] and declare the password using the `ENC[]` syntax.
 
 [1]: /agent/cluster_agent
 [2]: /agent/cluster_agent/clusterchecks/
-[3]: /agent/guide/secrets-management
+[3]: https://helm.sh
+[4]: /agent/guide/secrets-management
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -324,4 +325,3 @@ If you have installed and configured the integrations and Agent as described and
 [8]: https://app.datadoghq.com/databases
 [9]: /integrations/amazon_rds
 [10]: /database_monitoring/troubleshooting/?tab=mysql
-[11]: https://helm.sh

--- a/content/en/database_monitoring/setup_mysql/aurora.md
+++ b/content/en/database_monitoring/setup_mysql/aurora.md
@@ -217,8 +217,8 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the MySQL configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
-### Command Line with Helm
-Get up and running quickly by executing the following [helm][11] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+### Command line with helm
+Get up and running quickly by executing the following [Helm][11] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update

--- a/content/en/database_monitoring/setup_mysql/gcsql.md
+++ b/content/en/database_monitoring/setup_mysql/gcsql.md
@@ -243,8 +243,8 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the MySQL configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
-### Command Line with Helm
-Get up and running quickly by executing the following [helm][10] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+### Command line with helm
+Get up and running quickly by executing the following [Helm][10] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update

--- a/content/en/database_monitoring/setup_mysql/gcsql.md
+++ b/content/en/database_monitoring/setup_mysql/gcsql.md
@@ -244,7 +244,7 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the MySQL configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
 ### Command line with helm
-Get up and running quickly by executing the following [Helm][10] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+Get up and running quickly by executing the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update
@@ -312,11 +312,12 @@ spec:
 ```
 The Cluster Agent automatically registers this configuration and begin running the MySQL check.
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][3] and declare the password using the `ENC[]` syntax.
+To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][4] and declare the password using the `ENC[]` syntax.
 
 [1]: /agent/cluster_agent
 [2]: /agent/cluster_agent/clusterchecks/
-[3]: /agent/guide/secrets-management
+[3]: https://helm.sh
+[4]: /agent/guide/secrets-management
 {{% /tab %}}
 
 {{< /tabs >}}
@@ -348,4 +349,3 @@ If you have installed and configured the integrations and Agent as described and
 [7]: https://app.datadoghq.com/databases
 [8]: /integrations/google_cloudsql
 [9]: /database_monitoring/troubleshooting/?tab=mysql
-[10]: https://helm.sh

--- a/content/en/database_monitoring/setup_mysql/gcsql.md
+++ b/content/en/database_monitoring/setup_mysql/gcsql.md
@@ -243,8 +243,10 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the MySQL configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
-### Command line with helm
-Get up and running quickly by executing the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+### Command line with Helm
+
+Execute the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your Kubernetes cluster. Replace the values to match your account and environment:
+
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update

--- a/content/en/database_monitoring/setup_mysql/gcsql.md
+++ b/content/en/database_monitoring/setup_mysql/gcsql.md
@@ -243,6 +243,26 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the MySQL configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
+### Command Line with Helm
+Get up and running quickly by executing the following [helm][10] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+```bash
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+
+helm install <RELEASE_NAME> \
+  --set 'datadog.apiKey=<DATADOG_API_KEY>' \
+  --set 'clusterAgent.enabled=true' \
+  --set "clusterAgent.confd.mysql\.yaml=cluster_check: true
+init_config:
+instances:
+  - dbm: true
+    host: <INSTANCE_ADDRESS>
+    port: 3306
+    username: datadog
+    password: <UNIQUEPASSWORD" \
+  datadog/datadog
+```
+
 ### Configure with mounted files
 
 To configure a cluster check with a mounted configuration file, mount the configuration file in the Cluster Agent container on the path `/conf.d/mysql.yaml`:
@@ -328,3 +348,4 @@ If you have installed and configured the integrations and Agent as described and
 [7]: https://app.datadoghq.com/databases
 [8]: /integrations/google_cloudsql
 [9]: /database_monitoring/troubleshooting/?tab=mysql
+[10]: https://helm.sh

--- a/content/en/database_monitoring/setup_mysql/rds.md
+++ b/content/en/database_monitoring/setup_mysql/rds.md
@@ -224,8 +224,8 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the MySQL configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
-### Command Line with Helm
-Get up and running quickly by executing the following [helm][11] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+### Command line with helm
+Get up and running quickly by executing the following [Helm][11] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update

--- a/content/en/database_monitoring/setup_mysql/rds.md
+++ b/content/en/database_monitoring/setup_mysql/rds.md
@@ -224,6 +224,26 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the MySQL configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
+### Command Line with Helm
+Get up and running quickly by executing the following [helm][11] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+```bash
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+
+helm install <RELEASE_NAME> \
+  --set 'datadog.apiKey=<DATADOG_API_KEY>' \
+  --set 'clusterAgent.enabled=true' \
+  --set "clusterAgent.confd.mysql\.yaml=cluster_check: true
+init_config:
+instances:
+  - dbm: true
+    host: <INSTANCE_ADDRESS>
+    port: 3306
+    username: datadog
+    password: <UNIQUEPASSWORD" \
+  datadog/datadog
+```
+
 ### Configure with mounted files
 
 To configure a cluster check with a mounted configuration file, mount the configuration file in the Cluster Agent container on the path `/conf.d/mysql.yaml`:
@@ -309,3 +329,4 @@ If you have installed and configured the integrations and Agent as described and
 [8]: https://app.datadoghq.com/databases
 [9]: /integrations/amazon_rds
 [10]: /database_monitoring/troubleshooting/?tab=mysql
+[11]: https://helm.sh

--- a/content/en/database_monitoring/setup_mysql/rds.md
+++ b/content/en/database_monitoring/setup_mysql/rds.md
@@ -225,7 +225,7 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the MySQL configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
 ### Command line with helm
-Get up and running quickly by executing the following [Helm][11] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+Get up and running quickly by executing the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update
@@ -295,11 +295,12 @@ spec:
 
 The Cluster Agent automatically registers this configuration and begin running the MySQL check.
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][3] and declare the password using the `ENC[]` syntax.
+To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][4] and declare the password using the `ENC[]` syntax.
 
 [1]: /agent/cluster_agent
 [2]: /agent/cluster_agent/clusterchecks/
-[3]: /agent/guide/secrets-management
+[3]: https://helm.sh
+[4]: /agent/guide/secrets-management
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -329,4 +330,3 @@ If you have installed and configured the integrations and Agent as described and
 [8]: https://app.datadoghq.com/databases
 [9]: /integrations/amazon_rds
 [10]: /database_monitoring/troubleshooting/?tab=mysql
-[11]: https://helm.sh

--- a/content/en/database_monitoring/setup_mysql/rds.md
+++ b/content/en/database_monitoring/setup_mysql/rds.md
@@ -224,8 +224,10 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the MySQL configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
-### Command line with helm
-Get up and running quickly by executing the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+### Command line with Helm
+
+Execute the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your Kubernetes cluster. Replace the values to match your account and environment:
+
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -255,7 +255,8 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the Postgres configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
-### Command line with helm
+### Command line with Helm
+
 Get up and running quickly by executing the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
 ```bash
 helm repo add datadog https://helm.datadoghq.com

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -257,7 +257,8 @@ Follow the instructions to [enable the cluster checks][2] if not already enabled
 
 ### Command line with Helm
 
-Get up and running quickly by executing the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+Execute the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your Kubernetes cluster. Replace the values to match your account and environment:
+
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -256,7 +256,7 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the Postgres configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
 ### Command line with helm
-Get up and running quickly by executing the following [Helm][13] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+Get up and running quickly by executing the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update
@@ -326,11 +326,12 @@ spec:
 
 The Cluster Agent automatically registers this configuration and begin running the Postgres check.
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][3] and declare the password using the `ENC[]` syntax.
+To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][4] and declare the password using the `ENC[]` syntax.
 
 [1]: /agent/cluster_agent
 [2]: /agent/cluster_agent/clusterchecks/
-[3]: /agent/guide/secrets-management
+[3]: https://helm.sh
+[4]: /agent/guide/secrets-management
 {{% /tab %}}
 
 {{< /tabs >}}
@@ -364,4 +365,3 @@ If you have installed and configured the integrations and Agent as described and
 [10]: https://app.datadoghq.com/databases
 [11]: /integrations/amazon_rds
 [12]: /database_monitoring/troubleshooting/?tab=postgres
-[13]: https://helm.sh

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -255,6 +255,26 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the Postgres configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
+### Command Line with Helm
+Get up and running quickly by executing the following [helm][13] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+```bash
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+
+helm install <RELEASE_NAME> \
+  --set 'datadog.apiKey=<DATADOG_API_KEY>' \
+  --set 'clusterAgent.enabled=true' \
+  --set "clusterAgent.confd.mysql\.yaml=cluster_check: true
+init_config:
+instances:
+  - dbm: true
+    host: <INSTANCE_ADDRESS>
+    port: 3306
+    username: datadog
+    password: <UNIQUEPASSWORD" \
+  datadog/datadog
+```
+
 ### Configure with mounted files
 
 To configure a cluster check with a mounted configuration file, mount the configuration file in the Cluster Agent container on the path: `/conf.d/postgres.yaml`:
@@ -344,3 +364,4 @@ If you have installed and configured the integrations and Agent as described and
 [10]: https://app.datadoghq.com/databases
 [11]: /integrations/amazon_rds
 [12]: /database_monitoring/troubleshooting/?tab=postgres
+[13]: https://helm.sh

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -255,8 +255,8 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the Postgres configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
-### Command Line with Helm
-Get up and running quickly by executing the following [helm][13] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+### Command line with helm
+Get up and running quickly by executing the following [Helm][13] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update

--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -252,7 +252,7 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the Postgres configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
 ### Command line with helm
-Get up and running quickly by executing the following [Helm][13] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+Get up and running quickly by executing the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update
@@ -321,11 +321,12 @@ spec:
 
 The Cluster Agent automatically registers this configuration and begin running the Postgres check.
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][3] and declare the password using the `ENC[]` syntax.
+To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][4] and declare the password using the `ENC[]` syntax.
 
 [1]: /agent/cluster_agent
 [2]: /agent/cluster_agent/clusterchecks/
-[3]: /agent/guide/secrets-management
+[3]: https://helm.sh
+[4]: /agent/guide/secrets-management
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -357,4 +358,3 @@ If you have installed and configured the integrations and Agent as described and
 [10]: https://app.datadoghq.com/databases
 [11]: /integrations/google_cloudsql
 [12]: /database_monitoring/troubleshooting/?tab=postgres
-[13]: https://helm.sh

--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -251,8 +251,8 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the Postgres configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
-### Command Line with Helm
-Get up and running quickly by executing the following [helm][13] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+### Command line with helm
+Get up and running quickly by executing the following [Helm][13] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update

--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -251,8 +251,10 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the Postgres configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
-### Command line with helm
-Get up and running quickly by executing the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+### Command line with Helm
+
+Execute the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your Kubernetes cluster. Replace the values to match your account and environment:
+
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update

--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -251,6 +251,26 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the Postgres configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
+### Command Line with Helm
+Get up and running quickly by executing the following [helm][13] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+```bash
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+
+helm install <RELEASE_NAME> \
+  --set 'datadog.apiKey=<DATADOG_API_KEY>' \
+  --set 'clusterAgent.enabled=true' \
+  --set "clusterAgent.confd.mysql\.yaml=cluster_check: true
+init_config:
+instances:
+  - dbm: true
+    host: <INSTANCE_ADDRESS>
+    port: 3306
+    username: datadog
+    password: <UNIQUEPASSWORD" \
+  datadog/datadog
+```
+
 ### Configure with mounted files
 
 To configure a cluster check with a mounted configuration file, mount the configuration file in the Cluster Agent container on the path: `/conf.d/postgres.yaml`:
@@ -337,3 +357,4 @@ If you have installed and configured the integrations and Agent as described and
 [10]: https://app.datadoghq.com/databases
 [11]: /integrations/google_cloudsql
 [12]: /database_monitoring/troubleshooting/?tab=postgres
+[13]: https://helm.sh

--- a/content/en/database_monitoring/setup_postgres/rds.md
+++ b/content/en/database_monitoring/setup_postgres/rds.md
@@ -249,7 +249,7 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the Postgres configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
 ### Command line with helm
-Get up and running quickly by executing the following [Helm][13] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+Get up and running quickly by executing the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update
@@ -319,11 +319,12 @@ spec:
 
 The Cluster Agent automatically registers this configuration and begin running the Postgres check.
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][3] and declare the password using the `ENC[]` syntax.
+To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][4] and declare the password using the `ENC[]` syntax.
 
 [1]: /agent/cluster_agent
 [2]: /agent/cluster_agent/clusterchecks/
-[3]: /agent/guide/secrets-management
+[3]: https://helm.sh
+[4]: /agent/guide/secrets-management
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -356,4 +357,3 @@ If you have installed and configured the integrations and Agent as described and
 [10]: https://app.datadoghq.com/databases
 [11]: /integrations/amazon_rds
 [12]: /database_monitoring/troubleshooting/?tab=postgres
-[13]: https://helm.sh

--- a/content/en/database_monitoring/setup_postgres/rds.md
+++ b/content/en/database_monitoring/setup_postgres/rds.md
@@ -248,8 +248,10 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the Postgres configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
-### Command line with helm
-Get up and running quickly by executing the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+### Command line with Helm
+
+Execute the following [Helm][3] command to install the [Datadog Cluster Agent][1] on your Kubernetes cluster. Replace the values to match your account and environment:
+
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update

--- a/content/en/database_monitoring/setup_postgres/rds.md
+++ b/content/en/database_monitoring/setup_postgres/rds.md
@@ -248,6 +248,26 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the Postgres configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
+### Command Line with Helm
+Get up and running quickly by executing the following [helm][13] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+```bash
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+
+helm install <RELEASE_NAME> \
+  --set 'datadog.apiKey=<DATADOG_API_KEY>' \
+  --set 'clusterAgent.enabled=true' \
+  --set "clusterAgent.confd.mysql\.yaml=cluster_check: true
+init_config:
+instances:
+  - dbm: true
+    host: <INSTANCE_ADDRESS>
+    port: 3306
+    username: datadog
+    password: <UNIQUEPASSWORD" \
+  datadog/datadog
+```
+
 ### Configure with mounted files
 
 To configure a cluster check with a mounted configuration file, mount the configuration file in the Cluster Agent container on the path: `/conf.d/postgres.yaml`:
@@ -336,3 +356,4 @@ If you have installed and configured the integrations and Agent as described and
 [10]: https://app.datadoghq.com/databases
 [11]: /integrations/amazon_rds
 [12]: /database_monitoring/troubleshooting/?tab=postgres
+[13]: https://helm.sh

--- a/content/en/database_monitoring/setup_postgres/rds.md
+++ b/content/en/database_monitoring/setup_postgres/rds.md
@@ -248,8 +248,8 @@ If you have a Kubernetes cluster, use the [Datadog Cluster Agent][1] for Databas
 
 Follow the instructions to [enable the cluster checks][2] if not already enabled in your Kubernetes cluster. You can declare the Postgres configuration either with static files mounted in the Cluster Agent container or using service annotations:
 
-### Command Line with Helm
-Get up and running quickly by executing the following [helm][13] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
+### Command line with helm
+Get up and running quickly by executing the following [Helm][13] command to install the [Datadog Cluster Agent][1] on your kubernetes cluster. Replace the values to match your account and environment:
 ```bash
 helm repo add datadog https://helm.datadoghq.com
 helm repo update


### PR DESCRIPTION
This adds a quick start command line section using helm to install and configure the cluster agent. 