### PR TITLE
[Database Monitoring] Fix incorrect k8 service annotation

### DIFF
--- a/content/en/database_monitoring/setup_mysql/aurora.md
+++ b/content/en/database_monitoring/setup_mysql/aurora.md
@@ -283,9 +283,9 @@ metadata:
     tags.datadoghq.com/env: '<ENV>'
     tags.datadoghq.com/service: '<SERVICE>'
   annotations:
-    ad.datadoghq.com/mysql.check_names: '["mysql"]'
-    ad.datadoghq.com/mysql.init_configs: '[{}]'
-    ad.datadoghq.com/mysql.instances: |
+    ad.datadoghq.com/service.check_names: '["mysql"]'
+    ad.datadoghq.com/service.init_configs: '[{}]'
+    ad.datadoghq.com/service.instances: |
       [
         {
           "dbm": true,

--- a/content/en/database_monitoring/setup_mysql/gcsql.md
+++ b/content/en/database_monitoring/setup_mysql/gcsql.md
@@ -305,9 +305,9 @@ metadata:
     tags.datadoghq.com/env: '<ENV>'
     tags.datadoghq.com/service: '<SERVICE>'
   annotations:
-    ad.datadoghq.com/mysql.check_names: '["mysql"]'
-    ad.datadoghq.com/mysql.init_configs: '[{}]'
-    ad.datadoghq.com/mysql.instances: |
+    ad.datadoghq.com/service.check_names: '["mysql"]'
+    ad.datadoghq.com/service.init_configs: '[{}]'
+    ad.datadoghq.com/service.instances: |
       [
         {
           "dbm": true,

--- a/content/en/database_monitoring/setup_mysql/rds.md
+++ b/content/en/database_monitoring/setup_mysql/rds.md
@@ -288,9 +288,9 @@ metadata:
     tags.datadoghq.com/env: '<ENV>'
     tags.datadoghq.com/service: '<SERVICE>'
   annotations:
-    ad.datadoghq.com/mysql.check_names: '["mysql"]'
-    ad.datadoghq.com/mysql.init_configs: '[{}]'
-    ad.datadoghq.com/mysql.instances: |
+    ad.datadoghq.com/service.check_names: '["mysql"]'
+    ad.datadoghq.com/service.init_configs: '[{}]'
+    ad.datadoghq.com/service.instances: |
       [
         {
           "dbm": true,

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -309,9 +309,9 @@ metadata:
     tags.datadoghq.com/env: '<ENV>'
     tags.datadoghq.com/service: '<SERVICE>'
   annotations:
-    ad.datadoghq.com/postgres.check_names: '["postgres"]'
-    ad.datadoghq.com/postgres.init_configs: '[{}]'
-    ad.datadoghq.com/postgres.instances: |
+    ad.datadoghq.com/service.check_names: '["postgres"]'
+    ad.datadoghq.com/service.init_configs: '[{}]'
+    ad.datadoghq.com/service.instances: |
       [
         {
           "dbm": true,

--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -305,9 +305,9 @@ metadata:
     tags.datadoghq.com/env: '<ENV>'
     tags.datadoghq.com/service: '<SERVICE>'
   annotations:
-    ad.datadoghq.com/postgres.check_names: '["postgres"]'
-    ad.datadoghq.com/postgres.init_configs: '[{}]'
-    ad.datadoghq.com/postgres.instances: |
+    ad.datadoghq.com/service.check_names: '["postgres"]'
+    ad.datadoghq.com/service.init_configs: '[{}]'
+    ad.datadoghq.com/service.instances: |
       [
         {
           "dbm": true,

--- a/content/en/database_monitoring/setup_postgres/rds.md
+++ b/content/en/database_monitoring/setup_postgres/rds.md
@@ -305,9 +305,9 @@ metadata:
     tags.datadoghq.com/env: '<ENV>'
     tags.datadoghq.com/service: '<SERVICE>'
   annotations:
-    ad.datadoghq.com/postgres.check_names: '["postgres"]'
-    ad.datadoghq.com/postgres.init_configs: '[{}]'
-    ad.datadoghq.com/postgres.instances: |
+    ad.datadoghq.com/service.check_names: '["postgres"]'
+    ad.datadoghq.com/service.init_configs: '[{}]'
+    ad.datadoghq.com/service.instances: |
       [
         {
           "dbm": true,


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
The cluster agent is currently unable to detect the Kubernetes service listed in the documentation due to an incorrect annotation. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alex.barksdale/dbm-doc-fix-incorrect-k8-annotation
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
