### PR TITLE
remove exclusion on install_dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,9 +62,6 @@ install_dependencies:
   only:
     changes:
       - yarn.lock
-  except:
-    # skip on automated translation prs
-    - /^guacbot\/translation-[0-9]+$/i
 
 # ================== preview ================== #
 # If the branch has a name of <slack-user>/<feature-name> then ci builds a preview site


### PR DESCRIPTION
### What does this PR do?

This PR removes the exclusion so that translation prs create their own cache now. Without it it will fail every run

### Motivation

Viewing scheduled pipeline failures

### Preview

https://docs-staging.datadoghq.com/david.jones/remove-exclusion/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
