### PR TITLE
Clarify event monitor filtering syntax

### DIFF
--- a/content/en/monitors/monitor_types/event.md
+++ b/content/en/monitors/monitor_types/event.md
@@ -27,7 +27,10 @@ To create a [event monitor][1] in Datadog, use the main navigation: *Monitors --
 
 As you fill in the parameters below, the list of events above the search fields is filtered.
 
-* Match events containing `<TEXT>`
+* Match events containing `<TEXT>`:
+    * Multiple terms have an implied `AND`. For example `a b` finds events with both `a` and `b` somewhere in them.
+    * Use quotation marks `"a b"` to find events with the exact string `a b`.
+    * Use `OR` to find events that contain at least one of multiple terms. For example `a OR b` finds events with either `a` or `b` in them.
 * with status `error`, `warning`, `info`, or `success`
 * and priority `all`, `normal`, or `low`
 * from `<SOURCE>`


### PR DESCRIPTION
### What does this PR do?

Adds info about how multiple terms behave in the event monitor creation search field

### Motivation
hotjar feedback 

### Preview

https://docs-staging.datadoghq.com/kari/event-monitor-clarification/monitors/monitor_types/event/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
