### PR TITLE
[serverless] correct node layer version

### DIFF
--- a/layouts/shortcodes/latest-lambda-layer-version.html
+++ b/layouts/shortcodes/latest-lambda-layer-version.html
@@ -11,7 +11,7 @@
 
 <!-- Node Layer -->
 {{- if eq (.Get "layer") "node" -}}
-    62
+    59
 {{- end -}}
 
 <!-- Ruby Layer -->


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
Corrects the Node layer version. Should be 59 at the time of writing: https://github.com/DataDog/datadog-lambda-js/releases

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix version.

### Motivation
<!-- What inspired you to submit this pull request?-->
Wrong version!

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/dylan/fix-js-version/serverless/installation/nodejs/?tab=custom

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
