### PR TITLE
[WEB-1547] - description api linking

### DIFF
--- a/src/scripts/build-api-pages.js
+++ b/src/scripts/build-api-pages.js
@@ -9,6 +9,23 @@ const safeJsonStringify = require('safe-json-stringify');
 
 const supportedLangs = ['en'];
 
+const formatContentLinks = (content) => {
+  let output = content;
+  try {
+    const regex = /#\/(.+)\/([^\s]+)/gm;
+    // const str = `you can get the id from [this endpoint that lists id](#/{tagName}/{operationId})`;
+    const matches = regex.exec(content);
+    if(matches && matches.length > 2) {
+      const tagName = matches[1];
+      const operationId = matches[2];
+      output = content.replace(matches[0], `https://docs.datadoghq.com/api/latest/${getTagSlug(tagName)}/#${operationId}`)
+    }
+  } catch(e) {
+      console.log(e);
+  }
+  return output;
+};
+
 /**
  * Update the menu yaml file with api
  * @param {object} apiYaml - object with data
@@ -712,7 +729,7 @@ const descColumn = (key, value) => {
   if(value.deprecated) {
     desc = `**DEPRECATED**: ${desc}`;
   }
-  return `<div class="col-6 column">${marked(desc) ? marked(desc).trim() : ""}</div>`.trim();
+  return `<div class="col-6 column">${marked(formatContentLinks(desc)) ? marked(formatContentLinks(desc)).trim() : ""}</div>`.trim();
 };
 
 
@@ -990,5 +1007,6 @@ module.exports = {
   getSchema,
   getTagSlug,
   outputExample,
-  getJsonWrapChars
+  getJsonWrapChars,
+  formatContentLinks
 };

--- a/src/scripts/tests/build-api-pages.test.js
+++ b/src/scripts/tests/build-api-pages.test.js
@@ -1,5 +1,27 @@
 import * as bp from '../build-api-pages';
 
+describe('formatContentLinks', () => {
+
+  it('should replace relative links with ones to the docs api page', () => {
+    const expected = `you can get the id from [this endpoint that lists id](https://docs.datadoghq.com/api/latest/usage-metering/#get-the-list-of-available-monthly-custom-reports)`;
+    const actual = bp.formatContentLinks(`you can get the id from [this endpoint that lists id](#/Usage-Metering/get-the-list-of-available-monthly-custom-reports)`);
+    expect(actual).toEqual(expected);
+  });
+
+  it('should return same input when nothing to change', () => {
+    const expected = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas facilisis, sem nec rhoncus aliquet, leo est porta est, id venenatis lacus erat sed nisi.`;
+    const actual = bp.formatContentLinks(`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas facilisis, sem nec rhoncus aliquet, leo est porta est, id venenatis lacus erat sed nisi.`);
+    expect(actual).toEqual(expected);
+  })
+
+  it('should not replace regular links', () => {
+    const expected = `here is a link to google [google](https://www.google.com) yes!`;
+    const actual = bp.formatContentLinks(`here is a link to google [google](https://www.google.com) yes!`);
+    expect(actual).toEqual(expected);
+  })
+
+});
+
 describe(`updateMenu`, () => {
 
 


### PR DESCRIPTION
### What does this PR do?

formats api descriptions so that if a markdown link uses tagname and operation id anchor formatting that it be replaced with a full link to the api page. e.g `[text](#/{tagName}/{operationId})` converting to `https://docs.datadoghq.com/api/latest..`

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1547

### Preview
https://docs-staging.datadoghq.com/david.jones/api-linking/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
