### PR TITLE
adding a missed alias

### DIFF
--- a/content/en/events/guides/_index.md
+++ b/content/en/events/guides/_index.md
@@ -9,7 +9,7 @@ further_reading:
   tag: "Documentation"
   text: "Event monitors"
 aliases:
-    - /events/
+    - /developers/events/
 ---
 
 An event represents any record of activity noteworthy for engineers (devs, ops, and security). Use these guides to progamatically send events:


### PR DESCRIPTION
### What does this PR do?
Adds an alias for the events developer section

https://docs-staging.datadoghq.com/kaylyn/alias/developers/events/ should redirect to https://docs-staging.datadoghq.com/kaylyn/alias/events/guides/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
