### PR TITLE
Clarified the default role name when using Cloudformation.

### DIFF
--- a/content/en/integrations/faq/error-datadog-not-authorized-sts-assume-role.md
+++ b/content/en/integrations/faq/error-datadog-not-authorized-sts-assume-role.md
@@ -11,7 +11,7 @@ This error usually indicates an issue with the trust policy associated with the 
 
 Check the following points for the AWS account mentioned in the error:
 
-1. When creating an IAM role, ensure that you are using the correct IAM role name in the [Datadog AWS integration tile][2]. Extra spaces or characters in AWS or Datadog causes the role delegation to fail. If you deployed the role via CLoudformation, the default IAM role name is set to [DatadogIntegrationRole][4].
+1. When creating an IAM role, ensure that you are using the correct IAM role name in the [Datadog AWS integration tile][2]. Extra spaces or characters in AWS or Datadog causes the role delegation to fail. If you deployed the role using Cloudformation, the default IAM role name is set to [DatadogIntegrationRole][4].
     {{< img src="integrations/faq/aws-error-sts-assume-role-04.png" alt="AWS Create IAM Role - Review" >}}
 
 2. Ensure Datadog's account ID `464622532012` is entered under `Another AWS account`. Entering any other account ID causes the integration to fail. Also ensure `Required MFA` is **unchecked**:

--- a/content/en/integrations/faq/error-datadog-not-authorized-sts-assume-role.md
+++ b/content/en/integrations/faq/error-datadog-not-authorized-sts-assume-role.md
@@ -7,11 +7,11 @@ further_reading:
   text: "AWS Datadog installation"
 ---
 
-This error usually indicates an issue with the trust policy associated with the `DatadogAWSIntegrationRole`. Most of the time, this issue is caused by the [role delegation process][1].
+This error usually indicates an issue with the trust policy associated with the Datadog Integration Role. Most of the time, this issue is caused by the [role delegation process][1].
 
 Check the following points for the AWS account mentioned in the error:
 
-1. When creating an IAM role, ensure that you are using the correct IAM role name in the [Datadog AWS integration tile][2]. Extra spaces or characters in AWS or Datadog causes the role delegation to fail:
+1. When creating an IAM role, ensure that you are using the correct IAM role name in the [Datadog AWS integration tile][2]. Extra spaces or characters in AWS or Datadog causes the role delegation to fail. If you deployed the role via CLoudformation, the default is set to [DatadogIntegrationRole][4].
     {{< img src="integrations/faq/aws-error-sts-assume-role-04.png" alt="AWS Create IAM Role - Review" >}}
 
 2. Ensure Datadog's account ID `464622532012` is entered under `Another AWS account`. Entering any other account ID causes the integration to fail. Also ensure `Required MFA` is **unchecked**:
@@ -32,6 +32,7 @@ Still need help? Contact [Datadog support][3].
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /integrations/amazon_web_services/#installation
+[1]: /integrations/amazon_web_services/?tab=roledelegation#setup
 [2]: https://app.datadoghq.com/account/settings#integrations/amazon_web_services
 [3]: /help/
+[4]: https://github.com/DataDog/cloudformation-template/blob/master/aws/datadog_integration_role.yaml

--- a/content/en/integrations/faq/error-datadog-not-authorized-sts-assume-role.md
+++ b/content/en/integrations/faq/error-datadog-not-authorized-sts-assume-role.md
@@ -11,7 +11,7 @@ This error usually indicates an issue with the trust policy associated with the 
 
 Check the following points for the AWS account mentioned in the error:
 
-1. When creating an IAM role, ensure that you are using the correct IAM role name in the [Datadog AWS integration tile][2]. Extra spaces or characters in AWS or Datadog causes the role delegation to fail. If you deployed the role using Cloudformation, the default IAM role name is set to [DatadogIntegrationRole][4].
+1. When creating an IAM role, ensure that you are using the correct IAM role name in the [Datadog AWS integration tile][2]. Extra spaces or characters in AWS or Datadog causes the role delegation to fail. If you deployed the role using CloudFormation, the default IAM role name is set to [DatadogIntegrationRole][4].
     {{< img src="integrations/faq/aws-error-sts-assume-role-04.png" alt="AWS Create IAM Role - Review" >}}
 
 2. Ensure Datadog's account ID `464622532012` is entered under `Another AWS account`. Entering any other account ID causes the integration to fail. Also ensure `Required MFA` is **unchecked**:

--- a/content/en/integrations/faq/error-datadog-not-authorized-sts-assume-role.md
+++ b/content/en/integrations/faq/error-datadog-not-authorized-sts-assume-role.md
@@ -7,11 +7,11 @@ further_reading:
   text: "AWS Datadog installation"
 ---
 
-This error usually indicates an issue with the trust policy associated with the Datadog Integration Role. Most of the time, this issue is caused by the [role delegation process][1].
+This error usually indicates an issue with the trust policy associated with the Datadog integration role. Most of the time, this issue is caused by the [role delegation process][1].
 
 Check the following points for the AWS account mentioned in the error:
 
-1. When creating an IAM role, ensure that you are using the correct IAM role name in the [Datadog AWS integration tile][2]. Extra spaces or characters in AWS or Datadog causes the role delegation to fail. If you deployed the role via CLoudformation, the default is set to [DatadogIntegrationRole][4].
+1. When creating an IAM role, ensure that you are using the correct IAM role name in the [Datadog AWS integration tile][2]. Extra spaces or characters in AWS or Datadog causes the role delegation to fail. If you deployed the role via CLoudformation, the default IAM role name is set to [DatadogIntegrationRole][4].
     {{< img src="integrations/faq/aws-error-sts-assume-role-04.png" alt="AWS Create IAM Role - Review" >}}
 
 2. Ensure Datadog's account ID `464622532012` is entered under `Another AWS account`. Entering any other account ID causes the integration to fail. Also ensure `Required MFA` is **unchecked**:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Clarify that the default role name when deploying via Cloudformation is DatadogIntegrationRole; not DatadogAWSIntegrationRole as shown in the example images. This is a tricky problem to resolve for customers who are onboarding.

### Motivation
<!-- What inspired you to submit this pull request?-->
Encountered by customer.

### Preview
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/integrations/faq/error-datadog-not-authorized-sts-assume-role/
<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mecsantos-patch-1/integrations/faq/error-datadog-not-authorized-sts-assume-role/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
