### PR TITLE
New group delay documentation update

### DIFF
--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -194,9 +194,11 @@ In most cases this setting is not useful because you only want an alert to resol
 
 #### New group delay
 
-Delay the evaluation start by `N` seconds for new groups. The time (in seconds) to wait before starting alerting, to allow newly created groups to boot and applications to fully start. This should be a non-negative integer.
+Delay the evaluation start by `N` seconds for new groups.
 
-For example, if you are using containerized architecture, setting an evaluation delay prevents your monitor group-by containers from triggering due to high resource usage or high latency when a new container is created. The delay is applied to every new group (which has not been seen in the last 24 hours) and defaults to `60` seconds.
+The time (in seconds) to wait before starting alerting, to allow newly created groups to boot and applications to fully start. This should be a non-negative integer.
+
+For example, if you are using containerized architecture, setting an evaluation delay prevents monitor groups scoped on containers from triggering due to high resource usage or high latency when a new container is created. The delay is applied to every new group (which has not been seen in the last 24 hours) and defaults to `60` seconds.
 
 The option is available with multi-alert mode.
 #### Evaluation delay


### PR DESCRIPTION
line break after literal feature description (like other monitor options) + rephrasing for group by

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Small documentation update (page structure and rephrasing)

### Motivation
Review of changes made on [https://github.com/DataDog/documentation/pull/11161](https://github.com/DataDog/documentation/pull/11161)

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/antoine.dussault/new_group_delay_update/monitors/monitor_types/metric/?tab=threshold

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
