### PR TITLE
[Synthetics][SSV-789] Add ICMP metrics to public documentation

### DIFF
--- a/content/en/synthetics/metrics.md
+++ b/content/en/synthetics/metrics.md
@@ -41,7 +41,7 @@ Metrics starting with:
 
 {{< get-metrics-from-git "synthetics" "synthetics.icmp" >}}
 
-For more information on API test timings, read the guide to [API Test Timings and Variations][7].
+For more information on API test timings, read the guide on [API Test Timings and Variations][7].
 
 ### Browser tests
 

--- a/content/en/synthetics/metrics.md
+++ b/content/en/synthetics/metrics.md
@@ -37,7 +37,11 @@ Metrics starting with:
 
 {{< get-metrics-from-git "synthetics" "synthetics.tcp" >}}
 
-For more information on API test timings, read the guide to [API Test Timings and Variations][7]. 
+#### ICMP tests
+
+{{< get-metrics-from-git "synthetics" "synthetics.icmp" >}}
+
+For more information on API test timings, read the guide to [API Test Timings and Variations][7].
 
 ### Browser tests
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds the synthetics ICMP metrics to the public documentation

### Motivation
<!-- What inspired you to submit this pull request?-->
We are submitting new customer metrics for ICMP tests and we should document them with other metrics.
Relevant PRs:
- https://github.com/DataDog/dogweb/pull/64426 updates the catalog metadata
- https://github.com/DataDog/dogweb/pull/64502 makes sure the new metrics are submitted

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/felicite.lordon/synthetics/icmp-metrics/synthetics/metrics/#metrics

![Screenshot 2021-08-12 at 17 50 40](https://user-images.githubusercontent.com/45016621/129227961-e607b528-bf52-4c92-9426-9d7d9e261f10.png)
