### PR TITLE
[DOCS-1882] Clarify profiler already comes with tracing library setup

### DIFF
--- a/content/en/tracing/profiler/enabling.md
+++ b/content/en/tracing/profiler/enabling.md
@@ -19,9 +19,11 @@ further_reading:
       text: 'Introducing always-on production profiling in Datadog'
 ---
 
-Profiler is shipped within the following tracing libraries. Select your language below to learn how to enable profiler for your application:
+Profiler is shipped within the following tracing libraries. If you are already using [APM to collect traces][1] for your application, you can skip installing the library and go directly to enabling profiler.
 
-To get notified when a private beta is available for the **Node**, **PHP**, or **.NET** Profiler, [sign up here][1].
+Select your language below to learn how to enable profiler for your application:
+
+To get notified when a private beta is available for the **Node**, **PHP**, or **.NET** Profiler, [sign up here][2].
 
 {{< programming-lang-wrapper langs="java,python,go,ruby" >}}
 {{< programming-lang lang="java" >}}
@@ -66,7 +68,7 @@ The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler lib
         -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
     ```
 
-    **Note**: The `-javaagent` argument needs to be before `-jar`, adding it as a JVM option rather than an application argument. For more information, see the [Oracle documentation][6]:
+    **Note**: The `-javaagent` argument needs to be before `-jar`, adding it as a JVM option rather than an application argument. For more information, see the [Oracle documentation][5]:
 
     ```shell
     # Good:
@@ -75,11 +77,11 @@ The Datadog Profiler requires [JDK Flight Recorder][1]. The Datadog Profiler lib
     java -jar my-service.jar -javaagent:dd-java-agent.jar ...
     ```
 
-4. After a minute or two, you can visualize your profiles on the [Datadog APM > Profiling page][5].
+4. After a minute or two, you can visualize your profiles on the [Datadog APM > Profiling page][6].
 
 ## Enabling the allocation profiler
 
-In dd-java-agent v0.84.0+ and Java 15 and lower, the allocation profiler is opt-in because it can use excessive CPU in allocation-heavy applications. This isn't common, so you may want to try it in a staging environment to see if it affects your application. To enable it, see [Enabling the allocation profiler][8].
+In dd-java-agent v0.84.0+ and Java 15 and lower, the allocation profiler is opt-in because it can use excessive CPU in allocation-heavy applications. This isn't common, so you may want to try it in a staging environment to see if it affects your application. To enable it, see [Enabling the allocation profiler][7].
 
 ## Environment variables
 
@@ -88,7 +90,7 @@ In dd-java-agent v0.84.0+ and Java 15 and lower, the allocation profiler is opt-
 | `DD_PROFILING_ENABLED`                           | Boolean       | Alternate for `-Ddd.profiling.enabled` argument. Set to `true` to enable profiler.               |
 | `DD_PROFILING_ALLOCATION_ENABLED`                | Boolean       | Alternate for `-Ddd.profiling.allocation.enabled` argument. Set to `true` to enable the allocation profiler. It requires the profiler to be enabled already. |
 | `DD_SERVICE`                                     | String        | Your [service][3] name, for example, `web-backend`.     |
-| `DD_ENV`                                         | String        | Your [environment][7] name, for example: `production`.|
+| `DD_ENV`                                         | String        | Your [environment][8] name, for example: `production`.|
 | `DD_VERSION`                                     | String        | The version of your service.                             |
 | `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api, team:intake`.  |
 
@@ -96,10 +98,10 @@ In dd-java-agent v0.84.0+ and Java 15 and lower, the allocation profiler is opt-
 [2]: /tracing/profiler/profiler_troubleshooting/#java-8-support
 [3]: https://app.datadoghq.com/account/settings#agent/overview
 [4]: https://app.datadoghq.com/account/settings?agent_version=6#agent
-[5]: https://app.datadoghq.com/profiling
-[6]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
-[7]: /tracing/guide/setting_primary_tags_to_scope/#environment
-[8]: /tracing/profiler/profiler_troubleshooting/#enabling-the-allocation-profiler
+[5]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
+[6]: https://app.datadoghq.com/profiling
+[7]: /tracing/profiler/profiler_troubleshooting/#enabling-the-allocation-profiler
+[8]: /tracing/guide/setting_primary_tags_to_scope/#environment
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}
 
@@ -358,11 +360,12 @@ The Datadog Profiler requires MRI Ruby 2.1+. **Wall time profiling is available 
 
 ## Not sure what to do next?
 
-The [Getting Started with Profiler][2] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
+The [Getting Started with Profiler][3] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://docs.google.com/forms/d/e/1FAIpQLScb9GKmKfSoY6YNV2Wa5P8IzUn02tA7afCahk7S0XHfakjYQw/viewform
-[2]: /getting_started/profiler/
+[1]: /tracing/setup_overview/
+[2]: https://docs.google.com/forms/d/e/1FAIpQLScb9GKmKfSoY6YNV2Wa5P8IzUn02tA7afCahk7S0XHfakjYQw/viewform
+[3]: /getting_started/profiler/

--- a/content/en/tracing/profiler/enabling.md
+++ b/content/en/tracing/profiler/enabling.md
@@ -19,9 +19,9 @@ further_reading:
       text: 'Introducing always-on production profiling in Datadog'
 ---
 
-Profiler is shipped within the following tracing libraries. If you are already using [APM to collect traces][1] for your application, you can skip installing the library and go directly to enabling profiler.
+The profiler is shipped within the following tracing libraries. If you are already using [APM to collect traces][1] for your application, you can skip installing the library and go directly to enabling the profiler.
 
-Select your language below to learn how to enable profiler for your application:
+Select your language below to learn how to enable a profiler for your application:
 
 To get notified when a private beta is available for the **Node**, **PHP**, or **.NET** Profiler, [sign up here][2].
 

--- a/content/en/tracing/setup_overview/_index.md
+++ b/content/en/tracing/setup_overview/_index.md
@@ -31,5 +31,8 @@ In containerized, serverless, or certain other environments, there may be APM-sp
 
 To instrument an application written in a language that does not yet have official library support, see the list of [community tracing libraries][2].
 
+After you set up tracing, you are [one step from accessing profiling data by enabling Continuous Profiler][3]. Profiler is available for Java, Python, Go, and (beta) Ruby.
+
 [1]: /tracing/visualization/#trace
 [2]: /developers/community/libraries/#apm-tracing-client-libraries
+[3]: /tracing/profiler/enabling/

--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -37,11 +37,13 @@ For a description of the terminology used in APM, see the [Getting started with 
 
 Consult the [migration document][5] if you need to migrate from an older version of the tracer (e.g. v<0.6.x) to the newest version.
 
+When you set up tracing, you're also setting up Continuous Profiler, and you need only [enable Profiler][6] to start receiving profiling data from your app.
+
 ### Installation
 
 #### Follow the in-app documentation (recommended)
 
-Follow the [Quickstart instructions][6] within the Datadog app for the best experience, including:
+Follow the [Quickstart instructions][7] within the Datadog app for the best experience, including:
 
 - Step-by-step instructions scoped to your deployment configuration (hosts, Docker, Kubernetes, or Amazon ECS).
 - Dynamically set `service`, `env`, and `version` tags.
@@ -57,10 +59,10 @@ Datadog has a series of pluggable packages which provide out-of-the-box support 
 ## Configuration
 
 The Go tracer supports additional environment variables and functions for configuration.
-See all available options in the [configuration documentation][7].
+See all available options in the [configuration documentation][8].
 
 We highly recommend using `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, `service`, and `version` for your services.
-Check out the [Unified Service Tagging][8] documentation for recommendations on how to configure these environment variables. These variables are available for versions 1.24.0+ of the Go tracer.
+Check out the [Unified Service Tagging][9] documentation for recommendations on how to configure these environment variables. These variables are available for versions 1.24.0+ of the Go tracer.
 
 You may also elect to provide `env`, `service`, and `version` through the tracer's API:
 
@@ -154,11 +156,11 @@ For other environments, please refer to the [Integrations][5] documentation for 
 
 ## Configure APM environment name
 
-The [APM environment name][9] may be configured [in the agent][10] or using the [WithEnv][7] start option of the tracer.
+The [APM environment name][10] may be configured [in the agent][11] or using the [WithEnv][8] start option of the tracer.
 
 ### B3 headers extraction and injection
 
-The Datadog APM tracer supports [B3 headers extraction][11] and injection for distributed tracing.
+The Datadog APM tracer supports [B3 headers extraction][12] and injection for distributed tracing.
 
 Distributed headers injection and extraction is controlled by
 configuring injection/extraction styles. Two styles are
@@ -187,9 +189,10 @@ extracted value is used.
 [3]: /tracing/visualization/
 [4]: https://github.com/DataDog/dd-trace-go/tree/v1#contributing
 [5]: https://github.com/DataDog/dd-trace-go/tree/v1/MIGRATING.md
-[6]: https://app.datadoghq.com/apm/docs
-[7]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#StartOption
-[8]: /getting_started/tagging/unified_service_tagging
-[9]: /tracing/advanced/setting_primary_tags_to_scope/#environment
-[10]: /getting_started/tracing/#environment-name
-[11]: https://github.com/openzipkin/b3-propagation
+[6]: /tracing/profiler/enabling/?code-lang=go
+[7]: https://app.datadoghq.com/apm/docs
+[8]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#StartOption
+[9]: /getting_started/tagging/unified_service_tagging
+[10]: /tracing/advanced/setting_primary_tags_to_scope/#environment
+[11]: /getting_started/tracing/#environment-name
+[12]: https://github.com/openzipkin/b3-propagation

--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -24,6 +24,8 @@ The Java Tracing Library supports all JVMs on all platforms version 7 and higher
 
 All JVM-based languages, such as Scala (versions 2.10.x - 2.13.x), Groovy, Kotlin, and Clojure are supported in the Java tracer and profiler. For a full list of supported libraries, visit the [Compatibility Requirements][2] page.
 
+When you set up tracing, you're also setting up Continuous Profiler, and you need only [enable Profiler][1] to start receiving profiling data from your app.
+
 ## Installation and getting started
 
 ### Follow the in-app documentation (recommended)
@@ -664,7 +666,7 @@ Java APM has minimal impact on the overhead of an application:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/profiler/enabling/?tab=java
+[1]: /tracing/profiler/enabling/?code-lang=java
 [2]: /tracing/compatibility_requirements/java
 [3]: https://app.datadoghq.com/apm/docs
 [4]: https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -28,11 +28,13 @@ further_reading:
 
 Python versions `2.7+` and `3.5+` are supported.  For a full list of supported libraries, visit the [Compatibility Requirements][1] page.
 
+When you set up tracing, you're also setting up Continuous Profiler, and you need only [enable Profiler][2] to start receiving profiling data from your app.
+
 ## Installation and getting started
 
 ### Follow the in-app documentation (recommended)
 
-Follow the [Quickstart instructions][2] within the Datadog app for the best experience, including:
+Follow the [Quickstart instructions][3] within the Datadog app for the best experience, including:
 
 - Step-by-step instructions scoped to your deployment configuration (hosts, Docker, Kubernetes, or Amazon ECS).
 - Dynamically set `service`, `env`, and `version` tags.
@@ -117,11 +119,11 @@ For other environments, please refer to the [Integrations][5] documentation for 
 {{% /tab %}}
 {{< /tabs >}}
 
-For more advanced usage, configuration, and fine-grain control, see Datadog's [API documentation][3].
+For more advanced usage, configuration, and fine-grain control, see Datadog's [API documentation][4].
 
 ## Configuration
 
-When using **ddtrace-run**, the following [environment variable options][4] can be used:
+When using **ddtrace-run**, the following [environment variable options][5] can be used:
 
 `DD_TRACE_DEBUG`
 : **Default**: `false`<br>
@@ -130,13 +132,13 @@ Enable debug logging in the tracer.
 `DATADOG_PATCH_MODULES`
 : Override the modules patched for this application execution. Follow the format: `DATADOG_PATCH_MODULES=module:patch,module:patch...`
 
-It is recommended to use `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, `service`, and `version` for your services. Refer to the [Unified Service Tagging][5] documentation for recommendations on how to configure these environment variables.
+It is recommended to use `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, `service`, and `version` for your services. Refer to the [Unified Service Tagging][6] documentation for recommendations on how to configure these environment variables.
 
 `DD_ENV`
-: Set the application’s environment, for example: `prod`, `pre-prod`, `staging`. Learn more about [how to setup your environment][6]. Available in version 0.38+.
+: Set the application’s environment, for example: `prod`, `pre-prod`, `staging`. Learn more about [how to setup your environment][7]. Available in version 0.38+.
 
 `DD_SERVICE`
-: The service name to be used for this application. The value is passed through when setting up middleware for web framework integrations like Pylons, Flask, or Django. For tracing without a web integration, it is recommended that you set the service name in code ([for example, see these Django docs][7]). Available in version 0.38+.
+: The service name to be used for this application. The value is passed through when setting up middleware for web framework integrations like Pylons, Flask, or Django. For tracing without a web integration, it is recommended that you set the service name in code ([for example, see these Django docs][8]). Available in version 0.38+.
 
 `DD_SERVICE_MAPPING`
 : Define service name mappings to allow renaming services in traces, for example: `postgres:postgresql,defaultdb:postgresql`. Available in version 0.47+.
@@ -164,17 +166,18 @@ Override the port that the default tracer submit traces to.
 
 `DD_LOGS_INJECTION`
 : **Default**: `false`<br>
-Enable [connecting logs and trace injection][8].
+Enable [connecting logs and trace injection][9].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing/compatibility_requirements/python
-[2]: https://app.datadoghq.com/apm/docs
-[3]: https://ddtrace.readthedocs.io/en/stable/
-[4]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtracerun
-[5]: /getting_started/tagging/unified_service_tagging
-[6]: /tracing/guide/setting_primary_tags_to_scope/
-[7]: https://ddtrace.readthedocs.io/en/stable/integrations.html#django
-[8]: /tracing/connect_logs_and_traces/python/
+[2]: /tracing/profiler/enabling/?tab=python
+[3]: https://app.datadoghq.com/apm/docs
+[4]: https://ddtrace.readthedocs.io/en/stable/
+[5]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtracerun
+[6]: /getting_started/tagging/unified_service_tagging
+[7]: /tracing/guide/setting_primary_tags_to_scope/
+[8]: https://ddtrace.readthedocs.io/en/stable/integrations.html#django
+[9]: /tracing/connect_logs_and_traces/python/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds notes to Tracing (Java, Python, Go) and Profiler setup pages that if you are already using APM, you need only enable Profiler, not install from scratch.

### Motivation
DOCS-1882

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/docs-1882-profile-incl/tracing/setup_overview/setup/go
https://docs-staging.datadoghq.com/kari/docs-1882-profile-incl/tracing/setup_overview/setup/java
https://docs-staging.datadoghq.com/kari/docs-1882-profile-incl/tracing/setup_overview/setup/python
https://docs-staging.datadoghq.com/kari/docs-1882-profile-incl/tracing/setup_overview/setup/
https://docs-staging.datadoghq.com/kari/docs-1882-profile-incl/tracing/profiler/enabling

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
