### PR TITLE
Rename Azure App Services to Azure App Service in all docs

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1065,7 +1065,7 @@ main:
     url: serverless/troubleshooting/serverless_tracing_and_webpack
     parent: serverless_troubleshooting
     weight: 704
-  - name: Azure App Services Extension
+  - name: Azure App Service Extension
     url: serverless/azure_app_services
     parent: serverless
     identifier: serverless_app_services

--- a/content/en/account_management/billing/_index.md
+++ b/content/en/account_management/billing/_index.md
@@ -11,7 +11,7 @@ Datadog meters the count of hosts and custom metrics hourly. The billable count 
 
 ### Hosts
 
-A host is any physical or virtual OS instance that you monitor with Datadog. It could be a server, VM, node (in the case of Kubernetes), or App Service Plan instance (in the case of Azure App Services). Hosts can be instances with the Datadog Agent installed plus any AWS EC2s, GCP, Azure, or vSphere VMs monitored with Datadog integrations. Any EC2s or VMs with the Agent installed count as a single instance (no double-billing).
+A host is any physical or virtual OS instance that you monitor with Datadog. It could be a server, VM, node (in the case of Kubernetes), or App Service Plan instance (in the case of Azure App Service). Hosts can be instances with the Datadog Agent installed plus any AWS EC2s, GCP, Azure, or vSphere VMs monitored with Datadog integrations. Any EC2s or VMs with the Agent installed count as a single instance (no double-billing).
 
 Non-reporting hosts (status `???` in your [Infrastructure list][2]) do not count towards billing. It could take up to 2 hours for these hosts to drop out of the [Infrastructure List][2]. Datadog retains the historical data for these hosts (paid accounts). Metrics can be graphed on a dashboard by knowing the specific host name or tags.
 

--- a/content/en/integrations/guide/azure-portal.md
+++ b/content/en/integrations/guide/azure-portal.md
@@ -140,7 +140,7 @@ If the Agent was installed using a different method, you can not use the Datadog
 
 ### App Service extension
 
-Select "App Service extension" in the left sidebar to see a list of app services in the subscription. On this page, you can install the Datadog extension on Azure App Services to enable APM tracing and custom metrics.
+Select "App Service extension" in the left sidebar to see a list of app services in the subscription. On this page, you can install the Datadog extension on Azure App Service to enable APM tracing and custom metrics.
 
 For each app service, the following information is displayed:
 

--- a/content/en/serverless/azure_app_services.md
+++ b/content/en/serverless/azure_app_services.md
@@ -20,15 +20,15 @@ further_reading:
 
 ## Overview
 
-Microsoft [Azure App Services][1] is a group of serverless resources that enable you to build and host web apps, mobile back ends, event-driven functions, and RESTful APIs without managing infrastructure. It can host workloads of all sizes and offers auto-scaling and high availability options.
+Microsoft [Azure App Service][1] is a group of serverless resources that enable you to build and host web apps, mobile back ends, event-driven functions, and RESTful APIs without managing infrastructure. It can host workloads of all sizes and offers auto-scaling and high availability options.
 
-Datadog provides monitoring capabilities for all Azure App Services resource types:
+Datadog provides monitoring capabilities for all Azure App Service resource types:
 
 - Azure Monitor metrics for [Apps][2] and [Functions][3] using the [Azure Integration][2].
 - Custom metrics can be submitted using the API.
 - [Resource logs][4] can be submitted using [Event Hub][5].
 
-The Datadog extension for Azure App Services provides additional monitoring capabilities for [Azure Web Apps][6]. This support includes:
+The Datadog extension for Azure App Service provides additional monitoring capabilities for [Azure Web Apps][6]. This support includes:
 
 - Full distributed APM tracing using automatic instrumentation.
 - Support for manual APM instrumentation to customize spans.
@@ -62,7 +62,7 @@ The Datadog extension for Azure App Services provides additional monitoring capa
 
 1. Configure the Azure integration to monitor your web app and verify it is configured correctly by ensuring that you see an `azure.app_service.count` metric tagged with the name of your web application. **Note**: This step is critical for metric/trace correlation, functional trace panel views in the Datadog portal, and accurate billing.
 
-2. Open the [Azure Portal][10] and navigate to the dashboard for the Azure App Services instance you wish to instrument with Datadog.
+2. Open the [Azure Portal][10] and navigate to the dashboard for the Azure App Service instance you wish to instrument with Datadog.
 
 3. Go to the Application settings tab of the Configuration page.
     {{< img src="infrastructure/serverless/azure_app_services/config.png" alt="configuration page" >}}
@@ -84,7 +84,7 @@ The Datadog extension for Azure App Services provides additional monitoring capa
 
 ### Application logging from Azure web apps
 
-Sending logs from your application in Azure App Services to Datadog requires the use of Serilog. Submitting logs with this method allows for trace ID injection, which makes it possible to connect logs and traces in Datadog. To enable trace ID injection with the extension, add the application setting `DD_LOGS_INJECTION:true`.
+Sending logs from your application in Azure App Service to Datadog requires the use of Serilog. Submitting logs with this method allows for trace ID injection, which makes it possible to connect logs and traces in Datadog. To enable trace ID injection with the extension, add the application setting `DD_LOGS_INJECTION:true`.
 
 **Note**: Since this occurs inside your application, any Azure Platform logs you submit with diagnostic settings does not include the trace ID.
 
@@ -92,9 +92,9 @@ See documentation on [setting up agentless logging with Serilog][13] for detaile
 
 ## Custom metrics with DogStatsD
 
-The App Services extension includes an instance of [DogStatsD][7] (Datadog's metrics aggregation service). This enables you to submit custom metrics, service checks, and events directly to Datadog from Azure Web Apps with the extension.
+The Azure App Service extension includes an instance of [DogStatsD][7] (Datadog's metrics aggregation service). This enables you to submit custom metrics, service checks, and events directly to Datadog from Azure Web Apps with the extension.
 
-Writing custom metrics and checks in your web app is similar to the process for doing so with an application on a host running the Datadog Agent. To submit custom metrics to Datadog from Azure App Services using the extension:
+Writing custom metrics and checks in your web app is similar to the process for doing so with an application on a host running the Datadog Agent. To submit custom metrics to Datadog from Azure App Service using the extension:
 
 1. Add the [DogStatsD NuGet package][14] to your Visual Studio project.
 2. Initialize DogStatdD and write custom metrics in your application.
@@ -114,7 +114,7 @@ DogStatsd.Configure(new StatsdConfig() { ConstantTags = new[] { "app:sample.mvc.
 catch (Exception ex)
 {
 // An exception is thrown by the Configure call if the necessary environment variables are not present.
-// These environment variables are present in Azure App Services, but
+// These environment variables are present in Azure App Service, but
 // need to be set in order to test your custom metrics: DD_API_KEY:{api_key}, DD_AGENT_HOST:localhost
 // Ignore or log the exception as it suits you
 Console.WriteLine(ex);

--- a/content/en/serverless/azure_app_services.md
+++ b/content/en/serverless/azure_app_services.md
@@ -1,5 +1,5 @@
 ---
-title: Microsoft Azure App Services Extension
+title: Microsoft Azure App Service Extension
 kind: documentation
 aliases:
   - /infrastructure/serverless/azure_app_services/

--- a/content/en/tracing/setup_overview/setup/cpp.md
+++ b/content/en/tracing/setup_overview/setup/cpp.md
@@ -203,7 +203,7 @@ To set up Datadog APM in AWS Lambda, see the [Tracing Serverless Functions][1] d
 {{% /tab %}}
 {{% tab "Other Environments" %}}
 
-Tracing is available for a number of other environments, such as  [Heroku][1], [Cloud Foundry][2], [AWS Elastic Beanstalk][3], and [Azure App Services Extension][4].
+Tracing is available for a number of other environments, such as  [Heroku][1], [Cloud Foundry][2], [AWS Elastic Beanstalk][3], and [Azure App Service][4].
 
 For other environments, please refer to the [Integrations][5] documentation for that environment and [contact support][6] if you are encountering any setup issues.
 

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -20,7 +20,7 @@ further_reading:
     text: "Runtime metrics"
   - link: "/serverless/azure_app_services/"
     tag: "Documentation"
-    text: "Microsoft Azure App Services extension"
+    text: "Microsoft Azure App Service extension"
   - link: "/tracing/visualization/"
     tag: "Documentation"
     text: "Explore your services, resources, and traces"
@@ -331,7 +331,7 @@ To set up Datadog APM in AWS Lambda, see the [Tracing Serverless Functions][1] d
 
 {{% tab "Azure App Service" %}}
 
-To set up Datadog APM in Azure App Service, see the [Tracing Azure App Services Extension][1] documentation.
+To set up Datadog APM in Azure App Service, see the [Tracing Azure App Service Extension][1] documentation.
 
 
 [1]: /serverless/azure_app_services/

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -329,7 +329,7 @@ To set up Datadog APM in AWS Lambda, see the [Tracing Serverless Functions][1] d
 [1]: /tracing/serverless_functions/
 {{% /tab %}}
 
-{{% tab "Azure App Services Extension" %}}
+{{% tab "Azure App Service" %}}
 
 To set up Datadog APM in Azure App Service, see the [Tracing Azure App Services Extension][1] documentation.
 

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -25,7 +25,7 @@ further_reading:
     text: "Runtime metrics"
   - link: "/serverless/azure_app_services/"
     tag: "Documentation"
-    text: "Microsoft Azure App Services extension"
+    text: "Microsoft Azure App Service extension"
   - link: "/tracing/visualization/"
     tag: "Documentation"
     text: "Explore your services, resources, and traces"

--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -139,7 +139,7 @@ To set up Datadog APM in AWS Lambda, see the [Tracing Serverless Functions][1] d
 {{% /tab %}}
 {{% tab "Other Environments" %}}
 
-Tracing is available for a number of other environments, such as  [Heroku][1], [Cloud Foundry][2], [AWS Elastic Beanstalk][3], and [Azure App Services Extension][4].
+Tracing is available for a number of other environments, such as  [Heroku][1], [Cloud Foundry][2], [AWS Elastic Beanstalk][3], and [Azure App Service][4].
 
 For other environments, please refer to the [Integrations][5] documentation for that environment and [contact support][6] if you are encountering any setup issues.
 

--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -113,7 +113,7 @@ To set up Datadog APM in AWS Lambda, see the [Tracing Serverless Functions][1] d
 {{% /tab %}}
 {{% tab "Other Environments" %}}
 
-Tracing is available for a number of other environments, such as  [Heroku][1], [Cloud Foundry][2], [AWS Elastic Beanstalk][3], and [Azure App Services Extension][4].
+Tracing is available for a number of other environments, such as  [Heroku][1], [Cloud Foundry][2], [AWS Elastic Beanstalk][3], and [Azure App Service][4].
 
 For other environments, please refer to the [Integrations][5] documentation for that environment and [contact support][6] if you are encountering any setup issues.
 

--- a/content/en/tracing/setup_overview/setup/nodejs.md
+++ b/content/en/tracing/setup_overview/setup/nodejs.md
@@ -148,7 +148,7 @@ To set up Datadog APM in AWS Lambda, see the [Tracing Serverless Functions][1] d
 {{% /tab %}}
 {{% tab "Other Environments" %}}
 
-Tracing is available for a number of other environments, such as  [Heroku][1], [Cloud Foundry][2], [AWS Elastic Beanstalk][3], and [Azure App Services Extension][4].
+Tracing is available for a number of other environments, such as  [Heroku][1], [Cloud Foundry][2], [AWS Elastic Beanstalk][3], and [Azure App Service][4].
 
 For other environments, please refer to the [Integrations][5] documentation for that environment and [contact support][6] if you are encountering any setup issues.
 

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -78,7 +78,7 @@ To set up Datadog APM in AWS Lambda, see the [Tracing Serverless Functions][1] d
 {{% /tab %}}
 {{% tab "Other Environments" %}}
 
-Tracing is available for a number of other environments, such as  [Heroku][1], [Cloud Foundry][2], [AWS Elastic Beanstalk][3], and [Azure App Services Extension][4].
+Tracing is available for a number of other environments, such as  [Heroku][1], [Cloud Foundry][2], [AWS Elastic Beanstalk][3], and [Azure App Service][4].
 
 For other environments, please refer to the [Integrations][5] documentation for that environment and [contact support][6] if you are encountering any setup issues.
 

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -104,7 +104,7 @@ To set up Datadog APM in AWS Lambda, see the [Tracing Serverless Functions][1] d
 {{% /tab %}}
 {{% tab "Other Environments" %}}
 
-Tracing is available for a number of other environments, such as  [Heroku][1], [Cloud Foundry][2], [AWS Elastic Beanstalk][3], and [Azure App Services Extension][4].
+Tracing is available for a number of other environments, such as  [Heroku][1], [Cloud Foundry][2], [AWS Elastic Beanstalk][3], and [Azure App Service][4].
 
 For other environments, please refer to the [Integrations][5] documentation for that environment and [contact support][6] if you are encountering any setup issues.
 


### PR DESCRIPTION
### What does this PR do?
Removes the incorrect trailing "s" from Azure App Services in our documentation, since the name of the service is officially [Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/)

### Motivation
I found the inaccuracy while making an unrelated tracing docs update.

### Preview
Azure App Service page: https://docs-staging.datadoghq.com/zach.montoya/update-azure-app-service-everywhere/serverless/azure_app_services
Go (non-.NET) tracing setup page: https://docs-staging.datadoghq.com/zach.montoya/update-azure-app-service-everywhere/tracing/setup_overview/setup/go?tab=otherenvironments#configure-the-datadog-agent-for-apm
.NET Core tracing setup page: https://docs-staging.datadoghq.com/zach.montoya/update-azure-app-service-everywhere/tracing/setup_overview/setup/dotnet-core
.NET Framework tracing setup page: https://docs-staging.datadoghq.com/zach.montoya/update-azure-app-service-everywhere/tracing/setup_overview/setup/dotnet-framework

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
