### PR TITLE
Add note about retention v injestion

### DIFF
--- a/content/en/tracing/trace_retention_and_ingestion/_index.md
+++ b/content/en/tracing/trace_retention_and_ingestion/_index.md
@@ -49,6 +49,8 @@ In addition to the 'Spans Indexed' column per retention filter, there is also th
 
 For more information, refer to the [Usage Metrics][1] documentation, or see the [dashboard][3] available in your account.
 
+<div class="alert alert-info"><strong>Note</strong>: Retention filters do not affect what traces are collected by the Agent and sent to Datadog ("ingested"). The only way to change how much tracing data is ingested is through <a href="#ingestion-controls">ingestion controls</a>.</div>
+
 ### Datadog intelligent retention filter
 
 Intelligent retention is always active for your services, and it keeps a proportion of traces to help you monitor the health of your applications. All [service entry spans][4] are indexed for the traces kept by the intelligent retention filter.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Clarifies that retention filters to not somehow get pushed back to the Agent to affect ingestion.

### Motivation
hotjar feedback DOCS-2238

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/docs-2238-retention/tracing/trace_retention_and_ingestion/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
