### PR TITLE
APM > .NET > Clean up Setup & Compatibility pages

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -35,12 +35,12 @@ The .NET Tracer supports automatic instrumentation on the following .NET Core ve
 ## Supported processor architectures
 The .NET Tracer supports automatic instrumentation on the following architectures:
 
-| Processor architectures                                                                                                       |
-| ----------------------------------------------------------------------------------------------------------------------------- |
-| Windows x86 (`win-x86`)                                                                                                       |
-| Windows x64 (`win-x64`)                                                                                                       |
-| Linux x64 (`linux-x64`)                                                                                                       |
-| Alpine Linux x64 (`linux-musl-x64`)                                                                                           |
+| Processor architectures                                                 |
+| ------------------------------------------------------------------------|
+| Windows x86 (`win-x86`)                                                 |
+| Windows x64 (`win-x64`)                                                 |
+| Linux x64 (`linux-x64`)                                                 |
+| Alpine Linux x64 (`linux-musl-x64`)                                     |
 | Linux ARM64 (`linux-arm64`)<br><br>.NET 5 only, added in version 1.27.0 |
 
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -15,12 +15,14 @@ further_reading:
       tag: 'GitHub'
       text: 'Examples of Custom Instrumentation'
 ---
+
+
 - The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual Basic).
 
-- The .NET Tracer library for Datadog is open-source. For more information, see the [tracer Github repository][1].
+- The .NET Tracer library for Datadog is open source. For more information, see the [.NET Tracer repository][1].
 
 ## Supported .NET Framework runtimes
-The .NET Tracer supports instrumentation on .NET Framework 4.5 and above (using CLR v4.0). It also supports [.NET Core][2].
+The .NET Tracer supports automatic instrumentation on .NET Framework 4.5 and above. It also supports [.NET Core][2].
 
 | Version  | Microsoft End of Life |
 | -------- | --------------------- |
@@ -37,11 +39,12 @@ The .NET Tracer supports instrumentation on .NET Framework 4.5 and above (using 
  Additional information on .NET Framework support policy can be found within [Microsoft's .NET Framework Lifecycle Policy][3]. 
 
 ## Supported processor architectures
+The .NET Tracer supports automatic instrumentation on the following architectures:
 
-| Processor architectures                                                                                            |
-| ------------------------------------------------------------------------------------------------------------------ |
-| Windows x86 (`win-x86`)                                                                                            |
-| Windows x64 (`win-x64`)                                                                                            |
+| Processor architectures                                                 |
+| ------------------------------------------------------------------------|
+| Windows x86 (`win-x86`)                                                 |
+| Windows x64 (`win-x64`)                                                 |
 
 ## Integrations
 

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -351,7 +351,7 @@ To use custom instrumentation in your .NET application:
 1. Add the `Datadog.Trace` [NuGet package][2] to your application.
 2. In your application code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
 
-For additional details on custom instrumentation and custom tagging, see [.NET Custom Instrumentation documentation][3].
+For additional details on custom instrumentation and custom tagging, see the [.NET Custom Instrumentation][3] documentation.
 
 ## Configuration
 

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -559,7 +559,7 @@ Sets a list of integrations to disable. All other integrations remain enabled. I
 
 `DD_TRACE_<INTEGRATION_NAME>_ENABLED`
 : **TracerSettings property**: `Integrations[<INTEGRATION_NAME>].Enabled` <br>
-Enables or disables a specific integration. Valid values are: `true` or `false`. Integration names are listed in the [Integrations][8] section.<br>
+Enables or disables a specific integration. Valid values are: `true` or `false`. Integration names are listed in the [Integrations][5] section.<br>
 **Default**: `true`
 
 #### Experimental features

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -351,13 +351,13 @@ To use custom instrumentation in your .NET application:
 1. Add the `Datadog.Trace` [NuGet package][2] to your application.
 2. In your application code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
 
-For more details on custom instrumentation and custom tagging, see [.NET Custom Instrumentation documentation][3].
+For additional details on custom instrumentation and custom tagging, see [.NET Custom Instrumentation documentation][3].
 
-## Configure the tracer
+## Configuration
 
 {{< img src="tracing/dotnet/diagram_docs_net.png" alt=".NET Tracer configuration setting precedence"  >}}
 
-The .NET Tracer has configuration settings that can be set by any of these methods:
+The .NET Tracer has configuration settings which you can set by any of these methods:
 
 {{< tabs >}}
 
@@ -397,7 +397,7 @@ dotnet example.dll
 
 {{% tab "Code" %}}
 
-To configure the Tracer in application code, create a `TracerSettings` from the default configuration sources. Set properties on this `TracerSettings` instance before passing it to a `Tracer` constructor. For example:
+To configure the Tracer in application code, create a `TracerSettings` instance from the default configuration sources. Set properties on this `TracerSettings` instance before passing it to a `Tracer` constructor. For example:
 
 <div class="alert alert-warning">
   <strong>Note:</strong> Settings must be set on <code>TracerSettings</code> <em>before</em> creating the <code>Tracer</code>. Changes made to <code>TracerSettings</code> properties after the <code>Tracer</code> is created are ignored.
@@ -416,9 +416,6 @@ settings.ServiceName = "MyService";
 settings.ServiceVersion = "abc123";
 settings.AgentUri = new Uri("http://localhost:8126/");
 
-// disable the AdoNet integration
-settings.Integrations["AdoNet"].Enabled = false;
-
 // create a new Tracer using these settings
 var tracer = new Tracer(settings);
 
@@ -430,7 +427,7 @@ Tracer.Instance = tracer;
 
 {{% tab "JSON file" %}}
 
-To configure the Tracer using a JSON file, create `datadog.json` in the instrumented application's directory. The root JSON object must be an object with a key/value pair for each setting. For example:
+To configure the Tracer using a JSON file, create `datadog.json` in the instrumented application's directory. The root JSON object must be an object with a key-value pair for each setting. For example:
 
 ```json
 {
@@ -463,17 +460,15 @@ If specified, adds the `env` tag with the specified value to all generated spans
 
 `DD_SERVICE`
 : **TracerSettings property**: `ServiceName`<br>
-If specified, sets the service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (the IIS application name, process entry assembly, or process name). Added in version 1.17.0.
+If specified, sets the service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). Added in version 1.17.0.
 
 `DD_VERSION`
 : **TracerSettings property**: `ServiceVersion`<br>
 If specified, sets the version of the service. Added in version 1.17.0.
 
-
 #### Optional configuration
 
-The following table below lists configuration variables that are available for both automatic and custom instrumentation.
-
+The following configuration variables are available for both automatic and custom instrumentation:
 
 `DD_TRACE_AGENT_URL`
 : **TracerSettings property**: `AgentUri`<br>
@@ -496,15 +491,22 @@ Enables or disables automatic injection of correlation identifiers into applicat
 : **TracerSettings property**: `GlobalTags`<br>
 If specified, adds all of the specified tags to all generated spans.
 
-`DD_TRACE_DEBUG` 
-: **TracerSettings property**: `DebugEnabled`<br>
-Enables or disables debug logging. Valid values are: `true` or `false`<br>
+`DD_TRACE_DEBUG`
+: **TracerSettings property**: `DebugEnabled` <br>
+Enables or disables debug logging. Valid values are: `true` or `false`.<br>
 **Default**: `false`
 
 `DD_TRACE_HEADER_TAGS`
-: Accepts a map of case-insensitive header keys to tag names and automatically applies matching header values as tags on root spans. Also accepts entries without a specified tag name. <br>
+: **TracerSettings property**:`HeaderTags` <br>
+Accepts a map of case-insensitive header keys to tag names and automatically applies matching header values as tags on root spans. Also accepts entries without a specified tag name. <br>
 **Example**: `CASE-insensitive-Header:my-tag-name,User-ID:userId,My-Header-And-Tag-Name`<br>
 Added in version 1.18.3. Response header support and entries without tag names added in version 1.26.0.
+
+`DD_TAGS`
+: **TracerSettings property**: `GlobalTags`<br>
+If specified, adds all of the specified tags to all generated spans. <br>
+**Example**: `layer:api,team:intake` <br>
+Added in version 1.17.0.
 
 `DD_TRACE_LOG_DIRECTORY`
 : Sets the directory for .NET Tracer logs. <br>
@@ -518,29 +520,17 @@ Added in version 1.18.3. Response header support and entries without tag names a
 
 `DD_TRACE_SERVICE_MAPPING`
 : Rename services using configuration. Accepts a map of service name keys to rename, and the name to use instead, in the format `[from-key]:[to-name]`. <br>
-**Example:** `mysql:main-mysql-db, mongodb:offsite-mongodb-service`<br>
+**Example**: `mysql:main-mysql-db, mongodb:offsite-mongodb-service`<br>
 The `from-key` value is specific to the integration type, and should exclude the application name prefix. For example, to rename `my-application-sql-server` to `main-db`, use `sql-server:main-db`. Added in version 1.23.0
 
-`DD_TAGS`
-: **TracerSettings property**: `GlobalTags`<br>
-If specified, adds all of the specified tags to all generated spans. <br>
-**Example**: `layer:api,team:intake` <br>
-Added in version 1.17.0.
+#### Automatic instrumentation optional configuration
 
-
-#### Automatic instrumentation
-
-The following configuriation variables are available **only** when using automatic instrumentation.
-
+The following configuration variables are available **only** when using automatic instrumentation:
 
 `DD_TRACE_ENABLED`
 : **TracerSettings property**: `TraceEnabled`<br>
 Enables or disables all automatic instrumentation. Setting the environment variable to `false` completely disables the CLR profiler. For other configuration methods, the CLR profiler is still loaded, but traces will not be generated. Valid values are: `true` or `false`.<br>
 **Default**: `true`
-
-`DD_DISABLED_INTEGRATIONS`
-: **TracerSettings property**: `DisabledIntegrationNames`<br>
-Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][5] section.
 
 `DD_HTTP_CLIENT_ERROR_STATUSES`
 : Sets status code ranges that will cause HTTP client spans to be marked as errors. <br>
@@ -559,15 +549,22 @@ Added in version 1.23.0.
 : **TracerSettings property**: `AdoNetExcludedTypes` <br>
 Sets a list of `AdoNet` types (for example, `System.Data.SqlClient.SqlCommand`) that will be excluded from automatic instrumentation.
 
+#### Automatic instrumentation integration configuration
+
+The following table lists configuration variables that are available **only** when using automatic instrumentation and can be set for each integration.
+
+`DD_DISABLED_INTEGRATIONS`
+: **TracerSettings property**: `DisabledIntegrationNames` <br>
+Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][5] section.
+
 `DD_TRACE_<INTEGRATION_NAME>_ENABLED`
-: **TracerSettings property**: `Integrations[<INTEGRATION_NAME>].Enabled`<br>
-Enables or disables a specific integration. Valid values are: `true` or `false`. Integration names are listed in the [Integrations][5] section.<br>
+: **TracerSettings property**: `Integrations[<INTEGRATION_NAME>].Enabled` <br>
+Enables or disables a specific integration. Valid values are: `true` or `false`. Integration names are listed in the [Integrations][8] section.<br>
 **Default**: `true`
 
 #### Experimental features
 
 The following configuration variables are for features that are available for use but may change in future releases.
-
 
 `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED`
 : Enables improved resource names for web spans when set to `true`. Uses route template information where available, adds an additional span for ASP.NET Core integrations, and enables additional tags. Added in version 1.26.0.<br>

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -351,7 +351,7 @@ To use custom instrumentation in your .NET application:
 1. Add the `Datadog.Trace` [NuGet package][2] to your application.
 2. In your application code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
 
-For additional details on custom instrumentation and custom tagging, see the [.NET Custom Instrumentation][3] documentation.
+For additional details on custom instrumentation and custom tagging, see the [.NET Custom Instrumentation documentation][3].
 
 ## Configuration
 
@@ -460,7 +460,7 @@ If specified, adds the `env` tag with the specified value to all generated spans
 
 `DD_SERVICE`
 : **TracerSettings property**: `ServiceName`<br>
-If specified, sets the service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). Added in version 1.17.0.
+If specified, sets the service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (IIS application name, process entry assembly, or process name). Added in version 1.17.0.
 
 `DD_VERSION`
 : **TracerSettings property**: `ServiceVersion`<br>

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -149,7 +149,7 @@ To use custom instrumentation in your .NET application:
 1. Add the `Datadog.Trace` [NuGet package][5] to your application.
 2. In your application code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
 
-For additional details on custom instrumentation and custom tagging, see [.NET Custom Instrumentation documentation][6].
+For additional details on custom instrumentation and custom tagging, see the [.NET Custom Instrumentation][6] documentation.
 
 ## Configuration
 

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -149,7 +149,7 @@ To use custom instrumentation in your .NET application:
 1. Add the `Datadog.Trace` [NuGet package][5] to your application.
 2. In your application code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
 
-For additional details on custom instrumentation and custom tagging, see the [.NET Custom Instrumentation][6] documentation.
+For additional details on custom instrumentation and custom tagging, see the [.NET Custom Instrumentation documentation][6].
 
 ## Configuration
 
@@ -260,7 +260,7 @@ If specified, adds the `env` tag with the specified value to all generated spans
 
 `DD_SERVICE`
 : **TracerSettings property**: `ServiceName`<br>
-If specified, sets the service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). Added in version 1.17.0.
+If specified, sets the service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (IIS application name, process entry assembly, or process name). Added in version 1.17.0.
 
 `DD_VERSION`
 : **TracerSettings property**: `ServiceVersion`<br>

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -56,7 +56,7 @@ For a full list of supported libraries and processor architectures, see [Compati
 
 ### Automatic instrumentation
 
-<div class="alert alert-warning"> 
+<div class="alert alert-warning">
   <strong>Notes:</strong><br><ul><li>Datadog automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, APM). To ensure maximum visibility, run only one APM solution in your application environment.</li><li> If you are using both automatic and custom instrumentation, it is important to keep the package versions (for example, MSI and NuGet) in sync.</li></ul>
 </div>
 
@@ -142,15 +142,14 @@ Ensure you set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" 
 ## Custom instrumentation
 
 <div class="alert alert-warning">
-  <strong>Note:</strong>  If you are using both automatic and custom instrumentation, it is important to keep the package versions (for example, MSI and NuGet) in sync.
+  <strong>Note:</strong> If you are using both automatic and custom instrumentation, it is important to keep the package versions (for example, MSI and NuGet) in sync.
 </div>
 
 To use custom instrumentation in your .NET application:
-
 1. Add the `Datadog.Trace` [NuGet package][5] to your application.
 2. In your application code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
 
-For additional details on custom instrumentation and custom tagging, see [.NET Custom Instrumentation][6].
+For additional details on custom instrumentation and custom tagging, see [.NET Custom Instrumentation documentation][6].
 
 ## Configuration
 
@@ -162,7 +161,7 @@ The .NET Tracer has configuration settings which you can set by any of these met
 
 {{% tab "Environment variables" %}}
 
-To configure the Tracer using environment variables, set the variables before launching the instrumented application.
+To configure the tracer using environment variables, set the variables before launching the instrumented application.
 
 For example:
 
@@ -232,14 +231,14 @@ To configure the Tracer using an `app.config` or `web.config` file, use the `<ap
 
 {{% tab "JSON file" %}}
 
-To configure the Tracer using a JSON file, create `datadog.json` in the instrumented application's directory. The root JSON object must be a hash with a key-value pair for each setting. For example:
+To configure the Tracer using a JSON file, create `datadog.json` in the instrumented application's directory. The root JSON object must be an object with a key-value pair for each setting. For example:
 
 ```json
 {
-    "DD_TRACE_AGENT_URL": "http://localhost:8126",
-    "DD_ENV": "prod",
-    "DD_SERVICE": "MyService",
-    "DD_VERSION": "abc123",
+  "DD_TRACE_AGENT_URL": "http://localhost:8126",
+  "DD_ENV": "prod",
+  "DD_SERVICE": "MyService",
+  "DD_VERSION": "abc123",
 }
 ```
 
@@ -247,30 +246,29 @@ To configure the Tracer using a JSON file, create `datadog.json` in the instrume
 
 {{< /tabs >}}
 
-## Configuration settings
+### Configuration settings
 
 Using the methods described above, customize your tracing configuration with the following variables. Use the environment variable name (for example, `DD_TRACE_AGENT_URL`) when setting environment variables or configuration files. Use the TracerSettings property (for example, `AgentUri`) when changing settings in code.
 
-### Unified Service Tagging
+#### Unified Service Tagging
 
-To use [Unified Service Tagging][7], configure the following settings for your services.
-
+To use [Unified Service Tagging][7], configure the following settings for your services:
 
 `DD_ENV`
 : **TracerSettings property**: `Environment`<br>
-If specified, adds the `env` tag with the specified value to all generated spans. Added in version 1.17.0
+If specified, adds the `env` tag with the specified value to all generated spans. Added in version 1.17.0.
 
 `DD_SERVICE`
 : **TracerSettings property**: `ServiceName`<br>
-If specified, sets the service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). Added in version 1.17.0
+If specified, sets the service name. Otherwise, the .NET Tracer tries to determine service name automatically from application name (e.g. IIS application name, process entry assembly, or process name). Added in version 1.17.0.
 
 `DD_VERSION`
 : **TracerSettings property**: `ServiceVersion`<br>
-If specified, sets the version of the service. Added in version 1.17.0
+If specified, sets the version of the service. Added in version 1.17.0.
 
-### Additional optional configuration
+#### Optional configuration
 
-The configuration variables are available for both automatic and custom instrumentation:
+The following configuration variables are available for both automatic and custom instrumentation:
 
 `DD_TRACE_AGENT_URL`
 : **TracerSettings property**: `AgentUri`<br>
@@ -302,8 +300,16 @@ Added in version 1.18.3. Response header support and entries without tag names a
 
 `DD_TAGS`
 : **TracerSettings property**: `GlobalTags`<br>
-If specified, adds all of the specified tags to all generated spans. Added in version 1.17.0.<br>
-**Example**: `layer:api,team:intake`
+If specified, adds all of the specified tags to all generated spans. <br>
+**Example**: `layer:api,team:intake` <br>
+Added in version 1.17.0.
+
+`DD_TRACE_LOG_DIRECTORY`
+: Sets the directory for .NET Tracer logs. <br>
+**Default**: `%ProgramData%\Datadog .NET Tracer\logs\`
+
+`DD_TRACE_LOG_PATH`
+: Sets the path for the automatic instrumentation log file and determines the directory of all other .NET Tracer log files. Ignored if `DD_TRACE_LOG_DIRECTORY` is set.
 
 `DD_TRACE_LOGGING_RATE`
 : Sets rate limiting for log messages. If set, unique log lines are written once per `x` seconds. For example, to log a given message once per 60 seconds, set to `60`. Setting to `0` disables log rate limiting. Added in version 1.24.0. Disabled by default.
@@ -313,28 +319,17 @@ If specified, adds all of the specified tags to all generated spans. Added in ve
 **Example**: `mysql:main-mysql-db, mongodb:offsite-mongodb-service`<br>
 The `from-key` value is specific to the integration type, and should exclude the application name prefix. For example, to rename `my-application-sql-server` to `main-db`, use `sql-server:main-db`. Added in version 1.23.0
 
-### Automatic instrumentation optional configuration
+#### Automatic instrumentation optional configuration
 
-The configuration variables are available **only** when using automatic instrumentation:
+The following configuration variables are available **only** when using automatic instrumentation:
 
 `DD_TRACE_ENABLED`
 : **TracerSettings property**: `TraceEnabled`<br>
 Enables or disables all automatic instrumentation. Setting the environment variable to `false` completely disables the CLR profiler. For other configuration methods, the CLR profiler is still loaded, but traces will not be generated. Valid values are: `true` or `false`.<br>
 **Default**: `true`
 
-`DD_TRACE_LOG_DIRECTORY`
-: Sets the directory for .NET Tracer logs.<br>
-**Default**: `%ProgramData%\Datadog .NET Tracer\logs\`
-
-`DD_TRACE_LOG_PATH`
-: Sets the path for the automatic instrumentation log file and determines the directory of all other .NET Tracer log files. Ignored if `DD_TRACE_LOG_DIRECTORY` is set.
-
-`DD_DISABLED_INTEGRATIONS`
-: **TracerSettings property**: `DisabledIntegrationNames` <br>
-Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][8] section.
-
 `DD_HTTP_CLIENT_ERROR_STATUSES`
-: Sets status code ranges that will cause HTTP client spans to be marked as errors.<br>
+: Sets status code ranges that will cause HTTP client spans to be marked as errors. <br>
 **Default**: `400-499`
 
 `DD_HTTP_SERVER_ERROR_STATUSES`
@@ -342,17 +337,21 @@ Sets a list of integrations to disable. All other integrations remain enabled. I
 **Default**: `500-599`
 
 `DD_RUNTIME_METRICS_ENABLED`
-: Enables .NET runtime metrics. Valid values are `true` or `false`. Added in version 1.23.0.<br>
-**Default**: `false`
+: Enables .NET runtime metrics. Valid values are `true` or `false`. <br>
+**Default**: `false`<br>
+Added in version 1.23.0.
 
 `DD_TRACE_ADONET_EXCLUDED_TYPES`
 : **TracerSettings property**: `AdoNetExcludedTypes` <br>
 Sets a list of `AdoNet` types (for example, `System.Data.SqlClient.SqlCommand`) that will be excluded from automatic instrumentation.
 
-
-### Disable integration configuration
+#### Automatic instrumentation integration configuration
 
 The following table lists configuration variables that are available **only** when using automatic instrumentation and can be set for each integration.
+
+`DD_DISABLED_INTEGRATIONS`
+: **TracerSettings property**: `DisabledIntegrationNames` <br>
+Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][8] section.
 
 `DD_TRACE_<INTEGRATION_NAME>_ENABLED`
 : **TracerSettings property**: `Integrations[<INTEGRATION_NAME>].Enabled` <br>
@@ -361,7 +360,7 @@ Enables or disables a specific integration. Valid values are: `true` or `false`.
 
 #### Experimental features
 
-The configuration variables are for features that are available for use but may change in future releases.
+The following configuration variables are for features that are available for use but may change in future releases.
 
 `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED`
 : Enables improved resource names for web spans when set to `true`. Uses route template information where available, adds an additional span for ASP.NET Core integrations, and enables additional tags. Added in version 1.26.0.<br>


### PR DESCRIPTION
### What does this PR do?
This PR keeps the text in sync between the .NET Framework and .NET Core pages for setup and compatibility.

### Motivation
I noticed differences between the two pages in places there shouldn't have been.

### Preview
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-netcore-netframework-structure/tracing/setup_overview/setup/dotnet-framework/
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-netcore-netframework-structure/tracing/setup_overview/setup/dotnet-core/

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
