### PR TITLE
[doc] Notifications Local Time Update

### DIFF
--- a/content/en/monitors/notifications.md
+++ b/content/en/monitors/notifications.md
@@ -156,8 +156,8 @@ Template variables that return numerical values support operations and functions
 
 #### Local time
 
-Use the `local_time` function to transform a date into its local time: `{{local_time 'time_variable' 'timezone'}}`.
-For example, to show the last triggered time of the monitor in the Tokyo time zone in your notification, include the following in the notification message:
+Use the `local_time` function to add another date in your notification in the time zone of your choice. This function transforms a date into its local time: `{{local_time 'time_variable' 'timezone'}}`.
+For example, to add the last triggered time of the monitor in the Tokyo time zone in your notification, include the following in the notification message:
 
 ```
 {{local_time 'last_triggered_at' 'Asia/Tokyo'}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR updates the wording for the use of the local time function

### Motivation
The wording isn’t quite clear because it makes you believe you can actually change the UTC time when last the monitor was triggered which is not the case

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/douglaskamseu31_Notifcations_Local_Time/monitors/notifications/?tab=is_alert#local-time

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
