### PR TITLE
DOCS-1719 - Gain consistency on Flame Graph terminology

### DIFF
--- a/content/en/tracing/error_tracking/_index.md
+++ b/content/en/tracing/error_tracking/_index.md
@@ -23,7 +23,7 @@ Monitoring the errors collected by Datadog is critical to your system's health, 
 
 The Datadog tracers collect errors through integrations and manual instrumentation of the source code. Error spans within a trace are processed by Error Tracking __when they are located in the uppermost service span__, which is also called the _service entry span_.
 
-{{< img src="tracing/error_tracking/flamegraph_with_errors.png" alt="Flamegraph with errors"  >}}
+{{< img src="tracing/error_tracking/flamegraph_with_errors.png" alt="Flame graph with errors"  >}}
 
 Error Tracking computes a fingerprint for each error span it processes using the error type, the error message, and the frames that form the stack trace. Errors with the same fingerprint are grouped together and belong to the same _issue_.
 

--- a/content/en/tracing/generate_metrics/_index.md
+++ b/content/en/tracing/generate_metrics/_index.md
@@ -22,7 +22,7 @@ With Tracing without Limits™, you can generate metrics from 100% of ingested s
 
 You can pair these metrics with retention filters and Analytics monitors, or use them on their own.
 
-Use custom metrics for specific fixed queries and comparisons, while creating retention filters to allow arbitrary querying and investigation of the retained trace and its flamegraph.
+Use custom metrics for specific fixed queries and comparisons, while creating retention filters to allow arbitrary querying and investigation of the retained trace and its flame graph.
 
 **Billing Note:** Metrics created from ingested spans are billed as [Custom Metrics][2].
 

--- a/content/en/tracing/guide/add_span_md_and_graph_it.md
+++ b/content/en/tracing/guide/add_span_md_and_graph_it.md
@@ -235,9 +235,9 @@ The Trace table shows you both the overall latency distribution of all traces in
 
 3) **Click into one of your traces**
 
-{{< img src="tracing/guide/add_span_md_and_graph_it/span_md_4.png" alt="Flamegraph"  style="width:90%;">}}
+{{< img src="tracing/guide/add_span_md_and_graph_it/span_md_4.png" alt="Flame graph"  style="width:90%;">}}
 
-In this view you can see the **flamegraph** on top and the additional information windows beneath it. The Datadog flamegraph allows you to have an at a glance view of the duration and status of every logical unit (span) that impacts a request. The flamegraph is fully interactive and you can pan it (by dragging) or zoom in and out (by scrolling). Clicking on any span provides more information about that span in particular in the bottom part of the view.
+In this view you can see the **flame graph** on top and the additional information windows beneath it. The Datadog flame graph allows you to have an at a glance view of the duration and status of every logical unit (span) that impacts a request. The flame graph is fully interactive and you can pan it (by dragging) or zoom in and out (by scrolling). Clicking on any span provides more information about that span in particular in the bottom part of the view.
 
 The bottom part of the view includes additional information about the trace or any selected span. Here you can see all default tags as well as the ones you manually include. In addition to these, you can also switch to view associated Host and Log information.
 

--- a/content/en/tracing/guide/slowest_request_daily.md
+++ b/content/en/tracing/guide/slowest_request_daily.md
@@ -46,18 +46,18 @@ With Datadog APM, you can easily investigate the performance of your endpoints, 
 
 4. Set the time filter to `1d One Day`. Scroll down to the Traces table and **sort it by duration**, hover over over the top trace in the table and **click View Trace**
 
-    This is the Flamegraph and associated information. Here you can see the duration of each step in the trace and whether it is erroneous. This is useful in identifying slow components and error-prone ones. The Flamegraph can be zoomed, scrolled, and explored naturally. Under the Flamegraph you can see associated metadata, Logs, and Host information.
+    This is the Flame graph and associated information. Here you can see the duration of each step in the trace and whether it is erroneous. This is useful in identifying slow components and error-prone ones. The Flame graph can be zoomed, scrolled, and explored naturally. Under the Flame graph you can see associated metadata, Logs, and Host information.
 
-    The Flamegraph is a great way of identifying the precise piece of your stack that is erroneous or very latent. Errors are marked with red highlights and duration is represented by the horizontal length of the span, so very long spans are the slow ones. Learn more about using the Flamegraph in the [Trace View guide][6].
+    The Flame graph is a great way of identifying the precise piece of your stack that is erroneous or very latent. Errors are marked with red highlights and duration is represented by the horizontal length of the span, so very long spans are the slow ones. Learn more about using the Flame graph in the [Trace View guide][6].
 
-    Under the Flamegraph you can see all of the tags (including [custom ones][7]). From here you can also see associated logs (if you [connected Logs to your Traces][8]), see Host-level information such as CPU and memory usage.
+    Under the Flame graph you can see all of the tags (including [custom ones][7]). From here you can also see associated logs (if you [connected Logs to your Traces][8]), see Host-level information such as CPU and memory usage.
 
     {{< img src="tracing/guide/slowest_request_daily/slowest_trace_4.png" alt="Identifying the slowest trace and finding the bottleneck causing it"  style="width:90%;">}}
 
 5. **Click into the Host tab**, observe the CPU and memory performance of the underlying host while the request was hitting it.
 6. **Click Open Host Dashboard** to view all relevant data about the host
 
-Datadog APM seamlessly integrates with the other Datadog metrics and information - like infrastructure metrics and Logs. Using the Flamegraph, this information is available to you as well as any [custom metadata][7] you are sending with your traces.
+Datadog APM seamlessly integrates with the other Datadog metrics and information - like infrastructure metrics and Logs. Using the Flame graph, this information is available to you as well as any [custom metadata][7] you are sending with your traces.
 
 ## Further Reading
 

--- a/content/en/tracing/profiler/search_profiles.md
+++ b/content/en/tracing/profiler/search_profiles.md
@@ -42,7 +42,7 @@ The following measures are available:
 
 Click on a line to view a specific profile:
 
-{{< img src="tracing/profiling/profiling_flamegraph.gif" alt="A specic profile">}}
+{{< img src="tracing/profiling/profiling_flamegraph.gif" alt="A specific profile">}}
 
 The header contains information associated with your profile, like the service that generated it, or the environment and code version associated to it.
 

--- a/content/en/tracing/setup_overview/custom_instrumentation/java.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/java.md
@@ -148,7 +148,7 @@ if (span != null && (span instanceof MutableSpan)) {
 
 ## Adding spans
 
-If you aren’t using a [supported framework instrumentation][5], or you would like additional depth in your application’s [traces][3], you may want to add custom instrumentation to your code for complete flamegraphs or to measure execution times for pieces of code.
+If you aren’t using a [supported framework instrumentation][5], or you would like additional depth in your application’s [traces][3], you may want to add custom instrumentation to your code for complete flame graphs or to measure execution times for pieces of code.
 
 If modifying application code is not possible, use the environment variable `dd.trace.methods` to detail these methods.
 

--- a/content/en/tracing/visualization/_index.md
+++ b/content/en/tracing/visualization/_index.md
@@ -30,7 +30,7 @@ The APM UI provides many tools to troubleshoot application performance and corre
 | [Monitors][1]                   | APM metric monitors work like regular metric monitors, but with controls tailored specifically to APM. Use these monitors to receive alerts at the service level on hits, errors, and a variety of latency measures. |
 | [Trace](#trace)                 | A trace is used to track the time spent by an application processing a request and the status of this request. Each trace consists of one or more spans.                                                             |
 | [Span](#spans)                  | A span represents a logical unit of work in a distributed system for a given time period. Multiple spans construct a trace.                                                                                          |
-| [Service entry span](#service-entry-span) | A span is a service entry span when it is the entrypoint method for a request to a service. You can visualize this within Datadog APM when the color of the immediate parent on a flamegraph is a different color.                                                                                            |
+| [Service entry span](#service-entry-span) | A span is a service entry span when it is the entrypoint method for a request to a service. You can visualize this within Datadog APM when the color of the immediate parent on a flame graph is a different color.                                                                                            |
 | [Trace metrics](#trace-metrics) | Trace metrics are automatically collected and kept with a 15-month retention policy similar to other [Datadog metrics][2]. They can be used to identify and alert on hits, errors, or latency.                       |
 | [Indexed Span](#indexed-span) | Indexed Spans represent all spans indexed by retention filters or legacy App Analytics analyzed spans and can be used to search, query, and monitor in *Analytics*.                                                                                                |
 | [Span tags](#span-tags)         | Tag spans in the form of key-value pairs to correlate a request in the *Trace View* or filter in *Analytics*.                                                                                                    |
@@ -74,7 +74,7 @@ Resources represent a particular domain of a customer application. They could ty
 
 ## Trace
 
-A trace is used to track the time spent by an application processing a request and the status of this request. Each trace consists of one or more spans. During the lifetime of the request, you can see distributed calls across services (because a [trace-id is injected/extracted through HTTP headers][8]), [automatically instrumented libraries][3], and [manual instrumentation][9] using open-source tools like [OpenTracing][10] in the flamegraph view. In the Trace View page, each trace collects information that connects it to other parts of the platform, including [connecting logs to traces][11], [adding tags to spans][12], and [collecting runtime metrics][13].
+A trace is used to track the time spent by an application processing a request and the status of this request. Each trace consists of one or more spans. During the lifetime of the request, you can see distributed calls across services (because a [trace-id is injected/extracted through HTTP headers][8]), [automatically instrumented libraries][3], and [manual instrumentation][9] using open-source tools like [OpenTracing][10] in the flame graph view. In the Trace View page, each trace collects information that connects it to other parts of the platform, including [connecting logs to traces][11], [adding tags to spans][12], and [collecting runtime metrics][13].
 
 {{< img src="tracing/visualization/trace_view.png" alt="trace view" >}}
 
@@ -88,7 +88,7 @@ For the example below, the span `rack.request` is the entry-point span of the tr
 
 ## Service entry span
 
-A span is a service entry span when it is the entrypoint method for a request to a service. You can visualize this within Datadog APM when the color of the immediate parent on a flamegraph is a different color.  Services are also listed on the right when viewing a flamegraph.
+A span is a service entry span when it is the entrypoint method for a request to a service. You can visualize this within Datadog APM when the color of the immediate parent on a flame graph is a different color.  Services are also listed on the right when viewing a flame graph.
 
 For the example below, the service entry spans are:
 - rack.request


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
changes instances of `flamegraph` in docs text to `flame graph`

### Motivation
DOCS-1719

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/docs-1719-flame-graph/tracing/visualization/
https://docs-staging.datadoghq.com/kari/docs-1719-flame-graph/tracing/error_tracking/
https://docs-staging.datadoghq.com/kari/docs-1719-flame-graph/tracing/generate_metrics/
https://docs-staging.datadoghq.com/kari/docs-1719-flame-graph/tracing/guide/add_span_md_and_graph_it
https://docs-staging.datadoghq.com/kari/docs-1719-flame-graph/tracing/guide/slowest_request_daily
https://docs-staging.datadoghq.com/kari/docs-1719-flame-graph/tracing/profiler/search_profiles
https://docs-staging.datadoghq.com/kari/docs-1719-flame-graph/tracing/setup_overview/custom_instrumentation/java




### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
