### PR TITLE
DOCS-2303 - Move tracing api docs to tracing guide

### DIFF
--- a/content/en/tracing/guide/_index.md
+++ b/content/en/tracing/guide/_index.md
@@ -26,4 +26,5 @@ aliases:
     {{< nextlink href="tracing/guide/setting_primary_tags_to_scope/" >}}Setting Primary Tags To Scope{{< /nextlink >}}
     {{< nextlink href="tracing/guide/serverless_enable_aws_xray/" >}}Decide when to use Datadog APM and AWS X-Ray {{< /nextlink >}}
     {{< nextlink href="/tracing/guide/setting_up_apm_with_cpp/" >}}Setting Up APM with C++{{< /nextlink >}}
+    {{< nextlink href="/tracing/guide/send_traces_to_agent_by_api/" >}}Send Traces to the Agent by the Tracing API{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/tracing/guide/send_traces_to_agent_by_api.md
+++ b/content/en/tracing/guide/send_traces_to_agent_by_api.md
@@ -1,0 +1,121 @@
+---
+title: Send traces to the Agent by API
+kind: guide
+further_reading:
+  - link: '/tracing/'
+    tag: 'Documentation'
+    text: 'Learn about Datadog APM tracing'
+  - link: '/tracing/visualization/'
+    tag: 'Documentation'
+    text: 'APM Terminology and Overview'
+aliases:
+  - /api/latest/tracing/
+  - /api/v1/tracing/
+  - /api/v2/tracing/
+---
+
+Datadog APM allows you to collect performance metrics by tracing your code to determine which parts of your application are slow or inefficient.
+
+Tracing data is sent from your instrumented code to the Datadog Agent through an HTTP API. Datadog tracing libraries simplify sending metrics to the Datadog Agent. However you might want to interact directly with the API to instrument applications that cannot use the libraries or are written in languages that don’t yet have an official Datadog tracing library.
+
+The tracing API is an Agent API rather than a service side API. Submit your traces to the `http://localhost:8126/v0.3/traces` local endpoint so your Agent can forward them to Datadog.
+
+## Path
+
+{{< code-block lang="bash" >}}
+PUT http://localhost:8126/v0.3/traces
+{{< /code-block >}}
+
+## Request
+
+Traces can be sent as an array of traces:
+
+```
+[ trace1, trace2, trace3 ]
+```
+And each trace is an array of spans:
+
+```
+trace1 = [ span, span2, span3 ]
+```
+and each span is a dictionary with a `trace_id`, `span_id`, `resource` and so on. Each span within a trace should use the same `trace_id`. However, `trace_id` and span_id must have different values.
+
+### Model
+
+| Field      | Type    | Description                           |
+|------------|---------|---------------------------------------|
+| `duration`   | int64   | The duration of the request in nanoseconds. |
+| `error`      | int32   | Set this value to 1 to indicate if an error occurred. If an error occurs, you should pass additional information, such as the error message, type and stack information in the meta property. |
+| `meta`       | object  | A set of key-value metadata. Keys and values must be strings. |
+| - `<any-key>` | string | Additional properties for key-value metadata. |
+| metrics    | object  | A set of key-value metadata. Keys must be strings and values must be 64-bit floating point numbers. |
+| - `<any-key>` | double | Additional properties for key-value metrics. |
+| name       | string  | The span name. The span name must not be longer than 100 characters. |
+| `parent_id`  | int64   | The span integer ID of the parent span. |
+| `resource`   | string  | The resource you are tracing. The resource name must not be longer than 5000 characters. |
+| `service`    | string  | The service you are tracing. The service name must not be longer than 100 characters. |
+| `span_id`    | int64   | The span integer (64-bit unsigned) ID. |
+| `start`      | int64   | The start time of the request in nanoseconds from the UNIX epoch. |
+| `trace_id`   | int64   | The unique integer (64-bit unsigned) ID of the trace containing this span. |
+| `type`       | enum    | The type of request. Allowed enum values: `web`, `db`, `cache`, `custom` |
+
+
+### Example
+
+{{< code-block lang="json" >}}
+[
+  [
+    {
+      "duration": 12345,
+      "error": "integer",
+      "meta": {
+        "<any-key>": "string"
+      },
+      "metrics": {
+        "<any-key>": "number"
+      },
+      "name": "span_name",
+      "parent_id": "integer",
+      "resource": "/home",
+      "service": "service_name",
+      "span_id": 987654321,
+      "start": 0,
+      "trace_id": 123456789,
+      "type": "web"
+    }
+  ]
+]
+{{< /code-block >}}
+
+
+## Response
+
+200
+: OK
+
+### Example
+
+{{< code-block lang="curl" >}}
+# Curl command
+curl -X PUT "http://localhost:8126/v0.3/traces" \
+-H "Content-Type: application/json" \
+-d @- << EOF
+[
+  [
+    {
+      "duration": 12345,
+      "name": "span_name",
+      "resource": "/home",
+      "service": "service_name",
+      "span_id": 987654321,
+      "start": 0,
+      "trace_id": 123456789
+    }
+  ]
+]
+EOF
+{{< /code-block >}}
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
NOT NEW CONTENT. Migrates https://docs.datadoghq.com/api/latest/tracing/ to the tracing guides because we need to get rid of the warning that the PUT action isn't supported on any site. 

### Motivation
DOCS-2303

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/docs-2303-tracing-api/tracing/guide/send_traces_to_agent_by_api/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
