### PR TITLE
[SMI-366][SMI-328] Security notifications for HIPAA-compliant orgs

### DIFF
--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -42,7 +42,7 @@ These features are not available to customers who have signed Datadog's BAA:
 * You cannot [share][7] logs, security signals, or traces from the explorer through web integrations.
 * Security rules cannot include triggering group-by values in notification title.
 * Security rules cannot include message template variables.
-* Security rules cannot notify via webhooks.
+* Security rules cannot notify by webhooks.
 
 If you have any questions about how the Log Management Service satisfies the applicable requirements under HIPAA, contact your account manager.
 

--- a/content/en/security/logs.md
+++ b/content/en/security/logs.md
@@ -40,7 +40,9 @@ These features are not available to customers who have signed Datadog's BAA:
 * Notifications from Log Monitors cannot include log samples.
 * You cannot configure Log Monitors with a `group-by` clause.
 * You cannot [share][7] logs, security signals, or traces from the explorer through web integrations.
-* Security rules cannot send notifications.
+* Security rules cannot include triggering group-by values in notification title.
+* Security rules cannot include message template variables.
+* Security rules cannot notify via webhooks.
 
 If you have any questions about how the Log Management Service satisfies the applicable requirements under HIPAA, contact your account manager.
 


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This updates the documentation to reflect the new functionality for
HIPAA-compliant orgs: Notifications for security signals

### Motivation
<!-- What inspired you to submit this pull request?-->
Notifications for security signals (with the exception of webhooks) are now enabled for HIPAA-compliant orgs.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bjorn.marschollek/SMI-328/security/logs/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
