### PR TITLE
[rum] document missing data if page opened in background

### DIFF
--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -43,7 +43,9 @@ RUM view events collect extensive performance metrics for every single page view
 | [First Input Delay][6]        | Interactivity    | Time elapsed between a user’s first interaction with the page and the browser’s response.             | <100ms      |
 | [Cumulative Layout Shift][7]  | Visual stability | Quantifies unexpected page movement due to dynamically loaded content (for example, third-party ads) where 0 means no shifts happening. | <0.1        |
 
-**Note**: Metrics collected from your real users page views can differ from those calculated for pages loaded in a fixed environment like [Synthetics Browser tests][8].
+**Notes**:
+- First Input Delay and Largest Contentful Paint are not collected for pages opened in background (i.e. new tab or window without focus).
+- Metrics collected from your real users page views can differ from those calculated for pages loaded in a fixed environment like [Synthetics Browser tests][8].
 
 ### All performance metrics
 

--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -44,7 +44,7 @@ RUM view events collect extensive performance metrics for every single page view
 | [Cumulative Layout Shift][7]  | Visual stability | Quantifies unexpected page movement due to dynamically loaded content (for example, third-party ads) where 0 means no shifts happening. | <0.1        |
 
 **Notes**:
-- First Input Delay and Largest Contentful Paint are not collected for pages opened in background (i.e. new tab or window without focus).
+- First Input Delay and Largest Contentful Paint are not collected for pages opened in the background (for example, in a new tab or a window without focus).
 - Metrics collected from your real users page views can differ from those calculated for pages loaded in a fixed environment like [Synthetics Browser tests][8].
 
 ### All performance metrics


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* Added a note about missing FID and LCP in the case of background tab/window.

### Motivation
<!-- What inspired you to submit this pull request?-->
* Feedback collected on public slack

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hdelaby/background-no-data/real_user_monitoring/browser/monitoring_page_performance/#core-web-vitals

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
