### PR TITLE
Update Agent docs to mention the datadog-signing-keys package

### DIFF
--- a/content/en/agent/iot/_index.md
+++ b/content/en/agent/iot/_index.md
@@ -87,7 +87,7 @@ To manually install the IoT Agent on Debian-based operating systems, run the fol
 4. Update `apt` and install the IoT Agent:
     ```bash
     sudo apt-get update
-    sudo apt-get install datadog-iot-agent
+    sudo apt-get install datadog-iot-agent datadog-signing-keys
     ```
 
 5. Copy the example config and plug in your API key:

--- a/content/en/agent/versions/upgrade_to_agent_v6.md
+++ b/content/en/agent/versions/upgrade_to_agent_v6.md
@@ -198,7 +198,7 @@ Find below the manual upgrade instructions for:
 4. Update your local APT cache and install the Agent:
     ```
     sudo apt-get update
-    sudo apt-get install datadog-agent
+    sudo apt-get install datadog-agent datadog-signing-keys
     ```
 
 5. Copy the example configuration into place and plug in your API key:
@@ -328,7 +328,7 @@ Find below the manual upgrade instructions for:
 4. Update your local APT cache and install the Agent:
     ```
     sudo apt-get update
-    sudo apt-get install datadog-agent
+    sudo apt-get install datadog-agent datadog-signing-keys
     ```
 
 5. Copy the example configuration into place and plug in your API key:

--- a/content/en/security/agent.md
+++ b/content/en/security/agent.md
@@ -32,7 +32,7 @@ The official repositories and/or binary packages of the Agent are signed. Verify
 - MacOS PKG:
   - Apple certificate fingerprint `FDD2ADF623EA75E62C6DC6DBFBA7520CA549AB7314E660D78B0E3DCCF15B2FBA`
 
-On Debian and Ubuntu the `datadog-agent` package has a soft-dependency on the `datadog-signing-keys` package, which will make the above keys trusted by APT. Keeping the package updated will ensure the latest signing keys are present on your system.
+On Debian and Ubuntu, the `datadog-agent` package has a soft dependency on the `datadog-signing-keys` package, which makes the above keys trusted by APT. Keeping the package updated ensures the latest signing keys are present on your system.
 
 ## Information security
 

--- a/content/en/security/agent.md
+++ b/content/en/security/agent.md
@@ -32,6 +32,8 @@ The official repositories and/or binary packages of the Agent are signed. Verify
 - MacOS PKG:
   - Apple certificate fingerprint `FDD2ADF623EA75E62C6DC6DBFBA7520CA549AB7314E660D78B0E3DCCF15B2FBA`
 
+On Debian and Ubuntu the `datadog-agent` package has a soft-dependency on the `datadog-signing-keys` package, which will make the above keys trusted by APT. Keeping the package updated will ensure the latest signing keys are present on your system.
+
 ## Information security
 
 The Datadog Agent submits data to Datadog over a TLS-encrypted TCP connection by default. As of version 6, the Agent can be configured to enforce TLS 1.2 when connecting to Datadog. Customers who require the use of "strong cryptography," for example, to meet PCI requirements, should use Agent v6 and set the `force_tls_12: true` setting in the Agent's configuration file.

--- a/content/fr/agent/versions/upgrade_to_agent_v6.md
+++ b/content/fr/agent/versions/upgrade_to_agent_v6.md
@@ -173,7 +173,7 @@ Vous trouverez ci-dessous les instructions d'installation manuelle pour :
 3. Mettez à jour votre cache APT local et installez l'Agent :
     ```
     sudo apt-get update
-    sudo apt-get install datadog-agent
+    sudo apt-get install datadog-agent datadog-signing-keys
     ```
 
 4. Copiez l'exemple de configuration à l'emplacement adéquat et spécifiez votre clé d'API :
@@ -292,7 +292,7 @@ Vous trouverez ci-dessous les instructions d'installation manuelle pour :
 3. Mettez à jour votre cache APT local et installez l'Agent :
     ```
     sudo apt-get update
-    sudo apt-get install datadog-agent
+    sudo apt-get install datadog-agent datadog-signing-keys
     ```
 
 4. Copiez l'exemple de configuration à l'emplacement adéquat et spécifiez votre clé d'API :

--- a/content/ja/agent/versions/upgrade_to_agent_v6.md
+++ b/content/ja/agent/versions/upgrade_to_agent_v6.md
@@ -197,7 +197,7 @@ DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/ins
 4. ローカルの APT キャッシュを更新し、Agent をインストールします。
     ```
     sudo apt-get update
-    sudo apt-get install datadog-agent
+    sudo apt-get install datadog-agent datadog-signing-keys
     ```
 
 5. 構成サンプルを所定の位置にコピーし、適切な API キーを指定します。
@@ -327,7 +327,7 @@ DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/ins
 4. ローカルの APT キャッシュを更新し、Agent をインストールします。
     ```
     sudo apt-get update
-    sudo apt-get install datadog-agent
+    sudo apt-get install datadog-agent datadog-signing-keys
     ```
 
 5. 構成サンプルを所定の位置にコピーし、適切な API キーを指定します。


### PR DESCRIPTION
### What does this PR do?
Mention the new `datadog-signing-keys` package in the Agent Security and Agent Upgrade docs.

### Motivation
We recently added the datadog-signing-keys package.

### Preview
https://docs-staging.datadoghq.com/albertvaka/add-datadog-signing-keys/security/agent/
https://docs-staging.datadoghq.com/albertvaka/add-datadog-signing-keys/agent/versions/upgrade_to_agent_v6/