### PR TITLE
docs-1697 add rum as prereq

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -10,7 +10,7 @@ further_reading:
   text: "Official repository of the Datadog CLI"
 - link: "/real_user_monitoring/guide/upload-javascript-source-maps"
   tag: "Guide"
-  text: "Upload javascript source maps"
+  text: "Upload Javascript source maps"
 - link: "https://app.datadoghq.com/error-tracking"
   tag: "UI"
   text: "Error tracking"

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -14,6 +14,8 @@ further_reading:
 
 If your front-end Javascript source code is minified, you will need to upload your source maps to Datadog so that we are able to deobfuscate your different stack traces. For a given error, you will then get access to the file path, the line number, as well as a code snippet for each frame of the related stack trace.
 
+<div class="alert alert-info"><strong>Note</strong>: Only errors collected by <a href="/real_user_monitoring/">Real User Monitoring (RUM)</a> can be unminified and processed by <a href="/real_user_monitoring/error_tracking/">Error Tracking</a>.</div>
+
 ## Instrument your code
 You must configure your Javascript bundler so that, when minifying your source code, it generates source maps which directly include the related source code in the `sourcesContent` attribute. In addition, ensure that the size of each source map augmented with the size of the related minified file does not exceed __our limit of 50MB__. Check below for some configurations for popular Javascript bundlers.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Mentions that RUM is a prereq to doing this guide, and adds links

### Motivation
https://datadoghq.atlassian.net/browse/DOCS-1697

### Preview

https://docs-staging.datadoghq.com/kari/docs-1697-rum-prereq/real_user_monitoring/guide/upload-javascript-source-maps

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
