### PR TITLE
Update parsing.md

### DIFF
--- a/content/en/logs/log_configuration/parsing.md
+++ b/content/en/logs/log_configuration/parsing.md
@@ -61,6 +61,7 @@ After processing, the following structured log is generated:
 * Properties with null or empty values are not displayed.
 * A full list of regular expression syntax accepted by the Agent is available in the [RE2 repo][1].
 * The regex matcher applies an implicit `^`, to match the start of a string, and `$`, to match the end of a string.
+* Certain logs can produce large gaps of whitespace. Use `\n` and `\s+` to account for newlines and whitespace.
 
 ### Matcher and filter
 


### PR DESCRIPTION
### What does this PR do?
Adds a note that certain logs can produce large gaps of whitespace, and to account for that space with regex.

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/sarina/logs-regex-note/logs/log_configuration/parsing

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
