### PR TITLE
Update metric monitor maximum time range

### DIFF
--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -108,7 +108,7 @@ The alert conditions vary slightly based on the chosen detection method.
 
 * Trigger when the metric is `above`, `above or equal to`, `below`, or `below or equal to`
 * the threshold `on average`, `at least once`, `at all times`, or `in total`
-* during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between 1 minute and 48 hours.
+* during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between 1 minute and 168 hours.
 
 **Definitions**:
 


### PR DESCRIPTION
### What does this PR do?
Document the maximum timeframe that can be used in Metric monitors.

### Motivation
The limit has been increased.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/metric-monitor-timerange/monitors/monitor_types/metric/?tab=threshold#set-alert-conditions

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
