### PR TITLE
Add details for TCP log collection

### DIFF
--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -90,7 +90,7 @@ logs:
 
 If you are using Serilog, `Serilog.Sinks.Network` is an option for connecting with UDP.
 
-As of Agent version 7.31.0, the Agent keeps a TCP connection open indefinitely.
+In the Agent version 7.31.0+, the TCP connection stays open indefinitely even when idle.
 
 **Note**: The Agent supports raw string, JSON, and Syslog formatted logs. If you are sending logs in batch, use line break characters to separate your logs.
 

--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -78,7 +78,7 @@ logs:
 
 {{% tab "TCP/UDP" %}}
 
-To gather logs from your `<APP_NAME>` application that forwards its logs with TCP over port **10518**, create a `<APP_NAME>.d/conf.yaml` file at the root of your [Agent's configuration directory][1] with the following content:
+To gather logs from your `<APP_NAME>` application that forwards its logs with to TCP port **10518**, create a `<APP_NAME>.d/conf.yaml` file at the root of your [Agent's configuration directory][1] with the following content:
 
 ```yaml
 logs:
@@ -89,6 +89,10 @@ logs:
 ```
 
 If you are using Serilog, `Serilog.Sinks.Network` is an option for connecting with UDP.
+
+As of Agent version 7.31.0, the agent will keep a TCP connection open indefinitely.
+Previous versions closed conections after 60 seconds without log messages.
+On connection failure, your application should re-connect to the agent.
 
 **Note**: The Agent supports raw string, JSON, and Syslog formatted logs. If you are sending logs in batch, use line break characters to separate your logs.
 

--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -91,8 +91,6 @@ logs:
 If you are using Serilog, `Serilog.Sinks.Network` is an option for connecting with UDP.
 
 As of Agent version 7.31.0, the Agent keeps a TCP connection open indefinitely.
-Previous versions closed conections after 60 seconds without log messages.
-On connection failure, your application should reconnect to the Agent.
 
 **Note**: The Agent supports raw string, JSON, and Syslog formatted logs. If you are sending logs in batch, use line break characters to separate your logs.
 

--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -78,7 +78,7 @@ logs:
 
 {{% tab "TCP/UDP" %}}
 
-To gather logs from your `<APP_NAME>` application that forwards its logs with to TCP port **10518**, create a `<APP_NAME>.d/conf.yaml` file at the root of your [Agent's configuration directory][1] with the following content:
+To gather logs from your `<APP_NAME>` application that forwards its logs to TCP port **10518**, create a `<APP_NAME>.d/conf.yaml` file at the root of your [Agent's configuration directory][1] with the following content:
 
 ```yaml
 logs:
@@ -90,9 +90,9 @@ logs:
 
 If you are using Serilog, `Serilog.Sinks.Network` is an option for connecting with UDP.
 
-As of Agent version 7.31.0, the agent will keep a TCP connection open indefinitely.
+As of Agent version 7.31.0, the Agent keeps a TCP connection open indefinitely.
 Previous versions closed conections after 60 seconds without log messages.
-On connection failure, your application should re-connect to the agent.
+On connection failure, your application should reconnect to the Agent.
 
 **Note**: The Agent supports raw string, JSON, and Syslog formatted logs. If you are sending logs in batch, use line break characters to separate your logs.
 


### PR DESCRIPTION
### What does this PR do?

The behavior of the TCP log collection support has changed: it no longer
disconnects idle connections after 60s.  This behavior was not
documented.

This change adds documentation for the new behavior, even though it
matches the behavior a user might assume.  It also suggests
re-connecting on connection failure, as a reminder that TCP connections
in general are not failure-proof.

### Preview
https://docs-staging.datadoghq.com/dustin.mitchell/ac-76/agent/logs/?tab=tailfiles

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
