### PR TITLE
Adjust Vale message about vague link text 

### DIFF
--- a/.github/styles/Datadog/links.yml
+++ b/.github/styles/Datadog/links.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: "Avoid vague link text like '%s'."
+message: "Avoid vague link text like '%s' (ignore this error if you have other descriptive words along with '%s')."
 link: 'https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#links'
 ignorecase: true
 scope: link


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Changes the error message for vague link text, for when the flagged word is merely _part_ of the link text, not the whole text. That is, you should be able to say `see the [Profiler documentation][x]`.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
