### PR TITLE
Docs change for replacement API for get_correlation_ids

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/python.md
+++ b/content/en/tracing/connect_logs_and_traces/python.md
@@ -69,9 +69,7 @@ from ddtrace import tracer
 import structlog
 
 def tracer_injection(logger, log_method, event_dict):
-    # get correlation ids from current tracer context
-    log_correlation_context = tracer.get_log_correlation_context()
-    
+    # add current tracer logging context into log event dict 
     event_dict["dd"] = log_correlation_context
     return event_dict
 


### PR DESCRIPTION
### What does this PR do?
Updates the custom logging instrumentation docs with the new replacement API for `get_correlation_ids()`, which is `ddtrace.tracer.get_log_correlation_context()`.

### Motivation
Update to dd-trace-py's public API

### Preview
https://docs-staging.datadoghq.com/yunkim/get-logs-correlation-context/tracing/connect_logs_and_traces/python/

### Additional Notes
Should not be merged until the replacement API PR has been merged: https://github.com/DataDog/dd-trace-py/pull/2654

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
