### PR TITLE
[CIAPP-2521] Update version of CircleCI Orb

### DIFF
--- a/content/en/continuous_integration/setup_tests/agent.md
+++ b/content/en/continuous_integration/setup_tests/agent.md
@@ -227,7 +227,7 @@ For example:
 version: 2.1
 
 orbs:
-  datadog-agent: datadog/agent@0.0.1
+  datadog-agent: datadog/agent@0
 
 jobs:
   test:
@@ -250,7 +250,7 @@ workflows:
 version: 2.1
 
 orbs:
-  datadog-agent: datadog/agent@0.0.1
+  datadog-agent: datadog/agent@0
 
 jobs:
   test:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Changes the CircleCI Orb version to `0` so the user automatically gets the latest non-breaking version of the orb on each execution.

### Motivation
<!-- What inspired you to submit this pull request?-->

Released a new version of the orb (0.0.2). Instead of updating this every time there's a new minor/patch release, with this change we will support this new release and any future releases.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fermayo/ciapp-update-circleci-orb-version/continuous_integration/setup_tests/agent

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
