### PR TITLE
Removing alert for SLO status corrections so the links work

### DIFF
--- a/content/en/monitors/service_level_objectives/_index.md
+++ b/content/en/monitors/service_level_objectives/_index.md
@@ -164,15 +164,13 @@ After creating your SLO, you can use the SLO Summary dashboard widget to visuali
 
 ## SLO status corrections
 
-Status corrections allow you to specify time periods such as planned maintenance that an SLO excludes from its status and error budget calculations.
+Status corrections allow you to specify time periods such as planned maintenance that an SLO excludes from its status and error budget calculations. 
 
 When you create a correction window for an SLO, the time period you specify is removed from the SLO’s calculation. 
 - For monitor-based SLOs, time in the correction window is not counted.
 - For metric-based SLOs, all good and bad events in the correction window are not counted.
 
-<div class="alert alert-warning">
-Status corrections are in public beta. See the [SLO status corrections API][12], [Terraform][13], and the UI.
-</div>
+Status corrections are in public beta through the [SLO status corrections API][12], [Terraform][13], and the UI.
 
 #### Access in the UI 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Removes the alert for the public beta of SLO status corrections so the links work instead of showing up as text.

### Motivation
<!-- What inspired you to submit this pull request?-->
Noticed alert didn't allow for links

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/sophiah123/statuscorrectionsuidoc/monitors/service_level_objectives/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
