### PR TITLE
[CIAPP-2540] Add buildkite CI app integration docs

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1819,6 +1819,11 @@ main:
     parent: setup_pipelines
     identifier: ci_jenkins
     weight: 202
+  - name: Buildkite
+    url: continuous_integration/setup_pipelines/buildkite/
+    parent: setup_pipelines
+    identifier: ci_buildkite
+    weight: 203
   - name: Exploring Tests
     url: continuous_integration/explore_tests/
     parent: ci

--- a/content/en/continuous_integration/setup_pipelines/_index.md
+++ b/content/en/continuous_integration/setup_pipelines/_index.md
@@ -8,6 +8,7 @@ disable_sidebar: true
 {{< whatsnext desc="CI pipelines providers:" >}}
     {{< nextlink href="continuous_integration/setup_pipelines/gitlab" >}}GitLab{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_pipelines/jenkins" >}}Jenkins{{< /nextlink >}}
+    {{< nextlink href="continuous_integration/setup_pipelines/buildkite" >}}Buildkite{{< /nextlink >}}
 {{< /whatsnext >}}
 
  

--- a/content/en/continuous_integration/setup_pipelines/buildkite.md
+++ b/content/en/continuous_integration/setup_pipelines/buildkite.md
@@ -11,41 +11,42 @@ further_reading:
 ---
 
 {{< site-region region="us,eu" >}}
-## Configuring the Datadog integration
+## Configure the Datadog integration
 
 The Datadog integration for [Buildkite][2] works by using [webhooks][1] to send pipeline data to Datadog.
 
-Go to **Settings > Notification Services** in Buildkite and add a new webhook:
-
 {{< site-region region="us" >}}
-* **Webhook URL**: `https://webhook-intake.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
-* **Events**: Select `job.finished` and `build.finished`.
-* **Pipelines**: Select all pipelines or the subset of pipelines you want to trace.
+1. Go to **Settings > Notification Services** in Buildkite and add a new webhook:
+   * **Webhook URL**: `https://webhook-intake.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
+   * **Events**: Select `job.finished` and `build.finished`.
+   * **Pipelines**: Select all pipelines or the subset of pipelines you want to trace.
 
 [1]: https://app.datadoghq.com/organization-settings/api-keys
 {{< /site-region >}}
 
 {{< site-region region="eu" >}}
-* **Webhook URL**: `https://webhook-intake.datadoghq.eu/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
-* **Events**: Select `job.finished` and `build.finished`.
-* **Pipelines**: Select all pipelines or the subset of pipelines you want to trace.
+1. Go to **Settings > Notification Services** in Buildkite and add a new webhook:
+   * **Webhook URL**: `https://webhook-intake.datadoghq.eu/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
+   * **Events**: Select `job.finished` and `build.finished`.
+   * **Pipelines**: Select all pipelines or the subset of pipelines you want to trace.
 
 [1]: https://app.datadoghq.eu/organization-settings/api-keys
 {{< /site-region >}}
 
-Afterwards click on the **Add Webhook Notification** button to save the new webhook.
+2. Click **Add Webhook Notification** to save the new webhook.
 
 ## Visualize pipeline data in Datadog
 
 {{< site-region region="us" >}}
-After the integration is successfully configured, the [Pipelines][1] and [Pipeline Executions][2] pages populate with data after the pipelines finish.
+The [Pipelines][1] and [Pipeline Executions][2] pages populate with data after the pipelines finish.
 
 [1]: https://app.datadoghq.com/ci/pipelines
 [2]: https://app.datadoghq.com/ci/pipeline-executions
 {{< /site-region >}}
 
 {{< site-region region="eu" >}}
-After the integration is successfully configured, the [Pipelines][1] and [Pipeline Executions][2] pages populate with data after the pipelines finish.
+
+The [Pipelines][1] and [Pipeline Executions][2] pages populate with data after the pipelines finish.
 
 [1]: https://app.datadoghq.eu/ci/pipelines
 [2]: https://app.datadoghq.eu/ci/pipeline-executions
@@ -63,5 +64,5 @@ After the integration is successfully configured, the [Pipelines][1] and [Pipeli
 {{< /site-region >}}
 
 {{< site-region region="us3,gov" >}}
-The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported at this time.
+This feature is not supported for the selected Datadog site ({{< region-param key="dd_site_name" >}}).
 {{< /site-region >}}

--- a/content/en/continuous_integration/setup_pipelines/buildkite.md
+++ b/content/en/continuous_integration/setup_pipelines/buildkite.md
@@ -33,6 +33,8 @@ Go to **Settings > Notification Services** in Buildkite and add a new webhook:
 [1]: https://app.datadoghq.eu/organization-settings/api-keys
 {{< /site-region >}}
 
+Afterwards click on the **Add Webhook Notification** button to save the new webhook.
+
 ## Visualize pipeline data in Datadog
 
 {{< site-region region="us" >}}

--- a/content/en/continuous_integration/setup_pipelines/buildkite.md
+++ b/content/en/continuous_integration/setup_pipelines/buildkite.md
@@ -1,0 +1,65 @@
+---
+title: Set up Tracing on a Buildkite Pipeline
+kind: documentation
+further_reading:
+    - link: "/continuous_integration/explore_pipelines"
+      tag: "Documentation"
+      text: "Explore Pipeline Execution Results and Performance"
+    - link: "/continuous_integration/troubleshooting/"
+      tag: "Documentation"
+      text: "Troubleshooting CI"
+---
+
+{{< site-region region="us,eu" >}}
+## Configuring the Datadog integration
+
+The Datadog intragration for Buildkite works by using [webhooks][1] to send pipeline data to Datadog.
+
+Go to **Settings > Notificaton Services** in Buildkite and add a new webhook:
+
+{{< site-region region="us" >}}
+* **Webhook URL**: `https://webhooks-http-intake.logs.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
+* **Events**: Select `job.finished` and `build.finished`.
+* **Pipelines**: Select all pipelines or the subset of pipelines you want to trace.
+
+[1]: https://app.datadoghq.com/account/settings#api
+{{< /site-region >}}
+
+{{< site-region region="eu" >}}
+* **Webhook URL**: `https://webhooks-http-intake.logs.datadoghq.eu/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
+* **Events**: Select `job.finished` and `build.finished`.
+* **Pipelines**: Select all pipelines or the subset of pipelines you want to trace.
+
+[1]: https://app.datadoghq.eu/account/settings#api
+{{< /site-region >}}
+
+To set custom `env` or `service` parameters, add more query parameters in the webhooks URL: `&env=<YOUR_ENV>&service=<YOUR_SERVICE_NAME>`.
+
+## Visualize pipeline data in Datadog
+
+{{< site-region region="us" >}}
+After the integration is successfully configured, the [Pipelines][1] and [Pipeline Executions][2] pages populate with data after the pipelines finish.
+
+[1]: https://app.datadoghq.com/ci/pipelines
+[2]: https://app.datadoghq.com/ci/pipeline-executions
+{{< /site-region >}}
+
+{{< site-region region="eu" >}}
+After the integration is successfully configured, the [Pipelines][1] and [Pipeline Executions][2] pages populate with data after the pipelines finish.
+
+[1]: https://app.datadoghq.eu/ci/pipelines
+[2]: https://app.datadoghq.eu/ci/pipeline-executions
+{{< /site-region >}}
+
+**Note**: The Pipelines page shows data for only the default branch of each repository.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+{{< site-region region="us3,gov" >}}
+The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported at this time.
+{{< /site-region >}}
+
+[1]: https://buildkite.com/docs/apis/webhooks
+{{< /site-region >}}

--- a/content/en/continuous_integration/setup_pipelines/buildkite.md
+++ b/content/en/continuous_integration/setup_pipelines/buildkite.md
@@ -22,7 +22,7 @@ Go to **Settings > Notification Services** in Buildkite and add a new webhook:
 * **Events**: Select `job.finished` and `build.finished`.
 * **Pipelines**: Select all pipelines or the subset of pipelines you want to trace.
 
-[1]: https://app.datadoghq.com/account/settings#api
+[1]: https://app.datadoghq.com/organization-settings/api-keys
 {{< /site-region >}}
 
 {{< site-region region="eu" >}}
@@ -30,10 +30,11 @@ Go to **Settings > Notification Services** in Buildkite and add a new webhook:
 * **Events**: Select `job.finished` and `build.finished`.
 * **Pipelines**: Select all pipelines or the subset of pipelines you want to trace.
 
-[1]: https://app.datadoghq.eu/account/settings#api
+[1]: https://app.datadoghq.eu/organization-settings/api-keys
 {{< /site-region >}}
 
 To set custom `env` or `service` parameters, add more query parameters in the webhooks URL: `&env=<YOUR_ENV>&service=<YOUR_SERVICE_NAME>`.
+This tags are reserved by Data Dog and are used to tie telemetry together across the different products. See [Unified Service Tagging][3] for more information.
 
 ## Visualize pipeline data in Datadog
 
@@ -59,6 +60,7 @@ After the integration is successfully configured, the [Pipelines][1] and [Pipeli
 
 [1]: https://buildkite.com/docs/apis/webhooks
 [2]: https://buildkite.com
+[3]: /getting_started/tagging/unified_service_tagging
 {{< /site-region >}}
 
 {{< site-region region="us3,gov" >}}

--- a/content/en/continuous_integration/setup_pipelines/buildkite.md
+++ b/content/en/continuous_integration/setup_pipelines/buildkite.md
@@ -18,7 +18,7 @@ The Datadog integration for [Buildkite][2] works by using [webhooks][1] to send 
 Go to **Settings > Notification Services** in Buildkite and add a new webhook:
 
 {{< site-region region="us" >}}
-* **Webhook URL**: `https://webhooks-http-intake.logs.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
+* **Webhook URL**: `https://webhook-intake.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
 * **Events**: Select `job.finished` and `build.finished`.
 * **Pipelines**: Select all pipelines or the subset of pipelines you want to trace.
 

--- a/content/en/continuous_integration/setup_pipelines/buildkite.md
+++ b/content/en/continuous_integration/setup_pipelines/buildkite.md
@@ -26,7 +26,7 @@ Go to **Settings > Notification Services** in Buildkite and add a new webhook:
 {{< /site-region >}}
 
 {{< site-region region="eu" >}}
-* **Webhook URL**: `https://webhooks-http-intake.logs.datadoghq.eu/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
+* **Webhook URL**: `https://webhook-intake.datadoghq.eu/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
 * **Events**: Select `job.finished` and `build.finished`.
 * **Pipelines**: Select all pipelines or the subset of pipelines you want to trace.
 

--- a/content/en/continuous_integration/setup_pipelines/buildkite.md
+++ b/content/en/continuous_integration/setup_pipelines/buildkite.md
@@ -33,9 +33,6 @@ Go to **Settings > Notification Services** in Buildkite and add a new webhook:
 [1]: https://app.datadoghq.eu/organization-settings/api-keys
 {{< /site-region >}}
 
-To set custom `env` or `service` parameters, add more query parameters in the webhooks URL: `&env=<YOUR_ENV>&service=<YOUR_SERVICE_NAME>`.
-This tags are reserved by Data Dog and are used to tie telemetry together across the different products. See [Unified Service Tagging][3] for more information.
-
 ## Visualize pipeline data in Datadog
 
 {{< site-region region="us" >}}

--- a/content/en/continuous_integration/setup_pipelines/buildkite.md
+++ b/content/en/continuous_integration/setup_pipelines/buildkite.md
@@ -13,9 +13,9 @@ further_reading:
 {{< site-region region="us,eu" >}}
 ## Configuring the Datadog integration
 
-The Datadog intragration for Buildkite works by using [webhooks][1] to send pipeline data to Datadog.
+The Datadog integration for [Buildkite][2] works by using [webhooks][1] to send pipeline data to Datadog.
 
-Go to **Settings > Notificaton Services** in Buildkite and add a new webhook:
+Go to **Settings > Notification Services** in Buildkite and add a new webhook:
 
 {{< site-region region="us" >}}
 * **Webhook URL**: `https://webhooks-http-intake.logs.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
@@ -57,9 +57,10 @@ After the integration is successfully configured, the [Pipelines][1] and [Pipeli
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-{{< site-region region="us3,gov" >}}
-The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported at this time.
+[1]: https://buildkite.com/docs/apis/webhooks
+[2]: https://buildkite.com
 {{< /site-region >}}
 
-[1]: https://buildkite.com/docs/apis/webhooks
+{{< site-region region="us3,gov" >}}
+The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported at this time.
 {{< /site-region >}}


### PR DESCRIPTION
### What does this PR do?
Add documentation on how to use the CI Visibility product with Buildkite.

### Motivation

### Preview
https://docs-staging.datadoghq.com/carlos.gonzalez/add-buildkite-integration-docs/continuous_integration/setup_pipelines/buildkite

https://docs-staging.datadoghq.com/carlos.gonzalez/add-buildkite-integration-docs/continuous_integration/setup_pipelines
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
