### PR TITLE
Remove 'DNS is not supported' note for Windows

### DIFF
--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -200,7 +200,7 @@ To enable Network Performance Monitoring for Windows hosts:
     ```shell
     net /y stop datadogagent && net start datadogagent
     ```
-**Note**: Network Performance Monitoring monitors Windows hosts only, and not Windows containers. DNS metric collection is not supported for Windows systems.
+**Note**: Network Performance Monitoring monitors Windows hosts only, and not Windows containers. 
 
 
 [1]: /agent/basic_agent_usage/windows/?tab=commandline


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes old note about DNS metric collection not being supported for Windows. 

### Motivation
This is no longer accurate. 

### Preview
https://docs-staging.datadoghq.com/yael/dns_update/content/en/network_monitoring/performance/setup.md

### Additional Notes
You can merge asap. 
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
