### PR TITLE
CI-app - Swift - Add documentation about adding custom tags

### DIFF
--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -236,36 +236,38 @@ For Network auto-instrumentation, you can configure these additional settings:
 
 You can also disable or enable specific auto-instrumentation in some of the tests from Swift or Objective-C by importing the module `DatadogSDKTesting` and using the class: `DDInstrumentationControl`.
 
-## Adding custom tags
+## Custom tags
 
-### Using environment variables
+### Environment variables
 
 You can use `DD_TAGS` environment variable. It must contain pairs of `key:tag` separated by spaces. For example:
 {{< code-block lang="bash" >}}
-DDTAGS=tag-key-0:tag-value-0 tag-key-1:tag-value-1
+DD_TAGS=tag-key-0:tag-value-0 tag-key-1:tag-value-1
 {{< /code-block >}}
 
-If one of the values starts with the `$` character, it will be replaced with the environment variable with the same name if it exists, example:
+If one of the values starts with the `$` character, it is replaced with an environment variable of the same name (if it exists), for example:
 {{< code-block lang="bash" >}}
-DDTAGS=home:$HOME
+DD_TAGS=home:$HOME
 {{< /code-block >}}
 
-It also supports replacing a environment variable at the beggining of the value if contains non env variables supported characters (`a-z`,  `A-Z` or `_`):
+Using the `$` character also supports replacing an environment variable at the beginning of a value if contains non-environment variable supported characters (`a-z`,  `A-Z` or `_`), for example:
 {{< code-block lang="bash" >}}
 FOO = BAR
 DD_TAGS=key1:$FOO-v1 // expected: key1:BAR-v1
 {{< /code-block >}}
 
-### Using OpenTelemetry (only for Swift, Objective-C not supported)
+### OpenTelemetry
 
-Datadog swift testing framework uses [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-swift) as the tracing technology under the hood. You can access the OpenTelemetry tracer using `DDInstrumentationControl.openTelemetryTracer` and can use any OpenTelemetry api. For example, for adding a tag/attribute
+**Note**: Using OpenTelemetry is only supported for Swift.
+
+Datadog Swift testing framework uses [OpenTelemetry][2] as the tracing technology under the hood. You can access the OpenTelemetry tracer using `DDInstrumentationControl.openTelemetryTracer` and use any OpenTelemetry API. For example, to add a tag or attribute:
 
 {{< code-block lang="swift" >}}
 let tracer = DDInstrumentationControl.openTelemetryTracer
 tracer?.activeSpan?.setAttribute(key: "OTelTag", value: "OTelValue")
 {{< /code-block >}}
 
-Test target needs to link explicitly with `opentelemetry-swift`
+The test target needs to link explicitly with `opentelemetry-swift`.
 
 ## CI provider environment variables
 

--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -120,36 +120,47 @@ The user can also provide Git information by using custom environment variables.
 
 `DD_GIT_REPOSITORY_URL`
 : URL of the repository where the code is stored.
+**Example**: `git@github.com:MyCompany/MyApp.git`
 
 `DD_GIT_BRANCH`
 : Branch where this commit belongs.
+**Example**: `develop`
 
 `DD_GIT_TAG`
 : Tag of the commit, if it has one.
+**Example**: `1.0.1`
 
 `DD_GIT_COMMIT_SHA`
 : Commit SHA.
+**Example**: `a18ebf361cc831f5535e58ec4fae04ffd98d8152`
 
 `DD_GIT_COMMIT_MESSAGE`
 : Commit message.
+**Example**: `Set release number`
 
 `DD_GIT_COMMIT_AUTHOR_NAME`
 : Author name.
+**Example**: `John Doe`
 
 `DD_GIT_COMMIT_AUTHOR_EMAIL`
 : Author email.
+**Example**: `john@doe.com`
 
 `DD_GIT_COMMIT_AUTHOR_DATE`
 : Author date. ISO 8601 format.
+**Example**: `2021-03-12T16:00:28Z`
 
 `DD_GIT_COMMIT_COMMITTER_NAME`
 : Committer name.
+**Example**: `Jane Doe`
 
 `DD_GIT_COMMIT_COMMITTER_EMAIL`
 : Committer email.
+**Example**: `jane@doe.com`
 
 `DD_GIT_COMMIT_COMMITTER_DATE`
 : Committer date. ISO 8601 format.
+**Example**: `2021-03-12T16:00:28Z`
 
 ### Running tests
 
@@ -224,6 +235,37 @@ For Network auto-instrumentation, you can configure these additional settings:
 : Sets the maximum size reported from the payload. Default `1024` (Integer)
 
 You can also disable or enable specific auto-instrumentation in some of the tests from Swift or Objective-C by importing the module `DatadogSDKTesting` and using the class: `DDInstrumentationControl`.
+
+## Adding custom tags
+
+### Using environment variables
+
+You can use `DD_TAGS` environment variable. It must contain pairs of `key:tag` separated by spaces. For example:
+{{< code-block lang="bash" >}}
+DDTAGS=tag-key-0:tag-value-0 tag-key-1:tag-value-1
+{{< /code-block >}}
+
+If one of the values starts with the `$` character, it will be replaced with the environment variable with the same name if it exists, example:
+{{< code-block lang="bash" >}}
+DDTAGS=home:$HOME
+{{< /code-block >}}
+
+It also supports replacing a environment variable at the beggining of the value if contains non env variables supported characters (`a-z`,  `A-Z` or `_`):
+{{< code-block lang="bash" >}}
+FOO = BAR
+DD_TAGS=key1:$FOO-v1 // expected: key1:BAR-v1
+{{< /code-block >}}
+
+### Using OpenTelemetry (only for Swift, Objective-C not supported)
+
+Datadog swift testing framework uses [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-swift) as the tracing technology under the hood. You can access the OpenTelemetry tracer using `DDInstrumentationControl.openTelemetryTracer` and can use any OpenTelemetry api. For example, for adding a tag/attribute
+
+{{< code-block lang="swift" >}}
+let tracer = DDInstrumentationControl.openTelemetryTracer
+tracer?.activeSpan?.setAttribute(key: "OTelTag", value: "OTelValue")
+{{< /code-block >}}
+
+Test target needs to link explicitly with `opentelemetry-swift`
 
 ## CI provider environment variables
 


### PR DESCRIPTION
### What does this PR do?
Add documentation about adding custom tags
Also adds examples to the environment variables to provide Git metadata

### Motivation
Adding more documentation

### Preview
https://docs-staging.datadoghq.com/nachoBonafonte/CI-app-Swift-add-documentation-about-adding-custom-tags/continuous_integration/setup_tests/swift

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
