### PR TITLE
Add git information to all tracers and to troubleshooting guide

### DIFF
--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -72,6 +72,56 @@ The following list shows the default values for key configuration settings:
 
 All other [Datadog Tracer configuration][2] options can also be used.
 
+### Collecting Git and build metadata
+
+Correct Git information is essential for the CI visibility product. Both pipeline visualization and testing instrumentation use git to identify and group their results. Git metadata and build information is automatically collected using CI provider environment variables and is also collected using the local `.git` folder at the project path.
+
+The user can also provide Git information by using custom environment variables. This is useful for adding Git information for non-supported CI providers, or for .git folders that are not available from the running process. Custom environment variables are also useful for overwriting existing Git information. If these environment variables are set, they take precedence over those coming from the CI or from the .git folder. The list of supported environment variables for Git information includes the following:
+
+`DD_GIT_REPOSITORY_URL`
+: URL of the repository where the code is stored.
+**Example**: `git@github.com:MyCompany/MyApp.git`
+
+`DD_GIT_BRANCH`
+: Branch where this commit belongs.
+**Example**: `develop`
+
+`DD_GIT_TAG`
+: Tag of the commit, if it has one.
+**Example**: `1.0.1`
+
+`DD_GIT_COMMIT_SHA`
+: Commit SHA.
+**Example**: `a18ebf361cc831f5535e58ec4fae04ffd98d8152`
+
+`DD_GIT_COMMIT_MESSAGE`
+: Commit message.
+**Example**: `Set release number`
+
+`DD_GIT_COMMIT_AUTHOR_NAME`
+: Author name.
+**Example**: `John Doe`
+
+`DD_GIT_COMMIT_AUTHOR_EMAIL`
+: Author email.
+**Example**: `john@doe.com`
+
+`DD_GIT_COMMIT_AUTHOR_DATE`
+: Author date. ISO 8601 format.
+**Example**: `2021-03-12T16:00:28Z`
+
+`DD_GIT_COMMIT_COMMITTER_NAME`
+: Committer name.
+**Example**: `Jane Doe`
+
+`DD_GIT_COMMIT_COMMITTER_EMAIL`
+: Committer email.
+**Example**: `jane@doe.com`
+
+`DD_GIT_COMMIT_COMMITTER_DATE`
+: Committer date. ISO 8601 format.
+**Example**: `2021-03-12T16:00:28Z`
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/continuous_integration/setup_tests/java.md
+++ b/content/en/continuous_integration/setup_tests/java.md
@@ -170,6 +170,56 @@ All other [Datadog Tracer configuration][2] options can also be used.
 
 For example, to enable `OkHttp3` client request integration, add `-Ddd.integration.okhttp-3.enabled=true` to your setup.
 
+### Collecting Git and build metadata
+
+Correct Git information is essential for the CI visibility product. Both pipeline visualization and testing instrumentation use git to identify and group their results. Git metadata and build information is automatically collected using CI provider environment variables and is also collected using the local `.git` folder at the project path.
+
+The user can also provide Git information by using custom environment variables. This is useful for adding Git information for non-supported CI providers, or for .git folders that are not available from the running process. Custom environment variables are also useful for overwriting existing Git information. If these environment variables are set, they take precedence over those coming from the CI or from the .git folder. The list of supported environment variables for Git information includes the following:
+
+`DD_GIT_REPOSITORY_URL`
+: URL of the repository where the code is stored.
+**Example**: `git@github.com:MyCompany/MyApp.git`
+
+`DD_GIT_BRANCH`
+: Branch where this commit belongs.
+**Example**: `develop`
+
+`DD_GIT_TAG`
+: Tag of the commit, if it has one.
+**Example**: `1.0.1`
+
+`DD_GIT_COMMIT_SHA`
+: Commit SHA.
+**Example**: `a18ebf361cc831f5535e58ec4fae04ffd98d8152`
+
+`DD_GIT_COMMIT_MESSAGE`
+: Commit message.
+**Example**: `Set release number`
+
+`DD_GIT_COMMIT_AUTHOR_NAME`
+: Author name.
+**Example**: `John Doe`
+
+`DD_GIT_COMMIT_AUTHOR_EMAIL`
+: Author email.
+**Example**: `john@doe.com`
+
+`DD_GIT_COMMIT_AUTHOR_DATE`
+: Author date. ISO 8601 format.
+**Example**: `2021-03-12T16:00:28Z`
+
+`DD_GIT_COMMIT_COMMITTER_NAME`
+: Committer name.
+**Example**: `Jane Doe`
+
+`DD_GIT_COMMIT_COMMITTER_EMAIL`
+: Committer email.
+**Example**: `jane@doe.com`
+
+`DD_GIT_COMMIT_COMMITTER_DATE`
+: Committer date. ISO 8601 format.
+**Example**: `2021-03-12T16:00:28Z`
+
 
 ## Further reading
 

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -164,6 +164,56 @@ The following is a list of the most important configuration settings that can be
 
 All other [Datadog Tracer configuration][5] options can also be used.
 
+### Collecting Git and build metadata
+
+Correct Git information is essential for the CI visibility product. Both pipeline visualization and testing instrumentation use git to identify and group their results. Git metadata and build information is automatically collected using CI provider environment variables and is also collected using the local `.git` folder at the project path.
+
+The user can also provide Git information by using custom environment variables. This is useful for adding Git information for non-supported CI providers, or for .git folders that are not available from the running process. Custom environment variables are also useful for overwriting existing Git information. If these environment variables are set, they take precedence over those coming from the CI or from the .git folder. The list of supported environment variables for Git information includes the following:
+
+`DD_GIT_REPOSITORY_URL`
+: URL of the repository where the code is stored.
+**Example**: `git@github.com:MyCompany/MyApp.git`
+
+`DD_GIT_BRANCH`
+: Branch where this commit belongs.
+**Example**: `develop`
+
+`DD_GIT_TAG`
+: Tag of the commit, if it has one.
+**Example**: `1.0.1`
+
+`DD_GIT_COMMIT_SHA`
+: Commit SHA.
+**Example**: `a18ebf361cc831f5535e58ec4fae04ffd98d8152`
+
+`DD_GIT_COMMIT_MESSAGE`
+: Commit message.
+**Example**: `Set release number`
+
+`DD_GIT_COMMIT_AUTHOR_NAME`
+: Author name.
+**Example**: `John Doe`
+
+`DD_GIT_COMMIT_AUTHOR_EMAIL`
+: Author email.
+**Example**: `john@doe.com`
+
+`DD_GIT_COMMIT_AUTHOR_DATE`
+: Author date. ISO 8601 format.
+**Example**: `2021-03-12T16:00:28Z`
+
+`DD_GIT_COMMIT_COMMITTER_NAME`
+: Committer name.
+**Example**: `Jane Doe`
+
+`DD_GIT_COMMIT_COMMITTER_EMAIL`
+: Committer email.
+**Example**: `jane@doe.com`
+
+`DD_GIT_COMMIT_COMMITTER_DATE`
+: Committer date. ISO 8601 format.
+**Example**: `2021-03-12T16:00:28Z`
+
 
 ## Known limitations
 

--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -104,6 +104,52 @@ Additionally, configure the Datadog site to use the selected one ({{< region-par
 
 The Datadog CI CLI tries to extract git repository and commit metadata from CI provider environment variables and from the local `.git` directory and attach it to test executions. In order to read this directory, the [`git`][4] binary is required.
 
+The user can also provide Git information by using custom environment variables. This is useful for adding Git information for non-supported CI providers, or for .git folders that are not available from the running process. Custom environment variables are also useful for overwriting existing Git information. If these environment variables are set, they take precedence over those coming from the CI or from the .git folder. The list of supported environment variables for Git information includes the following:
+
+`DD_GIT_REPOSITORY_URL`
+: URL of the repository where the code is stored.
+**Example**: `git@github.com:MyCompany/MyApp.git`
+
+`DD_GIT_BRANCH`
+: Branch where this commit belongs.
+**Example**: `develop`
+
+`DD_GIT_TAG`
+: Tag of the commit, if it has one.
+**Example**: `1.0.1`
+
+`DD_GIT_COMMIT_SHA`
+: Commit SHA.
+**Example**: `a18ebf361cc831f5535e58ec4fae04ffd98d8152`
+
+`DD_GIT_COMMIT_MESSAGE`
+: Commit message.
+**Example**: `Set release number`
+
+`DD_GIT_COMMIT_AUTHOR_NAME`
+: Author name.
+**Example**: `John Doe`
+
+`DD_GIT_COMMIT_AUTHOR_EMAIL`
+: Author email.
+**Example**: `john@doe.com`
+
+`DD_GIT_COMMIT_AUTHOR_DATE`
+: Author date. ISO 8601 format.
+**Example**: `2021-03-12T16:00:28Z`
+
+`DD_GIT_COMMIT_COMMITTER_NAME`
+: Committer name.
+**Example**: `Jane Doe`
+
+`DD_GIT_COMMIT_COMMITTER_EMAIL`
+: Committer email.
+**Example**: `jane@doe.com`
+
+`DD_GIT_COMMIT_COMMITTER_DATE`
+: Committer date. ISO 8601 format.
+**Example**: `2021-03-12T16:00:28Z`
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/continuous_integration/setup_tests/python.md
+++ b/content/en/continuous_integration/setup_tests/python.md
@@ -64,6 +64,56 @@ The following environment variable can be used to configure the location of the 
 
 All other [Datadog Tracer configuration][3] options can also be used.
 
+### Collecting Git and build metadata
+
+Correct Git information is essential for the CI visibility product. Both pipeline visualization and testing instrumentation use git to identify and group their results. Git metadata and build information is automatically collected using CI provider environment variables and is also collected using the local `.git` folder at the project path.
+
+The user can also provide Git information by using custom environment variables. This is useful for adding Git information for non-supported CI providers, or for .git folders that are not available from the running process. Custom environment variables are also useful for overwriting existing Git information. If these environment variables are set, they take precedence over those coming from the CI or from the .git folder. The list of supported environment variables for Git information includes the following:
+
+`DD_GIT_REPOSITORY_URL`
+: URL of the repository where the code is stored.
+**Example**: `git@github.com:MyCompany/MyApp.git`
+
+`DD_GIT_BRANCH`
+: Branch where this commit belongs.
+**Example**: `develop`
+
+`DD_GIT_TAG`
+: Tag of the commit, if it has one.
+**Example**: `1.0.1`
+
+`DD_GIT_COMMIT_SHA`
+: Commit SHA.
+**Example**: `a18ebf361cc831f5535e58ec4fae04ffd98d8152`
+
+`DD_GIT_COMMIT_MESSAGE`
+: Commit message.
+**Example**: `Set release number`
+
+`DD_GIT_COMMIT_AUTHOR_NAME`
+: Author name.
+**Example**: `John Doe`
+
+`DD_GIT_COMMIT_AUTHOR_EMAIL`
+: Author email.
+**Example**: `john@doe.com`
+
+`DD_GIT_COMMIT_AUTHOR_DATE`
+: Author date. ISO 8601 format.
+**Example**: `2021-03-12T16:00:28Z`
+
+`DD_GIT_COMMIT_COMMITTER_NAME`
+: Committer name.
+**Example**: `Jane Doe`
+
+`DD_GIT_COMMIT_COMMITTER_EMAIL`
+: Committer email.
+**Example**: `jane@doe.com`
+
+`DD_GIT_COMMIT_COMMITTER_DATE`
+: Committer date. ISO 8601 format.
+**Example**: `2021-03-12T16:00:28Z`
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/continuous_integration/setup_tests/ruby.md
+++ b/content/en/continuous_integration/setup_tests/ruby.md
@@ -132,6 +132,56 @@ The following environment variable can be used to configure the location of the 
 
 All other [Datadog Tracer configuration][3] options can also be used.
 
+### Collecting Git and build metadata
+
+Correct Git information is essential for the CI visibility product. Both pipeline visualization and testing instrumentation use git to identify and group their results. Git metadata and build information is automatically collected using CI provider environment variables and is also collected using the local `.git` folder at the project path.
+
+The user can also provide Git information by using custom environment variables. This is useful for adding Git information for non-supported CI providers, or for .git folders that are not available from the running process. Custom environment variables are also useful for overwriting existing Git information. If these environment variables are set, they take precedence over those coming from the CI or from the .git folder. The list of supported environment variables for Git information includes the following:
+
+`DD_GIT_REPOSITORY_URL`
+: URL of the repository where the code is stored.
+**Example**: `git@github.com:MyCompany/MyApp.git`
+
+`DD_GIT_BRANCH`
+: Branch where this commit belongs.
+**Example**: `develop`
+
+`DD_GIT_TAG`
+: Tag of the commit, if it has one.
+**Example**: `1.0.1`
+
+`DD_GIT_COMMIT_SHA`
+: Commit SHA.
+**Example**: `a18ebf361cc831f5535e58ec4fae04ffd98d8152`
+
+`DD_GIT_COMMIT_MESSAGE`
+: Commit message.
+**Example**: `Set release number`
+
+`DD_GIT_COMMIT_AUTHOR_NAME`
+: Author name.
+**Example**: `John Doe`
+
+`DD_GIT_COMMIT_AUTHOR_EMAIL`
+: Author email.
+**Example**: `john@doe.com`
+
+`DD_GIT_COMMIT_AUTHOR_DATE`
+: Author date. ISO 8601 format.
+**Example**: `2021-03-12T16:00:28Z`
+
+`DD_GIT_COMMIT_COMMITTER_NAME`
+: Committer name.
+**Example**: `Jane Doe`
+
+`DD_GIT_COMMIT_COMMITTER_EMAIL`
+: Committer email.
+**Example**: `jane@doe.com`
+
+`DD_GIT_COMMIT_COMMITTER_DATE`
+: Committer date. ISO 8601 format.
+**Example**: `2021-03-12T16:00:28Z`
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -112,7 +112,7 @@ Additionally, configure the Datadog site to use the selected one ({{< region-par
 
 ### Collecting Git and build metadata
 
-Git metadata and build information is automatically collected using CI provider environment variables, that must be forwarded to the test application (see the section [CI provider environment variables](#CI-provider-environment-variables) below for a full list).
+Correct Git information is essential for the CI visibility product. Both pipeline visualization and testing instrumentation use git to identify and group their results. Git metadata and build information is automatically collected using CI provider environment variables, that must be forwarded to the test application (see the section [CI provider environment variables](#CI-provider-environment-variables) below for a full list).
 
 When running tests in a simulator, full Git metadata is collected using the local `.git` folder. In this case, Git-related environment variables don't have to be forwarded.
 

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -22,7 +22,44 @@ If you can see test results data in the **Test Runs** tab, but not the **Tests**
 
 1. Tracers first try to fetch Git metadata using the local `.git` folder by executing `git` commands. This is the preferred approach, as it populates all Git metadata fields, including commit message, author and committer information. Ensure the `.git` folder is present and the `git` binary is installed and in `$PATH`.
 2. If the `.git` folder is not present, or the `git` binary is not installed, tracers fallback to use the environment variables set by the CI provider to collect Git information. See the [Running tests inside a container][6] page for a list of environment variables that the tracer attempts to read for each supported CI provider. At a minimum, this populates the repository, commit hash, and branch information.
-3. If no CI provider environment variables are found, tests results are sent with no Git metadata.
+1. Tracers first try to use the environment variables set by the CI provider to collect Git information. See the [Running tests inside a container][6] page for a list of environment variables that the tracer attempts to read for each supported CI provider. At a minimum, this populates the repository, commit hash, and branch information.
+2. Tracers also try to fetch Git metadata using the local `.git` folder by executing `git` commands. This populates all Git metadata fields, including commit message, author and committer information. Ensure the `.git` folder is present and the `git` binary is installed and in `$PATH`. This information will only be fetched if no git information was readed from previous method or if the comit sha coincides.
+3. The user can also provide Git information by using custom environment variables. Custom environment variables are also useful for overwriting existing Git information. If these environment variables are set, they take precedence over those coming from the CI or from the .git folder. The list of supported environment variables for Git information includes the following:
+
+`DD_GIT_REPOSITORY_URL`
+: URL of the repository where the code is stored.
+
+`DD_GIT_BRANCH`
+: Branch where this commit belongs.
+
+`DD_GIT_TAG`
+: Tag of the commit, if it has one.
+
+`DD_GIT_COMMIT_SHA`
+: Commit SHA.
+
+`DD_GIT_COMMIT_MESSAGE`
+: Commit message.
+
+`DD_GIT_COMMIT_AUTHOR_NAME`
+: Author name.
+
+`DD_GIT_COMMIT_AUTHOR_EMAIL`
+: Author email.
+
+`DD_GIT_COMMIT_AUTHOR_DATE`
+: Author date. ISO 8601 format.
+
+`DD_GIT_COMMIT_COMMITTER_NAME`
+: Committer name.
+
+`DD_GIT_COMMIT_COMMITTER_EMAIL`
+: Committer email.
+
+`DD_GIT_COMMIT_COMMITTER_DATE`
+: Committer date. ISO 8601 format.
+
+4. If no CI provider environment variables are found, tests results are sent with no Git metadata.
 
 ### Need further help?
 


### PR DESCRIPTION
### What does this PR do?
Add git information to all tracers and to troubleshooting guide

### Motivation
All tracers were missing this information (except for Swift) and are going to support the new environment variables. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nachoBonafonte/CI-app-All-tracers-add-documentation-about-git-information/continuous_integration

### Additional Notes
This PR is created as draft until al tracers support the documented environment variables

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
