### PR TITLE
Update vector_aggregation.md

### DIFF
--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -63,7 +63,7 @@ Here is a configuration example that adds a tag to every log using the Vector Re
 ```yaml
 sources:
   datadog_agents:
-    type: datadog_logs
+    type: datadog_agent
     address: "[::]:8080" # The <VECTOR_PORT> mentioned above should be set to the port value used here
 
 transforms:
@@ -124,10 +124,10 @@ to fill relevant fields according to the expected schema.
 [7]: https://vector.dev/docs/reference/configuration/transforms/route/
 [8]: /getting_started/tagging
 [9]: https://vector.dev/docs/reference/vrl/
-[10]: https://vector.dev/docs/reference/configuration/sources/datadog_logs/
+[10]: https://vector.dev/docs/reference/configuration/sources/datadog_agent/
 [11]: https://vector.dev/docs/reference/configuration/sinks/datadog_logs/
 [12]: https://vector.dev/docs/reference/configuration/
 [13]: /agent/kubernetes/?tab=helm
-[14]: https://github.com/timberio/vector/tree/master/distribution/helm/vector-aggregator
+[14]: https://github.com/timberio/helm-charts/tree/master/charts/vector-aggregator
 [15]: https://vector.dev/docs/setup/installation/package-managers/helm/
 [16]: api/latest/logs/#send-logs


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Minor updates due to Vector release

### Motivation
<!-- What inspired you to submit this pull request?-->
Vector 0.16 deprecates the `datadog_logs` source, renaming it to `datadog_agent`. We also have migrated our Helm charts to a separate repo `timberio/helm-charts`.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/update-for-vector-0.16/agent/vector_aggregation

### Additional Notes
<!-- Anything else we should know when reviewing?-->

This should not be merged until Vector 0.16 is released, ETA 08/24

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
