### PR TITLE
DOCS-2288 Incident Management and Querying Edits

### DIFF
--- a/content/en/dashboards/querying/_index.md
+++ b/content/en/dashboards/querying/_index.md
@@ -170,7 +170,6 @@ status:error / status:info
 
 {{< img src="dashboards/querying/arithmetic_6.png" alt="Formula example - logs ratio" style="width:75%;" >}}
 
-
 **Note**: Formulas are not lettered. Arithmetic cannot be done between formulas.
 
 ### Create an alias
@@ -205,16 +204,8 @@ Select the following parameters from the graphing editor: Environment (`env`), P
 If your level of detail is resource or span, some widget types also require you to select a Resource name (`resource`) to narrow the scope of your query.
 
 ## Incident Management analytics
-Incident Management analytics provides you with the following measures:
 
-* Incident Count
-* Customer Impact Duration
-* Status Active Duration
-* Status Stable Duration
-* Time to Repair (customer impact end time - created time)
-* Time to Resolve (resolved time - created time)
-
-Incident Management analytics is supported in the following widgets:
+The following widgets support Incident Management analytics:
 
 * Timeseries
 * Top List 
@@ -224,16 +215,16 @@ Incident Management analytics is supported in the following widgets:
 
 To configure your graph using Incident Management analytics data, follow these steps:
 
-1. [Select your visualization](#select-your-visualization) (same as for metrics)
-2. Select `Incidents` from the data source dropdown menu
-3. Select a measure from the yellow dropdown menu
-     - **Default Statistic:** Count the number of incidents
-5. Select an aggregation for the measure
-6. (Optional) Select a rollup for the measure
-7. (Optional) Use the search bar to filter the statistic down to a specific subset of incidents
-8. (Optional) Select a facet in the pink dropdown menu to break the measure up by group and select a limited number of groups to display 
-9. [Title the graph](#create-a-title) (same as for metrics)
-10. Save your widget
+1. [Select your visualization](#select-your-visualization) (same as for metrics).
+2. Select `Incidents` from the data source dropdown menu.
+3. Select a measure from the yellow dropdown menu.
+     - **Default Statistic:** Counts the number of incidents.
+5. Select an aggregation for the measure.
+6. (Optional) Select a rollup for the measure.
+7. (Optional) Use the search bar to filter the statistic down to a specific subset of incidents.
+8. (Optional) Select a facet in the pink dropdown menu to break the measure up by group and select a limited number of groups to display .
+9. [Title the graph](#create-a-title) (same as for metrics).
+10. Save your widget.
 
 **Example:** Weekly Outage Customer Impact Duration by Service
 

--- a/content/en/monitors/incident_management/_index.md
+++ b/content/en/monitors/incident_management/_index.md
@@ -2,6 +2,10 @@
 title: Incident Management
 kind: documentation
 description: Create and manage incidents
+further_reading:
+- link: "dashboards/querying/#incident-management-analytics"
+  tag: "Documentation"
+  text: "Incident Management Analytics"
 ---
 
 {{< site-region region="gov" >}}
@@ -21,7 +25,7 @@ In the Datadog paradigm, any of the following are appropriate situations for dec
 
 ## Usage
 
-Incident Management requires no installation. To view your incidents, go to the [Incidents][1] page to see a feed of all ongoing incidents.  You can configure additional fields that appear for all incidents in [Incident Settings][2].
+Incident Management requires no installation. To view your incidents, go to the [Incidents][1] page to see a feed of all ongoing incidents. You can configure additional fields that appear for all incidents in [Incident Settings][2].
 
 **Note**: Manage and create incidents with the [Datadog Mobile App][3], available on the [Apple App Store][4] and [Google Play Store][5].
 
@@ -53,25 +57,25 @@ You can also add a monitor to an existing incident.
 
 {{< img src="monitors/incidents/existing.png" alt="Add a monitor to an existing incident" style="width:80%;">}}
 
-#### From the incidents page
+#### From the Incidents page
 
-In the [incidents UI][1], click the **New Incident** button to create an incident.
+In the [Datadog UI][1], click **New Incident** to create an incident.
 
 {{< img src="monitors/incidents/incident_declaration_modal.jpeg" alt="Incident Declaration Modal" style="width:80%;">}}
 
-The incident creation modal provides responders with a collapsible side panel that contains helper text and descriptions for the severities and statuses used by your organization. The helper text and descriptions are customizable in the [Incident Settings][17].
+The incident creation modal provides responders with a collapsible side panel that contains helper text and descriptions for the severities and statuses used by your organization. The helper text and descriptions are customizable in the [Incident Settings][6].
 
 {{< img src="monitors/incidents/incident_information_settings.jpeg" alt="Incident Information Settings" style="width:80%;">}}
 
 #### From Slack
 
-Once you have the [Datadog integration enabled on Slack][6], from any Slack channel you can use the slash command `/datadog incident` to declare a new incident.
+Once you have the [Datadog integration enabled on Slack][7], from any Slack channel you can use the slash command `/datadog incident` to declare a new incident.
 
 In the creation modal, you add a descriptive title, select whether customers were impacted (yes, no, or unknown) and select a severity level (1-5, unknown).
 
 If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user will become the Incident Commander. The Incident Commander (IC) can be changed later in-app if necessary. If the person declaring an incident is not a member of a Datadog account, then the IC is assigned to a generic `Slack app user` and can be assigned to another IC in-app.
 
-Read more about using the Datadog Slack App [here][7].
+Read more about using the Datadog Slack App [here][8].
 
 {{< img src="monitors/incidents/from-slack.png" alt="Create in incident from Slack" style="width:60%;">}}
 
@@ -79,9 +83,9 @@ If the user declaring the incident is a part of your Datadog account, then that 
 
 Once you declare an incident from Slack, it generates an incident channel.
 
-For more information about the Datadog Slack integration, check out [the docs][6].
+For more information about the Datadog Slack integration, check out [the docs][7].
 
-For non-EU customers who use Slack, [sign up for beta access][8] to the Datadog Slack app. For EU customers who use Slack, stay informed about the Slack app by emailing support@datadoghq.com.
+For non-EU customers who use Slack, [sign up for beta access][9] to the Datadog Slack app. For EU customers who use Slack, stay informed about the Slack app by emailing support@datadoghq.com.
 
 ### Describing the incident
 
@@ -139,44 +143,62 @@ As the status of an incident changes, Datadog tracks time-to-resolution as follo
 
 #### Assessment fields
 
-Assessment fields are the metadata and context that you can define per incident. These fields are [key:value metric tags][9]. These field keys are added in settings, and the values are then available when you are assessing the impact of an incident on the overview page. For example, you can add an Application field. The following fields are available for assessment in all incidents:
+Assessment fields are the metadata and context that you can define per incident. These fields are [key:value metric tags][10]. These field keys are added in settings, and the values are then available when you are assessing the impact of an incident on the overview page. For example, you can add an Application field. The following fields are available for assessment in all incidents:
 
 * **Root Cause**: This text field allows you to enter the description of the root cause, triggers, and contributing factors of the incident.
 * **Detection Method**: Specify how the incident was detected with these default options: customer, employee, monitor, other, or unknown.
-* **Services**: If you have APM configured, your APM services are available for incident assessment. To learn more about configuring your services in APM, see [the docs][10].
+* **Services**: If you have APM configured, your APM services are available for incident assessment. To learn more about configuring your services in APM, see [the docs][11].
     * If you are not using Datadog APM, you can upload service names as a CSV. Any values uploaded via CSV are only be available within Incident Management for incident assessment purposes.
     * Datadog deduplicates service names case-insensitively, so if you use "My Service" or "my service", only the manually added one is shown.
     * Datadog overrides APM service names in favor of the manually uploaded list.
     * Note that if the service is an APM service and no metrics are posted in the past seven days, it does not appear in the search results.
-    * Further integrate with Datadog products and accurately assess service impact. The Services property field is automatically populated with APM services for customers using Datadog APM
-* **Teams**: Defined under Incident Settings in the [Property Fields][11]. Upload a list of teams from a CSV file. Any values uploaded through CSV are only available within Incident Management for incident assessment purposes.
+    * Further integrate with Datadog products and accurately assess service impact. The Services property field is automatically populated with APM services for customers using Datadog APM.
+* **Teams**: Defined under Incident Settings in the [Property Fields][12]. Upload a list of teams from a CSV file. Any values uploaded through CSV are only available within Incident Management for incident assessment purposes.
+
+## Data collected
+
+Incident Management collects the following analytic measures:
+
+* Incident Count
+* Customer Impact Duration
+* Status Active Duration
+* Status Stable Duration
+* Time to Repair (customer impact end time - created time)
+* Time to Resolve (resolved time - created time)
+
+For more information about Incident Management graphs, see [Incident Management Analytics][13].
 
 ## Integrations
 
-In addition to integrating with [Slack][6], Incident Management also integrates with:
+In addition to integrating with [Slack][7], Incident Management also integrates with:
 
-- [PagerDuty][12] to send incident notifications to PagerDuty.
-- [Jira][13] to create a Jira ticket for an incident.
-- [Webhooks][14] to send incident notifications using webhooks (for example, [sending SMS to Twilio][15]).
+- [PagerDuty][14] to send incident notifications to PagerDuty.
+- [Jira][15] to create a Jira ticket for an incident.
+- [Webhooks][16] to send incident notifications using webhooks (for example, [sending SMS to Twilio][17]).
 
 ## Ready to try it out?
 
-Work through an example workflow in the [Getting Started with Incident Management][16] guide.
+Work through an example workflow in the [Getting Started with Incident Management][18] guide.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/incidents
 [2]: https://app.datadoghq.com/incidents/settings
 [3]: /mobile
 [4]: https://apps.apple.com/app/datadog/id1391380318
 [5]: https://play.google.com/store/apps/details?id=com.datadog.app
-[6]: /integrations/slack/?tab=slackapplicationbeta#using-the-slack-app
-[7]: /integrations/slack/
-[8]: https://app.datadoghq.com/incidents/ddslackapp
-[9]: /getting_started/tagging/assigning_tags?tab=noncontainerizedenvironments#overview
-[10]: /tracing/#2-instrument-your-application
-[11]: https://app.datadoghq.com/incidents/settings#Property-Fields
-[12]: /integrations/pagerduty/
-[13]: /integrations/jira/
-[14]: /integrations/webhooks/
-[15]: /integrations/webhooks/#sending-sms-through-twilio
-[16]: /getting_started/incident_management
-[17]: https://app.datadoghq.com/incidents/settings#Information
+[6]: https://app.datadoghq.com/incidents/settings#Information
+[7]: /integrations/slack/?tab=slackapplicationbeta#using-the-slack-app
+[8]: /integrations/slack/
+[9]: https://app.datadoghq.com/incidents/ddslackapp
+[10]: /getting_started/tagging/assigning_tags?tab=noncontainerizedenvironments#overview
+[11]: /tracing/#2-instrument-your-application
+[12]: https://app.datadoghq.com/incidents/settings#Property-Fields
+[13]: /dashboards/querying/#incident-management-analytics
+[14]: /integrations/pagerduty/
+[15]: /integrations/jira/
+[16]: /integrations/webhooks/
+[17]: /integrations/webhooks/#sending-sms-through-twilio
+[18]: /getting_started/incident_management


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Reorganized a section of Incident Management Analytics into Incident Management, added a Further Reading section in Querying, and included a reference link to the Querying documentation from Incident Management.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-2288

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/incident-management-analytics-reorg/monitors/incident_management/#usage

https://docs-staging.datadoghq.com/alai97/incident-management-analytics-reorg//dashboards/querying/#incident-management-analytics

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
