### PR TITLE
APM > Connect logs and traces > .NET - Update supported logging libraries

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -29,7 +29,7 @@ Configure the .NET Tracer with [Unified Service Tagging][1] for the best experie
 The .NET Tracer supports the following logging libraries:
 - [Serilog][2]
 - [log4net][3]
-- [NLog][4] (version 2.0+)
+- [NLog][4]
 
 ## Getting started
 

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -29,7 +29,7 @@ Configure the .NET Tracer with [Unified Service Tagging][1] for the best experie
 The .NET Tracer supports the following logging libraries:
 - [Serilog][2]
 - [log4net][3]
-- [NLog][4] (version 4.0+)
+- [NLog][4] (version 2.0+)
 
 ## Getting started
 

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -27,7 +27,7 @@ You can set up your logging library and .NET tracing configurations so that trac
 Configure the .NET Tracer with [Unified Service Tagging][1] for the best experience and helpful context when correlating application traces and logs.
 
 The .NET Tracer supports the following logging libraries:
-- [Serilog][2]
+- [Serilog][2] (version 2.0+)
 - [log4net][3]
 - [NLog][4]
 


### PR DESCRIPTION
### What does this PR do?
Updates the version numbers for .NET logging libraries supported for logs injection:
- Serilog support has been updated to only versions 2.0+
- NLog support has been updated to include ALL versions

### Motivation
In the .NET Tracer, we added more error-handling scenarios for logs injection and this surfaced some gaps we had in our support matrix.

### Preview
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-logs-injection-nlog/tracing/connect_logs_and_traces/dotnet?tab=serilog

### Additional Notes
The updated support for NLog will take effect in the next .NET Tracer official release, so this should not be merged until then.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
