### PR TITLE
Add Page Header in Integration Guides Page

### DIFF
--- a/content/en/integrations/guide/_index.md
+++ b/content/en/integrations/guide/_index.md
@@ -5,6 +5,8 @@ disable_sidebar: true
 private: true
 ---
 
+Integration Guides:
+
 {{< whatsnext desc=" " >}}
     {{< nextlink href="integrations/guide/requests" tag="documentation" >}}Request Datadog Integrations{{< /nextlink >}}
     {{< nextlink href="integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose" tag="AWS" >}}AWS CloudWatch Metric Streams with Kinesis Data Firehose{{< /nextlink >}}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add "Integration Guides:" before the list of guides.

### Motivation
<!-- What inspired you to submit this pull request?-->

Small nit for consistency in Guides pages.

### Preview
<!-- Impacted pages preview links-->

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/integration-guides-update/integrations/guide/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
