### PR TITLE
[ci-visibility] Simplify `jest` Instructions

### DIFF
--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -66,7 +66,7 @@ require('dd-trace').init({
 module.exports = require('jest-environment-node')
 ```
 
-<div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-node</code>, <code>jest-environment-jsdom</code>, <code>jest-jasmine2</code> and <code>jest-circus</code> (as of Jest 27) are installed together with <code>jest</code>, so they do not normally appear in your <code>package.json</code>. If you've extracted any of these libraries in your <code>package.json</code>, make sure the installed versions are the same as the one of <code>jest</code>.</div>
+<div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-node</code>, <code>jest-environment-jsdom</code>, <code>jest-jasmine2</code>, and <code>jest-circus</code> (as of Jest 27) are installed together with <code>jest</code>, so they do not normally appear in your <code>package.json</code>. If you've extracted any of these libraries in your <code>package.json</code>, make sure the installed versions are the same as the one of <code>jest</code>.</div>
 
 Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:
 

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -15,29 +15,29 @@ further_reading:
 Supported test frameworks:
 * Jest >= 24.8.0
   * Only `jsdom` (in package `jest-environment-jsdom`) and `node` (in package `jest-environment-node`) are supported as test environments. Custom environments like `@jest-runner/electron/environment` in `jest-electron-runner` are not supported.
-  * Only [`jest-circus`][1] is supported as a `testRunner`.
+  * Only [`jest-circus`][1] and [`jest-jasmine2`][2] are supported as `testRunner`.
 * Mocha >= 5.2.0
   * Mocha >= 9.0.0 has [partial support](#known-limitations).
 * Cucumber-js >= 7.0.0
 
 ## Prerequisites
 
-[Install the Datadog Agent to collect tests data][2].
+[Install the Datadog Agent to collect tests data][3].
 
 ## Installing the JavaScript tracer
 
-To install the [JavaScript tracer][3], run:
+To install the [JavaScript tracer][4], run:
 
 {{< code-block lang="bash" >}}
 yarn add --dev dd-trace
 {{< /code-block >}}
 
-For more information, see the [JavaScript tracer installation docs][4].
+For more information, see the [JavaScript tracer installation docs][5].
 
 ## Instrument your tests
 
 {{< tabs >}}
-{{% tab "Jest" %}}
+{{% tab "Jest (jest-circus)" %}}
 
 1. Install the `jest-circus` test runner:
 
@@ -69,10 +69,8 @@ And in `testEnvironment.js`:
 require('dd-trace').init({
   // Only activates test instrumentation on CI
   enabled: process.env.DD_ENV === 'ci',
-
   // Name of the service or library under test
-  service: 'my-ui-app',
-
+  service: 'my-javascript-app',
   // To guarantee test span delivery
   flushInterval: 300000
 })
@@ -93,6 +91,61 @@ DD_ENV=ci npm test
 [1]: https://jestjs.io/docs/en/configuration#testenvironment-string
 [2]: https://jestjs.io/docs/en/configuration#testrunner-string
 {{% /tab %}}
+{{% tab "Jest (jest-jasmine2)" %}}
+
+1. Install the `jest-jasmine2` test runner:
+
+```bash
+yarn add --dev jest-jasmine2
+```
+
+**Important**: The installed version of `jest-jasmine2` and `jest` must be the same. For example, if you're using `jest@25.5.4`, run:
+
+```bash
+yarn add --dev jest-jasmine2@25.5.4
+```
+
+2. Configure a custom [testEnvironment][1] and [testRunner][2] in your `jest.config.js` or however you are configuring `jest`:
+
+```javascript
+module.exports = {
+  // ...
+  testRunner: 'jest-jasmine2',
+  // It may be another route. It refers to the file below.
+  testEnvironment: '<rootDir>/testEnvironment.js',
+  // ...
+}
+```
+
+And in `testEnvironment.js`:
+
+```javascript
+require('dd-trace').init({
+  // Only activates test instrumentation on CI
+  enabled: process.env.DD_ENV === 'ci',
+  // Name of the service or library under test
+  service: 'my-javascript-app',
+  // To guarantee test span delivery
+  flushInterval: 300000
+})
+
+// jest-environment-jsdom is an option too
+module.exports = require('jest-environment-node')
+```
+
+<div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-node</code> and <code>jest-environment-jsdom</code> are installed together with <code>jest</code>, so they do not normally appear in your <code>package.json</code>. If you've extracted any of these libraries in your <code>package.json</code>, make sure the installed version is the same as the one of <code>jest</code>.</div>
+
+Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:
+
+```bash
+DD_ENV=ci npm test
+```
+
+
+[1]: https://jestjs.io/docs/en/configuration#testenvironment-string
+[2]: https://jestjs.io/docs/en/configuration#testrunner-string
+{{% /tab %}}
+
 {{% tab "Mocha" %}}
 
 Create a file in your project (for example, `init-tracer.js`) with the following contents:
@@ -162,13 +215,13 @@ The following is a list of the most important configuration settings that can be
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
 **Default**: `http://localhost:8126`
 
-All other [Datadog Tracer configuration][5] options can also be used.
+All other [Datadog Tracer configuration][6] options can also be used.
 
 
 ## Known limitations
 
 ### ES modules
-[Mocha >=9.0.0][6] uses an ESM-first approach to load test files. That means that if ES modules are used (for example, by defining test files with the `.mjs` extension), _the instrumentation is limited_. Tests are detected, but there isn't visibility into your test. For more information about ES modules, see the [NodeJS documentation][7].
+[Mocha >=9.0.0][7] uses an ESM-first approach to load test files. That means that if ES modules are used (for example, by defining test files with the `.mjs` extension), _the instrumentation is limited_. Tests are detected, but there isn't visibility into your test. For more information about ES modules, see the [NodeJS documentation][8].
 
 ### Browser tests
 The JavaScript tracer does not support browsers, so if you run browser tests with `mocha` or `jest`, there isn't visibility within the test itself.
@@ -190,14 +243,14 @@ Avoid this:
 })
 {{< /code-block >}}
 
-And use [`test.each`][8] instead:
+And use [`test.each`][9] instead:
 {{< code-block lang="javascript" >}}
 test.each([[1,2,3], [3,4,7]])('sums correctly %i and %i', (a,b,expected) => {
   expect(a+b).toEqual(expected)
 })
 {{< /code-block >}}
 
-For `mocha`, use [`mocha-each`][9]:
+For `mocha`, use [`mocha-each`][10]:
 {{< code-block lang="javascript" >}}
 const forEach = require('mocha-each');
 forEach([
@@ -217,11 +270,12 @@ When you use this approach, both the testing framework and CI Visibility can tel
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/facebook/jest/tree/master/packages/jest-circus
-[2]: /continuous_integration/setup_tests/agent/
-[3]: https://github.com/DataDog/dd-trace-js
-[4]: /tracing/setup_overview/setup/nodejs
-[5]: /tracing/setup_overview/setup/nodejs/?tab=containers#configuration
-[6]: https://github.com/mochajs/mocha/releases/tag/v9.0.0
-[7]: https://nodejs.org/api/packages.html#packages_determining_module_system
-[8]: https://jestjs.io/docs/api#testeachtablename-fn-timeout
-[9]: https://github.com/ryym/mocha-each
+[2]: https://github.com/facebook/jest/tree/master/packages/jest-jasmine2
+[3]: /continuous_integration/setup_tests/agent/
+[4]: https://github.com/DataDog/dd-trace-js
+[5]: /tracing/setup_overview/setup/nodejs
+[6]: /tracing/setup_overview/setup/nodejs/?tab=containers#configuration
+[7]: https://github.com/mochajs/mocha/releases/tag/v9.0.0
+[8]: https://nodejs.org/api/packages.html#packages_determining_module_system
+[9]: https://jestjs.io/docs/api#testeachtablename-fn-timeout
+[10]: https://github.com/ryym/mocha-each

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -15,55 +15,42 @@ further_reading:
 Supported test frameworks:
 * Jest >= 24.8.0
   * Only `jsdom` (in package `jest-environment-jsdom`) and `node` (in package `jest-environment-node`) are supported as test environments. Custom environments like `@jest-runner/electron/environment` in `jest-electron-runner` are not supported.
-  * Only [`jest-circus`][1] and [`jest-jasmine2`][2] are supported as `testRunner`.
+  * Only [`jest-circus`][1] and [`jest-jasmine2`][2] are supported as [`testRunner`][3].
 * Mocha >= 5.2.0
   * Mocha >= 9.0.0 has [partial support](#known-limitations).
 * Cucumber-js >= 7.0.0
 
 ## Prerequisites
 
-[Install the Datadog Agent to collect tests data][3].
+[Install the Datadog Agent to collect tests data][4].
 
 ## Installing the JavaScript tracer
 
-To install the [JavaScript tracer][4], run:
+To install the [JavaScript tracer][5], run:
 
 {{< code-block lang="bash" >}}
 yarn add --dev dd-trace
 {{< /code-block >}}
 
-For more information, see the [JavaScript tracer installation docs][5].
+For more information, see the [JavaScript tracer installation docs][6].
 
 ## Instrument your tests
 
 {{< tabs >}}
-{{% tab "Jest (jest-circus)" %}}
+{{% tab "Jest" %}}
 
-1. Install the `jest-circus` test runner:
-
-```bash
-yarn add --dev jest-circus
-```
-
-**Important**: The installed version of `jest-circus` and `jest` must be the same. For example, if you're using `jest@25.5.4`, run:
-
-```bash
-yarn add --dev jest-circus@25.5.4
-```
-
-2. Configure a custom [testEnvironment][1] and [testRunner][2] in your `jest.config.js` or however you are configuring `jest`:
+1. Configure a custom [`testEnvironment`][1] in your `jest.config.js` or however you are configuring `jest`:
 
 ```javascript
 module.exports = {
   // ...
-  testRunner: 'jest-circus/runner',
   // It may be another route. It refers to the file below.
   testEnvironment: '<rootDir>/testEnvironment.js',
   // ...
 }
 ```
 
-And in `testEnvironment.js`:
+2. In `testEnvironment.js`:
 
 ```javascript
 require('dd-trace').init({
@@ -79,7 +66,7 @@ require('dd-trace').init({
 module.exports = require('jest-environment-node')
 ```
 
-<div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-node</code> and <code>jest-environment-jsdom</code> are installed together with <code>jest</code>, so they do not normally appear in your <code>package.json</code>. If you've extracted any of these libraries in your <code>package.json</code>, make sure the installed version is the same as the one of <code>jest</code>.</div>
+<div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-node</code>, <code>jest-environment-jsdom</code>, <code>jest-jasmine2</code> and <code>jest-circus</code> (as of Jest 27) are installed together with <code>jest</code>, so they do not normally appear in your <code>package.json</code>. If you've extracted any of these libraries in your <code>package.json</code>, make sure the installed versions are the same as the one of <code>jest</code>.</div>
 
 Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:
 
@@ -89,61 +76,6 @@ DD_ENV=ci npm test
 
 
 [1]: https://jestjs.io/docs/en/configuration#testenvironment-string
-[2]: https://jestjs.io/docs/en/configuration#testrunner-string
-{{% /tab %}}
-{{% tab "Jest (jest-jasmine2)" %}}
-
-1. Install the `jest-jasmine2` test runner:
-
-```bash
-yarn add --dev jest-jasmine2
-```
-
-**Important**: The installed version of `jest-jasmine2` and `jest` must be the same. For example, if you're using `jest@25.5.4`, run:
-
-```bash
-yarn add --dev jest-jasmine2@25.5.4
-```
-
-2. Configure a custom [testEnvironment][1] and [testRunner][2] in your `jest.config.js` or however you are configuring `jest`:
-
-```javascript
-module.exports = {
-  // ...
-  testRunner: 'jest-jasmine2',
-  // It may be another route. It refers to the file below.
-  testEnvironment: '<rootDir>/testEnvironment.js',
-  // ...
-}
-```
-
-And in `testEnvironment.js`:
-
-```javascript
-require('dd-trace').init({
-  // Only activates test instrumentation on CI
-  enabled: process.env.DD_ENV === 'ci',
-  // Name of the service or library under test
-  service: 'my-javascript-app',
-  // To guarantee test span delivery
-  flushInterval: 300000
-})
-
-// jest-environment-jsdom is an option too
-module.exports = require('jest-environment-node')
-```
-
-<div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-node</code> and <code>jest-environment-jsdom</code> are installed together with <code>jest</code>, so they do not normally appear in your <code>package.json</code>. If you've extracted any of these libraries in your <code>package.json</code>, make sure the installed version is the same as the one of <code>jest</code>.</div>
-
-Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:
-
-```bash
-DD_ENV=ci npm test
-```
-
-
-[1]: https://jestjs.io/docs/en/configuration#testenvironment-string
-[2]: https://jestjs.io/docs/en/configuration#testrunner-string
 {{% /tab %}}
 
 {{% tab "Mocha" %}}
@@ -215,13 +147,13 @@ The following is a list of the most important configuration settings that can be
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
 **Default**: `http://localhost:8126`
 
-All other [Datadog Tracer configuration][6] options can also be used.
+All other [Datadog Tracer configuration][7] options can also be used.
 
 
 ## Known limitations
 
 ### ES modules
-[Mocha >=9.0.0][7] uses an ESM-first approach to load test files. That means that if ES modules are used (for example, by defining test files with the `.mjs` extension), _the instrumentation is limited_. Tests are detected, but there isn't visibility into your test. For more information about ES modules, see the [NodeJS documentation][8].
+[Mocha >=9.0.0][8] uses an ESM-first approach to load test files. That means that if ES modules are used (for example, by defining test files with the `.mjs` extension), _the instrumentation is limited_. Tests are detected, but there isn't visibility into your test. For more information about ES modules, see the [NodeJS documentation][9].
 
 ### Browser tests
 The JavaScript tracer does not support browsers, so if you run browser tests with `mocha` or `jest`, there isn't visibility within the test itself.
@@ -243,14 +175,14 @@ Avoid this:
 })
 {{< /code-block >}}
 
-And use [`test.each`][9] instead:
+And use [`test.each`][10] instead:
 {{< code-block lang="javascript" >}}
 test.each([[1,2,3], [3,4,7]])('sums correctly %i and %i', (a,b,expected) => {
   expect(a+b).toEqual(expected)
 })
 {{< /code-block >}}
 
-For `mocha`, use [`mocha-each`][10]:
+For `mocha`, use [`mocha-each`][11]:
 {{< code-block lang="javascript" >}}
 const forEach = require('mocha-each');
 forEach([
@@ -271,11 +203,12 @@ When you use this approach, both the testing framework and CI Visibility can tel
 
 [1]: https://github.com/facebook/jest/tree/master/packages/jest-circus
 [2]: https://github.com/facebook/jest/tree/master/packages/jest-jasmine2
-[3]: /continuous_integration/setup_tests/agent/
-[4]: https://github.com/DataDog/dd-trace-js
-[5]: /tracing/setup_overview/setup/nodejs
-[6]: /tracing/setup_overview/setup/nodejs/?tab=containers#configuration
-[7]: https://github.com/mochajs/mocha/releases/tag/v9.0.0
-[8]: https://nodejs.org/api/packages.html#packages_determining_module_system
-[9]: https://jestjs.io/docs/api#testeachtablename-fn-timeout
-[10]: https://github.com/ryym/mocha-each
+[3]: https://jestjs.io/docs/configuration#testrunner-string
+[4]: /continuous_integration/setup_tests/agent/
+[5]: https://github.com/DataDog/dd-trace-js
+[6]: /tracing/setup_overview/setup/nodejs
+[7]: /tracing/setup_overview/setup/nodejs/?tab=containers#configuration
+[8]: https://github.com/mochajs/mocha/releases/tag/v9.0.0
+[9]: https://nodejs.org/api/packages.html#packages_determining_module_system
+[10]: https://jestjs.io/docs/api#testeachtablename-fn-timeout
+[11]: https://github.com/ryym/mocha-each


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
* Simplify `jest` instructions now that we support `jest-jasmine2` too. 

### Motivation
* Make it easier for onboarding customers to use our `jest` instrumentation. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/juan-fernandez/ci-app-add-jasmine/continuous_integration/setup_tests/javascript/?tab=jestjestcircus#instrument-your-tests

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
