### PR TITLE
CI App - Swift - Add documentation for Cocoapods installation

### DIFF
--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -43,6 +43,17 @@ There are two ways of installing the testing framework:
 
 [1]: https://github.com/DataDog/dd-sdk-swift-testing
 {{% /tab %}}
+{{% tab "Using Cocoapods" %}}
+
+1. Add the DatadogSDKTesting dependency to the test targets of your Podfile:
+
+{{< code-block lang="ruby" >}}
+pod 'DatadogSDKTesting'
+{{< /code-block >}}
+
+2. If you run UITests, also add the dependency to the app running the tests.
+
+{{% /tab %}}
 {{% tab "Adding the framework directly" %}}
 
 1. Download and decompress `DatadogSDKTesting.zip` from the [release][1] page.
@@ -63,7 +74,7 @@ There are two ways of installing the testing framework:
 
 ### Configuring Datadog
 
-To enable testing instrumentation, add the following environment variables to your test target. You must also select your main target in `Expand variables based on` or `Target for Variable Expansion` if using test plans:
+To enable testing instrumentation, add the following environment variables to your test target [(*)](#Alternative-Configuration). You must also select your main target in `Expand variables based on` or `Target for Variable Expansion` if using test plans:
 
 {{< img src="continuous_integration/swift_env.png" alt="Swift Environments" >}}
 
@@ -116,50 +127,50 @@ Git metadata and build information is automatically collected using CI provider 
 
 When running tests in a simulator, full Git metadata is collected using the local `.git` folder. In this case, Git-related environment variables don't have to be forwarded.
 
-The user can also provide Git information by using custom environment variables. This is useful for adding Git information for non-supported CI providers, or for .git folders that are not available from the running process. Custom environment variables are also useful for overwriting existing Git information. If these environment variables are set, they take precedence over those coming from the CI or from the .git folder. The list of supported environment variables for Git information includes the following:
+The user can also provide Git information by using custom environment variables [(*)](#Alternative-Configuration). This is useful for adding Git information for non-supported CI providers, or for .git folders that are not available from the running process. Custom environment variables are also useful for overwriting existing Git information. If these environment variables are set, they take precedence over those coming from the CI or from the .git folder. The list of supported environment variables for Git information includes the following:
 
 `DD_GIT_REPOSITORY_URL`
-: URL of the repository where the code is stored.
+: URL of the repository where the code is stored.<br/>
 **Example**: `git@github.com:MyCompany/MyApp.git`
 
 `DD_GIT_BRANCH`
-: Branch where this commit belongs.
+: Branch where this commit belongs.<br/>
 **Example**: `develop`
 
 `DD_GIT_TAG`
-: Tag of the commit, if it has one.
+: Tag of the commit, if it has one.<br/>
 **Example**: `1.0.1`
 
 `DD_GIT_COMMIT_SHA`
-: Commit SHA.
+: Commit SHA.<br/>
 **Example**: `a18ebf361cc831f5535e58ec4fae04ffd98d8152`
 
 `DD_GIT_COMMIT_MESSAGE`
-: Commit message.
+: Commit message.<br/>
 **Example**: `Set release number`
 
 `DD_GIT_COMMIT_AUTHOR_NAME`
-: Author name.
+: Author name.<br/>
 **Example**: `John Doe`
 
 `DD_GIT_COMMIT_AUTHOR_EMAIL`
-: Author email.
+: Author email.<br/>
 **Example**: `john@doe.com`
 
 `DD_GIT_COMMIT_AUTHOR_DATE`
-: Author date. ISO 8601 format.
+: Author date. ISO 8601 format.<br/>
 **Example**: `2021-03-12T16:00:28Z`
 
 `DD_GIT_COMMIT_COMMITTER_NAME`
-: Committer name.
+: Committer name.<br/>
 **Example**: `Jane Doe`
 
 `DD_GIT_COMMIT_COMMITTER_EMAIL`
-: Committer email.
+: Committer email.<br/>
 **Example**: `jane@doe.com`
 
 `DD_GIT_COMMIT_COMMITTER_DATE`
-: Committer date. ISO 8601 format.
+: Committer date. ISO 8601 format.<br/>
 **Example**: `2021-03-12T16:00:28Z`
 
 ### Running tests
@@ -197,7 +208,7 @@ For the following configuration settings:
 
 ### Disabling auto-instrumentation
 
-The framework enables auto-instrumentation of all supported libraries, but in some cases this might not be desired. You can disable auto-instrumentation of certain libraries by setting the following environment variables:
+The framework enables auto-instrumentation of all supported libraries, but in some cases this might not be desired. You can disable auto-instrumentation of certain libraries by setting the following environment variables [(*)](#Alternative-Configuration):
 
 `DD_DISABLE_NETWORK_INSTRUMENTATION`
 : Disables all network instrumentation (Boolean)
@@ -235,6 +246,10 @@ For Network auto-instrumentation, you can configure these additional settings:
 : Sets the maximum size reported from the payload. Default `1024` (Integer)
 
 You can also disable or enable specific auto-instrumentation in some of the tests from Swift or Objective-C by importing the module `DatadogSDKTesting` and using the class: `DDInstrumentationControl`.
+
+## Alternative Configuration 
+
+Alternatively to setting environment variables, all the configuration can be provided by adding the settings to the `Info.plist` file of the Test bundles (not the App bundle). If the same setting is set both in a environment variable and in the `Info.plist` file, the environment variable takes precedence.
 
 ## Custom tags
 


### PR DESCRIPTION

### What does this PR do?
Add documentation for Cocoapods installation
Add information about a new way of configuring
Fix break lines in Git info examples

### Motivation
A new way of installing was added to the library
A new way of configuring was added to the library
Examples of Git info were looking bad without the line break

### Preview

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nachoBonafonte/CI-app-Swift-cocoapods-documentation/continuous_integration/setup_tests/swift

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
