### PR TITLE
Update integration examples to `logs:`

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -50,7 +50,7 @@ For example, to **filter OUT** logs that contain a Datadog email address, use th
 {{% tab "Configuration file" %}}
 
 ```yaml
-logs_config:
+logs:
   - type: file
     path: /my/test/file.log
     service: cardpayment
@@ -137,7 +137,7 @@ For example, to **filter IN** logs that contain a Datadog email address, use the
 {{% tab "Configuration file" %}}
 
 ```yaml
-logs_config:
+logs:
   - type: file
     path: /my/test/file.log
     service: cardpayment
@@ -152,7 +152,7 @@ logs_config:
 If you want to match one or more patterns you must define them in a single expression:
 
 ```yaml
-logs_config:
+logs:
   - type: file
     path: /my/test/file.log
     service: cardpayment
@@ -166,7 +166,7 @@ logs_config:
 If the patterns are too long to fit legibly on a single line you can break them into multiple lines:
 
 ```yaml
-logs_config:
+logs:
   - type: file
     path: /my/test/file.log
     service: cardpayment
@@ -253,7 +253,7 @@ For example, redact credit card numbers:
 {{% tab "Configuration file" %}}
 
 ```yaml
-logs_config:
+logs:
  - type: file
    path: /my/test/file.log
    service: cardpayment
@@ -359,7 +359,7 @@ For example, every Java log line starts with a timestamp in `yyyy-dd-mm` format.
 To send the example logs above with a configuration file, use the following `log_processing_rules`:
 
 ```yaml
-logs_config:
+logs:
  - type: file
    path: /var/log/pg_log.log
    service: database
@@ -463,7 +463,7 @@ If your log files are labeled by date or all stored in the same directory, confi
 Configuration example:
 
 ```yaml
-logs_config:
+logs:
   - type: file
     path: /var/log/myapp/*.log
     exclude_paths:
@@ -484,7 +484,7 @@ If applications logs are written in UTF-16 format, starting with Datadog Agent *
 Configuration example:
 
 ```yaml
-logs_config:
+logs:
   - type: file
     path: /test/log/hello-world.log
     tags: key:value


### PR DESCRIPTION
### What does this PR do?

Update examples to use `logs:` for integration level configuration.

- `logs[].log_processing_rules[]` is actually correct for integration level config
- `logs_config.processing_rules[]` is only applicable to [Global Processing Rules](https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfiles#global-processing-rules) defined in `datadog.yaml`

### Motivation
Came up in office hours

### Preview

https://docs-staging.datadoghq.com/ian.bucad/adv-log-config/agent/logs/advanced_log_collection

### Additional Notes

- https://github.com/DataDog/documentation/issues/10226
- https://github.com/DataDog/documentation/pull/10240
- `logs:` - https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/logs.yaml#L1
- `logs_config` - https://github.com/DataDog/datadog-agent/blob/7.30.x/pkg/config/config.go#L675

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
