### PR TITLE
Add AAS debug log location

### DIFF
--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -151,6 +151,7 @@ Logs files are saved in the following directories by default. Use the `DD_TRACE_
 |----------|-------------------------------------------|
 | Windows  | `%ProgramData%\Datadog .NET Tracer\logs\` |
 | Linux    | `/var/log/datadog/dotnet/`                |
+| Azure App Services | `%AzureAppServiceHomeDirectory%\LogFiles\datadog`|
 
 **Note:**: On Linux, you must create the logs directory before you enabled debug mode.
 


### PR DESCRIPTION
What does this PR do?
Add AAS debug log location

Motivation
We don't have the AAS location mentioned here:
https://docs.datadoghq.com/serverless/azure_app_services/#troubleshooting

### Preview
https://docs-staging.datadoghq.com/kozzie/add-aas-debug-log-location/tracing/troubleshooting/tracer_debug_logs

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
