### PR TITLE
Add integrations and ignore_autoconf rule

### DIFF
--- a/content/en/agent/faq/auto_conf.md
+++ b/content/en/agent/faq/auto_conf.md
@@ -14,7 +14,7 @@ further_reading:
 
 When the Agent runs as a container, it tries by default to Autodiscover other containers around it based on default Autodiscovery configuration files named `auto_conf.yaml`. You can find these files in the corresponding `conf.d/<INTEGRATION>.d/` folders for the following integrations:
 
-## Auto-Configuration Files
+## Auto-Configuration files
 
 | Integration                    | Auto-configuration file |
 | ------                         | --------                |
@@ -43,14 +43,14 @@ When the Agent runs as a container, it tries by default to Autodiscover other co
 
 The `auto_conf.yaml` configuration files cover all required parameters to set up a specific integration, with their corresponding [Autodiscovery Templates Variables][43] in place to take into account the containerized environment.
 
-## Customizing Configuration
-The auto configuration logic only supports the default configuration for any integration above. If you want to customize your Datadog integration configuration, refer to the Integrations Templates documentation to learn how to configure your Agent Autodiscovery. Any configuration discovered via Kubernetes Annotations or Docker Labels for a given container will take precedence over the `auto_conf.yaml` file.
+## Customizing configuration
+The auto configuration logic only supports the default configuration for any integration above. If you want to customize your Datadog integration configuration, see the Integrations Templates documentation to learn how to configure your Agent Autodiscovery. Any configuration discovered through Kubernetes Annotations or Docker Labels for a given container takes precedence over the `auto_conf.yaml` file.
 
 * [Using Key-Value Store][44]
 * [Using Kubernetes Annotations][45]
 * [Using Docker Labels][46]
 
-## Disabling Auto Configuration
+## Disabling auto-configuration
 
 To disable the Agent from using the `auto_conf.yaml` configuration you can add the environment variable `DD_IGNORE_AUTOCONF` for the desired integration(s) to disable. The environment variable:
 ```
@@ -82,7 +82,7 @@ Would would have the Agent ignore the [`redisdb.d/auto_conf.yaml`][38] and [`ist
 [18]: https://github.com/DataDog/integrations-core/blob/master/external_dns/datadog_checks/external_dns/data/auto_conf.yaml
 [19]: /integrations/harbor/
 [20]: https://github.com/DataDog/integrations-core/blob/master/harbor/datadog_checks/harbor/data/auto_conf.yaml
-[21]: /integrattions/istio
+[21]: /integrations/istio
 [22]: https://github.com/DataDog/integrations-core/blob/master/istio/datadog_checks/istio/data/auto_conf.yaml
 [23]: /agent/kubernetes/
 [24]: https://github.com/DataDog/integrations-core/blob/master/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Get the list of `auto_conf.yaml` files up to date (excluding the Datadog Cluster Agent) as well as add in the steps for the `DD_IGNORE_AUTOCONF` environment variable introduced in 7.24.0.

### Motivation
<!-- What inspired you to submit this pull request?-->
Expose to customers for easier reference.

### Preview
<!-- Impacted pages preview links-->
New Page: 
- https://docs-staging.datadoghq.com/jack.davenport/auto_conf_additions/agent/faq/auto_conf/

Old Page:
- https://docs.datadoghq.com/agent/faq/auto_conf/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Let the linter auto-update all the links and orders, hence the big change. But really was adding in `cilium`, `external_dns`, `istio`, `kube_controller_Manager`, and `kube_scheduler`.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
