### PR TITLE
Remove service accounts header

### DIFF
--- a/content/en/account_management/org_settings.md
+++ b/content/en/account_management/org_settings.md
@@ -10,7 +10,7 @@ Organization Settings allow you to manage users, groups, RBAC, keys, and tokens.
 #### Users
 
 Read the [user management][2] documentation to add, edit, and disable users.
-#### Service Accounts
+
 
 ### Groups
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes an empty header from the account management overview page, as the docs are still WIP and coming soon.

### Motivation
Nicholas Devlin in #documentation

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
