### PR TITLE
Remove log level example from ignore resources guide

### DIFF
--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -125,7 +125,6 @@ docker run -d --name datadog-agent \
               -e DD_API_KEY=<> \
         -e DD_APM_IGNORE_RESOURCES="Api::HealthchecksController#index$" \
               -e DD_APM_ENABLED=true \
-        -e DD_LOG_LEVEL=TRACE \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
               datadog/agent:latest
 {{< /code-block >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Removes DD_LOG_LEVEL=TRACE as part of the example
### Motivation
<!-- What inspired you to submit this pull request?-->

It's not needed in the example.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/tracing/guide/ignoring_apm_resources

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
