### PR TITLE
More clear for status correction that you must first click existing SLO

### DIFF
--- a/content/en/monitors/service_level_objectives/_index.md
+++ b/content/en/monitors/service_level_objectives/_index.md
@@ -176,7 +176,7 @@ Status corrections are in public beta through the [SLO status corrections API][1
 
 To access SLO status corrections in the UI:
 
-1. Create a new SLO or edit an existing one.
+1. Create a new SLO or click on an existing one.
 2. Navigate to an SLO’s detailed side panel view.
 3. Under the gear icon, select **Correct Status** to access the **Status Corrections** creation modal.
 4. Select the **Time Correction Window**, **Correction Type**, and add **Notes**.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
More clear language about clicking an existing SLO first before making status correction.

### Motivation
<!-- What inspired you to submit this pull request?-->
Exec feedback that this was unclear

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/sophiah123/clickexistingslo/monitors/service_level_objectives/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
