### PR TITLE
add sharedb to nodejs compatibility list

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/nodejs.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/nodejs.md
@@ -96,6 +96,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 | [oracledb][36]         | `>=5`    | Fully supported |                                                  |
 | [pg][37]               | `>=4`    | Fully supported | Supports `pg-native` when used with `pg`         |
 | [redis][38]            | `>=0.12` | Fully supported |                                                  |
+| [sharedb][61]          | `>=1`    | Fully supported |                                                  |
 | [tedious][39]          | `>=1`    | Fully supported | SQL Server driver for `mssql` and `sequelize`    |
 
 ### Worker compatibility
@@ -207,3 +208,4 @@ For additional information or to discuss [leave a comment on this github issue][
 [58]: https://nodejs.org/api/async_hooks.html
 [59]: https://www.meteor.com/
 [60]: https://github.com/DataDog/dd-trace-js/issues/1229
+[61]: https://share.github.io/sharedb/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add `sharedb` to NodeJS compatibility list.

### Motivation
<!-- What inspired you to submit this pull request?-->

Support for ShareDB has been added since dd-trace-js 1.3.0.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/rochdev/node-sharedb/tracing/setup_overview/compatibility_requirements/nodejs/#data-store-compatibility

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
