### PR TITLE
Logs intake not supported for US3

### DIFF
--- a/content/en/integrations/adobe_experience_manager.md
+++ b/content/en/integrations/adobe_experience_manager.md
@@ -38,6 +38,14 @@ Collect Adobe Experience Manager logs to track errors, request response time, an
 
 #### Log collection
 
+{{< site-region region="us3" >}}
+
+Log collection is not supported for this site.
+
+{{< /site-region >}}
+
+{{< site-region region="us,eu,gov" >}}
+
 _Available for Agent version >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent. Enable it in your `datadog.yaml` file with:
@@ -59,6 +67,9 @@ _Available for Agent version >6.0_
       Change the `path` and `service` parameter values and configure them for your environment.
 
 3. [Restart the Agent][3].
+
+
+{{< /site-region >}}
 
 ## Troubleshooting
 

--- a/content/en/integrations/adobe_experience_manager.md
+++ b/content/en/integrations/adobe_experience_manager.md
@@ -54,7 +54,7 @@ _Available for Agent version >6.0_
     logs_enabled: true
     ```
 
-2. Create `adobe.experience.manager.d/conf.yaml` in your [conf.d directory][2] and add the configuration below to start collecting your logs:
+2. Create `adobe.experience.manager.d/conf.yaml` in your [conf.d directory][1] and add the configuration below to start collecting your logs:
 
     ```yaml
     logs:
@@ -66,20 +66,20 @@ _Available for Agent version >6.0_
 
       Change the `path` and `service` parameter values and configure them for your environment.
 
-3. [Restart the Agent][3].
+3. [Restart the Agent][2].
 
+[1]: /agent/guide/agent-configuration-files/#agent-configuration-directory
+[2]: /agent/guide/agent-commands/#restart-the-agent
 
 {{< /site-region >}}
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][4].
+Need help? Contact [Datadog support][2].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/account/settings#agent
-[2]: /agent/guide/agent-configuration-files/#agent-configuration-directory
-[3]: /agent/guide/agent-commands/#restart-the-agent
-[4]: /help/
+[2]: /help/

--- a/content/en/integrations/apigee.md
+++ b/content/en/integrations/apigee.md
@@ -30,6 +30,14 @@ Collect Apigee proxy logs to track errors, response time, duration, latency and 
 
 #### Log collection
 
+{{< site-region region="us3" >}}
+
+Log collection is not supported for this site.
+
+{{< /site-region >}}
+
+{{< site-region region="us,eu,gov" >}}
+
 There are two methods available for collecting Apigee logs:
 
 1. Use Apigee's [JavaScript policy][1] to send logs to Datadog.
@@ -144,6 +152,9 @@ httpClient.send(myLoggingRequest);
 ```
 
 **Note**: Add more flow variables into JavaScript from the official [Apigee flow variable documentation][4].
+
+
+{{< /site-region >}}
 
 ## Troubleshooting
 

--- a/content/en/integrations/apigee.md
+++ b/content/en/integrations/apigee.md
@@ -153,19 +153,19 @@ httpClient.send(myLoggingRequest);
 
 **Note**: Add more flow variables into JavaScript from the official [Apigee flow variable documentation][4].
 
+[1]: https://docs.apigee.com/api-platform/reference/policies/javascript-policy
+[2]: https://docs.apigee.com/api-platform/reference/policies/message-logging-policy#samples
+[3]: /logs/log_configuration/attributes_naming_convention/#standard-attributes
+[4]: https://docs.apigee.com/api-platform/reference/variables-reference
 
 {{< /site-region >}}
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][5].
+Need help? Contact [Datadog support][1].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://docs.apigee.com/api-platform/reference/policies/javascript-policy
-[2]: https://docs.apigee.com/api-platform/reference/policies/message-logging-policy#samples
-[3]: /logs/log_configuration/attributes_naming_convention/#standard-attributes
-[4]: https://docs.apigee.com/api-platform/reference/variables-reference
-[5]: /help/
+[1]: /help/

--- a/content/en/integrations/pivotal_platform.md
+++ b/content/en/integrations/pivotal_platform.md
@@ -173,12 +173,13 @@ cf set-env app01 LOGS_CONFIG '[{"type":"tcp","port":"10514","source":"java","ser
 
 ##### Notification in case of misconfigured proxy
 
-For Agent v6.12+, when using a [proxy configuration][13] with the Buildpack, a verification is made to check if the connection can be established. Log collection is started depending on the result of this test.
+For Agent v6.12+, when using a [proxy configuration][1] with the Buildpack, a verification is made to check if the connection can be established. Log collection is started depending on the result of this test.
 
 If the connection fails to be established and the log collection is not started, an event like the one below is sent to your Datadog event stream. Set up a monitor to track these events and be notified when a misconfigured Buildpack is deployed:
 
 {{< img src="integrations/cloud_foundry/logs_misconfigured_proxy.png" alt="cloud-foundry-log-misconfigured_proxy"  >}}
 
+[1]: /agent/logs/proxy/
 
 {{< /site-region >}}
 
@@ -452,7 +453,6 @@ Your specific list of metrics may vary based on the PCF version and the deployme
 [10]: https://cloudfoundry.datadoghq.com/datadog-cloudfoundry-buildpack/datadog-cloudfoundry-buildpack-latest.zip
 [11]: https://github.com/cf-platform-eng/meta-buildpack
 [12]: /tracing/setup/
-[13]: /agent/logs/proxy/
 [14]: /libraries/
 [15]: https://bosh.io/docs/bosh-cli.html
 [16]: https://bosh.io/docs/cli-v2.html#install

--- a/content/en/integrations/pivotal_platform.md
+++ b/content/en/integrations/pivotal_platform.md
@@ -126,6 +126,14 @@ The Datadog Trace Agent (APM) is enabled by default. Learn more about setup for 
 
 #### Log collection
 
+{{< site-region region="us3" >}}
+
+Log collection is not supported for this site.
+
+{{< /site-region >}}
+
+{{< site-region region="us,eu,gov" >}}
+
 ##### Enable
 
 To start collecting logs from your application in Pivotal Platform, the Agent contained in the buildpack needs to be activated and log collection enabled.
@@ -170,6 +178,9 @@ For Agent v6.12+, when using a [proxy configuration][13] with the Buildpack, a v
 If the connection fails to be established and the log collection is not started, an event like the one below is sent to your Datadog event stream. Set up a monitor to track these events and be notified when a misconfigured Buildpack is deployed:
 
 {{< img src="integrations/cloud_foundry/logs_misconfigured_proxy.png" alt="cloud-foundry-log-misconfigured_proxy"  >}}
+
+
+{{< /site-region >}}
 
 ### Build
 


### PR DESCRIPTION
### What does this PR do?
Updates logs integration docs to say that US3 is not supported

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/sarina/us3-logs/integrations/adobe_experience_manager
https://docs-staging.datadoghq.com/sarina/us3-logs/integrations/apigee
https://docs-staging.datadoghq.com/sarina/us3-logs/integrations/pivotal_platform

### Additional Notes
This is one of four PRs related to this matter; all additional PRs are in their corresponding integrations repos

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
