### PR TITLE
fix translation error : unlink = supprimer

### DIFF
--- a/content/fr/tracing/setup_overview/setup/php.md
+++ b/content/fr/tracing/setup_overview/setup/php.md
@@ -424,7 +424,7 @@ Une fois l'installation terminée, redémarrez PHP (PHP-FPM ou le SAPI Apache).
 Pour supprimer le tracer PHP :
 
 1. Pour php-fpm, arrêtez le service php-fpm ou le serveur Web Apache.
-2. Dissociez les fichiers `98-ddtrace.ini` and `99-ddtrace-custom.ini` de votre dossier de configuration PHP.
+2. Supprimez les fichiers `98-ddtrace.ini` et `99-ddtrace-custom.ini` de votre dossier de configuration PHP.
 3. Pour php-fpm, redémarrez le service php-fpm ou le serveur Web Apache.
 
 **Remarque** : si vous utilisez une mise en cache secondaire dans OPcache en définissant le paramètre `opcache.file_cache`, supprimez le dossier de cache.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
fix french translation for `unlink` word

### Motivation
was reading documentation and the sentence was making no sense

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/master/content/fr/tracing/setup_overview/setup/php.md

### Additional Notes
love your software!

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
