### PR TITLE
[WEB-480] Fix link-checker

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,7 +144,7 @@ build_preview:
 link_checks_preview:
   <<: *base_template
   stage: post-deploy
-  timeout: 2h
+  timeout: 3h
   cache:
     <<: *cache
     policy: pull
@@ -293,7 +293,7 @@ index_internal_doc:
 test_live_link_checks:
   <<: *base_template
   stage: post-deploy
-  timeout: 2h
+  timeout: 3h
   cache:
     <<: *cache
     policy: pull

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,6 +144,7 @@ build_preview:
 link_checks_preview:
   <<: *base_template
   stage: post-deploy
+  timeout: 2h
   cache:
     <<: *cache
     policy: pull
@@ -292,6 +293,7 @@ index_internal_doc:
 test_live_link_checks:
   <<: *base_template
   stage: post-deploy
+  timeout: 2h
   cache:
     <<: *cache
     policy: pull

--- a/config/live/config.yaml
+++ b/config/live/config.yaml
@@ -36,7 +36,7 @@ deployment:
         cacheControl: "max-age=31536000, no-transform, public"
         gzip: false
       - pattern: "^.+\\.html$"
-        gzip: true
+        gzip: false
         contentType: "text/html; charset=utf-8"
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
       - pattern: "^.+\\.xml$"

--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -36,7 +36,7 @@ deployment:
         cacheControl: "max-age=31536000, no-transform, public"
         gzip: false
       - pattern: "^.+\\.html$"
-        gzip: true
+        gzip: false
         contentType: "text/html; charset=utf-8"
         cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
       - pattern: "^.+\\.xml$"

--- a/local/etc/link-check-config.js
+++ b/local/etc/link-check-config.js
@@ -16,6 +16,7 @@ module.exports = {
         slackChannel: '#guac-ops'
     },
     linkCheckOptions: {
+        cacheMaxAge: 21_600_000, // 6 hours
         filterLevel: 3,
         maxSockets: 100,
         excludeExternalLinks: false,

--- a/local/etc/link-check-config.js
+++ b/local/etc/link-check-config.js
@@ -8,7 +8,7 @@ module.exports = {
         slackChannel: '#guac-ops'
     },
     staging: {
-        serverUrl: 'https://docs-staging.datadoghq.com/',
+        serverUrl: 'https://docs-staging.datadoghq.com/bengl/remove-java-perf-guarantees/',
         slackChannel: '#guac-ops'
     },
     local: {
@@ -22,6 +22,8 @@ module.exports = {
         honorRobotExclusions: false,
         brokenLinkSlackLimit: 5,
         excludedKeywords: [
+            '**/v1/**',
+            '**/v2/**',
             '**/ja/**',
             '**/fr/**',
             '*wtime=*',
@@ -42,7 +44,6 @@ module.exports = {
             '*.txt',
             '*.yaml'
         ],
-        csvUrl:
-            'https://origin-static-assets.s3.amazonaws.com/documentation/brokenlinks/'
+        csvUrl: 'https://origin-static-assets.s3.amazonaws.com/documentation/brokenlinks/'
     }
 };

--- a/local/etc/link-check-config.js
+++ b/local/etc/link-check-config.js
@@ -8,7 +8,7 @@ module.exports = {
         slackChannel: '#guac-ops'
     },
     staging: {
-        serverUrl: 'https://docs-staging.datadoghq.com/bengl/remove-java-perf-guarantees/',
+        serverUrl: 'https://docs-staging.datadoghq.com/',
         slackChannel: '#guac-ops'
     },
     local: {


### PR DESCRIPTION
### What does this PR do?
The config was setup to compress HTML when deploying file to s3 which is breaking the link-checker scripts. This PR disables gzip in deploy config. Gzip is enabled at the edge, so not sure there's a benefit to having the source files compressed as well. 

### Motivation
Fix broken-link-checker

### Preview
https://docs-staging.datadoghq.com/nsollecito/blc-fix-deploy/

### Additional Notes
Gitlab Job showing results:
https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/82266316

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
