### PR TITLE
Updating Enrichment Table beta banner

### DIFF
--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -12,7 +12,7 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-The Enrichment Tables feature is currently in private beta. For more information, contact <a href="https://docs.datadoghq.com/help/">Datadog support</a>.
+The Enrichment Tables feature is currently in public beta. There are no billing implications for defining and querying enrichment tables during this period, and there will be ample notice if that changes. For more information, contact <a href="https://docs.datadoghq.com/help/">Datadog support</a>.
 </div>
 
 ## Overview

--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -12,7 +12,7 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-The Enrichment Tables feature is currently in public beta. There are no billing implications for defining and querying enrichment tables during this period, and there will be ample notice if that changes. For more information, contact <a href="https://docs.datadoghq.com/help/">Datadog support</a>.
+The Enrichment Tables feature is currently in public beta. There are no billing implications for defining and querying enrichment tables. For more information, contact <a href="https://docs.datadoghq.com/help/">Datadog support</a>.
 </div>
 
 ## Overview


### PR DESCRIPTION
### What does this PR do?
Updating the enrichment table banner to say it is in public beta instead of private beta

### Motivation
We are switching to public beta on monday

### Preview

https://docs-staging.datadoghq.com/charlie.meynet/et_public_beta/logs/guide/enrichment-tables

### Additional Notes

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
