### PR TITLE
Fix typo in log_collection/csharp.md

### DIFF
--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -251,7 +251,7 @@ If you have followed the instructions you should see in your file (for example `
 }
 ```
 
-If, despite the benefits of logging in JSON, you wish to log in raw string format, we recommend you update the `log4net convertion pattern` to automatically parse your logs with the C# integration Pipeline as follows:
+If, despite the benefits of logging in JSON, you wish to log in raw string format, we recommend you update the `log4net conversion pattern` to automatically parse your logs with the C# integration Pipeline as follows:
 
 ```text
 <param name="ConversionPattern" value="%date{yyyy-MM-dd HH:mm:ss.SSS} %level [%thread] %logger %method:%line - %message%n" />


### PR DESCRIPTION
### What does this PR do?
Fix typo of `convertion` to `conversion` spelling