### PR TITLE
Clarify DD_TRACE_SAMPLE_RATE for PHP Tracer

### DIFF
--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -309,8 +309,8 @@ Works for Linux. Set to `true` to retain capabilities on Datadog background thre
 **Note:** Enabling this option may compromise security. This option, standalone, does not pose a security risk. However, an attacker being able to exploit a vulnerability in PHP or web server may be able to escalate privileges with relative ease, if the web server or PHP were started with full capabilities, as the background threads will retain their original capabilities. Datadog recommends restricting the capabilities of the web server with the `setcap` utility.
 
 `DD_TRACE_SAMPLE_RATE`
-: **Default**: `1.0`<br>
-The sampling rate for the traces (defaults to: between `0.0` and `1.0`). For versions < `0.36.0`, this parameter is `DD_SAMPLING_RATE`.
+: **Default**: `null`<br>
+Enable [Tracing without Limits][19]. The sampling rate for the traces (defaults to: between `0.0` and `1.0`). For versions < `0.36.0`, this parameter is `DD_SAMPLING_RATE`.
 
 `DD_TRACE_SAMPLING_RULES`
 : **Default**: `null`<br>
@@ -774,3 +774,4 @@ For Apache, run:
 [16]: https://wiki.ubuntu.com/Debug%20Symbol%20Packages
 [17]: https://wiki.ubuntu.com/Debug%20Symbol%20Packages#Getting_-dbgsym.ddeb_packages
 [18]: https://valgrind.org/docs/manual/manual-core.html#manual-core.comment
+[19]: /tracing/trace_retention_and_ingestion/

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -310,7 +310,7 @@ Works for Linux. Set to `true` to retain capabilities on Datadog background thre
 
 `DD_TRACE_SAMPLE_RATE`
 : **Default**: `null`<br>
-Sets the trace sampling rate between `0.0` (0%) and `1.0` (100%, recommended). `1.0` or Tracing without Limits™, allows you to send all of your traffic and retention can be [configured within the Datadog app][19]. When this configuration is not set, the Datadog agent will keep an intelligent assortment of diverse traces. For versions < `0.36.0`, this parameter is `DD_SAMPLING_RATE`.
+Sets the trace sampling rate between `0.0` (0%) and `1.0` (100%, recommended). `1.0` or Tracing without Limits™, allows you to send all of your traffic and retention can be [configured within the Datadog app][19]. When this configuration is not set, the Datadog agent will keep an intelligent assortment of diverse traces. For versions < `0.36.0`, the sampling rate parameter is `DD_SAMPLING_RATE`.
 
 `DD_TRACE_SAMPLING_RULES`
 : **Default**: `null`<br>

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -310,7 +310,7 @@ Works for Linux. Set to `true` to retain capabilities on Datadog background thre
 
 `DD_TRACE_SAMPLE_RATE`
 : **Default**: `null`<br>
-Sets the trace sampling rate between `0.0` (0%) and `1.0` (100%, recommended). `1.0` or Tracing without Limits™, allows you to send all of your traffic and retention can be [configured within the Datadog app][19]. When this configuration is not set, the Datadog agent will keep an intelligent assortment of diverse traces. For versions < `0.36.0`, the sampling rate parameter is `DD_SAMPLING_RATE`.
+Sets the trace sampling rate between `0.0` (0%) and `1.0` (100%, recommended). `1.0` or Tracing without Limits™, allows you to send all of your traffic and retention can be [configured within the Datadog app][19]. For versions < `0.36.0`, the sampling rate parameter is `DD_SAMPLING_RATE`.
 
 `DD_TRACE_SAMPLING_RULES`
 : **Default**: `null`<br>

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -310,7 +310,7 @@ Works for Linux. Set to `true` to retain capabilities on Datadog background thre
 
 `DD_TRACE_SAMPLE_RATE`
 : **Default**: `null`<br>
-Sets the trace sampling rate between `0.0` (0%) and `1.0` (100%, recommended). `1.0` or Tracing without Limits™, allows you to send all of your traffic and retention can be [configured within the Datadog app][19]. For versions < `0.36.0`, the sampling rate parameter is `DD_SAMPLING_RATE`.
+Sets the trace sampling rate between `0.0` (0%) and `1.0` (100%, recommended). A value of`1.0`, Tracing without Limits™, sends all of your traffic. [Configure the retention][19] within the Datadog app. For versions before `0.36.0`, the sampling rate parameter is `DD_SAMPLING_RATE`.
 
 `DD_TRACE_SAMPLING_RULES`
 : **Default**: `null`<br>

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -310,7 +310,7 @@ Works for Linux. Set to `true` to retain capabilities on Datadog background thre
 
 `DD_TRACE_SAMPLE_RATE`
 : **Default**: `null`<br>
-Sets the trace sampling rate between `0.0` (0%) and `1.0` (100%, recommended). A value of`1.0`, Tracing without Limits™, sends all of your traffic. [Configure the retention][19] within the Datadog app. For versions before `0.36.0`, the sampling rate parameter is `DD_SAMPLING_RATE`.
+Sets the trace sampling rate between `0.0` (0%) and `1.0` (100%, recommended). A value of `1.0`, Tracing without Limits™, sends all of your traffic. [Configure the retention][19] within the Datadog app. For versions before `0.36.0`, the sampling rate parameter is `DD_SAMPLING_RATE`.
 
 `DD_TRACE_SAMPLING_RULES`
 : **Default**: `null`<br>

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -310,7 +310,7 @@ Works for Linux. Set to `true` to retain capabilities on Datadog background thre
 
 `DD_TRACE_SAMPLE_RATE`
 : **Default**: `null`<br>
-Enable [Tracing without Limits][19]. The sampling rate for the traces (defaults to: between `0.0` and `1.0`). For versions < `0.36.0`, this parameter is `DD_SAMPLING_RATE`.
+Sets the trace sampling rate between `0.0` (0%) and `1.0` (100%, recommended). `1.0` or Tracing without Limits™, allows you to send all of your traffic and retention can be [configured within the Datadog app][19]. When this configuration is not set, the Datadog agent will keep an intelligent assortment of diverse traces. For versions < `0.36.0`, this parameter is `DD_SAMPLING_RATE`.
 
 `DD_TRACE_SAMPLING_RULES`
 : **Default**: `null`<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Clarify DD_TRACE_SAMPLE_RATE defaults and functionality.

### Motivation
<!-- What inspired you to submit this pull request?-->
Encountered by customer. The document is misleading. It did not explicitly say that DD_TRACE_SAMPLE_RATE needs to be set to enable Tracing without Limits unlike our [Ruby documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/ruby#environment-variables).

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mecsantos/php-tracer-docs/tracing/setup_overview/setup/php/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Let's have APM confirm this as well.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
