### PR TITLE
monitor limits

### DIFF
--- a/content/en/monitors/monitor_types/apm.md
+++ b/content/en/monitors/monitor_types/apm.md
@@ -74,6 +74,7 @@ An alert is triggered whenever a metric deviates from an expected pattern.
     * **Monitor over a facet or measure**: If a facet is selected, the monitor alerts over the `Unique value count` of the facet. If a measure is selected, then it's similar to a metric monitor, and aggregation needs to be selected (`min`, `avg`, `sum`, `median`, `pc75`, `pc90`, `pc95`, `pc98`, `pc99`, or `max`).
 
 **Note:** Analytics monitors can only be created based on [Indexed Spans][4].
+There is a default limit of 1000 monitors per account. Reach out to help@datadoghq.com to lift this limit for your account.
 
 ### Select alert conditions
 

--- a/content/en/monitors/monitor_types/apm.md
+++ b/content/en/monitors/monitor_types/apm.md
@@ -74,7 +74,7 @@ An alert is triggered whenever a metric deviates from an expected pattern.
     * **Monitor over a facet or measure**: If a facet is selected, the monitor alerts over the `Unique value count` of the facet. If a measure is selected, then it's similar to a metric monitor, and aggregation needs to be selected (`min`, `avg`, `sum`, `median`, `pc75`, `pc90`, `pc95`, `pc98`, `pc99`, or `max`).
 
 **Note:** Analytics monitors can only be created based on [Indexed Spans][4].
-There is a default limit of 1000 monitors per account. Reach out to help@datadoghq.com to lift this limit for your account.
+<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 monitors per account. <a href="/help/">Contact Support</a> to lift this limit for your account.</div>
 
 ### Select alert conditions
 

--- a/content/en/monitors/monitor_types/log.md
+++ b/content/en/monitors/monitor_types/log.md
@@ -21,7 +21,7 @@ Once [log management is enabled][1] for your organization, you can create a logs
 
 To create a [logs monitor][2] in Datadog, use the main navigation: *Monitors --> New Monitor --> Logs*.
 
-*Note:* There is a default limit of 1000 log monitors per account. Reach out to help@datadoghq.com to lift this limit for your account.
+<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 monitors per account. <a href="/help/">Contact Support</a> to lift this limit for your account.</div>
 
 ### Define the search query
 

--- a/content/en/monitors/monitor_types/log.md
+++ b/content/en/monitors/monitor_types/log.md
@@ -21,6 +21,8 @@ Once [log management is enabled][1] for your organization, you can create a logs
 
 To create a [logs monitor][2] in Datadog, use the main navigation: *Monitors --> New Monitor --> Logs*.
 
+*Note:* There is a default limit of 1000 log monitors per account. Reach out to help@datadoghq.com to lift this limit for your account.
+
 ### Define the search query
 
 As you define the search query, the graph above the search fields updates.

--- a/content/en/monitors/monitor_types/real_user_monitoring.md
+++ b/content/en/monitors/monitor_types/real_user_monitoring.md
@@ -21,6 +21,8 @@ Once [Real User Monitoring is enabled][1] for your organization, you can create 
 
 To create a [RUM monitor][2] in Datadog, use the main navigation: *Monitors --> New Monitor --> Real User Monitoring*.
 
+*Note:* There is a default limit of 1000 RUM monitors per account. Reach out to help@datadoghq.com to lift this limit for your account.
+
 ### Define the search query
 
 As you define the search query, the graph above the search fields updates.

--- a/content/en/monitors/monitor_types/real_user_monitoring.md
+++ b/content/en/monitors/monitor_types/real_user_monitoring.md
@@ -21,7 +21,7 @@ Once [Real User Monitoring is enabled][1] for your organization, you can create 
 
 To create a [RUM monitor][2] in Datadog, use the main navigation: *Monitors --> New Monitor --> Real User Monitoring*.
 
-*Note:* There is a default limit of 1000 RUM monitors per account. Reach out to help@datadoghq.com to lift this limit for your account.
+<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 monitors per account. <a href="/help/">Contact Support</a> to lift this limit for your account.</div>
 
 ### Define the search query
 


### PR DESCRIPTION
### What does this PR do?
Document that we have a limit on the number of monitors that can be created by default and that this one can be lifted. 

### Motivation
Limit was recently introduced to catch automation scripts creating a lot of monitors that could instead be supported with multi-alerts.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
- https://docs-staging.datadoghq.com/nils/monitor-limits/monitors/monitor_types/apm/?tab=apmmetrics
- https://docs-staging.datadoghq.com/nils/monitor-limits/monitors/monitor_types/real_user_monitoring/
- https://docs-staging.datadoghq.com/nils/monitor-limits/monitors/monitor_types/log/


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
