### PR TITLE
roll back mention of max_returned_metrics parameter for JMX

### DIFF
--- a/content/en/integrations/faq/troubleshooting-jmx-integrations.md
+++ b/content/en/integrations/faq/troubleshooting-jmx-integrations.md
@@ -153,19 +153,9 @@ $ docker exec -it <AGENT_CONTAINER_NAME> agent status
 ### The 350 metric limit
 
 Datadog accepts a maximum of 350 metrics.
-A best practice is to limit your metrics to less than 350 by creating filters to refine those metrics collected; but if you need more than 350 metrics, it is possible to increase this limit by modifying the `max_returned_metrics` parameter in your JMX yaml config file. Here is an example:
+A best practice is to limit your metrics to less than 350 by creating filters to refine those metrics collected; but if you need more than 350 metrics, it is possible to increase this limit by modifying a parameter in your JMX config file.
 
-```yaml
-instances:
-  - host: localhost
-    port: 1234
-    max_returned_metrics: 2000
-```
-
-<div class="alert alert-warning">
-<strong>Important Note:</strong> Modifying the <code>max_returned_metrics</code> parameter can result in increases in custom metrics. <a href="https://docs.datadoghq.com/account_management/billing/custom_metrics/?tab=countrategauge#pagetitle">Please refer to this document for more information on custom metrics billing.</a>
-</div>
-
+[Please contact Datadog support if you would like to do this.][2]
 
 ### Java path
 

--- a/content/en/integrations/faq/troubleshooting-jmx-integrations.md
+++ b/content/en/integrations/faq/troubleshooting-jmx-integrations.md
@@ -155,7 +155,7 @@ $ docker exec -it <AGENT_CONTAINER_NAME> agent status
 Datadog accepts a maximum of 350 metrics.
 A best practice is to limit your metrics to less than 350 by creating filters to refine those metrics collected; but if you need more than 350 metrics, it is possible to increase this limit by modifying a parameter in your JMX config file.
 
-[Please contact Datadog support if you would like to do this.][2]
+[Please contact Datadog support if you would like to increase this limit.][2]
 
 ### Java path
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Rolling back the mention of the `max_returned_metrics` parameter

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
