### PR TITLE
Clarification for serverless webpack users

### DIFF
--- a/content/en/serverless/troubleshooting/serverless_tracing_and_webpack.md
+++ b/content/en/serverless/troubleshooting/serverless_tracing_and_webpack.md
@@ -26,8 +26,8 @@ Datadog's tracing libraries (`dd-trace`) are known to be not compatible with [we
     };
     ```
 
-1. Remove `datadog-lambda-js` and `dd-trace` from your `package.json` and the build process.
-2. If you are using `serverless-webpack` and the Serverless Framework, exclude `datadog-lambda-js` and `dd-trace` from your `serverless.yml`.
+3. Remove `datadog-lambda-js` and `dd-trace` from your `package.json` and the build process.
+4. If you are using `serverless-webpack` and the Serverless Framework, exclude `datadog-lambda-js` and `dd-trace` from your `serverless.yml`.
 
     **serverless.yml**
 

--- a/content/en/serverless/troubleshooting/serverless_tracing_and_webpack.md
+++ b/content/en/serverless/troubleshooting/serverless_tracing_and_webpack.md
@@ -2,15 +2,18 @@
 title: Node.js Lambda Tracing and Webpack Compatibility 
 kind: documentation
 further_reading:
-    - link: 'serverless/installation/node'
-      tag: 'Documentation'
+- link: '/serverless/installation/nodejs'
+  tag: 'Documentation'
+  text: 'Instrumenting Node.js Applications'
 ---
 
 # Compatibility
 
-Datadog's tracing libraries (`dd-trace`) are known to be not compatible with [webpack][1] due to the use of conditional imports and other issues. If using webpack and tracing your Node.js serverless functions:
+Datadog's tracing libraries (`dd-trace`) are known to be not compatible with [webpack][1] due to the use of conditional imports and other issues. While webpack cannot *build* `dd-trace`, your application can still *use* `dd-trace` and `datadog-lambda-js` provided by the *prebuilt* Datadog Lambda layer. Follow the instructions below:
 
-1. Mark `datadog-lambda-js` and `dd-trace` as [externals][2] for webpack, so webpack knows these dependencies will be available in the Lambda runtime.
+1. Follow the [installation instructions for Node.js][2] and ensure the Datadog Lambda layer is added to your Lambda function. 
+
+1. Mark `datadog-lambda-js` and `dd-trace` as [externals][3] for webpack, so webpack knows to skip building them as dependencies, because they are already available in the Lambda runtime provided by the Datadog Lambda layer.
 
     **webpack.config.js**
 
@@ -24,8 +27,9 @@ Datadog's tracing libraries (`dd-trace`) are known to be not compatible with [we
     };
     ```
 
-2. Remove `datadog-lambda-js` and `dd-trace` from your `package.json` and the build process. Instead, ensure you're importing these packages via [Lambda Layers][3].
-3. If you are using `serverless-webpack` and the Serverless Framework, exclude `datadog-lambda-js` and `dd-trace` from your `serverless.yml`.
+1. Remove `datadog-lambda-js` and `dd-trace` from your `package.json` and the build process.
+
+1. If you are using `serverless-webpack` and the Serverless Framework, exclude `datadog-lambda-js` and `dd-trace` from your `serverless.yml`.
 
     **serverless.yml**
 
@@ -38,7 +42,10 @@ Datadog's tracing libraries (`dd-trace`) are known to be not compatible with [we
             - datadog-lambda-js
     ```
 
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://webpack.js.org
-[2]: https://webpack.js.org/configuration/externals/
-[3]: https://github.com/DataDog/datadog-lambda-js/releases
+[2]: /serverless/installation/nodejs
+[3]: https://webpack.js.org/configuration/externals/

--- a/content/en/serverless/troubleshooting/serverless_tracing_and_webpack.md
+++ b/content/en/serverless/troubleshooting/serverless_tracing_and_webpack.md
@@ -9,11 +9,10 @@ further_reading:
 
 # Compatibility
 
-Datadog's tracing libraries (`dd-trace`) are known to be not compatible with [webpack][1] due to the use of conditional imports and other issues. While webpack cannot *build* `dd-trace`, your application can still *use* `dd-trace` and `datadog-lambda-js` provided by the *prebuilt* Datadog Lambda layer. Follow the instructions below:
+Datadog's tracing libraries (`dd-trace`) are known to be not compatible with [webpack][1] due to the use of conditional imports and other issues. While webpack cannot build `dd-trace`, your application can still use the `dd-trace` and `datadog-lambda-js` libraries provided by the prebuilt Datadog Lambda layer. Follow the instructions below:
 
 1. Follow the [installation instructions for Node.js][2] and ensure the Datadog Lambda layer is added to your Lambda function. 
-
-1. Mark `datadog-lambda-js` and `dd-trace` as [externals][3] for webpack, so webpack knows to skip building them as dependencies, because they are already available in the Lambda runtime provided by the Datadog Lambda layer.
+2. Mark `datadog-lambda-js` and `dd-trace` as [externals][3] for webpack. This tells webpack to skip building them as dependencies, since they are already available in the Lambda runtime provided by the Datadog Lambda layer.
 
     **webpack.config.js**
 
@@ -28,8 +27,7 @@ Datadog's tracing libraries (`dd-trace`) are known to be not compatible with [we
     ```
 
 1. Remove `datadog-lambda-js` and `dd-trace` from your `package.json` and the build process.
-
-1. If you are using `serverless-webpack` and the Serverless Framework, exclude `datadog-lambda-js` and `dd-trace` from your `serverless.yml`.
+2. If you are using `serverless-webpack` and the Serverless Framework, exclude `datadog-lambda-js` and `dd-trace` from your `serverless.yml`.
 
     **serverless.yml**
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Some clarification for serverless webpack users based on the feedback. It wasn't clear to the customer that how could they still use dd-trace and datadog-lambda-js when we are instructing them to exclude these packages from the build process. They are available in the lambda runtime provided by our lambda layer, but this wasn't clear to the customer.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tian.chu/update-sls-webpack-guide/serverless/troubleshooting/serverless_tracing_and_webpack

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
