### PR TITLE
Reverting this PR 11549 - PHP tracer doc

### DIFF
--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -309,8 +309,8 @@ Works for Linux. Set to `true` to retain capabilities on Datadog background thre
 **Note:** Enabling this option may compromise security. This option, standalone, does not pose a security risk. However, an attacker being able to exploit a vulnerability in PHP or web server may be able to escalate privileges with relative ease, if the web server or PHP were started with full capabilities, as the background threads will retain their original capabilities. Datadog recommends restricting the capabilities of the web server with the `setcap` utility.
 
 `DD_TRACE_SAMPLE_RATE`
-: **Default**: `null`<br>
-Sets the trace sampling rate between `0.0` (0%) and `1.0` (100%, recommended). A value of `1.0`, Tracing without Limits™, sends all of your traffic. [Configure the retention][19] within the Datadog app. For versions before `0.36.0`, the sampling rate parameter is `DD_SAMPLING_RATE`.
+: **Default**: `1.0`<br>
+The sampling rate for the traces (defaults to: between `0.0` and `1.0`). For versions < `0.36.0`, this parameter is `DD_SAMPLING_RATE`.
 
 `DD_TRACE_SAMPLING_RULES`
 : **Default**: `null`<br>
@@ -774,4 +774,3 @@ For Apache, run:
 [16]: https://wiki.ubuntu.com/Debug%20Symbol%20Packages
 [17]: https://wiki.ubuntu.com/Debug%20Symbol%20Packages#Getting_-dbgsym.ddeb_packages
 [18]: https://valgrind.org/docs/manual/manual-core.html#manual-core.comment
-[19]: /tracing/trace_retention_and_ingestion/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Reverting this PR: https://github.com/DataDog/documentation/pull/11549

### Motivation
<!-- What inspired you to submit this pull request?-->
APM confirms default of 1 is correct. It's a special case for PHP.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mecsantos/php-tracer/tracing/setup_overview/setup/php/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
