### PR TITLE
Update estimated logs usage dashboard JSON

### DIFF
--- a/static/resources/json/estimated_log_usage_dashboard_configuration.json
+++ b/static/resources/json/estimated_log_usage_dashboard_configuration.json
@@ -249,9 +249,9 @@
                     }
                 ],
                 "yaxis": {
-                    "include_zero": true,
                     "scale": "linear",
                     "label": "",
+                    "include_zero": true,
                     "min": "auto",
                     "max": "auto"
                 },
@@ -289,7 +289,7 @@
             "definition": {
                 "title": "Ingestion: Ingested Bytes",
                 "type": "group",
-                "background_color": "vivid_green",
+                "background_color": "blue",
                 "show_title": true,
                 "layout_type": "ordered",
                 "widgets": [
@@ -403,9 +403,9 @@
                                 }
                             ],
                             "yaxis": {
-                                "include_zero": true,
                                 "scale": "linear",
                                 "label": "",
+                                "include_zero": true,
                                 "min": "auto",
                                 "max": "auto"
                             },
@@ -479,12 +479,6 @@
                         }
                     }
                 ]
-            },
-            "layout": {
-                "x": 0,
-                "y": 5,
-                "width": 12,
-                "height": 11
             }
         },
         {
@@ -608,9 +602,9 @@
                                 }
                             ],
                             "yaxis": {
-                                "include_zero": true,
                                 "scale": "linear",
                                 "label": "",
+                                "include_zero": true,
                                 "min": "auto",
                                 "max": "auto"
                             },
@@ -684,12 +678,6 @@
                         }
                     }
                 ]
-            },
-            "layout": {
-                "x": 0,
-                "y": 16,
-                "width": 12,
-                "height": 1
             }
         },
         {
@@ -753,9 +741,9 @@
                                 }
                             ],
                             "yaxis": {
-                                "include_zero": true,
                                 "scale": "linear",
                                 "label": "",
+                                "include_zero": true,
                                 "min": "auto",
                                 "max": "auto"
                             },
@@ -816,9 +804,9 @@
                                 }
                             ],
                             "yaxis": {
-                                "include_zero": true,
                                 "scale": "linear",
                                 "label": "",
+                                "include_zero": true,
                                 "min": "auto",
                                 "max": "auto"
                             },
@@ -951,13 +939,6 @@
                         }
                     }
                 ]
-            },
-            "layout": {
-                "x": 0,
-                "y": 17,
-                "width": 12,
-                "height": 13,
-                "is_column_break": true
             }
         },
         {
@@ -1084,9 +1065,9 @@
                                 }
                             ],
                             "yaxis": {
-                                "include_zero": true,
                                 "scale": "linear",
                                 "label": "",
+                                "include_zero": true,
                                 "min": "auto",
                                 "max": "auto"
                             },
@@ -1141,9 +1122,9 @@
                                 }
                             ],
                             "yaxis": {
-                                "include_zero": true,
                                 "scale": "linear",
                                 "label": "",
+                                "include_zero": true,
                                 "min": "auto",
                                 "max": "auto"
                             },
@@ -1157,12 +1138,6 @@
                         }
                     }
                 ]
-            },
-            "layout": {
-                "x": 0,
-                "y": 30,
-                "width": 12,
-                "height": 9
             }
         },
         {
@@ -1211,12 +1186,12 @@
                                 }
                             },
                             "xaxis": {
-                                "include_zero": false,
-                                "scale": "log"
+                                "scale": "log",
+                                "include_zero": false
                             },
                             "yaxis": {
-                                "include_zero": false,
-                                "scale": "log"
+                                "scale": "log",
+                                "include_zero": false
                             },
                             "color_by_groups": [
                                 "service"
@@ -1266,8 +1241,8 @@
                                 }
                             },
                             "xaxis": {
-                                "include_zero": false,
-                                "scale": "log"
+                                "scale": "log",
+                                "include_zero": false
                             },
                             "yaxis": {
                                 "min": "0",
@@ -1416,12 +1391,6 @@
                         }
                     }
                 ]
-            },
-            "layout": {
-                "x": 0,
-                "y": 39,
-                "width": 12,
-                "height": 14
             }
         }
     ],
@@ -1438,9 +1407,7 @@
         }
     ],
     "layout_type": "ordered",
-    "is_read_only": false,
+    "is_read_only": true,
     "notify_list": [],
-    "restricted_roles": [],
-    "reflow_type": "fixed",
-    "id": "qz4-675-xct"
+    "reflow_type": "fixed"
 }


### PR DESCRIPTION
### What does this PR do?
Takes out the layout component in lines 943-945 as the component is deprecated

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/sarina/estimated-logs-use-dashboard/logs/guide/logs-monitors-on-volumes/#estimated-usage-dashboard

### Additional Notes
Download the dashboard JSON in the page above to ensure it downloads with the new content

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
