### PR TITLE
evaluation frequency depending on the evaluation timeframe

### DIFF
--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -110,6 +110,11 @@ The alert conditions vary slightly based on the chosen detection method.
 * the threshold `on average`, `at least once`, `at all times`, or `in total`
 * during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between 1 minute and 730 hours (1 month).
 
+Depending on the evaluation time frame selected, the evaluation frequency changes :
+* `timeframe < 24h` : evaluation is performed every 1 minute
+* `24h < timeframe < 48h` : evaluation is performed every 10 minutes
+* `timeframe > 48h` : evaluation is performed every 30 minutes
+
 **Definitions**:
 
 | Option                  | Description                                                                                                                                                                                                                   |

--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -110,10 +110,11 @@ The alert conditions vary slightly based on the chosen detection method.
 * the threshold `on average`, `at least once`, `at all times`, or `in total`
 * during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between 1 minute and 730 hours (1 month).
 
-Depending on the evaluation time frame selected, the evaluation frequency changes :
-* `timeframe < 24h` : evaluation is performed every 1 minute
-* `24h < timeframe < 48h` : evaluation is performed every 10 minutes
-* `timeframe > 48h` : evaluation is performed every 30 minutes
+The evaluation frequency changes based on the evaluation time frame you select:
+
+* `timeframe < 24h` : evaluation performs every 1 minute.
+* `24h < timeframe < 48h` : evaluation performs every 10 minutes.
+* `timeframe > 48h` : evaluation performs every 30 minutes.
 
 **Definitions**:
 

--- a/content/en/monitors/monitor_types/metric.md
+++ b/content/en/monitors/monitor_types/metric.md
@@ -112,9 +112,9 @@ The alert conditions vary slightly based on the chosen detection method.
 
 The evaluation frequency changes based on the evaluation time frame you select:
 
-* `timeframe < 24h` : evaluation performs every 1 minute.
-* `24h < timeframe < 48h` : evaluation performs every 10 minutes.
-* `timeframe > 48h` : evaluation performs every 30 minutes.
+* `timeframe < 24h`: evaluation performs every 1 minute.
+* `24h < timeframe < 48h`: evaluation performs every 10 minutes.
+* `timeframe > 48h`: evaluation performs every 30 minutes.
 
 **Definitions**:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates metric monitor documentation to explain evaluation frequency depending on the evaluation timeframe

### Motivation
This was changed recently for metric monitors

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/antoine.dussault/metric_monitors_evaluation_frequency/monitors/monitor_types/metric/?tab=threshold#set-alert-conditions

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
