### PR TITLE
Remove/add notes for logs and apm hosts

### DIFF
--- a/content/en/account_management/billing/usage_metrics.md
+++ b/content/en/account_management/billing/usage_metrics.md
@@ -28,15 +28,13 @@ Estimated usage metrics are generally available for the following usage types:
 | Logs Ingested Bytes           | `datadog.estimated_usage.logs.ingested_bytes`          |
 | Logs Ingested Events          | `datadog.estimated_usage.logs.ingested_events`   |
 | Analyzed Logs (security)      | `datadog.estimated_usage.security_monitoring.analyzed_bytes`   |
-| APM Hosts                     | `datadog.estimated_usage.apm_hosts`      |
+| APM Hosts                     | `datadog.estimated_usage.apm_hosts` (does not include Azure App Services hosts)      |
 | APM Indexed Spans             | `datadog.estimated_usage.apm.indexed_spans` |
 | APM Ingested Bytes            | `datadog.estimated_usage.apm.ingested_bytes` |
 | APM Ingested Spans            | `datadog.estimated_usage.apm.ingested_spans` |
 | Serverless Lambda Functions   | `datadog.estimated_usage.serverless.aws_lambda_functions` |
 | API test runs                 | `datadog.estimated_usage.synthetics.api_test_runs` |
 | Browser test runs             | `datadog.estimated_usage.synthetics.browser_test_runs`|
-
-Log-based usage metrics must be manually enabled from the [Generate Metrics][1] page.
 
 {{< img src="account_management/billing/usage-metrics-02.png" alt="Metric Names" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
1. Logs metrics are now automatically enabled when there is logs usage; remove the sentence about manually enabling
2. Add note that APM used on Azure App Services instances/hosts are not represented in the estimated usage metric for APM Hosts.


### Motivation
<!-- What inspired you to submit this pull request?-->
Update documentation to be accurate for details related to logs and apm host usage metrics

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
