### PR TITLE
Fix fallibility error in example vector config

### DIFF
--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -72,8 +72,8 @@ transforms:
     inputs:
       - datadog_agents
     source: |
-      # We use the `!` shorthand with the `string` function to error if .ddtags is not a "string"
-      # as we always expect the .ddtags field to be of type "string"
+      # The `!` shorthand is used here with the `string` function, it errors if .ddtags is not a "string".
+      # The .ddtags field is always expected to be a string.
       .ddtags = string!(.ddtags) + ",sender:vector"
 
 sinks:

--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -72,7 +72,9 @@ transforms:
     inputs:
       - datadog_agents
     source: |
-      .ddtags = .ddtags + ",sender:vector"
+      # We use the `!` shorthand with the `string` function to error if .ddtags is not a "string"
+      # as we always expect the .ddtags field to be of type "string"
+      .ddtags = string!(.ddtags) + ",sender:vector"
 
 sinks:
   to_datadog:


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates provided Vector configuration example to error if the `.ddtags` field is not of type "string" and documents the VRL usage.

### Motivation
<!-- What inspired you to submit this pull request?-->

A user noted that the provided configuration fails to compile as we don't properly handle the unkown type of the `.ddtags` field.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/spencer/fix-vector-configuration/agent/vector_aggregation/#vector-configuration

### Additional Notes
<!-- Anything else we should know when reviewing?-->

I _actually_ tested the configuration to ensure it was valid :smile:

```shell
~/C/g/D/documentation on  spencer/fix-vector-configuration [!] via 🐹 v1.16.4 via  v16.8.0
❯ cat /tmp/test.yaml
sources:
  datadog_agents:
    type: datadog_agent
    address: "[::]:8080" # The <VECTOR_PORT> mentioned above should be set to the port value used here

transforms:
  add_tags:
    type: remap
    inputs:
      - datadog_agents
    source: |
      # We use the abort argument with the `string` function
      # as we always expect the .ddtags field to be of type "string"
      .ddtags = string!(.ddtags) + ",sender:vector"

sinks:
  to_datadog:
    type: datadog_logs
    inputs:
       - add_tags
    default_api_key: "${DATADOG_API_KEY_ENV_VAR}"
    encoding:
      codec: json

~/C/g/D/documentation on  spencer/fix-vector-configuration [!] via 🐹 v1.16.4 via  v16.8.0
❯ vector validate /tmp/test.yaml
√ Loaded ["/tmp/test.yaml"]
√ Component configuration
√ Health check "to_datadog"
---------------------------
                  Validated
```

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
