### PR TITLE
[CIAPP] Update deprecated DNS for CI Visibility webhooks

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -112,14 +112,14 @@ As an alternative to using the native Datadog integration, you can use [webhooks
 
 Go to **Settings > Webhooks** in your repository (or GitLab instance settings), and add a new webhook:
 {{< site-region region="us" >}}
-* **URL**: `https://webhooks-http-intake.logs.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
+* **URL**: `https://webhook-intake.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
 * **Secret Token**: leave blank
 * **Trigger**: Select `Job events` and `Pipeline events`.
 
 [1]: https://app.datadoghq.com/account/settings#api
 {{< /site-region >}}
 {{< site-region region="eu" >}}
-* **URL**: `https://webhooks-http-intake.logs.datadoghq.eu/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
+* **URL**: `https://webhook-intake.datadoghq.eu/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
 * **Secret Token**: leave blank
 * **Trigger**: Select `Job events` and `Pipeline events`.
 

--- a/content/ja/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/ja/continuous_integration/setup_pipelines/gitlab.md
@@ -111,14 +111,14 @@ kubectl exec -it <task-runner-pod-name> -- \
 
 リポジトリ (または GitLab インスタンス設定) の **Settings > Webhooks** に移動し、新しい Webhook を追加します。
 {{< site-region region="us" >}}
-* **URL**: `https://webhooks-http-intake.logs.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` ここで、`<API_KEY>` は [Datadog API キー][1]です。
+* **URL**: `https://webhook-intake.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` ここで、`<API_KEY>` は [Datadog API キー][1]です。
 * **Secret Token**: 空白のままにします
 * **Trigger**: `Job events` と `Pipeline events` を選択します。
 
 [1]: https://app.datadoghq.com/account/settings#api
 {{< /site-region >}}
 {{< site-region region="eu" >}}
-* **URL**: `https://webhooks-http-intake.logs.datadoghq.eu/api/v2/webhook/?dd-api-key=<API_KEY>` ここで、`<API_KEY>` は [Datadog API キー][1]です。
+* **URL**: `https://webhook-intake.datadoghq.eu/api/v2/webhook/?dd-api-key=<API_KEY>` ここで、`<API_KEY>` は [Datadog API キー][1]です。
 * **Secret Token**: 空白のままにします
 * **Trigger**: `Job events` と `Pipeline events` を選択します。
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/adrian.lopezcalvo%2Fupdate-deprecated-dns-ci-visibility-webhooks/continuous_integration/setup_pipelines/gitlab
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
