### PR TITLE
Add missing HCL highlighting to some Terraform code samples

### DIFF
--- a/content/en/integrations/faq/aws-integration-with-terraform.md
+++ b/content/en/integrations/faq/aws-integration-with-terraform.md
@@ -12,7 +12,7 @@ If you use [Terraform][1], the script below creates the Datadog IAM policy insid
 * `YOUR_DD_EXTERNAL_ID`: A unique ID located in your [Datadog AWS Integration tile][2].
 * `AWS_PERMISSIONS_LIST`: The IAM policies needed by Datadog AWS integrations. The current list is available in the [Datadog AWS integration][3] documentation.
 
-```text
+```hcl
 variable "datadog_aws_integration_external_id" {
   default = "<YOUR_DD_EXTERNAL_ID>"
   description = ""

--- a/content/fr/integrations/terraform.md
+++ b/content/fr/integrations/terraform.md
@@ -48,7 +48,7 @@ Le fournisseur Datadog pour Terraform est disponible via le [registre Terraform]
 1. [Installer Terraform][2]
 2. Créez un répertoire destiné à stocker les fichiers de configuration de Terraform, par exemple : `terraform_config/`
 3. Créez un fichier `main.tf` dans le répertoire `terraform_config/` avec le contenu suivant :
-    ```
+    ```hcl
     terraform {
       required_providers {
         datadog = {
@@ -67,7 +67,7 @@ Le fournisseur Datadog pour Terraform est disponible via le [registre Terraform]
 4. Exécutez `terraform init`. Cette commande permet d'initialiser le répertoire pour l'utiliser avec Terraform et de récupérer le fournisseur Datadog.
 5. Créez n'importe quel fichier `.tf` dans le répertoire `terraform_config/`, puis commencez à créer des ressources Datadog. par exemple :
 
-    ```
+    ```hcl
     # monitor.tf
     resource "datadog_monitor" "process_alert_example" {
       name    = "Process Alert Monitor"

--- a/content/ja/integrations/terraform.md
+++ b/content/ja/integrations/terraform.md
@@ -48,7 +48,7 @@ Datadog Terraform プロバイダーは [Terraform レジストリ][1]を介し�
 1. [Terraform のインストール][2]
 2. Terraform のコンフィギュレーションファイルを含むディレクトリを作成します。例: `terraform_config/`
 3. `terraform_config/` ディレクトリに、以下の内容の `main.tf` ファイルを作成します。
-    ```
+    ```hcl
     terraform {
       required_providers {
         datadog = {
@@ -67,7 +67,7 @@ Datadog Terraform プロバイダーは [Terraform レジストリ][1]を介し�
 4. `terraform init` を実行します。これにより、Terraform での利用のためにディレクトリが初期化され、Datadog プロバイダーがプルされます。
 5. `terraform_config/` ディレクトリ内に任意の `.tf` ファイルを作成し、Datadog リソースの作成を開始します。例:
 
-    ```
+    ```hcl
     # monitor.tf
     resource "datadog_monitor" "process_alert_example" {
       name    = "Process Alert Monitor"


### PR DESCRIPTION
This PR adds some Hashicorp Configuration Language (HCL) highlighting to the existing Terraform code samples