### PR TITLE
DOCS-2454 update Browser SDK CSP documentation

### DIFF
--- a/content/en/real_user_monitoring/faq/content_security_policy.md
+++ b/content/en/real_user_monitoring/faq/content_security_policy.md
@@ -13,22 +13,29 @@ If you are using [Content Security Policy (CSP)][1] on your websites, add the fo
 
 Depending on the `site` option used to initialize [Real User Monitoring][2] or [browser logs collection][3], add the appropriate `connect-src` entry:
 
-{{< tabs >}}
-{{% tab "US" %}}
+{{< site-region region="us" >}}
 
 ```txt
 connect-src https://*.logs.datadoghq.com https://*.browser-intake-datadoghq.com
 ```
 
-{{% /tab %}}
-{{% tab "EU" %}}
+{{< /site-region >}}
+
+
+{{< site-region region="eu" >}}
 
 ```txt
 connect-src https://*.logs.datadoghq.eu https://*.browser-intake-datadoghq.eu
 ```
 
-{{% /tab %}}
-{{< /tabs >}}
+{{< /site-region >}}
+
+
+{{< site-region region="us3,gov" >}}
+
+This feature is unavailable for this site.
+
+{{< /site-region >}}
 
 ## CDN bundle URL
 

--- a/content/en/real_user_monitoring/faq/content_security_policy.md
+++ b/content/en/real_user_monitoring/faq/content_security_policy.md
@@ -9,95 +9,41 @@ further_reading:
 
 If you are using [Content Security Policy (CSP)][1] on your websites, add the following URLs to your existing directives depending on how you setup your Real User Monitoring or browser log collection:
 
+## Intake URLs
 
-## CDN async setup
-
-If you have the CDN async setup for [Real User Monitoring][2] or [browser log collection][3]:
-
-1. Add the `connect-src` depending of your Datadog Site:
-
-    {{< tabs >}}
-    {{% tab "US" %}}
-
-```txt
-connect-src https://*.logs.datadoghq.com
-```
-
-    {{% /tab %}}
-    {{% tab "EU" %}}
-
-```txt
-connect-src https://*.logs.datadoghq.eu
-```
-
-    {{% /tab %}}
-    {{< /tabs >}}
-
-2. Then add the `script-src` directive:
-
-    ```txt
-    script-src https://www.datadoghq-browser-agent.com
-    ```
-
-## CDN sync setup
-
-If you have the CDN sync setup for [Real User Monitoring][4] or [browser log collection][5]:
-
-1. Add the `connect-src` depending of your Datadog Site:
-
-    {{< tabs >}}
-    {{% tab "US" %}}
-
-```txt
-connect-src https://*.logs.datadoghq.com
-```
-
-    {{% /tab %}}
-    {{% tab "EU" %}}
-
-```txt
-connect-src https://*.logs.datadoghq.eu
-```
-
-    {{% /tab %}}
-    {{< /tabs >}}
-
-2. Then add the `script-src` directive:
-
-    ```txt
-    script-src https://www.datadoghq-browser-agent.com
-    ```
-
-## NPM setup
-
-If you have the NPM setup for [Real User Monitoring][6] or [browser log collection][7], add only the `connect-src` directive:
+Depending on the `site` option used to initialize [Real User Monitoring][2] or [browser logs collection][3], add the appropriate `connect-src` entry:
 
 {{< tabs >}}
 {{% tab "US" %}}
 
 ```txt
-connect-src https://*.logs.datadoghq.com
+connect-src https://*.logs.datadoghq.com https://*.browser-intake-datadoghq.com
 ```
 
 {{% /tab %}}
 {{% tab "EU" %}}
 
 ```txt
-connect-src https://*.logs.datadoghq.eu
+connect-src https://*.logs.datadoghq.eu https://*.browser-intake-datadoghq.eu
 ```
 
 {{% /tab %}}
 {{< /tabs >}}
 
+## CDN bundle URL
+
+If you are using the CDN async or CDN sync setup for [Real User Monitoring][4] or [browser log collection][5], you should also add the following `script-src` entry:
+
+```txt
+script-src https://www.datadoghq-browser-agent.com
+```
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-
 [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
-[2]: /real_user_monitoring/browser/#cdn-async
-[3]: /logs/log_collection/javascript/#cdn-async
-[4]: /real_user_monitoring/browser/#cdn-sync
-[5]: /logs/log_collection/javascript/#cdn-sync
-[6]: /real_user_monitoring/browser/#npm
-[7]: /logs/log_collection/javascript/#npm-setup
+[2]: /real_user_monitoring/browser/#initialization-parameters
+[3]: /logs/log_collection/javascript/#initialization-parameters
+[4]: /real_user_monitoring/browser/#setup
+[5]: /logs/log_collection/javascript/#setup


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

* Adjust the page structure so we don't repeat the same things 3 times

* Add the "alternate intake" URLs beside the classical ones since both will be used by default in the future.

### Motivation

Our customers start using session replay, clarify which URLs to add as CSP rules

### Preview

https://github.com/DataDog/documentation/blob/a9f9827b9ab241cc16ce782ccd7161a4ebf537cf/content/en/real_user_monitoring/faq/content_security_policy.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
