### PR TITLE
Note on escaping ascii control characters

### DIFF
--- a/content/en/logs/log_configuration/parsing.md
+++ b/content/en/logs/log_configuration/parsing.md
@@ -632,7 +632,7 @@ Other examples:
 
 ### ASCII Control Characters
 
-If your logs contain ASCII control characters, they will be serialised upon ingestion. These can be handled by explicitly escaping the serialised value within your grok parser.
+If your logs contain ASCII control characters, they are serialized upon ingestion. These can be handled by explicitly escaping the serialized value within your grok parser.
 
 ## Further Reading
 

--- a/content/en/logs/log_configuration/parsing.md
+++ b/content/en/logs/log_configuration/parsing.md
@@ -630,6 +630,9 @@ Other examples:
 | `value1,value2`              | `%{data::csv("key1,key2,key3")}`                                         | {"key1": "value1", "key2":"value2"}             |
 | `value1,,value3`             | `%{data::csv("key1,key2,key3")}`                                         | {"key1": "value1", "key3":"value3"}             |
 
+### ASCII Control Characters
+
+If your logs contain ASCII control characters, they will be serialised upon ingestion. These can be handled by explicitly escaping the serialised value within your grok parser.
 
 ## Further Reading
 

--- a/content/en/logs/log_configuration/parsing.md
+++ b/content/en/logs/log_configuration/parsing.md
@@ -630,7 +630,7 @@ Other examples:
 | `value1,value2`              | `%{data::csv("key1,key2,key3")}`                                         | {"key1": "value1", "key2":"value2"}             |
 | `value1,,value3`             | `%{data::csv("key1,key2,key3")}`                                         | {"key1": "value1", "key3":"value3"}             |
 
-### ASCII Control Characters
+### ASCII control characters
 
 If your logs contain ASCII control characters, they are serialized upon ingestion. These can be handled by explicitly escaping the serialized value within your grok parser.
 


### PR DESCRIPTION
### What does this PR do?

Adds in a note about escaping ASCII control characters within a grok parser to https://docs.datadoghq.com/logs/log_configuration/parsing/?tab=matchers#overview.

### Motivation
https://datadog.zendesk.com/agent/tickets/539315



### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
