### PR TITLE
Uchen/getting started reconciliation

### DIFF
--- a/content/en/getting_started/_index.md
+++ b/content/en/getting_started/_index.md
@@ -12,15 +12,18 @@ further_reading:
 ---
 
 {{< whatsnext desc="This section includes the following topics:">}}
+{{< nextlink href="/getting_started/application" >}}<u>Datadog</u>: Discover how to use Datadog UI: Dashboards, infrastructure list, maps, etc.{{< /nextlink >}}
+{{< nextlink href="/getting_started/site" >}}<u>Datadog Site</u>: Learn about the different Datadog sites and how to select one. TODO reword.{{< /nextlink >}}
 {{< nextlink href="/getting_started/agent" >}}<u>Agent</u>: Get Started with the Datadog Agent.{{< /nextlink >}}
-{{< nextlink href="/getting_started/application" >}}<u>Datadog Site</u>: Discover how to use Datadog UI: Dashboards, infrastructure list, maps, etc.{{< /nextlink >}}
 {{< nextlink href="/getting_started/integrations" >}}<u>Integrations</u>: Learn how to collect metrics, traces, and logs with Datadog integrations.{{< /nextlink >}}
 {{< nextlink href="/getting_started/dashboards" >}}<u>Dashboards</u>: Create, share, and maintain dashboards that answer the work questions that matter to you.{{< /nextlink >}}
 {{< nextlink href="/getting_started/monitors" >}}<u>Monitors</u>: Set up alerts and notifications so that your team knows when critical changes occur.{{< /nextlink >}}
 {{< nextlink href="/getting_started/logs" >}}<u>Logs</u>: Send your first logs and use Log processing to enrich them.{{< /nextlink >}}
 {{< nextlink href="/getting_started/tracing" >}}<u>Tracing</u>: Learn about tracing by setting up the Agent to trace a small application.{{< /nextlink >}}
 {{< nextlink href="/getting_started/profiler" >}}<u>Profiler</u>: Learn about using Continuous Profiler to find and fix performance problems in your code.{{< /nextlink >}}
-{{< nextlink href="/getting_started/tagging" >}}<u>Tagging</u>: Start tagging your metrics, logs, and traces.{{< /nextlink >}}
+{{< nextlink href="/getting_started/tagging" >}}<u>Tags</u>: Start tagging your metrics, logs, and traces.{{< /nextlink >}}
 {{< nextlink href="/getting_started/api" >}}<u>API</u>: Get started on Datadog HTTP API.{{< /nextlink >}}
 {{< nextlink href="/getting_started/synthetics" >}}<u>Synthetic Monitoring</u>: Start testing and monitoring your API endpoints and key business journeys with Synthetic tests.{{< /nextlink >}}
+{{< nextlink href="/getting_started/incident_management" >}}<u>Incident Management</u>: Manage your incidents with Datadog. TODO reword.{{< /nextlink >}}
+{{< nextlink href="/getting_started/learning_center" >}}<u>Learning Center</u>: Learn more about Datadog. TODO reword.{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/getting_started/_index.md
+++ b/content/en/getting_started/_index.md
@@ -12,18 +12,18 @@ further_reading:
 ---
 
 {{< whatsnext desc="This section includes the following topics:">}}
-{{< nextlink href="/getting_started/application" >}}<u>Datadog</u>: Discover how to use Datadog UI: Dashboards, infrastructure list, maps, etc.{{< /nextlink >}}
-{{< nextlink href="/getting_started/site" >}}<u>Datadog Site</u>: Learn about the different Datadog sites and how to select one. TODO reword.{{< /nextlink >}}
-{{< nextlink href="/getting_started/agent" >}}<u>Agent</u>: Get Started with the Datadog Agent.{{< /nextlink >}}
+{{< nextlink href="/getting_started/application" >}}<u>Datadog</u>: Discover how to use the Datadog UI: Dashboards, infrastructure list, maps, and more.{{< /nextlink >}}
+{{< nextlink href="/getting_started/site" >}}<u>Datadog Site</u>: Select the appropriate Datadog site for your region and security requirements.{{< /nextlink >}}
+{{< nextlink href="/getting_started/agent" >}}<u>Agent</u>: Send metrics and events from your hosts to Datadog.{{< /nextlink >}}
 {{< nextlink href="/getting_started/integrations" >}}<u>Integrations</u>: Learn how to collect metrics, traces, and logs with Datadog integrations.{{< /nextlink >}}
 {{< nextlink href="/getting_started/dashboards" >}}<u>Dashboards</u>: Create, share, and maintain dashboards that answer the work questions that matter to you.{{< /nextlink >}}
 {{< nextlink href="/getting_started/monitors" >}}<u>Monitors</u>: Set up alerts and notifications so that your team knows when critical changes occur.{{< /nextlink >}}
-{{< nextlink href="/getting_started/logs" >}}<u>Logs</u>: Send your first logs and use Log processing to enrich them.{{< /nextlink >}}
-{{< nextlink href="/getting_started/tracing" >}}<u>Tracing</u>: Learn about tracing by setting up the Agent to trace a small application.{{< /nextlink >}}
-{{< nextlink href="/getting_started/profiler" >}}<u>Profiler</u>: Learn about using Continuous Profiler to find and fix performance problems in your code.{{< /nextlink >}}
+{{< nextlink href="/getting_started/logs" >}}<u>Logs</u>: Send your first logs and use log processing to enrich them.{{< /nextlink >}}
+{{< nextlink href="/getting_started/tracing" >}}<u>Tracing</u>: Set up the Agent to trace a small application.{{< /nextlink >}}
+{{< nextlink href="/getting_started/profiler" >}}<u>Profiler</u>: Use Continuous Profiler to find and fix performance problems in your code.{{< /nextlink >}}
 {{< nextlink href="/getting_started/tagging" >}}<u>Tags</u>: Start tagging your metrics, logs, and traces.{{< /nextlink >}}
-{{< nextlink href="/getting_started/api" >}}<u>API</u>: Get started on Datadog HTTP API.{{< /nextlink >}}
+{{< nextlink href="/getting_started/api" >}}<u>API</u>: Get started with the Datadog HTTP API.{{< /nextlink >}}
 {{< nextlink href="/getting_started/synthetics" >}}<u>Synthetic Monitoring</u>: Start testing and monitoring your API endpoints and key business journeys with Synthetic tests.{{< /nextlink >}}
-{{< nextlink href="/getting_started/incident_management" >}}<u>Incident Management</u>: Manage your incidents with Datadog. TODO reword.{{< /nextlink >}}
-{{< nextlink href="/getting_started/learning_center" >}}<u>Learning Center</u>: Learn more about Datadog. TODO reword.{{< /nextlink >}}
+{{< nextlink href="/getting_started/incident_management" >}}<u>Incident Management</u>: Communicate and track problems in your systems.{{< /nextlink >}}
+{{< nextlink href="/getting_started/learning_center" >}}<u>Learning Center</u>: Leverage everything Datadog has to offer by enrolling in instructor-led classes.{{< /nextlink >}}
 {{< /whatsnext >}}


### PR DESCRIPTION
### What does this PR do?
- Make the list of Getting Started Guide links on the Getting Started page consistent with the list of Getting Started Guide links in the left menu.
- Update some descriptions on the Getting Started page to be correct, descriptive, and to follow the contributing guidelines.

### Motivation
I noticed the mismatch between menu links and page links while working on a new Getting Started Guide for Database Management.

### Preview
https://docs-staging.datadoghq.com/uchen/getting-started-reconciliation/getting_started/

### Additional Notes
None

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
