### PR TITLE
APM PHP logs injection using current_context()

### DIFF
--- a/content/en/logs/log_collection/php.md
+++ b/content/en/logs/log_collection/php.md
@@ -446,7 +446,7 @@ monolog:
 ### Laravel
 
 <div class="alert alert-warning">
-Note that the function <code>\DDTrace\trace_id()</code> has been introduced in version <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.53.0">0.53.0</a>.
+Note that the function <code>\DDTrace\current_context()</code> has been introduced in version <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.61.0">0.61.0</a>.
 </div>
 
 ```php
@@ -482,16 +482,17 @@ class AppServiceProvider extends ServiceProvider
 
         // Inject the trace and span ID to connect the log entry with the APM trace
         $monolog->pushProcessor(function ($record) use ($useJson) {
+            $context = \DDTrace\current_context();
             if ($useJson === true) {
                 $record['dd'] = [
-                    'trace_id' => \DDTrace\trace_id(),
-                    'span_id'  => \dd_trace_peek_span_id(),
+                    'trace_id' => $context['trace_id'],
+                    'span_id'  => $context['span_id'],
                 ];
             } else {
                 $record['message'] .= sprintf(
                     ' [dd.trace_id=%d dd.span_id=%d]',
-                    \DDTrace\trace_id(),
-                    \dd_trace_peek_span_id()
+                    $context['trace_id'],
+                    $context['span_id']
                 );
             }
             return $record;

--- a/content/en/tracing/connect_logs_and_traces/php.md
+++ b/content/en/tracing/connect_logs_and_traces/php.md
@@ -28,7 +28,7 @@ See the section below to learn how to connect your PHP Logs and traces manually.
 ## Manual injection
 
 <div class="alert alert-warning">
-Note that the function <code>\DDTrace\trace_id()</code> has been introduced in version <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.53.0">0.53.0</a>.
+Note that the function <code>\DDTrace\current_context()</code> has been introduced in version <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.61.0">0.61.0</a>.
 </div>
 
 To connect your logs and traces together, your logs must contain the `dd.trace_id` and `dd.span_id` attributes that respectively contain your trace ID and your span ID.
@@ -39,10 +39,11 @@ For instance, you would append those two attributes to your logs with:
 
 ```php
   <?php
+  $context = \DDTrace\current_context();
   $append = sprintf(
       ' [dd.trace_id=%d dd.span_id=%d]',
-      \DDTrace\trace_id(),
-      \dd_trace_peek_span_id()
+      $context['trace_id'],
+      $context['span_id']
   );
   my_error_logger('Error message.' . $append);
 ?>
@@ -53,10 +54,11 @@ If the logger implements the [**monolog/monolog** library][4], use `Logger::push
 ```php
 <?php
   $logger->pushProcessor(function ($record) {
+      $context = \DDTrace\current_context();
       $record['message'] .= sprintf(
           ' [dd.trace_id=%d dd.span_id=%d]',
-          \DDTrace\trace_id(),
-          \dd_trace_peek_span_id()
+          $context['trace_id'],
+          $context['span_id']
       );
       return $record;
   });
@@ -67,10 +69,11 @@ If your application uses json logs format instead of appending trace_id and span
 
 ```php
 <?php
+  $context = \DDTrace\current_context();
   $logger->pushProcessor(function ($record) {
       $record['dd'] = [
-          'trace_id' => \DDTrace\trace_id(),
-          'span_id'  => \dd_trace_peek_span_id(),
+          'trace_id' => $context['trace_id'],
+          'span_id'  => $context['span_id'],
       ];
 
       return $record;

--- a/content/fr/tracing/connect_logs_and_traces/php.md
+++ b/content/fr/tracing/connect_logs_and_traces/php.md
@@ -24,7 +24,7 @@ Consultez la section ci-dessous pour savoir comment associer vos logs PHP et vos
 ## Injecter manuellement des ID de trace et de span
 
 <div class="alert alert-warning">
-Veuillez noter que la fonction <code>\DDTrace\trace_id()</code> a été ajoutée avec la version <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.53.0">0.53.0</a>.
+Veuillez noter que la fonction <code>\DDTrace\current_context()</code> a été ajoutée avec la version <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.61.0">0.61.0</a>.
 </div>
 
 Pour associer vos logs et vos traces, vos logs doivent contenir les attributs `dd.trace_id` et `dd.span_id`, qui contiennent respectivement votre ID de trace et votre ID de span.
@@ -35,10 +35,11 @@ Par exemple, ces deux attributs seront ajoutés à vos logs de la manière suiva
 
 ```php
   <?php
+  $context = \DDTrace\current_context();
   $append = sprintf(
       ' [dd.trace_id=%d dd.span_id=%d]',
-      \DDTrace\trace_id(),
-      \dd_trace_peek_span_id()
+      $context['trace_id'],
+      $context['span_id']
   );
   my_error_logger('Error message.' . $append);
 ?>
@@ -48,11 +49,12 @@ Si le logger implémente la [bibliothèque **monolog/monolog**][4], utilisez `Lo
 
 ```php
 <?php
+  $context = \DDTrace\current_context();
   $logger->pushProcessor(function ($record) {
       $record['message'] .= sprintf(
           ' [dd.trace_id=%d dd.span_id=%d]',
-          \DDTrace\trace_id(),
-          \dd_trace_peek_span_id()
+          $context['trace_id'],
+          $context['span_id']
       );
       return $record;
   });
@@ -63,10 +65,11 @@ Si votre application utilise des logs au format json, au lieu d'ajouter les ID t
 
 ```php
 <?php
+  $context = \DDTrace\current_context();
   $logger->pushProcessor(function ($record) {
       $record['dd'] = [
-          'trace_id' => \DDTrace\trace_id(),
-          'span_id'  => \dd_trace_peek_span_id(),
+          'trace_id' => $context['trace_id'],
+          'span_id'  => $context['span_id'],
       ];
 
       return $record;

--- a/content/ja/logs/log_collection/php.md
+++ b/content/ja/logs/log_collection/php.md
@@ -444,7 +444,7 @@ monolog:
 ### Laravel
 
 <div class="alert alert-warning">
-注: 関数 <code>\DDTrace\trace_id()</code> は、バージョン <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.53.0">0.53.0</a> で導入されています。
+注: 関数 <code>\DDTrace\current_context()</code> は、バージョン <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.61.0">0.61.0</a> で導入されています。
 </div>
 
 ```php
@@ -480,16 +480,17 @@ class AppServiceProvider extends ServiceProvider
 
         // トレースおよびスパン ID を挿入してログエントリを APM トレースと接続
         $monolog->pushProcessor(function ($record) use ($useJson) {
+            $context = \DDTrace\current_context();
             if ($useJson === true) {
                 $record['dd'] = [
-                    'trace_id' => \DDTrace\trace_id(),
-                    'span_id'  => \dd_trace_peek_span_id(),
+                    'trace_id' => $context['trace_id'],
+                    'span_id'  => $context['span_id'],
                 ];
             } else {
                 $record['message'] .= sprintf(
                     ' [dd.trace_id=%d dd.span_id=%d]',
-                    \DDTrace\trace_id(),
-                    \dd_trace_peek_span_id()
+                    $context['trace_id'],
+                    $context['span_id']
                 );
             }
             return $record;

--- a/content/ja/tracing/connect_logs_and_traces/php.md
+++ b/content/ja/tracing/connect_logs_and_traces/php.md
@@ -27,7 +27,7 @@ PHP ログとトレースを手動で接続する方法については、以下�
 ## 手動挿入
 
 <div class="alert alert-warning">
-注: 関数 <code>\DDTrace\trace_id()</code> は、バージョン <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.53.0">0.53.0</a> で導入されています。
+注: 関数 <code>\DDTrace\current_context()</code> は、バージョン <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.61.0">0.61.0</a> で導入されています。
 </div>
 
 ログとトレースを一緒に接続するには、ログに、それぞれトレース ID とスパン ID を含む `dd.trace_id` 属性と `dd.span_id` 属性が含まれている必要があります。
@@ -38,10 +38,11 @@ PHP ログとトレースを手動で接続する方法については、以下�
 
 ```php
   <?php
+  $context = \DDTrace\current_context();
   $append = sprintf(
       ' [dd.trace_id=%d dd.span_id=%d]',
-      \DDTrace\trace_id(),
-      \dd_trace_peek_span_id()
+      $context['trace_id'],
+      $context['span_id']
   );
   my_error_logger('Error message.' . $append);
 ?>
@@ -52,10 +53,11 @@ PHP ログとトレースを手動で接続する方法については、以下�
 ```php
 <?php
   $logger->pushProcessor(function ($record) {
+      $context = \DDTrace\current_context();
       $record['message'] .= sprintf(
           ' [dd.trace_id=%d dd.span_id=%d]',
-          \DDTrace\trace_id(),
-          \dd_trace_peek_span_id()
+          $context['trace_id'],
+          $context['span_id']
       );
       return $record;
   });
@@ -66,10 +68,11 @@ PHP ログとトレースを手動で接続する方法については、以下�
 
 ```php
 <?php
+  $context = \DDTrace\current_context();
   $logger->pushProcessor(function ($record) {
       $record['dd'] = [
-          'trace_id' => \DDTrace\trace_id(),
-          'span_id'  => \dd_trace_peek_span_id(),
+          'trace_id' => $context['trace_id'],
+          'span_id'  => $context['span_id'],
       ];
 
       return $record;


### PR DESCRIPTION
### What does this PR do?
Updates code snippets to show how to use the newly provided function `DDTrace\current_context()` to extract a span context.

### Motivation
Before we had to different functions for trace and span id, in different namespaces, that were reflecting some internal implementation details rather than a sane API for users to interact with the current context.

### Preview
[Page 1](https://docs-staging.datadoghq.com/apm/php/logs-injection/tracing/connect_logs_and_traces/)
[Page 2](https://docs-staging.datadoghq.com/logs/log_collection/php/)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
