### PR TITLE
[dogstatsd] Clarify event title/message length measurement

### DIFF
--- a/content/en/developers/dogstatsd/datagram_shell.md
+++ b/content/en/developers/dogstatsd/datagram_shell.md
@@ -54,8 +54,8 @@ Here are some example datagrams:
 | `_e`                                 | Yes      | The datagram must begin with `_e`.                                                                                     |
 | `<TITLE>`                            | Yes      | The event title.                                                                                                       |
 | `<TEXT>`                             | Yes      | The event text. Insert line breaks with: `\\n`.                                                                        |
-| `<TITLE_UTF8_LENGTH>`                | Yes      | The length of the UTF-8-encoded `<TITLE>`                                                                              |
-| `<TEXT_UTF8_LENGTH>`                 | Yes      | The length of the UTF-8-encoded `<TEXT>`                                                                               |
+| `<TITLE_UTF8_LENGTH>`                | Yes      | The length (in bytes) of the UTF-8-encoded `<TITLE>`                                                                              |
+| `<TEXT_UTF8_LENGTH>`                 | Yes      | The length (in bytes) of the UTF-8-encoded `<TEXT>`                                                                               |
 | `d:<TIMESTAMP>`                      | No       | Add a timestamp to the event. The default is the current Unix epoch timestamp.                                         |
 | `h:<HOSTNAME>`                       | No       | Add a hostname to the event. No default.                                                                               |
 | `k:<AGGREGATION_KEY>`                | No       | Add an aggregation key to group the event with others that have the same key. No default.                              |


### PR DESCRIPTION
### What does this PR do?
Make it very explicit that the length should be measured in bytes, not in characters


### Preview
https://docs-staging.datadoghq.com/olivielpeau/dogstatsd-event-length-bytes/developers/dogstatsd/datagram_shell/?tab=events#pagetitle

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
