### PR TITLE
Add Profiling Estimated Usage Metrics

### DIFF
--- a/content/en/account_management/billing/usage_metrics.md
+++ b/content/en/account_management/billing/usage_metrics.md
@@ -35,6 +35,8 @@ Estimated usage metrics are generally available for the following usage types:
 | Serverless Lambda Functions   | `datadog.estimated_usage.serverless.aws_lambda_functions` |
 | API test runs                 | `datadog.estimated_usage.synthetics.api_test_runs` |
 | Browser test runs             | `datadog.estimated_usage.synthetics.browser_test_runs`|
+| Profiled Hosts                | `datadog.estimated_usage.profiling.hosts` |
+| Profiled Containers           | `datadog.estimated_usage.profiling.containers` |
 
 {{< img src="account_management/billing/usage-metrics-02.png" alt="Metric Names" >}}
 


### PR DESCRIPTION
Estimated Usage Metrics are now available for Profiled Hosts and Profiled Containers. We want to add this information to the public docs before sending the announcement so that customers can start using them.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
