### PR TITLE
Clarifying recording flow in case of config options

### DIFF
--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -45,7 +45,7 @@ Define the configuration of your browser test.
   * **Cookies**: Define cookies to add to the default browser cookies. Set multiple cookies using the format `<COOKIE_NAME1>=<COOKIE_VALUE1>; <COOKIE_NAME2>=<COOKIE_VALUE2>`.
   * **Proxy URL**: URL of the proxy the requests should go through (`http://<YOUR_USER>:<YOUR_PWD>@<YOUR_IP>:<YOUR_PORT>`).
   
-**Note:** These options are set at every test execution and on every step of your browser test. They are however only applied at execution time and not at recording time. You should consequently manually apply these on the page that is being used for recording and only then record steps the test should go through.
+**Note:** These options are set at every test execution and for every step of your browser test. They are however only applied at execution time and not at recording time. You should consequently manually apply these on the page that is being used for recording and only then record steps the test should go through.
 
 [1]: /synthetics/guide/identify_synthetics_bots/?tab=apitests
   {{% /tab %}}

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -45,7 +45,7 @@ Define the configuration of your browser test.
   * **Cookies**: Define cookies to add to the default browser cookies. Set multiple cookies using the format `<COOKIE_NAME1>=<COOKIE_VALUE1>; <COOKIE_NAME2>=<COOKIE_VALUE2>`.
   * **Proxy URL**: URL of the proxy the requests should go through (`http://<YOUR_USER>:<YOUR_PWD>@<YOUR_IP>:<YOUR_PORT>`).
   
-**Note:** These options are set at every test execution and for every step of your browser test. They are however only applied at execution time and not at recording time. You should consequently manually apply these on the page that is being used for recording and only then record steps the test should go through.
+**Note:** These request options are set at every test execution and apply to every step of your browser test at execution time, not recording time. If you need these options to be active to record following steps, you can manually apply these options on the page you are recording from and then create subsequent steps for your test.
 
 [1]: /synthetics/guide/identify_synthetics_bots/?tab=apitests
   {{% /tab %}}

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -45,6 +45,7 @@ Define the configuration of your browser test.
   * **Cookies**: Define cookies to add to the default browser cookies. Set multiple cookies using the format `<COOKIE_NAME1>=<COOKIE_VALUE1>; <COOKIE_NAME2>=<COOKIE_VALUE2>`.
   * **Proxy URL**: URL of the proxy the requests should go through (`http://<YOUR_USER>:<YOUR_PWD>@<YOUR_IP>:<YOUR_PORT>`).
   
+**Note:** These options are set at every test execution and on every step of your browser test. They are however only applied at execution time and not at recording time. You should consequently manually apply these on the page that is being used for recording and only then record steps the test should go through.
 
 [1]: /synthetics/guide/identify_synthetics_bots/?tab=apitests
   {{% /tab %}}

--- a/content/en/synthetics/guide/app-that-requires-login.md
+++ b/content/en/synthetics/guide/app-that-requires-login.md
@@ -71,7 +71,7 @@ The second way to ensure that your Datadog Browser tests can login into your app
 - Cookies
 - Basic, Digest, or NTLM credentials
 
-These are set at every test execution and on every step of your browser test. Note that these settings are only applied at execution time and not at recording time. You should consequently manually apply the configured headers, cookies, and/or credentials on the page that is being used for recording and only then record steps the test should perform post login. At execution time, the browser test however automatically first goes through authentication thanks to the header/cookie/credentials you applied and then performs all the recorded steps.
+These are set at every test execution and for every step of your browser test. Note that these settings are however only applied at execution time and not at recording time. You should consequently manually apply the configured headers, cookies, and/or credentials on the page that is being used for recording and only then record steps the test should perform post login. At execution time, the browser test automatically first goes through authentication thanks to the header/cookie/credentials you applied and then performs all the recorded steps.
 
 {{< img src="synthetics/guide/app_that_requires_login/bt_adv_options.jpg" alt="Login to your app with browser test configuration options">}}
 

--- a/content/en/synthetics/guide/app-that-requires-login.md
+++ b/content/en/synthetics/guide/app-that-requires-login.md
@@ -71,7 +71,9 @@ The second way to ensure that your Datadog Browser tests can login into your app
 - Cookies
 - Basic, Digest, or NTLM credentials
 
-These are set at every test execution and for every step of your browser test. Note that these settings are however only applied at execution time and not at recording time. You should consequently manually apply the configured headers, cookies, and/or credentials on the page that is being used for recording and only then record steps the test should perform post login. At execution time, the browser test automatically first goes through authentication thanks to the header/cookie/credentials you applied and then performs all the recorded steps.
+These configuration options are set at every test execution and apply to every step of your browser test at execution time, not recording time. 
+
+You can manually apply these configured headers, cookies, and credentials on the page you are recording from and then record steps your test performs post-login. By default, the browser test automatically passes through authentication with your specified headers, cookies, and/or credentials at execution time and then goes through all recorded steps.
 
 {{< img src="synthetics/guide/app_that_requires_login/bt_adv_options.jpg" alt="Login to your app with browser test configuration options">}}
 

--- a/content/en/synthetics/guide/app-that-requires-login.md
+++ b/content/en/synthetics/guide/app-that-requires-login.md
@@ -71,7 +71,7 @@ The second way to ensure that your Datadog Browser tests can login into your app
 - Cookies
 - Basic, Digest, or NTLM credentials
 
-These are set at every test execution and on every step of your browser test, consequently allowing you to start the recording of your steps directly post login.
+These are set at every test execution and on every step of your browser test. Note that these settings are only applied at execution time and not at recording time. You should consequently manually apply the configured headers, cookies, and/or credentials on the page that is being used for recording and only then record steps the test should perform post login. At execution time, the browser test however automatically first goes through authentication thanks to the header/cookie/credentials you applied and then performs all the recorded steps.
 
 {{< img src="synthetics/guide/app_that_requires_login/bt_adv_options.jpg" alt="Login to your app with browser test configuration options">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Clarify recording mechanism in browser tests when using advanced options

### Motivation
<!-- What inspired you to submit this pull request?-->
Internal report

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/margot.lepizzera/auth_clarification/synthetics/browser_tests

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
