### PR TITLE
APM > .NET -> Update support messaging on .NET Core 2.1

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -28,6 +28,7 @@ The .NET Tracer supports automatic instrumentation on the following .NET Core ve
 | -------------------- | --------------------- |
 | .NET 5               |                       |
 | .NET Core 3.1        | 12/03/2022            |
+| .NET Core 2.1        | 08/21/2021            |
 
  Additional information on .NET Core support policy can be found within [Microsoft's .NET Core Lifecycle Policy][3]. 
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -28,7 +28,6 @@ The .NET Tracer supports automatic instrumentation on the following .NET Core ve
 | -------------------- | --------------------- |
 | .NET 5               |                       |
 | .NET Core 3.1        | 12/03/2022            |
-| .NET Core 2.1        | 08/21/2021            |
 
  Additional information on .NET Core support policy can be found within [Microsoft's .NET Core Lifecycle Policy][3]. 
 
@@ -73,7 +72,7 @@ Don’t see your desired frameworks? Datadog is continually adding additional su
 
 ## Out of support .NET Core versions
 
-The .NET Tracer works on .NET Core 2.0, 2.2, and 3.0, but these versions reached their end of life and are no longer supported by Microsoft. See [Microsoft's support policy][3] for more details. We recommend using the latest patch version of .NET Core 2.1 or 3.1. Older versions of .NET Core may encounter the following runtime issues when enabling automatic instrumentation:
+The .NET Tracer works on .NET Core 2.0, 2.1, 2.2, and 3.0, but these versions reached their end of life and are no longer supported by Microsoft. See [Microsoft's support policy][3] for more details. We recommend using the latest patch version of .NET Core 3.1 or .NET 5. Older versions of .NET Core may encounter the following runtime issues when enabling automatic instrumentation:
 
 | Issue                                         | Affected .NET Core Versions               | Solution                                                               | More information                        |
 |-----------------------------------------------|-------------------------------------------|------------------------------------------------------------------------|-----------------------------------------|


### PR DESCRIPTION
### What does this PR do?
Updates the "Out of support .NET Core versions" section to recommend upgrading to .NET Core 3.1 and .NET 5, instead of .NET Core 2.1 which became out of support beginning on 08/21/2021.

### Motivation
.NET Core 2.1 recently hit end of life, so we need to update our messaging around support.

### Preview
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-support-netcore/tracing/setup_overview/compatibility_requirements/dotnet-core

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
