### PR TITLE
.NET + OpenTracing - resource name example

### DIFF
--- a/content/en/tracing/setup_overview/open_standards/dotnet.md
+++ b/content/en/tracing/setup_overview/open_standards/dotnet.md
@@ -38,7 +38,7 @@ Use OpenTracing to create a span.
 using (var scope =
        Tracer.Instance.StartActive("manual.sortorders"))
 {
-    scope.Span.ResourceName = "<RESOURCE NAME>"
+    scope.Span.ResourceName = "<RESOURCE NAME>";
     SortOrders();
 }
 ```
@@ -53,7 +53,7 @@ To trace code running in an asynchronous task, create a new scope within the bac
          using (var scope =
                 Tracer.Instance.StartActive("manual.sortorders.async"))
          {
-             scope.Span.ResourceName = "<RESOURCE NAME>"
+             scope.Span.ResourceName = "<RESOURCE NAME>";
              SortOrders();
          }
      });

--- a/content/en/tracing/setup_overview/open_standards/dotnet.md
+++ b/content/en/tracing/setup_overview/open_standards/dotnet.md
@@ -38,6 +38,7 @@ Use OpenTracing to create a span.
 using (var scope =
        Tracer.Instance.StartActive("manual.sortorders"))
 {
+    scope.Span.ResourceName = "<RESOURCE NAME>"
     SortOrders();
 }
 ```
@@ -52,6 +53,7 @@ To trace code running in an asynchronous task, create a new scope within the bac
          using (var scope =
                 Tracer.Instance.StartActive("manual.sortorders.async"))
          {
+             scope.Span.ResourceName = "<RESOURCE NAME>"
              SortOrders();
          }
      });


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Explains how to set resource name when using .NET and OpenTracing.

### Motivation
<!-- What inspired you to submit this pull request?-->

Our current docs don't explain this.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/dotnet-opentracing-example/tracing/setup_overview/open_standards/dotnet/#opentracing

### Additional Notes
<!-- Anything else we should know when reviewing?-->

This should be reviewed by someone in @DataDog/apm-dotnet along with the docs team.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
