### PR TITLE
carlos/iconfont-update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ clean-all: stop  ## Clean everything.
 	make clean-examples
 
 clean-build:  ## Remove build artifacts.
-	@if [ -d public ]; then rm -r public; fi
+	@if [ -d public ]; then rm -rf public; fi
 	@if [ static/images/integrations_logos/2020w2.pdf ]; then \
 	rm -f static/images/integrations_logos/2020w2.pdf ;fi
 

--- a/assets/styles/components/_header.scss
+++ b/assets/styles/components/_header.scss
@@ -169,10 +169,11 @@ body > header {
                 // product menu
                 &.product-menu {
                     column-count: 2;
-                    height: 415px;
+                    height: 455px;
                     column-fill: auto;
 
-                    img.menu-icon {
+                    i[class*='icon-'] {
+                        display: inline-block;
                         width: 18px;
                         margin-right: 12px;
                     }

--- a/assets/styles/components/_sidenav.scss
+++ b/assets/styles/components/_sidenav.scss
@@ -47,6 +47,12 @@ body {
     padding-right: 15px;
     padding-bottom: 50px;
 
+    i[class*='icon-'] {
+        display: inline-block;
+        width: 20px;
+        margin-top: 4px;
+    }
+
     .sticky {
         .col {
             padding-right: 0;

--- a/assets/styles/components/_sidenav.scss
+++ b/assets/styles/components/_sidenav.scss
@@ -52,9 +52,14 @@ body {
         width: 20px;
         margin-top: 4px;
     }
+
     // Exception for main sidenav since APM's title wraps to a second line
-    &:not(.navbar-sidenav .sidenav) .icon-apm,
-    &:not(.navbar-sidenav .sidenav) .icon-cog {
+    .en &:not(.navbar-sidenav .sidenav) .icon-apm,
+    .en &:not(.navbar-sidenav .sidenav) .icon-cog,
+    // Exceptions for FR site
+    .fr &:not(.navbar-sidenav .sidenav) .icon-security,
+    .fr &:not(.navbar-sidenav .sidenav) .icon-synthetics,
+    .fr &:not(.navbar-sidenav .sidenav) .icon-dev-code {
         @include media-breakpoint-only(lg) {
             align-self: flex-start;
             margin-top: 8px;
@@ -387,6 +392,29 @@ body {
                 font-size: 18px;
                 padding-top: 15px;
             }
+        }
+    }
+}
+
+.ja .sidenav {
+    i[class*='icon-'] {
+        margin-top: 0;
+    }
+
+    &:not(.navbar-sidenav .sidenav) [data-path='ja/security_monitoring'] .icon-security {
+        align-self: flex-start;
+        margin-top: 4px;
+    }
+
+    @include media-breakpoint-only(lg) {
+        &:not(.navbar-sidenav .sidenav) .icon-mobile,
+        &:not(.navbar-sidenav .sidenav) .icon-host-map,
+        &:not(.navbar-sidenav .sidenav) .icon-apm,
+        &:not(.navbar-sidenav .sidenav) .icon-rum,
+        &:not(.navbar-sidenav .sidenav) .icon-network,
+        &:not(.navbar-sidenav .sidenav) [data-path='ja/security_monitoring'] .icon-security {
+            align-self: flex-start;
+            margin-top: 4px;
         }
     }
 }

--- a/assets/styles/components/_sidenav.scss
+++ b/assets/styles/components/_sidenav.scss
@@ -53,9 +53,12 @@ body {
         margin-top: 4px;
     }
     // Exception for main sidenav since APM's title wraps to a second line
-    &:not(.navbar-sidenav .sidenav) .icon-apm {
-        align-self: flex-start;
-        margin-top: 8px;
+    &:not(.navbar-sidenav .sidenav) .icon-apm,
+    &:not(.navbar-sidenav .sidenav) .icon-cog {
+        @include media-breakpoint-only(lg) {
+            align-self: flex-start;
+            margin-top: 8px;
+        }
     }
 
     .sticky {

--- a/assets/styles/components/_sidenav.scss
+++ b/assets/styles/components/_sidenav.scss
@@ -52,6 +52,11 @@ body {
         width: 20px;
         margin-top: 4px;
     }
+    // Exception for main sidenav since APM's title wraps to a second line
+    &:not(.navbar-sidenav .sidenav) .icon-apm {
+        align-self: flex-start;
+        margin-top: 8px;
+    }
 
     .sticky {
         .col {

--- a/assets/styles/pages/_home.scss
+++ b/assets/styles/pages/_home.scss
@@ -193,6 +193,7 @@
             i[class*='icon-'] {
                 background: linear-gradient(45deg, #ae25b4, #632ca6);
                 background-clip: text;
+                -webkit-background-clip: text;
                 --webkit-text-fill-color: transparent;
             }
 

--- a/assets/styles/pages/_home.scss
+++ b/assets/styles/pages/_home.scss
@@ -18,8 +18,7 @@
         .docssearch {
             transform: none;
             #docssearchWrapper {
-                box-shadow: 0px 1px 4px rgba(30, 5, 36, 0.24),
-                    0px 1px 1px rgba(30, 5, 36, 0.16);
+                box-shadow: 0px 1px 4px rgba(30, 5, 36, 0.24), 0px 1px 1px rgba(30, 5, 36, 0.16);
                 position: relative;
             }
 
@@ -108,8 +107,7 @@
         margin: -60px auto 30px auto;
         background-color: white;
         border-radius: 3px;
-        box-shadow: 0px 1px 1px rgba(30, 5, 36, 0.16),
-            0px 1px 4px rgba(30, 5, 36, 0.24);
+        box-shadow: 0px 1px 1px rgba(30, 5, 36, 0.16), 0px 1px 4px rgba(30, 5, 36, 0.24);
         position: relative;
         @media (min-width: 768px) {
             margin: -60px auto 50px auto;
@@ -185,18 +183,19 @@
         .nav-tile {
             a {
                 padding: 10px 27px;
-                box-shadow: 0px 1px 1px rgba(30, 5, 36, 0.16),
-                    0px 1px 4px rgba(30, 5, 36, 0.24);
+                box-shadow: 0px 1px 1px rgba(30, 5, 36, 0.16), 0px 1px 4px rgba(30, 5, 36, 0.24);
                 transition: box-shadow ease-in-out 0.16s;
                 &:hover {
-                    box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.16),
-                        0px 4px 12px rgba(0, 0, 0, 0.24);
+                    box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.16), 0px 4px 12px rgba(0, 0, 0, 0.24);
                 }
             }
-            svg {
-                width: 15px;
-                height: 18px;
+
+            i[class*='icon-'] {
+                background: linear-gradient(45deg, #ae25b4, #632ca6);
+                background-clip: text;
+                --webkit-text-fill-color: transparent;
             }
+
             span {
                 padding-top: 5px;
             }

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -1,57 +1,58 @@
 // bootstrap customization & font setup
-@import "bootstrap-custom";
-@import "webfonts";
-@import "icons";
+@import 'bootstrap-custom';
+@import 'webfonts';
+@import 'icons';
 
 // base
-@import "base/variables";
-@import "base/mixins";
-@import "base/colors";
-@import "base/typography";
-@import "base/helpers";
+@import 'base/variables';
+@import 'base/mixins';
+@import 'base/colors';
+@import 'base/typography';
+@import 'base/helpers';
 
 // vendor
-@import "vendor/chroma-styles";
+@import 'vendor/chroma-styles';
 
 // docsearch
-@import "main_docsearch";
+@import 'main_docsearch';
 
 // global to all pages
-@import "pages/global";
+@import 'pages/global';
 // language specific
-@import "pages/ja";
-@import "pages/fr";
+@import 'pages/ja';
+@import 'pages/fr';
 
 // page specific styles that aren't partials go here
 // partial css lives with partial
-@import "pages/api";
-@import "pages/search";
-@import "pages/404";
-@import "pages/home";
-@import "pages/help";
-@import "pages/security_monitoring";
+@import 'pages/api';
+@import 'pages/search';
+@import 'pages/404';
+@import 'pages/home';
+@import 'pages/help';
+@import 'pages/security_monitoring';
 
 // Components
+@import 'components/iconfont'; // imported from websites-modules
 @import 'components/announcement-banner'; // imported from websites-modules
-@import "components/badge";
-@import "components/cards";
-@import "components/footer";
-@import "components/global-modals";
-@import "components/header";
-@import "components/integration-labels";
-@import "components/integration-breadcrumbs";
-@import "components/integrations";
-@import "components/platforms";
-@import "components/preview_banner";
-@import "components/questions";
-@import "components/language-region-select";
-@import "components/sidenav";
-@import "components/support";
-@import "components/table-of-contents";
-@import "components/tile-nav";
-@import "components/whats-next";
-@import "components/schema-table";
-@import "components/tab-toggle";
+@import 'components/badge';
+@import 'components/cards';
+@import 'components/footer';
+@import 'components/global-modals';
+@import 'components/header';
+@import 'components/integration-labels';
+@import 'components/integration-breadcrumbs';
+@import 'components/integrations';
+@import 'components/platforms';
+@import 'components/preview_banner';
+@import 'components/questions';
+@import 'components/language-region-select';
+@import 'components/sidenav';
+@import 'components/support';
+@import 'components/table-of-contents';
+@import 'components/tile-nav';
+@import 'components/whats-next';
+@import 'components/schema-table';
+@import 'components/tab-toggle';
 
 // for now just include ie fixes
-@import "ie";
+@import 'ie';

--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -41,6 +41,16 @@ module:
        target: layouts/partials/announcement_banner.html
      - source: assets/scss/components/_announcement-banner.scss
        target: assets/styles/components/_announcement-banner.scss
+     - source: assets/scss/base/_iconfont.scss
+       target: assets/styles/components/_iconfont.scss
+     - source: static/fonts/icon-font/iconfont.eot
+       target: static/fonts/iconfont.eot
+     - source: static/fonts/icon-font/iconfont.ttf
+       target: static/fonts/iconfont.ttf
+     - source: static/fonts/icon-font/iconfont.svg
+       target: static/fonts/iconfont.svg
+     - source: static/fonts/icon-font/iconfont.woff
+       target: static/fonts/iconfont.woff
 
   mounts:
     # default mounts

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -5,106 +5,121 @@ main_left:
     weight: -500
   - identifier: features
     name: Features
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/features.svg'' alt=''features icon''>'
+    pre: '<i class="icon-features align-middle"></i>'
     url: 'https://www.datadoghq.com/product/'
     weight: 1
     parent: product
   - identifier: integrations
     name: Integrations
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/integrations.svg'' alt=''integrations icon''>'
+    pre: '<i class="icon-integrations align-middle"></i>'
     url: 'https://www.datadoghq.com/product/platform/integrations/'
     weight: 2
     parent: product
   - identifier: dashboarding
     name: Dashboards
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/dashboard.svg'' alt=''dashboard icon''>'
+    pre: '<i class="icon-dashboard align-middle"></i>'
     url: 'https://www.datadoghq.com/product/platform/dashboards/'
     weight: 3
     parent: product
   - identifier: infrastructure
     name: Infrastructure Monitoring
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/host-map-2.svg'' alt=''infra icon''>'
+    pre: '<i class="icon-host-map align-middle"></i>'
     url: 'https://www.datadoghq.com/product/infrastructure-monitoring/'
     weight: 4
     parent: product
   - identifier: logs
     name: Log Management
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/log.svg'' alt=''log icon''>'
-    url: 'https://www.datadoghq.com/product/log-management/'
+    pre: '<i class="icon-log align-middle"></i>'
     weight: 5
     parent: product
   - identifier: apm
     name: APM
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/apm.svg'' alt=''apm icon''>'
-    url: 'https://www.datadoghq.com/product/apm/'
+    pre: '<i class="icon-apm align-middle"></i>'
     weight: 6
     parent: product
   - identifier: profiler
     name: Continuous Profiler
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/profiling-1.svg'' alt=''profiler icon''>'
+    pre: '<i class="icon-profiling-1 align-middle"></i>'
     url: 'https://www.datadoghq.com/product/code-profiling/'
     weight: 7
     parent: product
   - identifier: synthetics
     name: Synthetic Monitoring
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/synthetics.svg'' alt=''synthetics icon''>'
+    pre: '<i class="icon-synthetics align-middle"></i>'
     url: 'https://www.datadoghq.com/product/synthetic-monitoring/'
     weight: 8
     parent: product
   - identifier: rum
     name: Real User Monitoring
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/rum-2.svg'' alt=''rum icon''>'
-    url: 'https://www.datadoghq.com/product/real-user-monitoring/'
+    pre: '<i class="icon-rum align-middle"></i>'
     weight: 9
-    parent: product
-  - identifier: security-platform
-    name: Security Platform
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/security.svg'' alt=''security icon''>'
-    url: 'https://www.datadoghq.com/product/security-platform/'
-    weight: 10
-    parent: product
-  - identifier: security-monitoring
-    name: Security Monitoring
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/security.svg'' alt=''security icon''>'
-    url: 'https://www.datadoghq.com/product/security-platform/security-monitoring/'
-    weight: 11
-    parent: product
-  - identifier: cloud-security-posture-management
-    name: CSPM
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/security.svg'' alt=''security icon''>'
-    url: 'https://www.datadoghq.com/product/security-platform/cloud-security-posture-management/'
-    weight: 12
     parent: product
   - identifier: network
     name: Network Monitoring
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/network.svg'' alt=''network icon''>'
+    pre: '<i class="icon-network align-middle"></i>'
     url: 'https://www.datadoghq.com/product/network-monitoring'
+    weight: 10
+    parent: product
+  - identifier: security-platform
+    name: Security Platform
+    pre: '<i class="icon-security align-middle"></i>'
+    url: 'https://www.datadoghq.com/product/security-platform/'
+    weight: 11
+    parent: product
+  - identifier: security-monitoring
+    name: Security Monitoring
+    pre: '<i class="icon-security align-middle"></i>'
+    url: 'https://www.datadoghq.com/product/security-platform/security-monitoring/'
+    weight: 12
+    parent: product
+  - identifier: cloud-security-posture-management
+    name: CSPM
+    pre: '<i class="icon-cspm align-middle"></i>'
+    url: 'https://www.datadoghq.com/product/security-platform/cloud-security-posture-management/'
     weight: 13
     parent: product
+  - identifier: cloud-workload-security
+    name: Cloud Workload Security
+    pre: '<i class="icon-cws align-middle"></i>'
+    url: 'product/security-platform/cloud-workload-security/'
+    weight: 14
+    parent: 'product'
+  - identifier: error-tracking
+    name: Error Tracking
+    pre: '<i class="icon-error-tracking align-middle"></i>'
+    url: 'product/security-platform/error-tracking/'
+    weight: 15
+    parent: 'product'
   - identifier: incident
     name: Incident Management
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/incidents.svg'' alt=''incident icon''>'
-    url: 'https://www.datadoghq.com/product/incident-management'
-    weight: 14
-    parent: product
+    pre: '<i class="icon-incidents align-middle"></i>'
+    url: 'product/incident-management'
+    weight: 16
+    parent: 'product'
+  - identifier: database
+    name: Database Monitoring
+    pre: '<i class="icon-dbm align-middle"></i>'
+    url: 'product/database-monitoring'
+    weight: 17
+    parent: 'product'
   - identifier: serverless
     name: Serverless
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/serverless.svg'' alt=''serverless icon''>'
-    url: 'https://www.datadoghq.com/product/serverless-monitoring'
-    weight: 15
-    parent: product
+    pre: '<i class="icon-serverless align-middle"></i>'
+    url: 'product/serverless-monitoring/'
+    weight: 18
+    parent: 'product'
   - identifier: alerts
     name: Alerts
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/alert-1.svg'' alt=''alert icon''>'
-    url: 'https://www.datadoghq.com/product/alerts'
-    weight: 16
-    parent: product
+    pre: '<i class="icon-alert align-middle"></i>'
+    url: 'product/alerts/'
+    weight: 19
+    parent: 'product'
   - identifier: api
     name: API
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/datadoghq-api-icon-2.svg'' alt=''api icon''>'
+    pre: '<i class="icon-api align-middle"></i>'
     url: 'https://docs.datadoghq.com/api'
-    weight: 17
-    parent: product
+    weight: 20
+    parent: 'product'
   - identifier: customers
     name: Customers
     url: 'https://www.datadoghq.com/customers/'

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -340,7 +340,7 @@ main:
   - name: Getting Started
     identifier: getting_started
     url: getting_started/
-    pre: nav_start
+    pre: hex-ringed
     weight: 10000
   - name: Datadog
     identifier: getting_started_datadog
@@ -447,7 +447,7 @@ main:
     weight: 14
   - name: Agent
     url: agent/
-    pre: nav_agent
+    pre: agent-fill
     weight: 30000
     identifier: agent
   - name: Basic Agent Usage
@@ -795,7 +795,7 @@ main:
   - name: Integrations
     url: integrations/
     identifier: integrations_top_level
-    pre: nav_integrations
+    pre: integrations
     weight: 40000
   - name: Guides
     url: integrations/guide/
@@ -841,12 +841,12 @@ main:
   - name: Watchdog
     url: watchdog/
     identifier: watchdog_top_level
-    pre: nav_watchdog
+    pre: watchdog
     weight: 50000
   - name: Events
     url: events/
     identifier: events_top_level
-    pre: nav_events
+    pre: events
     weight: 60000
   - name: Guides
     url: events/guides/
@@ -875,7 +875,7 @@ main:
     weight: 104
   - name: Dashboards
     url: dashboards/
-    pre: nav_dashboards
+    pre: dashboard
     identifier: dashboards
     weight: 70000
   - name: Dashboard Layout
@@ -1085,12 +1085,12 @@ main:
   - name: Mobile Application
     url: mobile/
     identifier: mobile
-    pre: nav_mobile
+    pre: mobile
     weight: 80000
   - name: Infrastructure
     url: infrastructure/
     identifier: infrastructure
-    pre: nav_infrastructure
+    pre: host-map
     weight: 90000
   - name: Infrastructure List
     url: infrastructure/list/
@@ -1123,7 +1123,7 @@ main:
     weight: 7
   - name: Serverless
     url: serverless
-    pre: nav_serverless
+    pre: serverless
     identifier: serverless
     weight: 100000
   - name: Installation
@@ -1270,7 +1270,7 @@ main:
   - name: Metrics
     url: metrics/
     identifier: metrics_top_level
-    pre: nav_metrics
+    pre: metric
     weight: 110000
   - name: Explorer
     url: metrics/explorer/
@@ -1332,7 +1332,7 @@ main:
   - name: Notebooks
     url: notebooks/
     identifier: notebooks
-    pre: nav_notebooks
+    pre: notebook
     weight: 120000
   - name: Alerting
     url: monitors/
@@ -1486,7 +1486,7 @@ main:
     identifier: alerting_guide
   - name: APM & Continuous Profiler
     url: tracing/
-    pre: nav_tracing
+    pre: apm
     identifier: tracing
     weight: 140000
   - name: Send traces to Datadog
@@ -1933,7 +1933,7 @@ main:
     weight: 1705
   - name: CI Visibility
     url: continuous_integration/
-    pre: nav_ci
+    pre: ci
     identifier: ci
     weight: 150000
   - name: Tracing Tests
@@ -2027,7 +2027,7 @@ main:
     weight: 6
   - name: Database Monitoring
     url: database_monitoring/
-    pre: nav_dbm
+    pre: dbm
     identifier: dbm
     weight: 160000
   - name: Setting Up Postgres
@@ -2112,7 +2112,7 @@ main:
     weight: 6
   - name: Log Management
     url: logs/
-    pre: nav_logs
+    pre: log
     identifier: log_management
     weight: 170000
   - name: Log Collection & Integrations
@@ -2264,7 +2264,7 @@ main:
     weight: 7
   - name: Security Platform
     url: security_platform/
-    pre: nav_security_monitoring
+    pre: security
     identifier: security_platform
     weight: 180000
   - name: Security Monitoring
@@ -2381,7 +2381,7 @@ main:
     weight: 11
   - name: Synthetic Monitoring
     url: synthetics/
-    pre: nav_synthetics
+    pre: synthetics
     identifier: synthetics
     weight: 190000
   - name: API Tests
@@ -2488,7 +2488,7 @@ main:
     weight: 14
   - name: Real User Monitoring
     url: real_user_monitoring/
-    pre: nav_rum_2
+    pre: rum
     identifier: rum
     weight: 155000
   - name: Browser Monitoring
@@ -2669,7 +2669,7 @@ main:
     weight: 13
   - name: Network Monitoring
     url: network_monitoring/
-    pre: nav_network
+    pre: network
     identifier: nm_parent
     weight: 200000
   - name: Network Performance Monitoring
@@ -2766,7 +2766,7 @@ main:
     weight: 403
   - name: Developers
     url: developers/
-    pre: nav_developers
+    pre: dev-code
     identifier: dev_tools
     weight: 210000
   - name: DogStatsD
@@ -2873,12 +2873,12 @@ main:
     weight: 10
   - name: API
     url: api/
-    pre: nav_api
+    pre: api
     identifier: api
     weight: 220000
   - name: Account Management
     url: account_management/
-    pre: nav_account
+    pre: cog
     identifier: account_management
     weight: 230000
   - name: Switching between orgs
@@ -2956,7 +2956,7 @@ main:
     weight: 8
   - name: Security
     url: security/
-    pre: nav_security
+    pre: security
     identifier: security
     weight: 240000
   - name: Agent
@@ -2981,7 +2981,7 @@ main:
     weight: 5
   - name: Help
     url: help/
-    pre: nav_help
+    pre: info-fill
     identifier: help_top_level
     weight: 240000
   - name: Aggregating Agents

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2956,7 +2956,7 @@ main:
     weight: 8
   - name: Security
     url: security/
-    pre: security
+    pre: security-lock
     identifier: security
     weight: 240000
   - name: Agent

--- a/config/_default/menus/menus.fr.yaml
+++ b/config/_default/menus/menus.fr.yaml
@@ -5,106 +5,121 @@ main_left:
     weight: -500
   - identifier: features
     name: Fonctionnalités
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/features.svg' alt='icône fonctionnalités'>"
-    url: "https://www.datadoghq.com/product/"
+    pre: '<i class="icon-features align-middle"></i>'
+    url: 'https://www.datadoghq.com/product/'
     weight: 1
     parent: product
   - identifier: integrations
     name: Intégrations
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/integrations.svg' alt='icône intégrations'>"
-    url: "https://www.datadoghq.com/product/platform/integrations/"
+    pre: '<i class="icon-integrations align-middle"></i>'
+    url: 'https://www.datadoghq.com/product/platform/integrations/'
     weight: 2
     parent: product
   - identifier: dashboarding
     name: Dashboards
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/dashboard.svg' alt='icône dashboard'>"
-    url: "https://www.datadoghq.com/product/platform/dashboards/"
+    pre: '<i class="icon-dashboard align-middle"></i>'
+    url: 'https://www.datadoghq.com/product/platform/dashboards/'
     weight: 3
     parent: product
   - identifier: infrastructure
     name: Infrastructure Monitoring
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/host-map-2.svg' alt='infra icon'>"
-    url: "https://www.datadoghq.com/product/infrastructure-monitoring/"
+    pre: '<i class="icon-host-map align-middle"></i>'
+    url: 'https://www.datadoghq.com/product/infrastructure-monitoring/'
     weight: 4
     parent: product
   - identifier: logs
     name: Log Management
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/log.svg' alt='log icon'>"
-    url: "https://www.datadoghq.com/product/log-management/"
+    pre: '<i class="icon-log align-middle"></i>'
     weight: 5
     parent: product
   - identifier: apm
     name: APM
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/apm.svg' alt='apm icon'>"
-    url: "https://www.datadoghq.com/product/apm/"
+    pre: '<i class="icon-apm align-middle"></i>'
     weight: 6
     parent: product
   - identifier: profiler
     name: Continuous Profiler
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/profiling-1.svg' alt='profiler icon'>"
-    url: "https://www.datadoghq.com/product/code-profiling/"
+    pre: '<i class="icon-profiling-1 align-middle"></i>'
+    url: 'https://www.datadoghq.com/product/code-profiling/'
     weight: 7
     parent: product
   - identifier: synthetics
     name: Synthetic Monitoring
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/synthetics.svg' alt='synthetics icon'>"
-    url: "https://www.datadoghq.com/product/synthetic-monitoring/"
+    pre: '<i class="icon-synthetics align-middle"></i>'
+    url: 'https://www.datadoghq.com/product/synthetic-monitoring/'
     weight: 8
     parent: product
   - identifier: rum
     name: Real User Monitoring
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/rum-2.svg' alt='rum icon'>"
-    url: "https://www.datadoghq.com/product/real-user-monitoring/"
+    pre: '<i class="icon-rum align-middle"></i>'
     weight: 9
-    parent: product
-  - identifier: security-platform
-    name: Security Platform
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/security.svg' alt='security icon'>"
-    url: "https://www.datadoghq.com/product/security-platform/"
-    weight: 10
-    parent: product
-  - identifier: security-monitoring
-    name: Security Monitoring
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/security.svg' alt='security icon'>"
-    url: "https://www.datadoghq.com/product/security-platform/security-monitoring/"
-    weight: 11
-    parent: product
-  - identifier: cloud-security-posture-management
-    name: CSPM
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/security.svg' alt='security icon'>"
-    url: "https://www.datadoghq.com/product/security-platform/cloud-security-posture-management/"
-    weight: 12
     parent: product
   - identifier: network
     name: Network Monitoring
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/network.svg' alt='network icon'>"
-    url: "https://www.datadoghq.com/product/network-monitoring/"
+    pre: '<i class="icon-network align-middle"></i>'
+    url: 'https://www.datadoghq.com/product/network-monitoring'
+    weight: 10
+    parent: product
+  - identifier: security-platform
+    name: Security Platform
+    pre: '<i class="icon-security align-middle"></i>'
+    url: 'https://www.datadoghq.com/product/security-platform/'
+    weight: 11
+    parent: product
+  - identifier: security-monitoring
+    name: Security Monitoring
+    pre: '<i class="icon-security align-middle"></i>'
+    url: 'https://www.datadoghq.com/product/security-platform/security-monitoring/'
+    weight: 12
+    parent: product
+  - identifier: cloud-security-posture-management
+    name: CSPM
+    pre: '<i class="icon-cspm align-middle"></i>'
+    url: 'https://www.datadoghq.com/product/security-platform/cloud-security-posture-management/'
     weight: 13
     parent: product
-  - identifier: incident
-    name: Incident Management
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/incidents.svg' alt='incident icon'>"
-    url: "https://www.datadoghq.com/product/incident-management/"
+  - identifier: cloud-workload-security
+    name: 'Cloud Workload Security'
+    pre: '<i class="icon-cws align-middle"></i>'
+    url: 'product/security-platform/cloud-workload-security/'
     weight: 14
-    parent: product
-  - identifier: serverless
-    name: Serverless
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/serverless.svg' alt='serverless icon'>"
-    url: "https://www.datadoghq.com/product/serverless-monitoring/"
+    parent: 'product'
+  - identifier: error-tracking
+    name: 'Error Tracking'
+    pre: '<i class="icon-error-tracking align-middle"></i>'
+    url: 'product/security-platform/error-tracking/'
     weight: 15
-    parent: product
-  - identifier: alerts
-    name: Alerts
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/alert-1.svg' alt='alert icon'>"
-    url: "https://www.datadoghq.com/product/alerts/"
+    parent: 'product'
+  - identifier: incident
+    name: 'Incident Management'
+    pre: '<i class="icon-incidents align-middle"></i>'
+    url: 'product/incident-management'
     weight: 16
-    parent: product
-  - identifier: api
-    name: API
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/datadoghq-api-icon-2.svg'' alt=''icône api''>'
-    url: 'https://docs.datadoghq.com/api'
+    parent: 'product'
+  - identifier: database
+    name: 'Database Monitoring'
+    pre: '<i class="icon-dbm align-middle"></i>'
+    url: 'product/database-monitoring'
     weight: 17
-    parent: product
+    parent: 'product'
+  - identifier: serverless
+    name: 'Serverless'
+    pre: '<i class="icon-serverless align-middle"></i>'
+    url: 'product/serverless-monitoring/'
+    weight: 18
+    parent: 'product'
+  - identifier: alerts
+    name: 'Alerts'
+    pre: '<i class="icon-alert align-middle"></i>'
+    url: 'product/alerts/'
+    weight: 19
+    parent: 'product'
+  - identifier: api
+    name: 'API'
+    pre: '<i class="icon-api align-middle"></i>'
+    url: 'https://docs.datadoghq.com/api'
+    weight: 20
+    parent: 'product'
   - identifier: customers
     name: Clients
     url: "https://www.datadoghq.com/customers/"

--- a/config/_default/menus/menus.fr.yaml
+++ b/config/_default/menus/menus.fr.yaml
@@ -322,7 +322,7 @@ main:
   - name: Débuter
     identifier: getting_started
     url: getting_started/
-    pre: nav_start
+    pre: hex-ringed
     weight: 10000
   - name: Datadog
     identifier: getting_started_datadog
@@ -415,7 +415,7 @@ main:
     weight: 10
   - name: Agent
     url: agent/
-    pre: nav_agent
+    pre: agent-fill
     weight: 30000
     identifier: agent
   - name: Utilisation de base de l'Agent
@@ -753,21 +753,21 @@ main:
   - name: Intégrations
     url: integrations/
     identifier: integrations_top_level
-    pre: nav_integrations
+    pre: integrations
     weight: 40000
   - name: Watchdog
     url: watchdog/
     identifier: watchdog_top_level
-    pre: nav_watchdog
+    pre: watchdog
     weight: 50000
   - name: Événements
     url: events/
     identifier: events_top_level
-    pre: nav_events
+    pre: events
     weight: 60000
   - name: Dashboards
     url: dashboards/
-    pre: nav_dashboards
+    pre: dashboard
     identifier: dashboards
     weight: 70000
   - name: Screenboards
@@ -868,12 +868,12 @@ main:
   - name: Application mobile
     url: mobile/
     identifier: mobile
-    pre: nav_mobile
+    pre: mobile
     weight: 80000
   - name: Infrastructure
     url: infrastructure/
     identifier: infrastructure
-    pre: nav_infrastructure
+    pre: host-map
     weight: 90000
   - name: Liste des infrastructures
     url: infrastructure/list/
@@ -902,7 +902,7 @@ main:
     weight: 6
   - name: Sans serveur
     url: serverless
-    pre: nav_serverless
+    pre: serverless
     identifier: serverless
     weight: 100000
   - name: Installation
@@ -1036,7 +1036,7 @@ main:
   - name: Métriques
     url: metrics/
     identifier: metrics_top_level
-    pre: nav_metrics
+    pre: metric
     weight: 110000
   - name: Explorer
     url: metrics/explorer/
@@ -1054,7 +1054,7 @@ main:
   - name: Notebooks
     url: notebooks/
     identifier: notebooks
-    pre: nav_notebooks
+    pre: notebook
     weight: 120000
   - name: Alertes
     url: monitors/
@@ -1202,7 +1202,7 @@ main:
     parent: alerting
   - name: APM et tracing distribué
     url: tracing/
-    pre: nav_tracing
+    pre: apm
     identifier: tracing
     weight: 140000
   - name: Envoyer des traces à Datadog
@@ -1600,7 +1600,7 @@ main:
     weight: 1505
   - name: Log Management
     url: logs/
-    pre: nav_logs
+    pre: log
     identifier: log_management
     weight: 150000
   - name: Collecte de logs et intégrations
@@ -1760,7 +1760,7 @@ main:
     weight: 11
   - name: Sécurité et conformité
     url: security_monitoring/
-    pre: nav_security_monitoring
+    pre: security
     identifier: security_compliance_monitoring
     weight: 160000
   - name: Security Monitoring
@@ -1800,7 +1800,7 @@ main:
     weight: 3
   - name: Surveillance Synthetic
     url: synthetics/
-    pre: nav_synthetics
+    pre: synthetics
     identifier: synthetics
     weight: 170000
   - name: Tests API
@@ -1890,7 +1890,7 @@ main:
     weight: 11
   - name: Real User Monitoring
     url: real_user_monitoring/
-    pre: nav_rum_2
+    pre: rum
     identifier: rum
     weight: 150000
   - name: Surveillance Browser
@@ -2005,7 +2005,7 @@ main:
     weight: 8
   - name: Surveillance réseau
     url: network_performance_monitoring/
-    pre: nav_network
+    pre: network
     identifier: npm
     weight: 190000
   - name: Installation
@@ -2065,7 +2065,7 @@ main:
     weight: 605
   - name: Outils de développement
     url: developers/
-    pre: nav_developers
+    pre: dev-code
     identifier: dev_tools
     weight: 200000
   - name: DogStatsD
@@ -2232,12 +2232,12 @@ main:
     weight: 12
   - name: API
     url: api/
-    pre: nav_api
+    pre: api
     identifier: api
     weight: 210000
   - name: Gestion de compte
     url: account_management/
-    pre: nav_account
+    pre: cog
     identifier: account_management
     weight: 220000
   - name: Gestion des utilisateurs
@@ -2310,7 +2310,7 @@ main:
     weight: 8
   - name: Sécurité
     url: security/
-    pre: nav_security
+    pre: security-lock
     identifier: security
     weight: 230000
   - name: Agent
@@ -2331,7 +2331,7 @@ main:
     weight: 4
   - name: Aide
     url: help/
-    pre: nav_help
+    pre: info-fill
     identifier: help_top_level
     weight: 240000
 api_v1:

--- a/config/_default/menus/menus.ja.yaml
+++ b/config/_default/menus/menus.ja.yaml
@@ -5,106 +5,124 @@ main_left:
     weight: -500
   - identifier: features
     name: 機能
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/features.svg' alt='features icon'>"
+    pre: '<i class="icon-features align-middle"></i>'
     url: "https://www.datadoghq.com/ja/product/"
     weight: 1
     parent: product
   - identifier: integrations
     name: インテグレーション
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/integrations.svg' alt='integrations icon'>"
+    pre: '<i class="icon-integrations align-middle"></i>'
     url: "https://www.datadoghq.com/ja/product/platform/integrations/"
     weight: 2
     parent: product
   - identifier: dashboarding
     name: ダッシュボード
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/dashboard.svg' alt='dashboard icon'>"
+    pre: '<i class="icon-dashboard align-middle"></i>'
     url: "https://www.datadoghq.com/ja/product/platform/dashboards/"
     weight: 3
     parent: product
   - identifier: infrastructure
     name: インフラストラクチャーのモニタリング
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/host-map-2.svg' alt='infra icon'>"
+    pre: '<i class="icon-host-map align-middle"></i>'
     url: "https://www.datadoghq.com/ja/product/infrastructure-monitoring/"
     weight: 4
     parent: product
   - identifier: logs
     name: ログ管理
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/log.svg' alt='log icon'>"
+    pre: '<i class="icon-log align-middle"></i>'
     url: "https://www.datadoghq.com/ja/product/log-management/"
     weight: 5
     parent: product
   - identifier: apm
     name: APM
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/apm.svg' alt='apm icon'>"
+    pre: '<i class="icon-apm align-middle"></i>'
     url: "https://www.datadoghq.com/ja/product/apm/"
     weight: 6
     parent: product
   - identifier: profiler
     name: Continuous Profiler
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/profiling-1.svg' alt='profiler icon'>"
+    pre: '<i class="icon-profiling-1 align-middle"></i>'
     url: "https://www.datadoghq.com/ja/product/code-profiling/"
     weight: 7
     parent: product
   - identifier: synthetics
     name: Synthetic モニタリング
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/synthetics.svg' alt='synthetics icon'>"
+    pre: '<i class="icon-synthetics align-middle"></i>'
     url: "https://www.datadoghq.com/ja/product/synthetic-monitoring/"
     weight: 8
     parent: product
   - identifier: rum
     name: Real User Monitoring
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/rum-2.svg' alt='rum icon'>"
+    pre: '<i class="icon-rum align-middle"></i>'
     url: "https://www.datadoghq.com/ja/product/real-user-monitoring/"
     weight: 9
     parent: product
+  - identifier: network
+    name: ネットワークモニタリング
+    pre: '<i class="icon-network align-middle"></i>'
+    url: "https://www.datadoghq.com/ja/product/network-monitoring/"
+    weight: 10
+    parent: product
   - identifier: security-platform
     name: Security Platform
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/security.svg' alt='security icon'>"
+    pre: '<i class="icon-security align-middle"></i>'
     url: "https://www.datadoghq.com/ja/product/security-platform/"
-    weight: 10
+    weight: 11
     parent: product
   - identifier: security-monitoring
     name: セキュリティモニタリング
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/security.svg' alt='security icon'>"
+    pre: '<i class="icon-security align-middle"></i>'
     url: "https://www.datadoghq.com/ja/product/security-platform/security-monitoring/"
-    weight: 11
+    weight: 12
     parent: product
   - identifier: cloud-security-posture-management
     name: CSPM
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/security.svg' alt='security icon'>"
+    pre: '<i class="icon-security align-middle"></i>'
     url: "https://www.datadoghq.com/ja/product/security-platform/cloud-security-posture-management/"
-    weight: 12
-    parent: product
-  - identifier: network
-    name: ネットワークモニタリング
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/network.svg' alt='network icon'>"
-    url: "https://www.datadoghq.com/ja/product/network-monitoring/"
     weight: 13
     parent: product
+  - identifier: cloud-workload-security
+    name: Cloud Workload Security
+    pre: '<i class="icon-cws align-middle"></i>'
+    url: 'product/security-platform/cloud-workload-security/'
+    weight: 14
+    parent: 'product'
+  - identifier: error-tracking
+    name: Error Tracking
+    pre: '<i class="icon-error-tracking align-middle"></i>'
+    url: 'product/security-platform/error-tracking/'
+    weight: 15
+    parent: 'product'
   - identifier: incident
     name: インシデント管理
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/incidents.svg' alt='incident icon'>"
-    url: "https://www.datadoghq.com/ja/product/incident-management/"
-    weight: 14
-    parent: product
+    pre: '<i class="icon-incidents align-middle"></i>'
+    url: 'product/incident-management'
+    weight: 16
+    parent: 'product'
+  - identifier: database
+    name: Database Monitoring
+    pre: '<i class="icon-dbm align-middle"></i>'
+    url: 'product/database-monitoring'
+    weight: 17
+    parent: 'product'
   - identifier: serverless
     name: サーバーレス
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/serverless.svg' alt='serverless icon'>"
-    url: "https://www.datadoghq.com/ja/product/serverless-monitoring/"
-    weight: 15
-    parent: product
+    pre: '<i class="icon-serverless align-middle"></i>'
+    url: 'product/serverless-monitoring/'
+    weight: 18
+    parent: 'product'
   - identifier: alerts
     name: アラート
-    pre: "<img class='menu-icon' src='https://imgix.datadoghq.com/img/navbar/menu/alert-1.svg' alt='alert icon'>"
-    url: "https://www.datadoghq.com/ja/product/platform/alerts/"
-    weight: 16
-    parent: product
+    pre: '<i class="icon-alert align-middle"></i>'
+    url: 'product/alerts/'
+    weight: 19
+    parent: 'product'
   - identifier: api
     name: API
-    pre: '<img class=''menu-icon'' src=''https://imgix.datadoghq.com/img/navbar/menu/datadoghq-api-icon-2.svg'' alt=''api icon''>'
+    pre: '<i class="icon-api align-middle"></i>'
     url: 'https://docs.datadoghq.com/api'
-    weight: 17
-    parent: product
+    weight: 20
+    parent: 'product'
   - identifier: customers
     name: お客様
     url: "https://www.datadoghq.com/ja/customers/"

--- a/config/_default/menus/menus.ja.yaml
+++ b/config/_default/menus/menus.ja.yaml
@@ -334,7 +334,7 @@ main:
   - name: はじめに
     identifier: getting_started
     url: getting_started/
-    pre: nav_start
+    pre: hex-ringed
     weight: 10000
   - name: Datadog
     identifier: getting_started_datadog
@@ -432,7 +432,7 @@ main:
     weight: 11
   - name: エージェント
     url: agent/
-    pre: nav_agent
+    pre: agent-fill
     weight: 30000
     identifier: agent
   - name: 基本的な Agent の利用方法
@@ -775,21 +775,21 @@ main:
   - name: インテグレーション
     url: integrations/
     identifier: integrations_top_level
-    pre: nav_integrations
+    pre: integrations
     weight: 40000
   - name: Watchdog
     url: watchdog/
     identifier: watchdog_top_level
-    pre: nav_watchdog
+    pre: watchdog
     weight: 50000
   - name: イベント
     url: events/
     identifier: events_top_level
-    pre: nav_events
+    pre: events
     weight: 60000
   - name: ダッシュボード
     url: dashboards/
-    pre: nav_dashboards
+    pre: dashboard
     identifier: ダッシュボード
     weight: 70000
   - name: スクリーンボード
@@ -890,12 +890,12 @@ main:
   - name: モバイルアプリケーション
     url: mobile/
     identifier: モバイル
-    pre: nav_mobile
+    pre: mobile
     weight: 80000
   - name: インフラストラクチャー
     url: infrastructure/
     identifier: インフラストラクチャー
-    pre: nav_infrastructure
+    pre: host-map
     weight: 90000
   - name: インフラストラクチャーリスト
     url: infrastructure/list/
@@ -924,7 +924,7 @@ main:
     weight: 6
   - name: サーバーレス
     url: サーバーレス
-    pre: nav_serverless
+    pre: serverless
     identifier: サーバーレス
     weight: 100000
   - name: インストール
@@ -1066,7 +1066,7 @@ main:
   - name: メトリクス
     url: metrics/
     identifier: metrics_top_level
-    pre: nav_metrics
+    pre: metric
     weight: 110000
   - name: 高度なフィルタリング
     url: metrics/advanced-filtering/
@@ -1089,7 +1089,7 @@ main:
   - name: ノートブック
     url: notebooks/
     identifier: ノートブック
-    pre: nav_notebooks
+    pre: notebook
     weight: 120000
   - name: アラート設定
     url: monitors/
@@ -1237,7 +1237,7 @@ main:
     parent: アラート設定
   - name: APM と分散型トレーシング
     url: tracing/
-    pre: nav_tracing
+    pre: apm
     identifier: トレーシング
     weight: 140000
   - name: Datadog へトレースを送信
@@ -1645,7 +1645,7 @@ main:
     weight: 1505
   - name: ログ管理
     url: logs/
-    pre: nav_logs
+    pre: log
     identifier: log_management
     weight: 150000
   - name: ログの収集とインテグレーション
@@ -1797,7 +1797,7 @@ main:
     weight: 11
   - name: セキュリティ & コンプライアンス
     url: security_monitoring/
-    pre: nav_security_monitoring
+    pre: security
     identifier: security_compliance_monitoring
     weight: 160000
   - name: はじめに
@@ -1832,7 +1832,7 @@ main:
     weight: 5
   - name: Synthetic モニタリング
     url: synthetics/
-    pre: nav_synthetics
+    pre: synthetics
     identifier: synthetics
     weight: 170000
   - name: API テスト
@@ -1930,7 +1930,7 @@ main:
     weight: 12
   - name: リアルユーザーモニタリング
     url: real_user_monitoring/
-    pre: nav_rum_2
+    pre: rum
     identifier: rum
     weight: 150000
   - name: ブラウザのモニタリング
@@ -2055,7 +2055,7 @@ main:
     weight: 8
   - name: ネットワークモニタリング
     url: network_monitoring/
-    pre: nav_network
+    pre: network
     identifier: nm_parent
     weight: 190000
   - name: ネットワークパフォーマンスモニタリング
@@ -2120,7 +2120,7 @@ main:
     weight: 305
   - name: 開発ツール
     url: developers/
-    pre: nav_developers
+    pre: dev-code
     identifier: dev_tools
     weight: 200000
   - name: DogStatsD
@@ -2287,12 +2287,12 @@ main:
     weight: 12
   - name: API
     url: api/
-    pre: nav_api
+    pre: api
     identifier: api
     weight: 210000
   - name: アカウントの管理
     url: account_management/
-    pre: nav_account
+    pre: cog
     identifier: account_management
     weight: 220000
   - name: ユーザー管理
@@ -2365,7 +2365,7 @@ main:
     weight: 8
   - name: セキュリティ
     url: security/
-    pre: nav_security
+    pre: security
     identifier: security
     weight: 230000
   - name: エージェント
@@ -2386,7 +2386,7 @@ main:
     weight: 4
   - name: ヘルプ
     url: help/
-    pre: nav_help
+    pre: info-fill
     identifier: help_top_level
     weight: 240000
 footer_product:

--- a/data/partials/home.fr.yaml
+++ b/data/partials/home.fr.yaml
@@ -42,7 +42,7 @@ nav_sections:
             desc: Créer et gérer des monitors et des notifications
           - title: APM et tracing distribué
             link: tracing/
-            icon: profiling-1
+            icon: apm
             desc: Étudier précisément les performances de votre application
           - title: Log Management
             link: logs/

--- a/data/partials/home.fr.yaml
+++ b/data/partials/home.fr.yaml
@@ -18,82 +18,82 @@ nav_sections:
       - navtiles:
           - title: Agent
             link: agent/
-            icon: agent.svg
+            icon: agent-fill
             desc: Installer et configurer l'Agent Datadog pour recueillir et envoyer des données
           - title: Intégrations
             link: integrations/
-            icon: integration.svg
+            icon: integrations
             desc: 'Rassembler des données depuis vos systèmes, apps et services'
           - title: Dashboards
             link: dashboards/
-            icon: dashboard.svg
+            icon: dashboard
             desc: Visualiser vos données pour mieux les comprendre
           - title: Infrastructure
             link: infrastructure/
-            icon: host-map.svg
+            icon: host-map
             desc: 'Suivez vos hosts, conteneurs, processus et fonctions sans serveur'
           - title: Métriques
             link: metrics/
-            icon: metric.svg
+            icon: metric
             desc: Explorez vos métriques et créez des distributions
           - title: Alertes
             link: monitors/
-            icon: alert.svg
+            icon: alert
             desc: Créer et gérer des monitors et des notifications
           - title: APM et tracing distribué
             link: tracing/
-            icon: trace.svg
+            icon: profiling-1
             desc: Étudier précisément les performances de votre application
           - title: Log Management
             link: logs/
-            icon: logs.svg
+            icon: log
             desc: 'Recueillir, traiter, explorer, surveiller et archiver vos logs'
           - title: Security Monitoring
             link: security_monitoring/
-            icon: siem.svg
+            icon: security
             desc: Détecter les menaces en temps réel et analyser les alertes de sécurité
           - title: Surveillance synthétique
             link: synthetics/
-            icon: synthetics.svg
+            icon: synthetics
             desc: 'Garantir la disponibilité de l''application, identifier les problèmes locaux et surveiller les performances'
           - title: Real User Monitoring
             link: real_user_monitoring/
-            icon: rum-2.svg
+            icon: rum
             desc: Visualisez et analysez les performances de vos applications frontend
           - title: Surveillance réseau
             link: network_performance_monitoring/
-            icon: network.svg
+            icon: network
             desc: Visualisez en détail votre trafic réseau grâce aux objets tagués
           - title: Informatique sans serveur
             link: serverless/
-            icon: serverless.svg
+            icon: serverless
             desc: Une visibilité de bout en bout sur votre cycle de développement sans serveur
           - title: Application mobile
             link: mobile/
-            icon: mobile.svg
+            icon: mobile
             desc: Consultez les alertes et les dashboards Datadog sur votre appareil mobile
           - title: Watchdog
             link: watchdog/
-            icon: watchdog.svg
+            icon: watchdog
             desc: Identifiez automatiquement les tendances de vos métriques d'application et d'infrastructure
   - nav_section:
       - name: Configuration
       - navtiles:
           - title: API
             link: api/
-            icon: code.svg
+            icon: api
             desc: Utiliser l'API Datadog
           - title: Gestion de compte
             link: account_management/
-            icon: cog.svg
+            icon: cog
             desc: Gérer les réglages de votre compte
           - title: Sécurité
             link: 'https://www.datadoghq.com/security/'
-            icon: lock.svg
+            icon: security-lock
             desc: Découvrir comment Datadog protège vos données
           - title: Outils de développement
             link: developers/
-            icon: wrench.svg
+            icon: wrench
             desc: Développer des outils pour la plateforme Datadog
 popular_searches:
   - title: Documentation sur l'API

--- a/data/partials/home.ja.yaml
+++ b/data/partials/home.ja.yaml
@@ -18,86 +18,86 @@ nav_sections:
       - navtiles:
           - title: エージェント
             link: agent/
-            icon: agent.svg
+            icon: agent-fill
             desc: Datadog のエージェントをインストールして構成し、データを収集、送信
           - title: インテグレーション
             link: integrations/
-            icon: integration.svg
+            icon: integrations
             desc: システム、アプリケーション、サービスからデータを収集
           - title: 'ダッシュボード  '
             link: dashboards/
-            icon: dashboard.svg
+            icon: dashboard
             desc: データを可視化して詳細な情報を把握
           - title: インフラストラクチャー
             link: infrastructure/
-            icon: host-map.svg
+            icon: host-map
             desc: ホスト、コンテナ、プロセス、サーバーレス機能を追跡
           - title: メトリクス
             link: metrics/
-            icon: metric.svg
+            icon: metric
             desc: メトリクスを調べてディストリビューションを作成する
           - title: アラート設定
             link: monitors/
-            icon: alert.svg
+            icon: alert
             desc: モニターおよび通知の作成と管理
           - title: APM & Continuous Profiler
             link: tracing/
-            icon: trace.svg
+            icon: apm
             desc: アプリケーションのパフォーマンスを詳しく理解
           - title: ログ管理
             link: logs/
-            icon: logs.svg
+            icon: log
             desc: ログの収集、処理、確認、監視、アーカイブ
           - title: セキュリティプラットフォーム
             link: security_platform/
-            icon: siem.svg
+            icon: security
             desc: アプリケーションとインフラストラクチャー全体の脅威と構成ミスを検出する
           - title: Synthetic モニタリング
             link: synthetics/
-            icon: synthetics.svg
+            icon: synthetics
             desc: アプリケーションの稼働時間確保、局所的な問題の特定、パフォーマンスの追跡
           - title: リアルユーザーモニタリング
             link: real_user_monitoring/
-            icon: rum-2.svg
+            icon: rum
             desc: フロントエンドアプリケーションのパフォーマンスを視覚化して分析します
           - title: ネットワークモニタリング
             link: network_monitoring/
-            icon: network.svg
+            icon: network
             desc: タグ付きオブジェクトを使用してネットワークトラフィックを可視化する
           - title: サーバーレス
             link: serverless/
-            icon: serverless.svg
+            icon: serverless
             desc: サーバレス開発ライフサイクルに対するエンドツーエンドの可視性
           - title: モバイルアプリケーション
             link: mobile/
-            icon: mobile.svg
+            icon: mobile
             desc: Datadog アラートとダッシュボード をモバイル端末で表示
           - title: Watchdog
             link: watchdog/
-            icon: watchdog.svg
+            icon: watchdog
             desc: アプリケーションとインフラストラクチャーメトリクスの傾向を自動的に確認する
           - title: CI の可視性
             link: continuous_integration/
-            icon: ci.svg
+            icon: ci
             desc: テストとパイプラインのパフォーマンスと信頼性を追跡
   - nav_section:
       - name: コンフィギュレーション
       - navtiles:
           - title: API
             link: api/
-            icon: code.svg
+            icon: api
             desc: Datadog API の使用
           - title: アカウントの管理
             link: account_management/
-            icon: cog.svg
+            icon: cog
             desc: アカウント設定の管理
           - title: セキュリティ
             link: security/
-            icon: lock.svg
+            icon: security-lock
             desc: Datadog のデータ保護方法について
           - title: 開発者
             link: developers/
-            icon: wrench.svg
+            icon: wrench
             desc: Datadog プラットフォームの開発
 popular_searches:
   - title: API ドキュメント

--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -22,90 +22,90 @@ nav_sections:
     - navtiles:
       - title: Agent
         link: agent/
-        icon: agent.svg
+        icon: agent-fill
         desc: Install & configure the Datadog Agent to collect and send data
       - title: Integrations
         link: integrations/
-        icon: integration.svg
+        icon: integrations
         desc: Gather data from your systems, apps, & services
       - title: Dashboards
         link: dashboards/
-        icon: dashboard.svg
+        icon: dashboard
         desc: Visualize your data to gain insight
       - title: Infrastructure
         link: infrastructure/
-        icon: host-map.svg
+        icon: host-map
         desc: Track your hosts, containers, processes, and serverless functions
       - title: Metrics
         link: metrics/
-        icon: metric.svg
+        icon: metric
         desc: Explore your metrics and create distributions
       - title: Alerting
         link: monitors/
-        icon: alert.svg
+        icon: alert
         desc: Create & manage monitors & notifications
       - title: APM & Continuous Profiler
         link: tracing/
-        icon: trace.svg
+        icon: profiling-1
         desc: Gain insight on your application's performance
       - title: Log Management
         link: logs/
-        icon: logs.svg
+        icon: log
         desc: Collect, process, explore, monitor, & archive your logs
       - title: Security Platform
         link: security_platform/
-        icon: siem.svg
+        icon: security
         desc: Detect threats and misconfigurations across applications and infrastructure
       - title: Synthetic Monitoring
         link: synthetics/
-        icon: synthetics.svg
+        icon: synthetics
         desc: Ensure application uptime, identify regional issues, & track performance
       - title: Real User Monitoring
         link: real_user_monitoring/
-        icon: rum-2.svg
+        icon: rum
         desc: Visualize and analyze the performance of your front end applications
       - title: Network Monitoring
         link: network_monitoring/
-        icon: network.svg
+        icon: network
         desc: Gain visibility into your network traffic using tagged objects
       - title: Serverless
         link: serverless/
-        icon: serverless.svg
+        icon: serverless
         desc: End-to-end visibility into your serverless development lifecycle
       - title: Mobile application
         link: mobile/
-        icon: mobile.svg
+        icon: mobile
         desc: View Datadog alerts and dashboards on your mobile device
       - title: Watchdog
         link: watchdog/
-        icon: watchdog.svg
+        icon: watchdog
         desc: Automatically see trends in your applications & infrastructure metrics
       - title: CI Visibility
         link: continuous_integration/
-        icon: ci.svg
+        icon: ci
         desc: Track the performance and reliability of your tests and pipelines
       - title: Database Monitoring
         link: database_monitoring/
-        icon: dbm.svg
+        icon: dbm
         desc: Gain deep visibility into database and query performance
   - nav_section:
     - name: 'Configuration'
     - navtiles:
       - title: API
         link: api/
-        icon: code.svg
+        icon: api
         desc: Use the Datadog API
       - title: Account Management
         link: account_management/
-        icon: cog.svg
+        icon: cog
         desc: Control your account settings and manage billing
       - title: Security
         link: security/
-        icon: lock.svg
+        icon: security-lock
         desc: Learn how Datadog protects your data
       - title: Developers
         link: developers/
-        icon: wrench.svg
+        icon: wrench
         desc: Develop for the Datadog platform
 
 popular_searches:

--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -46,7 +46,7 @@ nav_sections:
         desc: Create & manage monitors & notifications
       - title: APM & Continuous Profiler
         link: tracing/
-        icon: profiling-1
+        icon: apm
         desc: Gain insight on your application's performance
       - title: Log Management
         link: logs/

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.2.12 // indirect
+require github.com/DataDog/websites-modules v1.2.13-0.20210908204410-84264c4f1c33 // indirect
 
 // replace github.com/DataDog/websites-modules => /Users/brian.deutsch/dd/websites-modules

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.2.13-0.20210908204410-84264c4f1c33 // indirect
+require github.com/DataDog/websites-modules v1.2.13-0.20210908220025-b1ee2a076265 // indirect
 
 // replace github.com/DataDog/websites-modules => /Users/brian.deutsch/dd/websites-modules

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.2.13-0.20210908220025-b1ee2a076265 // indirect
+require github.com/DataDog/websites-modules v1.2.14 // indirect
 
-// replace github.com/DataDog/websites-modules => /Users/brian.deutsch/dd/websites-modules
+// replace github.com/DataDog/websites-modules => /Users/carlos.santos/GitHub/websites-modules

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/DataDog/websites-modules v1.2.12 h1:fL6+1byCdg04ZSY2S9IQZRYq2CPDPMHcS3HKi3xHDKQ=
-github.com/DataDog/websites-modules v1.2.12/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.2.13-0.20210908204410-84264c4f1c33 h1:skyhQHyQ6ct/do0/vyGRz3iYViD2m0DzEXX70tRQkOA=
+github.com/DataDog/websites-modules v1.2.13-0.20210908204410-84264c4f1c33/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/DataDog/websites-modules v1.2.13-0.20210908204410-84264c4f1c33 h1:skyhQHyQ6ct/do0/vyGRz3iYViD2m0DzEXX70tRQkOA=
-github.com/DataDog/websites-modules v1.2.13-0.20210908204410-84264c4f1c33/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.2.13-0.20210908220025-b1ee2a076265 h1:NEONLs6tP2SO6Oxeyd0yZb8cupbqthjoQ8DtI58no98=
+github.com/DataDog/websites-modules v1.2.13-0.20210908220025-b1ee2a076265/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -107,7 +107,7 @@
                             {{ range $i, $navtile := $section.navtiles }}
                                 <div class="col-12 col-md-6 col-lg-4 col-xl-3 nav-tile d-flex mb-2 mb-md-3">
                                         <a class="d-flex flex-column align-items-center w-100 small font-semibold" href="{{ $navtile.link | absLangURL }}">
-                                                {{ partial "icon" (dict "context" $dot "name" $navtile.icon "color" "transparent" )}}
+                                                {{ partial "icon" (dict "name" $navtile.icon "size" "18px" "color" "transparent" )}}
                                                 {{ $navtile.title }}
                                                 <span class="font-regular text-center smaller">{{ $navtile.desc }}</span>
                                         </a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -107,8 +107,9 @@
                             {{ range $i, $navtile := $section.navtiles }}
                                 <div class="col-12 col-md-6 col-lg-4 col-xl-3 nav-tile d-flex mb-2 mb-md-3">
                                         <a class="d-flex flex-column align-items-center w-100 small font-semibold" href="{{ $navtile.link | absLangURL }}">
-                                                {{ partial "svg" (dict "context" $dot "src" $navtile.icon "color" "#632CA6" )}}
-                                                {{ $navtile.title }}<span class="font-regular text-center smaller">{{ $navtile.desc }}</span></a>
+                                                {{ partial "icon" (dict "context" $dot "name" $navtile.icon "color" "transparent" )}}
+                                                {{ $navtile.title }}
+                                                <span class="font-regular text-center smaller">{{ $navtile.desc }}</span>
                                         </a>
 
                                 </div>

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -13,75 +13,76 @@
             <div class="col">
                 <ul class="nav navbar-left">
                     {{ range .Site.Menus.main_left   }}
-                    {{ if .HasChildren }}
-                    <li class="dropdown {{ .Identifier }}-dropdown nav-item">
-                        <a href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}" class="nav-link dropdown {{ if eq .Name "Solutions" }} solutions{{ end }}">{{.Name}}</a>
-
-                        <!-- Menu: Solutions menu -->
-                        {{ if eq .Identifier "solutions" }}
-                          <ul class="dropdown-menu solutions-menu p-2">
-                            <div class="row">
-                              <div class="col-4">
-                                <p class="text-gray-dark small text-uppercase font-weight-bold no-event">Industry</p>
+                      {{ if .HasChildren }}
+                        <li class="dropdown {{ .Identifier }}-dropdown nav-item">
+                            <a href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}" class="nav-link dropdown {{ if eq .Name "Solutions" }} solutions{{ end }}">{{.Name}}</a>
+                            <!-- Menu: Solutions menu -->
+                            {{ if eq .Identifier "solutions" }}
+                              <ul class="dropdown-menu solutions-menu p-2">
+                                <div class="row">
+                                  <div class="col-4">
+                                    <p class="text-gray-dark small text-uppercase font-weight-bold no-event">Industry</p>
+                                    {{ range .Children }}
+                                      {{ if hasPrefix .Identifier "industry-" }}
+                                        <li class="nav-item">
+                                            <a class="d-block " href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
+                                        </li>
+                                      {{ end }}
+                                    {{ end }}
+                                  </div>
+                                  <div class="col-4">
+                                    <p class="text-gray-dark small text-uppercase font-weight-bold no-event">Technology</p>
+                                    {{ range .Children }}
+                                      {{ if hasPrefix .Identifier "technology-" }}
+                                        <li class="nav-item">
+                                            <a class="d-block " href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
+                                        </li>
+                                      {{ end }}
+                                    {{ end }}
+                                  </div>
+                                  <div class="col-4">
+                                    <p class="text-gray-dark small text-uppercase font-weight-bold no-event">Use-Case</p>
+                                    {{ range .Children }}
+                                      {{ if hasPrefix .Identifier "usecase-" }}
+                                        <li class="nav-item">
+                                            <a class="d-block " href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
+                                        </li>
+                                      {{ end }}
+                                    {{ end }}
+                                  </div>
+                                </div>
+                              </ul>
+                            <!--/ Menu: Solutions menu -->
+                            <!-- Menu: with sub-menus -->
+                            {{ else if eq .Identifier "product" }}
+                              <ul class="dropdown-menu product-menu p-2">
                                 {{ range .Children }}
-                                  {{ if hasPrefix .Identifier "industry-" }}
-                                    <li class="nav-item">
-                                        <a class="d-block " href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
-                                    </li>
-                                  {{ end }}
-                                {{ end }}
-                              </div>
-                              <div class="col-4">
-                                <p class="text-gray-dark small text-uppercase font-weight-bold no-event">Technology</p>
+                                  <li>
+                                      <a class="d-block" href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}">
+                                        {{ .Pre }}
+                                        <span class="menu-text d-inline-flex">{{ .Name | safeHTML }}</span>
+                                      </a>
+                                  </li>
+                                {{end}}
+                              </ul>
+                            {{ else }}
+                              <ul class="dropdown-menu p-2">
                                 {{ range .Children }}
-                                  {{ if hasPrefix .Identifier "technology-" }}
-                                    <li class="nav-item">
-                                        <a class="d-block " href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
-                                    </li>
-                                  {{ end }}
-                                {{ end }}
-                              </div>
-                              <div class="col-4">
-                                <p class="text-gray-dark small text-uppercase font-weight-bold no-event">Use-Case</p>
-                                {{ range .Children }}
-                                  {{ if hasPrefix .Identifier "usecase-" }}
-                                    <li class="nav-item">
-                                        <a class="d-block " href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
-                                    </li>
-                                  {{ end }}
-                                {{ end }}
-                              </div>
-                            </div>
-                          </ul>
-                        <!--/ Menu: Solutions menu -->
-
-                        <!-- Menu: with sub-menus -->
-                        {{ else if eq .Identifier "product" }}
-                          <ul class="dropdown-menu product-menu p-2">
-                            {{ range .Children }}
-                            <li>
-                                <a class="d-block" href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}">{{ .Pre }} <span class="menu-text d-inline-flex">{{ .Name | safeHTML }}</span></a>
-                            </li>
-                            {{end}}
-                          </ul>
-                        {{ else }}
-                          <ul class="dropdown-menu p-2">
-                            {{ range .Children }}
-                            <li>
-                                <a class="d-block" href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
-                            </li>
-                            {{end}}
-                          </ul>
-                        {{ end }}
-                        <!--/ Menu: with sub-menus -->
-                    </li>
-                    <!-- Menu: without sub-menus -->
-                    {{ else }}
-                    <li class="nav-item">
-                        <a class="{{ .Identifier }}-menu nav-link" href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
-                    </li>
-                  {{ end }}
-                  <!--/ Menu: without sub-menus -->
+                                  <li>
+                                      <a class="d-block" href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
+                                  </li>
+                                {{end}}
+                              </ul>
+                            {{ end }}
+                            <!--/ Menu: with sub-menus -->
+                        </li>
+                      <!-- Menu: without sub-menus -->
+                      {{ else }}
+                        <li class="nav-item">
+                            <a class="{{ .Identifier }}-menu nav-link" href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
+                        </li>
+                      {{ end }}
+                      <!--/ Menu: without sub-menus -->
                     {{ end }}
                 </ul>
             </div>
@@ -98,38 +99,39 @@
                 </a>
             </div>
             <div class="col">
-                <!-- Menu: Right menu items -->
-<ul class="nav justify-content-end">
-  {{ range .Site.Menus.main_right }}
-  {{ if .HasChildren }}
-      <li class="dropdown nav-item">
-        <a href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}" class="dropdown nav-link">{{.Name}}</a>
-        <ul class="dropdown-menu p-2" aria-labelledby="dropdownMenuButton">
-          {{ range .Children }}
-          <li class="nav-item">
-              <a class="d-block " href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
-          </li>
-          {{end}}
-        </ul>
-      </li>
-    {{ else }}
-      <li class="final nav-item {{ if eq .Identifier "get_started" }}nav-button {{ end }}">
-          <a {{ if eq .Identifier "get_started" }} class="{{ $SignUpClass }} btn btn-outline-primary sign-up-trigger text-uppercase" href="#" data-toggle="modal" data-target="#signupModal" style="min-width:120px" {{ else }} class="nav-link" href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"  {{ end }}>
-              {{ if eq .Identifier "get_started" }}
-                {{ if eq $.Lang "fr" }}
-                    <span class="d-none d-xl-block">{{ i18n "free_trial" }}</span>
-                {{ else }}
-                    <span class="d-none d-xl-block">{{ i18n "get_started_free" }}</span>
-                {{ end }}
-                  <span class="d-block d-xl-none">{{ i18n "get_started_free_short" }}</span>
-              {{ else }}
-                <span class="menu-text">{{ .Name | safeHTML }}</span>
-              {{ end }}</a>
-      </li>
-    {{end}}
-  {{end}}
-</ul>
-<!--/ Menu: Right menu items -->
+            <!-- Menu: Right menu items -->
+              <ul class="nav justify-content-end">
+                {{ range .Site.Menus.main_right }}
+                {{ if .HasChildren }}
+                    <li class="dropdown nav-item">
+                      <a href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}" class="dropdown nav-link">{{.Name}}</a>
+                      <ul class="dropdown-menu p-2" aria-labelledby="dropdownMenuButton">
+                        {{ range .Children }}
+                          <li class="nav-item">
+                              <a class="d-block " href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"><span class="menu-text">{{ .Name | safeHTML }}</span></a>
+                          </li>
+                        {{end}}
+                      </ul>
+                    </li>
+                  {{ else }}
+                    <li class="final nav-item {{ if eq .Identifier "get_started" }}nav-button {{ end }}">
+                        <a {{ if eq .Identifier "get_started" }} class="{{ $SignUpClass }} btn btn-outline-primary sign-up-trigger text-uppercase" href="#" data-toggle="modal" data-target="#signupModal" style="min-width:120px" {{ else }} class="nav-link" href="{{- partial "menulink" (slice .Identifier ( .URL ) $base $dot ) | safeURL -}}"  {{ end }}>
+                          {{ if eq .Identifier "get_started" }}
+                            {{ if eq $.Lang "fr" }}
+                                <span class="d-none d-xl-block">{{ i18n "free_trial" }}</span>
+                            {{ else }}
+                                <span class="d-none d-xl-block">{{ i18n "get_started_free" }}</span>
+                            {{ end }}
+                              <span class="d-block d-xl-none">{{ i18n "get_started_free_short" }}</span>
+                          {{ else }}
+                            <span class="menu-text">{{ .Name | safeHTML }}</span>
+                          {{ end }}
+                        </a>
+                    </li>
+                  {{end}}
+                {{end}}
+              </ul>
+              <!--/ Menu: Right menu items -->
             </div>
         </div>
     </div>
@@ -147,9 +149,9 @@
         <div class="collapse navbar-collapse" id="navbar-sidenav">
             <div class="container">
                 {{ if eq .Section "api"}}
-                {{ partial "nav/api-mobile-menu.html" . }}
+                  {{ partial "nav/api-mobile-menu.html" . }}
                 {{ else }}
-                {{ partial "nav/main-mobile-menu.html" . }}
+                  {{ partial "nav/main-mobile-menu.html" . }}
                 {{ end }}
             </div>
         </div>

--- a/layouts/partials/icon.html
+++ b/layouts/partials/icon.html
@@ -1,0 +1,16 @@
+{{ $size := "inherit" }}
+{{ $color := "" }}
+{{ $style := "" }}
+
+{{ if .size }}
+{{ $size = .size }}
+{{ end }}
+
+{{ if .color }}
+{{ $color = .color }}
+{{ end }}
+
+{{/* Combine contextual params into inline style */}}
+{{ $style = print "style='" (delimit (slice (print "font-size: " ($size)) (print "color: " ($color))) "; ") "'" }}
+
+<i class="icon-{{ .name }}" {{ $style | safeHTMLAttr }}></i>

--- a/layouts/partials/nav/main-menu.html
+++ b/layouts/partials/nav/main-menu.html
@@ -36,7 +36,11 @@
                         <li class="{{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }} {{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }}">
                             {{ $url_without_anchor = (index (split .URL "#") 0) }}
                             <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
-                                {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>
+                                {{ if .Pre }}
+                                  {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
+                                  {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}
+                                {{ end }}
+                                <span>{{ .Name }}</span>
                             </a>
                         {{ if .HasChildren }}
                             <ul class="list-unstyled sub-menu {{ if (or (eq .Name "Guides") (eq .Name "Widgets")) }} d-none {{ end }}">
@@ -44,7 +48,11 @@
                                 <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}" >
                                     {{ $url_without_anchor = (index (split .URL "#") 0) }}
                                     <a href="{{ .URL | relLangURL }}" data-type="{{- with site.GetPage .URL -}}{{- .Type -}}{{- end -}}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
-                                        {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>
+                                        {{ if .Pre }}
+                                          {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
+                                          {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}
+                                        {{ end }}
+                                        <span>{{ .Name }}</span>
                                     </a>
                                     {{/* 4th level, hide */}}
                                     {{ if .HasChildren }}
@@ -53,7 +61,11 @@
                                             <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}" >
                                                 {{ $url_without_anchor = (index (split .URL "#") 0) }}
                                                 <a data-name="{{- delimit (last 1 (split (strings.TrimSuffix "/" .URL) "/")) "" -}}" href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
-                                                    {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <span>{{ .Name }}</span>
+                                                    {{ if .Pre }}
+                                                      {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
+                                                      {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}
+                                                    {{ end }}
+                                                    <span>{{ .Name }}</span>
                                                 </a>
                                             </li>
                                         {{ end }}

--- a/layouts/partials/nav/main-menu.html
+++ b/layouts/partials/nav/main-menu.html
@@ -23,8 +23,13 @@
             <li class="nav-top-level {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}
             {{ if $currentPage.HasMenuCurrent "main" . }}active{{ end }}">
                 {{ $url_without_anchor = (index (split .URL "#") 0) }}
-                <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
-                    {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <div><span>{{ .Name }}</span></div>
+                <a href="{{ .URL | relLangURL }}" class="d-flex align-items-center" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
+                    {{ if .Pre }}
+                      {{ partial "icon" (dict "name" .Pre "size" "18px" )}}
+                    {{ end }}
+                    <div>
+                      <span>{{ .Name }}</span>
+                    </div>
                 </a>
                 <ul class="list-unstyled sub-menu {{ if (or (eq .Name "Guides") (eq .Name "Widgets")) }} d-none {{ end }}">
                     {{ range .Children }}
@@ -64,8 +69,13 @@
             </li>
         {{ else }}
             <li class="nav-top-level {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}">
-                <a href="{{ .URL | absLangURL }}" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
-                    {{ if .Pre }}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}{{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}{{ end }} <div><span>{{ .Name }}</span></div>
+                <a href="{{ .URL | absLangURL }}" class="d-flex align-items-center" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
+                    {{ if .Pre }}
+                      {{ partial "icon" (dict "name" .Pre "size" "18px" )}}
+                    {{ end }}
+                    <div>
+                      <span>{{ .Name }}</span>
+                    </div>
                 </a>
             </li>
         {{ end }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- adds the websites-modules iconfont to docs
- adds iconfont to the following areas
  - homepage nav tiles/cards
  - main sidenav (on search results)
  - mobile sidenav (hamburger menu)
- updates some icons in nav tiles and sidebar

### Motivation
- iconfont better depending on who you ask
- loading one font file instead of more SVGs
- utilizing shared resources from websites-modules repo
- https://datadoghq.atlassian.net/browse/WEB-1709
- looks better?

### Preview
https://docs-staging.datadoghq.com/carlos/iconfont-update/

### Additional Notes
- [ ] check to ensure there's only minimal diff between preview and prod. some diffs like sizing horizontally are inevitable due to the rendering diffs between a font vs an inline SVG

this change is a three-prong PR between `websites-modules`, `corp-hugo`, and `documentation`. i will be coordinating the merges from websites-modules first since the consuming sites need to have their `go.mod` files cleared and respective cloudfront cache purged for the fonts directories.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
