### PR TITLE
Add note about web app browser support

### DIFF
--- a/content/en/getting_started/site/_index.md
+++ b/content/en/getting_started/site/_index.md
@@ -28,4 +28,16 @@ Since the Datadog sites may support different Datadog functionalities depending 
 
 The Datadog for Government site (US1-FED) is meant to allow US government agencies and partners to monitor their applications and infrastructure. For information about the Datadog for Government site's security and compliance controls and frameworks, as well as how it supports FedRAMP, see the [security page][1].
 
+## Browser support
+
+The Datadog site can be accessed with a recent version of any of the four major browsers:
+- [Chrome][2]
+- [Firefox][3]
+- [Safari][4]
+- [Edge][5]
+
 [1]: https://www.datadoghq.com/security/
+[2]: https://www.google.com/chrome
+[3]: https://www.mozilla.org/en-US/firefox/new
+[4]: https://support.apple.com/en-us/HT204416
+[5]: https://www.microsoft.com/en-us/edge


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds an explicit mention of browser support for the Datadog web app

### Motivation
The web app hasn't been functional in Internet Explorer for a while now; this PR documents the browsers that _are_ supported to provide clarity.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/derek/browser-support/getting_started/site/#browser-support

<img width="1187" alt="Screen Shot 2021-09-08 at 9 11 33 PM" src="https://user-images.githubusercontent.com/1048442/132605804-5939eb71-d7fb-45d6-b0a6-94bd66b0cc92.png">

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.