### PR TITLE
doc update for end of downtimes new behaviour

### DIFF
--- a/content/en/monitors/downtimes.md
+++ b/content/en/monitors/downtimes.md
@@ -161,14 +161,15 @@ Monitors trigger events when they change between possible states: `ALERT`, `WARN
 
 **Note**: Muting or un-muting a monitor with the UI does not delete scheduled downtimes associated with the monitor. To edit or delete a downtime, use the [Manage Downtimes][1] page or the [API][6].
 
-If a monitor is in an alert-worthy state (`ALERT`, `WARNING`, or `NO DATA`) when downtime expires, the monitor is forced to recover and quickly triggers again if alert conditions are met. This applies to monitors that change state during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`), and also to monitors that already have an alert-worthy state when downtime begins.
+### Expiration
+
+If a monitor is in an alert-worthy state (`ALERT`, `WARNING`, or `NO DATA`) when downtime expires, the monitor triggers a new notification. This applies to monitors that change state during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`), and to monitors that already have an alert-worthy state when downtime begins.
 
 **Example 1:** If a monitor is in an alert state *before* downtime starts and *continues* for the duration of downtime:
 1. During downtime, notifications for this alert are suppressed.
 2. The monitor remains in an alert state (because the conditions are still met).
 3. The downtime ends.
-4. The monitor is forced to recover.
-5. The alert conditions are met, so a notification is sent.
+4. The alert conditions are met, so a notification is sent.
 
 **Example 2:** If a monitor is in an alert state *before* a downtime commences and recovers *during* that downtime:
 1. The state transitions from alert to `OK`.

--- a/content/en/monitors/downtimes.md
+++ b/content/en/monitors/downtimes.md
@@ -163,7 +163,7 @@ Monitors trigger events when they change between possible states: `ALERT`, `WARN
 
 ### Expiration
 
-If a monitor is in an alert-worthy state (`ALERT`, `WARNING`, or `NO DATA`) when downtime expires, the monitor triggers a new notification. This applies to monitors that change state during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`), and to monitors that already have an alert-worthy state when downtime begins.
+If a monitor is in an alert-worthy state (`ALERT`, `WARNING`, or `NO DATA`) when a downtime expires, the monitor triggers a new notification. This applies to monitors that change state during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`), and to monitors that already have an alert-worthy state when downtime begins.
 
 **Example 1:** If a monitor is in an alert state *before* downtime starts and *continues* for the duration of downtime:
 1. During downtime, notifications for this alert are suppressed.

--- a/content/en/monitors/downtimes.md
+++ b/content/en/monitors/downtimes.md
@@ -159,7 +159,7 @@ Monitors trigger events when they change between possible states: `ALERT`, `WARN
 
 {{< img src="monitors/downtimes/downtime_on_alert.png" alt="downtime on alert"  style="width:80%;">}}
 
-**Note**: Muting or un-muting a monitor with the UI does not delete scheduled downtimes associated with the monitor. To edit or delete a downtime, use the [Manage Downtimes][1] page or the [API][6].
+**Note**: Muting or un-muting a monitor from the monitor status page does not delete scheduled downtimes associated with the monitor. To edit or delete a downtime, use the [Manage Downtimes][1] page or the [API][6].
 
 ### Expiration
 
@@ -169,7 +169,7 @@ If a monitor is in an alert-worthy state (`ALERT`, `WARNING`, or `NO DATA`) when
 1. During downtime, notifications for this alert are suppressed.
 2. The monitor remains in an alert state (because the conditions are still met).
 3. The downtime ends.
-4. The alert conditions are met, so a notification is sent.
+4. The alert conditions are still met, so a notification is sent.
 
 **Example 2:** If a monitor is in an alert state *before* a downtime commences and recovers *during* that downtime:
 1. The state transitions from alert to `OK`.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
update downtime documentation : https://datadoghq.atlassian.net/browse/MNOTIF-268

### Motivation
<!-- What inspired you to submit this pull request?-->
Fix to remove the forced recovery at the end of downtimes

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/antoine.dussault/end_of_downtimes/monitors/downtimes

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
