### PR TITLE
Algolia config - Updates search special characters

### DIFF
--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -259,7 +259,7 @@
     ],
     "conversation_id": ["620036890"],
     "custom_settings": {
-        "separatorsToIndex": "_@.",
+        "separatorsToIndex": "_@.#",
         "attributeForDistinct": "url_without_anchor",
         "attributesForFaceting": ["language", "tags"],
         "optionalWords": ["the", "without"],

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -259,7 +259,7 @@
     ],
     "conversation_id": ["620036890"],
     "custom_settings": {
-        "separatorsToIndex": "_@.",
+        "separatorsToIndex": "_@.#",
         "attributeForDistinct": "url_without_anchor",
         "attributesForFaceting": ["language", "tags"],
         "optionalWords": ["the", "without"],


### PR DESCRIPTION
### What does this PR do?
Updates searchable characters in Algolia to include "#". This change was made manually in the UI, but needs to be set in the config to avoid being overwritten

### Motivation
Improve search experience for terms like "F#" 
https://dd.slack.com/archives/C0DESMBQU/p1630447520077800

### Preview
https://docs-staging.datadoghq.com/nsollecito/update-separators/search/?s=F%23

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
