### PR TITLE
[DOCS-2448] Tracing section fix lost hash links

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/ruby.md
+++ b/content/en/tracing/connect_logs_and_traces/ruby.md
@@ -30,7 +30,7 @@ Datadog.configure do |c|
 end
 ```
 
-**Note:** For `lograge` users who have also defined `lograge.custom_options` in an `initializers/lograge.rb` configuration file, because Rails loads initializers in alphabetical order, automatic trace correlation may not take effect, since `initializers/datadog.rb` would be overwritten by the `initializers/lograge.rb` initializer. To support automatic trace correlation with _existing_ `lograge.custom_options`, use the [Manual (Lograge)](#manual-lograge) configuration below.
+**Note:** For `lograge` users who have also defined `lograge.custom_options` in an `initializers/lograge.rb` configuration file, because Rails loads initializers in alphabetical order, automatic trace correlation may not take effect, since `initializers/datadog.rb` would be overwritten by the `initializers/lograge.rb` initializer. To support automatic trace correlation with _existing_ `lograge.custom_options`, use the [Manual Lograge](#lograge) configuration below.
 
 #### Manual injection
 ##### Lograge

--- a/content/en/tracing/setup_overview/custom_instrumentation/php.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/php.md
@@ -554,7 +554,7 @@ resources.ddtrace = true
 
 Prior to PHP 7, some frameworks provided ways to compile PHP classes—e.g., through the Laravel's `php artisan optimize` command.
 
-While this [has been deprecated][9] if you are using PHP 7.x, you still may use this caching mechanism in your app prior to version 7.x. In this case, Datadog suggests you use the [OpenTracing](#opentracing) API instead of adding `datadog/dd-trace` to your Composer file.
+While this [has been deprecated][9] if you are using PHP 7.x, you still may use this caching mechanism in your app prior to version 7.x. In this case, Datadog suggests you use the [OpenTracing][10] API instead of adding `datadog/dd-trace` to your Composer file.
 
 ## Legacy API upgrade guide
 
@@ -646,3 +646,4 @@ dd_trace('CustomDriver', 'doWork', function (...$args) {
 [7]: https://www.php.net/func_get_args
 [8]: https://github.com/DataDog/dd-trace-php/releases/latest
 [9]: https://laravel-news.com/laravel-5-6-removes-artisan-optimize
+[10]: /tracing/setup_overview/open_standards/php#opentracing

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -301,7 +301,7 @@ Install and configure the Datadog Agent to receive traces from your instrumented
 
     `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT`.
 
-    See [configure the tracer](#configure-the-tracer) for more information on how to set these variables.
+    See [Configuration](#configuration) for more information on how to set these variables.
 {{< site-region region="us3,eu,gov" >}} 
 
 4. Set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.

--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -31,7 +31,7 @@ The Go Tracer requires Go `1.12+` and Datadog Agent `>= 5.21.1`.  For a full lis
 
 ## Installation and getting started
 
-For configuration instructions and details about using the API, see the Datadog [API documentation][2]. For manual instrumentation, use the [integrations section](#integrations) below for Go libraries and frameworks supporting automatic instrumentation.
+For configuration instructions and details about using the API, see the Datadog [API documentation][2].
 
 For a description of the terminology used in APM, see the [Getting started with APM section][3]. For details about contributing, check the official repository [README.md][4].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
fixes hash-style links that have lost their anchor

### Motivation
DOCS-2448, broken link check

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/docs-2448-links/tracing/setup_overview/setup/go
https://docs-staging.datadoghq.com/kari/docs-2448-links/tracing/setup_overview/setup/dotnet-core
https://docs-staging.datadoghq.com/kari/docs-2448-links/tracing/connect_logs_and_traces/ruby
https://docs-staging.datadoghq.com/kari/docs-2448-links/tracing/setup_overview/custom_instrumentation/php

### Additional Notes
links in Ruby page are in a different repo, PR to follow there.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
