### PR TITLE
APM > .NET > Fix links to samples after repository re-arrange

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -60,7 +60,7 @@ var log = new LoggerConfiguration()
 For additional examples, see [the Serilog automatic trace ID injection project][1] on GitHub.
 
 
-[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/SerilogExample/Program.cs
+[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/SerilogExample/Program.cs
 {{% /tab %}}
 {{% tab "log4net" %}}
 Trace and span IDs are injected into application logs only after you enable mapped diagnostic context (MDC), as shown in the following example code:
@@ -82,7 +82,7 @@ Trace and span IDs are injected into application logs only after you enable mapp
 For additional examples, see [the log4net automatic trace ID injection project][1] on GitHub.
 
 
-[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/Log4NetExample/log4net.config
+[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/Log4NetExample/log4net.config
 {{% /tab %}}
 {{% tab "NLog" %}}
 
@@ -112,9 +112,9 @@ For NLog version 4.5:
 For additional examples, see the automatic trace ID injection projects using [NLog 4.0][1], [NLog 4.5][2], or [NLog 4.6][3] on GitHub.
 
 
-[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog40Example/NLog.config
-[2]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog45Example/NLog.config
-[3]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog46Example/NLog.config
+[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/NLog40Example/NLog.config
+[2]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/NLog45Example/NLog.config
+[3]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/NLog46Example/NLog.config
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -11,7 +11,7 @@ further_reading:
     - link: 'tracing/setup/dotnet-core'
       tag: 'Documentation'
       text: 'Instrument Your Application'
-    - link: 'https://github.com/DataDog/dd-trace-dotnet/tree/master/samples'
+    - link: 'https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples'
       tag: 'GitHub'
       text: 'Examples of Custom Instrumentation'
 ---

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -11,7 +11,7 @@ further_reading:
     - link: 'tracing/setup/dotnet-framework'
       tag: 'Documentation'
       text: 'Instrument Your Application'
-    - link: 'https://github.com/DataDog/dd-trace-dotnet/tree/master/samples'
+    - link: 'https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples'
       tag: 'GitHub'
       text: 'Examples of Custom Instrumentation'
 ---

--- a/content/en/tracing/setup_overview/custom_instrumentation/dotnet.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/dotnet.md
@@ -19,7 +19,7 @@ further_reading:
     - link: 'tracing/visualization/'
       tag: 'Documentation'
       text: 'Explore your services, resources, and traces'
-    - link: 'https://github.com/DataDog/dd-trace-dotnet/tree/master/samples'
+    - link: 'https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples'
       tag: 'GitHub'
       text: '.NET code samples'
 ---

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -27,7 +27,7 @@ further_reading:
   - link: "https://www.datadoghq.com/blog/net-monitoring-apm/"
     tag: "Blog"
     text: ".NET monitoring with Datadog APM and distributed tracing"
-  - link: "https://github.com/DataDog/dd-trace-dotnet/tree/master/samples"
+  - link: "https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples"
     tag: "GitHub"
     text: "Examples of custom instrumentation"
   - link: "https://github.com/DataDog/dd-trace-dotnet"

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -38,7 +38,7 @@ further_reading:
   - link: "https://www.datadoghq.com/blog/deploy-dotnet-core-aws-fargate/"
     tag: "Blog"
     text: "Monitor containerized ASP.NET Core applications on AWS Fargate"
-  - link: "https://github.com/DataDog/dd-trace-dotnet/tree/master/samples"
+  - link: "https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples"
     tag: "GitHub"
     text: "Examples of custom instrumentation"
   - link: "https://github.com/DataDog/dd-trace-dotnet"

--- a/content/fr/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/fr/tracing/connect_logs_and_traces/dotnet.md
@@ -56,7 +56,7 @@ var log = new LoggerConfiguration()
 Pour obtenir d'autres exemples, consultez le [projet d'injection automatique des ID de trace Serilog][1] sur GitHub.
 
 
-[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/SerilogExample/Program.cs
+[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/SerilogExample/Program.cs
 {{% /tab %}}
 {{% tab "log4net" %}}
 Pour injecter les ID de trace et de span dans les logs d'application, vous devez activer les MDC (contextes de diagnostics mappés), comme illustré dans l'exemple de code suivant :
@@ -78,7 +78,7 @@ Pour injecter les ID de trace et de span dans les logs d'application, vous devez
 Pour obtenir d'autres exemples, consultez le [projet d'injection automatique des ID de trace log4net][1] sur GitHub.
 
 
-[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/Log4NetExample/log4net.config
+[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/Log4NetExample/log4net.config
 {{% /tab %}}
 {{% tab "NLog" %}}
 
@@ -108,9 +108,9 @@ Pour la version 4.5 de NLog :
 Pour obtenir d'autres exemples, consultez les projets d'injection automatique des ID de trace avec [NLog 4.0][1], [NLog 4.5][2] ou [NLog 4.6][3] sur GitHub.
 
 
-[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog40Example/NLog.config
-[2]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog45Example/NLog.config
-[3]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog46Example/NLog.config
+[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/NLog40Example/NLog.config
+[2]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/NLog45Example/NLog.config
+[3]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/NLog46Example/NLog.config
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/fr/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/fr/tracing/setup_overview/setup/dotnet-core.md
@@ -24,7 +24,7 @@ further_reading:
   - link: /tracing/
     tag: Utilisation avancée
     text: Utilisation avancée
-  - link: 'https://github.com/DataDog/dd-trace-dotnet/tree/master/samples'
+  - link: 'https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples'
     tag: GitHub
     text: Exemples d'instrumentation personnalisée
   - link: /tracing/connect_logs_and_traces/dotnet/

--- a/content/fr/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/fr/tracing/setup_overview/setup/dotnet-framework.md
@@ -32,7 +32,7 @@ further_reading:
   - link: 'https://www.datadoghq.com/blog/net-monitoring-apm/'
     tag: Blog
     text: Surveillance .NET avec l'APM et le tracing distribué de Datadog
-  - link: 'https://github.com/DataDog/dd-trace-dotnet/tree/master/samples'
+  - link: 'https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples'
     tag: GitHub
     text: Exemples d'instrumentation personnalisée
   - link: 'https://github.com/DataDog/dd-trace-dotnet'

--- a/content/ja/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/ja/tracing/connect_logs_and_traces/dotnet.md
@@ -59,7 +59,7 @@ var log = new LoggerConfiguration()
 その他の例については、GitHub の [Serilog トレース ID 自動挿入プロジェクト][1]を参照してください。
 
 
-[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/SerilogExample/Program.cs
+[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/SerilogExample/Program.cs
 {{% /tab %}}
 {{% tab "log4net" %}}
 トレースおよびスパン ID は、マップされた診断コンテキスト (MDC) を有効にした後にのみアプリケーションログに挿入されます。以下のコード例を参照してください。
@@ -81,7 +81,7 @@ var log = new LoggerConfiguration()
 その他の例については、GitHub の [log4net トレース ID 自動挿入プロジェクト][1]を参照してください。
 
 
-[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/Log4NetExample/log4net.config
+[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/Log4NetExample/log4net.config
 {{% /tab %}}
 {{% tab "NLog" %}}
 
@@ -111,9 +111,9 @@ NLog バージョン 4.5 の場合
 その他の例については、GitHub で [NLog 4.0][1]、[NLog 4.5][2]、[NLog 4.6][3] を使用したトレース ID 自動挿入プロジェクトを参照してください。
 
 
-[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog40Example/NLog.config
-[2]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog45Example/NLog.config
-[3]: https://github.com/DataDog/dd-trace-dotnet/blob/master/samples/AutomaticTraceIdInjection/NLog46Example/NLog.config
+[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/NLog40Example/NLog.config
+[2]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/NLog45Example/NLog.config
+[3]: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/samples/AutomaticTraceIdInjection/NLog46Example/NLog.config
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/ja/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/ja/tracing/setup_overview/setup/dotnet-core.md
@@ -27,7 +27,7 @@ further_reading:
   - link: 'https://www.datadoghq.com/blog/net-monitoring-apm/'
     tag: ブログ
     text: Datadog APM と分散型トレーシングを使用した .NET のモニタリング
-  - link: 'https://github.com/DataDog/dd-trace-dotnet/tree/master/samples'
+  - link: 'https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples'
     tag: GitHub
     text: カスタムインスツルメンテーションの例
   - link: 'https://github.com/DataDog/dd-trace-dotnet'

--- a/content/ja/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/ja/tracing/setup_overview/setup/dotnet-framework.md
@@ -32,7 +32,7 @@ further_reading:
   - link: 'https://www.datadoghq.com/blog/net-monitoring-apm/'
     tag: ブログ
     text: Datadog APM と分散型トレーシングを使用した .NET のモニタリング
-  - link: 'https://github.com/DataDog/dd-trace-dotnet/tree/master/samples'
+  - link: 'https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples'
     tag: GitHub
     text: カスタムインスツルメンテーションの例
   - link: 'https://github.com/DataDog/dd-trace-dotnet'


### PR DESCRIPTION
### What does this PR do?
Fixes broken links to the .NET tracer repository

### Motivation
We recently (yesterday) rearranged the .NET tracer repository, which has broken various links

### Preview
* https://docs-staging.datadoghq.com/andrewlock/apm-dotnet/fix-links/tracing/setup_overview/compatibility_requirements/dotnet-core/
* https://docs-staging.datadoghq.com/andrewlock/apm-dotnet/fix-links/tracing/setup_overview/compatibility_requirements/dotnet-core/
* https://docs-staging.datadoghq.com/andrewlock/apm-dotnet/fix-links/tracing/setup_overview/compatibility_requirements/dotnet-framework/
* https://docs-staging.datadoghq.com/andrewlock/apm-dotnet/fix-links/tracing/setup_overview/custom_instrumentation/dotnet/
* https://docs-staging.datadoghq.com/andrewlock/apm-dotnet/fix-links/tracing/setup_overview/setup/dotnet-core/
* https://docs-staging.datadoghq.com/andrewlock/apm-dotnet/fix-links/tracing/setup_overview/setup/dotnet-framework/

### Additional Notes
I did a find and replace which also replaced the fr and ja localised docs, not sure if those changes should be included or if they should be excluded and mirrored later?

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
