### PR TITLE
Updates link checker jobs to use GIT_STRATEGY: none 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,6 +151,7 @@ link_checks_preview:
   environment: "preview"
   variables:
     URL: ${PREVIEW_DOMAIN}
+    GIT_STRATEGY: none
   script:
     - post_dd_event "documentation htmltest ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" "info"
     - htmltest
@@ -304,6 +305,7 @@ test_live_link_checks:
   environment: "live"
   variables:
     URL: ${LIVE_DOMAIN}
+    GIT_STRATEGY: none
   script:
     - post_dd_event "documentation htmltest ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" "info"
     - htmltest


### PR DESCRIPTION
### What does this PR do?
Disables git checkout on link check jobs in Gitlab

### Motivation
Improve pipeline

### Preview
https://docs-staging.datadoghq.com/nsollecito/skip-git/

### Additional Notes
Confirm repo is not cloned in Gitlab job:
https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/84595822

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
