### PR TITLE
Update registry link for agent container image

### DIFF
--- a/content/en/continuous_integration/setup_tests/agent.md
+++ b/content/en/continuous_integration/setup_tests/agent.md
@@ -31,7 +31,7 @@ If you are using a Kubernetes executor, Datadog recommends using the [Admission 
 
 If you are using a SaaS CI provider with no access to the underlying worker nodes, run the Datadog Agent in a container as a build service. This method is also available for an on-premises CI provider that uses a container-based executor if [installing the Datadog Agent on each worker node](#installing-the-agent-on-each-ci-worker-node) is not an option.
 
-To run the Datadog Agent as a container acting as a simple results forwarder, use the Docker image `datadog/agent:latest` and the following environment variables:
+To run the Datadog Agent as a container acting as a simple results forwarder, use the Docker image `gcr.io/datadoghq/agent:latest` and the following environment variables:
 
 `DD_API_KEY` (Required)
 : The [Datadog API key][4] used to upload the test results.<br/>
@@ -76,7 +76,7 @@ variables:
 resources:
   containers:
     - container: dd_agent
-      image: datadog/agent:latest
+      image: gcr.io/datadoghq/agent:latest
       ports:
         - 8126:8126
       env:
@@ -100,7 +100,7 @@ variables:
 resources:
   containers:
     - container: dd_agent
-      image: datadog/agent:latest
+      image: gcr.io/datadoghq/agent:latest
       ports:
         - 8126:8126
       env:
@@ -140,7 +140,7 @@ variables:
 
 test:
   services:
-    - name: datadog/agent:latest
+    - name: gcr.io/datadoghq/agent:latest
   script:
     - make test
 {{< /code-block >}}
@@ -156,7 +156,7 @@ variables:
 
 test:
   services:
-    - name: datadog/agent:latest
+    - name: gcr.io/datadoghq/agent:latest
   script:
     - make test
 {{< /code-block >}}
@@ -179,7 +179,7 @@ jobs:
   test:
     services:
       datadog-agent:
-        image: datadog/agent:latest
+        image: gcr.io/datadoghq/agent:latest
         ports:
           - 8126:8126
         env:
@@ -196,7 +196,7 @@ jobs:
   test:
     services:
       datadog-agent:
-        image: datadog/agent:latest
+        image: gcr.io/datadoghq/agent:latest
         ports:
           - 8126:8126
         env:
@@ -289,7 +289,7 @@ Regardless of which CI provider you use, if tests are run using [Docker Compose]
 version: '3'
 services:
   datadog-agent:
-    image: "datadog/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
       - DD_API_KEY
       - DD_INSIDE_CI=true
@@ -308,7 +308,7 @@ services:
 version: '3'
 services:
   datadog-agent:
-    image: "datadog/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
       - DD_API_KEY
       - DD_INSIDE_CI=true
@@ -331,7 +331,7 @@ Alternatively, share the same network namespace between the Agent container and 
 version: '3'
 services:
   datadog-agent:
-    image: "datadog/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
       - DD_API_KEY
       - DD_INSIDE_CI=true
@@ -347,7 +347,7 @@ services:
 version: '3'
 services:
   datadog-agent:
-    image: "datadog/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
       - DD_API_KEY
       - DD_INSIDE_CI=true

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -292,10 +292,10 @@ If you already have the [Agent running with a manifest][4]:
                 serviceAccountName: datadog-agent
                 containers:
                     - name: datadog-agent
-                      image: 'datadog/agent:latest'
+                      image: 'gcr.io/datadoghq/agent:latest'
                     # (...)
                     - name: system-probe
-                      image: 'datadog/agent:latest'
+                      image: 'gcr.io/datadoghq/agent:latest'
                       imagePullPolicy: Always
                       securityContext:
                           capabilities:
@@ -365,7 +365,7 @@ $ docker run -e DD_API_KEY="<DATADOG_API_KEY>" \
 --cap-add=SYS_PTRACE \
 --cap-add=NET_ADMIN \
 --cap-add=IPC_LOCK \
-datadog/agent:latest
+gcr.io/datadoghq/agent:latest
 ```
 
 Replace `<DATADOG_API_KEY>` with your [Datadog API key][1].
@@ -377,7 +377,7 @@ version: '3'
 services:
   ..
   datadog:
-    image: "datadog/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
        DD_SYSTEM_PROBE_ENABLED: 'true'
        DD_PROCESS_AGENT_ENABLED: 'true'

--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -126,7 +126,7 @@ docker run -d --name datadog-agent \
         -e DD_APM_IGNORE_RESOURCES="Api::HealthchecksController#index$" \
               -e DD_APM_ENABLED=true \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
-              datadog/agent:latest
+              gcr.io/datadoghq/agent:latest
 {{< /code-block >}}
 
 {{% /tab %}}

--- a/content/fr/agent/amazon_ecs/apm.md
+++ b/content/fr/agent/amazon_ecs/apm.md
@@ -19,7 +19,7 @@ Après avoir suivi les [instructions d'installation de l'agent Amazon ECS][1], a
     containerDefinitions": [
     {
       "name": "datadog-agent",
-      "image": "datadog/agent:latest",
+      "image": "gcr.io/datadoghq/agent:latest",
       "cpu": 10,
       "memory": 256,
       "essential": true,

--- a/content/fr/agent/kubernetes/apm.md
+++ b/content/fr/agent/kubernetes/apm.md
@@ -88,7 +88,7 @@ Mettez à jour votre manifeste `datadog-agent.yaml` comme suit :
 ```
 agent:
   image:
-    name: "datadog/agent:latest"
+    name: "gcr.io/datadoghq/agent:latest"
   apm:
     enabled: true
 ```

--- a/content/fr/integrations/ecs_fargate.md
+++ b/content/fr/integrations/ecs_fargate.md
@@ -80,7 +80,7 @@ Les instructions ci-dessous vous expliquent comment configurer la tâche à l'ai
 6. Choisissez une valeur pour **Task memory** et **Task CPU** en fonction de vos besoins.
 7. Cliquez sur le bouton **Add container**.
 8. Pour **Container name**, saisissez `datadog-agent`.
-9. Pour **Image**, saisissez `datadog/agent:latest`.
+9. Pour **Image**, saisissez `public.ecr.aws/datadog/agent:latest`.
 10. Pour le champ **Memory Limits**, saisissez `256` comme limite logicielle.
 11. Faites défiler jusqu'à atteindre la section **Advanced container configuration**, puis saisissez `10` pour **CPU units**.
 12. Pour le champ **Env Variables**, ajoutez la **clé** `DD_API_KEY` et saisissez votre [clé d'API Datadog][5] en tant que valeur. _Si vous préférez stocker vos secrets dans S3, consultez le [guide de configuration d'ECS][6]._

--- a/content/fr/integrations/k6.md
+++ b/content/fr/integrations/k6.md
@@ -72,7 +72,7 @@ Pour obtenir des instructions détaillées, consultez la [documentation de k6][2
         -e DD_API_KEY=<YOUR_DATADOG_API_KEY> \
         -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=1 \
         -p 8125:8125/udp \
-        datadog/agent:latest
+        gcr.io/datadoghq/agent:latest
     ```
 
     **Remarque** : remplacez `<YOUR_DATADOG_API_KEY>` par votre clé d'[API][5]. Si votre compte utilise le site européen de Datadog, définissez `DD_SITE` sur `datadoghq.eu`.

--- a/content/fr/integrations/mesos.md
+++ b/content/fr/integrations/mesos.md
@@ -36,7 +36,7 @@ docker run -d --name datadog-agent \
   -e DD_API_KEY= \
   -e MESOS_MASTER=true \
   -e MARATHON_URL=http://leader.mesos:8080 \
-  datadog/agent:latest
+  gcr.io/datadoghq/agent:latest
 ```
 
 Spécifiez votre clé d'API Datadog et votre URL d'API Mesos Master dans la commande ci-dessus.
@@ -173,7 +173,7 @@ Si vous n'utilisez pas DC/OS, définissez l'application Agent Datadog via l'inte
       }
     ],
     "docker": {
-      "image": "datadog/agent:latest",
+      "image": "gcr.io/datadoghq/agent:latest",
       "network": "BRIDGE",
       "portMappings": [
         {

--- a/content/fr/integrations/systemd.md
+++ b/content/fr/integrations/systemd.md
@@ -65,7 +65,7 @@ docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro \
               -v /sys/fs/cgroup/:/host/sys/fs/cgroup/:ro \
               -v /run/systemd/:/host/run/systemd/:ro \
               -e DD_API_KEY=<VOTRE_CLÉ_API> \
-              datadog/agent:latest
+              gcr.io/datadoghq/agent:latest
 ```
 
 ### Configuration

--- a/content/fr/logs/guide/how-to-set-up-only-logs.md
+++ b/content/fr/logs/guide/how-to-set-up-only-logs.md
@@ -91,7 +91,7 @@ spec:
     spec:
       serviceAccountName: datadog-agent
       containers:
-      - image: gcr.io/datadog/agent:latest
+      - image: gcr.io/datadoghq/agent:latest
         imagePullPolicy: Always
         name: datadog-agent
         ports:

--- a/content/fr/network_monitoring/performance/setup.md
+++ b/content/fr/network_monitoring/performance/setup.md
@@ -295,10 +295,10 @@ Si l'[Agent est déjà exécuté avec un manifeste][4] :
                 serviceAccountName: datadog-agent
                 containers:
                     - name: datadog-agent
-                      image: 'datadog/agent:latest'
+                      image: 'gcr.io/datadoghq/agent:latest'
                     # (...)
                     - name: system-probe
-                      image: 'datadog/agent:latest'
+                      image: 'gcr.io/datadoghq/agent:latest'
                       imagePullPolicy: Always
                       securityContext:
                           capabilities:
@@ -368,7 +368,7 @@ $ docker run -e DD_API_KEY="<CLÉ_API_DATADOG>" \
 --cap-add=SYS_PTRACE \
 --cap-add=NET_ADMIN \
 --cap-add=IPC_LOCK \
-datadog/agent:latest
+gcr.io/datadoghq/agent:latest
 ```
 
 Remplacez `<CLÉ_API_DATADOG>` par votre [clé d'API Datadog][1].
@@ -380,7 +380,7 @@ version: '3'
 services:
   ..
   datadog:
-    image: "datadog/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
        DD_SYSTEM_PROBE_ENABLED: 'true'
        DD_PROCESS_AGENT_ENABLED: 'true'

--- a/content/fr/network_performance_monitoring/installation.md
+++ b/content/fr/network_performance_monitoring/installation.md
@@ -246,10 +246,10 @@ Si l'[Agent est déjà exécuté avec un manifeste][3] :
                 serviceAccountName: datadog-agent
                 containers:
                     - name: datadog-agent
-                      image: 'datadog/agent:latest'
+                      image: 'gcr.io/datadoghq/agent:latest'
                     # (...)
                     - name: system-probe
-                      image: 'datadog/agent:latest'
+                      image: 'gcr.io/datadoghq/agent:latest'
                       imagePullPolicy: Always
                       securityContext:
                           capabilities:
@@ -318,7 +318,7 @@ $ docker run -e DD_API_KEY="<CLÉ_API_DATADOG>" \
 --cap-add=SYS_PTRACE \
 --cap-add=NET_ADMIN \
 --cap-add=IPC_LOCK \
-datadog/agent:latest
+gcr.io/datadoghq/agent:latest
 ```
 
 Remplacez `<CLÉ_API_DATADOG>` par votre [clé d'API Datadog][1].
@@ -330,7 +330,7 @@ version: '3'
 services:
   ..
   datadog:
-    image: "datadog/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
        DD_SYSTEM_PROBE_ENABLED: 'true'
        DD_PROCESS_AGENT_ENABLED: 'true'

--- a/content/fr/tagging/assigning_tags.md
+++ b/content/fr/tagging/assigning_tags.md
@@ -131,7 +131,7 @@ services:
       - DD_API_KEY= "<CLÉ_API_DATADOG>"
       - DD_DOCKER_LABELS_AS_TAGS={"my.custom.label.project":"projecttag","my.custom.label.version":"versiontag"}
       - DD_TAGS="key1:value1 key2:value2 key3:value3"
-    image: 'datadog/agent:latest'
+    image: 'gcr.io/datadoghq/agent:latest'
     deploy:
       restart_policy:
         condition: on-failure

--- a/content/ja/continuous_integration/setup_tests/agent.md
+++ b/content/ja/continuous_integration/setup_tests/agent.md
@@ -29,7 +29,7 @@ Kubernetes エグゼキューターを使用している場合、Datadog は [Ad
 
 基底のワーカーノードにアクセスできない SaaS CI プロバイダーを使用している場合は、コンテナ内の Datadog Agent をビルドサービスとして実行します。このメソッドは、[各ワーカーノードへの Datadog Agent のインストール](#installing-the-agent-on-each-ci-worker-node)というオプションがない場合に、コンテナベースのエグゼキューターを使用するオンプレミス CI プロバイダーでも使用できます。
 
-単純な結果フォワーダーとして機能するコンテナとして Datadog Agent を実行するには、Docker イメージ `datadog/agent:latest` と次の環境変数を使用します。
+単純な結果フォワーダーとして機能するコンテナとして Datadog Agent を実行するには、Docker イメージ `gcr.io/datadoghq/agent:latest` と次の環境変数を使用します。
 
 `DD_API_KEY` (必須)
 : テスト結果のアップロードに使用される [Datadog API キー][4]。<br/>
@@ -74,7 +74,7 @@ variables:
 resources:
   containers:
     - container: dd_agent
-      image: datadog/agent:latest
+      image: gcr.io/datadoghq/agent:latest
       ports:
         - 8126:8126
       env:
@@ -98,7 +98,7 @@ variables:
 resources:
   containers:
     - container: dd_agent
-      image: datadog/agent:latest
+      image: gcr.io/datadoghq/agent:latest
       ports:
         - 8126:8126
       env:
@@ -138,7 +138,7 @@ variables:
 
 test:
   services:
-    - name: datadog/agent:latest
+    - name: gcr.io/datadoghq/agent:latest
   script:
     - make test
 {{< /code-block >}}
@@ -154,7 +154,7 @@ variables:
 
 test:
   services:
-    - name: datadog/agent:latest
+    - name: gcr.io/datadoghq/agent:latest
   script:
     - make test
 {{< /code-block >}}
@@ -177,7 +177,7 @@ jobs:
   test:
     services:
       datadog-agent:
-        image: datadog/agent:latest
+        image: gcr.io/datadoghq/agent:latest
         ports:
           - 8126:8126
         env:
@@ -194,7 +194,7 @@ jobs:
   test:
     services:
       datadog-agent:
-        image: datadog/agent:latest
+        image: gcr.io/datadoghq/agent:latest
         ports:
           - 8126:8126
         env:
@@ -287,7 +287,7 @@ workflows:
 version: '3'
 services:
   datadog-agent:
-    image: "datadog/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
       - DD_API_KEY
       - DD_INSIDE_CI=true
@@ -306,7 +306,7 @@ services:
 version: '3'
 services:
   datadog-agent:
-    image: "datadog/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
       - DD_API_KEY
       - DD_INSIDE_CI=true
@@ -329,7 +329,7 @@ services:
 version: '3'
 services:
   datadog-agent:
-    image: "datadog/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
       - DD_API_KEY
       - DD_INSIDE_CI=true
@@ -345,7 +345,7 @@ services:
 version: '3'
 services:
   datadog-agent:
-    image: "datadog/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
       - DD_API_KEY
       - DD_INSIDE_CI=true

--- a/content/ja/integrations/amazon_elasticbeanstalk.md
+++ b/content/ja/integrations/amazon_elasticbeanstalk.md
@@ -301,7 +301,7 @@ echo -e "process_config:\n  enabled: \"true\"\n" >> /etc/datadog-agent/datadog.y
 ```text
  "containerDefinitions": [    {
       "name": "dd-agent",
-      "image": "datadog/agent:latest",
+      "image": "public.ecr.aws/datadog/agent:latest",
       "environment": [
           {
               "name": "DD_API_KEY",

--- a/content/ja/integrations/ecs_fargate.md
+++ b/content/ja/integrations/ecs_fargate.md
@@ -82,7 +82,7 @@ Fargate の主要な作業単位はタスクで、これはタスク定義内で
 6. ニーズに合わせて **Task memory** と **Task CPU** を選択します。
 7. **Add container** ボタンをクリックします。
 8. **Container name** に `datadog-agent` と入力します。
-9. **Image** に `datadog/agent:latest` と入力します。
+9. **Image** に `gcr.io/datadoghq/agent:latest` と入力します。
 10. **Memory Limits** に、ソフト制限として `256` を入力します。
 11. **Advanced container configuration** セクションまでスクロールし、**CPU units** に `10` と入力します。
 12. **Env Variables** に**キー** `DD_API_KEY` を追加し、[Datadog API キー][5]を値として入力します。_シークレットを s3 に保存する場合は、[ECS 構成ガイド][6]を参照してください_。

--- a/content/ja/integrations/k6.md
+++ b/content/ja/integrations/k6.md
@@ -72,7 +72,7 @@ k6 インテグレーションを使用すると、k6 テストのパフォー�
         -e DD_API_KEY=<YOUR_DATADOG_API_KEY> \
         -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=1 \
         -p 8125:8125/udp \
-        datadog/agent:latest
+        gcr.io/datadoghq/agent:latest
     ```
 
     **注**: `<Datadog API キー>` を [API][5] キーに置き換えます。アカウントが Datadog EU に登録されている場合は、`DD_SITE` を `datadoghq.eu` にします。

--- a/content/ja/integrations/mesos.md
+++ b/content/ja/integrations/mesos.md
@@ -36,7 +36,7 @@ docker run -d --name datadog-agent \
   -e DD_API_KEY=<YOUR_DATADOG_API_KEY> \
   -e MESOS_MASTER=true \
   -e MARATHON_URL=http://leader.mesos:8080 \
-  datadog/agent:latest
+  gcr.io/datadoghq/agent:latest
 ```
 
 上のコマンドの Datadog API キーと Mesos Master の API URL は、適切な値に置き換えてください。
@@ -172,7 +172,7 @@ DC/OS を使用していない場合は、Marathon Web UI を使用するか、�
       }
     ],
     "docker": {
-      "image": "datadog/agent:latest",
+      "image": "gcr.io/datadoghq/agent:latest",
       "network": "BRIDGE",
       "portMappings": [
         {

--- a/content/ja/network_monitoring/performance/setup.md
+++ b/content/ja/network_monitoring/performance/setup.md
@@ -288,10 +288,10 @@ Helm をお使いでない場合は、Kubernetes を使用してネットワー�
                 serviceAccountName: datadog-agent
                 containers:
                     - name: datadog-agent
-                      image: 'datadog/agent:latest'
+                      image: 'gcr.io/datadoghq/agent:latest'
                     # (...)
                     - name: system-probe
-                      image: 'datadog/agent:latest'
+                      image: 'gcr.io/datadoghq/agent:latest'
                       imagePullPolicy: Always
                       securityContext:
                           capabilities:
@@ -361,7 +361,7 @@ $ docker run -e DD_API_KEY="<DATADOG_API_キー>" \
 --cap-add=SYS_PTRACE \
 --cap-add=NET_ADMIN \
 --cap-add=IPC_LOCK \
-datadog/agent:latest
+gcr.io/datadoghq/agent:latest
 ```
 
 `<API_キー>` を、ご使用の [Datadog API キー][1]に置き換えます。
@@ -373,7 +373,7 @@ version: '3'
 services:
   ..
   datadog:
-    image: "datadog/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
        DD_SYSTEM_PROBE_ENABLED: 'true'
        DD_PROCESS_AGENT_ENABLED: 'true'

--- a/content/ja/network_performance_monitoring/installation.md
+++ b/content/ja/network_performance_monitoring/installation.md
@@ -248,10 +248,10 @@ Kubernetes を使用してネットワークパフォーマンスのモニタリ
                 serviceAccountName: datadog-agent
                 containers:
                     - name: datadog-agent
-                      image: 'datadog/agent:latest'
+                      image: 'gcr.io/datadoghq/agent:latest'
                     # (...)
                     - name: system-probe
-                      image: 'datadog/agent:latest'
+                      image: 'gcr.io/datadoghq/agent:latest'
                       imagePullPolicy: Always
                       securityContext:
                           capabilities:
@@ -320,7 +320,7 @@ $ docker run -e DD_API_KEY="<DATADOG_API_キー>" \
 --cap-add=SYS_PTRACE \
 --cap-add=NET_ADMIN \
 --cap-add=IPC_LOCK \
-datadog/agent:latest
+gcr.io/datadoghq/agent:latest
 ```
 
 `<API_キー>` を、ご使用の [Datadog API キー][1]に置き換えます。
@@ -332,7 +332,7 @@ version: '3'
 services:
   ..
   datadog:
-    image: "datadog/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
        DD_SYSTEM_PROBE_ENABLED: 'true'
        DD_PROCESS_AGENT_ENABLED: 'true'

--- a/static/resources/json/datadog-agent-ecs-fargate.json
+++ b/static/resources/json/datadog-agent-ecs-fargate.json
@@ -4,7 +4,7 @@
   "containerDefinitions": [
       {
           "name": "datadog-agent",
-          "image": "datadog/agent:latest",
+          "image": "public.ecr.aws/datadog/agent:latest",
           "essential": true,
           "environment": [
               {

--- a/static/resources/json/datadog-agent-ecs-win.json
+++ b/static/resources/json/datadog-agent-ecs-win.json
@@ -2,7 +2,7 @@
   "containerDefinitions": [
     {
       "name": "datadog-agent",
-      "image": "datadog/agent:latest",
+      "image": "public.ecr.aws/datadog/agent:latest",
       "cpu": 512,
       "memory": 512,
       "essential": true,

--- a/static/resources/json/datadog-agent-ecs.json
+++ b/static/resources/json/datadog-agent-ecs.json
@@ -2,7 +2,7 @@
   "containerDefinitions": [
     {
       "name": "datadog-agent",
-      "image": "datadog/agent:latest",
+      "image": "public.ecr.aws/datadog/agent:latest",
       "cpu": 100,
       "memory": 512,
       "essential": true,

--- a/static/resources/json/datadog-agent-ecs1.json
+++ b/static/resources/json/datadog-agent-ecs1.json
@@ -2,7 +2,7 @@
   "containerDefinitions": [
     {
       "name": "datadog-agent",
-      "image": "datadog/agent:latest",
+      "image": "public.ecr.aws/datadog/agent:latest",
       "cpu": 100,
       "memory": 512,
       "essential": true,

--- a/static/resources/json/datadog-agent-sysprobe-ecs.json
+++ b/static/resources/json/datadog-agent-sysprobe-ecs.json
@@ -17,7 +17,7 @@
         }
       ],
       "essential": true,
-      "image": "datadog/agent:latest",
+      "image": "public.ecr.aws/datadog/agent:latest",
       "linuxParameters": {
         "capabilities": {
           "add": [

--- a/static/resources/json/datadog-agent-sysprobe-ecs1.json
+++ b/static/resources/json/datadog-agent-sysprobe-ecs1.json
@@ -17,7 +17,7 @@
         }
       ],
       "essential": true,
-      "image": "datadog/agent:latest",
+      "image": "public.ecr.aws/datadog/agent:latest",
       "linuxParameters": {
         "capabilities": {
           "add": [


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update the documentation to use the default registries:
* gcr.io/datadoghq/agent by default.
* public.ecr.aws/datadog/agent when it is for an aws environment.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/clamoriniere/ecs-ecr-registry

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
