### PR TITLE
remove a few more mentions of DockerHub

### DIFF
--- a/content/en/agent/amazon_ecs/_index.md
+++ b/content/en/agent/amazon_ecs/_index.md
@@ -317,7 +317,7 @@ Need help? Contact [Datadog support][20].
 [2]: https://docs.datadoghq.com/integrations/faq/agent-5-amazon-ecs/
 [3]: https://docs.datadoghq.com/agent/docker/integrations/?tab=docker
 [4]: https://docs.datadoghq.com/integrations/ecs_fargate/
-[5]: https://hub.docker.com/r/datadog/agent
+[5]: https://gallery.ecr.aws/datadog/agent
 [6]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_GetStarted_EC2.html
 [7]: https://docs.datadoghq.com/agent/autodiscovery/
 [8]: /agent/amazon_ecs/apm/

--- a/content/en/agent/guide/container-images-for-docker-environments.md
+++ b/content/en/agent/guide/container-images-for-docker-environments.md
@@ -12,7 +12,7 @@ further_reading:
 
 ## Overview
 
-If you are using Docker, there are several container images available through GCR, ECR and Docker Hub that you may want to use within your environment:
+If you are using Docker, there are several container images available through GCR, ECR, and Docker Hub that you may want to use within your environment:
 
 {{< tabs >}}
 {{% tab "GCR" %}}

--- a/content/en/agent/guide/container-images-for-docker-environments.md
+++ b/content/en/agent/guide/container-images-for-docker-environments.md
@@ -12,9 +12,50 @@ further_reading:
 
 ## Overview
 
-If you are using Docker, there are several container images available through Docker Hub and GCR that you may want to use within your environment:
+If you are using Docker, there are several container images available through GCR, ECR and Docker Hub that you may want to use within your environment:
 
 {{< tabs >}}
+{{% tab "GCR" %}}
+
+| Datadog service                          | GCR                                      | GCR Pull Command                                                  |
+|------------------------------------------|------------------------------------------|-------------------------------------------------------------------|
+| [Docker Agent][1]                        | [Docker Agent (v6+)][2]                  | `docker pull gcr.io/datadoghq/agent`                              |
+| Docker Agent (v 5)                       | [Docker Agent (v5)][2]                   | `docker pull gcr.io/datadoghq/docker-dd-agent`                    |
+| [DogStatsD][3]                           | [DogStatsD][4]                           | `docker pull gcr.io/datadoghq/dogstatsd`                          |
+| [Datadog Cluster Agent][5]               | [Cluster Agent][6]                       | `docker pull gcr.io/datadoghq/cluster-agent`                      |
+| [Synthetics Private Location Worker][7]  | [Synthetics Private Location Worker][8]  | `docker pull gcr.io/datadoghq/synthetics-private-location-worker` |
+
+
+[1]: /agent/docker/
+[2]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/agent
+[3]: /developers/dogstatsd/
+[4]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/dogstatsd
+[5]: /agent/cluster_agent/
+[6]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/cluster-agent
+[7]: /getting_started/synthetics/private_location/
+[8]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/synthetics-private-location-worker
+{{% /tab %}}
+{{% tab "ECR" %}}
+
+| Datadog service                         | Docker Hub                               | Docker Pull Command                                                     |
+|-----------------------------------------|------------------------------------------|-------------------------------------------------------------------------|
+| [Docker Agent][1]                       | [Docker Agent (v6+)][2]                  | `docker pull public.ecr.aws/datadog/agent`                              |
+| Docker Agent (v 5)                      | [Docker Agent (v5)][3]                   | `docker pull public.ecr.aws/datadog/docker-dd-agent`                    |
+| [DogStatsD][4]                          | [DogStatsD][5]                           | `docker pull public.ecr.aws/datadog/dogstatsd`                          |
+| [Datadog Cluster Agent][6]              | [Cluster Agent][7]                       | `docker pull public.ecr.aws/datadog/cluster-agent`                      |
+| [Synthetics Private Location Worker][8] | [Synthetics Private Location Worker][9]  | `docker pull public.ecr.aws/datadog/synthetics-private-location-worker` |
+
+
+[1]: /agent/docker/
+[2]: https://gallery.ecr.aws/datadog/agent
+[3]: https://gallery.ecr.aws/datadog/docker-dd-agent
+[4]: /developers/dogstatsd/
+[5]: https://gallery.ecr.aws/datadog/dogstatsd
+[6]: /agent/cluster_agent/
+[7]: https://gallery.ecr.aws/datadog/cluster-agent
+[8]: /getting_started/synthetics/private_location
+[9]: https://gallery.ecr.aws/datadog/synthetics-private-location-worker
+{{% /tab %}}
 {{% tab "Docker Hub" %}}
 
 | Datadog service                         | Docker Hub                               | Docker Pull Command                              |
@@ -35,26 +76,6 @@ If you are using Docker, there are several container images available through Do
 [7]: https://hub.docker.com/r/datadog/cluster-agent
 [8]: /getting_started/synthetics/private_location
 [9]: https://hub.docker.com/r/datadog/synthetics-private-location-worker
-{{% /tab %}}
-{{% tab "GCR" %}}
-
-| Datadog service                          | GCR                                      | GCR Pull Command                                                  |
-|------------------------------------------|------------------------------------------|-------------------------------------------------------------------|
-| [Docker Agent][1]                        | [Docker Agent (v6+)][2]                  | `docker pull gcr.io/datadoghq/agent`                              |
-| Docker Agent (v 5)                       | [Docker Agent (v5)][2]                   | `docker pull gcr.io/datadoghq/docker-dd-agent`                    |
-| [DogStatsD][3]                           | [DogStatsD][4]                           | `docker pull gcr.io/datadoghq/dogstatsd`                          |
-| [Datadog Cluster Agent][5]               | [Cluster Agent][6]                       | `docker pull gcr.io/datadoghq/cluster-agent`                      |
-| [Synthetics Private Location Worker][7]  | [Synthetics Private Location Worker][8]  | `docker pull gcr.io/datadoghq/synthetics-private-location-worker` |
-
-
-[1]: /agent/docker/
-[2]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/agent
-[3]: /developers/dogstatsd/
-[4]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/dogstatsd
-[5]: /agent/cluster_agent/
-[6]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/cluster-agent
-[7]: /getting_started/synthetics/private_location/
-[8]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/synthetics-private-location-worker
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/database_monitoring/setup_mysql/aurora.md
+++ b/content/en/database_monitoring/setup_mysql/aurora.md
@@ -206,7 +206,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "username": "datadog",
     "password": "<UNIQUEPASSWORD>"
   }]' \
-  datadog/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 ### Dockerfile
@@ -214,7 +214,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
 Labels can also be specified in a `Dockerfile`, so you can build and deploy a custom agent without changing any infrastructure configuration:
 
 ```Dockerfile
-FROM datadog/agent:7.30.0
+FROM gcr.io/datadoghq/agent:7.30.0
 
 LABEL "com.datadoghq.ad.check_names"='["mysql"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'

--- a/content/en/database_monitoring/setup_mysql/gcsql.md
+++ b/content/en/database_monitoring/setup_mysql/gcsql.md
@@ -231,7 +231,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "username": "datadog",
     "password": "<UNIQUEPASSWORD>"
   }]' \
-  datadog/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 ### Dockerfile
@@ -239,7 +239,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
 Labels can also be specified in a `Dockerfile`, so you can build and deploy a custom agent without changing any infrastructure configuration:
 
 ```Dockerfile
-FROM datadog/agent:7.30.0
+FROM gcr.io/datadoghq/agent:7.30.0
 
 LABEL "com.datadoghq.ad.check_names"='["mysql"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'

--- a/content/en/database_monitoring/setup_mysql/rds.md
+++ b/content/en/database_monitoring/setup_mysql/rds.md
@@ -213,7 +213,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "username": "datadog",
     "password": "<UNIQUEPASSWORD>"
   }]' \
-  datadog/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 ### Dockerfile
@@ -221,7 +221,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
 Labels can also be specified in a `Dockerfile`, so you can build and deploy a custom agent without changing any infrastructure configuration:
 
 ```Dockerfile
-FROM datadog/agent:7.30.0
+FROM gcr.io/datadoghq/agent:7.30.0
 
 LABEL "com.datadoghq.ad.check_names"='["mysql"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -235,7 +235,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "username": "datadog",
     "password": "<UNIQUEPASSWORD>"
   }]' \
-  datadog/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 For Postgres 9.6, add the following settings to the instance config where host and port are specified:
@@ -250,7 +250,7 @@ pg_stat_activity_view: datadog.pg_stat_activity()
 Labels can also be specified in a `Dockerfile`, so you can build and deploy a custom agent without changing any infrastructure configuration:
 
 ```Dockerfile
-FROM datadog/agent:7.30.0
+FROM gcr.io/datadoghq/agent:7.30.0
 
 LABEL "com.datadoghq.ad.check_names"='["postgres"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'

--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -230,7 +230,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "username": "datadog",
     "password": "<UNIQUEPASSWORD>"
   }]' \
-  datadog/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 For Postgres 9.6, add the following settings to the instance config where host and port are specified:
@@ -245,7 +245,7 @@ pg_stat_activity_view: datadog.pg_stat_activity()
 Labels can also be specified in a `Dockerfile`, so you can build and deploy a custom agent without changing any infrastructure configuration:
 
 ```Dockerfile
-FROM datadog/agent:7.30.0
+FROM gcr.io/datadoghq/agent:7.30.0
 
 LABEL "com.datadoghq.ad.check_names"='["postgres"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'

--- a/content/en/database_monitoring/setup_postgres/rds.md
+++ b/content/en/database_monitoring/setup_postgres/rds.md
@@ -229,7 +229,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "username": "datadog",
     "password": "<UNIQUEPASSWORD>"
   }]' \
-  datadog/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 For Postgres 9.6, add the following settings to the instance config where host and port are specified:
@@ -244,7 +244,7 @@ pg_stat_activity_view: datadog.pg_stat_activity()
 Labels can also be specified in a `Dockerfile`, so you can build and deploy a custom agent without changing any infrastructure configuration:
 
 ```Dockerfile
-FROM datadog/agent:7.30.0
+FROM gcr.io/datadoghq/agent:7.30.0
 
 LABEL "com.datadoghq.ad.check_names"='["postgres"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'

--- a/content/en/security_platform/cloud_workload_security/getting_started.md
+++ b/content/en/security_platform/cloud_workload_security/getting_started.md
@@ -81,7 +81,7 @@ DOCKER_CONTENT_TRUST=1 \
   -e DD_RUNTIME_SECURITY_CONFIG_ENABLED=true \
   -e DD_SYSTEM_PROBE_ENABLED=true \
   -e HOST_ROOT=/host/root \
-  -e DD_API_KEY=<API KEY> datadog/agent:7-jmx
+  -e DD_API_KEY=<API KEY> gcr.io/datadoghq/agent:7-jmx
 
 {{< /code-block >}}
 

--- a/content/fr/agent/amazon_ecs/_index.md
+++ b/content/fr/agent/amazon_ecs/_index.md
@@ -106,7 +106,7 @@ aws ecs register-task-definition --cli-input-json <chemin vers datadog-agent-ecs
 8. Pour Linux uniquement, ajoutez un autre volume avec le nom `cgroup` et le chemin source `/sys/fs/cgroup/` (ou `/cgroup/` si vous utilisez une AMI Amazon Linux 1 d'origine).
 9. Cliquez sur le gros bouton **Add container**.
 10. Pour **Container name**, saisissez `datadog-agent`.
-11. Pour le champ **Image**, saisissez `gcr.io/datadoghq/agent:latest`.
+11. Pour le champ **Image**, saisissez `public.ecr.aws/datadog/agent:latest`.
 12. Pour **Maximum memory**, indiquez `256`. **Remarque** : en cas d'utilisation intense des ressources, il se peut que vous ayez besoin de rehausser la limite de mémoire.
 13. Faites défiler jusqu'à atteindre la section **Advanced container configuration**, puis saisissez `10` pour **CPU units**.
 **Remarque** : pour Windows, pour **CPU units**, saisissez au moins `512`, afin d'éviter l'erreur `Timeout while starting the service`.
@@ -301,7 +301,7 @@ Besoin d'aide ? Contactez [l'assistance Datadog][20].
 [2]: https://docs.datadoghq.com/fr/integrations/faq/agent-5-amazon-ecs/
 [3]: https://docs.datadoghq.com/fr/agent/docker/integrations/?tab=docker
 [4]: https://docs.datadoghq.com/fr/integrations/ecs_fargate/
-[5]: https://hub.docker.com/r/datadog/agent
+[5]: https://gallery.ecr.aws/datadog/agent
 [6]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_GetStarted_EC2.html
 [7]: https://docs.datadoghq.com/fr/agent/autodiscovery/
 [8]: /fr/agent/amazon_ecs/apm/

--- a/content/fr/agent/amazon_ecs/apm.md
+++ b/content/fr/agent/amazon_ecs/apm.md
@@ -13,13 +13,13 @@ further_reading:
 
 Après avoir suivi les [instructions d'installation de l'agent Amazon ECS][1], activez la collecte de traces en suivant les instructions ci-dessous.
 
-1. Configurez les paramètres suivants dans la définition de tâche pour le conteneur `datadog/agent`. Définissez le port du host/conteneur `portMappings` sur `8126` avec le protocole `tcp` :
+1. Configurez les paramètres suivants dans la définition de tâche pour le conteneur `datadog-agent`. Définissez le port du host/conteneur `portMappings` sur `8126` avec le protocole `tcp` :
 
     {{< code-block lang="json" >}}
     containerDefinitions": [
     {
       "name": "datadog-agent",
-      "image": "gcr.io/datadoghq/agent:latest",
+      "image": "public.ecr.aws/datadog/agent:latest",
       "cpu": 10,
       "memory": 256,
       "essential": true,

--- a/content/fr/agent/guide/container-images-for-docker-environments.md
+++ b/content/fr/agent/guide/container-images-for-docker-environments.md
@@ -11,9 +11,29 @@ further_reading:
 ---
 ## Présentation
 
-Si vous utilisez actuellement Docker, plusieurs images de conteneur disponibles via Docker Hub et GCR peuvent être utilisées dans votre environnement :
+Si vous utilisez actuellement Docker, plusieurs images de conteneur disponibles via GCR et Docker Hub peuvent être utilisées dans votre environnement :
 
 {{< tabs >}}
+{{% tab "GCR" %}}
+
+| Produit Datadog                          | GCR                                      | Commande Pull GCR                                                  |
+|------------------------------------------|------------------------------------------|-------------------------------------------------------------------|
+| [Agent Docker][1]                        | [Agent Docker (v6+)][2]                  | `docker pull gcr.io/datadoghq/agent`                              |
+| Agent Docker (v5)                       | [Agent Docker (v5)][2]                   | `docker pull gcr.io/datadoghq/docker-dd-agent`                    |
+| [DogStatsD][3]                           | [DogStatsD][4]                           | `docker pull gcr.io/datadoghq/dogstatsd`                          |
+| [Agent de cluster Datadog][5]               | [Agent de Cluster][6]                       | `docker pull gcr.io/datadoghq/cluster-agent`                      |
+| [Worker d'emplacement privé Synthetic][7]  | [Worker d'emplacement privé Synthetic][8]  | `docker pull gcr.io/datadoghq/synthetics-private-location-worker` |
+
+[1]: /fr/agent/docker/
+[2]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/agent
+[3]: /fr/developers/dogstatsd/
+[4]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/dogstatsd
+[5]: /fr/agent/cluster_agent/
+[6]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/cluster-agent
+[7]: /fr/getting_started/synthetics/private_location/
+[8]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/synthetics-private-location-worker
+
+{{% /tab %}}
 {{% tab "Docker Hub" %}}
 
 | Produit Datadog                         | Docker Hub                               | Commande Pull Docker                              |
@@ -33,26 +53,6 @@ Si vous utilisez actuellement Docker, plusieurs images de conteneur disponibles 
 [7]: https://hub.docker.com/r/datadog/cluster-agent
 [8]: /fr/getting_started/synthetics/private_location.md
 [9]: https://hub.docker.com/r/datadog/synthetics-private-location-worker
-
-{{% /tab %}}
-{{% tab "GCR" %}}
-
-| Produit Datadog                          | GCR                                      | Commande Pull GCR                                                  |
-|------------------------------------------|------------------------------------------|-------------------------------------------------------------------|
-| [Agent Docker][1]                        | [Agent Docker (v6+)][2]                  | `docker pull gcr.io/datadoghq/agent`                              |
-| Agent Docker (v5)                       | [Agent Docker (v5)][2]                   | `docker pull gcr.io/datadoghq/docker-dd-agent`                    |
-| [DogStatsD][3]                           | [DogStatsD][4]                           | `docker pull gcr.io/datadoghq/dogstatsd`                          |
-| [Agent de cluster Datadog][5]               | [Agent de Cluster][6]                       | `docker pull gcr.io/datadoghq/cluster-agent`                      |
-| [Worker d'emplacement privé Synthetic][7]  | [Worker d'emplacement privé Synthetic][8]  | `docker pull gcr.io/datadoghq/synthetics-private-location-worker` |
-
-[1]: /fr/agent/docker/
-[2]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/agent
-[3]: /fr/developers/dogstatsd/
-[4]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/dogstatsd
-[5]: /fr/agent/cluster_agent/
-[6]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/cluster-agent
-[7]: /fr/getting_started/synthetics/private_location/
-[8]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/synthetics-private-location-worker
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/fr/agent/kubernetes/_index.md
+++ b/content/fr/agent/kubernetes/_index.md
@@ -76,7 +76,7 @@ Activez ensuite les fonctionnalités Datadog que vous souhaitez utiliser, comme 
 **Remarques** :
 
 - Pour obtenir la liste complète des paramètres disponibles pour le chart Datadog et leurs valeurs par défaut, consultez le [README du référentiel Helm Datadog][7].
-- Si Google Container Registry ([gcr.io/datadoghq][8]) n'est pas accessible dans votre région de déploiement, utilisez le registre Docker Hub avec les images [datadog/agent][9] et [datadog/agent-de-cluster][10] et la configuration suivante dans le fichier `values.yaml` :
+- Si Google Container Registry ([gcr.io/datadoghq][8]) n'est pas accessible dans votre région de déploiement, utilisez le registre Docker Hub avec les images [datadog/agent][9] et [datadog/cluster-agent][10] et la configuration suivante dans le fichier `values.yaml` :
 
     ```yaml
     agents:

--- a/content/fr/integrations/azure_iot_edge.md
+++ b/content/fr/integrations/azure_iot_edge.md
@@ -90,7 +90,7 @@ Suivez les étapes ci-dessous pour configurer l'appareil IoT Edge, les modules d
 
 3. Installez et configurez l'Agent Datadog en tant que **module personnalisé** :
     - Définissez le nom du module. Par exemple : `datadog-agent`.
-    - Définissez l'URI de l'image de l'Agent. Par exemple : `datadog/agent:7`.
+    - Définissez l'URI de l'image de l'Agent. Par exemple : `gcr.io/datadoghq/agent:7`.
     - Sous « Environment Variables », configurez votre `DD_API_KEY`. Vous pouvez également définir d'autres paramètres de configuration ici (voir [Variables d'environnement de l'Agent][6]).
     - Sous « Container Create Options », ajoutez la configuration suivante en fonction du système d'exploitation de votre appareil. **Remarque** : `NetworkId` doit correspondre au nom de réseau défini dans le fichier `config.yaml` de l'appareil.
 

--- a/content/fr/integrations/eks_fargate.md
+++ b/content/fr/integrations/eks_fargate.md
@@ -150,7 +150,7 @@ spec:
      - name: "<NOM_APPLICATION>"
        image: "<IMAGE_APPLICATION>"
      ## Exécution de l'Agent en tant que sidecar
-     - image: datadog/agent
+     - image: public.ecr.aws/datadog/agent
        name: datadog-agent
        env:
        - name: DD_API_KEY
@@ -206,7 +206,7 @@ spec:
      - name: "<NOM_APPLICATION>"
        image: "<IMAGE_APPLICATION>"
      ## Exécution de l'Agent en tant que sidecar
-     - image: datadog/agent
+     - image: public.ecr.aws/datadog/agent
        name: datadog-agent
        env:
        - name: DD_API_KEY
@@ -259,7 +259,7 @@ spec:
      - name: "<NOM_APPLICATION>"
        image: "<IMAGE_APPLICATION>"
      ## Exécution de l'Agent en tant que sidecar
-     - image: datadog/agent
+     - image: public.ecr.aws/datadog/agent
        name: datadog-agent
        ## Activation du port 8125 pour la collecte de métriques DogStatsD
        ports:
@@ -338,7 +338,7 @@ spec:
      - name: "<NOM_APPLICATION>"
        image: "<IMAGE_APPLICATION>"
      ## Exécution de l'Agent en tant que sidecar
-     - image: datadog/agent
+     - image: public.ecr.aws/datadog/agent
        name: datadog-agent
        ## Activation du port 8126 pour la collecte de traces
        ports:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

remove a few more mentions of DockerHub, and replace some pull commands with ECR for AWS services which will be cheaper for our AWS customers.

### Motivation
<!-- What inspired you to submit this pull request?-->

We still have too many `docker pull` from dockerhub compared to ecr and gcr.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/haissam/remove-more-dockerhub-mentions/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
