### PR TITLE
Remove configuration paramters not available on aurora mysql 5.6

### DIFF
--- a/content/en/database_monitoring/setup_mysql/aurora.md
+++ b/content/en/database_monitoring/setup_mysql/aurora.md
@@ -54,8 +54,6 @@ Configure the following in the [DB Parameter Group][3] and then **restart the se
 | <code style="word-break:break-all;">`performance_schema_consumer_events_statements_current`</code> | `ON` | Required. Enables monitoring of currently running queries. |
 | <code style="word-break:break-all;">`performance_schema_consumer_events_statements_history`</code> | `ON` | Optional. Enables tracking recent query history per thread. If enabled it increases the likelihood of capturing execution details from infrequent queries. |
 | <code style="word-break:break-all;">`performance_schema_consumer_events_statements_history_long`</code> | `ON` | Optional. Enables tracking of a larger number of recent queries across all threads. If enabled it increases the likelihood of capturing execution details from infrequent queries. |
-| `max_digest_length` | `4096` | Required for collection of larger queries. Increases the size of SQL digest text in `events_statements_*` tables. If left at the default value then queries longer than `1024` characters will not be collected. |
-| <code style="word-break:break-all;">`performance_schema_max_digest_length`</code> | `4096` | Must match `max_digest_length`. |
 
 [1]: https://dev.mysql.com/doc/refman/8.0/en/performance-schema-quick-start.html
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
It was reported that the docs included a parameter for aurora mysql 5.6 that isn't available in the mysql version that aurora mysql 5.6 is based on (which is 5.6.10a). `max_digest_length` was introduced in mysql 5.6.24 according to the [mysql doc](https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_max_digest_length). Before that, it was hardcoded to 1024 bytes so any query text longer than that would be truncated in that configuration.  

### Motivation
Report of a customer reporting an error trying to add that configuration.

### Preview
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/alex.normand/alex.normand/remove-unavailable-config-for-aurora-mysql-5.6/database_monitoring/setup_mysql/aurora?tab=mysql56
<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
