### PR TITLE
(DOCS-2401) update links developers/metrics -> metrics

### DIFF
--- a/config/_default/menus/menus.fr.yaml
+++ b/config/_default/menus/menus.fr.yaml
@@ -2099,27 +2099,27 @@ main:
     identifier: marketplace
     weight: 2
   - name: Métriques custom
-    url: developers/metrics/
+    url: metrics/
     parent: dev_tools
     identifier: dev_tools_metrics
     weight: 3
   - name: Types de métriques
-    url: developers/metrics/types/
+    url: metrics/types/
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_metrics_type
     weight: 301
   - name: Envoi - Check de l'Agent
-    url: developers/metrics/agent_metrics_submission/
+    url: metrics/agent_metrics_submission/
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_agent
     weight: 302
   - name: Envoi - DogStatsD
-    url: developers/metrics/dogstatsd_metrics_submission/
+    url: metrics/dogstatsd_metrics_submission/
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_dogstatsd
     weight: 303
   - name: Envoi - Powershell
-    url: developers/metrics/powershell_metrics_submission
+    url: metrics/powershell_metrics_submission
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_powershell
     weight: 304
@@ -2129,12 +2129,12 @@ main:
     identifier: dev_tools_metrics_api
     weight: 305
   - name: Modificateurs de type de métriques
-    url: developers/metrics/type_modifiers/
+    url: metrics/type_modifiers/
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_modifiers
     weight: 306
   - name: Unités des métriques
-    url: developers/metrics/units/
+    url: metrics/units/
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_units
     weight: 307

--- a/config/_default/menus/menus.ja.yaml
+++ b/config/_default/menus/menus.ja.yaml
@@ -2154,27 +2154,27 @@ main:
     identifier: マーケットプレイス
     weight: 2
   - name: カスタムメトリクス
-    url: developers/metrics/
+    url: metrics/
     parent: dev_tools
     identifier: dev_tools_metrics
     weight: 3
   - name: メトリクスタイプ
-    url: developers/metrics/types/
+    url: metrics/types/
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_metrics_type
     weight: 301
   - name: 送信 - Agent チェック
-    url: developers/metrics/agent_metrics_submission/
+    url: metrics/agent_metrics_submission/
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_agent
     weight: 302
   - name: 送信 - DogStatsD
-    url: developers/metrics/dogstatsd_metrics_submission/
+    url: metrics/dogstatsd_metrics_submission/
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_dogstatsd
     weight: 303
   - name: 送信 - Powershell
-    url: developers/metrics/powershell_metrics_submission
+    url: metrics/powershell_metrics_submission
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_powershell
     weight: 304
@@ -2184,12 +2184,12 @@ main:
     identifier: dev_tools_metrics_api
     weight: 305
   - name: メトリクスタイプのモディファイアー
-    url: developers/metrics/type_modifiers/
+    url: metrics/type_modifiers/
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_modifiers
     weight: 306
   - name: メトリクスのユニット
-    url: developers/metrics/units/
+    url: metrics/units/
     parent: dev_tools_metrics
     identifier: dev_tools_metrics_units
     weight: 307

--- a/content/en/account_management/billing/custom_metrics.md
+++ b/content/en/account_management/billing/custom_metrics.md
@@ -69,9 +69,9 @@ To obtain the temperature in Florida, you can simply recombine the custom metric
 - `temperature{country:USA, state:Florida, city:Miami}`
 - `temperature{state:Florida, city:Miami, country:USA}`
 
-[1]: /developers/metrics/types/?tab=count#metric-types
-[2]: /developers/metrics/types/?tab=rate#metric-types
-[3]: /developers/metrics/types/?tab=gauge#metric-types
+[1]: /metrics/types/?tab=count#metric-types
+[2]: /metrics/types/?tab=rate#metric-types
+[3]: /metrics/types/?tab=gauge#metric-types
 {{% /tab %}}
 {{% tab "Histogram" %}}
 
@@ -92,8 +92,8 @@ By default, the Agent generates five custom metrics for each of the original fou
 - Configure which percentile aggregation you want to send to Datadog with the `histogram_percentiles` parameter in your [datadog.yaml configuration file][3]. By default, only the `95percentile`, 95th percentile, is sent out to Datadog.
 
 
-[1]: /developers/metrics/types/?tab=histogram#metric-types
-[2]: /developers/metrics/types/?tab=histogram#definition
+[1]: /metrics/types/?tab=histogram#metric-types
+[2]: /metrics/types/?tab=histogram#definition
 [3]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{% tab "Distribution" %}}
@@ -131,7 +131,7 @@ You can customize [which tag combination][2] aggregations are created for any DI
 
 The number of custom metrics from a [DISTRIBUTION metric][1] is five times the unique combination of metric name and tag values. As a result of the tag customization, `request.Latency` reporting a total of **5\*3 = 15 custom metrics**
 
-[1]: /developers/metrics/types/?tab=distribution#definition
+[1]: /metrics/types/?tab=distribution#definition
 [2]: /metrics/distributions/#customize-tagging
 {{% /tab %}}
 {{< /tabs >}}
@@ -175,8 +175,8 @@ For technical questions, contact [Datadog support][24].
 For billing questions, contact your [Customer Success][9] Manager.
 
 [1]: /integrations/
-[2]: /developers/metrics/custom_metrics/
-[3]: /developers/metrics/types/#metric-types
+[2]: /metrics/custom_metrics/
+[3]: /metrics/types/#metric-types
 [4]: /account_management/users/default_roles/
 [5]: https://app.datadoghq.com/account/usage/hourly
 [6]: /account_management/billing/usage_details/

--- a/content/en/account_management/billing/pricing.md
+++ b/content/en/account_management/billing/pricing.md
@@ -87,7 +87,7 @@ For technical questions, contact [Datadog support][5].
 Contact [Sales][6] or your [Customer Success][7] Manager to discuss hourly pricing or billing for your account.
 
 [1]: https://www.datadoghq.com/pricing
-[2]: /developers/metrics/custom_metrics/
+[2]: /metrics/custom_metrics/
 [3]: /tracing/trace_retention_and_ingestion/#retention-filters
 [4]: /tracing/trace_retention_and_ingestion/
 [5]: /help/

--- a/content/en/account_management/billing/usage_details.md
+++ b/content/en/account_management/billing/usage_details.md
@@ -31,7 +31,7 @@ In product specific tabs, view your month-to-date usage of the products in that 
 The month-to-date usage shown above is "All" usage, which includes non-billable usage such as product trials. Most accounts are able to view "Billable" usage, which only shows usage that contributes to your final bill. The "Billable" view breaks out on-demand usage above your commitments and allocations.
 
 {{< img src="account_management/billing/usage-details-v2-07.png" alt="Usage Summary - Billable" >}}
-For API users, endpoints are available to access ["All"][8] usage and ["Billable"][9] usage.
+For API users, endpoints are available to access ["All"][2] usage and ["Billable"][3] usage.
 
 Month-to-date usage of each product is calculated as follows:
 
@@ -42,7 +42,7 @@ Month-to-date usage of each product is calculated as follows:
 | APM Hosts                | Shows the 99th percentile of all distinct APM hosts over all hours in the current month.                                    |
 | Profiled Hosts           | Shows the 99th percentile of all distinct profiled hosts over all hours in the current month.                               |
 | Profiled Containers      | Shows the average of all distinct profiled containers over all hours in the current month.                                  |
-| Custom Metrics           | Shows the average number of distinct [custom metrics][2] over all hours in the current month.                               |
+| Custom Metrics           | Shows the average number of distinct [custom metrics][4] over all hours in the current month.                               |
 | Ingested Custom Metrics  | Shows the average number of distinct INGESTED custom metrics over all hours in the current month.                           |
 | Ingested Logs            | Shows the sum of all log bytes ingested over all hours in the current month.                                                |
 | Indexed Logs             | Shows the sum of all log events indexed over all hours in the current month.                                                |
@@ -92,16 +92,16 @@ The "All" view provides the following information about all your custom metrics:
 * Average custom metrics per hour
 * Max custom metrics per hour
 * Search for a metric within all your custom metrics
-* This data can be downloaded as a CSV file, with a maximum of 300,000 custom metrics. You can download over 300,000 custom metrics using our [API endpoint][7].
+* This data can be downloaded as a CSV file, with a maximum of 300,000 custom metrics. You can download over 300,000 custom metrics using our [API endpoint][5].
 
 
-For more details on your metrics, navigate to the [Metrics Summary][3] by hovering over the row of the metric you are interested in and clicking on the meter icon that shows up on the right side.
+For more details on your metrics, navigate to the [Metrics Summary][6] by hovering over the row of the metric you are interested in and clicking on the meter icon that shows up on the right side.
 
 {{< img src="account_management/billing/usage-metrics-05.png" alt="Overview of Top Custom Metrics table" >}}
 
 ## Logs usage by index
 
-In the Log Management tab, this table displays your hourly, daily, monthly, and annual indexed log usage by index name and retention period. It also shows the breakdown between live logs and [rehydrated logs][4]. The following information is provided:
+In the Log Management tab, this table displays your hourly, daily, monthly, and annual indexed log usage by index name and retention period. It also shows the breakdown between live logs and [rehydrated logs][7]. The following information is provided:
 
 * Index name
 * Retention period in days
@@ -114,17 +114,17 @@ This data can be downloaded as a CSV file.
 
 ## Troubleshooting
 
-For technical questions, contact [Datadog support][5].
+For technical questions, contact [Datadog support][8].
 
-For billing questions, contact your [Customer Success][6] Manager.
+For billing questions, contact your [Customer Success][9] Manager.
+
 
 [1]: https://app.datadoghq.com/account/usage/hourly
-[2]: /developers/metrics/custom_metrics/
-[3]: https://docs.datadoghq.com/metrics/summary/#overview
-[4]: https://docs.datadoghq.com/logs/archives/rehydrating/?tab=awss3#overview
-[5]: /help/
-[6]: mailto:success@datadoghq.com
-[7]: https://docs.datadoghq.com/api/latest/usage-metering/#get-all-custom-metrics-by-hourly-average
-[8]: https://docs.datadoghq.com/api/latest/usage-metering/#get-usage-across-your-multi-org-account
-[9]: https://docs.datadoghq.com/api/latest/usage-metering/#get-billable-usage-across-your-account
-
+[2]: https://docs.datadoghq.com/api/latest/usage-metering/#get-usage-across-your-multi-org-account
+[3]: https://docs.datadoghq.com/api/latest/usage-metering/#get-billable-usage-across-your-account
+[4]: /metrics/custom_metrics/
+[5]: https://docs.datadoghq.com/api/latest/usage-metering/#get-all-custom-metrics-by-hourly-average
+[6]: https://docs.datadoghq.com/metrics/summary/#overview
+[7]: https://docs.datadoghq.com/logs/archives/rehydrating/?tab=awss3#overview
+[8]: /help/
+[9]: mailto:success@datadoghq.com

--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -63,12 +63,12 @@ The Agent forwarder send metrics over HTTPS to Datadog. Buffering prevents netwo
 
 In v6, DogStatsD is a Golang implementation of [Etsy's StatsD][5] metric aggregation daemon. It is used to receive and roll up arbitrary metrics over UDP or Unix socket, thus allowing custom code to be instrumented without adding latency. Learn more about [DogStatsD][6].
 
-[1]: /developers/metrics/dogstatsd_metrics_submission/#metrics
+[1]: /metrics/dogstatsd_metrics_submission/#metrics
 [2]: /tracing/guide/terminology/
 [3]: /agent/guide/network/#open-ports
 [4]: /developers/custom_checks/write_agent_check/
 [5]: https://github.com/etsy/statsd
-[6]: /developers/metrics/dogstatsd_metrics_submission/
+[6]: /metrics/dogstatsd_metrics_submission/
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
@@ -105,7 +105,7 @@ minfds = 100  # Your hard limit
 ```
 
 [1]: /integrations/
-[2]: /developers/metrics/custom_metrics/
+[2]: /metrics/custom_metrics/
 [3]: /agent/guide/network/?tab=agentv5v4#open-ports
 [4]: /agent/proxy/?tab=agentv5
 [5]: /agent/faq/network/

--- a/content/en/agent/faq/how-is-the-system-mem-used-metric-calculated.md
+++ b/content/en/agent/faq/how-is-the-system-mem-used-metric-calculated.md
@@ -2,7 +2,7 @@
 title: How is the 'system.mem.used' metric calculated?
 kind: faq
 further_reading:
-- link: "/developers/metrics/"
+- link: "/metrics/"
   tag: "Documentation"
   text: "Learn more about Metrics"
 ---

--- a/content/en/agent/versions/_index.md
+++ b/content/en/agent/versions/_index.md
@@ -76,7 +76,7 @@ To see all changes between Agent v5 and v6, consult the [Datadog Agent dedicated
 [2]: /agent/guide/agent-commands/
 [3]: /developers/dogstatsd/unix_socket/
 [4]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md
-[5]: /developers/metrics/types/?tab=distribution#metric-types
+[5]: /metrics/types/?tab=distribution#metric-types
 [6]: /infrastructure/process/
 [7]: https://www.datadoghq.com/blog/monitor-prometheus-metrics
 [8]: /logs/

--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -34,7 +34,7 @@ The list above is not comprehensive of all rate limits on Datadog API's. If you 
 
 [1]: /help/
 [2]: /api/v1/metrics/
-[3]: /developers/metrics/custom_metrics/
+[3]: /metrics/custom_metrics/
 [4]: /api/v1/metrics/#query-timeseries-points
 [5]: /api/v1/logs/#get-a-list-of-logs
 [6]: /api/v1/snapshots/

--- a/content/en/api/v1/rate-limits/_index.md
+++ b/content/en/api/v1/rate-limits/_index.md
@@ -31,7 +31,7 @@ Regarding the API rate limit policy:
 
 [1]: /help/
 [2]: /api/v1/metrics/
-[3]: /developers/metrics/custom_metrics/
+[3]: /metrics/custom_metrics/
 [4]: /api/v1/metrics/#query-timeseries-points
 [5]: /api/v1/logs/#get-a-list-of-logs
 [6]: /api/v1/snapshots/

--- a/content/en/api/v2/rate-limits/_index.md
+++ b/content/en/api/v2/rate-limits/_index.md
@@ -31,7 +31,7 @@ Regarding the API rate limit policy:
 
 [1]: /help/
 [2]: /api/v1/metrics/
-[3]: /developers/metrics/custom_metrics/
+[3]: /metrics/custom_metrics/
 [4]: /api/v1/metrics/#query-timeseries-points
 [5]: /api/v1/logs/#get-a-list-of-logs
 [6]: /api/v1/snapshots/

--- a/content/en/dashboards/faq/interpolation-the-fill-modifier-explained.md
+++ b/content/en/dashboards/faq/interpolation-the-fill-modifier-explained.md
@@ -74,5 +74,5 @@ Linear interpolation is a great fit for metrics reported on a steady basis from 
 
 Null prevents graphs from displaying interpolated values 5 min after the last real value.
 
-[1]: /developers/metrics/types/
+[1]: /metrics/types/
 [2]: /dashboards/faq/i-see-unexpected-drops-to-zero-on-my-graph-why/

--- a/content/en/dashboards/faq/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs.md
+++ b/content/en/dashboards/faq/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs.md
@@ -2,7 +2,7 @@
 title: Why does zooming out a timeframe also smooth out my graphs?
 kind: faq
 further_reading:
-- link: "/developers/metrics/types/"
+- link: "/metrics/types/"
   tag: "Documentation"
   text: "Discover Datadog metrics types"
 - link: "/dashboards/functions/rollup/"
@@ -28,4 +28,4 @@ You can manually append the `.rollup()` function to your query to adjust the met
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /developers/metrics/type_modifiers/
+[1]: /metrics/type_modifiers/

--- a/content/en/dashboards/functions/interpolation.md
+++ b/content/en/dashboards/functions/interpolation.md
@@ -101,4 +101,4 @@ default_zero(avg:custom_metric{*})
 
 [1]: /getting_started/from_the_query_to_the_graph/#proceed-to-space-aggregation
 [2]: /monitors/guide/as-count-in-monitor-evaluations/
-[3]: /developers/metrics/
+[3]: /metrics/

--- a/content/en/dashboards/functions/rollup.md
+++ b/content/en/dashboards/functions/rollup.md
@@ -81,5 +81,5 @@ Rollups should usually be avoided in [monitor][5] queries, because of the possib
 [1]: /dashboards/functions/#proceed-to-time-aggregation
 [2]: /metrics/faq/rollup-for-distributions-with-percentiles/
 [3]: https://www.datadoghq.com/blog/visualize-statsd-metrics-counts-graphing
-[4]: /developers/metrics/type_modifiers/
+[4]: /metrics/type_modifiers/
 [5]: /monitors/monitor_types/metric/

--- a/content/en/dashboards/guide/how-to-graph-percentiles-in-datadog.md
+++ b/content/en/dashboards/guide/how-to-graph-percentiles-in-datadog.md
@@ -45,8 +45,8 @@ Histograms are computed every 10 seconds on a host per host basis by the Datadog
 
 [Read more about the Datadog histograms characteristics][5]
 
-[1]: /developers/metrics/dogstatsd_metrics_submission/
+[1]: /metrics/dogstatsd_metrics_submission/
 [2]: https://github.com/DataDog/dd-agent/blob/master/aggregator.py
 [3]: /developers/community/libraries/
-[4]: /developers/metrics/histograms/
+[4]: /metrics/histograms/
 [5]: /developers/faq/characteristics-of-datadog-histograms/

--- a/content/en/dashboards/guide/query-to-the-graph.md
+++ b/content/en/dashboards/guide/query-to-the-graph.md
@@ -162,10 +162,10 @@ Documentation about [StatsD/DogStatsD][10].
 [1]: /dashboards/timeboard/
 [2]: /dashboards/screenboard/
 [3]: /agent/
-[4]: /developers/metrics/custom_metrics/
+[4]: /metrics/custom_metrics/
 [5]: /dashboards/faq/how-is-data-aggregated-in-graphs/
 [6]: /dashboards/faq/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs/
 [7]: /dashboards/functions/rollup/
 [8]: /dashboards/faq/i-m-switching-between-the-sum-min-max-avg-aggregators-but-the-values-look-the-same/
 [9]: https://www.datadoghq.com/blog/visualize-statsd-metrics-counts-graphing
-[10]: /developers/metrics/dogstatsd_metrics_submission/
+[10]: /metrics/dogstatsd_metrics_submission/

--- a/content/en/developers/_index.md
+++ b/content/en/developers/_index.md
@@ -72,7 +72,7 @@ A [custom check][11], also know as a custom Agent check, lets you send internal 
 ### Sending data by data types
 
 {{< whatsnext desc="Learn about the types of data you can submit to Datadog and how to submit them:" >}}
-    {{< nextlink href="/developers/metrics" >}}<u>Custom Metrics</u>: A deep-dive into custom metrics at Datadog. This section explains metrics types, what they represent, how to submit them, and how they are used throughout Datadog.{{< /nextlink >}}
+    {{< nextlink href="/metrics" >}}<u>Custom Metrics</u>: A deep-dive into custom metrics at Datadog. This section explains metrics types, what they represent, how to submit them, and how they are used throughout Datadog.{{< /nextlink >}}
     {{< nextlink href="events/guides/" >}}<u>Events</u>: Explore how to submit events to Datadog with custom Agent checks, DogStatsD, or the Datadog API.{{< /nextlink >}}
     {{< nextlink href="/developers/service_checks" >}}<u>Service Checks</u>: Explore how to submit the up or down status of a specific service to Datadog.{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/developers/community/libraries.md
+++ b/content/en/developers/community/libraries.md
@@ -169,7 +169,7 @@ A Winston Datadog [transport][62].
 
 If you've written a Datadog library and would like to add it to this page, send an email to [opensource@datadoghq.com][65].
 
-[1]: /developers/metrics/dogstatsd_metrics_submission/
+[1]: /metrics/dogstatsd_metrics_submission/
 [2]: /tracing/
 [3]: /serverless/
 [4]: /api/
@@ -214,7 +214,7 @@ If you've written a Datadog library and would like to add it to this page, send 
 [43]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-datadog.html
 [44]: https://github.com/brigade/logstash-output-dogstatsd
 [45]: https://docs.moogsoft.com/AIOps.6.2.0/Datadog-Solution-Pak_13737047.html
-[46]: /developers/metrics/custom_metrics/
+[46]: /metrics/custom_metrics/
 [47]: https://github.com/simplifi/ngx_lua_datadog
 [48]: https://github.com/dailymotion/lua-resty-dogstatsd
 [49]: http://www.mediba.jp

--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -43,7 +43,7 @@ DogStatsD accepts [custom metrics][5], [events][6], and [service checks][7] over
 
 Because it uses UDP, your application can send metrics to DogStatsD and resume its work without waiting for a response. If DogStatsD ever becomes unavailable, your application doesn't experience an interruption.
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/dogstatsd.png" alt="dogstatsd"   >}}
+{{< img src="metrics/dogstatsd_metrics_submission/dogstatsd.png" alt="dogstatsd"   >}}
 
 As it receives data, DogStatsD aggregates multiple data points for each unique metric into a single data point over a period of time called _the flush interval_ (ten seconds, by default).
 
@@ -174,7 +174,7 @@ To set [tag cardinality][5] for the metrics collected using origin detection, se
 [3]: https://kubernetes.io/docs/setup/independent/troubleshooting-kubeadm/#hostport-services-do-not-work
 [4]: /developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
 [5]: /getting_started/tagging/assigning_tags/#environment-variables
-[6]: /developers/metrics/custom_metrics/
+[6]: /metrics/custom_metrics/
 {{% /tab %}}
 {{% tab "Helm" %}}
 
@@ -211,7 +211,7 @@ To gather custom metrics with [DogStatsD][1] with helm:
 
      With this, any pod running your application is able to send DogStatsD metrics through port `8125` on `$DD_AGENT_HOST`.
 
-[1]: /developers/metrics/dogstatsd_metrics_submission/
+[1]: /metrics/dogstatsd_metrics_submission/
 [2]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
 [3]: https://github.com/containernetworking/cni
 [4]: https://kubernetes.io/docs/setup/independent/troubleshooting-kubeadm/#hostport-services-do-not-work
@@ -516,7 +516,7 @@ For more information, see the [NonBlockingStatsDClient Class][1] documentation.
 DogStatsD and StatsD are broadly similar, however, DogStatsD contains advanced features which are specific to Datadog, including available data types, events, service checks, and tags:
 
 {{< whatsnext desc="">}}
-{{< nextlink href="/developers/metrics/dogstatsd_metrics_submission/" >}}Send metrics to Datadog with DogStatsD.{{< /nextlink >}}
+{{< nextlink href="/metrics/dogstatsd_metrics_submission/" >}}Send metrics to Datadog with DogStatsD.{{< /nextlink >}}
 {{< nextlink href="/events/guides/dogstatsd/" >}}Send events to Datadog with DogStatsD.{{< /nextlink >}}
 {{< nextlink href="/developers/service_checks/dogstatsd_service_checks_submission/" >}}Send service checks to Datadog with DogStatsD.{{< /nextlink >}}
 {{< /whatsnext >}}
@@ -524,11 +524,11 @@ DogStatsD and StatsD are broadly similar, however, DogStatsD contains advanced f
 If you're interested in learning more about the datagram format used by DogStatsD, or want to develop your own Datadog library, see the [datagram and shell usage][9] section, which also explains how to send metrics and events straight from the command line.
 
 [1]: https://github.com/etsy/statsd
-[2]: /developers/metrics/dogstatsd_metrics_submission/
+[2]: /metrics/dogstatsd_metrics_submission/
 [3]: https://hub.docker.com/r/datadog/dogstatsd
 [4]: https://gcr.io/datadoghq/dogstatsd
-[5]: /developers/metrics/custom_metrics/
+[5]: /metrics/custom_metrics/
 [6]: /events/guides/dogstatsd/
 [7]: /developers/service_checks/dogstatsd_service_checks_submission/
 [8]: /getting_started/tagging/unified_service_tagging
-[9]: /developers/metrics/
+[9]: /metrics/

--- a/content/en/developers/dogstatsd/data_aggregation.md
+++ b/content/en/developers/dogstatsd/data_aggregation.md
@@ -49,9 +49,9 @@ Among all values received during the same flush interval, the aggregated value s
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /developers/dogstatsd/
-[2]: /developers/metrics/dogstatsd_metrics_submission/
-[3]: /developers/metrics/types/?tab=count#metric-types
-[4]: /developers/metrics/types/
-[5]: /developers/metrics/types/?tab=gauge#metric-types
-[6]: /developers/metrics/types/?tab=histogram#metric-types
-[7]: /developers/metrics/types/?tab=distribution#metric-types
+[2]: /metrics/dogstatsd_metrics_submission/
+[3]: /metrics/types/?tab=count#metric-types
+[4]: /metrics/types/
+[5]: /metrics/types/?tab=gauge#metric-types
+[6]: /metrics/types/?tab=histogram#metric-types
+[7]: /metrics/types/?tab=distribution#metric-types

--- a/content/en/developers/dogstatsd/datagram_shell.md
+++ b/content/en/developers/dogstatsd/datagram_shell.md
@@ -41,8 +41,8 @@ Here are some example datagrams:
 - `users.online:1|c|@0.5|#country:china`: Track active China users and use a sample rate.
 
 
-[1]: /developers/metrics/#naming-metrics
-[2]: /developers/metrics/types/
+[1]: /metrics/#naming-metrics
+[2]: /metrics/types/
 [3]: /getting_started/tagging/
 {{% /tab %}}
 {{% tab "Events" %}}

--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -692,6 +692,6 @@ See [DataDog/dogstatsd-csharp-client][1] for more information about the client c
 [1]: /agent/
 [2]: /developers/dogstatsd/unix_socket/
 [3]: /developers/dogstatsd/#code
-[4]: /developers/metrics/dogstatsd_metrics_submission/#sample-rates
+[4]: /metrics/dogstatsd_metrics_submission/#sample-rates
 [5]: /developers/dogstatsd/high_throughput/#note-on-sysctl-in-kubernetes
 [6]: https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/

--- a/content/en/developers/dogstatsd/unix_socket.md
+++ b/content/en/developers/dogstatsd/unix_socket.md
@@ -3,7 +3,7 @@ title: DogStatsD over Unix Domain Socket
 kind: documentation
 description: 'Usage documentation for DogStatsD over Unix Domain Sockets'
 aliases:
-    - /developers/metrics/unix_socket/
+    - /metrics/unix_socket/
 further_reading:
     - link: 'developers/dogstatsd'
       tag: 'Documentation'
@@ -229,8 +229,8 @@ For guidelines on creating additional implementation options, see the [datadog-a
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /developers/metrics/dogstatsd_metrics_submission/
-[2]: /developers/metrics/custom_metrics/
+[1]: /metrics/dogstatsd_metrics_submission/
+[2]: /metrics/custom_metrics/
 [3]: https://github.com/DataDog/datadog-go#unix-domain-sockets-client
 [4]: https://github.com/DataDog/java-dogstatsd-client#unix-domain-socket-support
 [5]: https://github.com/DataDog/datadogpy#instantiate-the-dogstatsd-client-with-uds

--- a/content/en/developers/faq/is-there-an-alternative-to-dogstatsd-and-the-api-to-submit-metrics-threadstats.md
+++ b/content/en/developers/faq/is-there-an-alternative-to-dogstatsd-and-the-api-to-submit-metrics-threadstats.md
@@ -84,7 +84,7 @@ For more information, see the [Threadstats aggregation][6] documentation.
 
 [1]: https://github.com/DataDog/datadogpy/tree/master/datadog
 [2]: /api/
-[3]: /developers/metrics/dogstatsd_metrics_submission/
+[3]: /metrics/dogstatsd_metrics_submission/
 [4]: https://github.com/DataDog/datadogpy
 [5]: /developers/dogstatsd/
 [6]: https://github.com/DataDog/datadogpy/blob/master/datadog/threadstats/metrics.py

--- a/content/en/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
+++ b/content/en/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
@@ -93,6 +93,6 @@ dog metric post -h
 {{< img src="developers/faq/dogshell_test.png" alt="dogshell_test"  >}}
 
 [1]: https://github.com/DataDog/datadogpy
-[2]: /developers/metrics/dogstatsd_metrics_submission/
+[2]: /metrics/dogstatsd_metrics_submission/
 [3]: https://github.com/DataDog/datadogpy#installation
 [4]: https://github.com/DataDog/datadogpy/tree/master/datadog/dogshell

--- a/content/en/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags.md
+++ b/content/en/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags.md
@@ -2,7 +2,7 @@
 title: What best practices are recommended for naming metrics and tags?
 kind: faq
 further_reading:
-- link: "/developers/metrics/"
+- link: "/metrics/"
   tag: "Documentation"
   text: "Learn more about Datadog metrics"
 - link: "/getting_started/tagging/"

--- a/content/en/getting_started/agent/_index.md
+++ b/content/en/getting_started/agent/_index.md
@@ -111,7 +111,7 @@ For help troubleshooting the Agent:
 {{< /whatsnext >}}
 
 [1]: /integrations/
-[2]: /developers/metrics/dogstatsd_metrics_submission/
+[2]: /metrics/dogstatsd_metrics_submission/
 [3]: /api/
 [4]: /infrastructure/process/
 [5]: /logs/

--- a/content/en/getting_started/integrations/_index.md
+++ b/content/en/getting_started/integrations/_index.md
@@ -216,6 +216,6 @@ tagging
 [38]: /agent/guide/agent-configuration-files/#agent-configuration-directory
 [39]: https://app.datadoghq.com/event/stream
 [40]: https://github.com/DataDog/integrations-core/blob/master/http_check/datadog_checks/http_check/data/conf.yaml.example#L13
-[41]: /developers/metrics/
-[42]: /developers/metrics/custom_metrics/
+[41]: /metrics/
+[42]: /metrics/custom_metrics/
 [43]: /monitors/guide/visualize-your-service-check-in-the-datadog-ui/

--- a/content/en/getting_started/tagging/_index.md
+++ b/content/en/getting_started/tagging/_index.md
@@ -112,7 +112,7 @@ After you have [assigned tags][3] at the host and [integration][9] level, start 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /getting_started/tagging/using_tags/
-[2]: /developers/metrics/
+[2]: /metrics/
 [3]: /getting_started/tagging/assigning_tags/
 [4]: /getting_started/tagging/assigning_tags/#configuration-files
 [5]: /getting_started/tagging/assigning_tags/#ui

--- a/content/en/getting_started/tagging/assigning_tags.md
+++ b/content/en/getting_started/tagging/assigning_tags.md
@@ -97,7 +97,7 @@ hostname: mymachine.mydomain
 [1]: /getting_started/integrations/
 [2]: /agent/guide/agent-configuration-files/
 [3]: /getting_started/tagging/#defining-tags
-[4]: /developers/metrics/dogstatsd_metrics_submission/#host-tag-key
+[4]: /metrics/dogstatsd_metrics_submission/#host-tag-key
 [5]: /dashboards/querying/#arithmetic-between-two-metrics
 {{% /tab %}}
 {{% tab "Agent v5" %}}
@@ -139,7 +139,7 @@ hostname: mymachine.mydomain
 [1]: /getting_started/integrations/
 [2]: /agent/guide/agent-configuration-files/
 [3]: /getting_started/tagging/#defining-tags
-[4]: /developers/metrics/dogstatsd_metrics_submission/#host-tag-key
+[4]: /metrics/dogstatsd_metrics_submission/#host-tag-key
 [5]: /dashboards/querying/#arithmetic-between-two-metrics
 {{% /tab %}}
 {{< /tabs >}}
@@ -299,7 +299,7 @@ Create percentile aggregations within [Distribution Metrics][1] by applying an a
 {{< img src="tagging/assigning_tags/global_metrics_selection.png" alt="Create Monitor Tags" style="width:80%;">}}
 
 [1]: /metrics/distributions/
-[2]: /developers/metrics/custom_metrics/
+[2]: /metrics/custom_metrics/
 {{% /tab %}}
 {{% tab "Integrations" %}}
 
@@ -409,4 +409,4 @@ Special consideration is necessary when assigning the `host` tag to DogStatsD me
 [7]: /tracing/setup/
 [8]: /developers/dogstatsd/
 [9]: /developers/community/libraries/
-[10]: /developers/metrics/dogstatsd_metrics_submission/#host-tag-key
+[10]: /metrics/dogstatsd_metrics_submission/#host-tag-key

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -320,7 +320,7 @@ If your service has access to `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`, then the
 
 **Note**: The Datadog DogStatsD clients for .NET and PHP do not yet support this functionality.
 
-[1]: /developers/metrics/
+[1]: /metrics/
 {{% /tab %}}
 
 {{% tab "System Metrics" %}}

--- a/content/en/infrastructure/process/increase_process_retention.md
+++ b/content/en/infrastructure/process/increase_process_retention.md
@@ -74,5 +74,5 @@ Once created, you can use process distribution aggregate and percentile metrics 
 
 [1]: https://app.datadoghq.com/process?view=metrics
 [2]: https://app.datadoghq.com/process
-[3]: /developers/metrics/custom_metrics/
+[3]: /metrics/custom_metrics/
 [4]: /dashboards/correlations/

--- a/content/en/integrations/faq/how-to-collect-metrics-from-custom-mysql-queries.md
+++ b/content/en/integrations/faq/how-to-collect-metrics-from-custom-mysql-queries.md
@@ -65,4 +65,4 @@ Adding the following custom query to your MySQL `conf.yaml` collects the metric 
 
 [1]: https://github.com/DataDog/integrations-core/blob/master/mysql/datadog_checks/mysql/data/conf.yaml.example
 [2]: /api/
-[3]: /developers/metrics/dogstatsd_metrics_submission/
+[3]: /metrics/dogstatsd_metrics_submission/

--- a/content/en/integrations/faq/snmp.md
+++ b/content/en/integrations/faq/snmp.md
@@ -322,7 +322,7 @@ Additional helpful documentation, links, and articles:
 [8]: https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/conf.yaml.example#L3
 [9]: /agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [10]: /agent/kubernetes/integrations/
-[11]: /developers/metrics/custom_metrics/
+[11]: /metrics/custom_metrics/
 [12]: /account_management/billing/custom_metrics/
 [13]: /agent/guide/agent-commands/#agent-status-and-information
 [14]: /help/

--- a/content/en/integrations/guide/collect-sql-server-custom-metrics.md
+++ b/content/en/integrations/guide/collect-sql-server-custom-metrics.md
@@ -197,5 +197,5 @@ If your custom metrics are not appearing in Datadog, check the Agent log file. I
 
 [1]: /integrations/sqlserver/
 [2]: https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-databases-object
-[3]: /developers/metrics/#metric-types
-[4]: /developers/metrics/histograms/
+[3]: /metrics/#metric-types
+[4]: /metrics/histograms/

--- a/content/en/integrations/guide/mongo-custom-query-collection.md
+++ b/content/en/integrations/guide/mongo-custom-query-collection.md
@@ -59,7 +59,7 @@ This would emit one `gauge` metric `mongo.users` with one tag: `user:active`.
 **Note**: The metric type defined is `gauge`. See the [metric type documentation][2] to learn more.
 
 [1]: https://docs.mongodb.com/manual/reference/command/count/#dbcmd.count
-[2]: /developers/metrics/types/
+[2]: /metrics/types/
 {{% /tab %}}
 {{% tab "Find" %}}
 
@@ -90,7 +90,7 @@ This would emit one `gauge` metric `mongo.example2.user.age` with two tags: `nam
 **Note**: The metric type defined is `gauge`. See the [metric type documentation][2] to learn more.
 
 [1]: https://docs.mongodb.com/manual/reference/command/find/#dbcmd.find
-[2]: /developers/metrics/types/
+[2]: /metrics/types/
 {{% /tab %}}
 {{% tab "Aggregate" %}}
 

--- a/content/en/integrations/guide/prometheus-metrics.md
+++ b/content/en/integrations/guide/prometheus-metrics.md
@@ -59,9 +59,9 @@ If the parameter `send_distribution_buckets` is `true`, the histogram is convert
 If the parameter `send_distribution_counts_as_monotonic` is `true`, each metric ending in `_count` is submitted as `monotonic_count`. [Read more about monotonic counters][4].
 
 [1]: /agent/kubernetes/prometheus/
-[2]: /developers/metrics/types/
+[2]: /metrics/types/
 [3]: https://prometheus.io/docs/concepts/metric_types/#counter
-[4]: /developers/metrics/agent_metrics_submission/?tab=count#monotonic-count
+[4]: /metrics/agent_metrics_submission/?tab=count#monotonic-count
 [5]: https://prometheus.io/docs/concepts/metric_types/#gauge
 [6]: https://prometheus.io/docs/concepts/metric_types/#histogram
 [7]: https://www.datadoghq.com/blog/engineering/computing-accurate-percentiles-with-ddsketch/

--- a/content/en/integrations/pivotal_platform.md
+++ b/content/en/integrations/pivotal_platform.md
@@ -445,7 +445,7 @@ Your specific list of metrics may vary based on the PCF version and the deployme
 [2]: https://network.pivotal.io/products/datadog-application-monitoring
 [3]: /integrations/pivotal_pks/
 [4]: https://docs.cloudfoundry.org/buildpacks/understand-buildpacks.html#supply-script
-[5]: /developers/metrics/dogstatsd_metrics_submission/
+[5]: /metrics/dogstatsd_metrics_submission/
 [6]: https://docs.cloudfoundry.org/buildpacks/use-multiple-buildpacks.html
 [7]: https://github.com/cloudfoundry/multi-buildpack
 [8]: https://github.com/cloudfoundry/multi-buildpack#usage

--- a/content/en/logs/guide/getting-started-lwl.md
+++ b/content/en/logs/guide/getting-started-lwl.md
@@ -133,7 +133,7 @@ To learn more about Logging Without Limits™ and how to better utilize features
 [4]: https://app.datadoghq.com/logs/patterns
 [5]: /logs/live_tail/
 [6]: /logs/archives/
-[7]: /developers/metrics/
+[7]: /metrics/
 [8]: /logs/logs_to_metrics/
 [9]: /monitors/monitor_types/anomaly/
 [10]: https://app.datadoghq.com/monitors#/triggered

--- a/content/en/logs/log_configuration/logs_to_metrics.md
+++ b/content/en/logs/log_configuration/logs_to_metrics.md
@@ -87,7 +87,7 @@ An extra `status` tag is available on the `datadog.estimated_usage.logs.ingested
 [6]: /logs/search_syntax/
 [7]: /logs/explorer/facets/#quantitative-facets-measures
 [8]: /getting_started/tagging/
-[9]: /developers/metrics/custom_metrics/
+[9]: /metrics/custom_metrics/
 [10]: /security/logs/#hipaa-enabled-customers
 [11]: /account_management/billing/custom_metrics/?tab=countrategauge
-[12]: /developers/metrics/#naming-metrics
+[12]: /metrics/#naming-metrics

--- a/content/en/metrics/_index.md
+++ b/content/en/metrics/_index.md
@@ -158,10 +158,10 @@ See the [full Metrics Summary documentation][21] for more details.
 [9]: /logs/logs_to_metrics/
 [10]: /metrics/custom_metrics/
 [11]: /agent/
-[12]: /developers/metrics/dogstatsd_metrics_submission/
+[12]: /metrics/dogstatsd_metrics_submission/
 [13]: /api/
 [14]: https://docs.datadoghq.com/agent/basic_agent_usage/
-[15]: /developers/metrics/types/
+[15]: /metrics/types/
 [16]: /getting_started/tagging/using_tags/
 [17]: /dashboards/functions/
 [18]: /metrics/distributions/

--- a/content/en/metrics/agent_metrics_submission.md
+++ b/content/en/metrics/agent_metrics_submission.md
@@ -2,7 +2,7 @@
 title: "Metric Submission: Custom Agent Check"
 kind: documentation
 aliases:
-  - /developers/metrics/agent_metrics_submission/
+  - /metrics/agent_metrics_submission/
 further_reading:
 - link: "/developers/custom_checks/write_agent_check/"
   tag: "Documentation"
@@ -226,14 +226,14 @@ Follow the steps below to create a [custom Agent check][2] that sends all metric
 
 6. Verify your metrics are reporting to Datadog on your [Metric Summary page][6]:
 
-{{< img src="developers/metrics/agent_metrics_submission/metrics_metrics_summary.png" alt="Metrics in metric summary"  style="width:80%;">}}
+{{< img src="metrics/agent_metrics_submission/metrics_metrics_summary.png" alt="Metrics in metric summary"  style="width:80%;">}}
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /developers/custom_checks/write_agent_check/
-[2]: /developers/metrics/types/
+[2]: /metrics/types/
 [3]: /agent/guide/agent-configuration-files/#agent-configuration-directory
 [4]: /agent/guide/agent-commands/#restart-the-agent
 [5]: /agent/guide/agent-commands/#agent-information

--- a/content/en/metrics/custom_metrics.md
+++ b/content/en/metrics/custom_metrics.md
@@ -5,10 +5,10 @@ aliases:
   - /guides/metrics/
   - /metrictypes/
   - /units/
-  - /developers/metrics/datagram_shell
-  - /developers/metrics/custom_metrics/
+  - /metrics/datagram_shell
+  - /metrics/custom_metrics/
   - /getting_started/custom_metrics
-  - /developers/metrics/
+  - /metrics/
 further_reading:
 - link: "/developers/dogstatsd/"
   tag: "Documentation"
@@ -54,9 +54,9 @@ The following custom metric naming convention must be followed:
 ## Submitting custom metrics
 
 {{< whatsnext desc="There are multiple ways to send metrics to Datadog:">}}
-    {{< nextlink href="/developers/metrics/agent_metrics_submission" >}}Custom Agent check{{< /nextlink >}}
-    {{< nextlink href="/developers/metrics/dogstatsd_metrics_submission" >}}DogStatsD{{< /nextlink >}}
-    {{< nextlink href="/developers/metrics/powershell_metrics_submission" >}}PowerShell{{< /nextlink >}}
+    {{< nextlink href="/metrics/agent_metrics_submission" >}}Custom Agent check{{< /nextlink >}}
+    {{< nextlink href="/metrics/dogstatsd_metrics_submission" >}}DogStatsD{{< /nextlink >}}
+    {{< nextlink href="/metrics/powershell_metrics_submission" >}}PowerShell{{< /nextlink >}}
     {{< nextlink href="/serverless/custom_metrics" >}}AWS Lambda{{< /nextlink >}}
     {{< nextlink href="/api/v1/metrics/#submit-metrics" >}}Datadog's HTTP API{{< /nextlink >}}
     {{< nextlink href="/logs/log_configuration/logs_to_metrics/#generate-a-log-based-metric" >}}Generate Log-based metrics{{< /nextlink >}}
@@ -76,13 +76,13 @@ You can also use one of the [Datadog official and community contributed API and 
 
 [1]: /integrations/
 [2]: /account_management/billing/custom_metrics/#standard-integrations
-[3]: /developers/metrics/dogstatsd_metrics_submission/
-[4]: /developers/metrics/agent_metrics_submission/
+[3]: /metrics/dogstatsd_metrics_submission/
+[4]: /metrics/agent_metrics_submission/
 [5]: https://app.datadoghq.com/account/usage/hourly
 [6]: /account_management/billing/custom_metrics/#counting-custom-metrics
 [7]: /metrics
-[8]: /developers/metrics/types/
-[9]: /developers/metrics/types/?tab=rate#metric-types
-[10]: /developers/metrics/types/?tab=count#metric-types
+[8]: /metrics/types/
+[9]: /metrics/types/?tab=rate#metric-types
+[10]: /metrics/types/?tab=count#metric-types
 [11]: /developers/dogstatsd/data_aggregation/#how-is-aggregation-performed-with-the-dogstatsd-server
 [12]: /developers/community/libraries/

--- a/content/en/metrics/distributions.md
+++ b/content/en/metrics/distributions.md
@@ -6,7 +6,7 @@ aliases:
   - /developers/faq/characteristics-of-datadog-histograms/
   - /graphing/metrics/distributions/
 further_reading:
-  - link: "/developers/metrics/dogstatsd_metrics_submission/"
+  - link: "/metrics/dogstatsd_metrics_submission/"
     tag: "Documentation"
     text: "Using Distributions in DogStatsD"
 ---
@@ -66,6 +66,6 @@ https://app.datadoghq.com/event/stream?tags_execution=and&per_page=30&query=tags
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: /developers/metrics/types/
+[1]: /metrics/types/
 [2]: https://app.datadoghq.com/metric/distribution_metrics
 [3]: https://app.datadoghq.com/event/stream

--- a/content/en/metrics/dogstatsd_metrics_submission.md
+++ b/content/en/metrics/dogstatsd_metrics_submission.md
@@ -6,12 +6,12 @@ aliases:
   - /developers/faq/reduce-submission-rate
   - /developers/faq/why-is-my-counter-metric-showing-decimal-values
   - /developers/faq/dog-statsd-sample-rate-parameter-explained
-  - /developers/metrics/dogstatsd_metrics_submission/
+  - /metrics/dogstatsd_metrics_submission/
 further_reading:
 - link: "/developers/dogstatsd/"
   tag: "Documentation"
   text: "Introduction to DogStatsD"
-- link: "/developers/metrics/types/"
+- link: "/metrics/types/"
   tag: "Documentation"
   text: "Datadog Metric Types"
 ---
@@ -204,11 +204,11 @@ while (TRUE) {
 
 After running the code above, your metrics data is available to graph in Datadog:
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/increment_decrement.png" alt="Increment Decrement" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/increment_decrement.png" alt="Increment Decrement" >}}
 
 Since the value is submitted as a `COUNT` it's stored as `RATE` in Datadog. To get raw counts within Datadog, apply a function to your series such as the [Cumulative Sum][3] or [Integral][4] function:
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/increment_decrement_cumsum.png" alt="Increment Decrement with Cumsum" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/increment_decrement_cumsum.png" alt="Increment Decrement with Cumsum" >}}
 
 ### GAUGE
 
@@ -367,7 +367,7 @@ while (TRUE) {
 
 After running the code above, your metric data is available to graph in Datadog:
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/gauge.png" alt="Gauge" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/gauge.png" alt="Gauge" >}}
 
 ### SET
 
@@ -503,7 +503,7 @@ while (TRUE) {
 
 After running the code above, your metrics data is available to graph in Datadog:
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/set.png" alt="Set" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/set.png" alt="Set" >}}
 
 ### HISTOGRAM
 
@@ -672,7 +672,7 @@ The above instrumentation produces the following metrics:
 
 After running the code above, your metrics data is available to graph in Datadog:
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/histogram.png" alt="Histogram" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/histogram.png" alt="Histogram" >}}
 
 #### TIMER
 
@@ -777,7 +777,7 @@ As DogStatsD receives the timer metric data, it calculates the statistical distr
 
 DogStatsD treats `TIMER` as a `HISTOGRAM` metric. Whether you use the `TIMER` or `HISTOGRAM` metric type, you are sending the same data to Datadog. After running the code above, your metrics data is available to graph in Datadog:
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/timer.png" alt="Timer" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/timer.png" alt="Timer" >}}
 
 ### DISTRIBUTION
 
@@ -1057,11 +1057,11 @@ The host tag is assigned automatically by the Datadog Agent aggregating the metr
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /developers/dogstatsd/
-[2]: /developers/metrics/types/?tab=count#definition
+[2]: /metrics/types/?tab=count#definition
 [3]: /dashboards/functions/arithmetic/#cumulative-sum
 [4]: /dashboards/functions/arithmetic/#integral
-[5]: /developers/metrics/types/?tab=gauge#definition
-[6]: /developers/metrics/types/?tab=histogram#definition
+[5]: /metrics/types/?tab=gauge#definition
+[6]: /metrics/types/?tab=histogram#definition
 [7]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 [8]: /metrics/distributions/
-[9]: /developers/metrics/types/?tab=distribution#definition
+[9]: /metrics/types/?tab=distribution#definition

--- a/content/en/metrics/guide/tag-configuration-cardinality-estimation-tool.md
+++ b/content/en/metrics/guide/tag-configuration-cardinality-estimation-tool.md
@@ -53,7 +53,7 @@ https://api.datadoghq.com/metric/estimate?metric_name=dist.dd.dogweb.latency&gro
 
 
 [1]: /account_management/api-app-keys/
-[2]: /developers/metrics/types/?tab=distribution#metric-types
-[3]: /developers/metrics/types/?tab=distribution#calculation-of-percentile-aggregations
-[4]: /developers/metrics/types/?tab=count#metric-types
-[5]: /developers/metrics/types/?tab=gauge#metric-types
+[2]: /metrics/types/?tab=distribution#metric-types
+[3]: /metrics/types/?tab=distribution#calculation-of-percentile-aggregations
+[4]: /metrics/types/?tab=count#metric-types
+[5]: /metrics/types/?tab=gauge#metric-types

--- a/content/en/metrics/powershell_metrics_submission.md
+++ b/content/en/metrics/powershell_metrics_submission.md
@@ -4,7 +4,7 @@ kind: documentation
 aliases:
   - /developers/faq/powershell-api-examples
   - /developers/faq/submitting-metrics-via-powershell
-  - /developers/metrics/powershell_metrics_submission/
+  - /metrics/powershell_metrics_submission/
 ---
 
 Datadog can collect metrics via the Agent as well as via the API independently of which language you decide to use. This page gives examples of both using PowerShell.
@@ -150,7 +150,7 @@ $http_request.responseText
 [See the ncracker/dd_metric GitHub repository for more code examples][6].
 
 [1]: https://app.datadoghq.com/account/settings#api
-[2]: /developers/metrics/dogstatsd_metrics_submission/
+[2]: /metrics/dogstatsd_metrics_submission/
 [3]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
 [4]: /api/v1/hosts/
 [5]: /api/v1/metrics/

--- a/content/en/metrics/summary.md
+++ b/content/en/metrics/summary.md
@@ -126,9 +126,9 @@ For any particular tag key, you can:
 [1]: https://app.datadoghq.com/metric/summary
 [2]: /metrics/explorer/
 [3]: /dashboards/
-[4]: /developers/metrics/custom_metrics/
+[4]: /metrics/custom_metrics/
 [5]: /getting_started/tagging/
 [6]: /api/v1/metrics/#edit-metric-metadata
-[7]: /developers/metrics/units/
-[8]: /developers/metrics/types/
+[7]: /metrics/units/
+[8]: /metrics/types/
 [9]: /integrations/

--- a/content/en/metrics/type_modifiers.md
+++ b/content/en/metrics/type_modifiers.md
@@ -2,9 +2,9 @@
 title: Metric Type Modifiers
 kind: documentation
 aliases:
- - /developers/metrics/metric_type_modifiers
+ - /metrics/metric_type_modifiers
  - /graphing/faq/as_count_validation
- - /developers/metrics/type_modifiers/
+ - /metrics/type_modifiers/
 further_reading:
 - link: "/developers/dogstatsd/"
   tag: "Documentation"
@@ -79,7 +79,7 @@ Depending on the metric type you applied them to, the behavior differs:
 
 While it is not normally required, it is possible to change a metric's type in the [metric summary page][4]:
 
-{{< img src="developers/metrics/type_modifiers/metric_type.png" alt="Metric Type"  style="width:70%;">}}
+{{< img src="metrics/type_modifiers/metric_type.png" alt="Metric Type"  style="width:70%;">}}
 
 Example use case:
 
@@ -97,7 +97,7 @@ If you are not willing to lose the historical data submitted as a `GAUGE`, creat
 
 **Note**: For the AgentCheck, `self.increment` does not calculate the delta for a monotonically increasing counter; instead, it reports the value passed in at the check run. To send the delta value on a monotonically increasing counter, use `self.monotonic_count`.
 
-[1]: /developers/metrics/types/
+[1]: /metrics/types/
 [2]: /metrics/introduction/#time-aggregation
 [3]: /dashboards/faq/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs/
 [4]: https://app.datadoghq.com/metric/summary

--- a/content/en/metrics/types.md
+++ b/content/en/metrics/types.md
@@ -2,15 +2,15 @@
 title: Metrics Types
 kind: documentation
 aliases:
-    - /developers/metrics/counts/
-    - /developers/metrics/distributions/
-    - /developers/metrics/gauges/
-    - /developers/metrics/histograms/
-    - /developers/metrics/rates/
-    - /developers/metrics/sets/
-    - /developers/metrics_type/
-    - /developers/metrics/metrics_type/
-    - /developers/metrics/types/
+    - /metrics/counts/
+    - /metrics/distributions/
+    - /metrics/gauges/
+    - /metrics/histograms/
+    - /metrics/rates/
+    - /metrics/sets/
+    - /metrics_type/
+    - /metrics/metrics_type/
+    - /metrics/types/
 further_reading:
     - link: 'developers/dogstatsd'
       tag: 'Documentation'
@@ -246,10 +246,10 @@ Submit your COUNT type metrics from one of the following sources:
 **Note**: When submitting a COUNT metric type through DogStatsD, the metric appears as a RATE in-app to ensure relevant comparison across different Agents. Consequently, StatsD counts may appear with a decimal value within Datadog (since they are normalized over a time interval to report units per second).
 
 
-[1]: /developers/metrics/agent_metrics_submission/?tab=count#count
-[2]: /developers/metrics/agent_metrics_submission/?tab=count#monotonic-count
+[1]: /metrics/agent_metrics_submission/?tab=count#count
+[2]: /metrics/agent_metrics_submission/?tab=count#monotonic-count
 [3]: /api/v1/metrics/#submit-metrics
-[4]: /developers/metrics/dogstatsd_metrics_submission/#count
+[4]: /metrics/dogstatsd_metrics_submission/#count
 {{% /tab %}}
 {{% tab "RATE" %}}
 
@@ -263,7 +263,7 @@ Submit your RATE type metrics from one of the following sources:
 **Note**: When submitting a RATE metric type through DogStatsD, the metric appears as a GAUGE in-app to ensure relevant comparison across different Agents.
 
 
-[1]: /developers/metrics/agent_metrics_submission/?tab=rate
+[1]: /metrics/agent_metrics_submission/?tab=rate
 [2]: /api/v1/metrics/#submit-metrics
 {{% /tab %}}
 {{% tab "GAUGE" %}}
@@ -277,9 +277,9 @@ Submit your GAUGE type metrics from one of the following sources:
 | [DogStatsD][3]    | `dog.gauge(...)`                     | GAUGE           | GAUGE               |
 
 
-[1]: /developers/metrics/agent_metrics_submission/?tab=gauge
+[1]: /metrics/agent_metrics_submission/?tab=gauge
 [2]: /api/v1/metrics/#submit-metrics
-[3]: /developers/metrics/dogstatsd_metrics_submission/#gauge
+[3]: /metrics/dogstatsd_metrics_submission/#gauge
 {{% /tab %}}
 {{% tab "HISTOGRAM" %}}
 
@@ -293,8 +293,8 @@ Submit your HISTOGRAM type metrics from one of the following sources:
 **Note**: If you submit a TIMER metric to the Datadog Agent, it is equivalent to submitting a HISTOGRAM metric type within DogStatsD (not to be confused with timers in the standard StatsD). Timers represent duration data only; for example, the amount of time a section of code takes to execute or how long it takes to fully render a page.
 
 
-[1]: /developers/metrics/agent_metrics_submission/?tab=histogram
-[2]: /developers/metrics/dogstatsd_metrics_submission/#histogram
+[1]: /metrics/agent_metrics_submission/?tab=histogram
+[2]: /metrics/dogstatsd_metrics_submission/#histogram
 {{% /tab %}}
 {{% tab "DISTRIBUTION" %}}
 
@@ -305,7 +305,7 @@ Submit your DISTRIBUTION type metrics from the following source:
 | [DogStatsD][1]    | `dog.distribution(...)`    | DISTRIBUTION    | GAUGE, COUNT         |
 
 
-[1]: /developers/metrics/dogstatsd_metrics_submission/#distribution
+[1]: /metrics/dogstatsd_metrics_submission/#distribution
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -334,21 +334,21 @@ Find below a summary of all available metric submission sources and methods with
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /developers/metrics/type_modifiers/
+[1]: /metrics/type_modifiers/
 [2]: /dashboards/functions/
 [3]: /metrics/summary/
 [4]: https://statsd.readthedocs.io/en/v3.2.1/types.html#sets
-[5]: /developers/metrics/agent_metrics_submission/
-[6]: /developers/metrics/dogstatsd_metrics_submission/
+[5]: /metrics/agent_metrics_submission/
+[6]: /metrics/dogstatsd_metrics_submission/
 [7]: /api/v1/metrics/#submit-metrics
 [8]: /developers/dogstatsd/#how-it-works
-[9]: /developers/metrics/agent_metrics_submission/?tab=count#count
-[10]: /developers/metrics/agent_metrics_submission/?tab=count#monotonic-count
-[11]: /developers/metrics/agent_metrics_submission/?tab=gauge
-[12]: /developers/metrics/agent_metrics_submission/?tab=histogram
-[13]: /developers/metrics/agent_metrics_submission/?tab=rate
-[14]: /developers/metrics/dogstatsd_metrics_submission/#gauge
-[15]: /developers/metrics/dogstatsd_metrics_submission/#distribution
-[16]: /developers/metrics/dogstatsd_metrics_submission/#count
-[17]: /developers/metrics/dogstatsd_metrics_submission/#set
-[18]: /developers/metrics/dogstatsd_metrics_submission/#histogram
+[9]: /metrics/agent_metrics_submission/?tab=count#count
+[10]: /metrics/agent_metrics_submission/?tab=count#monotonic-count
+[11]: /metrics/agent_metrics_submission/?tab=gauge
+[12]: /metrics/agent_metrics_submission/?tab=histogram
+[13]: /metrics/agent_metrics_submission/?tab=rate
+[14]: /metrics/dogstatsd_metrics_submission/#gauge
+[15]: /metrics/dogstatsd_metrics_submission/#distribution
+[16]: /metrics/dogstatsd_metrics_submission/#count
+[17]: /metrics/dogstatsd_metrics_submission/#set
+[18]: /metrics/dogstatsd_metrics_submission/#histogram

--- a/content/en/metrics/units.md
+++ b/content/en/metrics/units.md
@@ -2,8 +2,8 @@
 title: Metrics Units
 kind: documentation
 aliases:
-- /developers/metrics/metrics_units
-- /developers/metrics/units/
+- /metrics/metrics_units
+- /metrics/units/
 further_reading:
 - link: "/dashboards/"
   tag: "Documentation"
@@ -14,13 +14,13 @@ further_reading:
 
 Metric units are displayed automatically in places such as on timeseries graphs, query value widgets, and top lists.
 
-{{< img src="developers/metrics/units/redis_dash_metrics_units.png" alt="Redis dash metric units"  style="width:100%;">}}
+{{< img src="metrics/units/redis_dash_metrics_units.png" alt="Redis dash metric units"  style="width:100%;">}}
 
 On timeseries graphs, you can hover your cursor over any graph to see the relevant units. The raw data is automatically converted to readable display units such as fractions of a second (ms) and millions of bytes per second (MiB/s).
 
 Units are also displayed at the bottom of timeboard graphs, and metric descriptions are available by selecting **Metrics Info** from the gear dropdown:
 
-{{< img src="developers/metrics/units/annotated_ops.png" alt="Annotated ops"  style="width:100%;">}}
+{{< img src="metrics/units/annotated_ops.png" alt="Annotated ops"  style="width:100%;">}}
 
 To change a metric unit, navigate to the [metric summary][1] page and select a metric. Click **Edit** under **Metadata** and select a unit, such as `bit` or `byte` from the dropdown menu.
 

--- a/content/en/monitors/guide/slo-checklist.md
+++ b/content/en/monitors/guide/slo-checklist.md
@@ -100,7 +100,7 @@ _Example: 99% of requests should complete in less than 250 ms over a 30-day wind
 
 [1]: https://app.datadoghq.com/slo
 [2]: https://app.datadoghq.com/monitors#create/metric
-[3]: /developers/metrics
+[3]: /metrics
 [4]: /integrations
 [5]: /tracing/generate_metrics/
 [6]: /logs/logs_to_metrics/

--- a/content/en/serverless/azure_app_services.md
+++ b/content/en/serverless/azure_app_services.md
@@ -170,5 +170,5 @@ d. Still need help? Contact [Datadog support][18].
 [14]: /logs/log_collection/csharp/?tab=serilog#agentless-logging
 [15]: https://www.nuget.org/packages/DogStatsD-CSharp-Client
 [16]: /developers/dogstatsd/?tab=net#code
-[17]: /developers/metrics/
+[17]: /metrics/
 [18]: /help

--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -225,4 +225,4 @@ Where:
 [7]: /agent/guide/private-link/
 [8]: /agent/proxy/
 [9]: /serverless/forwarder/
-[10]: /developers/metrics/
+[10]: /metrics/

--- a/content/en/tracing/generate_metrics/_index.md
+++ b/content/en/tracing/generate_metrics/_index.md
@@ -79,7 +79,7 @@ After a metric is created, only two fields can be updated:
 
 [1]: /tracing/trace_retention_and_ingestion
 [2]: /account_management/billing/custom_metrics/
-[3]: https://docs.datadoghq.com/developers/metrics/#overview
+[3]: https://docs.datadoghq.com/metrics/#overview
 [4]: /monitors/monitor_types/anomaly/#overview
 [5]: /tracing/trace_search_and_analytics/
 [6]: /tracing/trace_search_and_analytics/query_syntax/#analytics-query
@@ -87,4 +87,4 @@ After a metric is created, only two fields can be updated:
 [8]: https://app.datadoghq.com/apm/getting-started
 [9]: https://app.datadoghq.com/apm/traces/generate-metrics
 [10]: /tracing/trace_search_and_analytics/query_syntax/
-[11]: /developers/metrics/#naming-metrics
+[11]: /metrics/#naming-metrics

--- a/content/en/tracing/guide/ddsketch_trace_metrics.md
+++ b/content/en/tracing/guide/ddsketch_trace_metrics.md
@@ -71,6 +71,6 @@ max:trace.sample_span{datacenter:production, service:bar, resource:ghijk5678}
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /metrics/distributions/
-[2]: /developers/metrics/types/?tab=distribution#metric-types
+[2]: /metrics/types/?tab=distribution#metric-types
 [3]: /tracing/guide/setting_primary_tags_to_scope/#add-a-second-primary-tag-in-datadog
 [4]: https://www.datadoghq.com/blog/engineering/computing-accurate-percentiles-with-ddsketch/

--- a/content/en/tracing/guide/metrics_namespace.md
+++ b/content/en/tracing/guide/metrics_namespace.md
@@ -194,8 +194,8 @@ With the following definitions:
 [2]: /tracing/setup/
 [3]: /tracing/visualization/#trace-metrics
 [4]: /tracing/guide/setting_primary_tags_to_scope/#add-a-second-primary-tag-in-datadog
-[5]: /developers/metrics/types/?tab=count#metric-types
-[6]: /developers/metrics/types/?tab=gauge#metric-types
+[5]: /metrics/types/?tab=count#metric-types
+[6]: /metrics/types/?tab=gauge#metric-types
 [7]: /tracing/visualization/services_list/#services-types
 [8]: /tracing/visualization/#services
 [9]: /tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm/

--- a/content/en/tracing/runtime_metrics/nodejs.md
+++ b/content/en/tracing/runtime_metrics/nodejs.md
@@ -44,7 +44,7 @@ Along with displaying these metrics in your APM Service Page, Datadog provides a
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/apm/services
-[2]: /developers/metrics/dogstatsd_metrics_submission/#setup
+[2]: /metrics/dogstatsd_metrics_submission/#setup
 [3]: /agent/docker/#dogstatsd-custom-metrics
 [4]: /developers/dogstatsd/?tab=kubernetes#agent
 [5]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task

--- a/content/en/tracing/runtime_metrics/python.md
+++ b/content/en/tracing/runtime_metrics/python.md
@@ -54,7 +54,7 @@ Along with displaying these metrics in your APM Service Page, Datadog provides a
 
 [1]: https://app.datadoghq.com/apm/services
 [2]: https://github.com/DataDog/dd-trace-py/releases/tag/v0.24.0
-[3]: /developers/metrics/dogstatsd_metrics_submission/#setup
+[3]: /metrics/dogstatsd_metrics_submission/#setup
 [4]: /agent/docker/#dogstatsd-custom-metrics
 [5]: /developers/dogstatsd/?tab=kubernetes#agent
 [6]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task

--- a/content/en/tracing/runtime_metrics/ruby.md
+++ b/content/en/tracing/runtime_metrics/ruby.md
@@ -63,7 +63,7 @@ Along with displaying these metrics in your APM Service Page, Datadog provides a
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://rubygems.org/gems/dogstatsd-ruby
-[2]: /developers/metrics/dogstatsd_metrics_submission/#setup
+[2]: /metrics/dogstatsd_metrics_submission/#setup
 [3]: https://app.datadoghq.com/apm/service
 [4]: /agent/docker/#dogstatsd-custom-metrics
 [5]: /developers/dogstatsd/?tab=kubernetes#agent

--- a/content/fr/account_management/billing/custom_metrics.md
+++ b/content/fr/account_management/billing/custom_metrics.md
@@ -68,9 +68,9 @@ Pour connaître la température en Floride, il vous suffit de combiner les métr
 - `temperature{country:USA, state:Florida, city:Miami}`
 - `temperature{state:Florida, city:Miami, country:USA}`
 
-[1]: /fr/developers/metrics/types/?tab=count#metric-types
-[2]: /fr/developers/metrics/types/?tab=rate#metric-types
-[3]: /fr/developers/metrics/types/?tab=gauge#metric-types
+[1]: /fr/metrics/types/?tab=count#metric-types
+[2]: /fr/metrics/types/?tab=rate#metric-types
+[3]: /fr/metrics/types/?tab=gauge#metric-types
 {{% /tab %}}
 {{% tab "Histogram" %}}
 
@@ -91,8 +91,8 @@ Par défaut, l'Agent génère cinq métriques custom pour chacune des quatre com
 - Configurez les agrégations par centile que vous souhaitez envoyer à Datadog à l'aide du paramètre `histogram_percentiles` dans votre [fichier de configuration datadog.yaml][2]. Par défaut, seul le 95e centile, `95percentile`, est envoyé à Datadog.
 
 
-[1]: /fr/developers/metrics/types/?tab=histogram#metric-types
-[2]: /fr/developers/metrics/types/?tab=histogram#definition
+[1]: /fr/metrics/types/?tab=histogram#metric-types
+[2]: /fr/metrics/types/?tab=histogram#definition
 [3]: /fr/agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{% tab "Distribution" %}}
@@ -130,7 +130,7 @@ Vous avez la possibilité de personnaliser les agrégations de [combinaisons de 
 
 Le nombre de métriques custom envoyées par une [métrique DISTRIBUTION][1] correspond au nombre de combinaisons uniques de nom de métrique et de valeurs de tag multiplié par cinq. Ainsi, une fois les tags personnalisés, la métrique `request.Latency` envoie **5\*3 = 15 métriques custom** au total.
 
-[1]: /fr/developers/metrics/types/?tab=distribution#definition
+[1]: /fr/metrics/types/?tab=distribution#definition
 [2]: /fr/metrics/distributions/#customize-tagging
 {{% /tab %}}
 {{< /tabs >}}
@@ -174,8 +174,8 @@ Pour toute question technique, contactez [l'assistance Datadog][24].
 Pour toute question concernant la facturation, contactez votre [chargé de compte][9].
 
 [1]: /fr/integrations/
-[2]: /fr/developers/metrics/custom_metrics/
-[3]: /fr/developers/metrics/types/#metric-types
+[2]: /fr/metrics/custom_metrics/
+[3]: /fr/metrics/types/#metric-types
 [4]: /fr/account_management/users/default_roles/
 [5]: https://app.datadoghq.com/account/usage/hourly
 [6]: /fr/account_management/billing/usage_details/

--- a/content/fr/account_management/billing/pricing.md
+++ b/content/fr/account_management/billing/pricing.md
@@ -80,7 +80,7 @@ Pour toute question technique, contactez [l'assistance Datadog][5].
 Contactez le [service commercial][6] ou votre [chargé de compte][7] pour toute question concernant la tarification horaire ou la facturation pour votre compte.
 
 [1]: https://www.datadoghq.com/pricing
-[2]: /fr/developers/metrics/custom_metrics/
+[2]: /fr/metrics/custom_metrics/
 [3]: /fr/tracing/trace_retention_and_ingestion/#retention-filters
 [4]: /fr/tracing/trace_retention_and_ingestion/
 [5]: /fr/help/

--- a/content/fr/account_management/billing/usage_details.md
+++ b/content/fr/account_management/billing/usage_details.md
@@ -105,6 +105,6 @@ Pour toute question technique, contactez [l'assistance Datadog][3].
 Pour toute question concernant la facturation, contactez votre [chargé de compte][4].
 
 [1]: https://app.datadoghq.com/account/usage/hourly
-[2]: /fr/developers/metrics/custom_metrics/
+[2]: /fr/metrics/custom_metrics/
 [3]: /fr/help/
 [4]: mailto:success@datadoghq.com

--- a/content/fr/agent/basic_agent_usage/_index.md
+++ b/content/fr/agent/basic_agent_usage/_index.md
@@ -62,12 +62,12 @@ Le Forwarder de l'Agent envoie les métriques à Datadog via HTTPS. Une mise en 
 
 Dans la version 6, DogStatsD est une implémentation Golang du daemon d'agrégation des métriques [StatsD d'Etsy][5]. Il est utilisé pour recueillir et rassembler des métriques arbitraires via le protocole UDP ou un socket Unix, ce qui permet d'instrumenter du code personnalisé sans augmenter la latence de votre application. En savoir plus sur [DogStatsD][6].
 
-[1]: /fr/developers/metrics/dogstatsd_metrics_submission/#metrics
+[1]: /fr/metrics/dogstatsd_metrics_submission/#metrics
 [2]: /fr/tracing/guide/terminology/
 [3]: /fr/agent/guide/network/#open-ports
 [4]: /fr/developers/custom_checks/write_agent_check/
 [5]: https://github.com/etsy/statsd
-[6]: /fr/developers/metrics/dogstatsd_metrics_submission/
+[6]: /fr/metrics/dogstatsd_metrics_submission/
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
@@ -104,7 +104,7 @@ minfds = 100  # Votre limite stricte
 ```
 
 [1]: /fr/integrations/
-[2]: /fr/developers/metrics/custom_metrics/
+[2]: /fr/metrics/custom_metrics/
 [3]: /fr/agent/guide/network/?tab=agentv5v4#open-ports
 [4]: /fr/agent/proxy/?tab=agentv5
 [5]: /fr/agent/faq/network/

--- a/content/fr/agent/versions/_index.md
+++ b/content/fr/agent/versions/_index.md
@@ -75,7 +75,7 @@ Pour découvrir l'ensemble des nouveautés de l'Agent v6 par rapport à la v5, 
 [2]: /fr/agent/guide/agent-commands/
 [3]: /fr/developers/dogstatsd/unix_socket/
 [4]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md
-[5]: /fr/developers/metrics/types/?tab=distribution#metric-types
+[5]: /fr/metrics/types/?tab=distribution#metric-types
 [6]: /fr/infrastructure/process/
 [7]: https://www.datadoghq.com/blog/monitor-prometheus-metrics
 [8]: /fr/logs/

--- a/content/fr/api/v1/rate-limits/_index.md
+++ b/content/fr/api/v1/rate-limits/_index.md
@@ -29,7 +29,7 @@ Quelques précisions concernant la politique de limitation de débit des API :
 
 [1]: /fr/help/
 [2]: /fr/api/v1/metrics/
-[3]: /fr/developers/metrics/custom_metrics/
+[3]: /fr/metrics/custom_metrics/
 [4]: /fr/api/v1/metrics/#query-timeseries-points
 [5]: /fr/api/v1/logs/#get-a-list-of-logs
 [6]: /fr/api/v1/snapshots/

--- a/content/fr/dashboards/functions/interpolation.md
+++ b/content/fr/dashboards/functions/interpolation.md
@@ -100,4 +100,4 @@ default_zero(avg:custom_metric{*})
 
 [1]: /fr/getting_started/from_the_query_to_the_graph/#proceed-to-space-aggregation
 [2]: /fr/monitors/guide/as-count-in-monitor-evaluations/
-[3]: /fr/developers/metrics/
+[3]: /fr/metrics/

--- a/content/fr/dashboards/functions/rollup.md
+++ b/content/fr/dashboards/functions/rollup.md
@@ -71,5 +71,5 @@ L'utilisation d'un cumul dans une requête de [monitor][4] est généralement à
 
 [1]: /fr/dashboards/functions/#proceed-to-time-aggregation
 [2]: https://www.datadoghq.com/blog/visualize-statsd-metrics-counts-graphing
-[3]: /fr/developers/metrics/type_modifiers/
+[3]: /fr/metrics/type_modifiers/
 [4]: /fr/monitors/monitor_types/metric/

--- a/content/fr/dashboards/guide/how-to-graph-percentiles-in-datadog.md
+++ b/content/fr/dashboards/guide/how-to-graph-percentiles-in-datadog.md
@@ -44,8 +44,8 @@ Les histogrammes sont calculés toutes les 10 secondes sur un host par l'Agent D
 
 [En savoir plus sur les caractéristiques des histogrammes Datadog][5]
 
-[1]: /fr/developers/metrics/dogstatsd_metrics_submission/
+[1]: /fr/metrics/dogstatsd_metrics_submission/
 [2]: https://github.com/DataDog/dd-agent/blob/master/aggregator.py
 [3]: /fr/developers/community/libraries/
-[4]: /fr/developers/metrics/histograms/
+[4]: /fr/metrics/histograms/
 [5]: /fr/developers/faq/characteristics-of-datadog-histograms/

--- a/content/fr/dashboards/guide/query-to-the-graph.md
+++ b/content/fr/dashboards/guide/query-to-the-graph.md
@@ -161,10 +161,10 @@ Documentation relative à [StatsD/DogStatsD][10].
 [1]: /fr/dashboards/timeboard/
 [2]: /fr/dashboards/screenboard/
 [3]: /fr/agent/
-[4]: /fr/developers/metrics/custom_metrics/
+[4]: /fr/metrics/custom_metrics/
 [5]: /fr/dashboards/faq/how-is-data-aggregated-in-graphs/
 [6]: /fr/dashboards/faq/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs/
 [7]: /fr/dashboards/functions/rollup/
 [8]: /fr/dashboards/faq/i-m-switching-between-the-sum-min-max-avg-aggregators-but-the-values-look-the-same/
 [9]: https://www.datadoghq.com/blog/visualize-statsd-metrics-counts-graphing
-[10]: /fr/developers/metrics/dogstatsd_metrics_submission/
+[10]: /fr/metrics/dogstatsd_metrics_submission/

--- a/content/fr/developers/_index.md
+++ b/content/fr/developers/_index.md
@@ -36,7 +36,7 @@ Les développeurs disposent de plusieurs options pour l'envoi des données non p
 ### Types
 
 {{< whatsnext desc="Familiarisez-vous avec les différents types de données que vous pouvez envoyer à Datadog :" >}}
-    {{< nextlink href="/developers/metrics" >}}<u>Métriques custom</u> : plongez au cœur des métriques custom de Datadog et découvrez les différents types de métriques, ce qu'ils représentent, comment les envoyer et leur rôle au sein de l'écosystème Datadog.{{< /nextlink >}}
+    {{< nextlink href="/metrics" >}}<u>Métriques custom</u> : plongez au cœur des métriques custom de Datadog et découvrez les différents types de métriques, ce qu'ils représentent, comment les envoyer et leur rôle au sein de l'écosystème Datadog.{{< /nextlink >}}
     {{< nextlink href="/developers/events" >}}<u>Événements</u> : découvrez comment envoyer des événements à Datadog avec des checks custom d'Agent, DogStatsD ou l'API Datadog.{{< /nextlink >}}
     {{< nextlink href="/developers/service_checks" >}}<u>Checks de service</u> : apprenez à envoyer des checks de service à Datadog avec des checks custom d'Agent, DogStatsD ou l'API Datadog{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/fr/developers/dogstatsd/_index.md
+++ b/content/fr/developers/dogstatsd/_index.md
@@ -42,7 +42,7 @@ DogStatsD accepte les [métriques custom][5], les [événements][6] et les [chec
 
 Grâce au protocole UDP, votre application peut envoyer des métriques à DogStatsD et reprendre sa tâche sans attendre de réponse. Si jamais DogStatsD devient indisponible, votre application continue à fonctionner sans interruption.
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/dogstatsd.png" alt="dogstatsd">}}
+{{< img src="metrics/dogstatsd_metrics_submission/dogstatsd.png" alt="dogstatsd">}}
 
 Lorsque DogStatsD reçoit des données, il agrège de nombreux points de données pour chaque métrique en un point de données unique sur une période désignée par le terme _intervalle de transmission_ (par défaut, dix secondes).
 
@@ -175,7 +175,7 @@ Pour définir la [cardinalité des tags][5] pour les métriques recueillies avec
 [3]: https://kubernetes.io/docs/setup/independent/troubleshooting-kubeadm/#hostport-services-do-not-work
 [4]: /fr/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
 [5]: /fr/getting_started/tagging/assigning_tags/#environment-variables
-[6]: /fr/developers/metrics/custom_metrics/
+[6]: /fr/metrics/custom_metrics/
 {{% /tab %}}
 {{% tab "Helm" %}}
 
@@ -211,7 +211,7 @@ Pour recueillir des métriques custom via [DogStatsD][1] avec Helm :
 
      Grâce à ce manifeste, un pod exécutant votre application peut transmettre des métriques DogStatsD via le port `8125` sur `$DD_AGENT_HOST`.
 
-[1]: /fr/developers/metrics/dogstatsd_metrics_submission/
+[1]: /fr/metrics/dogstatsd_metrics_submission/
 [2]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
 [3]: https://github.com/containernetworking/cni
 [4]: https://kubernetes.io/docs/setup/independent/troubleshooting-kubeadm/#hostport-services-do-not-work
@@ -487,7 +487,7 @@ Pour en savoir plus, consultez la documentation relative à la [classe NonBlocki
 DogStatsD et StatsD sont assez semblables. Toutefois, DogStatsD comprend des fonctionnalités avancées propres à Datadog, notamment en ce qui concerne les types de données, les événements, les checks de service et les tags disponibles :
 
 {{< whatsnext desc="">}}
-{{< nextlink href="/developers/metrics/dogstatsd_metrics_submission/" >}}Envoyer des métriques à Datadog avec DogStatsD{{< /nextlink >}}
+{{< nextlink href="/metrics/dogstatsd_metrics_submission/" >}}Envoyer des métriques à Datadog avec DogStatsD{{< /nextlink >}}
 {{< nextlink href="/events/guides/dogstatsd/" >}}Envoyer des événements à Datadog avec DogStatsD{{< /nextlink >}}
 {{< nextlink href="/developers/service_checks/dogstatsd_service_checks_submission/" >}}Envoyer des checks de service à Datadog avec DogStatsD{{< /nextlink >}}
 {{< /whatsnext >}}
@@ -495,12 +495,12 @@ DogStatsD et StatsD sont assez semblables. Toutefois, DogStatsD comprend des fon
 Si vous souhaitez approfondir vos connaissances sur le format des datagrammes utilisé par DogStatsD, ou concevoir votre propre bibliothèque Datadog, consultez la section [Datagramme et interface système][10], qui décrit également comment envoyer des métriques et des événements directement depuis la ligne de commande.
 
 [1]: https://github.com/etsy/statsd
-[2]: /fr/developers/metrics/dogstatsd_metrics_submission/
+[2]: /fr/metrics/dogstatsd_metrics_submission/
 [3]: https://hub.docker.com/r/datadog/dogstatsd
 [4]: https://gcr.io/datadoghq/dogstatsd
-[5]: /fr/developers/metrics/custom_metrics/
+[5]: /fr/metrics/custom_metrics/
 [6]: /fr/events/guides/dogstatsd/
 [7]: /fr/developers/service_checks/dogstatsd_service_checks_submission/
 [8]: /fr/developers/community/libraries/#api-and-dogstatsd-client-libraries
 [9]: /fr/getting_started/tagging/unified_service_tagging
-[10]: /fr/developers/metrics/
+[10]: /fr/metrics/

--- a/content/fr/developers/dogstatsd/data_aggregation.md
+++ b/content/fr/developers/dogstatsd/data_aggregation.md
@@ -48,9 +48,9 @@ Parmi toutes les valeurs reçues pendant un même intervalle de transmission, la
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /fr/developers/dogstatsd/
-[2]: /fr/developers/metrics/dogstatsd_metrics_submission/
-[3]: /fr/developers/metrics/types/?tab=count#metric-types
-[4]: /fr/developers/metrics/types/
-[5]: /fr/developers/metrics/types/?tab=gauge#metric-types
-[6]: /fr/developers/metrics/types/?tab=histogram#metric-types
-[7]: /fr/developers/metrics/types/?tab=distribution#metric-types
+[2]: /fr/metrics/dogstatsd_metrics_submission/
+[3]: /fr/metrics/types/?tab=count#metric-types
+[4]: /fr/metrics/types/
+[5]: /fr/metrics/types/?tab=gauge#metric-types
+[6]: /fr/metrics/types/?tab=histogram#metric-types
+[7]: /fr/metrics/types/?tab=distribution#metric-types

--- a/content/fr/developers/dogstatsd/datagram_shell.md
+++ b/content/fr/developers/dogstatsd/datagram_shell.md
@@ -40,8 +40,8 @@ Voici quelques exemples de datagrammes :
 - `users.online:1|c|@0.5|#country:china` : surveille les utilisateurs chinois actifs et utilisez un taux d'échantillonnage.
 
 
-[1]: /fr/developers/metrics/#naming-metrics
-[2]: /fr/developers/metrics/types/
+[1]: /fr/metrics/#naming-metrics
+[2]: /fr/metrics/types/
 [3]: /fr/getting_started/tagging/
 {{% /tab %}}
 {{% tab "Événements" %}}

--- a/content/fr/developers/dogstatsd/high_throughput.md
+++ b/content/fr/developers/dogstatsd/high_throughput.md
@@ -662,6 +662,6 @@ Consultez le référentiel [DataDog/dogstatsd-csharp-client][1] pour en savoir p
 [1]: /fr/agent/
 [2]: /fr/developers/dogstatsd/unix_socket/
 [3]: /fr/developers/dogstatsd/#code
-[4]: /fr/developers/metrics/dogstatsd_metrics_submission/#sample-rates
+[4]: /fr/metrics/dogstatsd_metrics_submission/#sample-rates
 [5]: /fr/developers/dogstatsd/high_throughput/#note-on-sysctl-in-kubernetes
 [6]: https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/

--- a/content/fr/developers/dogstatsd/unix_socket.md
+++ b/content/fr/developers/dogstatsd/unix_socket.md
@@ -3,7 +3,7 @@ title: Utiliser DogStatsD via un socket de domaine Unix
 kind: documentation
 description: Documentation relative à l'utilisation de DogStatsD via un socket de domaine Unix
 aliases:
-  - /fr/developers/metrics/unix_socket/
+  - /fr/metrics/unix_socket/
 further_reading:
   - link: developers/dogstatsd
     tag: Documentation
@@ -228,8 +228,8 @@ Pour découvrir comment créer des options d'implémentation supplémentaires, r
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /fr/developers/metrics/dogstatsd_metrics_submission/
-[2]: /fr/developers/metrics/custom_metrics/
+[1]: /fr/metrics/dogstatsd_metrics_submission/
+[2]: /fr/metrics/custom_metrics/
 [3]: https://github.com/DataDog/datadog-go#unix-domain-sockets-client
 [4]: https://github.com/DataDog/java-dogstatsd-client#unix-domain-socket-support
 [5]: https://github.com/DataDog/datadogpy#instantiate-the-dogstatsd-client-with-uds

--- a/content/fr/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
+++ b/content/fr/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
@@ -91,6 +91,6 @@ dog metric post -h
 {{< img src="developers/faq/dogshell_test.png" alt="dogshell_test" >}}
 
 [1]: https://github.com/DataDog/datadogpy
-[2]: /fr/developers/metrics/dogstatsd_metrics_submission/
+[2]: /fr/metrics/dogstatsd_metrics_submission/
 [3]: https://github.com/DataDog/datadogpy#installation
 [4]: https://github.com/DataDog/datadogpy/tree/master/datadog/dogshell

--- a/content/fr/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags.md
+++ b/content/fr/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags.md
@@ -2,7 +2,7 @@
 title: "Quelles sont les bonnes pratiques à adopter pour nommer les métriques et les tags\_?"
 kind: faq
 further_reading:
-  - link: /developers/metrics/
+  - link: /metrics/
     tag: Documentation
     text: En savoir plus sur les métriques Datadog
   - link: /getting_started/tagging/

--- a/content/fr/developers/integrations/check_references.md
+++ b/content/fr/developers/integrations/check_references.md
@@ -139,6 +139,6 @@ Le fichier `service_checks.json` contient les attributs obligatoires suivants :
 [3]: http://yaml-online-parser.appspot.com/
 [4]: https://docs.datadoghq.com/fr/integrations/
 [5]: https://www.uuidgenerator.net
-[6]: https://docs.datadoghq.com/fr/developers/metrics/metrics_type/
-[7]: https://docs.datadoghq.com/fr/developers/metrics/metrics_units/
+[6]: https://docs.datadoghq.com/fr/metrics/metrics_type/
+[7]: https://docs.datadoghq.com/fr/metrics/metrics_units/
 [8]: https://docs.datadoghq.com/fr/getting_started/tagging/

--- a/content/fr/developers/integrations/new_check_howto.md
+++ b/content/fr/developers/integrations/new_check_howto.md
@@ -429,7 +429,7 @@ Pour les versions >= 6.12 de l'Agent :
 [2]: /fr/developers/integrations/python
 [3]: https://github.com/DataDog/integrations-extras
 [4]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_dev
-[5]: https://docs.datadoghq.com/fr/developers/metrics/agent_metrics_submission/
+[5]: https://docs.datadoghq.com/fr/metrics/agent_metrics_submission/
 [6]: https://github.com/DataDog/datadog-agent/blob/6.2.x/docs/dev/checks/python/check_api.md
 [7]: https://docs.pytest.org/en/latest
 [8]: https://tox.readthedocs.io/en/latest

--- a/content/fr/developers/libraries.md
+++ b/content/fr/developers/libraries.md
@@ -167,7 +167,7 @@ Un [transport][62] Winston/Datadog.
 
 Si vous avez rédigé une bibliothèque Datadog et que vous souhaitez l'ajouter à cette page, contactez-nous par e-mail à l'adresse [opensource@datadoghq.com][65].
 
-[1]: /fr/developers/metrics/dogstatsd_metrics_submission/
+[1]: /fr/metrics/dogstatsd_metrics_submission/
 [2]: /fr/tracing/
 [3]: /fr/serverless/
 [4]: /fr/api/
@@ -212,7 +212,7 @@ Si vous avez rédigé une bibliothèque Datadog et que vous souhaitez l'ajouter 
 [43]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-datadog.html
 [44]: https://github.com/brigade/logstash-output-dogstatsd
 [45]: https://docs.moogsoft.com/AIOps.6.2.0/Datadog-Solution-Pak_13737047.html
-[46]: /fr/developers/metrics/custom_metrics/
+[46]: /fr/metrics/custom_metrics/
 [47]: https://github.com/simplifi/ngx_lua_datadog
 [48]: https://github.com/dailymotion/lua-resty-dogstatsd
 [49]: http://www.mediba.jp

--- a/content/fr/developers/metrics/_index.md
+++ b/content/fr/developers/metrics/_index.md
@@ -6,8 +6,8 @@ aliases:
   - /fr/guides/metrics/
   - /fr/metrictypes/
   - /fr/units/
-  - /fr/developers/metrics/datagram_shell
-  - /fr/developers/metrics/custom_metrics/
+  - /fr/metrics/datagram_shell
+  - /fr/metrics/custom_metrics/
   - /fr/getting_started/custom_metrics
 further_reading:
   - link: /developers/dogstatsd/
@@ -53,9 +53,9 @@ La convention de nommage suivante s'applique aux métriques custom :
 ## Envoi de métriques custom
 
 {{< whatsnext desc="Il existe plusieurs façons d'envoyer des métriques à Datadog :">}}
-    {{< nextlink href="/developers/metrics/agent_metrics_submission" >}}Check custom d'Agent{{< /nextlink >}}
-    {{< nextlink href="/developers/metrics/dogstatsd_metrics_submission" >}}DogStatsD{{< /nextlink >}}
-    {{< nextlink href="/developers/metrics/powershell_metrics_submission" >}}PowerShell{{< /nextlink >}}
+    {{< nextlink href="/metrics/agent_metrics_submission" >}}Check custom d'Agent{{< /nextlink >}}
+    {{< nextlink href="/metrics/dogstatsd_metrics_submission" >}}DogStatsD{{< /nextlink >}}
+    {{< nextlink href="/metrics/powershell_metrics_submission" >}}PowerShell{{< /nextlink >}}
     {{< nextlink href="/api/v1/metrics/#submit-metrics" >}}API HTTP de Datadog{{< /nextlink >}}
 {{< /whatsnext >}}
 
@@ -71,13 +71,13 @@ Vous pouvez également utiliser l'une des [bibliothèques client de Datadog et s
 
 [1]: /fr/integrations/
 [2]: /fr/account_management/billing/custom_metrics/#standard-integrations
-[3]: /fr/developers/metrics/dogstatsd_metrics_submission/
-[4]: /fr/developers/metrics/agent_metrics_submission/
+[3]: /fr/metrics/dogstatsd_metrics_submission/
+[4]: /fr/metrics/agent_metrics_submission/
 [5]: https://app.datadoghq.com/account/usage/hourly
 [6]: /fr/account_management/billing/custom_metrics/#counting-custom-metrics
 [7]: /fr/graphing/metrics/introduction/
-[8]: /fr/developers/metrics/types/
-[9]: /fr/developers/metrics/types/?tab=rate#metric-types
-[10]: /fr/developers/metrics/types/?tab=count#metric-types
+[8]: /fr/metrics/types/
+[9]: /fr/metrics/types/?tab=rate#metric-types
+[10]: /fr/metrics/types/?tab=count#metric-types
 [11]: /fr/developers/dogstatsd/data_aggregation/#how-is-aggregation-performed-with-the-dogstatsd-server
 [12]: /fr/developers/community/libraries/

--- a/content/fr/developers/metrics/agent_metrics_submission.md
+++ b/content/fr/developers/metrics/agent_metrics_submission.md
@@ -223,14 +223,14 @@ Suivez les étapes ci-dessous pour créer un [check custom d'Agent][2] qui trans
 
 6. Vérifiez que vos métriques sont transmises à Datadog sur votre [page Metric Summary][6] :
 
-{{< img src="developers/metrics/agent_metrics_submission/metrics_metrics_summary.png" alt="Métriques dans le Metric Summary" style="width:80%;">}}
+{{< img src="metrics/agent_metrics_submission/metrics_metrics_summary.png" alt="Métriques dans le Metric Summary" style="width:80%;">}}
 
 ## Pour aller plus loin
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /fr/developers/custom_checks/write_agent_check/
-[2]: /fr/developers/metrics/types/
+[2]: /fr/metrics/types/
 [3]: /fr/agent/guide/agent-configuration-files/#agent-configuration-directory
 [4]: /fr/agent/guide/agent-commands/#restart-the-agent
 [5]: /fr/agent/guide/agent-commands/#agent-information

--- a/content/fr/developers/metrics/dogstatsd_metrics_submission.md
+++ b/content/fr/developers/metrics/dogstatsd_metrics_submission.md
@@ -10,7 +10,7 @@ further_reading:
   - link: /developers/dogstatsd/
     tag: Documentation
     text: Présentation de DogStatsD
-  - link: /developers/metrics/types/
+  - link: /metrics/types/
     tag: Documentation
     text: Types de métrique Datadog
 ---
@@ -198,11 +198,11 @@ while (TRUE) {
 
 Une fois le code ci-dessus exécuté, les données de vos métriques peuvent être représentées graphiquement dans Datadog :
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/increment_decrement.png" alt="Incrémenter décrémenter" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/increment_decrement.png" alt="Incrémenter décrémenter" >}}
 
 La valeur étant envoyée en tant que `COUNT`, elle est stockée en tant que `RATE` dans Datadog. Pour récupérer des counts bruts dans Datadog, appliquez une fonction à votre série, telle que la fonction [Somme cumulée][3] ou [Intégrale][4] :
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/increment_decrement_cumsum.png" alt="Incrémenter/décrémenter avec somme cumulée" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/increment_decrement_cumsum.png" alt="Incrémenter/décrémenter avec somme cumulée" >}}
 
 ### GAUGE
 
@@ -362,7 +362,7 @@ while (TRUE) {
 
 Une fois le code ci-dessus exécuté, les données de votre métrique peuvent être représentées graphiquement dans Datadog :
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/gauge.png" alt="Gauge" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/gauge.png" alt="Gauge" >}}
 
 ### SET
 
@@ -499,7 +499,7 @@ while (TRUE) {
 
 Une fois le code ci-dessus exécuté, les données de vos métriques peuvent être représentées graphiquement dans Datadog :
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/set.png" alt="Set" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/set.png" alt="Set" >}}
 
 ### HISTOGRAM
 
@@ -669,7 +669,7 @@ L'instrumentation ci-dessus génère les métriques suivantes :
 
 Une fois le code ci-dessus exécuté, les données de vos métriques peuvent être représentées graphiquement dans Datadog :
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/histogram.png" alt="Histogram" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/histogram.png" alt="Histogram" >}}
 
 #### TIMER
 
@@ -775,7 +775,7 @@ Lorsque DogStatsD reçoit les données de la métrique timer, il calcule la dist
 
 DogStatsD traite les métriques `TIMER` en tant que métriques `HISTOGRAM`. Que vous utilisiez le type de métrique `TIMER` ou `HISTOGRAM`, vous envoyez les mêmes données à Datadog. Une fois le code ci-dessus exécuté, les données de vos métriques peuvent être représentées graphiquement dans Datadog :
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/timer.png" alt="Timer" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/timer.png" alt="Timer" >}}
 
 ### DISTRIBUTION
 
@@ -1056,11 +1056,11 @@ Le tag host est attribué automatiquement par l'Agent Datadog chargé de l'agré
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /fr/developers/dogstatsd/
-[2]: /fr/developers/metrics/types/?tab=count#definition
+[2]: /fr/metrics/types/?tab=count#definition
 [3]: /fr/dashboards/functions/arithmetic/#cumulative-sum
 [4]: /fr/dashboards/functions/arithmetic/#integral
-[5]: /fr/developers/metrics/types/?tab=gauge#definition
-[6]: /fr/developers/metrics/types/?tab=histogram#definition
+[5]: /fr/metrics/types/?tab=gauge#definition
+[6]: /fr/metrics/types/?tab=histogram#definition
 [7]: /fr/agent/guide/agent-configuration-files/#agent-main-configuration-file
 [8]: /fr/metrics/distributions/
-[9]: /fr/developers/metrics/types/?tab=distribution#definition
+[9]: /fr/metrics/types/?tab=distribution#definition

--- a/content/fr/developers/metrics/powershell_metrics_submission.md
+++ b/content/fr/developers/metrics/powershell_metrics_submission.md
@@ -148,7 +148,7 @@ $http_request.responseText
 [Consultez le référentiel GitHub ncracker/dd_metric pour découvrir d'autres exemples de code][6].
 
 [1]: https://app.datadoghq.com/account/settings#api
-[2]: /fr/developers/metrics/dogstatsd_metrics_submission/
+[2]: /fr/metrics/dogstatsd_metrics_submission/
 [3]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
 [4]: /fr/api/v1/hosts/
 [5]: /fr/api/v1/metrics/

--- a/content/fr/developers/metrics/type_modifiers.md
+++ b/content/fr/developers/metrics/type_modifiers.md
@@ -2,7 +2,7 @@
 title: Modificateurs de type de métriques
 kind: documentation
 aliases:
-  - /fr/developers/metrics/metric_type_modifiers
+  - /fr/metrics/metric_type_modifiers
   - /fr/graphing/faq/as_count_validation
 further_reading:
   - link: /developers/dogstatsd/
@@ -77,7 +77,7 @@ Le type de métrique `GAUGE` représente la valeur finale et absolue d'une métr
 
 Bien que cette opération ne soit généralement pas requise, vous pouvez modifier le type d'une métrique dans la [page de résumé des métriques][4] :
 
-{{< img src="developers/metrics/type_modifiers/metric_type.png" alt="Type de métrique"  style="width:70%;">}}
+{{< img src="metrics/type_modifiers/metric_type.png" alt="Type de métrique"  style="width:70%;">}}
 
 Exemple de scénario :
 
@@ -95,7 +95,7 @@ Si vous ne souhaitez pas perdre les données historiques envoyées en tant que t
 
 **Remarque** : pour le check de l'Agent, `self.increment` ne calcule pas le delta pour un accroissement uniforme de counter, mais signale la valeur transmise lors du check. Pour envoyer la valeur delta pour un accroissement uniforme de counter, utilisez `self.monotonic_count`. 
 
-[1]: /fr/developers/metrics/types/
+[1]: /fr/metrics/types/
 [2]: /fr/metrics/introduction/#time-aggregation
 [3]: /fr/dashboards/faq/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs/
 [4]: https://app.datadoghq.com/metric/summary

--- a/content/fr/developers/metrics/types.md
+++ b/content/fr/developers/metrics/types.md
@@ -2,14 +2,14 @@
 title: Types de métriques
 kind: documentation
 aliases:
-  - /fr/developers/metrics/counts/
-  - /fr/developers/metrics/distributions/
-  - /fr/developers/metrics/gauges/
-  - /fr/developers/metrics/histograms/
-  - /fr/developers/metrics/rates/
-  - /fr/developers/metrics/sets/
-  - /fr/developers/metrics_type/
-  - /fr/developers/metrics/metrics_type/
+  - /fr/metrics/counts/
+  - /fr/metrics/distributions/
+  - /fr/metrics/gauges/
+  - /fr/metrics/histograms/
+  - /fr/metrics/rates/
+  - /fr/metrics/sets/
+  - /fr/metrics_type/
+  - /fr/metrics/metrics_type/
 further_reading:
   - link: developers/dogstatsd
     tag: Documentation
@@ -220,10 +220,10 @@ Envoyez vos métriques de type COUNT depuis l'une des sources suivantes :
 **Remarque** : lorsque vous envoyez une métrique de type COUNT via DogStatsD, la métrique stockée dans Datadog possède le type RATE, afin de garantir la pertinence des comparaisons entre les différents Agents. Par conséquent, les totaux StatsD peuvent comporter des décimales dans Datadog (puisqu'ils sont normalisés sur un intervalle dans le but de transmettre des unités par seconde).
 
 
-[1]: /fr/developers/metrics/agent_metrics_submission/?tab=count#count
-[2]: /fr/developers/metrics/agent_metrics_submission/?tab=count#monotonic-count
+[1]: /fr/metrics/agent_metrics_submission/?tab=count#count
+[2]: /fr/metrics/agent_metrics_submission/?tab=count#monotonic-count
 [3]: /fr/api/v1/metrics/#submit-metrics
-[4]: /fr/developers/metrics/dogstatsd_metrics_submission/#count
+[4]: /fr/metrics/dogstatsd_metrics_submission/#count
 {{% /tab %}}
 {{% tab "RATE" %}}
 
@@ -237,7 +237,7 @@ Envoyez vos métriques de type RATE depuis l'une des sources suivantes :
 **Remarque** : lorsque vous envoyez une métrique de type RATE via DogStatsD, la métrique stockée dans Datadog possède le type GAUGE, afin de garantir la pertinence des comparaisons entre les différents Agents.
 
 
-[1]: /fr/developers/metrics/agent_metrics_submission/?tab=rate
+[1]: /fr/metrics/agent_metrics_submission/?tab=rate
 [2]: /fr/api/v1/metrics/#submit-metrics
 {{% /tab %}}
 {{% tab "GAUGE" %}}
@@ -251,9 +251,9 @@ Envoyez vos métriques de type GAUGE depuis l'une des sources suivantes :
 | [DogStatsD][3]    | `dog.gauge(...)`                     | GAUGE           | GAUGE               |
 
 
-[1]: /fr/developers/metrics/agent_metrics_submission/?tab=gauge
+[1]: /fr/metrics/agent_metrics_submission/?tab=gauge
 [2]: /fr/api/v1/metrics/#submit-metrics
-[3]: /fr/developers/metrics/dogstatsd_metrics_submission/#gauge
+[3]: /fr/metrics/dogstatsd_metrics_submission/#gauge
 {{% /tab %}}
 {{% tab "HISTOGRAM" %}}
 
@@ -267,8 +267,8 @@ Envoyez vos métriques de type HISTOGRAM depuis l'une des sources suivantes :
 **Remarque** : l'envoi d'une métrique TIMER à l'Agent Datadog correspond à l'envoi d'une métrique HISTOGRAM dans DogStatsD. Ne confondez pas les métriques TIMER et les timers de StatsD standard. Les métriques TIMER représentent uniquement les données caractérisées par une durée, par exemple le temps d'exécution d'une section de code ou le temps d'affichage d'une page entière.
 
 
-[1]: /fr/developers/metrics/agent_metrics_submission/?tab=histogram
-[2]: /fr/developers/metrics/dogstatsd_metrics_submission/#histogram
+[1]: /fr/metrics/agent_metrics_submission/?tab=histogram
+[2]: /fr/metrics/dogstatsd_metrics_submission/#histogram
 {{% /tab %}}
 {{% tab "DISTRIBUTION" %}}
 
@@ -279,7 +279,7 @@ Envoyez vos métriques de type DISTRIBUTION depuis la source suivante :
 | [DogStatsD][1]    | `dog.distribution(...)`    | DISTRIBUTION    | GAUGE, COUNT         |
 
 
-[1]: /fr/developers/metrics/dogstatsd_metrics_submission/#distribution
+[1]: /fr/metrics/dogstatsd_metrics_submission/#distribution
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -308,21 +308,21 @@ Vous trouverez ci-dessous une synthèse de l'ensemble des sources et des méthod
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /fr/developers/metrics/type_modifiers/
+[1]: /fr/metrics/type_modifiers/
 [2]: /fr/dashboards/functions/
 [3]: /fr/metrics/summary/
 [4]: https://statsd.readthedocs.io/en/v3.2.1/types.html#sets
-[5]: /fr/developers/metrics/agent_metrics_submission/
-[6]: /fr/developers/metrics/dogstatsd_metrics_submission/
+[5]: /fr/metrics/agent_metrics_submission/
+[6]: /fr/metrics/dogstatsd_metrics_submission/
 [7]: /fr/api/v1/metrics/#submit-metrics
 [8]: /fr/developers/dogstatsd/#how-it-works
-[9]: /fr/developers/metrics/agent_metrics_submission/?tab=count#count
-[10]: /fr/developers/metrics/agent_metrics_submission/?tab=count#monotonic-count
-[11]: /fr/developers/metrics/agent_metrics_submission/?tab=gauge
-[12]: /fr/developers/metrics/agent_metrics_submission/?tab=histogram
-[13]: /fr/developers/metrics/agent_metrics_submission/?tab=rate
-[14]: /fr/developers/metrics/dogstatsd_metrics_submission/#gauge
-[15]: /fr/developers/metrics/dogstatsd_metrics_submission/#distribution
-[16]: /fr/developers/metrics/dogstatsd_metrics_submission/#count
-[17]: /fr/developers/metrics/dogstatsd_metrics_submission/#set
-[18]: /fr/developers/metrics/dogstatsd_metrics_submission/#histogram
+[9]: /fr/metrics/agent_metrics_submission/?tab=count#count
+[10]: /fr/metrics/agent_metrics_submission/?tab=count#monotonic-count
+[11]: /fr/metrics/agent_metrics_submission/?tab=gauge
+[12]: /fr/metrics/agent_metrics_submission/?tab=histogram
+[13]: /fr/metrics/agent_metrics_submission/?tab=rate
+[14]: /fr/metrics/dogstatsd_metrics_submission/#gauge
+[15]: /fr/metrics/dogstatsd_metrics_submission/#distribution
+[16]: /fr/metrics/dogstatsd_metrics_submission/#count
+[17]: /fr/metrics/dogstatsd_metrics_submission/#set
+[18]: /fr/metrics/dogstatsd_metrics_submission/#histogram

--- a/content/fr/developers/metrics/units.md
+++ b/content/fr/developers/metrics/units.md
@@ -2,7 +2,7 @@
 title: Unités des métriques
 kind: documentation
 aliases:
-  - /fr/developers/metrics/metrics_units
+  - /fr/metrics/metrics_units
 further_reading:
   - link: /dashboards/
     tag: Documentation
@@ -34,15 +34,15 @@ Pour éliminer toute ambiguïté et vous aider à mieux comprendre vos systèmes
 
 Les unités sont affichées automatiquement sur des graphiques de série temporelle, des widgets de valeur de requête et des Top Lists, comme indiqué sur la capture d'écran suivante d'un dashboard Redis :
 
-{{< img src="developers/metrics/units/redis_dash_metrics_units.png" alt="unités de métriques dash. Redis"  style="width:70%;">}}
+{{< img src="metrics/units/redis_dash_metrics_units.png" alt="unités de métriques dash. Redis"  style="width:70%;">}}
 
 Sur des graphiques de série temporelle, déplacez votre curseur sur un graphique pour afficher les unités pertinentes. Les données brutes sont automatiquement converties en unités d'affichage lisibles (fractions de seconde en ms, millions d'octets par seconde en MiB/s, etc.) :
 
-{{< img src="developers/metrics/units/postgres_commits.png" alt="commits postgres"  style="width:70%;">}}
+{{< img src="metrics/units/postgres_commits.png" alt="commits postgres"  style="width:70%;">}}
 
 Les unités sont également affichées en bas des graphiques de timeboard. Vous pouvez accéder aux descriptions des métriques en sélectionnant **Metrics Info** dans la liste déroulante :
 
-{{< img src="developers/metrics/units/annotated_ops.png" alt="Opérations annotées"  style="width:70%;">}}
+{{< img src="metrics/units/annotated_ops.png" alt="Opérations annotées"  style="width:70%;">}}
 
 Pour modifier l'unité d'une métrique, accédez à la page [Metrics Summary][1] et sélectionnez une métrique. Cliquez sur **Edit** sous **Metadata**, puis sélectionnez une unité telle que `bit` ou `byte` depuis le menu déroulant.
 

--- a/content/fr/getting_started/agent/_index.md
+++ b/content/fr/getting_started/agent/_index.md
@@ -110,7 +110,7 @@ Pour dépanner plus facilement l'Agent :
 {{< /whatsnext >}}
 
 [1]: /fr/integrations/
-[2]: /fr/developers/metrics/dogstatsd_metrics_submission/
+[2]: /fr/metrics/dogstatsd_metrics_submission/
 [3]: /fr/api/
 [4]: /fr/infrastructure/process/
 [5]: /fr/logs/

--- a/content/fr/getting_started/integrations/_index.md
+++ b/content/fr/getting_started/integrations/_index.md
@@ -214,6 +214,6 @@ Tags
 [38]: /fr/agent/guide/agent-configuration-files/#agent-configuration-directory
 [39]: https://app.datadoghq.com/event/stream
 [40]: https://github.com/DataDog/integrations-core/blob/master/http_check/datadog_checks/http_check/data/conf.yaml.example#L13
-[41]: /fr/developers/metrics/
-[42]: /fr/developers/metrics/custom_metrics/
+[41]: /fr/metrics/
+[42]: /fr/metrics/custom_metrics/
 [43]: /fr/monitors/guide/visualize-your-service-check-in-the-datadog-ui/

--- a/content/fr/getting_started/tagging/_index.md
+++ b/content/fr/getting_started/tagging/_index.md
@@ -108,7 +108,7 @@ Datadog vous conseille d'utiliser le tagging de service unifié lorsque vous ass
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /fr/getting_started/tagging/using_tags/
-[2]: /fr/developers/metrics/
+[2]: /fr/metrics/
 [3]: /fr/getting_started/tagging/assigning_tags/
 [4]: /fr/getting_started/tagging/assigning_tags/#configuration-files
 [5]: /fr/getting_started/tagging/assigning_tags/#ui

--- a/content/fr/getting_started/tagging/assigning_tags.md
+++ b/content/fr/getting_started/tagging/assigning_tags.md
@@ -96,7 +96,7 @@ hostname: mamachine.mondomaine
 [1]: /fr/getting_started/integrations/
 [2]: /fr/agent/guide/agent-configuration-files/
 [3]: /fr/getting_started/tagging/#defining-tags
-[4]: /fr/developers/metrics/dogstatsd_metrics_submission/#host-tag-key
+[4]: /fr/metrics/dogstatsd_metrics_submission/#host-tag-key
 [5]: /fr/dashboards/querying/#arithmetic-between-two-metrics
 {{% /tab %}}
 {{% tab "Agent v5" %}}
@@ -138,7 +138,7 @@ hostname: mamachine.mondomaine
 [1]: /fr/getting_started/integrations/
 [2]: /fr/agent/guide/agent-configuration-files/
 [3]: /fr/getting_started/tagging/#defining-tags
-[4]: /fr/developers/metrics/dogstatsd_metrics_submission/#host-tag-key
+[4]: /fr/metrics/dogstatsd_metrics_submission/#host-tag-key
 [5]: /fr/dashboards/querying/#arithmetic-between-two-metrics
 {{% /tab %}}
 {{< /tabs >}}
@@ -298,7 +298,7 @@ Créez des agrégations par centile dans les [métriques de distribution][1] en 
 {{< img src="tagging/assigning_tags/global_metrics_selection.png" alt="Tags création de monitor"  style="width:80%;">}}
 
 [1]: /fr/metrics/distributions/
-[2]: /fr/developers/metrics/custom_metrics/
+[2]: /fr/metrics/custom_metrics/
 {{% /tab %}}
 {{% tab "Intégrations" %}}
 
@@ -408,4 +408,4 @@ Des précautions particulières doivent être prises pour l'assignation du tag `
 [7]: /fr/tracing/setup/
 [8]: /fr/developers/dogstatsd/
 [9]: /fr/developers/community/libraries/
-[10]: /fr/developers/metrics/dogstatsd_metrics_submission/#host-tag-key
+[10]: /fr/metrics/dogstatsd_metrics_submission/#host-tag-key

--- a/content/fr/getting_started/tagging/unified_service_tagging.md
+++ b/content/fr/getting_started/tagging/unified_service_tagging.md
@@ -307,7 +307,7 @@ Si votre service a accès à `DD_ENV`, `DD_SERVICE` et `DD_VERSION`, alors le cl
 
 **Remarque** : les clients Datadog DogStatsD pour .NET et PHP ne prennent pas encore en charge cette fonctionnalité.
 
-[1]: /fr/developers/metrics/
+[1]: /fr/metrics/
 {{% /tab %}}
 
 {{% tab "Métriques système" %}}

--- a/content/fr/infrastructure/process/generate_process_metrics.md
+++ b/content/fr/infrastructure/process/generate_process_metrics.md
@@ -75,5 +75,5 @@ Une fois créées, vous pouvez utiliser les métriques de distribution agrégée
 [1]: https://forms.gle/Bo664kv8Y1Avmzmg6
 [2]: https://app.datadoghq.com/process?view=metrics
 [3]: https://app.datadoghq.com/process
-[4]: /fr/developers/metrics/custom_metrics/
+[4]: /fr/metrics/custom_metrics/
 [5]: /fr/dashboards/correlations/

--- a/content/fr/infrastructure/process/increase_process_retention.md
+++ b/content/fr/infrastructure/process/increase_process_retention.md
@@ -73,5 +73,5 @@ Une fois créées, vous pouvez utiliser les métriques de distribution agrégée
 
 [1]: https://app.datadoghq.com/process?view=metrics
 [2]: https://app.datadoghq.com/process
-[3]: /fr/developers/metrics/custom_metrics/
+[3]: /fr/metrics/custom_metrics/
 [4]: /fr/dashboards/correlations/

--- a/content/fr/integrations/activemq.md
+++ b/content/fr/integrations/activemq.md
@@ -288,7 +288,7 @@ Besoin d'aide ? Contactez [l'assistance Datadog][6].
 [8]: https://www.datadoghq.com/blog/monitor-activemq-metrics-performance
 [9]: https://docs.datadoghq.com/fr/agent/guide/agent-configuration-files/#agent-configuration-directory
 [10]: https://github.com/DataDog/integrations-core/blob/master/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
-[11]: https://docs.datadoghq.com/fr/developers/metrics/custom_metrics/
+[11]: https://docs.datadoghq.com/fr/metrics/custom_metrics/
 [12]: https://docs.datadoghq.com/fr/account_management/billing/custom_metrics/
 [13]: https://docs.datadoghq.com/fr/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [14]: https://docs.datadoghq.com/fr/agent/guide/autodiscovery-with-jmx/?tab=containerizedagent

--- a/content/fr/integrations/concourse_ci.md
+++ b/content/fr/integrations/concourse_ci.md
@@ -79,7 +79,7 @@ Besoin d'aide ? Contactez [l'assistance Datadog][6].
 
 [1]: https://concourse-ci.org/concepts.html
 [2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://docs.datadoghq.com/fr/developers/metrics/custom_metrics/
+[3]: https://docs.datadoghq.com/fr/metrics/custom_metrics/
 [4]: https://concourse-ci.org/metrics.html#configuring-metrics
 [5]: https://github.com/DataDog/integrations-extras/blob/master/concourse_ci/metadata.csv
 [6]: https://docs.datadoghq.com/fr/help/

--- a/content/fr/integrations/go_expvar.md
+++ b/content/fr/integrations/go_expvar.md
@@ -77,7 +77,7 @@ Pour configurer ce check lorsque l'Agent est exécuté sur un host :
 [1]: https://docs.datadoghq.com/fr/agent/guide/agent-configuration-files/#agent-configuration-directory
 [2]: https://github.com/DataDog/integrations-core/blob/master/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
 [3]: https://docs.datadoghq.com/fr/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[4]: https://docs.datadoghq.com/fr/developers/metrics/custom_metrics/
+[4]: https://docs.datadoghq.com/fr/metrics/custom_metrics/
 [5]: https://docs.datadoghq.com/fr/account_management/billing/custom_metrics/
 [6]: https://docs.datadoghq.com/fr/help/
 {{% /tab %}}

--- a/content/fr/integrations/guide/collect-sql-server-custom-metrics.md
+++ b/content/fr/integrations/guide/collect-sql-server-custom-metrics.md
@@ -196,5 +196,5 @@ Si vos métriques custom n'apparaissent pas dans Datadog, vérifiez le fichier d
 
 [1]: /fr/integrations/sqlserver/
 [2]: https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-databases-object
-[3]: /fr/developers/metrics/#metric-types
-[4]: /fr/developers/metrics/histograms/
+[3]: /fr/metrics/#metric-types
+[4]: /fr/metrics/histograms/

--- a/content/fr/integrations/guide/mongo-custom-query-collection.md
+++ b/content/fr/integrations/guide/mongo-custom-query-collection.md
@@ -58,7 +58,7 @@ Cela génère une métrique `gauge` `mongo.users` avec le tag `user:active`.
 **Remarque** : le type de métrique défini est `gauge`. Consultez la [documentation relative aux types de métriques][2] pour en savoir plus.
 
 [1]: https://docs.mongodb.com/manual/reference/command/count/#dbcmd.count
-[2]: /fr/developers/metrics/types/
+[2]: /fr/metrics/types/
 {{% /tab %}}
 {{% tab "Find" %}}
 
@@ -89,7 +89,7 @@ Cela génère une métrique `gauge` `mongo.example2.user.age` avec deux tags : 
 **Remarque** : le type de métrique défini est `gauge`. Consultez la [documentation relative aux types de métriques][2] pour en savoir plus.
 
 [1]: https://docs.mongodb.com/manual/reference/command/find/#dbcmd.find
-[2]: /fr/developers/metrics/types/
+[2]: /fr/metrics/types/
 {{% /tab %}}
 {{% tab "Aggregate" %}}
 

--- a/content/fr/integrations/guide/prometheus-metrics.md
+++ b/content/fr/integrations/guide/prometheus-metrics.md
@@ -58,9 +58,9 @@ Si le paramètre `send_distribution_buckets` est défini sur `true`, les métriq
 Si le paramètre `send_distribution_counts_as_monotonic` est défini sur `true`, chaque métrique qui se termine par `_count` est envoyée en tant que `monotonic_count`. [En savoir plus sur les counters monotones][4].
 
 [1]: /fr/agent/kubernetes/prometheus/
-[2]: /fr/developers/metrics/types/
+[2]: /fr/metrics/types/
 [3]: https://prometheus.io/docs/concepts/metric_types/#counter
-[4]: /fr/developers/metrics/agent_metrics_submission/?tab=count#monotonic-count
+[4]: /fr/metrics/agent_metrics_submission/?tab=count#monotonic-count
 [5]: https://prometheus.io/docs/concepts/metric_types/#gauge
 [6]: https://prometheus.io/docs/concepts/metric_types/#histogram
 [7]: https://www.datadoghq.com/blog/engineering/computing-accurate-percentiles-with-ddsketch/

--- a/content/fr/integrations/nagios.md
+++ b/content/fr/integrations/nagios.md
@@ -73,7 +73,7 @@ Pour configurer ce check lorsque l'Agent est exécuté sur un host :
 [1]: https://docs.datadoghq.com/fr/agent/guide/agent-configuration-files/#agent-configuration-directory
 [2]: https://github.com/DataDog/integrations-core/blob/master/nagios/datadog_checks/nagios/data/conf.yaml.example
 [3]: https://docs.datadoghq.com/fr/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[4]: https://docs.datadoghq.com/fr/developers/metrics/custom_metrics/
+[4]: https://docs.datadoghq.com/fr/metrics/custom_metrics/
 [5]: https://docs.datadoghq.com/fr/account_management/billing/custom_metrics/
 {{% /tab %}}
 {{% tab "Environnement conteneurisé" %}}

--- a/content/fr/integrations/node.md
+++ b/content/fr/integrations/node.md
@@ -77,7 +77,7 @@ Besoin d'aide ? Contactez [l'assistance Datadog][5].
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/brightcove/hot-shots
-[2]: https://docs.datadoghq.com/fr/developers/metrics/
+[2]: https://docs.datadoghq.com/fr/metrics/
 [3]: https://docs.datadoghq.com/fr/tracing/setup/nodejs/
 [4]: https://docs.datadoghq.com/fr/logs/log_collection/nodejs/
 [5]: https://docs.datadoghq.com/fr/help/

--- a/content/fr/integrations/openmetrics.md
+++ b/content/fr/integrations/openmetrics.md
@@ -37,7 +37,7 @@ supported_os:
 
 Extrayez des métriques custom depuis des endpoints OpenMetrics.
 
-<div class="alert alert-warning">Toutes les métriques récupérées par cette intégration sont considérées comme des <a href="https://docs.datadoghq.com/developers/metrics/custom_metrics">métriques custom</a>.</div>
+<div class="alert alert-warning">Toutes les métriques récupérées par cette intégration sont considérées comme des <a href="https://docs.datadoghq.com/metrics/custom_metrics">métriques custom</a>.</div>
 
 ## Configuration
 

--- a/content/fr/integrations/pdh_check.md
+++ b/content/fr/integrations/pdh_check.md
@@ -72,5 +72,5 @@ Le check PDH n'inclut aucun check de service.
 [3]: https://github.com/DataDog/integrations-core/blob/master/pdh_check/datadog_checks/pdh_check/data/conf.yaml.example
 [4]: https://docs.datadoghq.com/fr/agent/guide/agent-commands/#restart-the-agent
 [5]: https://docs.datadoghq.com/fr/agent/guide/agent-commands/#agent-status-and-information
-[6]: https://docs.datadoghq.com/fr/developers/metrics/custom_metrics/
+[6]: https://docs.datadoghq.com/fr/metrics/custom_metrics/
 [7]: https://docs.datadoghq.com/fr/account_management/billing/custom_metrics/

--- a/content/fr/integrations/pivotal_platform.md
+++ b/content/fr/integrations/pivotal_platform.md
@@ -429,7 +429,7 @@ Les métriques disponibles peuvent varier en fonction de la version de PCF et du
 [2]: https://network.pivotal.io/products/datadog-application-monitoring
 [3]: /fr/integrations/pivotal_pks/
 [4]: https://docs.cloudfoundry.org/buildpacks/understand-buildpacks.html#supply-script
-[5]: /fr/developers/metrics/dogstatsd_metrics_submission/
+[5]: /fr/metrics/dogstatsd_metrics_submission/
 [6]: https://docs.cloudfoundry.org/buildpacks/use-multiple-buildpacks.html
 [7]: https://github.com/cloudfoundry/multi-buildpack
 [8]: https://github.com/cloudfoundry/multi-buildpack#usage

--- a/content/fr/integrations/prometheus.md
+++ b/content/fr/integrations/prometheus.md
@@ -39,7 +39,7 @@ Connectez-vous à Prometheus pour :
 **Remarque :** nous vous conseillons d'utiliser le [check OpenMetrics][1] du fait de son efficacité accrue et de sa prise en charge complète du format texte Prometheus. N'utilisez le check Prometheus que lorsque l'endpoint de métriques ne prend pas en charge un format texte.
 
 <div class="alert alert-warning">
-Toutes les métriques récupérées par cette intégration sont considérées comme étant des <a href="https://docs.datadoghq.com/developers/metrics/custom_metrics">métriques custom</a>.
+Toutes les métriques récupérées par cette intégration sont considérées comme étant des <a href="https://docs.datadoghq.com/metrics/custom_metrics">métriques custom</a>.
 </div>
 
 **Consultez la section [Collecte de métriques Prometheus[2] pour découvrir comment configurer un check Prometheus.**

--- a/content/fr/integrations/windows_service.md
+++ b/content/fr/integrations/windows_service.md
@@ -140,7 +140,7 @@ Besoin d'aide ? Contactez [l'assistance Datadog][8].
 [2]: https://docs.datadoghq.com/fr/agent/guide/agent-configuration-files/#agent-configuration-directory
 [3]: https://github.com/DataDog/integrations-core/blob/master/windows_service/datadog_checks/windows_service/data/conf.yaml.example
 [4]: https://docs.datadoghq.com/fr/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[5]: https://docs.datadoghq.com/fr/developers/metrics/custom_metrics/
+[5]: https://docs.datadoghq.com/fr/metrics/custom_metrics/
 [6]: https://docs.datadoghq.com/fr/account_management/billing/custom_metrics/
 [7]: https://docs.datadoghq.com/fr/agent/guide/agent-commands/#agent-status-and-information
 [8]: https://docs.datadoghq.com/fr/help/

--- a/content/fr/integrations/wmi_check.md
+++ b/content/fr/integrations/wmi_check.md
@@ -171,7 +171,7 @@ Besoin d'aide ? Contactez [l'assistance Datadog][14].
 [7]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa394084.aspx
 [8]: https://technet.microsoft.com/en-us/library/Hh921475.aspx
 [9]: https://msdn.microsoft.com/en-us/library/aa393067.aspx
-[10]: https://docs.datadoghq.com/fr/developers/metrics/custom_metrics/
+[10]: https://docs.datadoghq.com/fr/metrics/custom_metrics/
 [11]: https://docs.datadoghq.com/fr/account_management/billing/custom_metrics/
 [12]: https://docs.datadoghq.com/fr/agent/guide/agent-commands/#agent-status-and-information
 [13]: https://github.com/DataDog/integrations-core/blob/master/wmi_check/metadata.csv

--- a/content/fr/logs/guide/getting-started-lwl.md
+++ b/content/fr/logs/guide/getting-started-lwl.md
@@ -130,7 +130,7 @@ Pour en savoir plus sur la fonctionnalité Logging without Limits™ et exploite
 [4]: https://app.datadoghq.com/logs/patterns
 [5]: /fr/logs/live_tail/
 [6]: /fr/logs/archives/
-[7]: /fr/developers/metrics/
+[7]: /fr/metrics/
 [8]: /fr/logs/logs_to_metrics/
 [9]: /fr/monitors/monitor_types/anomaly/
 [10]: https://app.datadoghq.com/monitors#/triggered

--- a/content/fr/logs/logs_to_metrics.md
+++ b/content/fr/logs/logs_to_metrics.md
@@ -86,7 +86,7 @@ Un tag `status` supplémentaire est disponible pour la métrique `datadog.estima
 [6]: /fr/logs/search_syntax/
 [7]: /fr/logs/explorer/facets/#quantitative-facets-measures
 [8]: /fr/getting_started/tagging/
-[9]: /fr/developers/metrics/custom_metrics/
+[9]: /fr/metrics/custom_metrics/
 [10]: /fr/security/logs/#hipaa-enabled-customers
 [11]: /fr/account_management/billing/custom_metrics/?tab=countrategauge
-[12]: /fr/developers/metrics/#naming-metrics
+[12]: /fr/metrics/#naming-metrics

--- a/content/fr/metrics/_index.md
+++ b/content/fr/metrics/_index.md
@@ -151,12 +151,12 @@ Consultez la section [Metrics Summary][21] pour en savoir plus.
 [7]: /fr/integrations/
 [8]: /fr/integrations/amazon_ec2/
 [9]: /fr/logs/logs_to_metrics/
-[10]: /fr/developers/metrics/
+[10]: /fr/metrics/
 [11]: /fr/agent/
-[12]: /fr/developers/metrics/dogstatsd_metrics_submission/
+[12]: /fr/metrics/dogstatsd_metrics_submission/
 [13]: /fr/api/
 [14]: https://docs.datadoghq.com/fr/agent/basic_agent_usage/
-[15]: /fr/developers/metrics/types/
+[15]: /fr/metrics/types/
 [16]: /fr/getting_started/tagging/using_tags/
 [17]: /fr/dashboards/functions/
 [18]: /fr/metrics/distributions/

--- a/content/fr/metrics/distributions.md
+++ b/content/fr/metrics/distributions.md
@@ -6,7 +6,7 @@ aliases:
   - /fr/developers/faq/characteristics-of-datadog-histograms/
   - /fr/graphing/metrics/distributions/
 further_reading:
-  - link: /developers/metrics/dogstatsd_metrics_submission/
+  - link: /metrics/dogstatsd_metrics_submission/
     tag: Documentation
     text: Utilisation des distributions dans DogStatsD
 ---
@@ -52,5 +52,5 @@ Pour en savoir plus sur le nombre de métriques custom créées à partir de mé
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /fr/developers/metrics/types/
+[1]: /fr/metrics/types/
 [2]: https://app.datadoghq.com/metric/distribution_metrics

--- a/content/fr/metrics/summary.md
+++ b/content/fr/metrics/summary.md
@@ -101,9 +101,9 @@ Pour chaque clé de tag spécifique, vous pouvez également effectuer les opéra
 [1]: https://app.datadoghq.com/metric/summary
 [2]: /fr/metrics/explorer/
 [3]: /fr/dashboards/
-[4]: /fr/developers/metrics/custom_metrics/
+[4]: /fr/metrics/custom_metrics/
 [5]: /fr/getting_started/tagging/
 [6]: /fr/api/v1/metrics/#edit-metric-metadata
-[7]: /fr/developers/metrics/units/
-[8]: /fr/developers/metrics/types/
+[7]: /fr/metrics/units/
+[8]: /fr/metrics/types/
 [9]: /fr/integrations/

--- a/content/fr/monitors/guide/slo-checklist.md
+++ b/content/fr/monitors/guide/slo-checklist.md
@@ -98,7 +98,7 @@ _Exemple : 99 % des requêtes doivent se terminer en moins de 250 ms sur une 
 
 [1]: https://app.datadoghq.com/slo
 [2]: https://app.datadoghq.com/monitors#create/metric
-[3]: /fr/developers/metrics
+[3]: /fr/metrics
 [4]: /fr/integrations
 [5]: /fr/tracing/generate_metrics/
 [6]: /fr/logs/logs_to_metrics/

--- a/content/fr/serverless/azure_app_services.md
+++ b/content/fr/serverless/azure_app_services.md
@@ -155,5 +155,5 @@ Pour commencer à résoudre les éventuels problèmes concernant votre applicati
 [13]: /fr/logs/log_collection/csharp/?tab=serilog#agentless-logging
 [14]: https://www.nuget.org/packages/DogStatsD-CSharp-Client
 [15]: /fr/developers/dogstatsd/?tab=net#code
-[16]: /fr/developers/metrics/
+[16]: /fr/metrics/
 [17]: /fr/help

--- a/content/fr/serverless/custom_metrics/_index.md
+++ b/content/fr/serverless/custom_metrics/_index.md
@@ -250,7 +250,7 @@ Où :
 [2]: /fr/tracing/generate_metrics/
 [3]: https://docs.datadoghq.com/fr/metrics/distributions/
 [4]: /fr/serverless/forwarder/
-[5]: /fr/developers/metrics/
+[5]: /fr/metrics/
 [6]: /fr/serverless/installation/
 [7]: /fr/metrics/distributions/#customize-tagging
 [8]: https://aws.amazon.com/premiumsupport/knowledge-center/internet-access-lambda-function

--- a/content/fr/tagging/_index.md
+++ b/content/fr/tagging/_index.md
@@ -99,7 +99,7 @@ Vous pouvez utiliser l'une (ou l'ensemble) des méthodes suivantes pour assigner
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /fr/getting_started/tagging/using_tags
-[2]: /fr/developers/metrics/
+[2]: /fr/metrics/
 [3]: /fr/getting_started/tagging/assigning_tags
 [4]: /fr/getting_started/tagging/assigning_tags/#configuration-files
 [5]: /fr/getting_started/tagging/assigning_tags/#environment-variables

--- a/content/fr/tagging/assigning_tags.md
+++ b/content/fr/tagging/assigning_tags.md
@@ -263,7 +263,7 @@ Créez des agrégations par centile dans les [métriques de distribution][1] en 
 {{< img src="tagging/assigning_tags/global_metrics_selection.png" alt="Tags création de monitor"  style="width:80%;">}}
 
 [1]: /fr/metrics/distributions/
-[2]: /fr/developers/metrics/custom_metrics/
+[2]: /fr/metrics/custom_metrics/
 {{% /tab %}}
 {{% tab "Intégrations" %}}
 
@@ -434,7 +434,7 @@ Les intégrations web sont basées sur un système d'authentification. Les métr
 [1]: /fr/getting_started/tagging/#defining-tags
 [2]: /fr/agent/docker/#environment-variables
 [3]: /fr/api/
-[4]: /fr/developers/metrics/dogstatsd_metrics_submission/
+[4]: /fr/metrics/dogstatsd_metrics_submission/
 [5]: /fr/integrations/
 [6]: /fr/agent/faq/how-datadog-agent-determines-the-hostname/
 [7]: /fr/dashboards/querying/#arithmetic-between-two-metrics
@@ -444,7 +444,7 @@ Les intégrations web sont basées sur un système d'authentification. Les métr
 [11]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/ecs_extract.go
 [12]: /fr/tracing/guide/setting_primary_tags_to_scope/
 [13]: /fr/libraries/
-[14]: /fr/developers/metrics/dogstatsd_metrics_submission/#host-tag-key
+[14]: /fr/metrics/dogstatsd_metrics_submission/#host-tag-key
 [15]: /fr/agent/faq/why-should-i-install-the-agent-on-my-cloud-instances/
 [16]: /fr/integrations/amazon_api_gateway/
 [17]: /fr/integrations/amazon_auto_scaling/

--- a/content/fr/tracing/generate_metrics/_index.md
+++ b/content/fr/tracing/generate_metrics/_index.md
@@ -79,7 +79,7 @@ Lorsqu'une métrique est créée, seuls deux champs peuvent être mis à jour :
 
 [1]: /fr/tracing/trace_retention_and_ingestion
 [2]: /fr/account_management/billing/custom_metrics/
-[3]: https://docs.datadoghq.com/fr/developers/metrics/#overview
+[3]: https://docs.datadoghq.com/fr/metrics/#overview
 [4]: /fr/monitors/monitor_types/anomaly/#overview
 [5]: /fr/tracing/trace_search_and_analytics/
 [6]: /fr/tracing/trace_search_and_analytics/query_syntax/#analytics-query
@@ -87,4 +87,4 @@ Lorsqu'une métrique est créée, seuls deux champs peuvent être mis à jour :
 [8]: https://app.datadoghq.com/apm/getting-started
 [9]: https://app.datadoghq.com/apm/traces/generate-metrics
 [10]: /fr/tracing/trace_search_and_analytics/query_syntax/
-[11]: /fr/developers/metrics/#naming-metrics
+[11]: /fr/metrics/#naming-metrics

--- a/content/fr/tracing/guide/ddsketch_trace_metrics.md
+++ b/content/fr/tracing/guide/ddsketch_trace_metrics.md
@@ -70,6 +70,6 @@ max:trace.sample_span{datacenter:production, service:bar, resource:ghijk5678}
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /fr/metrics/distributions/
-[2]: /fr/developers/metrics/types/?tab=distribution#metric-types
+[2]: /fr/metrics/types/?tab=distribution#metric-types
 [3]: /fr/tracing/guide/setting_primary_tags_to_scope/#add-a-second-primary-tag-in-datadog
 [4]: https://www.datadoghq.com/blog/engineering/computing-accurate-percentiles-with-ddsketch/

--- a/content/fr/tracing/guide/metrics_namespace.md
+++ b/content/fr/tracing/guide/metrics_namespace.md
@@ -187,8 +187,8 @@ Les paramètres sont définis comme suit :
 [2]: /fr/tracing/setup/
 [3]: /fr/tracing/visualization/#trace-metrics
 [4]: /fr/tracing/guide/setting_primary_tags_to_scope/#add-a-second-primary-tag-in-datadog
-[5]: /fr/developers/metrics/types/?tab=count#metric-types
-[6]: /fr/developers/metrics/types/?tab=gauge#metric-types
+[5]: /fr/metrics/types/?tab=count#metric-types
+[6]: /fr/metrics/types/?tab=gauge#metric-types
 [7]: /fr/tracing/visualization/services_list/#services-types
 [8]: /fr/tracing/visualization/#services
 [9]: /fr/tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm/

--- a/content/fr/tracing/runtime_metrics/nodejs.md
+++ b/content/fr/tracing/runtime_metrics/nodejs.md
@@ -43,7 +43,7 @@ Datadog fournit non seulement ces métriques sur votre page Service de l'APM, ma
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/apm/services
-[2]: /fr/developers/metrics/dogstatsd_metrics_submission/#setup
+[2]: /fr/metrics/dogstatsd_metrics_submission/#setup
 [3]: /fr/agent/docker/#dogstatsd-custom-metrics
 [4]: /fr/developers/dogstatsd/?tab=kubernetes#agent
 [5]: /fr/integrations/amazon_ecs/?tab=python#create-an-ecs-task

--- a/content/fr/tracing/runtime_metrics/python.md
+++ b/content/fr/tracing/runtime_metrics/python.md
@@ -46,7 +46,7 @@ Datadog fournit non seulement ces métriques sur votre page Service de l'APM, ma
 
 [1]: https://app.datadoghq.com/apm/services
 [2]: https://github.com/DataDog/dd-trace-py/releases/tag/v0.24.0
-[3]: /fr/developers/metrics/dogstatsd_metrics_submission/#setup
+[3]: /fr/metrics/dogstatsd_metrics_submission/#setup
 [4]: /fr/agent/docker/#dogstatsd-custom-metrics
 [5]: /fr/developers/dogstatsd/?tab=kubernetes#agent
 [6]: /fr/integrations/amazon_ecs/?tab=python#create-an-ecs-task

--- a/content/fr/tracing/runtime_metrics/ruby.md
+++ b/content/fr/tracing/runtime_metrics/ruby.md
@@ -62,7 +62,7 @@ Datadog fournit non seulement ces métriques sur votre page Service de l'APM, ma
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://rubygems.org/gems/dogstatsd-ruby
-[2]: /fr/developers/metrics/dogstatsd_metrics_submission/#setup
+[2]: /fr/metrics/dogstatsd_metrics_submission/#setup
 [3]: https://app.datadoghq.com/apm/service
 [4]: /fr/agent/docker/#dogstatsd-custom-metrics
 [5]: /fr/developers/dogstatsd/?tab=kubernetes#agent

--- a/content/ja/account_management/billing/custom_metrics.md
+++ b/content/ja/account_management/billing/custom_metrics.md
@@ -68,9 +68,9 @@ Florida の気温を入手するには、単に次のようにカスタムメト
 - `temperature{country:USA, state:Florida, city:Miami}`
 - `temperature{state:Florida, city:Miami, country:USA}`
 
-[1]: /ja/developers/metrics/types/?tab=count#metric-types
-[2]: /ja/developers/metrics/types/?tab=rate#metric-types
-[3]: /ja/developers/metrics/types/?tab=gauge#metric-types
+[1]: /ja/metrics/types/?tab=count#metric-types
+[2]: /ja/metrics/types/?tab=rate#metric-types
+[3]: /ja/metrics/types/?tab=gauge#metric-types
 {{% /tab %}}
 {{% tab "Histogram" %}}
 
@@ -91,8 +91,8 @@ Florida の気温を入手するには、単に次のようにカスタムメト
 - Datadog に送信するパーセンタイル集計を、[datadog.yaml 構成ファイル][3]の `histogram_percentiles` パラメーターで構成します。デフォルトでは、パーセンタイル順位が 95 の `95percentile` だけが Datadog に送信されます。
 
 
-[1]: /ja/developers/metrics/types/?tab=histogram#metric-types
-[2]: /ja/developers/metrics/types/?tab=histogram#definition
+[1]: /ja/metrics/types/?tab=histogram#metric-types
+[2]: /ja/metrics/types/?tab=histogram#definition
 [3]: /ja/agent/guide/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{% tab "Distribution" %}}
@@ -130,7 +130,7 @@ DISTRIBUTION メトリクスを集計する[タグの組み合わせ][2]をカ�
 
 [DISTRIBUTION メトリクス][1]のカスタムメトリクス数は、メトリクス名とタグ値の一意の組み合わせ数に 5 を掛けた数になります。タグをカスタマイズした結果として、`request.Latency` から報告される**カスタムメトリクス総数は 5×*3 = 15** になります。
 
-[1]: /ja/developers/metrics/types/?tab=distribution#definition
+[1]: /ja/metrics/types/?tab=distribution#definition
 [2]: /ja/metrics/distributions/#customize-tagging
 {{% /tab %}}
 {{< /tabs >}}
@@ -174,8 +174,8 @@ Datadog では、料金プランごとに一定数のカスタムメトリクス
 請求に関するご質問は、[カスタマーサクセス][9]マネージャーにお問い合わせください。
 
 [1]: /ja/integrations/
-[2]: /ja/developers/metrics/custom_metrics/
-[3]: /ja/developers/metrics/types/#metric-types
+[2]: /ja/metrics/custom_metrics/
+[3]: /ja/metrics/types/#metric-types
 [4]: /ja/account_management/users/default_roles/
 [5]: https://app.datadoghq.com/account/usage/hourly
 [6]: /ja/account_management/billing/usage_details/

--- a/content/ja/account_management/billing/pricing.md
+++ b/content/ja/account_management/billing/pricing.md
@@ -86,7 +86,7 @@ Indexed Span のボリュームと Ingested Span のボリュームの両方に�
 アカウントの 1 時間ごとの料金または請求については、[セールス][6]または[カスタマーサクセス][7]マネージャーにお問い合わせください。
 
 [1]: https://www.datadoghq.com/pricing
-[2]: /ja/developers/metrics/custom_metrics/
+[2]: /ja/metrics/custom_metrics/
 [3]: /ja/tracing/trace_retention_and_ingestion/#retention-filters
 [4]: /ja/tracing/trace_retention_and_ingestion/
 [5]: /ja/help/

--- a/content/ja/account_management/billing/usage_details.md
+++ b/content/ja/account_management/billing/usage_details.md
@@ -117,7 +117,7 @@ Log Management タブにあるこの表には、インデックス名および�
 課金に関するご質問は、[カスタマーサクセス][6]マネージャーにお問い合わせください。
 
 [1]: https://app.datadoghq.com/account/usage/hourly
-[2]: /ja/developers/metrics/custom_metrics/
+[2]: /ja/metrics/custom_metrics/
 [3]: https://docs.datadoghq.com/ja/metrics/summary/#overview
 [4]: https://docs.datadoghq.com/ja/logs/archives/rehydrating/?tab=awss3#overview
 [5]: /ja/help/

--- a/content/ja/agent/basic_agent_usage/_index.md
+++ b/content/ja/agent/basic_agent_usage/_index.md
@@ -62,12 +62,12 @@ Agent フォワーダーは、メトリクスを HTTPS 経由で Datadog に送�
 
 v6 の DogStatsD は、[Etsy の StatsD][5] メトリクス集計デーモンの Go 言語実装です。UDP または Unix ソケット経由で任意のメトリクスを受信してロールアップするために使用され、構成要素の一部としてカスタムコードを組み込んでもレイテンシーが発生しません。DogStatsD についての詳細は[こちら][6]でご確認いただけます。
 
-[1]: /ja/developers/metrics/dogstatsd_metrics_submission/#metrics
+[1]: /ja/metrics/dogstatsd_metrics_submission/#metrics
 [2]: /ja/tracing/guide/terminology/
 [3]: /ja/agent/guide/network/#open-ports
 [4]: /ja/developers/custom_checks/write_agent_check/
 [5]: https://github.com/etsy/statsd
-[6]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[6]: /ja/metrics/dogstatsd_metrics_submission/
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
@@ -104,7 +104,7 @@ minfds = 100 # ハードウェア制限
 ```
 
 [1]: /ja/integrations/
-[2]: /ja/developers/metrics/custom_metrics/
+[2]: /ja/metrics/custom_metrics/
 [3]: /ja/agent/guide/network/?tab=agentv5v4#open-ports
 [4]: /ja/agent/proxy/?tab=agentv5
 [5]: /ja/agent/faq/network/

--- a/content/ja/agent/versions/_index.md
+++ b/content/ja/agent/versions/_index.md
@@ -75,7 +75,7 @@ Agent v5 から Agent v6 へのすべての変更内容については、[Datado
 [2]: /ja/agent/guide/agent-commands/
 [3]: /ja/developers/dogstatsd/unix_socket/
 [4]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md
-[5]: /ja/developers/metrics/types/?tab=distribution#metric-types
+[5]: /ja/metrics/types/?tab=distribution#metric-types
 [6]: /ja/infrastructure/process/
 [7]: https://www.datadoghq.com/blog/monitor-prometheus-metrics
 [8]: /ja/logs/

--- a/content/ja/api/latest/rate-limits/_index.md
+++ b/content/ja/api/latest/rate-limits/_index.md
@@ -30,7 +30,7 @@ API レート制限ポリシーについて
 
 [1]: /ja/help/
 [2]: /ja/api/v1/metrics/
-[3]: /ja/developers/metrics/custom_metrics/
+[3]: /ja/metrics/custom_metrics/
 [4]: /ja/api/v1/metrics/#query-timeseries-points
 [5]: /ja/api/v1/logs/#get-a-list-of-logs
 [6]: /ja/api/v1/snapshots/

--- a/content/ja/api/v1/rate-limits/_index.md
+++ b/content/ja/api/v1/rate-limits/_index.md
@@ -30,7 +30,7 @@ API レート制限ポリシーについて
 
 [1]: /ja/help/
 [2]: /ja/api/v1/metrics/
-[3]: /ja/developers/metrics/custom_metrics/
+[3]: /ja/metrics/custom_metrics/
 [4]: /ja/api/v1/metrics/#query-timeseries-points
 [5]: /ja/api/v1/logs/#get-a-list-of-logs
 [6]: /ja/api/v1/snapshots/

--- a/content/ja/api/v2/rate-limits/_index.md
+++ b/content/ja/api/v2/rate-limits/_index.md
@@ -30,7 +30,7 @@ API レート制限ポリシーについて
 
 [1]: /ja/help/
 [2]: /ja/api/v1/metrics/
-[3]: /ja/developers/metrics/custom_metrics/
+[3]: /ja/metrics/custom_metrics/
 [4]: /ja/api/v1/metrics/#query-timeseries-points
 [5]: /ja/api/v1/logs/#get-a-list-of-logs
 [6]: /ja/api/v1/snapshots/

--- a/content/ja/dashboards/functions/interpolation.md
+++ b/content/ja/dashboards/functions/interpolation.md
@@ -100,4 +100,4 @@ default_zero(avg:custom_metric{*})
 
 [1]: /ja/getting_started/from_the_query_to_the_graph/#proceed-to-space-aggregation
 [2]: /ja/monitors/guide/as-count-in-monitor-evaluations/
-[3]: /ja/developers/metrics/
+[3]: /ja/metrics/

--- a/content/ja/dashboards/functions/rollup.md
+++ b/content/ja/dashboards/functions/rollup.md
@@ -80,5 +80,5 @@ aliases:
 [1]: /ja/dashboards/functions/#proceed-to-time-aggregation
 [2]: /ja/metrics/faq/rollup-for-distributions-with-percentiles/
 [3]: https://www.datadoghq.com/blog/visualize-statsd-metrics-counts-graphing
-[4]: /ja/developers/metrics/type_modifiers/
+[4]: /ja/metrics/type_modifiers/
 [5]: /ja/monitors/monitor_types/metric/

--- a/content/ja/dashboards/guide/how-to-graph-percentiles-in-datadog.md
+++ b/content/ja/dashboards/guide/how-to-graph-percentiles-in-datadog.md
@@ -44,8 +44,8 @@ Agent の構成ファイルの「histogram_percentiles」行を次のように�
 
 [Datadog のヒストグラムの特性については、こちらを参照してください][5]。
 
-[1]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[1]: /ja/metrics/dogstatsd_metrics_submission/
 [2]: https://github.com/DataDog/dd-agent/blob/master/aggregator.py
 [3]: /ja/developers/community/libraries/
-[4]: /ja/developers/metrics/histograms/
+[4]: /ja/metrics/histograms/
 [5]: /ja/developers/faq/characteristics-of-datadog-histograms/

--- a/content/ja/dashboards/guide/query-to-the-graph.md
+++ b/content/ja/dashboards/guide/query-to-the-graph.md
@@ -161,10 +161,10 @@ Datadog は、次の 4 つの空間集計関数を提供しています。
 [1]: /ja/dashboards/timeboard/
 [2]: /ja/dashboards/screenboard/
 [3]: /ja/agent/
-[4]: /ja/developers/metrics/custom_metrics/
+[4]: /ja/metrics/custom_metrics/
 [5]: /ja/dashboards/faq/how-is-data-aggregated-in-graphs/
 [6]: /ja/dashboards/faq/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs/
 [7]: /ja/dashboards/functions/rollup/
 [8]: /ja/dashboards/faq/i-m-switching-between-the-sum-min-max-avg-aggregators-but-the-values-look-the-same/
 [9]: https://www.datadoghq.com/blog/visualize-statsd-metrics-counts-graphing
-[10]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[10]: /ja/metrics/dogstatsd_metrics_submission/

--- a/content/ja/developers/_index.md
+++ b/content/ja/developers/_index.md
@@ -36,7 +36,7 @@ further_reading:
 ### 種類
 
 {{< whatsnext desc="Learn about the types of data you can submit to Datadog:" >}}
-    {{< nextlink href="/developers/metrics" >}}<u>カスタムメトリクス</u>: Datadog のカスタムメトリクスについて掘り下げて説明します。メトリクスのタイプや、それぞれのタイプが表すもの、送信方法、および Datadog 全体でどのように使用されるかを、このセクションで説明します。{{< /nextlink >}}
+    {{< nextlink href="/metrics" >}}<u>カスタムメトリクス</u>: Datadog のカスタムメトリクスについて掘り下げて説明します。メトリクスのタイプや、それぞれのタイプが表すもの、送信方法、および Datadog 全体でどのように使用されるかを、このセクションで説明します。{{< /nextlink >}}
     {{< nextlink href="/developers/events" >}}<u>イベント</u>: カスタム Agent チェック、DogStatsD、または Datadog API を使用して、Datadog にイベントを送信する方法について説明します。{{< /nextlink >}}
     {{< nextlink href="/developers/service_checks" >}}<u>サービスチェック</u>: カスタム Agent チェック、DogStatsD、または Datadog API を使用して、Datadog にサービスチェックを送信する方法について説明します。{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/ja/developers/community/libraries.md
+++ b/content/ja/developers/community/libraries.md
@@ -168,7 +168,7 @@ Winston Datadog [転送][62]。
 
 Datadog ライブラリを作成し、このページに追加する場合は、[opensource@datadoghq.com][65] にメールを送信してください。
 
-[1]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[1]: /ja/metrics/dogstatsd_metrics_submission/
 [2]: /ja/tracing/
 [3]: /ja/serverless/
 [4]: /ja/api/
@@ -213,7 +213,7 @@ Datadog ライブラリを作成し、このページに追加する場合は、
 [43]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-datadog.html
 [44]: https://github.com/brigade/logstash-output-dogstatsd
 [45]: https://docs.moogsoft.com/AIOps.6.2.0/Datadog-Solution-Pak_13737047.html
-[46]: /ja/developers/metrics/custom_metrics/
+[46]: /ja/metrics/custom_metrics/
 [47]: https://github.com/simplifi/ngx_lua_datadog
 [48]: https://github.com/dailymotion/lua-resty-dogstatsd
 [49]: http://www.mediba.jp

--- a/content/ja/developers/dogstatsd/_index.md
+++ b/content/ja/developers/dogstatsd/_index.md
@@ -42,7 +42,7 @@ DogStatsD は、UDP 経由で[カスタムメトリクス][5]、[イベント][6
 
 UDP を使用するため、アプリケーションはメトリクスを DogStatsD に送信した後、応答を待たずに自身の作業を再開できます。DogStatsD を利用できなくなった場合でも、アプリケーションは中断しません。
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/dogstatsd.png" alt="dogstatsd"   >}}
+{{< img src="metrics/dogstatsd_metrics_submission/dogstatsd.png" alt="dogstatsd"   >}}
 
 DogStatsD は、データを受け取ると共に、_フラッシュ間隔_と呼ばれる時間間隔（デフォルトで 10 秒）でメトリクスごとに複数のデータポイントを 1 つのデータポイントに集計します。
 
@@ -174,7 +174,7 @@ env:
 [3]: https://kubernetes.io/docs/setup/independent/troubleshooting-kubeadm/#hostport-services-do-not-work
 [4]: /ja/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
 [5]: /ja/getting_started/tagging/assigning_tags/#environment-variables
-[6]: /ja/developers/metrics/custom_metrics/
+[6]: /ja/metrics/custom_metrics/
 {{% /tab %}}
 {{% tab "Helm" %}}
 
@@ -210,7 +210,7 @@ env:
 
      これにより、アプリケーションを実行しているポッドは、`$DD_AGENT_HOST` のポート `8125` から DogStatsD メトリクスを送信できるようになります。
 
-[1]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[1]: /ja/metrics/dogstatsd_metrics_submission/
 [2]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
 [3]: https://github.com/containernetworking/cni
 [4]: https://kubernetes.io/docs/setup/independent/troubleshooting-kubeadm/#hostport-services-do-not-work
@@ -500,7 +500,7 @@ using (var dogStatsdService = new DogStatsdService())
 DogStatsD と StatsD はほぼ同じですが、DogStatsD には、使用可能なデータ型、イベント、サービスチェック、タグなど、Datadog に固有の高度な機能が含まれています。
 
 {{< whatsnext desc="">}}
-    {{< nextlink href="/developers/metrics/dogstatsd_metrics_submission/" >}}DogStatsD でメトリクスを Datadog に送信します。{{< /nextlink >}}
+    {{< nextlink href="/metrics/dogstatsd_metrics_submission/" >}}DogStatsD でメトリクスを Datadog に送信します。{{< /nextlink >}}
     {{< nextlink href="/events/guides/dogstatsd/" >}}DogStatsD でイベントを Datadog に送信します。{{< /nextlink >}}
     {{< nextlink href="/developers/service_checks/dogstatsd_service_checks_submission/" >}}DogStatsD でサービスチェックを Datadog に送信します。{{< /nextlink >}}
 {{< /whatsnext >}}
@@ -508,12 +508,12 @@ DogStatsD と StatsD はほぼ同じですが、DogStatsD には、使用可能�
 DogStatsD が使用するデータグラム形式についてさらに理解を深めたい場合、または独自の Datadog ライブラリを開発したい場合は、[データグラムとシェルの使用][10]を参照してください。ここでは、メトリクスとイベントをコマンドラインから直接送信する方法についても説明しています。
 
 [1]: https://github.com/etsy/statsd
-[2]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[2]: /ja/metrics/dogstatsd_metrics_submission/
 [3]: https://hub.docker.com/r/datadog/dogstatsd
 [4]: https://gcr.io/datadoghq/dogstatsd
-[5]: /ja/developers/metrics/custom_metrics/
+[5]: /ja/metrics/custom_metrics/
 [6]: /ja/events/guides/dogstatsd/
 [7]: /ja/developers/service_checks/dogstatsd_service_checks_submission/
 [8]: /ja/developers/community/libraries/#api-and-dogstatsd-client-libraries
 [9]: /ja/getting_started/tagging/unified_service_tagging
-[10]: /ja/developers/metrics/
+[10]: /ja/metrics/

--- a/content/ja/developers/dogstatsd/data_aggregation.md
+++ b/content/ja/developers/dogstatsd/data_aggregation.md
@@ -48,9 +48,9 @@ Datadog の DogStatsD は、StatsD プロトコルを、いくつか固有の機
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /ja/developers/dogstatsd/
-[2]: /ja/developers/metrics/dogstatsd_metrics_submission/
-[3]: /ja/developers/metrics/types/?tab=count#metric-types
-[4]: /ja/developers/metrics/types/
-[5]: /ja/developers/metrics/types/?tab=gauge#metric-types
-[6]: /ja/developers/metrics/types/?tab=histogram#metric-types
-[7]: /ja/developers/metrics/types/?tab=distribution#metric-types
+[2]: /ja/metrics/dogstatsd_metrics_submission/
+[3]: /ja/metrics/types/?tab=count#metric-types
+[4]: /ja/metrics/types/
+[5]: /ja/metrics/types/?tab=gauge#metric-types
+[6]: /ja/metrics/types/?tab=histogram#metric-types
+[7]: /ja/metrics/types/?tab=distribution#metric-types

--- a/content/ja/developers/dogstatsd/datagram_shell.md
+++ b/content/ja/developers/dogstatsd/datagram_shell.md
@@ -40,8 +40,8 @@ further_reading:
 - `users.online:1|c|@0.5|#country:china`: アクティブな中国ユーザーを追跡し、サンプルレートを使用します。
 
 
-[1]: /ja/developers/metrics/#naming-metrics
-[2]: /ja/developers/metrics/types/
+[1]: /ja/metrics/#naming-metrics
+[2]: /ja/metrics/types/
 [3]: /ja/getting_started/tagging/
 {{% /tab %}}
 {{% tab "Events" %}}

--- a/content/ja/developers/dogstatsd/high_throughput.md
+++ b/content/ja/developers/dogstatsd/high_throughput.md
@@ -686,6 +686,6 @@ dogstatsdConfig.Advanced.TelemetryFlushInterval = null;
 [1]: /ja/agent/
 [2]: /ja/developers/dogstatsd/unix_socket/
 [3]: /ja/developers/dogstatsd/#code
-[4]: /ja/developers/metrics/dogstatsd_metrics_submission/#sample-rates
+[4]: /ja/metrics/dogstatsd_metrics_submission/#sample-rates
 [5]: /ja/developers/dogstatsd/high_throughput/#note-on-sysctl-in-kubernetes
 [6]: https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/

--- a/content/ja/developers/dogstatsd/unix_socket.md
+++ b/content/ja/developers/dogstatsd/unix_socket.md
@@ -3,7 +3,7 @@ title: Unix ドメインソケット上の DogStatsD
 kind: documentation
 description: Unix ドメインソケット上の DogStatsD の使用ガイド
 aliases:
-  - /ja/developers/metrics/unix_socket/
+  - /ja/metrics/unix_socket/
 further_reading:
   - link: developers/dogstatsd
     tag: Documentation
@@ -228,8 +228,8 @@ socat -s -u UDP-RECV:8125 UNIX-SENDTO:/var/run/datadog/dsd.socket
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /ja/developers/metrics/dogstatsd_metrics_submission/
-[2]: /ja/developers/metrics/custom_metrics/
+[1]: /ja/metrics/dogstatsd_metrics_submission/
+[2]: /ja/metrics/custom_metrics/
 [3]: https://github.com/DataDog/datadog-go#unix-domain-sockets-client
 [4]: https://github.com/DataDog/java-dogstatsd-client#unix-domain-socket-support
 [5]: https://github.com/DataDog/datadogpy#instantiate-the-dogstatsd-client-with-uds

--- a/content/ja/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
+++ b/content/ja/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
@@ -91,6 +91,6 @@ dog metric post -h
 {{< img src="developers/faq/dogshell_test.png" alt="dogshell_test"  >}}
 
 [1]: https://github.com/DataDog/datadogpy
-[2]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[2]: /ja/metrics/dogstatsd_metrics_submission/
 [3]: https://github.com/DataDog/datadogpy#installation
 [4]: https://github.com/DataDog/datadogpy/tree/master/datadog/dogshell

--- a/content/ja/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags.md
+++ b/content/ja/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags.md
@@ -2,7 +2,7 @@
 title: メトリクスやタグの命名で推奨されるベストプラクティス
 kind: faq
 further_reading:
-  - link: /developers/metrics/
+  - link: /metrics/
     tag: Documentation
     text: Datadog メトリクスの詳細
   - link: /getting_started/tagging/

--- a/content/ja/developers/integrations/check_references.md
+++ b/content/ja/developers/integrations/check_references.md
@@ -138,6 +138,6 @@ YAML 構文の詳細については、[Wikipedia][2] を参照してください
 [3]: http://yaml-online-parser.appspot.com/
 [4]: https://docs.datadoghq.com/ja/integrations/
 [5]: https://www.uuidgenerator.net
-[6]: https://docs.datadoghq.com/ja/developers/metrics/metrics_type/
-[7]: https://docs.datadoghq.com/ja/developers/metrics/metrics_units/
+[6]: https://docs.datadoghq.com/ja/metrics/metrics_type/
+[7]: https://docs.datadoghq.com/ja/metrics/metrics_units/
 [8]: https://docs.datadoghq.com/ja/getting_started/tagging/

--- a/content/ja/developers/integrations/new_check_howto.md
+++ b/content/ja/developers/integrations/new_check_howto.md
@@ -441,7 +441,7 @@ Agent バージョン >= 6.12 の場合
 [2]: /ja/developers/integrations/python
 [3]: https://github.com/DataDog/integrations-extras
 [4]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_dev
-[5]: https://docs.datadoghq.com/ja/developers/metrics/agent_metrics_submission/
+[5]: https://docs.datadoghq.com/ja/metrics/agent_metrics_submission/
 [6]: https://github.com/DataDog/datadog-agent/blob/6.2.x/docs/dev/checks/python/check_api.md
 [7]: https://docs.pytest.org/en/latest
 [8]: https://tox.readthedocs.io/en/latest

--- a/content/ja/developers/libraries.md
+++ b/content/ja/developers/libraries.md
@@ -167,7 +167,7 @@ Winston Datadog [転送][62]。
 
 Datadog ライブラリを作成し、このページに追加する場合は、[opensource@datadoghq.com][65] にメールを送信してください。
 
-[1]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[1]: /ja/metrics/dogstatsd_metrics_submission/
 [2]: /ja/tracing/
 [3]: /ja/serverless/
 [4]: /ja/api/
@@ -212,7 +212,7 @@ Datadog ライブラリを作成し、このページに追加する場合は、
 [43]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-datadog.html
 [44]: https://github.com/brigade/logstash-output-dogstatsd
 [45]: https://docs.moogsoft.com/AIOps.6.2.0/Datadog-Solution-Pak_13737047.html
-[46]: /ja/developers/metrics/custom_metrics/
+[46]: /ja/metrics/custom_metrics/
 [47]: https://github.com/simplifi/ngx_lua_datadog
 [48]: https://github.com/dailymotion/lua-resty-dogstatsd
 [49]: http://www.mediba.jp

--- a/content/ja/developers/metrics/_index.md
+++ b/content/ja/developers/metrics/_index.md
@@ -6,8 +6,8 @@ aliases:
   - /ja/guides/metrics/
   - /ja/metrictypes/
   - /ja/units/
-  - /ja/developers/metrics/datagram_shell
-  - /ja/developers/metrics/custom_metrics/
+  - /ja/metrics/datagram_shell
+  - /ja/metrics/custom_metrics/
   - /ja/getting_started/custom_metrics
 further_reading:
   - link: /developers/dogstatsd/
@@ -53,9 +53,9 @@ Datadog のカスタムメトリクスには、以下のプロパティがあり
 ## カスタムメトリクスの送信
 
 {{< whatsnext desc="メトリクスを Datadog に送信する方法はいくつかあります。">}}
-    {{< nextlink href="/developers/metrics/agent_metrics_submission" >}}カスタム Agent チェック{{< /nextlink >}}
-    {{< nextlink href="/developers/metrics/dogstatsd_metrics_submission" >}}DogStatsD{{< /nextlink >}}
-    {{< nextlink href="/developers/metrics/powershell_metrics_submission" >}}PowerShell{{< /nextlink >}}
+    {{< nextlink href="/metrics/agent_metrics_submission" >}}カスタム Agent チェック{{< /nextlink >}}
+    {{< nextlink href="/metrics/dogstatsd_metrics_submission" >}}DogStatsD{{< /nextlink >}}
+    {{< nextlink href="/metrics/powershell_metrics_submission" >}}PowerShell{{< /nextlink >}}
     {{< nextlink href="/api/v1/metrics/#submit-metrics" >}}Datadog の HTTP API{{< /nextlink >}}
 {{< /whatsnext >}}
 
@@ -71,13 +71,13 @@ Datadog のカスタムメトリクスには、以下のプロパティがあり
 
 [1]: /ja/integrations/
 [2]: /ja/account_management/billing/custom_metrics/#standard-integrations
-[3]: /ja/developers/metrics/dogstatsd_metrics_submission/
-[4]: /ja/developers/metrics/agent_metrics_submission/
+[3]: /ja/metrics/dogstatsd_metrics_submission/
+[4]: /ja/metrics/agent_metrics_submission/
 [5]: https://app.datadoghq.com/account/usage/hourly
 [6]: /ja/account_management/billing/custom_metrics/#counting-custom-metrics
 [7]: /ja/metrics
-[8]: /ja/developers/metrics/types/
-[9]: /ja/developers/metrics/types/?tab=rate#metric-types
-[10]: /ja/developers/metrics/types/?tab=count#metric-types
+[8]: /ja/metrics/types/
+[9]: /ja/metrics/types/?tab=rate#metric-types
+[10]: /ja/metrics/types/?tab=count#metric-types
 [11]: /ja/developers/dogstatsd/data_aggregation/#how-is-aggregation-performed-with-the-dogstatsd-server
 [12]: /ja/developers/community/libraries/

--- a/content/ja/developers/metrics/agent_metrics_submission.md
+++ b/content/ja/developers/metrics/agent_metrics_submission.md
@@ -223,14 +223,14 @@ self.histogram(name, value, tags=None, hostname=None, device_name=None)
 
 6. [メトリクスの概要ページ][6]でメトリクスが Datadog に報告を行っているかを確認します。
 
-{{< img src="developers/metrics/agent_metrics_submission/metrics_metrics_summary.png" alt="メトリクスの概要に記されたメトリクス"  style="width:80%;">}}
+{{< img src="metrics/agent_metrics_submission/metrics_metrics_summary.png" alt="メトリクスの概要に記されたメトリクス"  style="width:80%;">}}
 
 ## その他の参考資料
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /ja/developers/custom_checks/write_agent_check/
-[2]: /ja/developers/metrics/types/
+[2]: /ja/metrics/types/
 [3]: /ja/agent/guide/agent-configuration-files/#agent-configuration-directory
 [4]: /ja/agent/guide/agent-commands/#restart-the-agent
 [5]: /ja/agent/guide/agent-commands/#agent-information

--- a/content/ja/developers/metrics/dogstatsd_metrics_submission.md
+++ b/content/ja/developers/metrics/dogstatsd_metrics_submission.md
@@ -10,7 +10,7 @@ further_reading:
   - link: /developers/dogstatsd/
     tag: ドキュメント
     text: DogStatsD 入門
-  - link: /developers/metrics/types/
+  - link: /metrics/types/
     tag: ドキュメント
     text: Datadog メトリクスタイプ
 ---
@@ -202,11 +202,11 @@ while (TRUE) {
 
 上のコードを実行すると、メトリクスデータを Datadog でグラフ化できます。
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/increment_decrement.png" alt="Increment Decrement" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/increment_decrement.png" alt="Increment Decrement" >}}
 
 値は `COUNT` として送信されるため、Datadog に `RATE` として保存されます。Datadog で未加工のカウントを取得するには、[累積合計][3] や [積分][4] などの関数を系列に適用します。
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/increment_decrement_cumsum.png" alt="Increment Decrement with Cumsum" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/increment_decrement_cumsum.png" alt="Increment Decrement with Cumsum" >}}
 
 ### GAUGE
 
@@ -365,7 +365,7 @@ while (TRUE) {
 
 上のコードを実行すると、メトリクスデータを Datadog でグラフ化できます。
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/gauge.png" alt="Gauge" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/gauge.png" alt="Gauge" >}}
 
 ### SET
 
@@ -501,7 +501,7 @@ while (TRUE) {
 
 上のコードを実行すると、メトリクスデータを Datadog でグラフ化できます。
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/set.png" alt="Set" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/set.png" alt="Set" >}}
 
 ### HISTOGRAM
 
@@ -670,7 +670,7 @@ while (TRUE) {
 
 上のコードを実行すると、メトリクスデータを Datadog でグラフ化できます。
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/histogram.png" alt="Histogram" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/histogram.png" alt="Histogram" >}}
 
 #### タイマー
 
@@ -775,7 +775,7 @@ DogStatsD はタイマーメトリクスデータを受け取ると、レンダ�
 
 DogStatsD は `TIMER` を `HISTOGRAM` メトリクスとして扱います。使用するメトリクスのタイプが `TIMER` であろうと `HISTOGRAM` であろうと、Datadog に送信されるのは同じデータです。上のコードを実行すると、メトリクスデータを Datadog でグラフ化できます。
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/timer.png" alt="Timer" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/timer.png" alt="Timer" >}}
 
 ### DISTRIBUTION
 
@@ -1055,11 +1055,11 @@ $statsd->increment('example_metric.increment', array('environment' => 'dev', 'ac
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /ja/developers/dogstatsd/
-[2]: /ja/developers/metrics/types/?tab=count#definition
+[2]: /ja/metrics/types/?tab=count#definition
 [3]: /ja/dashboards/functions/arithmetic/#cumulative-sum
 [4]: /ja/dashboards/functions/arithmetic/#integral
-[5]: /ja/developers/metrics/types/?tab=gauge#definition
-[6]: /ja/developers/metrics/types/?tab=histogram#definition
+[5]: /ja/metrics/types/?tab=gauge#definition
+[6]: /ja/metrics/types/?tab=histogram#definition
 [7]: /ja/agent/guide/agent-configuration-files/#agent-main-configuration-file
 [8]: /ja/metrics/distributions/
-[9]: /ja/developers/metrics/types/?tab=distribution#definition
+[9]: /ja/metrics/types/?tab=distribution#definition

--- a/content/ja/developers/metrics/powershell_metrics_submission.md
+++ b/content/ja/developers/metrics/powershell_metrics_submission.md
@@ -148,7 +148,7 @@ $http_request.responseText
 [その他のコード例については、ncracker/dd_metric GitHub リポジトリを参照してください][6]。
 
 [1]: https://app.datadoghq.com/account/settings#api
-[2]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[2]: /ja/metrics/dogstatsd_metrics_submission/
 [3]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
 [4]: /ja/api/v1/hosts/
 [5]: /ja/api/v1/metrics/

--- a/content/ja/developers/metrics/type_modifiers.md
+++ b/content/ja/developers/metrics/type_modifiers.md
@@ -2,7 +2,7 @@
 title: メトリクスタイプのモディファイアー
 kind: documentation
 aliases:
-  - /ja/developers/metrics/metric_type_modifiers
+  - /ja/metrics/metric_type_modifiers
   - /ja/graphing/faq/as_count_validation
 further_reading:
   - link: /developers/dogstatsd/
@@ -77,7 +77,7 @@ further_reading:
 
 通常は必要ありませんが、[メトリクスサマリーページ][4]でメトリクスのタイプを変更することができます。
 
-{{< img src="developers/metrics/type_modifiers/metric_type.png" alt="メトリクスタイプ"  style="width:70%;">}}
+{{< img src="metrics/type_modifiers/metric_type.png" alt="メトリクスタイプ"  style="width:70%;">}}
 
 使用例：
 
@@ -95,7 +95,7 @@ further_reading:
 
 **注**: Agent チェックの `self.increment` は、単調増加カウンターの増分を計算するのではなく、チェック実行時に渡された値を報告します。単調増加カウンターの増分値を送信する場合は、`self.monotonic_count` を使用してください。
 
-[1]: /ja/developers/metrics/types/
+[1]: /ja/metrics/types/
 [2]: /ja/metrics/introduction/#time-aggregation
 [3]: /ja/dashboards/faq/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs/
 [4]: https://app.datadoghq.com/metric/summary

--- a/content/ja/developers/metrics/types.md
+++ b/content/ja/developers/metrics/types.md
@@ -2,14 +2,14 @@
 title: メトリクスタイプ
 kind: documentation
 aliases:
-  - /ja/developers/metrics/counts/
-  - /ja/developers/metrics/distributions/
-  - /ja/developers/metrics/gauges/
-  - /ja/developers/metrics/histograms/
-  - /ja/developers/metrics/rates/
-  - /ja/developers/metrics/sets/
-  - /ja/developers/metrics_type/
-  - /ja/developers/metrics/metrics_type/
+  - /ja/metrics/counts/
+  - /ja/metrics/distributions/
+  - /ja/metrics/gauges/
+  - /ja/metrics/histograms/
+  - /ja/metrics/rates/
+  - /ja/metrics/sets/
+  - /ja/metrics_type/
+  - /ja/metrics/metrics_type/
 further_reading:
   - link: developers/dogstatsd
     tag: ドキュメント
@@ -244,10 +244,10 @@ GAUGE、HISTOGRAM などのメトリクスタイプと同様に、DISTRIBUTION �
 **注**: DogStatsD を介して COUNT メトリクスタイプを送信する場合、メトリクスは異なる Agent 間の関連する比較を確保するためにアプリ内に RATE として表示されます。その結果、StatsD カウントは Datadog 内に 10 進数値で表示される場合があります（1 秒あたりの単位を報告するために時間間隔で正規化されるため）。
 
 
-[1]: /ja/developers/metrics/agent_metrics_submission/?tab=count#count
-[2]: /ja/developers/metrics/agent_metrics_submission/?tab=count#monotonic-count
+[1]: /ja/metrics/agent_metrics_submission/?tab=count#count
+[2]: /ja/metrics/agent_metrics_submission/?tab=count#monotonic-count
 [3]: /ja/api/v1/metrics/#submit-metrics
-[4]: /ja/developers/metrics/dogstatsd_metrics_submission/#count
+[4]: /ja/metrics/dogstatsd_metrics_submission/#count
 {{% /tab %}}
 {{% tab "RATE" %}}
 
@@ -261,7 +261,7 @@ GAUGE、HISTOGRAM などのメトリクスタイプと同様に、DISTRIBUTION �
 **注**: DogStatsD を介して RATE メトリクスタイプを送信する場合、メトリクスは異なる Agent 間の関連する比較を確保するためにアプリ内に GAUGE として表示されます。
 
 
-[1]: /ja/developers/metrics/agent_metrics_submission/?tab=rate
+[1]: /ja/metrics/agent_metrics_submission/?tab=rate
 [2]: /ja/api/v1/metrics/#submit-metrics
 {{% /tab %}}
 {{% tab "GAUGE" %}}
@@ -275,9 +275,9 @@ GAUGE、HISTOGRAM などのメトリクスタイプと同様に、DISTRIBUTION �
 | [DogStatsD][3]    | `dog.gauge(...)`                     | GAUGE           | GAUGE               |
 
 
-[1]: /ja/developers/metrics/agent_metrics_submission/?tab=gauge
+[1]: /ja/metrics/agent_metrics_submission/?tab=gauge
 [2]: /ja/api/v1/metrics/#submit-metrics
-[3]: /ja/developers/metrics/dogstatsd_metrics_submission/#gauge
+[3]: /ja/metrics/dogstatsd_metrics_submission/#gauge
 {{% /tab %}}
 {{% tab "HISTOGRAM" %}}
 
@@ -291,8 +291,8 @@ GAUGE、HISTOGRAM などのメトリクスタイプと同様に、DISTRIBUTION �
 **注**: TIMER メトリクスを Datadog Agent に送信する場合、これは DogStatsD 内で HISTOGRAM メトリクスタイプを送信することと同等です（標準 StatsD のタイマーと混同しないでください）。タイマーは期間データのみを表します。たとえば、コードのセクションの実行にかかる時間や、ページを完全にレンダリングするのにかかる時間などです。
 
 
-[1]: /ja/developers/metrics/agent_metrics_submission/?tab=histogram
-[2]: /ja/developers/metrics/dogstatsd_metrics_submission/#histogram
+[1]: /ja/metrics/agent_metrics_submission/?tab=histogram
+[2]: /ja/metrics/dogstatsd_metrics_submission/#histogram
 {{% /tab %}}
 {{% tab "DISTRIBUTION" %}}
 
@@ -303,7 +303,7 @@ GAUGE、HISTOGRAM などのメトリクスタイプと同様に、DISTRIBUTION �
 | [DogStatsD][1]    | `dog.distribution(...)`    | DISTRIBUTION    | GAUGE、COUNT         |
 
 
-[1]: /ja/developers/metrics/dogstatsd_metrics_submission/#distribution
+[1]: /ja/metrics/dogstatsd_metrics_submission/#distribution
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -332,21 +332,21 @@ GAUGE、HISTOGRAM などのメトリクスタイプと同様に、DISTRIBUTION �
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /ja/developers/metrics/type_modifiers/
+[1]: /ja/metrics/type_modifiers/
 [2]: /ja/dashboards/functions/
 [3]: /ja/metrics/summary/
 [4]: https://statsd.readthedocs.io/en/v3.2.1/types.html#sets
-[5]: /ja/developers/metrics/agent_metrics_submission/
-[6]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[5]: /ja/metrics/agent_metrics_submission/
+[6]: /ja/metrics/dogstatsd_metrics_submission/
 [7]: /ja/api/v1/metrics/#submit-metrics
 [8]: /ja/developers/dogstatsd/#how-it-works
-[9]: /ja/developers/metrics/agent_metrics_submission/?tab=count#count
-[10]: /ja/developers/metrics/agent_metrics_submission/?tab=count#monotonic-count
-[11]: /ja/developers/metrics/agent_metrics_submission/?tab=gauge
-[12]: /ja/developers/metrics/agent_metrics_submission/?tab=histogram
-[13]: /ja/developers/metrics/agent_metrics_submission/?tab=rate
-[14]: /ja/developers/metrics/dogstatsd_metrics_submission/#gauge
-[15]: /ja/developers/metrics/dogstatsd_metrics_submission/#distribution
-[16]: /ja/developers/metrics/dogstatsd_metrics_submission/#count
-[17]: /ja/developers/metrics/dogstatsd_metrics_submission/#set
-[18]: /ja/developers/metrics/dogstatsd_metrics_submission/#histogram
+[9]: /ja/metrics/agent_metrics_submission/?tab=count#count
+[10]: /ja/metrics/agent_metrics_submission/?tab=count#monotonic-count
+[11]: /ja/metrics/agent_metrics_submission/?tab=gauge
+[12]: /ja/metrics/agent_metrics_submission/?tab=histogram
+[13]: /ja/metrics/agent_metrics_submission/?tab=rate
+[14]: /ja/metrics/dogstatsd_metrics_submission/#gauge
+[15]: /ja/metrics/dogstatsd_metrics_submission/#distribution
+[16]: /ja/metrics/dogstatsd_metrics_submission/#count
+[17]: /ja/metrics/dogstatsd_metrics_submission/#set
+[18]: /ja/metrics/dogstatsd_metrics_submission/#histogram

--- a/content/ja/developers/metrics/units.md
+++ b/content/ja/developers/metrics/units.md
@@ -2,7 +2,7 @@
 title: メトリクスのユニット
 kind: documentation
 aliases:
-  - /ja/developers/metrics/metrics_units
+  - /ja/metrics/metrics_units
 further_reading:
   - link: /dashboards/
     tag: ドキュメント
@@ -12,13 +12,13 @@ further_reading:
 
 メトリクス単位は、時系列グラフ、クエリ値ウィジェット、トップリストなどに自動的に表示されます。
 
-{{< img src="developers/metrics/units/redis_dash_metrics_units.png" alt="Redis ダッシュボードのメトリクス単位"  style="width:100%;">}}
+{{< img src="metrics/units/redis_dash_metrics_units.png" alt="Redis ダッシュボードのメトリクス単位"  style="width:100%;">}}
 
 時系列グラフ上でカーソルを動かすと、関連する単位が表示されます。元データは、わかりやすい表示単位に自動的に変換されます (1 秒未満は ms、毎秒 100 万バイトは MiB/s など)。
 
 単位は、タイムボードグラフの下部にも表示されます。歯車アイコンのドロップダウンから **Metrics Info** を選択することで、メトリクスの説明を表示できます。
 
-{{< img src="developers/metrics/units/annotated_ops.png" alt="アノテーション付き Ops"  style="width:100%;">}}
+{{< img src="metrics/units/annotated_ops.png" alt="アノテーション付き Ops"  style="width:100%;">}}
 
 メトリクス単位を変更するには、[Metric Summary][1] ページに移動し、**Metadata** セクションで **Edit** をクリックし、ドロップダウンメニューから `bit` や `byte` などの単位を選択します。
 

--- a/content/ja/getting_started/agent/_index.md
+++ b/content/ja/getting_started/agent/_index.md
@@ -110,7 +110,7 @@ Agent のトラブルシューティングに関するヘルプ
 {{< /whatsnext >}}
 
 [1]: /ja/integrations/
-[2]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[2]: /ja/metrics/dogstatsd_metrics_submission/
 [3]: /ja/api/
 [4]: /ja/infrastructure/process/
 [5]: /ja/logs/

--- a/content/ja/getting_started/integrations/_index.md
+++ b/content/ja/getting_started/integrations/_index.md
@@ -214,6 +214,6 @@ tagging
 [38]: /ja/agent/guide/agent-configuration-files/#agent-configuration-directory
 [39]: https://app.datadoghq.com/event/stream
 [40]: https://github.com/DataDog/integrations-core/blob/master/http_check/datadog_checks/http_check/data/conf.yaml.example#L13
-[41]: /ja/developers/metrics/
-[42]: /ja/developers/metrics/custom_metrics/
+[41]: /ja/metrics/
+[42]: /ja/metrics/custom_metrics/
 [43]: /ja/monitors/guide/visualize-your-service-check-in-the-datadog-ui/

--- a/content/ja/getting_started/tagging/_index.md
+++ b/content/ja/getting_started/tagging/_index.md
@@ -113,7 +113,7 @@ Datadog では、タグを付ける際のベストプラクティスとして、
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /getting_started/tagging/using_tags/
-[2]: /developers/metrics/
+[2]: /metrics/
 [3]: /getting_started/tagging/assigning_tags/
 [4]: /getting_started/tagging/assigning_tags/#configuration-files
 [5]: /getting_started/tagging/assigning_tags/#ui

--- a/content/ja/getting_started/tagging/assigning_tags.md
+++ b/content/ja/getting_started/tagging/assigning_tags.md
@@ -95,7 +95,7 @@ hostname: mymachine.mydomain
 [1]: /ja/getting_started/integrations/
 [2]: /ja/agent/guide/agent-configuration-files/
 [3]: /ja/getting_started/tagging/#defining-tags
-[4]: /ja/developers/metrics/dogstatsd_metrics_submission/#host-tag-key
+[4]: /ja/metrics/dogstatsd_metrics_submission/#host-tag-key
 [5]: /ja/dashboards/querying/#arithmetic-between-two-metrics
 {{% /tab %}}
 {{% tab "Agent v5" %}}
@@ -137,7 +137,7 @@ hostname: mymachine.mydomain
 [1]: /ja/getting_started/integrations/
 [2]: /ja/agent/guide/agent-configuration-files/
 [3]: /ja/getting_started/tagging/#defining-tags
-[4]: /ja/developers/metrics/dogstatsd_metrics_submission/#host-tag-key
+[4]: /ja/metrics/dogstatsd_metrics_submission/#host-tag-key
 [5]: /ja/dashboards/querying/#arithmetic-between-two-metrics
 {{% /tab %}}
 {{< /tabs >}}
@@ -297,7 +297,7 @@ Datadog トレーサーは環境変数、システムプロパティ、または
 {{< img src="tagging/assigning_tags/global_metrics_selection.png" alt="モニタータグを作成"  style="width:80%;">}}
 
 [1]: /ja/metrics/distributions/
-[2]: /ja/developers/metrics/custom_metrics/
+[2]: /ja/metrics/custom_metrics/
 {{% /tab %}}
 {{% tab "Integrations" %}}
 
@@ -407,4 +407,4 @@ def algorithm_two():
 [7]: /ja/tracing/setup/
 [8]: /ja/developers/dogstatsd/
 [9]: /ja/developers/community/libraries/
-[10]: /ja/developers/metrics/dogstatsd_metrics_submission/#host-tag-key
+[10]: /ja/metrics/dogstatsd_metrics_submission/#host-tag-key

--- a/content/ja/getting_started/tagging/unified_service_tagging.md
+++ b/content/ja/getting_started/tagging/unified_service_tagging.md
@@ -319,7 +319,7 @@ com.datadoghq.tags.version
 
 **注**: .NET および PHP 用の Datadog DogStatsD クライアントは、まだこの機能をサポートしていません。
 
-[1]: /ja/developers/metrics/
+[1]: /ja/metrics/
 {{% /tab %}}
 
 {{% tab "システムメトリクス" %}}

--- a/content/ja/infrastructure/generate_process_metrics.md
+++ b/content/ja/infrastructure/generate_process_metrics.md
@@ -74,5 +74,5 @@ further_reading:
 [1]: https://forms.gle/Bo664kv8Y1Avmzmg6
 [2]: https://app.datadoghq.com/process?view=metrics
 [3]: https://app.datadoghq.com/process
-[4]: /ja/developers/metrics/custom_metrics/
+[4]: /ja/metrics/custom_metrics/
 [5]: /ja/dashboards/correlations/

--- a/content/ja/infrastructure/process/generate_process_metrics.md
+++ b/content/ja/infrastructure/process/generate_process_metrics.md
@@ -75,5 +75,5 @@ further_reading:
 [1]: https://forms.gle/Bo664kv8Y1Avmzmg6
 [2]: https://app.datadoghq.com/process?view=metrics
 [3]: https://app.datadoghq.com/process
-[4]: /ja/developers/metrics/custom_metrics/
+[4]: /ja/metrics/custom_metrics/
 [5]: /ja/dashboards/correlations/

--- a/content/ja/infrastructure/process/increase_process_retention.md
+++ b/content/ja/infrastructure/process/increase_process_retention.md
@@ -73,5 +73,5 @@ further_reading:
 
 [1]: https://app.datadoghq.com/process?view=metrics
 [2]: https://app.datadoghq.com/process
-[3]: /ja/developers/metrics/custom_metrics/
+[3]: /ja/metrics/custom_metrics/
 [4]: /ja/dashboards/correlations/

--- a/content/ja/integrations/activemq.md
+++ b/content/ja/integrations/activemq.md
@@ -287,7 +287,7 @@ ActiveMQ XML チェックには、サービスのチェック機能は含まれ�
 [8]: https://www.datadoghq.com/blog/monitor-activemq-metrics-performance
 [9]: https://docs.datadoghq.com/ja/agent/guide/agent-configuration-files/#agent-configuration-directory
 [10]: https://github.com/DataDog/integrations-core/blob/master/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
-[11]: https://docs.datadoghq.com/ja/developers/metrics/custom_metrics/
+[11]: https://docs.datadoghq.com/ja/metrics/custom_metrics/
 [12]: https://docs.datadoghq.com/ja/account_management/billing/custom_metrics/
 [13]: https://docs.datadoghq.com/ja/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [14]: https://docs.datadoghq.com/ja/agent/guide/autodiscovery-with-jmx/?tab=containerizedagent

--- a/content/ja/integrations/concourse_ci.md
+++ b/content/ja/integrations/concourse_ci.md
@@ -79,7 +79,7 @@ Metric Emitter (Datadog):
 
 [1]: https://concourse-ci.org/concepts.html
 [2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://docs.datadoghq.com/ja/developers/metrics/custom_metrics/
+[3]: https://docs.datadoghq.com/ja/metrics/custom_metrics/
 [4]: https://concourse-ci.org/metrics.html#configuring-metrics
 [5]: https://github.com/DataDog/integrations-extras/blob/master/concourse_ci/metadata.csv
 [6]: https://docs.datadoghq.com/ja/help/

--- a/content/ja/integrations/go_expvar.md
+++ b/content/ja/integrations/go_expvar.md
@@ -77,7 +77,7 @@ Go サービスで [expvar パッケージ][4]をまだ使用していない場�
 [1]: https://docs.datadoghq.com/ja/agent/guide/agent-configuration-files/#agent-configuration-directory
 [2]: https://github.com/DataDog/integrations-core/blob/master/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
 [3]: https://docs.datadoghq.com/ja/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[4]: https://docs.datadoghq.com/ja/developers/metrics/custom_metrics/
+[4]: https://docs.datadoghq.com/ja/metrics/custom_metrics/
 [5]: https://docs.datadoghq.com/ja/account_management/billing/custom_metrics/
 [6]: https://docs.datadoghq.com/ja/help/
 {{% /tab %}}

--- a/content/ja/integrations/guide/collect-sql-server-custom-metrics.md
+++ b/content/ja/integrations/guide/collect-sql-server-custom-metrics.md
@@ -196,5 +196,5 @@ GO
 
 [1]: /ja/integrations/sqlserver/
 [2]: https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-databases-object
-[3]: /ja/developers/metrics/#metric-types
-[4]: /ja/developers/metrics/histograms/
+[3]: /ja/metrics/#metric-types
+[4]: /ja/metrics/histograms/

--- a/content/ja/integrations/guide/mongo-custom-query-collection.md
+++ b/content/ja/integrations/guide/mongo-custom-query-collection.md
@@ -58,7 +58,7 @@ custom_queries:
 **注**: 定義されているメトリクスタイプは `gauge` です。詳細については、[メトリクスタイプのドキュメント][2] を参照してください。
 
 [1]: https://docs.mongodb.com/manual/reference/command/count/#dbcmd.count
-[2]: /ja/developers/metrics/types/
+[2]: /ja/metrics/types/
 {{% /tab %}}
 {{% tab "Find" %}}
 
@@ -89,7 +89,7 @@ custom_queries:
 **注**: 定義されているメトリクスタイプは `gauge` です。詳細については、[メトリクスタイプのドキュメント][2] を参照してください。
 
 [1]: https://docs.mongodb.com/manual/reference/command/find/#dbcmd.find
-[2]: /ja/developers/metrics/types/
+[2]: /ja/metrics/types/
 {{% /tab %}}
 {{% tab "Aggregate" %}}
 

--- a/content/ja/integrations/guide/prometheus-metrics.md
+++ b/content/ja/integrations/guide/prometheus-metrics.md
@@ -58,9 +58,9 @@ Datadog のメトリクスタイプの詳細については、[Datadog メトリ
 パラメーター `send_distribution_counts_as_monotonic` が `true` の場合、`_count` で終わる各メトリクスは `monotonic_count` として送信されます。[単調カウンターについての詳細はこちらを参照してください][4]。
 
 [1]: /ja/agent/kubernetes/prometheus/
-[2]: /ja/developers/metrics/types/
+[2]: /ja/metrics/types/
 [3]: https://prometheus.io/docs/concepts/metric_types/#counter
-[4]: /ja/developers/metrics/agent_metrics_submission/?tab=count#monotonic-count
+[4]: /ja/metrics/agent_metrics_submission/?tab=count#monotonic-count
 [5]: https://prometheus.io/docs/concepts/metric_types/#gauge
 [6]: https://prometheus.io/docs/concepts/metric_types/#histogram
 [7]: https://www.datadoghq.com/blog/engineering/computing-accurate-percentiles-with-ddsketch/

--- a/content/ja/integrations/nagios.md
+++ b/content/ja/integrations/nagios.md
@@ -73,7 +73,7 @@ Nagios チェックは [Datadog Agent][1] パッケージに含まれていま�
 [1]: https://docs.datadoghq.com/ja/agent/guide/agent-configuration-files/#agent-configuration-directory
 [2]: https://github.com/DataDog/integrations-core/blob/master/nagios/datadog_checks/nagios/data/conf.yaml.example
 [3]: https://docs.datadoghq.com/ja/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[4]: https://docs.datadoghq.com/ja/developers/metrics/custom_metrics/
+[4]: https://docs.datadoghq.com/ja/metrics/custom_metrics/
 [5]: https://docs.datadoghq.com/ja/account_management/billing/custom_metrics/
 {{% /tab %}}
 {{% tab "Containerized" %}}

--- a/content/ja/integrations/node.md
+++ b/content/ja/integrations/node.md
@@ -77,7 +77,7 @@ _Agent v6.0 以上で使用可能_
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/brightcove/hot-shots
-[2]: https://docs.datadoghq.com/ja/developers/metrics/
+[2]: https://docs.datadoghq.com/ja/metrics/
 [3]: https://docs.datadoghq.com/ja/tracing/setup/nodejs/
 [4]: https://docs.datadoghq.com/ja/logs/log_collection/nodejs/
 [5]: https://docs.datadoghq.com/ja/help/

--- a/content/ja/integrations/openmetrics.md
+++ b/content/ja/integrations/openmetrics.md
@@ -37,7 +37,7 @@ supported_os:
 
 任意の OpenMetrics エンドポイントからカスタムメトリクスを抽出します。
 
-<div class="alert alert-warning">All the metrics retrieved by this integration are considered <a href="https://docs.datadoghq.com/developers/metrics/custom_metrics">custom metrics</a>.</div>
+<div class="alert alert-warning">All the metrics retrieved by this integration are considered <a href="https://docs.datadoghq.com/metrics/custom_metrics">custom metrics</a>.</div>
 
 ## セットアップ
 

--- a/content/ja/integrations/pdh_check.md
+++ b/content/ja/integrations/pdh_check.md
@@ -72,5 +72,5 @@ PDH チェックには、サービスのチェック機能は含まれません�
 [3]: https://github.com/DataDog/integrations-core/blob/master/pdh_check/datadog_checks/pdh_check/data/conf.yaml.example
 [4]: https://docs.datadoghq.com/ja/agent/guide/agent-commands/#restart-the-agent
 [5]: https://docs.datadoghq.com/ja/agent/guide/agent-commands/#agent-status-and-information
-[6]: https://docs.datadoghq.com/ja/developers/metrics/custom_metrics/
+[6]: https://docs.datadoghq.com/ja/metrics/custom_metrics/
 [7]: https://docs.datadoghq.com/ja/account_management/billing/custom_metrics/

--- a/content/ja/integrations/pivotal_platform.md
+++ b/content/ja/integrations/pivotal_platform.md
@@ -429,7 +429,7 @@ Datadog Firehose Nozzle は、CounterEvent (イベントではなくメトリク
 [2]: https://network.pivotal.io/products/datadog-application-monitoring
 [3]: /ja/integrations/pivotal_pks/
 [4]: https://docs.cloudfoundry.org/buildpacks/understand-buildpacks.html#supply-script
-[5]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[5]: /ja/metrics/dogstatsd_metrics_submission/
 [6]: https://docs.cloudfoundry.org/buildpacks/use-multiple-buildpacks.html
 [7]: https://github.com/cloudfoundry/multi-buildpack
 [8]: https://github.com/cloudfoundry/multi-buildpack#usage

--- a/content/ja/integrations/prometheus.md
+++ b/content/ja/integrations/prometheus.md
@@ -39,7 +39,7 @@ Prometheus に接続して:
 **注**: [OpenMetrics チェック][1]の方が効率性が高く Prometheus のテキスト形式を完全にサポートしているので、OpenMetrics チェックの使用をお勧めします。Prometheus チェックは、メトリクスのエンドポイントがテキスト形式をサポートしていない場合にのみ使用してください。
 
 <div class="alert alert-warning">
-このインテグレーションによって取得されたメトリクスはすべて、<a href="https://docs.datadoghq.com/developers/metrics/custom_metrics">カスタムメトリクス</a>と見なされます。
+このインテグレーションによって取得されたメトリクスはすべて、<a href="https://docs.datadoghq.com/metrics/custom_metrics">カスタムメトリクス</a>と見なされます。
 </div>
 
 **Prometheus チェックを構成する方法については、[Prometheus メトリクスの収集のガイド][2]を参照してください。**

--- a/content/ja/integrations/windows_service.md
+++ b/content/ja/integrations/windows_service.md
@@ -126,7 +126,7 @@ Windows Service チェックには、イベントは含まれません。
 [2]: https://docs.datadoghq.com/ja/agent/guide/agent-configuration-files/#agent-configuration-directory
 [3]: https://github.com/DataDog/integrations-core/blob/master/windows_service/datadog_checks/windows_service/data/conf.yaml.example
 [4]: https://docs.datadoghq.com/ja/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[5]: https://docs.datadoghq.com/ja/developers/metrics/custom_metrics/
+[5]: https://docs.datadoghq.com/ja/metrics/custom_metrics/
 [6]: https://docs.datadoghq.com/ja/account_management/billing/custom_metrics/
 [7]: https://docs.datadoghq.com/ja/agent/guide/agent-commands/#agent-status-and-information
 [8]: https://github.com/DataDog/integrations-core/blob/master/windows_service/assets/service_checks.json

--- a/content/ja/integrations/wmi_check.md
+++ b/content/ja/integrations/wmi_check.md
@@ -237,6 +237,6 @@ WMI チェックには、サービスのチェック機能は含まれません�
 [8]: https://technet.microsoft.com/en-us/library/Hh921475.aspx
 [9]: https://msdn.microsoft.com/en-us/library/aa393067.aspx
 [10]: https://docs.datadoghq.com/ja/agent/guide/agent-commands/#agent-status-and-information
-[11]: https://docs.datadoghq.com/ja/developers/metrics/custom_metrics/
+[11]: https://docs.datadoghq.com/ja/metrics/custom_metrics/
 [12]: https://docs.datadoghq.com/ja/account_management/billing/custom_metrics/
 [13]: https://docs.datadoghq.com/ja/help/

--- a/content/ja/logs/guide/getting-started-lwl.md
+++ b/content/ja/logs/guide/getting-started-lwl.md
@@ -130,7 +130,7 @@ Logging Without Limits™ の詳細やログエクスポローラー、Live Tail
 [4]: https://app.datadoghq.com/logs/patterns
 [5]: /ja/logs/live_tail/
 [6]: /ja/logs/archives/
-[7]: /ja/developers/metrics/
+[7]: /ja/metrics/
 [8]: /ja/logs/logs_to_metrics/
 [9]: /ja/monitors/monitor_types/anomaly/
 [10]: https://app.datadoghq.com/monitors#/triggered

--- a/content/ja/logs/log_configuration/logs_to_metrics.md
+++ b/content/ja/logs/log_configuration/logs_to_metrics.md
@@ -86,7 +86,7 @@ Export メニューで "Generate new metric" を選択し、Analytics の検索�
 [6]: /ja/logs/search_syntax/
 [7]: /ja/logs/explorer/facets/#quantitative-facets-measures
 [8]: /ja/getting_started/tagging/
-[9]: /ja/developers/metrics/custom_metrics/
+[9]: /ja/metrics/custom_metrics/
 [10]: /ja/security/logs/#hipaa-enabled-customers
 [11]: /ja/account_management/billing/custom_metrics/?tab=countrategauge
-[12]: /ja/developers/metrics/#naming-metrics
+[12]: /ja/metrics/#naming-metrics

--- a/content/ja/logs/logs_to_metrics.md
+++ b/content/ja/logs/logs_to_metrics.md
@@ -85,7 +85,7 @@ Export メニューで "Generate new metric" を選択し、Analytics の検索�
 [6]: /ja/logs/search_syntax/
 [7]: /ja/logs/explorer/facets/#quantitative-facets-measures
 [8]: /ja/getting_started/tagging/
-[9]: /ja/developers/metrics/custom_metrics/
+[9]: /ja/metrics/custom_metrics/
 [10]: /ja/security/logs/#hipaa-enabled-customers
 [11]: /ja/account_management/billing/custom_metrics/?tab=countrategauge
-[12]: /ja/developers/metrics/#naming-metrics
+[12]: /ja/metrics/#naming-metrics

--- a/content/ja/metrics/_index.md
+++ b/content/ja/metrics/_index.md
@@ -10,7 +10,7 @@ aliases:
 ---
 {{< whatsnext desc="このセクションには、次のトピックが含まれています。">}}
     {{< nextlink href="/metrics/explorer" >}}<u>メトリクスエクスプローラー</u> - すべてのメトリクスを探索し分析します。{{< /nextlink >}}
-    {{< nextlink href="/developers/metrics/types" >}}<u>メトリクスタイプ</u> - Datadog に送信可能なメトリクスの種類。{{< /nextlink >}}
+    {{< nextlink href="/metrics/types" >}}<u>メトリクスタイプ</u> - Datadog に送信可能なメトリクスの種類。{{< /nextlink >}}
     {{< nextlink href="/metrics/advanced-filtering" >}}<u>高度なフィルタリング</u> - データをフィルタリングして、返されるメトリクスのスコープを絞り込みます。{{< /nextlink >}}
     {{< nextlink href="/metrics/summary" >}}<u>メトリクスの概要</u> - Datadog にレポートされるすべてのメトリクスをリストします。{{< /nextlink >}}
     {{< nextlink href="metrics/distributions/" >}}<u>ディストリビューションメトリクス</u> - データセット全体のグローバルパーセンタイルを計算します。{{< /nextlink >}}
@@ -154,12 +154,12 @@ Datadog Agent が、送信するデータポイントごとに Datadog のサー
 [7]: /ja/integrations/
 [8]: /ja/integrations/amazon_ec2/
 [9]: /ja/logs/logs_to_metrics/
-[10]: /ja/developers/metrics/
+[10]: /ja/metrics/
 [11]: /ja/agent/
-[12]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[12]: /ja/metrics/dogstatsd_metrics_submission/
 [13]: /ja/api/
 [14]: https://docs.datadoghq.com/ja/agent/basic_agent_usage/
-[15]: /ja/developers/metrics/types/
+[15]: /ja/metrics/types/
 [16]: /ja/getting_started/tagging/using_tags/
 [17]: /ja/dashboards/functions/
 [18]: /ja/metrics/distributions/

--- a/content/ja/metrics/agent_metrics_submission.md
+++ b/content/ja/metrics/agent_metrics_submission.md
@@ -2,7 +2,7 @@
 title: "メトリクスの送信: \bカスタム Agent チェック"
 kind: documentation
 aliases:
-  - /ja/developers/metrics/agent_metrics_submission/
+  - /ja/metrics/agent_metrics_submission/
 further_reading:
   - link: /developers/custom_checks/write_agent_check/
     tag: ドキュメント
@@ -225,14 +225,14 @@ self.histogram(name, value, tags=None, hostname=None, device_name=None)
 
 6. [メトリクスの概要ページ][6]でメトリクスが Datadog に報告を行っているかを確認します。
 
-{{< img src="developers/metrics/agent_metrics_submission/metrics_metrics_summary.png" alt="メトリクスの概要に記されたメトリクス"  style="width:80%;">}}
+{{< img src="metrics/agent_metrics_submission/metrics_metrics_summary.png" alt="メトリクスの概要に記されたメトリクス"  style="width:80%;">}}
 
 ## その他の参考資料
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /ja/developers/custom_checks/write_agent_check/
-[2]: /ja/developers/metrics/types/
+[2]: /ja/metrics/types/
 [3]: /ja/agent/guide/agent-configuration-files/#agent-configuration-directory
 [4]: /ja/agent/guide/agent-commands/#restart-the-agent
 [5]: /ja/agent/guide/agent-commands/#agent-information

--- a/content/ja/metrics/custom_metrics.md
+++ b/content/ja/metrics/custom_metrics.md
@@ -5,10 +5,10 @@ aliases:
   - /ja/guides/metrics/
   - /ja/metrictypes/
   - /ja/units/
-  - /ja/developers/metrics/datagram_shell
-  - /ja/developers/metrics/custom_metrics/
+  - /ja/metrics/datagram_shell
+  - /ja/metrics/custom_metrics/
   - /ja/getting_started/custom_metrics
-  - /ja/developers/metrics/
+  - /ja/metrics/
 further_reading:
   - link: /developers/dogstatsd/
     tag: ドキュメント
@@ -53,9 +53,9 @@ Datadog のカスタムメトリクスには、以下のプロパティがあり
 ## カスタムメトリクスの送信
 
 {{< whatsnext desc="メトリクスを Datadog に送信する方法は複数あります。">}}
-    {{< nextlink href="/developers/metrics/agent_metrics_submission" >}}カスタム Agent チェック{{< /nextlink >}}
-    {{< nextlink href="/developers/metrics/dogstatsd_metrics_submission" >}}DogStatsD{{< /nextlink >}}
-    {{< nextlink href="/developers/metrics/powershell_metrics_submission" >}}PowerShell{{< /nextlink >}}
+    {{< nextlink href="/metrics/agent_metrics_submission" >}}カスタム Agent チェック{{< /nextlink >}}
+    {{< nextlink href="/metrics/dogstatsd_metrics_submission" >}}DogStatsD{{< /nextlink >}}
+    {{< nextlink href="/metrics/powershell_metrics_submission" >}}PowerShell{{< /nextlink >}}
     {{< nextlink href="/serverless/custom_metrics" >}}AWS Lambda{{< /nextlink >}}
     {{< nextlink href="/api/v1/metrics/#submit-metrics" >}}Datadog の HTTP API{{< /nextlink >}}
     {{< nextlink href="/logs/log_configuration/logs_to_metrics/#generate-a-log-based-metric" >}}ログベースのメトリクスを生成する{{< /nextlink >}}
@@ -75,13 +75,13 @@ Datadog のカスタムメトリクスには、以下のプロパティがあり
 
 [1]: /ja/integrations/
 [2]: /ja/account_management/billing/custom_metrics/#standard-integrations
-[3]: /ja/developers/metrics/dogstatsd_metrics_submission/
-[4]: /ja/developers/metrics/agent_metrics_submission/
+[3]: /ja/metrics/dogstatsd_metrics_submission/
+[4]: /ja/metrics/agent_metrics_submission/
 [5]: https://app.datadoghq.com/account/usage/hourly
 [6]: /ja/account_management/billing/custom_metrics/#counting-custom-metrics
 [7]: /ja/metrics
-[8]: /ja/developers/metrics/types/
-[9]: /ja/developers/metrics/types/?tab=rate#metric-types
-[10]: /ja/developers/metrics/types/?tab=count#metric-types
+[8]: /ja/metrics/types/
+[9]: /ja/metrics/types/?tab=rate#metric-types
+[10]: /ja/metrics/types/?tab=count#metric-types
 [11]: /ja/developers/dogstatsd/data_aggregation/#how-is-aggregation-performed-with-the-dogstatsd-server
 [12]: /ja/developers/community/libraries/

--- a/content/ja/metrics/distributions.md
+++ b/content/ja/metrics/distributions.md
@@ -6,7 +6,7 @@ aliases:
   - /ja/developers/faq/characteristics-of-datadog-histograms/
   - /ja/graphing/metrics/distributions/
 further_reading:
-  - link: /developers/metrics/dogstatsd_metrics_submission/
+  - link: /metrics/dogstatsd_metrics_submission/
     tag: ドキュメント
     text: DogStatsD でのディストリビューションの使用
 ---
@@ -66,6 +66,6 @@ https://app.datadoghq.com/event/stream?tags_execution=and&per_page=30&query=tags
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: /ja/developers/metrics/types/
+[1]: /ja/metrics/types/
 [2]: https://app.datadoghq.com/metric/distribution_metrics
 [3]: https://app.datadoghq.com/event/stream

--- a/content/ja/metrics/dogstatsd_metrics_submission.md
+++ b/content/ja/metrics/dogstatsd_metrics_submission.md
@@ -6,12 +6,12 @@ aliases:
   - /ja/developers/faq/reduce-submission-rate
   - /ja/developers/faq/why-is-my-counter-metric-showing-decimal-values
   - /ja/developers/faq/dog-statsd-sample-rate-parameter-explained
-  - /ja/developers/metrics/dogstatsd_metrics_submission/
+  - /ja/metrics/dogstatsd_metrics_submission/
 further_reading:
   - link: /developers/dogstatsd/
     tag: ドキュメント
     text: DogStatsD 入門
-  - link: /developers/metrics/types/
+  - link: /metrics/types/
     tag: ドキュメント
     text: Datadog メトリクスタイプ
 ---
@@ -203,11 +203,11 @@ while (TRUE) {
 
 上のコードを実行すると、メトリクスデータを Datadog でグラフ化できます。
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/increment_decrement.png" alt="Increment Decrement" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/increment_decrement.png" alt="Increment Decrement" >}}
 
 値は `COUNT` として送信されるため、Datadog に `RATE` として保存されます。Datadog で未加工のカウントを取得するには、[累積合計][3] や [積分][4] などの関数を系列に適用します。
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/increment_decrement_cumsum.png" alt="Increment Decrement with Cumsum" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/increment_decrement_cumsum.png" alt="Increment Decrement with Cumsum" >}}
 
 ### GAUGE
 
@@ -366,7 +366,7 @@ while (TRUE) {
 
 上のコードを実行すると、メトリクスデータを Datadog でグラフ化できます。
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/gauge.png" alt="Gauge" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/gauge.png" alt="Gauge" >}}
 
 ### SET
 
@@ -502,7 +502,7 @@ while (TRUE) {
 
 上のコードを実行すると、メトリクスデータを Datadog でグラフ化できます。
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/set.png" alt="Set" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/set.png" alt="Set" >}}
 
 ### HISTOGRAM
 
@@ -671,7 +671,7 @@ while (TRUE) {
 
 上のコードを実行すると、メトリクスデータを Datadog でグラフ化できます。
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/histogram.png" alt="Histogram" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/histogram.png" alt="Histogram" >}}
 
 #### タイマー
 
@@ -776,7 +776,7 @@ DogStatsD はタイマーメトリクスデータを受け取ると、レンダ�
 
 DogStatsD は `TIMER` を `HISTOGRAM` メトリクスとして扱います。使用するメトリクスのタイプが `TIMER` であろうと `HISTOGRAM` であろうと、Datadog に送信されるのは同じデータです。上のコードを実行すると、メトリクスデータを Datadog でグラフ化できます。
 
-{{< img src="developers/metrics/dogstatsd_metrics_submission/timer.png" alt="Timer" >}}
+{{< img src="metrics/dogstatsd_metrics_submission/timer.png" alt="Timer" >}}
 
 ### DISTRIBUTION
 
@@ -1056,11 +1056,11 @@ $statsd->increment('example_metric.increment', array('environment' => 'dev', 'ac
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /ja/developers/dogstatsd/
-[2]: /ja/developers/metrics/types/?tab=count#definition
+[2]: /ja/metrics/types/?tab=count#definition
 [3]: /ja/dashboards/functions/arithmetic/#cumulative-sum
 [4]: /ja/dashboards/functions/arithmetic/#integral
-[5]: /ja/developers/metrics/types/?tab=gauge#definition
-[6]: /ja/developers/metrics/types/?tab=histogram#definition
+[5]: /ja/metrics/types/?tab=gauge#definition
+[6]: /ja/metrics/types/?tab=histogram#definition
 [7]: /ja/agent/guide/agent-configuration-files/#agent-main-configuration-file
 [8]: /ja/metrics/distributions/
-[9]: /ja/developers/metrics/types/?tab=distribution#definition
+[9]: /ja/metrics/types/?tab=distribution#definition

--- a/content/ja/metrics/guide/tag-configuration-cardinality-estimation-tool.md
+++ b/content/ja/metrics/guide/tag-configuration-cardinality-estimation-tool.md
@@ -52,7 +52,7 @@ https://api.datadoghq.com/metric/estimate?metric_name=dist.dd.dogweb.latency&gro
 
 
 [1]: /ja/account_management/api-app-keys/
-[2]: /ja/developers/metrics/types/?tab=distribution#metric-types
-[3]: /ja/developers/metrics/types/?tab=distribution#calculation-of-percentile-aggregations
-[4]: /ja/developers/metrics/types/?tab=count#metric-types
-[5]: /ja/developers/metrics/types/?tab=gauge#metric-types
+[2]: /ja/metrics/types/?tab=distribution#metric-types
+[3]: /ja/metrics/types/?tab=distribution#calculation-of-percentile-aggregations
+[4]: /ja/metrics/types/?tab=count#metric-types
+[5]: /ja/metrics/types/?tab=gauge#metric-types

--- a/content/ja/metrics/powershell_metrics_submission.md
+++ b/content/ja/metrics/powershell_metrics_submission.md
@@ -4,7 +4,7 @@ kind: documentation
 aliases:
   - /ja/developers/faq/powershell-api-examples
   - /ja/developers/faq/submitting-metrics-via-powershell
-  - /ja/developers/metrics/powershell_metrics_submission/
+  - /ja/metrics/powershell_metrics_submission/
 ---
 Datadog は、使用する言語に関係なく、Agent および API を介してメトリクスを収集できます。このページでは、PowerShell を使用した両方の例を示します。
 
@@ -149,7 +149,7 @@ $http_request.responseText
 [その他のコード例については、ncracker/dd_metric GitHub リポジトリを参照してください][6]。
 
 [1]: https://app.datadoghq.com/account/settings#api
-[2]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[2]: /ja/metrics/dogstatsd_metrics_submission/
 [3]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
 [4]: /ja/api/v1/hosts/
 [5]: /ja/api/v1/metrics/

--- a/content/ja/metrics/summary.md
+++ b/content/ja/metrics/summary.md
@@ -125,9 +125,9 @@ further_reading:
 [1]: https://app.datadoghq.com/metric/summary
 [2]: /ja/metrics/explorer/
 [3]: /ja/dashboards/
-[4]: /ja/developers/metrics/custom_metrics/
+[4]: /ja/metrics/custom_metrics/
 [5]: /ja/getting_started/tagging/
 [6]: /ja/api/v1/metrics/#edit-metric-metadata
-[7]: /ja/developers/metrics/units/
-[8]: /ja/developers/metrics/types/
+[7]: /ja/metrics/units/
+[8]: /ja/metrics/types/
 [9]: /ja/integrations/

--- a/content/ja/metrics/type_modifiers.md
+++ b/content/ja/metrics/type_modifiers.md
@@ -2,9 +2,9 @@
 title: メトリクスタイプのモディファイアー
 kind: documentation
 aliases:
-  - /ja/developers/metrics/metric_type_modifiers
+  - /ja/metrics/metric_type_modifiers
   - /ja/graphing/faq/as_count_validation
-  - /ja/developers/metrics/type_modifiers/
+  - /ja/metrics/type_modifiers/
 further_reading:
   - link: /developers/dogstatsd/
     tag: ドキュメント
@@ -78,7 +78,7 @@ further_reading:
 
 通常は必要ありませんが、[メトリクスサマリーページ][4]でメトリクスのタイプを変更することができます。
 
-{{< img src="developers/metrics/type_modifiers/metric_type.png" alt="メトリクスタイプ"  style="width:70%;">}}
+{{< img src="metrics/type_modifiers/metric_type.png" alt="メトリクスタイプ"  style="width:70%;">}}
 
 使用例：
 
@@ -96,7 +96,7 @@ further_reading:
 
 **注**: Agent チェックの `self.increment` は、単調増加カウンターの増分を計算するのではなく、チェック実行時に渡された値を報告します。単調増加カウンターの増分値を送信する場合は、`self.monotonic_count` を使用してください。
 
-[1]: /ja/developers/metrics/types/
+[1]: /ja/metrics/types/
 [2]: /ja/metrics/introduction/#time-aggregation
 [3]: /ja/dashboards/faq/why-does-zooming-out-a-timeframe-also-smooth-out-my-graphs/
 [4]: https://app.datadoghq.com/metric/summary

--- a/content/ja/metrics/types.md
+++ b/content/ja/metrics/types.md
@@ -2,15 +2,15 @@
 title: メトリクスタイプ
 kind: documentation
 aliases:
-  - /ja/developers/metrics/counts/
-  - /ja/developers/metrics/distributions/
-  - /ja/developers/metrics/gauges/
-  - /ja/developers/metrics/histograms/
-  - /ja/developers/metrics/rates/
-  - /ja/developers/metrics/sets/
-  - /ja/developers/metrics_type/
-  - /ja/developers/metrics/metrics_type/
-  - /ja/developers/metrics/types/
+  - /ja/metrics/counts/
+  - /ja/metrics/distributions/
+  - /ja/metrics/gauges/
+  - /ja/metrics/histograms/
+  - /ja/metrics/rates/
+  - /ja/metrics/sets/
+  - /ja/metrics_type/
+  - /ja/metrics/metrics_type/
+  - /ja/metrics/types/
 further_reading:
   - link: developers/dogstatsd
     tag: ドキュメント
@@ -245,10 +245,10 @@ GAUGE、HISTOGRAM などのメトリクスタイプと同様に、DISTRIBUTION �
 **注**: DogStatsD を介して COUNT メトリクスタイプを送信する場合、メトリクスは異なる Agent 間の関連する比較を確保するためにアプリ内に RATE として表示されます。その結果、StatsD カウントは Datadog 内に 10 進数値で表示される場合があります（1 秒あたりの単位を報告するために時間間隔で正規化されるため）。
 
 
-[1]: /ja/developers/metrics/agent_metrics_submission/?tab=count#count
-[2]: /ja/developers/metrics/agent_metrics_submission/?tab=count#monotonic-count
+[1]: /ja/metrics/agent_metrics_submission/?tab=count#count
+[2]: /ja/metrics/agent_metrics_submission/?tab=count#monotonic-count
 [3]: /ja/api/v1/metrics/#submit-metrics
-[4]: /ja/developers/metrics/dogstatsd_metrics_submission/#count
+[4]: /ja/metrics/dogstatsd_metrics_submission/#count
 {{% /tab %}}
 {{% tab "RATE" %}}
 
@@ -262,7 +262,7 @@ GAUGE、HISTOGRAM などのメトリクスタイプと同様に、DISTRIBUTION �
 **注**: DogStatsD を介して RATE メトリクスタイプを送信する場合、メトリクスは異なる Agent 間の関連する比較を確保するためにアプリ内に GAUGE として表示されます。
 
 
-[1]: /ja/developers/metrics/agent_metrics_submission/?tab=rate
+[1]: /ja/metrics/agent_metrics_submission/?tab=rate
 [2]: /ja/api/v1/metrics/#submit-metrics
 {{% /tab %}}
 {{% tab "GAUGE" %}}
@@ -276,9 +276,9 @@ GAUGE、HISTOGRAM などのメトリクスタイプと同様に、DISTRIBUTION �
 | [DogStatsD][3]    | `dog.gauge(...)`                     | GAUGE           | GAUGE               |
 
 
-[1]: /ja/developers/metrics/agent_metrics_submission/?tab=gauge
+[1]: /ja/metrics/agent_metrics_submission/?tab=gauge
 [2]: /ja/api/v1/metrics/#submit-metrics
-[3]: /ja/developers/metrics/dogstatsd_metrics_submission/#gauge
+[3]: /ja/metrics/dogstatsd_metrics_submission/#gauge
 {{% /tab %}}
 {{% tab "HISTOGRAM" %}}
 
@@ -292,8 +292,8 @@ GAUGE、HISTOGRAM などのメトリクスタイプと同様に、DISTRIBUTION �
 **注**: TIMER メトリクスを Datadog Agent に送信する場合、これは DogStatsD 内で HISTOGRAM メトリクスタイプを送信することと同等です（標準 StatsD のタイマーと混同しないでください）。タイマーは期間データのみを表します。たとえば、コードのセクションの実行にかかる時間や、ページを完全にレンダリングするのにかかる時間などです。
 
 
-[1]: /ja/developers/metrics/agent_metrics_submission/?tab=histogram
-[2]: /ja/developers/metrics/dogstatsd_metrics_submission/#histogram
+[1]: /ja/metrics/agent_metrics_submission/?tab=histogram
+[2]: /ja/metrics/dogstatsd_metrics_submission/#histogram
 {{% /tab %}}
 {{% tab "DISTRIBUTION" %}}
 
@@ -304,7 +304,7 @@ GAUGE、HISTOGRAM などのメトリクスタイプと同様に、DISTRIBUTION �
 | [DogStatsD][1]    | `dog.distribution(...)`    | DISTRIBUTION    | GAUGE、COUNT         |
 
 
-[1]: /ja/developers/metrics/dogstatsd_metrics_submission/#distribution
+[1]: /ja/metrics/dogstatsd_metrics_submission/#distribution
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -333,21 +333,21 @@ GAUGE、HISTOGRAM などのメトリクスタイプと同様に、DISTRIBUTION �
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /ja/developers/metrics/type_modifiers/
+[1]: /ja/metrics/type_modifiers/
 [2]: /ja/dashboards/functions/
 [3]: /ja/metrics/summary/
 [4]: https://statsd.readthedocs.io/en/v3.2.1/types.html#sets
-[5]: /ja/developers/metrics/agent_metrics_submission/
-[6]: /ja/developers/metrics/dogstatsd_metrics_submission/
+[5]: /ja/metrics/agent_metrics_submission/
+[6]: /ja/metrics/dogstatsd_metrics_submission/
 [7]: /ja/api/v1/metrics/#submit-metrics
 [8]: /ja/developers/dogstatsd/#how-it-works
-[9]: /ja/developers/metrics/agent_metrics_submission/?tab=count#count
-[10]: /ja/developers/metrics/agent_metrics_submission/?tab=count#monotonic-count
-[11]: /ja/developers/metrics/agent_metrics_submission/?tab=gauge
-[12]: /ja/developers/metrics/agent_metrics_submission/?tab=histogram
-[13]: /ja/developers/metrics/agent_metrics_submission/?tab=rate
-[14]: /ja/developers/metrics/dogstatsd_metrics_submission/#gauge
-[15]: /ja/developers/metrics/dogstatsd_metrics_submission/#distribution
-[16]: /ja/developers/metrics/dogstatsd_metrics_submission/#count
-[17]: /ja/developers/metrics/dogstatsd_metrics_submission/#set
-[18]: /ja/developers/metrics/dogstatsd_metrics_submission/#histogram
+[9]: /ja/metrics/agent_metrics_submission/?tab=count#count
+[10]: /ja/metrics/agent_metrics_submission/?tab=count#monotonic-count
+[11]: /ja/metrics/agent_metrics_submission/?tab=gauge
+[12]: /ja/metrics/agent_metrics_submission/?tab=histogram
+[13]: /ja/metrics/agent_metrics_submission/?tab=rate
+[14]: /ja/metrics/dogstatsd_metrics_submission/#gauge
+[15]: /ja/metrics/dogstatsd_metrics_submission/#distribution
+[16]: /ja/metrics/dogstatsd_metrics_submission/#count
+[17]: /ja/metrics/dogstatsd_metrics_submission/#set
+[18]: /ja/metrics/dogstatsd_metrics_submission/#histogram

--- a/content/ja/metrics/units.md
+++ b/content/ja/metrics/units.md
@@ -2,8 +2,8 @@
 title: メトリクスのユニット
 kind: documentation
 aliases:
-  - /ja/developers/metrics/metrics_units
-  - /ja/developers/metrics/units/
+  - /ja/metrics/metrics_units
+  - /ja/metrics/units/
 further_reading:
   - link: /dashboards/
     tag: ドキュメント
@@ -13,13 +13,13 @@ further_reading:
 
 メトリクス単位は、時系列グラフ、クエリ値ウィジェット、トップリストなどの場所に自動的に表示されます。
 
-{{< img src="developers/metrics/units/redis_dash_metrics_units.png" alt="Redis ダッシュボードのメトリクス単位"  style="width:100%;">}}
+{{< img src="metrics/units/redis_dash_metrics_units.png" alt="Redis ダッシュボードのメトリクス単位"  style="width:100%;">}}
 
 時系列グラフ上にカーソルを合わせると、関連する単位が表示されます。元データは、わかりやすい表示単位に自動的に変換されます (1 秒未満は ms、毎秒 100 万バイトは MiB/s など)。
 
 単位は、タイムボードグラフの下部にも表示されます。歯車アイコンのドロップダウンから **Metrics Info** を選択することで、メトリクスの説明を表示できます。
 
-{{< img src="developers/metrics/units/annotated_ops.png" alt="アノテーション付き Ops"  style="width:100%;">}}
+{{< img src="metrics/units/annotated_ops.png" alt="アノテーション付き Ops"  style="width:100%;">}}
 
 メトリクス単位を変更するには、[Metric Summary][1] ページに移動し、**Metadata** セクションで **Edit** をクリックし、ドロップダウンメニューから `bit` や `byte` などの単位を選択します。
 

--- a/content/ja/monitors/guide/slo-checklist.md
+++ b/content/ja/monitors/guide/slo-checklist.md
@@ -99,7 +99,7 @@ _例: リクエストの 99% は、30 日間で 250 ms 未満で完了する必�
 
 [1]: https://app.datadoghq.com/slo
 [2]: https://app.datadoghq.com/monitors#create/metric
-[3]: /ja/developers/metrics
+[3]: /ja/metrics
 [4]: /ja/integrations
 [5]: /ja/tracing/generate_metrics/
 [6]: /ja/logs/logs_to_metrics/

--- a/content/ja/serverless/azure_app_services.md
+++ b/content/ja/serverless/azure_app_services.md
@@ -155,5 +155,5 @@ DogStatsd.Increment("sample.startup");
 [13]: /ja/logs/log_collection/csharp/?tab=serilog#agentless-logging
 [14]: https://www.nuget.org/packages/DogStatsD-CSharp-Client
 [15]: /ja/developers/dogstatsd/?tab=net#code
-[16]: /ja/developers/metrics/
+[16]: /ja/metrics/
 [17]: /ja/help

--- a/content/ja/serverless/custom_metrics/_index.md
+++ b/content/ja/serverless/custom_metrics/_index.md
@@ -224,4 +224,4 @@ MONITORING|<UNIX_EPOCH_タイムスタンプ>|<メトリクス値>|<メトリク
 [7]: /ja/agent/guide/private-link/
 [8]: /ja/agent/proxy/
 [9]: /ja/serverless/forwarder/
-[10]: /ja/developers/metrics/
+[10]: /ja/metrics/

--- a/content/ja/tracing/generate_metrics/_index.md
+++ b/content/ja/tracing/generate_metrics/_index.md
@@ -79,7 +79,7 @@ Tracing without Limits™ を使用すると、[保持フィルター][1]でイ�
 
 [1]: /ja/tracing/trace_retention_and_ingestion
 [2]: /ja/account_management/billing/custom_metrics/
-[3]: https://docs.datadoghq.com/ja/developers/metrics/#overview
+[3]: https://docs.datadoghq.com/ja/metrics/#overview
 [4]: /ja/monitors/monitor_types/anomaly/#overview
 [5]: /ja/tracing/trace_search_and_analytics/
 [6]: /ja/tracing/trace_search_and_analytics/query_syntax/#analytics-query
@@ -87,4 +87,4 @@ Tracing without Limits™ を使用すると、[保持フィルター][1]でイ�
 [8]: https://app.datadoghq.com/apm/getting-started
 [9]: https://app.datadoghq.com/apm/traces/generate-metrics
 [10]: /ja/tracing/trace_search_and_analytics/query_syntax/
-[11]: /ja/developers/metrics/#naming-metrics
+[11]: /ja/metrics/#naming-metrics

--- a/content/ja/tracing/guide/ddsketch_trace_metrics.md
+++ b/content/ja/tracing/guide/ddsketch_trace_metrics.md
@@ -70,6 +70,6 @@ max:trace.sample_span{datacenter:production, service:bar, resource:ghijk5678}
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /ja/metrics/distributions/
-[2]: /ja/developers/metrics/types/?tab=distribution#metric-types
+[2]: /ja/metrics/types/?tab=distribution#metric-types
 [3]: /ja/tracing/guide/setting_primary_tags_to_scope/#add-a-second-primary-tag-in-datadog
 [4]: https://www.datadoghq.com/blog/engineering/computing-accurate-percentiles-with-ddsketch/

--- a/content/ja/tracing/guide/metrics_namespace.md
+++ b/content/ja/tracing/guide/metrics_namespace.md
@@ -213,8 +213,8 @@ aliases:
 [2]: /ja/tracing/setup/
 [3]: /ja/tracing/visualization/#trace-metrics
 [4]: /ja/tracing/guide/setting_primary_tags_to_scope/#add-a-second-primary-tag-in-datadog
-[5]: /ja/developers/metrics/types/?tab=count#metric-types
-[6]: /ja/developers/metrics/types/?tab=gauge#metric-types
+[5]: /ja/metrics/types/?tab=count#metric-types
+[6]: /ja/metrics/types/?tab=gauge#metric-types
 [7]: /ja/tracing/visualization/services_list/#services-types
 [8]: /ja/tracing/visualization/#services
 [9]: /ja/tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm/

--- a/content/ja/tracing/runtime_metrics/nodejs.md
+++ b/content/ja/tracing/runtime_metrics/nodejs.md
@@ -43,7 +43,7 @@ Datadog では、APM サービス詳細画面にこれらのメトリクスを�
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/apm/services
-[2]: /ja/developers/metrics/dogstatsd_metrics_submission/#setup
+[2]: /ja/metrics/dogstatsd_metrics_submission/#setup
 [3]: /ja/agent/docker/#dogstatsd-custom-metrics
 [4]: /ja/developers/dogstatsd/?tab=kubernetes#agent
 [5]: /ja/integrations/amazon_ecs/?tab=python#create-an-ecs-task

--- a/content/ja/tracing/runtime_metrics/python.md
+++ b/content/ja/tracing/runtime_metrics/python.md
@@ -53,7 +53,7 @@ Datadog では、APM サービス詳細画面にこれらのメトリクスを�
 
 [1]: https://app.datadoghq.com/apm/services
 [2]: https://github.com/DataDog/dd-trace-py/releases/tag/v0.24.0
-[3]: /ja/developers/metrics/dogstatsd_metrics_submission/#setup
+[3]: /ja/metrics/dogstatsd_metrics_submission/#setup
 [4]: /ja/agent/docker/#dogstatsd-custom-metrics
 [5]: /ja/developers/dogstatsd/?tab=kubernetes#agent
 [6]: /ja/integrations/amazon_ecs/?tab=python#create-an-ecs-task

--- a/content/ja/tracing/runtime_metrics/ruby.md
+++ b/content/ja/tracing/runtime_metrics/ruby.md
@@ -62,7 +62,7 @@ Datadog では、APM サービス詳細画面にこれらのメトリクスを�
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://rubygems.org/gems/dogstatsd-ruby
-[2]: /ja/developers/metrics/dogstatsd_metrics_submission/#setup
+[2]: /ja/metrics/dogstatsd_metrics_submission/#setup
 [3]: https://app.datadoghq.com/apm/service
 [4]: /ja/agent/docker/#dogstatsd-custom-metrics
 [5]: /ja/developers/dogstatsd/?tab=kubernetes#agent


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This updates all links in the content folder and the ja/fr menus that contained `developers/metrics` to just `metrics` as those pages were migrated successfully and while we have aliases in place, I should've also followed up with updating the links.

### Motivation
DOCS-2401


### Additional Notes
How I did this:
In VS Code I did a find and replace in the content folder only, as other folders contain links that are autogenerated from external repos so it didn't make sense to update them if they'd just be overwritten.
In hindsight, I probably should've done my commit without letting the link formatter run, sorry about all the extra noise in this PR from that.

In theory, if the build passes (minus the known failure of the link checker) this should be good to merge.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
