### PR TITLE
DOCS-2476 Run Synthetic Tests from Private Locations and Getting Started with Private Locations Edits

### DIFF
--- a/content/en/getting_started/synthetics/private_location.md
+++ b/content/en/getting_started/synthetics/private_location.md
@@ -27,7 +27,7 @@ You can also use private locations to:
 - **Verify the application performance in your internal testing environment** before you release new features to production with [Synthetic CI/CD Testing][1].
 - **Compare the application performance** from inside and outside your internal network.
 
-Private locations are Docker containers that you can install anywhere inside your private network. You can access the [private location worker image][2] on Docker Hub.
+Private locations are Docker containers that you can install anywhere inside your private network. You can access the [private location worker image][2] on Google Container Registry.
 
 Once you've created and installed your private location, you can assign [Synthetic tests][3] to your private location just like you would with a managed location. Your private locations test results display identically to your managed location test results. 
 
@@ -78,7 +78,7 @@ You can use your new private location just like a managed location to run Synthe
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /synthetics/ci/
-[2]: https://hub.docker.com/r/datadog/synthetics-private-location-worker
+[2]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/synthetics-private-location-worker?pli=1
 [3]: /getting_started/synthetics/
 [4]: https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce
 [5]: https://app.datadoghq.com/synthetics/list

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -38,7 +38,7 @@ Your private location worker pulls your test configurations from Datadog’s ser
 
 ### Docker
 
-Private locations are Docker containers that you can install anywhere inside your private network. You can access the [private location worker image][3] on Docker Hub. It can run on a Linux based OS or Windows OS if the [Docker engine][4] is available on your host and can run in Linux containers mode.
+Private locations are Docker containers that you can install anywhere inside your private network. You can access the [private location worker image][3] on Google Container Registry. It can run on a Linux based OS or Windows OS if the [Docker engine][4] is available on your host and can run in Linux containers mode.
 
 ### Datadog private locations endpoints
 
@@ -611,7 +611,7 @@ Although it's important to initially add resources that are consistent with the 
 
 [1]: /synthetics/ci
 [2]: /synthetics/
-[3]: https://hub.docker.com/r/datadog/synthetics-private-location-worker
+[3]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/synthetics-private-location-worker?pli=1
 [4]: https://docs.docker.com/engine/install/
 [5]: /synthetics/private_locations/configuration/#proxy-configuration
 [6]: https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update the Synthetic private location worker link from Docker Hub to GCR in Run Synthetic Tests from Private Locations and Getting Started with Private Locations.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-2476

### Preview

https://docs-staging.datadoghq.com/alai97/private-location-worker-gcr-image-link/synthetics/private_locations/
https://docs-staging.datadoghq.com/alai97/private-location-worker-gcr-image-link/getting_started/synthetics/private_location/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
