### PR TITLE
Fix borked hashes

### DIFF
--- a/content/en/agent/amazon_ecs/_index.md
+++ b/content/en/agent/amazon_ecs/_index.md
@@ -166,7 +166,7 @@ To collect processes information for all your containers and send it to Datadog:
 {{< tabs >}}
 {{% tab "Linux" %}}
 
-1. Follow the [above instructions](#aws-cli) to install the Datadog Agent.
+1. Follow the [above instructions](#setup) to install the Datadog Agent.
 2. Update your [datadog-agent-ecs.json][1] file ([datadog-agent-ecs1.json][2] if you are using an original Amazon Linux AMI) with the following configuration:
 
 ```json
@@ -218,7 +218,7 @@ To collect processes information for all your containers and send it to Datadog:
 {{% /tab %}}
 {{% tab "Windows" %}}
 
-1. Follow the [above instructions](#aws-cli) to install the Datadog Agent.
+1. Follow the [above instructions](#setup) to install the Datadog Agent.
 2. Update your [datadog-agent-ecs-win.json][1] file with the following configuration:
 
 ```json
@@ -246,8 +246,8 @@ To collect processes information for all your containers and send it to Datadog:
 
 **This feature is available for Linux only**
 
- 1. Follow the [above instructions](#aws-cli) to install the Datadog Agent.
-  - If you are installing for the first time, there is a `datadog-agent-ecs.json` file available, [datadog-agent-sysprobe-ecs.json][16] ([datadog-agent-sysprobe-ecs1.json][17] if you are using an original Amazon Linux AMI), for use with the [above instructions](#aws-cli). **Note**: Initial NPM setup requires the CLI, as you cannot add `linuxParameters` in the AWS UI.
+ 1. Follow the [above instructions](#setup) to install the Datadog Agent.
+  - If you are installing for the first time, there is a `datadog-agent-ecs.json` file available, [datadog-agent-sysprobe-ecs.json][16] ([datadog-agent-sysprobe-ecs1.json][17] if you are using an original Amazon Linux AMI), for use with the [above instructions](#setup). **Note**: Initial NPM setup requires the CLI, as you cannot add `linuxParameters` in the AWS UI.
  2. If you already have a task definition, update your [datadog-agent-ecs.json][18] file ([datadog-agent-ecs1.json][19] if you are using an original Amazon Linux AMI) with the following configuration:
 
  ```json

--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -85,7 +85,7 @@ The commands related to log collection are:
 : Adds a log configuration that enables log collection for all containers.
 
 `-e DD_LOGS_CONFIG_DOCKER_CONTAINER_USE_FILE=true`            
-: Adds a log configuration that enables Docker container log collection from file. Available in the Datadog Agent 7.27.0/6.27.0+. Check the [dedicated section](#docker-containers-log-collection-from-file) for additional details.
+: Adds a log configuration that enables Docker container log collection from file. Available in the Datadog Agent 7.27.0/6.27.0+. Check the [dedicated section](#docker-container-log-collection-from-file) for additional details.
 
 `-v /opt/datadog-agent/run:/opt/datadog-agent/run:rw`         
 : To prevent loss of container logs during restarts or network issues, the last log line collected for each container in this directory is stored on the host.

--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -40,7 +40,7 @@ sudo rm -f /opt/datadog-agent/agent/datadog-cert.pem && sudo /etc/init.d/datadog
 
 #### Windows
 
-If your Agent is configured to use a proxy, follow the [dedicated section below](#windows-agent-5-x-configured-to-use-a-proxy-or-the-curl-http-client) instead.
+If your Agent is configured to use a proxy, follow the [dedicated section below](#windows-agent-5x-configured-to-use-a-proxy-or-the-curl-http-client) instead.
 
 *Using the CLI*
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
fixes borked hashes from the Agent tab of Sarina's spreadsheet

### Motivation
they're borked

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jorie/DOCS-2444/agent/docker/log
https://docs-staging.datadoghq.com/jorie/DOCS-2444/agent/amazon_ecs
https://docs-staging.datadoghq.com/jorie/DOCS-2444/agent/faq/certificate_verify_failed-error

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
