### PR TITLE
Update API Key link on Agent GSG to the Organization Settings page

### DIFF
--- a/content/en/getting_started/agent/_index.md
+++ b/content/en/getting_started/agent/_index.md
@@ -119,7 +119,7 @@ For help troubleshooting the Agent:
 [7]: https://www.datadoghq.com
 [8]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent
 [9]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
-[10]: https://app.datadoghq.com/account/settings#api
+[10]: https://app.datadoghq.com/organization-settings/api-keys
 [11]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
 [12]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent#environment-variables
 [13]: /agent/guide/agent-commands/#agent-status-and-information


### PR DESCRIPTION
### What does this PR do?
Update API Key link on Agent Getting Started Guide to the Organization Settings page.

### Motivation
Noticed that the previous version links to the Account Settings page, which no longer has the API Keys.

### Preview
https://docs-staging.datadoghq.com/ursula/api-key-links

### Additional Notes
Found the same issue in the API docs, and will submit a similar PR in the datadog-api-spec repo.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
