### PR TITLE
[DOCS-2488]Add documentation for using extension with private link

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -57,8 +57,8 @@ dd_url: https://agent.datadoghq.com
 
 | Forwarder | Datadog Logs Service Name |
 | --------- | ------------------------- |
-| Datadog Agent | `com.amazonaws.vpce.us-east-1.vpce-svc-025a56b9187ac1f63` |
-| Lambda or custom forwarder | `com.amazonaws.vpce.us-east-1.vpce-svc-06394d10ccaf6fb97` |
+| Datadog Agent or Lambda Extension | `com.amazonaws.vpce.us-east-1.vpce-svc-025a56b9187ac1f63` |
+| Lambda forwarder or custom forwarder | `com.amazonaws.vpce.us-east-1.vpce-svc-06394d10ccaf6fb97` |
 
 {{% /tab %}}
 {{% tab "API" %}}
@@ -105,7 +105,7 @@ dd_url: https://agent.datadoghq.com
 10. Wait for the status to move from _Pending_ to _Available_. This can take up to 10 minutes.
     {{< img src="agent/guide/private_link/vpc_status.png" alt="VPC status" style="width:60%;" >}}
 
-    Once it shows _Available_, the AWS PrivateLink is ready to be used. 
+    Once it shows _Available_, the AWS PrivateLink is ready to be used.
 11. If you are collecting logs data, ensure your Agent is configured to send logs over HTTPS. If it's not already there, add the following to the [Agent `datadog.yaml` configuration file][2]:
 
     ```yaml
@@ -126,7 +126,7 @@ dd_url: https://agent.datadoghq.com
 
 ### Inter-region peering
 
-To route traffic to Datadog's PrivateLink offering in `us-east-1` from other regions, use inter-region [Amazon VPC peering][6]. 
+To route traffic to Datadog's PrivateLink offering in `us-east-1` from other regions, use inter-region [Amazon VPC peering][6].
 
 Inter-region VPC peering enables you to establish connections between VPCs across different AWS regions. This allows VPC resources in different regions to communicate with each other using private IP addresses.
 

--- a/content/en/serverless/guide/_index.md
+++ b/content/en/serverless/guide/_index.md
@@ -11,4 +11,5 @@ kind: guide
 {{< whatsnext desc="Using the Datadog Lambda Extension:" >}}
     {{< nextlink href="/serverless/guide/extension_motivation" >}}Deciding to migrate to the Datadog Lambda Extension{{< /nextlink >}}
     {{< nextlink href="/serverless/guide/forwarder_extension_migration" >}}Migrating from the Datadog Forwarder to the Datadog Lambda Extension{{< /nextlink >}}
+    {{< nextlink href="/serverless/guide/extension_private_link" >}}Datadog Lambda Extension AWS PrivateLink Setup{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/serverless/guide/extension_private_link.md
+++ b/content/en/serverless/guide/extension_private_link.md
@@ -33,7 +33,7 @@ By default, the Extension uses different API endpoints than the Datadog Agent. O
 ```
 DD_URL="https://agent.datadoghq.com"
 DD_LOGS_CONFIG_USE_HTTP=true
-DD_LOGS_CONFIG_LOGS_DD_URL="agent-http-intake.logs.datadoghq.com"
+DD_LOGS_CONFIG_LOGS_DD_URL="agent-http-intake.logs.datadoghq.com:443"
 ```
 
 Alternatively, you can configure the Extension by adding a [`datadog.yaml`][5] file in the same folder as the Lambda handler code.
@@ -42,7 +42,7 @@ Alternatively, you can configure the Extension by adding a [`datadog.yaml`][5] f
 dd_url: https://agent.datadoghq.com
 logs_config:
     use_http: true
-    logs_dd_url: agent-http-intake.logs.datadoghq.com
+    logs_dd_url: agent-http-intake.logs.datadoghq.com:443
 ```
 
 ## Further Reading

--- a/content/en/serverless/guide/extension_private_link.md
+++ b/content/en/serverless/guide/extension_private_link.md
@@ -16,19 +16,19 @@ Datadog exposes AWS PrivateLink endpoints in <b>us-east-1</b>.
 <div class="alert alert-warning">Datadog PrivateLink does not support the Datadog for Government site.</div>
 {{< /site-region >}}
 
-This guide walks you through how to set up the [Datadog Lambda Extension](1) inside a VPC using [AWS PrivateLink](2).
+This guide walks you through how to set up the [Datadog Lambda Extension][1] inside a VPC using [AWS PrivateLink][2].
 
 ## Overview
 
-The Datadog Lambda Extension is a companion process that augments your Lambda functions to collect data such as logs, traces and metrics and forwards them to Datadog. For functions running inside a Virtual Private Cloud (VPC) network access may be restricted by Subnet routing rules and Network ACLs, preventing access to Datadog's API. This article covers adding Datadog's AWS PrivateLink endpoints to your VPC, and related setup of the Datadog Lambda Extension.
+The Datadog Lambda Extension is a companion process that augments your Lambda functions to collect data such as logs, traces, and metrics and forwards them to Datadog. For functions running inside a Virtual Private Cloud (VPC) network access may be restricted by subnet routing rules or network ACLs, preventing access to Datadog's API. This article covers adding Datadog's AWS PrivateLink endpoints to your VPC, in addition to related setup of the Datadog Lambda Extension.
 
-## Connect VPC to Datadog PrivateLink Endpoints
+## Connect VPC to Datadog PrivateLink endpoints
 
-Add Datadog's Private Link endpoints to your VPC, as described in [this guide](3). The Extension requires the Metric, Log, API and Trace endpoints. For regions outside us-east-1, you may want to set up [inter-region peering](4).
+Add Datadog's Private Link endpoints to your VPC, as described in the [PrivateLink guide][3]. The Extension requires the metric, log, API, and trace endpoints. For regions outside `us-east-1`, you may want to set up [inter-region peering][4].
 
-## Extension Configuration
+## Extension configuration
 
-By default, the Extension uses different API endpoints to the Datadog Agent. Override the endpoints by setting the following environment variables on the lambda.
+By default, the Extension uses different API endpoints than the Datadog Agent. Override the endpoints by setting the following environment variables on the Lambda function.
 
 ```
 DD_URL="https://agent.datadoghq.com"
@@ -36,7 +36,7 @@ DD_LOGS_CONFIG_USE_HTTP=true
 DD_LOGS_CONFIG_LOGS_DD_URL="agent-http-intake.logs.datadoghq.com"
 ```
 
-Alterntaively, the Extension can also be configured by adding a [datadog.yaml](5) file in the same folder as the lambda handler code.
+Alternatively, you can configure the Extension by adding a [`datadog.yaml`][5] file in the same folder as the Lambda handler code.
 
 ```
 dd_url: https://agent.datadoghq.com

--- a/content/en/serverless/guide/extension_private_link.md
+++ b/content/en/serverless/guide/extension_private_link.md
@@ -1,0 +1,56 @@
+---
+title: Datadog Lambda Extension AWS PrivateLink Setup
+kind: guide
+further_reading:
+    - link: '/agent/guide/private-link/'
+      tag: 'Documentation'
+      text: 'Connect to Datadog over AWS PrivateLink'
+
+---
+
+<div class="alert alert-info">
+Datadog exposes AWS PrivateLink endpoints in <b>us-east-1</b>.
+</div>
+
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Datadog PrivateLink does not support the Datadog for Government site.</div>
+{{< /site-region >}}
+
+This guide walks you through how to set up the [Datadog Lambda Extension](1) inside a VPC using [AWS PrivateLink](2).
+
+## Overview
+
+The Datadog Lambda Extension is a companion process that augments your Lambda functions to collect data such as logs, traces and metrics and forwards them to Datadog. For functions running inside a Virtual Private Cloud (VPC) network access may be restricted by Subnet routing rules and Network ACLs, preventing access to Datadog's API. This article covers adding Datadog's AWS PrivateLink endpoints to your VPC, and related setup of the Datadog Lambda Extension.
+
+## Connect VPC to Datadog PrivateLink Endpoints
+
+Add Datadog's Private Link endpoints to your VPC, as described in [this guide](3). The Extension requires the Metric, Log, API and Trace endpoints. For regions outside us-east-1, you may want to set up [inter-region peering](4).
+
+## Extension Configuration
+
+By default, the Extension uses different API endpoints to the Datadog Agent. Override the endpoints by setting the following environment variables on the lambda.
+
+```
+DD_URL="https://agent.datadoghq.com"
+DD_LOGS_CONFIG_USE_HTTP=true
+DD_LOGS_CONFIG_LOGS_DD_URL="agent-http-intake.logs.datadoghq.com"
+```
+
+Alterntaively, the Extension can also be configured by adding a [datadog.yaml](5) file in the same folder as the lambda handler code.
+
+```
+dd_url: https://agent.datadoghq.com
+logs_config:
+    use_http: true
+    logs_dd_url: agent-http-intake.logs.datadoghq.com
+```
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /serverless/enhanced_lambda_metrics
+[2]: https://aws.amazon.com/privatelink/
+[3]: /agent/guide/private-link/?tab=metrics#aws-vpc-endpoint
+[4]: /agent/guide/private-link/?tab=logs#inter-region-peering
+[5]: /agent/guide/agent-configuration-files


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a guide describing how to configure the Lambda Extension with a VPC using Private Link.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->
https://docs-staging.datadoghq.com/darcy.rayner/add-lambda-vpc-documentation/serverless/guide/extension_private_link

https://docs-staging.datadoghq.com/darcy.rayner/add-lambda-vpc-documentation/agent/guide/private-link
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
