### PR TITLE
[rum] Explicitly mention sdk request method for proxy conf

### DIFF
--- a/content/en/real_user_monitoring/faq/proxy_rum_data.md
+++ b/content/en/real_user_monitoring/faq/proxy_rum_data.md
@@ -7,7 +7,7 @@ The Real User Monitoring (RUM) SDK can be configured to send requests through a 
 
 ## SDK initialization
 
-When you set the `proxyUrl` [initialization parameter][1], all RUM data is sent to the specified URL (for example, www.proxy.com/foo).
+When you set the `proxyUrl` [initialization parameter][1], all RUM data is sent to the specified URL using POST method (for example, www.proxy.com/foo).
 
 {{< tabs >}}
 {{% tab "NPM" %}}
@@ -58,12 +58,12 @@ window.DD_RUM &&
 
 ## Proxy setup
 
-When your proxy receives data from the RUM SDK, it must be forwarded to Datadog. The RUM SDK adds the `ddforward` query parameter to all requests to your proxy. This query parameter contains the URL where all data must be forwarded to.
+When your proxy receives data from the RUM SDK, it must be forwarded to Datadog. The RUM SDK adds the `ddforward` query parameter to all POST requests to your proxy. This query parameter contains the URL where all data must be forwarded to.
 
 To successfully proxy request to Datadog:
 
 1. Add a `X-Forwarded-For` header containing the request client IP address, for accurate geoIP.
-2. Forward the request to the URL set in the `ddforward` query parameter.
+2. Forward the request to the URL set in the `ddforward` query parameter using POST method.
 
 **Note:** The request body must remain unchanged.
 

--- a/content/en/real_user_monitoring/faq/proxy_rum_data.md
+++ b/content/en/real_user_monitoring/faq/proxy_rum_data.md
@@ -7,7 +7,7 @@ The Real User Monitoring (RUM) SDK can be configured to send requests through a 
 
 ## SDK initialization
 
-When you set the `proxyUrl` [initialization parameter][1], all RUM data is sent to the specified URL using POST method (for example, www.proxy.com/foo).
+When you set the `proxyUrl` [initialization parameter][1], all RUM data is sent to the specified URL using POST method (for example, https://www.proxy.com/foo).
 
 {{< tabs >}}
 {{% tab "NPM" %}}

--- a/content/en/real_user_monitoring/faq/proxy_rum_data.md
+++ b/content/en/real_user_monitoring/faq/proxy_rum_data.md
@@ -7,7 +7,7 @@ The Real User Monitoring (RUM) SDK can be configured to send requests through a 
 
 ## SDK initialization
 
-When you set the `proxyUrl` [initialization parameter][1], all RUM data is sent to the specified URL using POST method (for example, https://www.proxy.com/foo).
+When you set the `proxyUrl` [initialization parameter][1], all RUM data is sent to the specified URL using the POST method (for example, `https://www.proxy.com/foo`).
 
 {{< tabs >}}
 {{% tab "NPM" %}}
@@ -63,7 +63,7 @@ When your proxy receives data from the RUM SDK, it must be forwarded to Datadog.
 To successfully proxy request to Datadog:
 
 1. Add a `X-Forwarded-For` header containing the request client IP address, for accurate geoIP.
-2. Forward the request to the URL set in the `ddforward` query parameter using POST method.
+2. Forward the request to the URL set in the `ddforward` query parameter using the POST method.
 
 **Note:** The request body must remain unchanged.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the proxy documentation to be more explicit on which http method we use

### Motivation
Browser SDK new feature

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/sdk-proxy-post-method/real_user_monitoring/faq/proxy_rum_data


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
