### PR TITLE
[CIAPP] Add doc about how to configure CI Visibility in Jenkins via Groovy scripts

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -48,9 +48,9 @@ Install and enable the [Datadog Jenkins plugin][3] v3.1.0 or newer:
 {{< img src="ci/ci-jenkins-plugin-config.png" alt="Datadog Plugin configuration for Jenkins" style="width:100%;">}}
 {{% /tab %}}
 {{% tab "Using configuration-as-code" %}}
-If your Jenkins instance uses the Jenkins [`configuration-as-code`][1] plugin, follow the next instructions:
+If your Jenkins instance uses the Jenkins [`configuration-as-code`][1] plugin:
 
-1. Create or modify the configuration yaml adding the entry for `datadogGlobalConfiguration`
+1. Create or modify the configuration YAML by adding an entry for `datadogGlobalConfiguration`:
 ```yaml
 unclassified:
   datadogGlobalConfiguration:
@@ -103,7 +103,7 @@ d.save()
 {{% /tab %}}
 {{% tab "Using Environment Variables" %}}
 
-1. Set the following environment variables in your Jenkins instance machine:
+1. Set the following environment variables on your Jenkins instance machine:
 ```bash
 # Select the Datadog Agent mode
 DATADOG_JENKINS_PLUGIN_REPORT_WITH=DSD
@@ -173,9 +173,9 @@ Second, enable job log collection on the Datadog Plugin:
 8. Save your configuration.
 {{% /tab %}}
 {{% tab "Using configuration-as-code" %}}
-If your Jenkins instance uses the Jenkins [`configuration-as-code`][1] plugin, follow the next instructions:
+If your Jenkins instance uses the Jenkins [`configuration-as-code`][1] plugin:
 
-1. Modify the configuration yaml for the entry `datadogGlobalConfiguration`
+1. Modify the configuration YAML for the entry `datadogGlobalConfiguration`:
 ```yaml
 unclassified:
   datadogGlobalConfiguration:
@@ -223,7 +223,7 @@ d.save()
 {{% /tab %}}
 {{% tab "Using Environment Variables" %}}
 
-1. Set the following environment variables in your Jenkins instance machine:
+1. Set the following environment variables on your Jenkins instance machine:
 ```bash
 # Select the Datadog Agent mode
 DATADOG_JENKINS_PLUGIN_REPORT_WITH=DSD

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -48,7 +48,7 @@ Install and enable the [Datadog Jenkins plugin][3] v3.1.0 or newer:
 {{< img src="ci/ci-jenkins-plugin-config.png" alt="Datadog Plugin configuration for Jenkins" style="width:100%;">}}
 {{% /tab %}}
 {{% tab "Using configuration-as-code" %}}
-If your Jenkins instance uses the [Jenkins `configuration-as-code` plugin][1], follow the next instructions:
+If your Jenkins instance uses the Jenkins [`configuration-as-code`][1] plugin, follow the next instructions:
 
 1. Create or modify the configuration yaml adding the entry for `datadogGlobalConfiguration`
 ```yaml
@@ -173,7 +173,7 @@ Second, enable job log collection on the Datadog Plugin:
 8. Save your configuration.
 {{% /tab %}}
 {{% tab "Using configuration-as-code" %}}
-If your Jenkins instance uses the [Jenkins `configuration-as-code` plugin][1], follow the next instructions:
+If your Jenkins instance uses the Jenkins [`configuration-as-code`][1] plugin, follow the next instructions:
 
 1. Modify the configuration yaml for the entry `datadogGlobalConfiguration`
 ```yaml

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -47,11 +47,35 @@ Install and enable the [Datadog Jenkins plugin][3] v3.1.0 or newer:
 
 {{< img src="ci/ci-jenkins-plugin-config.png" alt="Datadog Plugin configuration for Jenkins" style="width:100%;">}}
 {{% /tab %}}
+{{% tab "Using configuration-as-code"}}
+If your Jenkins instance uses the [Jenkins `configuration-as-code` plugin][1], follow the next instructions:
+
+1. Create or modify the configuration yaml adding the entry for `datadogGlobalConfiguration`
+```yaml
+unclassified:
+  datadogGlobalConfiguration:
+    # Select the `Datadog Agent` mode.
+    reportWith: "DSD"
+    # Configure the `Agent` host
+    targetHost: "agent-host"
+    # Configure the `Traces Collection` port (default `8126`).
+    targetTraceCollectionPort: 8126
+    # Enable CI Visibility flag
+    enableCiVisibility: true
+    # (Optional) Configure your CI Instance name
+    ciInstanceName: "jenkins"
+```
+2. In your Jenkins instance web interface, go to **Manage Jenkins > Configuration as Code**.
+3. Apply or reload the configuration.
+4. Check the configuration using the `View Configuration` button.
+
+[1]: https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/README.md
+{{% /tab %}}
 {{% tab "Using Groovy" %}}
 
 1. In your Jenkins instance web interface, go to **Manage Jenkins > Script Console**.
 2. Run the configuration script:
-{{< code-block lang="groovy" >}}
+```groovy
 import jenkins.model.*
 import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration
 
@@ -65,7 +89,7 @@ d.setReportWith('DSD')
 d.setTargetHost('<agent host>')
 
 // Configure the Traces Collection port (default 8126)
-d.setTargetTraceCollectionPort(<agent trace collection port>)
+d.setTargetTraceCollectionPort(8126)
 
 // Enable CI Visibility
 d.setEnableCiVisibility(true)
@@ -75,7 +99,7 @@ d.setCiInstanceName("jenkins")
 
 // Save config
 d.save()
-{{< /code-block >}}
+```
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -126,11 +150,33 @@ Second, enable job log collection on the Datadog Plugin:
 7. Check the connectivity with the Datadog Agent.
 8. Save your configuration.
 {{% /tab %}}
+{{% tab "Using configuration-as-code"}}
+If your Jenkins instance uses the [Jenkins `configuration-as-code` plugin][1], follow the next instructions:
+
+1. Modify the configuration yaml for the entry `datadogGlobalConfiguration`
+```yaml
+unclassified:
+  datadogGlobalConfiguration:
+    # Select the `Datadog Agent` mode.
+    reportWith: "DSD"
+    # Configure the `Agent` host
+    targetHost: "agent-host"
+    # Configure the `Log Collection` port, as configured in the previous step.
+    targetLogCollectionPort: 10518
+    # Enable Log collection
+    collectBuildLogs: true
+```
+2. In your Jenkins instance web interface, go to **Manage Jenkins > Configuration as Code**.
+3. Click on `Reload existing configuration`.
+4. Check the configuration using the `View Configuration` button.
+
+[1]: https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/README.md
+{{% /tab %}}
 {{% tab "Using Groovy" %}}
 
 1. In your Jenkins instance web interface, go to **Manage Jenkins > Script Console**.
 2. Run the configuration script:
-{{< code-block lang="groovy" >}}
+```groovy
 import jenkins.model.*
 import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration
 
@@ -144,13 +190,14 @@ d.setReportWith('DSD')
 d.setTargetHost('<agent host>')
 
 // Configure the Log Collection port, as configured in the previous step.
-d.setTargetLogCollectionPort(<agent log collection port>)
+d.setTargetLogCollectionPort(10518)
 
 // Enable log collection
 d.setCollectBuildLogs(true)
 
 // Save config
 d.save()
+```
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -32,6 +32,9 @@ Install and enable the [Datadog Jenkins plugin][3] v3.1.0 or newer:
 
 ## Enabling CI Visibility on the plugin
 
+{{< tabs >}}
+{{% tab "Using UI" %}}
+
 1. In your Jenkins instance web interface, go to **Manage Jenkins > Configure System**.
 2. Go to the `Datadog Plugin` section, scrolling down the configuration screen.
 3. Select the `Datadog Agent` mode.
@@ -41,14 +44,46 @@ Install and enable the [Datadog Jenkins plugin][3] v3.1.0 or newer:
 7. (Optional) Configure your CI Instance name.
 8. Check the connectivity with the Datadog Agent.
 9. Save your configuration.
-10. To verify that CI Visibility is enabled, go to `Jenkins Log` and search for:
+
+{{< img src="ci/ci-jenkins-plugin-config.png" alt="Datadog Plugin configuration for Jenkins" style="width:100%;">}}
+{{% /tab %}}
+{{% tab "Using Groovy" %}}
+1. In your Jenkins instance web interface, go to **Manage Jenkins > Script Console**.
+2. Run the configuration script:
+{{< code-block lang="groovy" >}}
+import jenkins.model.*
+import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration
+
+def j = Jenkins.getInstance()
+def d = j.getDescriptor("org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration")
+
+// Select the `Datadog Agent` mode
+d.setReportWith('DSD')
+
+// Configure the Agent host.
+d.setTargetHost('<agent host>')
+
+// Configure the `Traces Collection` port (default `8126`)
+d.setTargetTraceCollectionPort(<agent trace collection port>)
+
+// Enable CI Visibility
+d.setEnableCiVisibility(true)
+
+// (Optional) Configure your CI Instance name
+d.setCiInstanceName("jenkins")
+
+// Save config
+d.save()
+{{< /code-block >}}
+{{% /tab %}}
+{{< /tabs >}}
+
+To verify that CI Visibility is enabled, go to `Jenkins Log` and search for:
 
 {{< code-block lang="text" >}}
 Re/Initialize Datadog-Plugin Agent Http Client
 TRACE -> http://<HOST>:<TRACE_PORT>/v0.3/traces
 {{< /code-block >}}
-
-{{< img src="ci/ci-jenkins-plugin-config.png" alt="Datadog Plugin configuration for Jenkins" style="width:100%;">}}
 
 ## Enable job log collection
 
@@ -78,6 +113,8 @@ With this setup, the Agent listens in port `10518` for logs.
 
 Second, enable job log collection on the Datadog Plugin:
 
+{{< tabs >}}
+{{% tag "Using UI" %}}
 1. In the web interface of your Jenkins instance, go to **Manage Jenkins > Configure System**.
 2. Go to the `Datadog Plugin` section, scrolling down the configuration screen.
 3. Select the `Datadog Agent` mode.
@@ -86,6 +123,33 @@ Second, enable job log collection on the Datadog Plugin:
 6. Click on `Enable Log Collection` checkbox to activate it.
 7. Check the connectivity with the Datadog Agent.
 8. Save your configuration.
+{{% /tab %}}
+{{% tab "Using Groovy" %}}
+1. In your Jenkins instance web interface, go to **Manage Jenkins > Script Console**.
+2. Run the configuration script:
+{{< code-block lang="groovy" >}}
+import jenkins.model.*
+import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration
+
+def j = Jenkins.getInstance()
+def d = j.getDescriptor("org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration")
+
+// Select the `Datadog Agent` mode
+d.setReportWith('DSD')
+
+// Configure the Agent host, if not previously configured.
+d.setTargetHost('<agent host>')
+
+// Configure the `Log Collection` port, as configured in the previous step.
+d.setTargetLogCollectionPort(<agent log collection port>)
+
+// Enable log collection
+d.setCollectBuildLogs(true)
+
+// Save config
+d.save()
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Set the default branch name
 

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -58,13 +58,13 @@ import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration
 def j = Jenkins.getInstance()
 def d = j.getDescriptor("org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration")
 
-// Select the `Datadog Agent` mode
+// Select the Datadog Agent mode
 d.setReportWith('DSD')
 
 // Configure the Agent host.
 d.setTargetHost('<agent host>')
 
-// Configure the `Traces Collection` port (default `8126`)
+// Configure the Traces Collection port (default 8126)
 d.setTargetTraceCollectionPort(<agent trace collection port>)
 
 // Enable CI Visibility
@@ -137,13 +137,13 @@ import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration
 def j = Jenkins.getInstance()
 def d = j.getDescriptor("org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration")
 
-// Select the `Datadog Agent` mode
+// Select the Datadog Agent mode
 d.setReportWith('DSD')
 
 // Configure the Agent host, if not previously configured.
 d.setTargetHost('<agent host>')
 
-// Configure the `Log Collection` port, as configured in the previous step.
+// Configure the Log Collection port, as configured in the previous step.
 d.setTargetLogCollectionPort(<agent log collection port>)
 
 // Enable log collection

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -51,20 +51,20 @@ Install and enable the [Datadog Jenkins plugin][3] v3.1.0 or newer:
 If your Jenkins instance uses the Jenkins [`configuration-as-code`][1] plugin:
 
 1. Create or modify the configuration YAML by adding an entry for `datadogGlobalConfiguration`:
-```yaml
-unclassified:
-  datadogGlobalConfiguration:
-    # Select the `Datadog Agent` mode.
-    reportWith: "DSD"
-    # Configure the `Agent` host
-    targetHost: "agent-host"
-    # Configure the `Traces Collection` port (default `8126`).
-    targetTraceCollectionPort: 8126
-    # Enable CI Visibility flag
-    enableCiVisibility: true
-    # (Optional) Configure your CI Instance name
-    ciInstanceName: "jenkins"
-```
+    ```yaml
+    unclassified:
+        datadogGlobalConfiguration:
+            # Select the `Datadog Agent` mode.
+            reportWith: "DSD"
+            # Configure the `Agent` host
+            targetHost: "agent-host"
+            # Configure the `Traces Collection` port (default `8126`).
+            targetTraceCollectionPort: 8126
+            # Enable CI Visibility flag
+            enableCiVisibility: true
+            # (Optional) Configure your CI Instance name
+            ciInstanceName: "jenkins"
+    ```
 2. In your Jenkins instance web interface, go to **Manage Jenkins > Configuration as Code**.
 3. Apply or reload the configuration.
 4. Check the configuration using the `View Configuration` button.
@@ -75,51 +75,51 @@ unclassified:
 
 1. In your Jenkins instance web interface, go to **Manage Jenkins > Script Console**.
 2. Run the configuration script:
-```groovy
-import jenkins.model.*
-import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration
+    ```groovy
+    import jenkins.model.*
+    import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration
 
-def j = Jenkins.getInstance()
-def d = j.getDescriptor("org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration")
+    def j = Jenkins.getInstance()
+    def d = j.getDescriptor("org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration")
 
-// Select the Datadog Agent mode
-d.setReportWith('DSD')
+    // Select the Datadog Agent mode
+    d.setReportWith('DSD')
 
-// Configure the Agent host.
-d.setTargetHost('<agent host>')
+    // Configure the Agent host.
+    d.setTargetHost('<agent host>')
 
-// Configure the Traces Collection port (default 8126)
-d.setTargetTraceCollectionPort(8126)
+    // Configure the Traces Collection port (default 8126)
+    d.setTargetTraceCollectionPort(8126)
 
-// Enable CI Visibility
-d.setEnableCiVisibility(true)
+    // Enable CI Visibility
+    d.setEnableCiVisibility(true)
 
-// (Optional) Configure your CI Instance name
-d.setCiInstanceName("jenkins")
+    // (Optional) Configure your CI Instance name
+    d.setCiInstanceName("jenkins")
 
-// Save config
-d.save()
-```
+    // Save config
+    d.save()
+    ```
 {{% /tab %}}
 {{% tab "Using Environment Variables" %}}
 
 1. Set the following environment variables on your Jenkins instance machine:
-```bash
-# Select the Datadog Agent mode
-DATADOG_JENKINS_PLUGIN_REPORT_WITH=DSD
+    ```bash
+    # Select the Datadog Agent mode
+    DATADOG_JENKINS_PLUGIN_REPORT_WITH=DSD
 
-# Configure the Agent host
-DATADOG_JENKINS_PLUGIN_TARGET_HOST=agent-host
+    # Configure the Agent host
+    DATADOG_JENKINS_PLUGIN_TARGET_HOST=agent-host
 
-# Configure the Traces Collection port (default 8126)
-DATADOG_JENKINS_PLUGIN_TARGET_TRACE_COLLECTION_PORT=8126
+    # Configure the Traces Collection port (default 8126)
+    DATADOG_JENKINS_PLUGIN_TARGET_TRACE_COLLECTION_PORT=8126
 
-# Enable CI Visibility
-DATADOG_JENKINS_PLUGIN_ENABLE_CI_VISIBILITY=true
+    # Enable CI Visibility
+    DATADOG_JENKINS_PLUGIN_ENABLE_CI_VISIBILITY=true
 
-# (Optional) Configure your CI Instance name
-DATADOG_JENKINS_PLUGIN_CI_VISIBILITY_CI_INSTANCE_NAME=jenkins
-```
+    # (Optional) Configure your CI Instance name
+    DATADOG_JENKINS_PLUGIN_CI_VISIBILITY_CI_INSTANCE_NAME=jenkins
+    ```
 2. Restart your Jenkins instance.
 
 {{% /tab %}}
@@ -175,21 +175,21 @@ Second, enable job log collection on the Datadog Plugin:
 {{% tab "Using configuration-as-code" %}}
 If your Jenkins instance uses the Jenkins [`configuration-as-code`][1] plugin:
 
-1. Modify the configuration YAML for the entry `datadogGlobalConfiguration`:
-```yaml
-unclassified:
-  datadogGlobalConfiguration:
-    # Select the `Datadog Agent` mode.
-    reportWith: "DSD"
-    # Configure the `Agent` host
-    targetHost: "agent-host"
-    # Configure the `Log Collection` port, as configured in the previous step.
-    targetLogCollectionPort: 10518
-    # Enable Log collection
-    collectBuildLogs: true
-```
+1. Create or modify the configuration YAML for the entry `datadogGlobalConfiguration`:
+    ```yaml
+    unclassified:
+    datadogGlobalConfiguration:
+        # Select the `Datadog Agent` mode.
+        reportWith: "DSD"
+        # Configure the `Agent` host
+        targetHost: "agent-host"
+        # Configure the `Log Collection` port, as configured in the previous step.
+        targetLogCollectionPort: 10518
+        # Enable Log collection
+        collectBuildLogs: true
+    ```
 2. In your Jenkins instance web interface, go to **Manage Jenkins > Configuration as Code**.
-3. Click on `Reload existing configuration`.
+3. Apply or reload the configuration.
 4. Check the configuration using the `View Configuration` button.
 
 [1]: https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/README.md
@@ -198,45 +198,45 @@ unclassified:
 
 1. In your Jenkins instance web interface, go to **Manage Jenkins > Script Console**.
 2. Run the configuration script:
-```groovy
-import jenkins.model.*
-import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration
+    ```groovy
+    import jenkins.model.*
+    import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration
 
-def j = Jenkins.getInstance()
-def d = j.getDescriptor("org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration")
+    def j = Jenkins.getInstance()
+    def d = j.getDescriptor("org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration")
 
-// Select the Datadog Agent mode
-d.setReportWith('DSD')
+    // Select the Datadog Agent mode
+    d.setReportWith('DSD')
 
-// Configure the Agent host, if not previously configured.
-d.setTargetHost('<agent host>')
+    // Configure the Agent host, if not previously configured.
+    d.setTargetHost('<agent host>')
 
-// Configure the Log Collection port, as configured in the previous step.
-d.setTargetLogCollectionPort(10518)
+    // Configure the Log Collection port, as configured in the previous step.
+    d.setTargetLogCollectionPort(10518)
 
-// Enable log collection
-d.setCollectBuildLogs(true)
+    // Enable log collection
+    d.setCollectBuildLogs(true)
 
-// Save config
-d.save()
-```
+    // Save config
+    d.save()
+    ```
 {{% /tab %}}
 {{% tab "Using Environment Variables" %}}
 
 1. Set the following environment variables on your Jenkins instance machine:
-```bash
-# Select the Datadog Agent mode
-DATADOG_JENKINS_PLUGIN_REPORT_WITH=DSD
+    ```bash
+    # Select the Datadog Agent mode
+    DATADOG_JENKINS_PLUGIN_REPORT_WITH=DSD
 
-# Configure the Agent host
-DATADOG_JENKINS_PLUGIN_TARGET_HOST=agent-host
+    # Configure the Agent host
+    DATADOG_JENKINS_PLUGIN_TARGET_HOST=agent-host
 
-# Configure the Log Collection port, as configured in the previous step.
-DATADOG_JENKINS_PLUGIN_TARGET_LOG_COLLECTION_PORT=10518
+    # Configure the Log Collection port, as configured in the previous step.
+    DATADOG_JENKINS_PLUGIN_TARGET_LOG_COLLECTION_PORT=10518
 
-# Enable log collection
-DATADOG_JENKINS_PLUGIN_COLLECT_BUILD_LOGS=true
-```
+    # Enable log collection
+    DATADOG_JENKINS_PLUGIN_COLLECT_BUILD_LOGS=true
+    ```
 2. Restart your Jenkins instance.
 
 {{% /tab %}}

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -114,7 +114,7 @@ With this setup, the Agent listens in port `10518` for logs.
 Second, enable job log collection on the Datadog Plugin:
 
 {{< tabs >}}
-{{% tag "Using UI" %}}
+{{% tab "Using UI" %}}
 1. In the web interface of your Jenkins instance, go to **Manage Jenkins > Configure System**.
 2. Go to the `Datadog Plugin` section, scrolling down the configuration screen.
 3. Select the `Datadog Agent` mode.

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -101,6 +101,28 @@ d.setCiInstanceName("jenkins")
 d.save()
 ```
 {{% /tab %}}
+{{% tab "Using Environment Variables" %}}
+
+1. Set the following environment variables in your Jenkins instance machine:
+```bash
+# Select the Datadog Agent mode
+DATADOG_JENKINS_PLUGIN_REPORT_WITH=DSD
+
+# Configure the Agent host
+DATADOG_JENKINS_PLUGIN_TARGET_HOST=agent-host
+
+# Configure the Traces Collection port (default 8126)
+DATADOG_JENKINS_PLUGIN_TARGET_TRACE_COLLECTION_PORT=8126
+
+# Enable CI Visibility
+DATADOG_JENKINS_PLUGIN_ENABLE_CI_VISIBILITY=true
+
+# (Optional) Configure your CI Instance name
+DATADOG_JENKINS_PLUGIN_CI_VISIBILITY_CI_INSTANCE_NAME=jenkins
+```
+2. Restart your Jenkins instance.
+
+{{% /tab %}}
 {{< /tabs >}}
 
 To verify that CI Visibility is enabled, go to `Jenkins Log` and search for:
@@ -198,6 +220,25 @@ d.setCollectBuildLogs(true)
 // Save config
 d.save()
 ```
+{{% /tab %}}
+{{% tab "Using Environment Variables" %}}
+
+1. Set the following environment variables in your Jenkins instance machine:
+```bash
+# Select the Datadog Agent mode
+DATADOG_JENKINS_PLUGIN_REPORT_WITH=DSD
+
+# Configure the Agent host
+DATADOG_JENKINS_PLUGIN_TARGET_HOST=agent-host
+
+# Configure the Log Collection port, as configured in the previous step.
+DATADOG_JENKINS_PLUGIN_TARGET_LOG_COLLECTION_PORT=10518
+
+# Enable log collection
+DATADOG_JENKINS_PLUGIN_COLLECT_BUILD_LOGS=true
+```
+2. Restart your Jenkins instance.
+
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -48,6 +48,7 @@ Install and enable the [Datadog Jenkins plugin][3] v3.1.0 or newer:
 {{< img src="ci/ci-jenkins-plugin-config.png" alt="Datadog Plugin configuration for Jenkins" style="width:100%;">}}
 {{% /tab %}}
 {{% tab "Using Groovy" %}}
+
 1. In your Jenkins instance web interface, go to **Manage Jenkins > Script Console**.
 2. Run the configuration script:
 {{< code-block lang="groovy" >}}
@@ -115,6 +116,7 @@ Second, enable job log collection on the Datadog Plugin:
 
 {{< tabs >}}
 {{% tab "Using UI" %}}
+
 1. In the web interface of your Jenkins instance, go to **Manage Jenkins > Configure System**.
 2. Go to the `Datadog Plugin` section, scrolling down the configuration screen.
 3. Select the `Datadog Agent` mode.
@@ -125,6 +127,7 @@ Second, enable job log collection on the Datadog Plugin:
 8. Save your configuration.
 {{% /tab %}}
 {{% tab "Using Groovy" %}}
+
 1. In your Jenkins instance web interface, go to **Manage Jenkins > Script Console**.
 2. Run the configuration script:
 {{< code-block lang="groovy" >}}

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -47,7 +47,7 @@ Install and enable the [Datadog Jenkins plugin][3] v3.1.0 or newer:
 
 {{< img src="ci/ci-jenkins-plugin-config.png" alt="Datadog Plugin configuration for Jenkins" style="width:100%;">}}
 {{% /tab %}}
-{{% tab "Using configuration-as-code"}}
+{{% tab "Using configuration-as-code" %}}
 If your Jenkins instance uses the [Jenkins `configuration-as-code` plugin][1], follow the next instructions:
 
 1. Create or modify the configuration yaml adding the entry for `datadogGlobalConfiguration`
@@ -172,7 +172,7 @@ Second, enable job log collection on the Datadog Plugin:
 7. Check the connectivity with the Datadog Agent.
 8. Save your configuration.
 {{% /tab %}}
-{{% tab "Using configuration-as-code"}}
+{{% tab "Using configuration-as-code" %}}
 If your Jenkins instance uses the [Jenkins `configuration-as-code` plugin][1], follow the next instructions:
 
 1. Modify the configuration yaml for the entry `datadogGlobalConfiguration`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds how to configure CI Visibility in Jenkins using Groovy (via scripts)

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/drodriguezhdez/jenkins_config/continuous_integration/setup_pipelines/jenkins/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
