### PR TITLE
(DOCS-2484) Add environment variables to tracing obfuscation.

### DIFF
--- a/content/en/tracing/setup_overview/configure_data_security/_index.md
+++ b/content/en/tracing/setup_overview/configure_data_security/_index.md
@@ -38,7 +38,36 @@ Datadog enforces several filtering mechanisms on spans as a baseline, to provide
 
 ## Agent trace obfuscation
 
-Agent [trace][2] obfuscation is disabled by default. Enable it in your `datadog.yaml` configuration file to obfuscate all information attached to your traces.
+Agent [trace][2] obfuscation is disabled by default. Enable it in your `datadog.yaml` configuration file to obfuscate information attached to your traces.
+
+List of all environment variables available for Agent trace obfuscation:
+
+`DD_APM_CONFIG_OBFUSCATION_ELASTICSEARCH_ENABLED`
+: Whether or not to enable obfuscation in Elasticsearch.
+
+`DD_APM_CONFIG_OBFUSCATION_ELASTICSEARCH_KEEP_VALUES`
+: Whether or not to store obfuscated values from Elasticsearch.
+
+`DD_APM_CONFIG_OBFUSCATION_HTTP_REMOVE_PATHS_WITH_DIGITS`
+: A string containing values to remove from HTTP paths for obfuscation.
+
+`DD_APM_CONFIG_OBFUSCATION_HTTP_REMOVE_QUERY_STRING`
+: A string containing one or more query strings to remove for obfuscation.
+
+`DD_APM_CONFIG_OBFUSCATION_MEMCACHED_ENABLED`
+: Whether or not to enable obfuscation of `memcached`.
+
+`DD_APM_CONFIG_OBFUSCATION_MONGODB_ENABLED`
+: Whether or not to enable obfuscation of `mongodb`. 
+
+`DD_APM_CONFIG_OBFUSCATION_MONGODB_KEEP_VALUES`
+: Whether or not to store obfuscated values from `mongodb`.
+
+`DD_APM_CONFIG_OBFUSCATION_REDIS_ENABLED`
+: Whether or not to enable obfuscation for `redis`.
+
+`DD_APM_CONFIG_OBFUSCATION_REMOVE_STACK_TRACES`
+: Whether or not to remove stack traces for obfuscation.
 
 This option works with the following services:
 
@@ -50,7 +79,6 @@ This option works with the following services:
 * `remove_stack_traces`
 
 **Note:** You can use automatic scrubbing for multiple types of services at the same time.  Configure each in the `obfuscation` section of your `datadog.yaml` file.
-
 {{< tabs >}}
 {{% tab "MongoDB" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a description list of environment variables to this page.

### Motivation
DOCS-2484

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jorie/DOCS-2484/tracing/setup_overview/configure_data_security/?tab=mongodb#agent-trace-obfuscation

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
