### PR TITLE
[cayetano.delgado] remove broken image tag

### DIFF
--- a/content/en/metrics/agent_metrics_submission.md
+++ b/content/en/metrics/agent_metrics_submission.md
@@ -224,9 +224,7 @@ Follow the steps below to create a [custom Agent check][2] that sends all metric
         (...)
     ```
 
-6. Verify your metrics are reporting to Datadog on your [Metric Summary page][6]:
-
-{{< img src="metrics/agent_metrics_submission/metrics_metrics_summary.png" alt="Metrics in metric summary"  style="width:80%;">}}
+6. Verify your metrics are reporting to Datadog on your [Metric Summary page][6].
 
 ## Further Reading
 


### PR DESCRIPTION
This can be removed because the image is missing.

{{< img src="metrics/agent_metrics_submission/metrics_metrics_summary.png" alt="Metrics in metric summary"  style="width:80%;">}}

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
