### PR TITLE
add blog link to continuous profiler

### DIFF
--- a/content/en/tracing/profiler/_index.md
+++ b/content/en/tracing/profiler/_index.md
@@ -19,6 +19,9 @@ further_reading:
     - link: 'https://www.datadoghq.com/blog/datadog-github-action-vulnerability-analysis/'
       tags: 'Blog'
       text: 'Datadog GitHub Action for continuous vulnerability analysis.'
+    - link: 'https://www.datadoghq.com/blog/code-optimization-datadog-profile-comparison/'
+      tags: 'Blog'
+      text: 'Compare and optimize your code with Datadog Profile Comparison.'
 
 ---
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/cswatt/add-link/tracing/profiler/
https://docs-staging.datadoghq.com/cswatt/add-link/tracing/profiler/compare_profiles

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
