### PR TITLE
[WEB-1721] Menu update for guides

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -818,42 +818,6 @@ main:
     identifier: integration_guides
     parent: integrations_top_level
     weight: 1
-  - name: Request Datadog Integrations
-    url: integrations/guide/requests/
-    parent: integration_guides
-    weight: 10
-  - name: AWS CloudWatch Metric Streams with Kinesis Data Firehose
-    url: integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose/
-    parent: integration_guides
-    weight: 11
-  - name: Amazon CloudFormation
-    url: integrations/guide/amazon_cloudformation/
-    parent: integration_guides
-    weight: 12
-  - name: Azure Portal
-    url: integrations/guide/azure-portal/
-    parent: integration_guides
-    weight: 13
-  - name: Mongo Custom Metrics
-    url: integrations/guide/mongo-custom-query-collection/
-    parent: integration_guides
-    weight: 14
-  - name: Prometheus Metrics
-    url: integrations/guide/prometheus-metrics/
-    parent: integration_guides
-    weight: 15
-  - name: Prometheus and OpenMetrics from a Host
-    url: integrations/guide/prometheus-host-collection/
-    parent: integration_guides
-    weight: 16
-  - name: SQL Server Custom Metrics
-    url: integrations/guide/collect-sql-server-custom-metrics/
-    parent: integration_guides
-    weight: 17
-  - name: Freshservice Tickets Using Webhooks
-    url: integrations/guide/freshservice-tickets-using-webhooks/
-    parent: integration_guides
-    weight: 18
   - name: Watchdog
     url: watchdog/
     identifier: watchdog_top_level
@@ -869,22 +833,6 @@ main:
     identifier: events_guides
     parent: events_top_level
     weight: 1
-  - name: Custom Agent Check
-    url: events/guides/agent/
-    parent: events_guides
-    weight: 100
-  - name: DogStatsD
-    url: events/guides/dogstatsd/
-    parent: events_guides
-    weight: 101
-  - name: Email
-    url: events/guides/email/
-    parent: events_guides
-    weight: 102
-  - name: Email
-    url: events/guides/email/
-    parent: events_guides
-    weight: 103
   - name: API
     url: api/latest/events/#post-an-event
     parent: events_guides
@@ -1267,22 +1215,6 @@ main:
     identifier: serverless_guides
     parent: serverless
     weight: 9
-  - name: Datadog Forwarder - Node
-    url: serverless/guide/datadog_forwarder_node/
-    parent: serverless_guides
-    weight: 10
-  - name: Datadog Forwarder - Python
-    url: serverless/guide/datadog_forwarder_python/
-    parent: serverless_guides
-    weight: 11
-  - name: Migrating to the Datadog Lambda Extension
-    url: serverless/guide/extension_motivation/
-    parent: serverless_guides
-    weight: 12
-  - name: Migrating from the Datadog Forwarder to the Datadog Lambda Extension
-    url: serverless/guide/forwarder_extension_migration/
-    parent: serverless_guides
-    weight: 13
   - name: Metrics
     url: metrics/
     identifier: metrics_top_level
@@ -2037,10 +1969,6 @@ main:
     parent: ci
     identifier: ci_guides
     weight: 5
-  - name: Flaky Test Management
-    url: continuous_integration/guides/flaky_test_management/
-    parent: ci_guides
-    weight: 10
   - name: Troubleshooting
     url: continuous_integration/troubleshooting/
     parent: ci
@@ -2392,14 +2320,6 @@ main:
     parent: security_platform
     identifier: security_platform_guides
     weight: 7
-  - name: Monitor Authentication Logs for Security Threats
-    url: security_platform/guide/monitor-authentication-logs-for-security-threats/
-    parent: security_platform_guides
-    weight: 10
-  - name: Security Filters with the Security Monitoring API
-    url: security_platform/guide/how-to-setup-security-filters-using-security-monitoring-api/
-    parent: security_platform_guides
-    weight: 11
   - name: Synthetic Monitoring
     url: synthetics/
     pre: synthetics
@@ -2672,22 +2592,6 @@ main:
     parent: rum
     identifier: rum_guides
     weight: 9
-  - name: Send Custom Actions
-    url: real_user_monitoring/guide/send-rum-custom-actions/
-    parent: rum_guides
-    weight: 10
-  - name: Upload Javascript Source Maps
-    url: real_user_monitoring/guide/upload-javascript-source-maps/
-    parent: rum_guides
-    weight: 11
-  - name: Enrich and Control Browser Data with beforeSend
-    url: real_user_monitoring/guide/enrich-and-control-rum-data/
-    parent: rum_guides
-    weight: 12
-  - name: Upgrade the Browser SDK to V3
-    url: real_user_monitoring/guide/browser-sdk-upgrade/
-    parent: rum_guides
-    weight: 13
   - name: Network Monitoring
     url: network_monitoring/
     pre: network
@@ -2718,22 +2622,6 @@ main:
     identifier: npm_guides
     parent: npm
     weight: 104
-  - name: Manage Cloud Traffic Costs with NPM
-    url: network_monitoring/performance/guide/manage_traffic_costs_with_npm/
-    parent: npm_guides
-    weight: 105
-  - name: Detecting a Network Outage
-    url: network_monitoring/performance/guide/detecting_a_network_outage/
-    parent: npm_guides
-    weight: 106
-  - name: NPM AWS Supported Services
-    url: network_monitoring/performance/guide/aws_supported_services/
-    parent: npm_guides
-    weight: 107
-  - name: NPM GCP Supported Services
-    url: network_monitoring/performance/guide/gcp_supported_services
-    parent: npm_guides
-    weight: 108
   - name: DNS Monitoring
     url: network_monitoring/dns/
     parent: nm_parent
@@ -2769,22 +2657,6 @@ main:
     parent: ndm
     identifier: ndm_guide
     weight: 305
-  - name: Tags with Regex
-    url: network_monitoring/devices/guide/tags-with-regex/
-    parent: ndm_guide
-    weight: 400
-  - name: Cluster Agent
-    url: network_monitoring/devices/guide/cluster-agent/
-    parent: ndm_guide
-    weight: 401
-  - name: Build a Profile
-    url: network_monitoring/devices/guide/build-ndm-profile/
-    parent: ndm_guide
-    weight: 402
-  - name: Migrating to the SNMP Core Check
-    url: network_monitoring/devices/guide/migrating-to-snmp-core-check/
-    parent: ndm_guide
-    weight: 403
   - name: Developers
     url: developers/
     pre: dev-code

--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -142,15 +142,12 @@ function getPathElement() {
     path = path.replace(/^\//, '');
     path = path.replace(/\/$/, '');
 
-    console.log(`path = ${path}`)
-
     let sideNavPathElement = document.querySelector(`.side [data-path="${path}"]`);
     let mobileNavPathElement = document.querySelector(`header [data-path="${path}"]`);
 
     if (path.includes('/guide')) {
-        const dataPathString = path.substr(0, path.indexOf('guide'));
-
-        console.log(`path includes /guide.  data path string = ${dataPathString}`);
+        const docsActiveSection = path.substr(0, path.indexOf('/guide'));
+        const dataPathString = `${docsActiveSection}/guide`;
 
         sideNavPathElement = document.querySelector(`.side [data-path*="${dataPathString}"]`);
         mobileNavPathElement = document.querySelector(`header [data-path*="${dataPathString}"]`); 
@@ -200,12 +197,6 @@ function getPathElement() {
     //     );
     // }
 
-    // if (path.includes('serverless/guide/')) {
-    //     console.log('path includes serverless/guide.');
-    //     aPath = document.querySelector('.side [data-path*="serverless/guide"]');
-    //     maPath = document.querySelector('header [data-path*="serverless/guide"]');
-    // }
-
     // if url is domain + /integrations/**
     if (
         `${replaceURL(domain)}/${replacePath(path)}`.includes(
@@ -223,13 +214,11 @@ function getPathElement() {
     }
     
     if (sideNavPathElement) {
-        console.log(sideNavPathElement)
         sideNavPathElement.classList.add('active');
         hasParentLi(sideNavPathElement);
     }
 
     if (mobileNavPathElement) {
-        console.log(mobileNavPathElement);
         mobileNavPathElement.classList.add('active');
         hasParentLi(mobileNavPathElement);
     }

--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -142,11 +142,15 @@ function getPathElement() {
     path = path.replace(/^\//, '');
     path = path.replace(/\/$/, '');
 
+    console.log(`path = ${path}`)
+
     let sideNavPathElement = document.querySelector(`.side [data-path="${path}"]`);
     let mobileNavPathElement = document.querySelector(`header [data-path="${path}"]`);
 
     if (path.includes('/guide')) {
         const dataPathString = path.substr(0, path.indexOf('guide'));
+
+        console.log(`path includes /guide.  data path string = ${dataPathString}`);
 
         sideNavPathElement = document.querySelector(`.side [data-path*="${dataPathString}"]`);
         mobileNavPathElement = document.querySelector(`header [data-path*="${dataPathString}"]`); 
@@ -219,11 +223,13 @@ function getPathElement() {
     }
     
     if (sideNavPathElement) {
+        console.log(sideNavPathElement)
         sideNavPathElement.classList.add('active');
         hasParentLi(sideNavPathElement);
     }
 
     if (mobileNavPathElement) {
+        console.log(mobileNavPathElement);
         mobileNavPathElement.classList.add('active');
         hasParentLi(mobileNavPathElement);
     }

--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -142,54 +142,65 @@ function getPathElement() {
     path = path.replace(/^\//, '');
     path = path.replace(/\/$/, '');
 
-    let aPath = document.querySelector(`.side [data-path="${path}"]`);
-    let maPath = document.querySelector(`header [data-path="${path}"]`);
+    let sideNavPathElement = document.querySelector(`.side [data-path="${path}"]`);
+    let mobileNavPathElement = document.querySelector(`header [data-path="${path}"]`);
+
+    if (path.includes('/guide')) {
+        const dataPathString = path.substr(0, path.indexOf('guide'));
+
+        sideNavPathElement = document.querySelector(`.side [data-path*="${dataPathString}"]`);
+        mobileNavPathElement = document.querySelector(`header [data-path*="${dataPathString}"]`); 
+    }
 
     // TODO: fix exceptions for specific nav links that have the same url but both open the same place
-     if (path.includes('agent/guide')) {
-        aPath = document.querySelector('.side [data-path*="agent/guide"]');
-        maPath = document.querySelector('header [data-path*="agent/guide"]');
-    } 
+    // if (path.includes('agent/guide')) {
+    //     aPath = document.querySelector('.side [data-path*="agent/guide"]');
+    //     maPath = document.querySelector('header [data-path*="agent/guide"]');
+    // } 
 
-    if (path.includes('tracing/guide')) {
-        aPath = document.querySelector('.side [data-path*="tracing/guide"]');
-        maPath = document.querySelector('header [data-path*="tracing/guide"]');
-    }
+    // if (path.includes('tracing/guide')) {
+    //     aPath = document.querySelector('.side [data-path*="tracing/guide"]');
+    //     maPath = document.querySelector('header [data-path*="tracing/guide"]');
+    // }
 
-    if (path.includes('monitors/guide')) {
-        aPath = document.querySelector('.side [data-path*="monitors/guide"]');
-        maPath = document.querySelector('header [data-path*="monitors/guide"]');
-    }
+    // if (path.includes('monitors/guide')) {
+    //     aPath = document.querySelector('.side [data-path*="monitors/guide"]');
+    //     maPath = document.querySelector('header [data-path*="monitors/guide"]');
+    // }
 
-    if (path.includes('logs/guide')) {
-        aPath = document.querySelector('.side [data-path*="logs/guide"]');
-        maPath = document.querySelector('header [data-path*="logs/guide"]');
-    }
+    // if (path.includes('logs/guide')) {
+    //     aPath = document.querySelector('.side [data-path*="logs/guide"]');
+    //     maPath = document.querySelector('header [data-path*="logs/guide"]');
+    // }
 
     if (path.includes('account_management/billing')) {
-        aPath = document.querySelector(
+        sideNavPathElement = document.querySelector(
             '.side [data-path*="account_management/billing"]'
         );
-        maPath = document.querySelector(
+        mobileNavPathElement = document.querySelector(
             'header [data-path*="account_management/billing"]'
         );
     }
 
+    // if (path.includes('developers/guide')) {
+    //     aPath = document.querySelector('.side [data-path*="developers/guide"]');
+    //     maPath = document.querySelector(
+    //         'header [data-path*="developers/guide"]'
+    //     );
+    // }
 
-    if (path.includes('developers/guide')) {
-        aPath = document.querySelector('.side [data-path*="developers/guide"]');
-        maPath = document.querySelector(
-            'header [data-path*="developers/guide"]'
-        );
-    }
+    // if (path.includes('synthetics/guide')) {
+    //     aPath = document.querySelector('.side [data-path*="synthetics/guide"]');
+    //     maPath = document.querySelector(
+    //         'header [data-path*="synthetics/guide"]'
+    //     );
+    // }
 
-    if (path.includes('synthetics/guide')) {
-        aPath = document.querySelector('.side [data-path*="synthetics/guide"]');
-        maPath = document.querySelector(
-            'header [data-path*="synthetics/guide"]'
-        );
-    }
-
+    // if (path.includes('serverless/guide/')) {
+    //     console.log('path includes serverless/guide.');
+    //     aPath = document.querySelector('.side [data-path*="serverless/guide"]');
+    //     maPath = document.querySelector('header [data-path*="serverless/guide"]');
+    // }
 
     // if url is domain + /integrations/**
     if (
@@ -199,22 +210,22 @@ function getPathElement() {
             `${replaceURL(domain)}/integrations/guide`
         )
     ) {
-        aPath = document.querySelector(
+        sideNavPathElement = document.querySelector(
             '.side .nav-top-level > [data-path*="integrations"]'
         );
-        maPath = document.querySelector(
+        mobileNavPathElement = document.querySelector(
             'header .nav-top-level > [data-path*="integrations"]'
         );
     }
     
-    if (aPath) {
-        aPath.classList.add('active');
-        hasParentLi(aPath);
+    if (sideNavPathElement) {
+        sideNavPathElement.classList.add('active');
+        hasParentLi(sideNavPathElement);
     }
 
-    if (maPath) {
-        maPath.classList.add('active');
-        hasParentLi(maPath);
+    if (mobileNavPathElement) {
+        mobileNavPathElement.classList.add('active');
+        hasParentLi(mobileNavPathElement);
     }
 }
 

--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -145,6 +145,7 @@ function getPathElement() {
     let sideNavPathElement = document.querySelector(`.side [data-path="${path}"]`);
     let mobileNavPathElement = document.querySelector(`header [data-path="${path}"]`);
 
+    // Select sidenav/mobile links by data-path attribute to ensure active class is set correctly on specific sub-pages
     if (path.includes('/guide')) {
         const docsActiveSection = path.substr(0, path.indexOf('/guide'));
         const dataPathString = `${docsActiveSection}/guide`;
@@ -152,27 +153,6 @@ function getPathElement() {
         sideNavPathElement = document.querySelector(`.side [data-path*="${dataPathString}"]`);
         mobileNavPathElement = document.querySelector(`header [data-path*="${dataPathString}"]`); 
     }
-
-    // TODO: fix exceptions for specific nav links that have the same url but both open the same place
-    // if (path.includes('agent/guide')) {
-    //     aPath = document.querySelector('.side [data-path*="agent/guide"]');
-    //     maPath = document.querySelector('header [data-path*="agent/guide"]');
-    // } 
-
-    // if (path.includes('tracing/guide')) {
-    //     aPath = document.querySelector('.side [data-path*="tracing/guide"]');
-    //     maPath = document.querySelector('header [data-path*="tracing/guide"]');
-    // }
-
-    // if (path.includes('monitors/guide')) {
-    //     aPath = document.querySelector('.side [data-path*="monitors/guide"]');
-    //     maPath = document.querySelector('header [data-path*="monitors/guide"]');
-    // }
-
-    // if (path.includes('logs/guide')) {
-    //     aPath = document.querySelector('.side [data-path*="logs/guide"]');
-    //     maPath = document.querySelector('header [data-path*="logs/guide"]');
-    // }
 
     if (path.includes('account_management/billing')) {
         sideNavPathElement = document.querySelector(
@@ -182,20 +162,6 @@ function getPathElement() {
             'header [data-path*="account_management/billing"]'
         );
     }
-
-    // if (path.includes('developers/guide')) {
-    //     aPath = document.querySelector('.side [data-path*="developers/guide"]');
-    //     maPath = document.querySelector(
-    //         'header [data-path*="developers/guide"]'
-    //     );
-    // }
-
-    // if (path.includes('synthetics/guide')) {
-    //     aPath = document.querySelector('.side [data-path*="synthetics/guide"]');
-    //     maPath = document.querySelector(
-    //         'header [data-path*="synthetics/guide"]'
-    //     );
-    // }
 
     // if url is domain + /integrations/**
     if (

--- a/src/scripts/helpers/browser.js
+++ b/src/scripts/helpers/browser.js
@@ -36,16 +36,3 @@ export const getQueryParameterByName = (name, currentURL) => {
 
   return decodeURIComponent(results[2].replace(/\+/g, ' '));
 }
-
-export const removePreviewBranchFromPath = () => {
-  const { origin, pathname } = window.location;
-  let path = pathname;
-
-  if (origin.includes('//docs-staging')) {
-    const test = path.slice(1, -1)  // removing leading+trailing '/'.
-    const arrayTest = test.split('/').splice(0, 2);
-    path = arrayTest.join('/');
-  }
-
-  return path;
-}

--- a/src/scripts/helpers/browser.js
+++ b/src/scripts/helpers/browser.js
@@ -36,3 +36,16 @@ export const getQueryParameterByName = (name, currentURL) => {
 
   return decodeURIComponent(results[2].replace(/\+/g, ' '));
 }
+
+export const removePreviewBranchFromPath = () => {
+  const { origin, pathname } = window.location;
+  let path = pathname;
+
+  if (origin.includes('//docs-staging')) {
+    const test = path.slice(1, -1)  // removing leading+trailing '/'.
+    const arrayTest = test.split('/').splice(0, 2);
+    path = arrayTest.join('/');
+  }
+
+  return path;
+}


### PR DESCRIPTION
### What does this PR do?
- Allows all guide pages to open and highlight the correct nav menu item, so Docs team doesn't have to continue adding these to `menu.yaml`
- Removes previously added guide subpages to `menu.yaml`

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1721

### Preview
- [x] Correct nav menu item should be active on both side nav and mobile navs. https://docs-staging.datadoghq.com/brian.deutsch/menu-guide-update/agent/guide/autodiscovery-with-jmx/
- [x] The same functionality works when using async loading (navigate around to guide pages using left-side nav).
- [x] The same functionality works when the guide pages are nested: https://docs-staging.datadoghq.com/brian.deutsch/menu-guide-update/network_monitoring/devices/guide/migrating-to-snmp-core-check/?tab=snmpv2

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
