### PR TITLE
[agent] Update kubernetes_state_core documentation

### DIFF
--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -63,7 +63,7 @@ datadog:
 
 From the Datadog-Operator v0.7.0
 
-To enable the `kubernetes_state_core` check, the setting `spec.features.kubeStateMetricsCore.enabled` need to be set to `true` in the DatadogAgent resource.
+To enable the `kubernetes_state_core` check, the setting `spec.features.kubeStateMetricsCore.enabled` must be set to `true` in the DatadogAgent resource.
 
 DatadogAgent Kubernetes Resource:
 
@@ -89,13 +89,13 @@ spec:
 
 ### Tags removal
 
-With `kubernetes_state`, several tags were flagged as deprecated and replaced by new tags. To provide a migration path check both tags was send with the metrics.
+With `kubernetes_state`, several tags have been flagged as deprecated and replaced by new tags. To determine your migration path, check which tags are sent with your metrics.
 
-With `kubernetes_state_core` only the none deprecated tags are send.
+With `kubernetes_state_core`, only the non-deprecated tags are sent.
 
 Before migrating to `kubernetes_state_core`, verify that only official tags are used in monitors and dashboards.
 
-Here is the mapping between deprecated and official tags
+Here is the mapping between deprecated tags and the official tags that have replaced them:
 
 | deprecated tag        | official tag                |
 |-----------------------|-----------------------------|

--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -59,9 +59,60 @@ datadog:
 ```
 
 {{% /tab %}}
+{{% tab "Operator" %}}
+
+From the Datadog-Operator v0.7.0
+
+To enable the `kubernetes_state_core` check, the setting `spec.features.kubeStateMetricsCore.enabled` need to be set to `true` in the DatadogAgent resource.
+
+DatadogAgent Kubernetes Resource:
+
+```
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  credentials:
+    apiKey: <DATADOG_API_KEY>
+    appKey: <DATADOG_APP_KEY>
+  features:
+    kubeStateMetricsCore:
+      enabled: true
+  # ...
+```
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Migration from kubernetes_state to kubernetes_state_core
+
+### Tags removal
+
+With `kubernetes_state`, several tags were flagged as deprecated and replaced by new tags. To provide a migration path check both tags was send with the metrics.
+
+With `kubernetes_state_core` only the none deprecated tags are send.
+
+Before migrating to `kubernetes_state_core`, verify that only official tags are used in monitors and dashboards.
+
+Here is the mapping between deprecated and official tags
+
+| deprecated tag        | official tag                |
+|-----------------------|-----------------------------|
+| cluster_name          | kube_cluster_name           |
+| container             | kube_container_name         |
+| cronjob               | kube_cronjob                |
+| daemonset             | kube_daemon_set             |
+| deployment            | kube_deployment             |
+| image                 | image_name                  |
+| job                   | kube_job                    |
+| job_name              | kube_job                    |
+| namespace             | kube_namespace              |
+| phase                 | pod_phase                   |
+| pod                   | pod_name                    |
+| replicaset            | kube_replica_set            |
+| replicationcontroller | kube_replication_controller |
+| statefulset           | kube_stateful_set           |
 
 ### Backward incompatibility changes
 

--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -89,9 +89,7 @@ Note: Datadog Operator v0.7.0 or greater is required.
 
 In the original `kubernetes_state` check, several tags have been flagged as deprecated and replaced by new tags. To determine your migration path, check which tags are submitted with your metrics.
 
-With `kubernetes_state_core`, only the non-deprecated tags are sent.
-
-Before migrating to `kubernetes_state_core`, verify that only official tags are used in monitors and dashboards.
+In the `kubernetes_state_core` check, only the non-deprecated tags are submitted. Before migrating from `kubernetes_state` to `kubernetes_state_core`, verify that only official tags are used in monitors and dashboards.
 
 Here is the mapping between deprecated tags and the official tags that have replaced them:
 

--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -61,11 +61,7 @@ datadog:
 {{% /tab %}}
 {{% tab "Operator" %}}
 
-From the Datadog-Operator v0.7.0
-
-To enable the `kubernetes_state_core` check, the setting `spec.features.kubeStateMetricsCore.enabled` must be set to `true` in the DatadogAgent resource.
-
-DatadogAgent Kubernetes Resource:
+To enable the `kubernetes_state_core` check, the setting `spec.features.kubeStateMetricsCore.enabled` must be set to `true` in the DatadogAgent resource:
 
 ```
 apiVersion: datadoghq.com/v1alpha1
@@ -82,6 +78,8 @@ spec:
   # ...
 ```
 
+Note: Datadog Operator v0.7.0 or greater is required.
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -89,7 +87,7 @@ spec:
 
 ### Tags removal
 
-With `kubernetes_state`, several tags have been flagged as deprecated and replaced by new tags. To determine your migration path, check which tags are sent with your metrics.
+In the original `kubernetes_state` check, several tags have been flagged as deprecated and replaced by new tags. To determine your migration path, check which tags are submitted with your metrics.
 
 With `kubernetes_state_core`, only the non-deprecated tags are sent.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

* Document the tags deprecated in `kubernetes_state` check and removed in `kubernetes_state_core`.
* Explain how to configure the `kubernetes_state_core` with the operator.

### Motivation

ease the migration to `kubernetes_state_core`

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/clamoriniere/ksm-core-migration/integrations/kubernetes_state_core

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
