### PR TITLE
apm/php: explain where error log messages go

### DIFF
--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -252,7 +252,7 @@ Enable tracing of PHP scripts from the CLI
 
 `DD_TRACE_DEBUG`
 : **Default**: `false`<br>
-Enable [debug mode](#custom-url-to-resource-mapping) for the tracer
+Enable debug mode. When `true`, log messages are sent to the device or file set in the `error_log` INI setting. The actual value of `error_log` might be different than the output of `php -i` as it can be overwritten in the PHP-FPM/Apache configuration files.
 
 `DD_TRACE_ENABLED`
 : **Default**: `true`<br>


### PR DESCRIPTION
### What does this PR do?

Explain when APM PHP debug messages can be found.

### Motivation

We had report of some confusion while customers searched for the log files we needed to triage issues.

### Preview
[Preview](https://docs-staging.datadoghq.com/apm/php/logs/tracing/setup_overview/setup/php/?tab=containers#configuration


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
