### PR TITLE
add Session Replay worker to CSP docs

### DIFF
--- a/content/en/real_user_monitoring/faq/content_security_policy.md
+++ b/content/en/real_user_monitoring/faq/content_security_policy.md
@@ -48,6 +48,14 @@ connect-src https://*.browser-intake-ddog-gov.com
 
 {{< /site-region >}}
 
+## Session Replay worker
+
+If you are using Session Replay, make sure to allow `blob` workers by adding the following `worker-src` entry:
+
+```txt
+worker-src: blob:;
+```
+
 ## CDN bundle URL
 
 If you are using the CDN async or CDN sync setup for [Real User Monitoring][4] or [browser log collection][5], you should also add the following `script-src` entry:

--- a/content/en/real_user_monitoring/faq/content_security_policy.md
+++ b/content/en/real_user_monitoring/faq/content_security_policy.md
@@ -50,7 +50,7 @@ connect-src https://*.browser-intake-ddog-gov.com
 
 ## Session Replay worker
 
-If you are using Session Replay, make sure to allow `blob` workers by adding the following `worker-src` entry:
+If you are using Session Replay, make sure to allow Workers with `blob:` URI schemes by adding the following `worker-src` entry:
 
 ```txt
 worker-src: blob:;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add instructions to allow Session Replay worker via the Content-Security-Policy header.

### Motivation

Some customers have CSP preventing Session Replay to work at all.

### Preview

https://github.com/DataDog/documentation/blob/7b29b60baa64b4cd1e8d12f1cbbae5147350ddae/content/en/real_user_monitoring/faq/content_security_policy.md#session-replay-worker

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
