### PR TITLE
Adds increased logs disclaimer

### DIFF
--- a/content/en/agent/troubleshooting/debug_mode.md
+++ b/content/en/agent/troubleshooting/debug_mode.md
@@ -15,6 +15,8 @@ further_reading:
 
 ## Agent
 
+The Agent by default logs in INFO level. You can set the log level to DEBUG to get more information from your logs. We don’t recommend enabling debug mode for an extended period of time, because it increases the number of logs indexed by Datadog. Use it sparingly, for debugging purposes only. Set the log level back to INFO when done.
+
 To enable the Agent full debug mode:
 
 {{< tabs >}}

--- a/content/en/agent/troubleshooting/debug_mode.md
+++ b/content/en/agent/troubleshooting/debug_mode.md
@@ -15,7 +15,9 @@ further_reading:
 
 ## Agent
 
-The Agent by default logs in INFO level. You can set the log level to DEBUG to get more information from your logs. We don’t recommend enabling debug mode for an extended period of time, because it increases the number of logs indexed by Datadog. Use it sparingly, for debugging purposes only. Set the log level back to INFO when done.
+The Agent, by default, logs in `INFO` level. You can set the log level to `DEBUG` to get more information from your logs.
+
+**Note**: Debug mode is meant for debugging purposes only. Datadog recommends only enabling `DEBUG` for a certain window of time as it increases the number of indexed logs. Set the log level back to `INFO` when done.
 
 To enable the Agent full debug mode:
 


### PR DESCRIPTION
This update adds a note at the top of the page to set the log level back to info after enabling debug mode to avoid increased logs getting indexed by Datadog

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
https://datadog.zendesk.com/agent/tickets/533277
Customer had debug mode enabled for a month and received a higher bill than normal. 
The wording for the disclaimer was formatted off of tracer debug logs: https://docs.datadoghq.com/tracing/troubleshooting/tracer_debug_logs/#enable-debug-mode 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
