### PR TITLE
Carlos/hotfix-producticon-fixes

### DIFF
--- a/data/partials/home.fr.yaml
+++ b/data/partials/home.fr.yaml
@@ -93,7 +93,7 @@ nav_sections:
             desc: Découvrir comment Datadog protège vos données
           - title: Outils de développement
             link: developers/
-            icon: wrench
+            icon: dev-code
             desc: Développer des outils pour la plateforme Datadog
 popular_searches:
   - title: Documentation sur l'API

--- a/data/partials/home.ja.yaml
+++ b/data/partials/home.ja.yaml
@@ -97,7 +97,7 @@ nav_sections:
             desc: Datadog のデータ保護方法について
           - title: 開発者
             link: developers/
-            icon: wrench
+            icon: dev-code
             desc: Datadog プラットフォームの開発
 popular_searches:
   - title: API ドキュメント

--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -109,7 +109,7 @@ nav_sections:
         desc: Learn how Datadog protects your data
       - title: Developers
         link: developers/
-        icon: wrench
+        icon: dev-code
         desc: Develop for the Datadog platform
 
 popular_searches:

--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -38,7 +38,7 @@ nav_sections:
         desc: Track your hosts, containers, processes, and serverless functions
       - title: Events
         link: events/
-        icon: events.svg
+        icon: events
         desc: Track notable changes and alerts across applications and infrastructure
       - title: Metrics
         link: metrics/

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,3 @@
 github.com/DataDog/websites-modules v1.2.13-0.20210908220025-b1ee2a076265 h1:NEONLs6tP2SO6Oxeyd0yZb8cupbqthjoQ8DtI58no98=
 github.com/DataDog/websites-modules v1.2.13-0.20210908220025-b1ee2a076265/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.2.14/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- update the developers homepage nav tile icon to the code icon
- fix the events homepage nav tile icon

### Motivation
reported by Derek Howles and Kaylyn Sigler

### Preview
https://docs-staging.datadoghq.com/carlos/hotfix-producticon-fixes/

in the case of the developers homepage nav tiles, check the FR and JA homepages as well:
https://docs-staging.datadoghq.com/carlos/hotfix-producticon-fixes/fr/
https://docs-staging.datadoghq.com/carlos/hotfix-producticon-fixes/ja/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
