### PR TITLE
(DOCS-2507) re-remove this sidebar nav item

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1077,10 +1077,6 @@ main:
     url: infrastructure/process/increase_process_retention/
     parent: infrastructure_process
     weight: 101
-  - name: Generate Process Metrics
-    url: infrastructure/process/generate_process_metrics/
-    parent: infrastructure
-    weight: 6
   - name: Live Containers
     url: infrastructure/livecontainers/
     parent: infrastructure


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Six months ago, "Generate Process Metrics" was renamed to "Increase Process Retention". I updated the menus.en.yaml file in this commit: https://github.com/DataDog/documentation/commit/f974d6ba80092d56cf61b49aa88f181f1e4d40be

But for some reason, it got added back in recently in this commit: https://github.com/DataDog/documentation/commit/631d92eabd5f4abfb526ff7238359d165a9e782c

### Motivation
Noticed this link had resurrected itself and that it led to nowhere

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jorie/DOCS-2507/infrastructure/process/increase_process_retention/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
