### PR TITLE
[ci-app] CI Visibility – Add `cypress` Instructions

### DIFF
--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -124,6 +124,43 @@ DD_ENV=ci npm test
 {{< /code-block >}}
 
 {{% /tab %}}
+
+{{% tab "Cypress" %}}
+
+1. Set [`pluginsFile`][1] to `"dd-trace/cypress/plugin"`, for example through [`cypress.json`][2]:
+{{< code-block lang="json" filename="cypress.json" >}}
+{
+  "pluginsFile": "dd-trace/cypress/plugin"
+}
+{{< /code-block >}}
+
+If you've already defined a `pluginsFile`, you can still initialise the instrumentation with:
+{{< code-block lang="javascript" filename="cypress/plugins/index.js" >}}
+module.exports = (on, config) => {
+  // your previous code goes here
+  require('dd-trace/cypress/plugin')(on, config)
+}
+{{< /code-block >}}
+
+2. Add the following line to the [`supportFile`][3]:
+{{< code-block lang="javascript" filename="cypress/support/index.js" >}}
+// your previous code goes here
+require('dd-trace/cypress/support')
+{{< /code-block >}}
+
+
+Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:
+
+{{< code-block lang="bash" >}}
+DD_ENV=ci npm test
+{{< /code-block >}}
+
+
+
+[1]: https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Plugins-file
+[2]: https://docs.cypress.io/guides/references/configuration#cypress-json
+[3]: https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Support-file
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Configuration settings

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -19,6 +19,8 @@ Supported test frameworks:
 * Mocha >= 5.2.0
   * Mocha >= 9.0.0 has [partial support](#known-limitations).
 * Cucumber-js >= 7.0.0
+* Cypress >= 6.7.0
+  * From `dd-trace>=1.4.0`
 
 ## Prerequisites
 
@@ -137,14 +139,14 @@ DD_ENV=ci npm test
 If you've already defined a `pluginsFile`, you can still initialise the instrumentation with:
 {{< code-block lang="javascript" filename="cypress/plugins/index.js" >}}
 module.exports = (on, config) => {
-  // your previous code goes here
+  // your previous code is before this line
   require('dd-trace/cypress/plugin')(on, config)
 }
 {{< /code-block >}}
 
 2. Add the following line to the [`supportFile`][3]:
 {{< code-block lang="javascript" filename="cypress/support/index.js" >}}
-// your previous code goes here
+// your previous code is before this line
 require('dd-trace/cypress/support')
 {{< /code-block >}}
 

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -136,7 +136,7 @@ DD_ENV=ci npm test
 }
 {{< /code-block >}}
 
-If you've already defined a `pluginsFile`, you can still initialise the instrumentation with:
+If you've already defined a `pluginsFile`, you can still initialize the instrumentation with:
 {{< code-block lang="javascript" filename="cypress/plugins/index.js" >}}
 module.exports = (on, config) => {
   // your previous code is before this line


### PR DESCRIPTION
### What does this PR do?
Add `cypress` instructions.

### Motivation
Allow users to start using the new instrumentation. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/juan-fernandez/ci-app-add-cypress-instrumentation/continuous_integration/setup_tests/javascript/?tab=cypress

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
