### PR TITLE
Note on metrics monitor threshold value

### DIFF
--- a/content/en/monitors/create/types/metric.md
+++ b/content/en/monitors/create/types/metric.md
@@ -106,7 +106,7 @@ The alert conditions vary slightly based on the chosen detection method.
 {{< tabs >}}
 {{% tab "Threshold" %}}
 
-* Trigger when the metric is `above`, `above or equal to`, `below`, or `below or equal to` (if value is between 0 and 1 a leading 0 is required, eg. 0.3)
+* Trigger when the metric is `above`, `above or equal to`, `below`, or `below or equal to`. If the value is between zero and one, a leading zero is required. For example, `0.3`.
 * the threshold `on average`, `at least once`, `at all times`, or `in total`
 * during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between 1 minute and 730 hours (1 month).
 

--- a/content/en/monitors/create/types/metric.md
+++ b/content/en/monitors/create/types/metric.md
@@ -106,7 +106,7 @@ The alert conditions vary slightly based on the chosen detection method.
 {{< tabs >}}
 {{% tab "Threshold" %}}
 
-* Trigger when the metric is `above`, `above or equal to`, `below`, or `below or equal to`
+* Trigger when the metric is `above`, `above or equal to`, `below`, or `below or equal to` (if value is between 0 and 1 a leading 0 is required, eg. 0.3)
 * the threshold `on average`, `at least once`, `at all times`, or `in total`
 * during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between 1 minute and 730 hours (1 month).
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a note on the metric monitor's threshold value form validation. If there is no leading zero for values between 0 and 1, the monitor cannot be saved.

### Motivation
https://datadog.zendesk.com/agent/tickets/559532
This customer pointed out that they could not save their metric monitor when they inputted a threshold value of .9 instead of 0.9. I have also reproduced and tested and got the same results.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
