### PR TITLE
fix metrics developers redirects

### DIFF
--- a/content/en/developers/dogstatsd/unix_socket.md
+++ b/content/en/developers/dogstatsd/unix_socket.md
@@ -3,7 +3,7 @@ title: DogStatsD over Unix Domain Socket
 kind: documentation
 description: 'Usage documentation for DogStatsD over Unix Domain Sockets'
 aliases:
-    - /metrics/unix_socket/
+    - /developers/metrics/unix_socket/
 further_reading:
     - link: 'developers/dogstatsd'
       tag: 'Documentation'

--- a/content/en/metrics/agent_metrics_submission.md
+++ b/content/en/metrics/agent_metrics_submission.md
@@ -2,7 +2,7 @@
 title: "Metric Submission: Custom Agent Check"
 kind: documentation
 aliases:
-  - /metrics/agent_metrics_submission/
+  - /developers/metrics/agent_metrics_submission/
 further_reading:
 - link: "/developers/custom_checks/write_agent_check/"
   tag: "Documentation"

--- a/content/en/metrics/custom_metrics.md
+++ b/content/en/metrics/custom_metrics.md
@@ -5,8 +5,8 @@ aliases:
   - /guides/metrics/
   - /metrictypes/
   - /units/
-  - /metrics/datagram_shell
-  - /metrics/custom_metrics/
+  - /developers/metrics/datagram_shell
+  - /developers/metrics/custom_metrics/
   - /getting_started/custom_metrics
   - /developers/metrics/
 further_reading:

--- a/content/en/metrics/custom_metrics.md
+++ b/content/en/metrics/custom_metrics.md
@@ -8,7 +8,7 @@ aliases:
   - /metrics/datagram_shell
   - /metrics/custom_metrics/
   - /getting_started/custom_metrics
-  - /metrics/
+  - /developers/metrics/
 further_reading:
 - link: "/developers/dogstatsd/"
   tag: "Documentation"

--- a/content/en/metrics/powershell_metrics_submission.md
+++ b/content/en/metrics/powershell_metrics_submission.md
@@ -4,7 +4,7 @@ kind: documentation
 aliases:
   - /developers/faq/powershell-api-examples
   - /developers/faq/submitting-metrics-via-powershell
-  - /metrics/powershell_metrics_submission/
+  - /developers/metrics/powershell_metrics_submission/
 ---
 
 Datadog can collect metrics via the Agent as well as via the API independently of which language you decide to use. This page gives examples of both using PowerShell.

--- a/content/en/metrics/type_modifiers.md
+++ b/content/en/metrics/type_modifiers.md
@@ -2,7 +2,7 @@
 title: Metric Type Modifiers
 kind: documentation
 aliases:
- - /metrics/metric_type_modifiers
+ - /developers/metrics/metric_type_modifiers
  - /graphing/faq/as_count_validation
  - /developers/metrics/type_modifiers/
 further_reading:

--- a/content/en/metrics/type_modifiers.md
+++ b/content/en/metrics/type_modifiers.md
@@ -4,7 +4,7 @@ kind: documentation
 aliases:
  - /metrics/metric_type_modifiers
  - /graphing/faq/as_count_validation
- - /metrics/type_modifiers/
+ - /developers/metrics/type_modifiers/
 further_reading:
 - link: "/developers/dogstatsd/"
   tag: "Documentation"

--- a/content/en/metrics/types.md
+++ b/content/en/metrics/types.md
@@ -2,14 +2,14 @@
 title: Metrics Types
 kind: documentation
 aliases:
-    - /metrics/counts/
-    - /metrics/distributions/
-    - /metrics/gauges/
-    - /metrics/histograms/
-    - /metrics/rates/
-    - /metrics/sets/
-    - /metrics_type/
-    - /metrics/metrics_type/
+    - /developers/metrics/counts/
+    - /developers/metrics/distributions/
+    - /developers/metrics/gauges/
+    - /developers/metrics/histograms/
+    - /developers/metrics/rates/
+    - /developers/metrics/sets/
+    - /developers/metrics_type/
+    - /developers/metrics/metrics_type/
     - /developers/metrics/types/
 further_reading:
     - link: 'developers/dogstatsd'

--- a/content/en/metrics/units.md
+++ b/content/en/metrics/units.md
@@ -3,7 +3,7 @@ title: Metrics Units
 kind: documentation
 aliases:
 - /metrics/metrics_units
-- /metrics/units/
+- /developers/metrics/units/
 further_reading:
 - link: "/dashboards/"
   tag: "Documentation"

--- a/content/en/metrics/units.md
+++ b/content/en/metrics/units.md
@@ -2,7 +2,7 @@
 title: Metrics Units
 kind: documentation
 aliases:
-- /metrics/metrics_units
+- /developers/metrics/metrics_units
 - /developers/metrics/units/
 further_reading:
 - link: "/dashboards/"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes the rest of the metrics redirects that got overwritten by find and replace

### Motivation
I broke them :(

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
