### PR TITLE
frontmatter width

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -766,13 +766,13 @@ class Integrations:
                 item["draft"] = not item.get("is_public", False)
                 item["integration_id"] = item.get("integration_id", integration_id)
                 fm = yaml.safe_dump(
-                    item, width=150, default_style='"', default_flow_style=False, allow_unicode=True
+                    item, width=float("inf"), default_style='"', default_flow_style=False, allow_unicode=True
                 ).rstrip()
                 # simple bool cleanups with replace
                 fm = fm.replace('!!bool "false"', 'false')
                 fm = fm.replace('!!bool "true"', 'true')
             else:
-                fm = yaml.safe_dump({"kind": "integration"}, width=150, default_style='"', default_flow_style=False,
+                fm = yaml.safe_dump({"kind": "integration"}, width=float("inf"), default_style='"', default_flow_style=False,
                                     allow_unicode=True).rstrip()
         return template.format(
             front_matter=fm, content=content


### PR DESCRIPTION
### What does this PR do?

Remove width restriction on generated integration front matter.
This is to avoid escaped new lines which were cause parsing issues in translations.

Before
```
"description": "This integration allows you to create tickets from triggered alerts in Datadog, and update existing tickets with new information as it arises.\
  \ Additionally, you can see JIRA ticket creations as events within Datadog to overlay with all of your metrics."
```

After
```
"description": "This integration allows you to create tickets from triggered alerts in Datadog, and update existing tickets with new information as it arises. Additionally, you can see JIRA ticket creations as events within Datadog to overlay with all of your metrics."
```

### Motivation

To fix errors in receiving translations

### Preview

Just test that integrations pages are working as expected.
https://docs-staging.datadoghq.com/david.jones/fix-fm-translation/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
