### PR TITLE
Add examples for how to use DD_TRACE_AGENT_URL

### DIFF
--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -163,7 +163,7 @@ Override the port that the default tracer submit traces to.
 
 `DD_TRACE_AGENT_URL`
 : The URL of the Trace Agent that the tracer submits to. Takes priority over hostname and port, if set. Supports Unix Domain Sockets in combination with the `apm_config.receiver_socket` in your `datadog.yaml` file, or the `DD_APM_RECEIVER_SOCKET` environment variable.
-  Example for http url: `localhost:8126`
+  Example for http url: `DD_TRACE_AGENT_URL=localhost:8126`
   Example for UDS: `DD_TRACE_AGENT_URL=unix:///var/run/datadog/dsd.socket`
 
 `DD_LOGS_INJECTION`

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -163,6 +163,8 @@ Override the port that the default tracer submit traces to.
 
 `DD_TRACE_AGENT_URL`
 : The URL of the Trace Agent that the tracer submits to. Takes priority over hostname and port, if set. Supports Unix Domain Sockets in combination with the `apm_config.receiver_socket` in your `datadog.yaml` file, or the `DD_APM_RECEIVER_SOCKET` environment variable.
+  Example for http url: `localhost:8126`
+  Example for UDS: `DD_TRACE_AGENT_URL=unix:///var/run/datadog/dsd.socket`
 
 `DD_LOGS_INJECTION`
 : **Default**: `false`<br>

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -162,9 +162,7 @@ Override the address of the trace Agent host that the default tracer attempts to
 Override the port that the default tracer submit traces to.
 
 `DD_TRACE_AGENT_URL`
-: The URL of the Trace Agent that the tracer submits to. Takes priority over hostname and port, if set. Supports Unix Domain Sockets in combination with the `apm_config.receiver_socket` in your `datadog.yaml` file, or the `DD_APM_RECEIVER_SOCKET` environment variable.
-  Example for http url: `DD_TRACE_AGENT_URL=localhost:8126`
-  Example for UDS: `DD_TRACE_AGENT_URL=unix:///var/run/datadog/dsd.socket`
+: The URL of the Trace Agent that the tracer submits to. If set, this takes priority over hostname and port. Supports Unix Domain Sockets (UDS) in combination with the `apm_config.receiver_socket` in your `datadog.yaml` file or the `DD_APM_RECEIVER_SOCKET` environment variable. For example, `DD_TRACE_AGENT_URL=localhost:8126` for HTTP URL and `DD_TRACE_AGENT_URL=unix:///var/run/datadog/dsd.socket` for UDS.
 
 `DD_LOGS_INJECTION`
 : **Default**: `false`<br>

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -162,7 +162,7 @@ Override the address of the trace Agent host that the default tracer attempts to
 Override the port that the default tracer submit traces to.
 
 `DD_TRACE_AGENT_URL`
-: The URL of the Trace Agent that the tracer submits to. If set, this takes priority over hostname and port. Supports Unix Domain Sockets (UDS) in combination with the `apm_config.receiver_socket` in your `datadog.yaml` file or the `DD_APM_RECEIVER_SOCKET` environment variable. For example, `DD_TRACE_AGENT_URL=localhost:8126` for HTTP URL and `DD_TRACE_AGENT_URL=unix:///var/run/datadog/dsd.socket` for UDS.
+: The URL of the Trace Agent that the tracer submits to. If set, this takes priority over hostname and port. Supports Unix Domain Sockets (UDS) in combination with the `apm_config.receiver_socket` in your `datadog.yaml` file or the `DD_APM_RECEIVER_SOCKET` environment variable. For example, `DD_TRACE_AGENT_URL=http://localhost:8126` for HTTP URL and `DD_TRACE_AGENT_URL=unix:///var/run/datadog/dsd.socket` for UDS.
 
 `DD_LOGS_INJECTION`
 : **Default**: `false`<br>


### PR DESCRIPTION
The UDS setup is not intuitive and will probably lead to confusion if tried without an example.

### Motivation
Working on UDS and realizing passing url is not intuitive, as we move towards using UDS more often with customers, it would be helpful if they knew how to configure it correctly from the Python tracer side. 


### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
