### PR TITLE
Carlos/iconfont infra alerting update

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -113,7 +113,7 @@ main_left:
     parent: product
   - identifier: alerts
     name: Alerts
-    pre: <i class="icon-alert align-middle"></i>
+    pre: <i class="icon-monitor align-middle"></i>
     url: 'https://www.datadoghq.com/product/alerts/'
     weight: 19
     parent: product

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1308,7 +1308,7 @@ main:
     weight: 120000
   - name: Alerting
     url: monitors/
-    pre: alert
+    pre: monitor
     identifier: alerting
     weight: 130000
   - name: Create Monitors

--- a/config/_default/menus/menus.fr.yaml
+++ b/config/_default/menus/menus.fr.yaml
@@ -110,7 +110,7 @@ main_left:
     parent: 'product'
   - identifier: alerts
     name: 'Alerts'
-    pre: '<i class="icon-alert align-middle"></i>'
+    pre: '<i class="icon-monitor align-middle"></i>'
     url: 'product/alerts/'
     weight: 19
     parent: 'product'

--- a/config/_default/menus/menus.fr.yaml
+++ b/config/_default/menus/menus.fr.yaml
@@ -1073,7 +1073,7 @@ main:
     weight: 120000
   - name: Alertes
     url: monitors/
-    pre: alert
+    pre: monitor
     identifier: alerting
     weight: 130000
   - name: Monitors

--- a/config/_default/menus/menus.ja.yaml
+++ b/config/_default/menus/menus.ja.yaml
@@ -113,7 +113,7 @@ main_left:
     parent: 'product'
   - identifier: alerts
     name: アラート
-    pre: '<i class="icon-alert align-middle"></i>'
+    pre: '<i class="icon-monitor align-middle"></i>'
     url: 'product/alerts/'
     weight: 19
     parent: 'product'

--- a/config/_default/menus/menus.ja.yaml
+++ b/config/_default/menus/menus.ja.yaml
@@ -1111,7 +1111,7 @@ main:
     weight: 120000
   - name: アラート設定
     url: monitors/
-    pre: alert
+    pre: monitor
     identifier: アラート設定
     weight: 130000
   - name: モニター

--- a/data/partials/home.fr.yaml
+++ b/data/partials/home.fr.yaml
@@ -38,7 +38,7 @@ nav_sections:
             desc: Explorez vos métriques et créez des distributions
           - title: Alertes
             link: monitors/
-            icon: alert
+            icon: monitor
             desc: Créer et gérer des monitors et des notifications
           - title: APM et tracing distribué
             link: tracing/

--- a/data/partials/home.ja.yaml
+++ b/data/partials/home.ja.yaml
@@ -38,7 +38,7 @@ nav_sections:
             desc: メトリクスを調べてディストリビューションを作成する
           - title: アラート設定
             link: monitors/
-            icon: alert
+            icon: monitor
             desc: モニターおよび通知の作成と管理
           - title: APM & Continuous Profiler
             link: tracing/

--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -46,7 +46,7 @@ nav_sections:
         desc: Explore your metrics and create distributions
       - title: Alerting
         link: monitors/
-        icon: alert
+        icon: monitor
         desc: Create & manage monitors & notifications
       - title: APM & Continuous Profiler
         link: tracing/

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.2.14 // indirect
+require github.com/DataDog/websites-modules v1.2.15-0.20210922161744-4d783d008349 // indirect
 
 // replace github.com/DataDog/websites-modules => /Users/carlos.santos/GitHub/websites-modules

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.2.15-0.20210922161744-4d783d008349 // indirect
+require github.com/DataDog/websites-modules v1.2.15 // indirect
 
 // replace github.com/DataDog/websites-modules => /Users/carlos.santos/GitHub/websites-modules

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/DataDog/websites-modules v1.2.13-0.20210908220025-b1ee2a076265 h1:NEONLs6tP2SO6Oxeyd0yZb8cupbqthjoQ8DtI58no98=
-github.com/DataDog/websites-modules v1.2.13-0.20210908220025-b1ee2a076265/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
-github.com/DataDog/websites-modules v1.2.14 h1:l+wDZQiKJLWZgowIoQkvbQ38rcjca7Nnhda2ZMzu9s8=
-github.com/DataDog/websites-modules v1.2.14/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.2.15-0.20210922161744-4d783d008349 h1:EhmVLofpTkMdVy9xjVUrMBzGWxWd4bOtS/hvk9n/yp4=
+github.com/DataDog/websites-modules v1.2.15-0.20210922161744-4d783d008349/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/DataDog/websites-modules v1.2.15-0.20210922161744-4d783d008349 h1:EhmVLofpTkMdVy9xjVUrMBzGWxWd4bOtS/hvk9n/yp4=
-github.com/DataDog/websites-modules v1.2.15-0.20210922161744-4d783d008349/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.2.15 h1:+H/qdSeiWrFIWw0reTc7gtgy+g0uz+LixnGE8ccBrbg=
+github.com/DataDog/websites-modules v1.2.15/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=


### PR DESCRIPTION
### What does this PR do?
- updates these icons
  - infrastructure/host-map icon to the DRUIDS version
  - alerting icon from alert `=>` monitor

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1741

### Preview
#### product dropdown menu in mobile main nav/homepage product tile for infra and alerting
https://docs-staging.datadoghq.com/carlos/iconfont-infra-alerting-update/
https://docs-staging.datadoghq.com/carlos/iconfont-infra-alerting-update/ja/
https://docs-staging.datadoghq.com/carlos/iconfont-infra-alerting-update/fr/

- [x] painstakingly check the following:
  - [x] infra/host-map icon stroke on the outlined top-right hex should be ever so bolder than prod
  - [x] alerts uses `icon-monitor` instead of `icon-alert`

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
