### PR TITLE
[NTGW] Update link to Logs API

### DIFF
--- a/content/en/developers/marketplace/_index.md
+++ b/content/en/developers/marketplace/_index.md
@@ -261,7 +261,7 @@ Email techpartners@datadoghq.com if you have any questions.
 [13]: /developers/custom_checks/prometheus/
 [14]: /developers/integrations/new_check_howto/?tab=configurationtemplate#write-the-check
 [15]: /developers/dogstatsd/?tab=hostagent
-[16]: /api/
+[16]: /api/latest/logs/
 [17]: /api/latest/metrics/
 [18]: /api/latest/events/
 [19]: /api/latest/service-checks/


### PR DESCRIPTION
Link to the logs API in the "Build a bi-directional integration" section previously pointed to the main API page. This update changes the link to https://docs.datadoghq.com/api/latest/logs/

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
