### PR TITLE
Fix naming collision with 'Host Map' pages.

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -935,6 +935,7 @@ main:
     url: dashboards/widgets/hostmap/
     parent: dashboards_widgets
     weight: 21
+    identifier: widgets_host_map
   - name: Iframe
     url: dashboards/widgets/iframe/
     parent: dashboards_widgets
@@ -1083,28 +1084,29 @@ main:
   - name: Infrastructure List
     url: infrastructure/list/
     parent: infrastructure
-    weight: 2
+    weight: 1
   - name: Host Map
     url: infrastructure/hostmap/
     parent: infrastructure
-    weight: 3
+    weight: 2
+    identifier: infrastructure_host_map
   - name: Container Map
     url: infrastructure/containermap/
     parent: infrastructure
-    weight: 4
+    weight: 3
   - name: Live Processes
     url: infrastructure/process/
     parent: infrastructure
     identifier: infrastructure_process
-    weight: 5
+    weight: 4
   - name: Increase Process Retention
     url: infrastructure/process/increase_process_retention/
     parent: infrastructure_process
-    weight: 101
+    weight: 401
   - name: Live Containers
     url: infrastructure/livecontainers/
     parent: infrastructure
-    weight: 7
+    weight: 5
   - name: Serverless
     url: serverless
     pre: serverless


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
adds `identifier` to both of the Host Map entries in the menus.en.yaml so that the one in infrastructure shows up.

### Motivation
Host Map was not appearing under Infrastructure because there are two pages that go by that name. Adding identifiers fixes this issue.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jorie/fix-host-map/infrastructure

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
