### PR TITLE
DOCS-2543 iOS Monitoring Navigation Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,8 @@ content/en/real_user_monitoring/error_tracking/android.md
 content/en/real_user_monitoring/browser/_index.md
 content/en/logs/log_collection/javascript.md
 content/en/real_user_monitoring/ios.md
+content/en/real_user_monitoring/ios/crash_reporting.md
+content/en/real_user_monitoring/error_tracking/ios.md
 content/en/real_user_monitoring/ios/*
 content/en/real_user_monitoring/reactnative.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,6 @@ content/en/real_user_monitoring/browser/_index.md
 content/en/logs/log_collection/javascript.md
 content/en/real_user_monitoring/ios.md
 content/en/real_user_monitoring/ios/crash_reporting.md
-content/en/real_user_monitoring/error_tracking/ios.md
 content/en/real_user_monitoring/ios/*
 content/en/real_user_monitoring/reactnative.md
 

--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,12 @@ clean-auto-doc: ##Remove all doc automatically created
 	rm -f content/en/real_user_monitoring/android/integrated_libraries.md ;fi
 	@if [ content/en/real_user_monitoring/error_tracking/android.md ]; then \
 	rm -f content/en/real_user_monitoring/error_tracking/android.md ;fi
+	@if [ content/en/real_user_monitoring/error_tracking/ios.md ]; then \
+	rm -f content/en/real_user_monitoring/error_tracking/ios.md ;fi
 	@if [ content/en/real_user_monitoring/browser/_index.md ]; then \
 	rm -f content/en/real_user_monitoring/browser/_index.md ;fi
+	@if [ content/en/real_user_monitoring/ios/crash_reporting.md ]; then \
+	rm -f content/en/real_user_monitoring/ios/crash_reporting.md ;fi
 	@if [ -d content/en/real_user_monitoring/ios ]; then \
 	find ./content/en/real_user_monitoring/ios -type f -maxdepth 1 -exec rm -rf {} \; ;fi
 	@if [ content/en/real_user_monitoring/reactnative.md ]; then \

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2559,15 +2559,15 @@ main:
     parent: rum
     identifier: rum_ios
     weight: 3
-  - name: Crash Reporting & Error Tracking
-    url: real_user_monitoring/ios/crash_reporting/
-    parent: rum_ios
-    identifier: rum_ios_crash_reporting
-    weight: 301
   - name: Data Collected
     url: real_user_monitoring/ios/data_collected/
     parent: rum_ios
     identifier: rum_ios_data_collected
+    weight: 301
+  - name: Crash Reporting
+    url: real_user_monitoring/ios/crash_reporting/
+    parent: rum_ios
+    identifier: rum_ios_crash_reporting
     weight: 302
   - name: Advanced Configuration
     url: real_user_monitoring/ios/advanced_configuration/

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2650,7 +2650,7 @@ main:
     identifier: rum_error_tracking_android
     weight: 803
   - name: Track iOS Errors
-    url: real_user_monitoring/error_tracking/ios
+    url: real_user_monitoring/ios/crash_reporting/
     parent: rum_error_tracking
     identifier: rum_error_tracking_ios
     weight: 804

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2649,6 +2649,11 @@ main:
     parent: rum_error_tracking
     identifier: rum_error_tracking_android
     weight: 803
+  - name: Track iOS Errors
+    url: real_user_monitoring/error_tracking/ios
+    parent: rum_error_tracking
+    identifier: rum_error_tracking_ios
+    weight: 804
   - name: Guides
     url: real_user_monitoring/guide/
     parent: rum

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2559,16 +2559,21 @@ main:
     parent: rum
     identifier: rum_ios
     weight: 3
+  - name: Crash Reporting & Error Tracking
+    url: real_user_monitoring/ios/crash_reporting/
+    parent: rum_ios
+    identifier: rum_ios_crash_reporting
+    weight: 301
   - name: Data Collected
     url: real_user_monitoring/ios/data_collected/
     parent: rum_ios
     identifier: rum_ios_data_collected
-    weight: 301
+    weight: 302
   - name: Advanced Configuration
     url: real_user_monitoring/ios/advanced_configuration/
     parent: rum_ios
     identifier: rum_ios_advanced
-    weight: 302
+    weight: 303
   - name: Troubleshooting
     url: real_user_monitoring/ios/troubleshooting/
     parent: rum_ios

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -478,7 +478,7 @@
               text: "dd-sdk-android Source code"
             - link: "tracing/visualization/"
               tag: "Documentation"
-              text: "Explore your services, resources and traces"
+              text: "Explore your services, resources, and traces"
 
   - repo_name: dd-sdk-ios
     contents:
@@ -522,7 +522,7 @@
               text: "dd-sdk-ios Source code"
             - link: "tracing/visualization/"
               tag: "Documentation"
-              text: "Explore your services, resources and traces"
+              text: "Explore your services, resources, and traces"
 
     - action: pull-and-push-folder
       branch: master
@@ -533,6 +533,16 @@
         path_to_remove: 'docs/rum_collection/'
         front_matters:
           dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
+
+    - action: pull-and-push-folder
+      branch: priyanshi/ios_crash_reporting
+      globs:
+        - docs/error_tracking/*
+      options:
+        dest_dir: '/real_user_monitoring/error_tracking/'
+        path_to_remove: 'docs/error_tracking/'
+        front_matters:
+          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/error_tracking/" ]
 
   - repo_name: dd-sdk-reactnative
     contents:

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -535,7 +535,7 @@
           dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
 
     - action: pull-and-push-folder
-      branch: priyanshi/ios_crash_reporting
+      branch: master
       globs:
         - docs/error_tracking/*
       options:

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -525,14 +525,14 @@
               text: "Explore your services, resources, and traces"
 
     - action: pull-and-push-folder
-      branch: master
+      branch: priyanshi/ios_crash_reporting
       globs:
         - docs/rum_collection/*
       options:
         dest_dir: '/real_user_monitoring/ios/'
         path_to_remove: 'docs/rum_collection/'
         front_matters:
-          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
+          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/priyanshi/ios_crash_reporting/docs/rum_collection/" ]
 
     - action: pull-and-push-folder
       branch: priyanshi/ios_crash_reporting
@@ -542,7 +542,7 @@
         dest_dir: '/real_user_monitoring/error_tracking/'
         path_to_remove: 'docs/error_tracking/'
         front_matters:
-          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/error_tracking/" ]
+          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/priyanshi/ios_crash_reporting/docs/error_tracking/" ]
 
   - repo_name: dd-sdk-reactnative
     contents:

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -525,24 +525,24 @@
               text: "Explore your services, resources, and traces"
 
     - action: pull-and-push-folder
-      branch: priyanshi/ios_crash_reporting
+      branch: master
       globs:
         - docs/rum_collection/*
       options:
         dest_dir: '/real_user_monitoring/ios/'
         path_to_remove: 'docs/rum_collection/'
         front_matters:
-          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/priyanshi/ios_crash_reporting/docs/rum_collection/" ]
+          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
 
     - action: pull-and-push-folder
-      branch: priyanshi/ios_crash_reporting
+      branch: master
       globs:
         - docs/error_tracking/*
       options:
         dest_dir: '/real_user_monitoring/error_tracking/'
         path_to_remove: 'docs/error_tracking/'
         front_matters:
-          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/priyanshi/ios_crash_reporting/docs/error_tracking/" ]
+          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/error_tracking/" ]
 
   - repo_name: dd-sdk-reactnative
     contents:

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -535,7 +535,7 @@
           dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
 
     - action: pull-and-push-folder
-      branch: master
+      branch: priyanshi/ios_crash_reporting
       globs:
         - docs/error_tracking/*
       options:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -536,7 +536,7 @@
           dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
 
     - action: pull-and-push-folder
-      branch: master
+      branch: priyanshi/ios_crash_reporting
       globs:
         - docs/error_tracking/*
       options:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -526,14 +526,14 @@
               text: "Explore your services, resources, and traces"
 
     - action: pull-and-push-folder
-      branch: master
+      branch: priyanshi/ios_crash_reporting
       globs:
         - docs/rum_collection/*
       options:
         dest_dir: '/real_user_monitoring/ios/'
         path_to_remove: 'docs/rum_collection/'
         front_matters:
-          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
+          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/priyanshi/ios_crash_reporting/docs/rum_collection/" ]
 
     - action: pull-and-push-folder
       branch: priyanshi/ios_crash_reporting

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -523,7 +523,7 @@
               text: "dd-sdk-ios Source code"
             - link: "tracing/visualization/"
               tag: "Documentation"
-              text: "Explore your services, resources and traces"
+              text: "Explore your services, resources, and traces"
 
     - action: pull-and-push-folder
       branch: master
@@ -534,6 +534,16 @@
         path_to_remove: 'docs/rum_collection/'
         front_matters:
           dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
+
+    - action: pull-and-push-folder
+      branch: priyanshi/ios_crash_reporting
+      globs:
+        - docs/error_tracking/*
+      options:
+        dest_dir: '/real_user_monitoring/error_tracking/'
+        path_to_remove: 'docs/error_tracking/'
+        front_matters:
+          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/error_tracking/" ]
 
   - repo_name: dd-sdk-reactnative
     contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -526,24 +526,24 @@
               text: "Explore your services, resources, and traces"
 
     - action: pull-and-push-folder
-      branch: priyanshi/ios_crash_reporting
+      branch: master
       globs:
         - docs/rum_collection/*
       options:
         dest_dir: '/real_user_monitoring/ios/'
         path_to_remove: 'docs/rum_collection/'
         front_matters:
-          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/priyanshi/ios_crash_reporting/docs/rum_collection/" ]
+          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
 
     - action: pull-and-push-folder
-      branch: priyanshi/ios_crash_reporting
+      branch: master
       globs:
         - docs/error_tracking/*
       options:
         dest_dir: '/real_user_monitoring/error_tracking/'
         path_to_remove: 'docs/error_tracking/'
         front_matters:
-          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/priyanshi/ios_crash_reporting/docs/error_tracking/" ]
+          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/error_tracking/" ]
 
   - repo_name: dd-sdk-reactnative
     contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -543,7 +543,7 @@
         dest_dir: '/real_user_monitoring/error_tracking/'
         path_to_remove: 'docs/error_tracking/'
         front_matters:
-          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/error_tracking/" ]
+          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/priyanshi/ios_crash_reporting/docs/error_tracking/" ]
 
   - repo_name: dd-sdk-reactnative
     contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -536,7 +536,7 @@
           dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
 
     - action: pull-and-push-folder
-      branch: priyanshi/ios_crash_reporting
+      branch: master
       globs:
         - docs/error_tracking/*
       options:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds Crash Reporting & Error Tracking page in the TOC. 

Before you merge this Documentation PR, remember to swap the `branch:` in the pull_config.yaml and pull_config_preview files!

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-2543

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/ios-monitoring-crash-reporting-link/real_user_monitoring/ios/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
