### PR TITLE
[docs]kris-casey/add clarification

### DIFF
--- a/content/en/agent/amazon_ecs/logs.md
+++ b/content/en/agent/amazon_ecs/logs.md
@@ -12,7 +12,7 @@ further_reading:
 
 ## Overview
 
-Datadog Agent 6+ collects logs from containers. The recommended way to collect logs from ECS containers is to enable containerized logging within your `datadog-agent-ecs.json` or `datadog-agent-ecs1.json` file. However, if your application emits logs to files in any capacity (logs that are not written to `stdout`/`stderr`), you need to [deploy the Datadog Agent on your host](#custom-log-collection) and use custom log collection to tail files.
+Datadog Agent 6+ collects logs from containers. The recommended way to collect logs from ECS containers is to enable containerized logging within your `datadog-agent-ecs.json` or `datadog-agent-ecs1.json` file. However, if your application emits logs to files in any capacity (logs that are not written to `stdout`/`stderr`), you need to use [autodiscovery][2] with [container labels](#container-label) (available for Agent v7.25.0+/6.25.0+) or [deploy the Datadog Agent on your host](#custom-log-collection) and use custom log collection to tail files.
 
 ## Installation
 
@@ -160,7 +160,7 @@ To collect all logs written by running applications in your ECS containers and s
 
 If your container writes any logs to files, follow the [Custom Log Collection documentation][1] to tail files for logs.
 
-To gather logs from your `<APP_NAME>` application stored in `<PATH_LOG_FILE>/<LOG_FILE_NAME>.log` create a `<APP_NAME>.d/conf.yaml` file at the root of your [Agent's configuration directory][2] with the following content:
+To gather logs from your `<APP_NAME>` application stored in `<PATH_LOG_FILE>/<LOG_FILE_NAME>.log` create a `<APP_NAME>.d/conf.yaml` file at the root of your [Agent's configuration directory][6] with the following content:
 
 ```yaml
 logs:
@@ -187,7 +187,8 @@ The `source` attribute is used to identify the integration to use for each conta
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/logs/?tab=tailfiles#custom-log-collection
-[2]: /agent/logs/#custom-log-collection
+[2]: /agent/docker/log/?tab=containerinstallation#log-integrations
 [3]: /getting_started/tagging/assigning_tags/?tab=noncontainerizedenvironments#methods-for-assigning-tags
 [4]: /agent/docker/log/?tab=logcollectionfromfile#examples
 [5]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html
+[6]: /agent/logs/#custom-log-collection


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Added clarification to the beginning of the doc as to the options for logging in ECS.
Also changed the link for autodiscovery since it was pointing to host-Agent custom log tailing.

### Motivation
I was working on a ticket for ECS logging and was confused by the beginning, which sounded like logs writing to a file only had the option to install the Agent on the host, but the container-labels option involves the Agent in the container and the files being mounted. 
When writing up the response to the customer to provide an explanation and links, I noticed the autodiscovery link pointed to the host-Agent file-tailing instructions, which was also confusing. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>
(Still not sure how to do this.)

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
