### PR TITLE
Fast Retry Interval Edits

### DIFF
--- a/content/en/synthetics/api_tests/dns_tests.md
+++ b/content/en/synthetics/api_tests/dns_tests.md
@@ -82,7 +82,7 @@ When you set the alert conditions to: `An alert is triggered if any assertion fa
 
 #### Fast retry
 
-Your test can trigger retries in case of failed test result. By default, the retries are performed 300 ms after the first failed test result. The retry interval can be configured with the [API][7].
+Your test can trigger retries in case of failed test result. Configuration is available to better suit your alerting sensibility.
 
 Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
 
@@ -172,7 +172,6 @@ If you have access to the [custom role feature][13], add your user to any custom
 [4]: /synthetics/search/#search
 [5]: /synthetics/cicd_testing
 [6]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-[7]: /api/latest/synthetics/#edit-an-api-test
 [8]: /monitors/notifications/?tab=is_alert#notification
 [9]: https://www.markdownguide.org/basic-syntax/
 [10]: /monitors/notifications/?tab=is_recoveryis_alert_recovery#conditional-variables

--- a/content/en/synthetics/api_tests/dns_tests.md
+++ b/content/en/synthetics/api_tests/dns_tests.md
@@ -82,7 +82,7 @@ When you set the alert conditions to: `An alert is triggered if any assertion fa
 
 #### Fast retry
 
-Your test can trigger retries in case of failed test result. Configuration is available to better suit your alerting sensibility.
+Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
 
 Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
 

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -132,7 +132,7 @@ When you set the alert conditions to: `An alert is triggered if any assertion fa
 
 #### Fast retry
 
-Your test can trigger retries in case of failed test result. Configuration is available to better suit your alerting sensibility.
+Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
 
 Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
 

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -132,7 +132,7 @@ When you set the alert conditions to: `An alert is triggered if any assertion fa
 
 #### Fast retry
 
-Your test can trigger retries in case of a failed test result. By default, the retries are performed 300 ms after the first failed test result. The retry interval can be configured with the [API][9].
+Your test can trigger retries in case of failed test result. Configuration is available to better suit your alerting sensibility.
 
 Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
 
@@ -228,7 +228,6 @@ If you have access to the [custom role feature][16], add your user to any custom
 [6]: https://restfulapi.net/json-jsonpath/
 [7]: https://www.w3schools.com/xml/xpath_syntax.asp
 [8]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-[9]: /api/latest/synthetics/#edit-an-api-test
 [10]: /monitors/notifications/?tab=is_alert#notification
 [11]: https://www.markdownguide.org/basic-syntax/
 [12]: /monitors/notifications/?tab=is_recoveryis_alert_recovery#conditional-variables

--- a/content/en/synthetics/api_tests/icmp_tests.md
+++ b/content/en/synthetics/api_tests/icmp_tests.md
@@ -79,7 +79,7 @@ When you set the alert conditions to: `An alert is triggered if any assertion fa
 
 #### Fast retry
 
-Your test can trigger retries in case of a failed test result. By default, the retries are performed 300 ms after the first failed test result. The retry interval can be configured with the [API][6].
+Your test can trigger retries in case of failed test result. Configuration is available to better suit your alerting sensibility.
 
 Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
 
@@ -158,7 +158,6 @@ If you have access to the [custom role feature][12], add your user to any custom
 [3]: /synthetics/cicd_testing
 [4]: /synthetics/api_tests/icmp_tests
 [5]: /synthetics/search/#search
-[6]: /api/latest/synthetics/#edit-an-api-test
 [7]: /monitors/notifications/?tab=is_alert#notification
 [8]: https://www.markdownguide.org/basic-syntax/
 [9]: /monitors/notifications/?tab=is_recoveryis_alert_recovery#conditional-variables

--- a/content/en/synthetics/api_tests/icmp_tests.md
+++ b/content/en/synthetics/api_tests/icmp_tests.md
@@ -79,7 +79,7 @@ When you set the alert conditions to: `An alert is triggered if any assertion fa
 
 #### Fast retry
 
-Your test can trigger retries in case of failed test result. Configuration is available to better suit your alerting sensibility.
+Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
 
 Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
 

--- a/content/en/synthetics/api_tests/ssl_tests.md
+++ b/content/en/synthetics/api_tests/ssl_tests.md
@@ -89,7 +89,7 @@ When you set the alert conditions to: `An alert is triggered if any assertion fa
 
 #### Fast retry
 
-Your test can trigger retries in case of failed test result. Configuration is available to better suit your alerting sensibility.
+Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
 
 Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
 

--- a/content/en/synthetics/api_tests/ssl_tests.md
+++ b/content/en/synthetics/api_tests/ssl_tests.md
@@ -89,7 +89,7 @@ When you set the alert conditions to: `An alert is triggered if any assertion fa
 
 #### Fast retry
 
-Your test can trigger retries in case of a failed test result. By default, the retries are performed 300 ms after the first failed test result. The retry interval can be configured with the [API][7].
+Your test can trigger retries in case of failed test result. Configuration is available to better suit your alerting sensibility.
 
 Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
 
@@ -183,7 +183,6 @@ If you have access to the [custom role feature][14], add your user to any custom
 [4]: /synthetics/search/#search
 [5]: /synthetics/cicd_testing
 [6]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-[7]: /api/latest/synthetics/#edit-an-api-test
 [8]: /monitors/notifications/?tab=is_alert#notification
 [9]: https://www.markdownguide.org/basic-syntax/
 [10]: /monitors/notifications/?tab=is_recoveryis_alert_recovery#conditional-variables

--- a/content/en/synthetics/api_tests/tcp_tests.md
+++ b/content/en/synthetics/api_tests/tcp_tests.md
@@ -76,7 +76,7 @@ When you set the alert conditions to: `An alert is triggered if any assertion fa
 
 #### Fast retry
 
-Your test can trigger retries in case of a failed test result. By default, the retries are performed 300 ms after the first failed test result. The retry interval can be configured with the [API][6].
+Your test can trigger retries in case of failed test result. Configuration is available to better suit your alerting sensibility.
 
 Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
 
@@ -166,7 +166,6 @@ If you have access to the [custom role feature][12], add your user to any custom
 [3]: /synthetics/api_tests/tcp_tests
 [4]: /synthetics/search/#search
 [5]: /synthetics/cicd_testing
-[6]: /api/latest/synthetics/#edit-an-api-test
 [7]: /monitors/notifications/?tab=is_alert#notification
 [8]: https://www.markdownguide.org/basic-syntax/
 [9]: /monitors/notifications/?tab=is_recoveryis_alert_recovery#conditional-variables

--- a/content/en/synthetics/api_tests/tcp_tests.md
+++ b/content/en/synthetics/api_tests/tcp_tests.md
@@ -76,7 +76,7 @@ When you set the alert conditions to: `An alert is triggered if any assertion fa
 
 #### Fast retry
 
-Your test can trigger retries in case of failed test result. Configuration is available to better suit your alerting sensibility.
+Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
 
 Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
 

--- a/content/en/synthetics/api_tests/udp_tests.md
+++ b/content/en/synthetics/api_tests/udp_tests.md
@@ -66,7 +66,7 @@ You can set alert conditions to determine the circumstances under which a test s
 
 #### Fast retry
 
-Your test can trigger retries in case of failed test result. By default, the retries are performed 300 ms after the first failed test result. The retry interval can be configured with the [API][5].
+Your test can trigger retries in case of failed test result. Configuration is available to better suit your alerting sensibility.
 
 Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
 
@@ -168,7 +168,6 @@ If you have access to the [custom role feature][11], add your user to any custom
 [2]: /synthetics/private_locations/
 [3]: /synthetics/search/#search
 [4]: /synthetics/cicd_testing/
-[5]: api/latest/synthetics/#edit-an-api-test
 [6]: /monitors/notify/#notify-your-team
 [7]: https://www.markdownguide.org/basic-syntax/
 [8]: /monitors/notify/variables/?tab=is_alert#conditional-variables

--- a/content/en/synthetics/api_tests/udp_tests.md
+++ b/content/en/synthetics/api_tests/udp_tests.md
@@ -66,7 +66,7 @@ You can set alert conditions to determine the circumstances under which a test s
 
 #### Fast retry
 
-Your test can trigger retries in case of failed test result. Configuration is available to better suit your alerting sensibility.
+Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
 
 Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
 

--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -170,7 +170,7 @@ When you set the alert conditions to: `An alert is triggered if any assertion fa
 
 #### Fast retry
 
-Your test can trigger retries in case of failed test result. Configuration is available to better suit your alerting sensibility.
+Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
 
 Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
 

--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -170,7 +170,7 @@ When you set the alert conditions to: `An alert is triggered if any assertion fa
 
 #### Fast retry
 
-Your test can trigger retries in case of a failed test result. By default, the retries are performed 300 ms after the first failed test result. The retry interval can be configured with the [API][11].
+Your test can trigger retries in case of failed test result. Configuration is available to better suit your alerting sensibility.
 
 Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
 
@@ -269,7 +269,6 @@ If you have access to the [custom role feature][18], add your user to any custom
 [8]: https://restfulapi.net/json-jsonpath/
 [9]: https://www.w3schools.com/xml/xpath_syntax.asp
 [10]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-[11]: /api/latest/synthetics/#edit-an-api-test
 [12]: /monitors/notifications/?tab=is_alert#notification
 [13]: http://daringfireball.net/projects/markdown/syntax
 [14]: /monitors/notifications/?tab=is_recoveryis_alert_recovery#conditional-variables


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Remove the API link to configure the Fast Retry interval in the API Test creation workflow.
 
### Motivation
<!-- What inspired you to submit this pull request?-->

Users no longer need to configure the API to set the interval; they can use the UI to input numbers for # of tries and amount of time between retries.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hugo.puceat/synthetics/http_tests

+ all API test types pages

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
