### PR TITLE
[apm] update apdex docs to include new apdex metric and deprecation notice for legacy apdex metrics

### DIFF
--- a/content/en/tracing/guide/metrics_namespace.md
+++ b/content/en/tracing/guide/metrics_namespace.md
@@ -162,27 +162,35 @@ With the following definitions:
 
 ### Apdex
 
+`trace.<SPAN_NAME>.apdex`
+: **Prerequisite:** This metric exists for any HTTP/WEB APM service.<br>
+**Description:** Measures the [Apdex][9] score for each web service.<br>
+**Metric type:** [GAUGE][6].<br>
+**Tags:** `env`, `service`, `resource` / `resource_name`, `version`, `synthetics`, and [the second primary tag][4].
+
+**The following legacy apdex metrics are deprecated.**
+
 `trace.<SPAN_NAME>.apdex.by.resource_<2ND_PRIM_TAG>_service`
 : **Prerequisite:** This metric exists for any HTTP/WEB APM service.<br>
-**Description:** Represent the [Apdex][9] score for all combination of resources, [2nd primary tag][4]s and services.<br>
+**Description:** Represents the [Apdex][9] score for all combination of resources, [2nd primary tag][4]s and services.<br>
 **Metric type:** [GAUGE][6].<br>
-**Tags:** `env`, `service`, `resource`, and [the second primary tag][4].
+**Tags:** `env`, `service`, `resource` / `resource_name`, and [the second primary tag][4].
 
 `trace.<SPAN_NAME>.apdex.by.resource_service`
 : **Prerequisite:** This metric exists for any HTTP/WEB APM service.<br>
-**Description:** Measure the [Apdex][9] score for each combination of resources and web services.<br>
+**Description:** Measures the [Apdex][9] score for each combination of resources and web services.<br>
 **Metric type:** [GAUGE][6].<br>
-**Tags:** `env`, `service`, and `resource`
+**Tags:** `env`, `service`, and `resource` / `resource_name`.
 
 `trace.<SPAN_NAME>.apdex.by.<2ND_PRIM_TAG>_service`
 : **Prerequisite:** This metric exists for any HTTP/WEB APM service.<br>
-**Description:** Measure the [Apdex][9] score for each combination of [2nd primary tag][4] and web services.<br>
+**Description:** Measures the [Apdex][9] score for each combination of [2nd primary tag][4] and web services.<br>
 **Metric type:** [GAUGE][6].<br>
 **Tags:** `env`, `service`, and [the second primary tag][4].
 
 `trace.<SPAN_NAME>.apdex.by.service`
 : **Prerequisite:** This metric exists for any HTTP/WEB APM service.<br>
-**Description:** Measure the [Apdex][9] score for each web services.<br>
+**Description:** Measures the [Apdex][9] score for each web service.<br>
 **Metric type:** [GAUGE][6].<br>
 **Tags:** `env` and `service`.
 


### PR DESCRIPTION
### What does this PR do?

Updates the metrics guide for apdex to include the new apdex metric. Includes a deprecation notice for legacy apdex metrics.

### Motivation

To complement the release of new trace apdex metrics.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
