### PR TITLE
[doc] edit typo

### DIFF
--- a/content/en/agent/kubernetes/distributions.md
+++ b/content/en/agent/kubernetes/distributions.md
@@ -24,7 +24,7 @@ further_reading:
 
 ## Overview
 
-This section aims to document specificities and to provide good base configuration for all major Kubernetes distributions.
+This section aims to document specifics and to provide good base configuration for all major Kubernetes distributions.
 These configuration can then be customized to add any Datadog feature.
 
 * [AWS Elastic Kubernetes Service (EKS)](#EKS)

--- a/content/en/agent/kubernetes/distributions.md
+++ b/content/en/agent/kubernetes/distributions.md
@@ -24,7 +24,7 @@ further_reading:
 
 ## Overview
 
-This section aims to document specificites and to provide good base configuration for all major Kubernetes distributions.
+This section aims to document specificities and to provide good base configuration for all major Kubernetes distributions.
 These configuration can then be customized to add any Datadog feature.
 
 * [AWS Elastic Kubernetes Service (EKS)](#EKS)


### PR DESCRIPTION
Line 27 changed from "specificites" to "specificities".

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Edits typo on line 27. 

### Motivation
I was reviewing the documentation for a ticket and decided to fix something in the moment. 
doc: https://docs.datadoghq.com/agent/kubernetes/distributions/?tab=helm#GKE 

### Preview
<!-- Impacted pages preview links-->
https://github.com/DataDog/documentation/commit/4f5365066735ec60dce5cc247717cc4e6ef06dd4

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ffakih5-kubernetes-distributions-doc-typo-fix/?quick_pull=1

### Additional Notes
You are awesome! 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
