### PR TITLE
v2 manifest support

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -377,6 +377,7 @@ class Integrations:
         with open(file_name) as f:
             try:
                 data = json.load(f)
+                data = self.process_manifest(data, basename(dirname(file_name)))
                 data_name = data.get("name", "").lower()
                 if data_name in [
                     k
@@ -585,6 +586,7 @@ class Integrations:
         if exists(manifest):
             try:
                 manifest_json = json.load(open(manifest))
+                manifest_json = self.process_manifest(manifest_json, basename(dirname(file_name)))
             except JSONDecodeError:
                 no_integration_issue = False
                 manifest_json = {}
@@ -814,3 +816,22 @@ class Integrations:
             )
 
         return dependencies
+
+    def process_manifest(self, manifest_json, name):
+        """ Takes manifest and converts v2 and above to v1 expected formats for now """
+        manifest_version = manifest_json.get("manifest_version", '1.0.0').split('.')
+        split_version = manifest_version[0] if len(manifest_version) > 1 else '1'
+        if split_version != '1':
+            # v2 or above
+            manifest_json["integration_id"] = manifest_json.get("app_id", "")
+            categories = []
+            for tag in manifest_json.get("classifier_tags", []):
+                key, value = tag.split("::")
+                if key.lower() == "category":
+                    categories.append(value.lower())
+            manifest_json["categories"] = categories
+            manifest_json["public_title"] = manifest_json.get("tile", {}).get("title", '')
+            manifest_json["is_public"] = manifest_json.get("display_on_public_website", False)
+            manifest_json["short_description"] = manifest_json.get("tile", {}).get("description", '')
+            manifest_json["name"] = manifest_json.get("name", name)
+        return manifest_json

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -819,7 +819,7 @@ class Integrations:
 
     def process_manifest(self, manifest_json, name):
         """ Takes manifest and converts v2 and above to v1 expected formats for now """
-        manifest_version = manifest_json.get("manifest_version", '1.0.0').split('.')
+        manifest_version = (manifest_json.get("manifest_version", '1.0.0') or '1.0.0').split('.')
         split_version = manifest_version[0] if len(manifest_version) > 1 else '1'
         if split_version != '1':
             # v2 or above
@@ -827,11 +827,13 @@ class Integrations:
             categories = []
             supported_os = []
             for tag in manifest_json.get("classifier_tags", []):
-                key, value = tag.split("::")
-                if key.lower() == "category":
-                    categories.append(value.lower())
-                if key.lower() == "supported os":
-                    supported_os.append(value.lower())
+                # in some cases tag was null/None
+                if tag:
+                    key, value = tag.split("::")
+                    if key.lower() == "category":
+                        categories.append(value.lower())
+                    if key.lower() == "supported os":
+                        supported_os.append(value.lower())
             manifest_json["categories"] = categories
             manifest_json["supported_os"] = supported_os
             manifest_json["public_title"] = manifest_json.get("tile", {}).get("title", '')

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -825,11 +825,15 @@ class Integrations:
             # v2 or above
             manifest_json["integration_id"] = manifest_json.get("app_id", "")
             categories = []
+            supported_os = []
             for tag in manifest_json.get("classifier_tags", []):
                 key, value = tag.split("::")
                 if key.lower() == "category":
                     categories.append(value.lower())
+                if key.lower() == "supported os":
+                    supported_os.append(value.lower())
             manifest_json["categories"] = categories
+            manifest_json["supported_os"] = supported_os
             manifest_json["public_title"] = manifest_json.get("tile", {}).get("title", '')
             manifest_json["is_public"] = manifest_json.get("display_on_public_website", False)
             manifest_json["short_description"] = manifest_json.get("tile", {}).get("description", '')


### PR DESCRIPTION
### What does this PR do?

This PR adds some support for v2 manifests by adapting the new key/values pairs to what the existing (v1) code expects. 
There are currently no v2 manifests live so you shouldn't see any difference on the preview. 
This code is tested locally as working against v2 draft prs. 

### Motivation

marketplace discussions 

### Preview

Shouldn't see anything different than live here
https://docs-staging.datadoghq.com/david.jones/support-manifestv2/integrations/

### Additional Notes

This is the short term solution to provide support now while wrapping up the longer term ideas.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
