### PR TITLE
[doc] Python - Connect log and traces - trace remapper suggestion

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/python.md
+++ b/content/en/tracing/connect_logs_and_traces/python.md
@@ -106,7 +106,7 @@ Once the logger is configured, executing a traced function that logs an event yi
 {"event": "In tracer context", "dd.trace_id": 9982398928418628468, "dd.span_id": 10130028953923355146, "dd.env": "dev", "dd.service": "hello", "dd.version": "abc123"}
 ```
 
-**Note**: If you are not using a [Datadog Log Integration][3] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings. More information can be found in the [FAQ on this topic][4].
+**Note**: If you are not using a [Datadog Log Integration][3] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings and remapped thanks to the [Trace Remapper][5]. More information can be found in the [Why can’t I see my correlated logs in the Trace ID panel?][4] FAQ.
 
 [See the Python logging documentation][3] to ensure that the Python Log Integration is properly configured so that your Python logs are automatically parsed.
 
@@ -118,3 +118,4 @@ Once the logger is configured, executing a traced function that logs an event yi
 [2]: /tracing/visualization/#trace
 [3]: /logs/log_collection/python/#configure-the-datadog-agent
 [4]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom
+[5]: /logs/log_configuration/processors/#trace-remapper

--- a/content/en/tracing/connect_logs_and_traces/python.md
+++ b/content/en/tracing/connect_logs_and_traces/python.md
@@ -106,7 +106,7 @@ Once the logger is configured, executing a traced function that logs an event yi
 {"event": "In tracer context", "dd.trace_id": 9982398928418628468, "dd.span_id": 10130028953923355146, "dd.env": "dev", "dd.service": "hello", "dd.version": "abc123"}
 ```
 
-**Note**: If you are not using a [Datadog Log Integration][3] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings and remapped thanks to the [Trace Remapper][5]. More information can be found in the [Why can’t I see my correlated logs in the Trace ID panel?][4] FAQ.
+**Note**: If you are not using a [Datadog Log Integration][3] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings and remapped using the [Trace Remapper][4]. For more information, see [Why can’t I see my correlated logs in the Trace ID panel?][5].
 
 [See the Python logging documentation][3] to ensure that the Python Log Integration is properly configured so that your Python logs are automatically parsed.
 
@@ -117,5 +117,5 @@ Once the logger is configured, executing a traced function that logs an event yi
 [1]: /getting_started/tagging/unified_service_tagging
 [2]: /tracing/visualization/#trace
 [3]: /logs/log_collection/python/#configure-the-datadog-agent
-[4]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom
-[5]: /logs/log_configuration/processors/#trace-remapper
+[4]: /logs/log_configuration/processors/#trace-remapper
+[5]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom


### PR DESCRIPTION




<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add's a specific reference to the trace remapper in the Connect Logs and Traces documentation for Python. The change is modeled after what appears in the same page for PHP documentation: https://docs.datadoghq.com/tracing/connect_logs_and_traces/php/

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer suggestion in ticket: https://datadog.zendesk.com/agent/tickets/563218

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/gullwings13-python-connect-logs-and-traces-suggestion/tracing/connect_logs_and_traces/python.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
