### PR TITLE
Update description for lambda.enhanced.errors metric

### DIFF
--- a/content/en/serverless/enhanced_lambda_metrics/_index.md
+++ b/content/en/serverless/enhanced_lambda_metrics/_index.md
@@ -23,7 +23,7 @@ The following real-time enhanced Lambda metrics are available, and they are tagg
 : Measures the number of times a function is invoked in response to an event or invocation API call.
 
 `aws.lambda.enhanced.errors`          
-: Measures the number of invocations that failed due to errors in the function (response code 4XX).
+: Measures the number of invocations that failed due to errors in the function.
 
 `aws.lambda.enhanced.max_memory_used` 
 : Measures the maximum amount of memory (mb) used by the function.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the misleading description for the `aws.lambda.enhanced.errors` metric. I have no clue where `(response code 4XX)` originates from and it's definitely inaccurate and misleading.

### Motivation
Customers misinterpreting the metric description and got confused.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tian.chu/update-lambda-errors-description/serverless/enhanced_lambda_metrics/#real-time-enhanced-lambda-metrics

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
