### PR TITLE
remove bracket characters in placeholder

### DIFF
--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -29,7 +29,7 @@ If no user account is specified on the command line, the installer attempts to c
 
 If a user account is specified on the command line, but this user account is not found on the system, the installer attempts to create it. If a password was specified, the installer uses that password, otherwise it generate a random password.
 
-To specify the optional username and password on the command line pass the following properties to the `msiexec` command:
+To specify the optional USERNAME and PASSWORD on the command line pass the following properties to the `msiexec` command ( **Note:** Remove bracket `<>` characters from username and password placeholders):
 
 ```shell
 msiexec /i ddagent.msi DDAGENTUSER_NAME=<USERNAME> DDAGENTUSER_PASSWORD=<PASSWORD>


### PR DESCRIPTION
Added a reminder in docs to remove bracket characters from command. This is in response to the following ticket. https://datadog.zendesk.com/agent/tickets/559588

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This is just a reminder to remove the bracket characters from the username and password  from the command as these are not supported characters. https://docs.microsoft.com/en-us/windows/win32/adschema/a-samaccountname?redirectedfrom=MSDN

### Motivation
https://datadog.zendesk.com/agent/tickets/559588

### Preview

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
