### PR TITLE
2022 Agent Key Rotation docs

### DIFF
--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -44,8 +44,8 @@ For hosts running older versions of the install methods listed above or older ve
 Run the following commands on the host:
 
 ```bash
-$ curl -o /tmp/DATADOG_APT_KEY_F14F620E.public https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
-$ sudo apt-key add /tmp/DATADOG_APT_KEY_F14F620E.public
+$ curl -o /tmp/DATADOG_APT_KEY_F14F620E https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
+$ sudo apt-key add /tmp/DATADOG_APT_KEY_F14F620E
 ```
 
 {{% /tab %}}
@@ -54,8 +54,8 @@ $ sudo apt-key add /tmp/DATADOG_APT_KEY_F14F620E.public
 Run the following commands on the host:
 
 ```
-$ curl -o /tmp/DATADOG_RPM_KEY_FD4BF915.public https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
-$ sudo rpm --import /tmp/DATADOG_RPM_KEY_FD4BF915.public
+$ curl -o /tmp/DATADOG_RPM_KEY_FD4BF915 https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+$ sudo rpm --import /tmp/DATADOG_RPM_KEY_FD4BF915
 ```
 
 {{% /tab %}}

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -44,7 +44,8 @@ For hosts running older versions of the install methods listed above or older ve
 Run the following commands on the host:
 
 ```bash
-$ wget -qO - https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo apt-key add -
+$ curl -o /tmp/DATADOG_APT_KEY_F14F620E.public https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
+$ sudo apt-key add /tmp/DATADOG_APT_KEY_F14F620E.public
 ```
 
 {{% /tab %}}

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -3,7 +3,7 @@ title: 2022 Linux Agent Key Rotation
 kind: faq
 ---
 
-As a common best practice, Datadog periodically rotates the keys and certificates used to sign our Agent packages. The following GPG keys, used to sign the Agent RPM and DEB packages, reach their end-of-life in June 2022 and will be rotated in April 2022:
+As a common best practice, Datadog periodically rotates the keys and certificates used to sign Datadog's Agent packages. The following GPG keys, used to sign the Agent RPM and DEB packages, reach their end-of-life in June 2022 and will be rotated in April 2022:
 
 - The RPM signing key with hash [`A4C0B90D7443CF6E4E8AA341F1068E14E09422B3`][1] will be rotated in April 4th 2022 and will be replaced by the key with hash [`C6559B690CA882F023BDF3F63F4D1729FD4BF915`][2]
 - The DEB signing key with hash [`A2923DFF56EDA6E76E55E492D3A80E30382E94DE`][3] will be rotated in April 18th 2022 and will be replaced by the key with hash `D75CEA17048B9ACBF186794B32637D44F14F620E`[4]
@@ -11,7 +11,7 @@ As a common best practice, Datadog periodically rotates the keys and certificate
 Customers using Datadog's RPM or DEB packages might require a manual action to import the new key on their systems in order to install or upgrade the Agent after the rotation takes place.
 
 <div class="alert alert-info">
-Note that this DOES NOT affect the functionality of already running Agents, and only limits the ability to install or upgrade to a newer version of the Agent. This also doesn't affect Windows or MacOS Agents, nor Dockerized Linux Agents.
+**Note**: This DOES NOT affect the functionality of already running Agents, and only limits the ability to install or upgrade to a newer version of the Agent. This also doesn't affect Windows or MacOS Agents, nor Dockerized Linux Agents.
 </div>
 
 If you're using one of the following install methods, your hosts trust the key automatically and no further action is needed:
@@ -24,13 +24,13 @@ If you're using one of the following install methods, your hosts trust the key a
 * [Elastic Beanstalk][10] config templates updated as of Mar 29, 2021 (should contain `DATADOG_RPM_KEY_FD4BF915.public` under `gpgkey`)
 * Containerized Agents (Docker/Kubernetes): No action needed on any version
 
-Additionally, if you are using the DEB version of the Agent version 7.31.0 or greater, your hosts should also trust the new key autmatically.
+Additionally, if you are using the DEB version of the Agent version 7.31.0 or greater, your hosts should have installed the `datadog-signing-keys` package that automatically trusts the new key.
 
-If unsure, refer to the steps in [Check if a host trusts the new GPG key](#check-if-a-host-trusts-the-new-gpg-key).
+If unsure, read the steps in [Check if a host trusts the new GPG key](#check-if-a-host-trusts-the-new-gpg-key).
 
-Trying to install or upgrade the Agent package without trusting the new key will result in `NOKEY` errors when installing the RPM package and `NO_PUBKEY` errors when installing the DEB package.
+Trying to install or upgrade the Agent package without trusting the new key results in `NOKEY` errors when installing the RPM package and `NO_PUBKEY` errors when installing the DEB package.
 
-For hosts running older versions of the install methods listed above or older versions of the DEB package, we recommend you update your install method to the last available version. Alternatively, for Debian/Ubuntu users, update the Agent to version 7.31.0 or greater. Otherwise, you can also add the new keys manually following these instructions:
+For hosts running older versions of the install methods listed above or older versions of the DEB package, Datadog recommends updating the install method to the latest version. Alternatively, Debian and Ubuntu users can update the Agent to version 7.31.0 or greater. Otherwise, the keys can be manually updated on host by following these instructions:
 
 ### Manual update
 
@@ -46,7 +46,7 @@ $ wget -qO - https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo a
 {{% /tab %}}
 {{% tab "RedHat/CentOS" %}}
 
-Edit the `/etc/yum.repos.d/datadog.repo` and make sure it includes both the old and new keys in the `gpgkey` section:
+Edit the `/etc/yum.repos.d/datadog.repo` and make sure it includes the following list of keys in the `gpgkey` section:
 
 ```
 gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
@@ -58,7 +58,7 @@ gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
 {{% /tab %}}
 {{% tab "SUSE" %}}
 
-Edit the `/etc/zypp/repos.d/datadog.repo` and make sure it includes both the old and new keys in the `gpgkey` section:
+Edit the `/etc/zypp/repos.d/datadog.repo` and make sure it includes the following list of keys in the `gpgkey` section:
 
 ```
 gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -1,0 +1,122 @@
+---
+title: 2022 Linux Agent Key Rotation
+kind: faq
+---
+
+As a common best practice, Datadog periodically rotates the keys and certificates used to sign our Agent packages. The following GPG keys, used to sign the Agent RPM and DEB packages, reach their end-of-life in June 2022 and will be rotated in April 2022:
+
+- The RPM signing key with hash [`A4C0B90D7443CF6E4E8AA341F1068E14E09422B3`][1] will be rotated in April 4th 2022 and will be replaced by the key with hash [`C6559B690CA882F023BDF3F63F4D1729FD4BF915`][2]
+- The DEB signing key with hash [`A2923DFF56EDA6E76E55E492D3A80E30382E94DE`][3] will be rotated in April 18th 2022 and will be replaced by the key with hash `D75CEA17048B9ACBF186794B32637D44F14F620E`[4]
+
+Customers using Datadog's RPM or DEB packages might require a manual action to import the new key on their systems in order to install or upgrade the Agent after the rotation takes place.
+
+<div class="alert alert-info">
+Note that this DOES NOT affect the functionality of already running Agents, and only limits the ability to install or upgrade to a newer version of the Agent. This also doesn't affect Windows or MacOS Agents, nor Dockerized Linux Agents.
+</div>
+
+If you're using one of the following install methods, your hosts trust the key automatically and no further action is needed:
+
+* [Agent install script][5] v1.5.0 (released Jun 29, 2021)
+* [Chef cookbook][6] v4.11.0 (released Aug 10, 2021)
+* [Ansible role][7] v4.9.0 (released May 6, 2021)
+* [Puppet module][8] v3.13 (released Aug 11, 2021)
+* [SaltStack formula][9] v3.4 (released Aug 12, 2021)
+* [Elastic Beanstalk][10] config templates updated as of Mar 29, 2021 (should contain `DATADOG_RPM_KEY_FD4BF915.public` under `gpgkey`)
+* Containerized Agents (Docker/Kubernetes): No action needed on any version
+
+Additionally, if you are using the DEB version of the Agent version 7.31.0 or greater, your hosts should also trust the new key autmatically.
+
+If unsure, refer to the steps in [Check if a host trusts the new GPG key](#check-if-a-host-trusts-the-new-gpg-key).
+
+Trying to install or upgrade the Agent package without trusting the new key will result in `NOKEY` errors when installing the RPM package and `NO_PUBKEY` errors when installing the DEB package.
+
+For hosts running older versions of the install methods listed above or older versions of the DEB package, we recommend you update your install method to the last available version. Alternatively, for Debian/Ubuntu users, update the Agent to version 7.31.0 or greater. Otherwise, you can also add the new keys manually following these instructions:
+
+### Manual update
+
+{{< tabs >}}
+{{% tab "Debian/Ubuntu" %}}
+
+Run the following commands on the host:
+
+```bash
+$ wget -qO - https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo apt-key add -
+```
+
+{{% /tab %}}
+{{% tab "RedHat/CentOS" %}}
+
+Edit the `/etc/yum.repos.d/datadog.repo` and make sure it includes both the old and new keys in the `gpgkey` section:
+
+```
+gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY.public
+```
+
+{{% /tab %}}
+{{% tab "SUSE" %}}
+
+Edit the `/etc/zypp/repos.d/datadog.repo` and make sure it includes both the old and new keys in the `gpgkey` section:
+
+```
+gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+       https://keys.datadoghq.com/DATADOG_RPM_KEY.public
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Check if a host trusts the new GPG key
+
+
+{{< tabs >}}
+{{% tab "Debian/Ubuntu" %}}
+
+Run the following commands on the host:
+
+```bash
+$ apt-key list
+```
+
+And check the output for Datadog's key fingerprint `F14F620E` (sometimes a space is included: `F14F 620E`).
+
+{{% /tab %}}
+{{% tab "RedHat/CentOS" %}}
+
+Run the following commands on the host:
+
+```bash
+$ grep DATADOG_RPM_KEY_FD4BF915.public /etc/yum.repos.d/*datadog*.repo
+```
+
+And check the output is not empty.
+
+{{% /tab %}}
+{{% tab "SUSE" %}}
+
+Run the following commands on the host:
+
+```bash
+$ grep DATADOG_RPM_KEY_FD4BF915.public /etc/zypp/repos.d/datadog.repo
+```
+
+And check the output is not empty.
+
+{{% /tab %}}
+{{< /tabs >}}
+
+
+[1]: https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+[2]: https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+[3]: https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public
+[4]: https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
+[5]: https://app.datadoghq.com/account/settings#agent
+[6]: https://github.com/DataDog/chef-datadog
+[7]: https://github.com/DataDog/ansible-datadog
+[8]: https://github.com/DataDog/puppet-datadog-agent
+[9]: https://github.com/DataDog/datadog-formula
+[10]: https://docs.datadoghq.com/integrations/amazon_elasticbeanstalk

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -5,8 +5,8 @@ kind: faq
 
 As a common best practice, Datadog periodically rotates the keys and certificates used to sign Datadog's Agent packages. The following GPG keys, used to sign the Agent RPM and DEB packages, reach their end-of-life in June 2022 and will be rotated in April 2022:
 
-- The RPM signing key with hash [`A4C0B90D7443CF6E4E8AA341F1068E14E09422B3`][1] will be rotated in April 4th 2022 and will be replaced by the key with hash [`C6559B690CA882F023BDF3F63F4D1729FD4BF915`][2]
-- The DEB signing key with hash [`A2923DFF56EDA6E76E55E492D3A80E30382E94DE`][3] will be rotated in April 18th 2022 and will be replaced by the key with hash [`D75CEA17048B9ACBF186794B32637D44F14F620E`][4]
+- The RPM signing key with hash [`A4C0B90D7443CF6E4E8AA341F1068E14E09422B3`][1] will be rotated in April 11th 2022 and will be replaced by the key with hash [`C6559B690CA882F023BDF3F63F4D1729FD4BF915`][2]
+- The DEB signing key with hash [`A2923DFF56EDA6E76E55E492D3A80E30382E94DE`][3] will be rotated in May 2nd 2022 and will be replaced by the key with hash [`D75CEA17048B9ACBF186794B32637D44F14F620E`][4]
 
 Customers using Datadog's RPM or DEB packages might require a manual action to import the new key on their systems in order to install or upgrade the Agent after the rotation takes place.
 
@@ -34,7 +34,7 @@ If you're unsure if a host trusts the new signing key, you can [check](#check-if
 
 For hosts running older versions of the install methods listed above or older versions of the DEB package, Datadog recommends updating the install method to the latest version. Alternatively Debian and Ubuntu users can update the Agent to version 7.31.0 or greater. Otherwise, the key can be [manually updated](#manual-update).
 
-## What happens if I don't trust the new key by April 2022?
+## What happens if I don't trust the new key before it is rotated?
 
 {{< tabs >}}
 {{% tab "Debian/Ubuntu" %}}

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -32,9 +32,31 @@ Additionally, if you are using the DEB version of the Agent version 7.31.0 or gr
 
 If you're unsure if a host trusts the new signing key, you can [check](#check-if-a-host-trusts-the-new-gpg-key).
 
-Trying to install or upgrade the Agent package without trusting the new key results in `NOKEY` errors when installing the RPM package and `NO_PUBKEY` errors when installing the DEB package.
+For hosts running older versions of the install methods listed above or older versions of the DEB package, Datadog recommends updating the install method to the latest version. Alternatively Debian and Ubuntu users can update the Agent to version 7.31.0 or greater. Otherwise, the key can be [manually updated](#manual-update).
 
-For hosts running older versions of the install methods listed above or older versions of the DEB package, Datadog recommends updating the install method to the latest version. Alternatively Debian and Ubuntu users can update the Agent to version 7.31.0 or greater. Otherwise, the keys can be manually updated:
+## What happens if I don't trust the new key by April 2022?
+
+{{< tabs >}}
+{{% tab "Debian/Ubuntu" %}}
+
+Trying to install or upgrade Agent packages without trusting the new key results in `NO_PUBKEY` errors. This applies to both newly released and existing versions of the Agent.
+
+```
+The following signatures couldn't be verified because the public key is not available: NO_PUBKEY
+```
+
+{{% /tab %}}
+{{% tab "RedHat/CentOS/SUSE" %}}
+
+Installing new versions of the Agent released since April 2022 causes `NOKEY` errors. Older versions of the Agent can still be installed.
+
+```
+The GPG keys listed for the "Datadog, Inc." repository are already installed but they are not correct for this package.
+Check that the correct key URLs are configured for this repository.
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Manual update
 

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -23,6 +23,8 @@ If you're using one of the following install methods, your hosts trust the key a
 * [SaltStack formula][9] v3.4 (released Aug 12, 2021)
 * [Elastic Beanstalk][10] config templates updated as of Mar 29, 2021 (should contain `DATADOG_RPM_KEY_FD4BF915.public` under `gpgkey`)
 * Containerized Agents (Docker/Kubernetes): No action needed on any version
+* Heroku: No action needed on any version.
+* Windows/MacOS Agents: No action needed on any version.
 
 Additionally, if you are using the DEB version of the Agent version 7.31.0 or greater, your hosts should have installed the `datadog-signing-keys` package that automatically trusts the new key.
 

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -84,13 +84,13 @@ $ rpm -q gpg-pubkey-fd4bf915
 If the key is trusted, the command has a 0 exit code and outputs:
 
 ```
-gpg-pubkey-e09422b3-57744e9e
+gpg-pubkey-fd4bf915-5f573efe
 ```
 
 Otherwise, the command returns a non-0 exit code and the following output:
 
 ```
-package gpg-pubkey-e09422b3 is not installed
+package gpg-pubkey-fd4bf915 is not installed
 ```
 
 {{% /tab %}}

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -116,6 +116,11 @@ package gpg-pubkey-fd4bf915 is not installed
 {{% /tab %}}
 {{< /tabs >}}
 
+## Impact for Agent 5 users
+
+Agent 5 users on DEB-based systems (Debian/Ubuntu) are also required to trust the new signing key in order to install or upgrade the Agent after the rotation date. Agent 5 users on RPM-based systems (RedHat/CentOS/SUSE) are not affected by this rotation.
+
+Note that Agent 5 uses Python 2 which reached end-of-life on January 1st 2021. We recommend you [upgrade to Agent 7][12].
 
 [1]: https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
 [2]: https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
@@ -128,3 +133,4 @@ package gpg-pubkey-fd4bf915 is not installed
 [9]: https://github.com/DataDog/datadog-formula
 [10]: https://github.com/DataDog/heroku-buildpack-datadog
 [11]: https://docs.datadoghq.com/integrations/amazon_elasticbeanstalk
+[12]: https://app.datadoghq.com/account/settings#agent

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -6,33 +6,33 @@ kind: faq
 As a common best practice, Datadog periodically rotates the keys and certificates used to sign Datadog's Agent packages. The following GPG keys, used to sign the Agent RPM and DEB packages, reach their end-of-life in June 2022 and will be rotated in April 2022:
 
 - The RPM signing key with hash [`A4C0B90D7443CF6E4E8AA341F1068E14E09422B3`][1] will be rotated in April 4th 2022 and will be replaced by the key with hash [`C6559B690CA882F023BDF3F63F4D1729FD4BF915`][2]
-- The DEB signing key with hash [`A2923DFF56EDA6E76E55E492D3A80E30382E94DE`][3] will be rotated in April 18th 2022 and will be replaced by the key with hash `D75CEA17048B9ACBF186794B32637D44F14F620E`[4]
+- The DEB signing key with hash [`A2923DFF56EDA6E76E55E492D3A80E30382E94DE`][3] will be rotated in April 18th 2022 and will be replaced by the key with hash [`D75CEA17048B9ACBF186794B32637D44F14F620E`][4]
 
 Customers using Datadog's RPM or DEB packages might require a manual action to import the new key on their systems in order to install or upgrade the Agent after the rotation takes place.
 
 <div class="alert alert-info">
-**Note**: This DOES NOT affect the functionality of already running Agents, and only limits the ability to install or upgrade to a newer version of the Agent. This also doesn't affect Windows or MacOS Agents, nor Dockerized Linux Agents.
+<strong>Note</strong>: This DOES NOT affect the functionality of already running Agents, and only limits the ability to install or upgrade to a newer version of the Agent. This also doesn't affect Windows or MacOS Agents, nor Dockerized Linux Agents.
 </div>
 
 If you're using one of the following install methods, your hosts trust the key automatically and no further action is needed:
 
-* [Agent install script][5] v1.5.0 (released Jun 29, 2021)
-* [Chef cookbook][6] v4.11.0 (released Aug 10, 2021)
-* [Ansible role][7] v4.9.0 (released May 6, 2021)
-* [Puppet module][8] v3.13 (released Aug 11, 2021)
-* [SaltStack formula][9] v3.4 (released Aug 12, 2021)
-* [Elastic Beanstalk][10] config templates updated as of Mar 29, 2021 (should contain `DATADOG_RPM_KEY_FD4BF915.public` under `gpgkey`)
+* [Agent install script][5] v1.6.0 or later (released Jul 26, 2021)
+* [Chef cookbook][6] v4.11.0 or later (released Aug 10, 2021)
+* [Ansible role][7] v4.10.0 or later (released May 25, 2021)
+* [Puppet module][8] v3.13.0 or later (released Aug 11, 2021)
+* [SaltStack formula][9] v3.4 or later (released Aug 12, 2021)
+* [Heroku buildpack][10] v1.26  or later (released May 26, 2021)
+* [Elastic Beanstalk][11] config templates updated as of Mar 29, 2021 or later (should contain `DATADOG_RPM_KEY_FD4BF915.public` under `gpgkey`)
 * Containerized Agents (Docker/Kubernetes): No action needed on any version
-* Heroku: No action needed on any version.
 * Windows/MacOS Agents: No action needed on any version.
 
-Additionally, if you are using the DEB version of the Agent version 7.31.0 or greater, your hosts should have installed the `datadog-signing-keys` package that automatically trusts the new key.
+Additionally, if you are using the DEB version of the Agent version 7.31.0 or greater, your hosts should have the `datadog-signing-keys` package installed, which will make APT recognize the signature by the new key on the Datadog APT repository.
 
 If unsure, read the steps in [Check if a host trusts the new GPG key](#check-if-a-host-trusts-the-new-gpg-key).
 
 Trying to install or upgrade the Agent package without trusting the new key results in `NOKEY` errors when installing the RPM package and `NO_PUBKEY` errors when installing the DEB package.
 
-For hosts running older versions of the install methods listed above or older versions of the DEB package, Datadog recommends updating the install method to the latest version. Alternatively, Debian and Ubuntu users can update the Agent to version 7.31.0 or greater. Otherwise, the keys can be manually updated on host by following these instructions:
+For hosts running older versions of the install methods listed above or older versions of the DEB package, Datadog recommends updating the install method to the latest version. Alternatively Debian and Ubuntu users can update the Agent to version 7.31.0 or greater. Otherwise, the keys can be manually updated on host by following these instructions:
 
 ### Manual update
 
@@ -46,27 +46,15 @@ $ wget -qO - https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo a
 ```
 
 {{% /tab %}}
-{{% tab "RedHat/CentOS" %}}
+{{% tab "RedHat/CentOS/SUSE" %}}
 
 Edit the `/etc/yum.repos.d/datadog.repo` and make sure it includes the following list of keys in the `gpgkey` section:
 
-```
-gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY.public
-```
-
-{{% /tab %}}
-{{% tab "SUSE" %}}
-
-Edit the `/etc/zypp/repos.d/datadog.repo` and make sure it includes the following list of keys in the `gpgkey` section:
+{{% tab "" %}}
 
 ```
-gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY.public
+$ curl -o /tmp/DATADOG_RPM_KEY_FD4BF915.public https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+$ sudo rpm --import /tmp/DATADOG_RPM_KEY_FD4BF915.public
 ```
 
 {{% /tab %}}
@@ -84,29 +72,28 @@ Run the following commands on the host:
 $ apt-key list
 ```
 
-And check the output for Datadog's key fingerprint `F14F620E` (sometimes a space is included: `F14F 620E`).
+And check the output for Datadog's key fingerprint ending in `F14F620E` or (with a space) `F14F 620E`.
 
 {{% /tab %}}
-{{% tab "RedHat/CentOS" %}}
+{{% tab "RedHat/CentOS/SUSE" %}}
 
 Run the following commands on the host:
 
 ```bash
-$ grep DATADOG_RPM_KEY_FD4BF915.public /etc/yum.repos.d/*datadog*.repo
+$ rpm -q gpg-pubkey-fd4bf915
 ```
 
-And check the output is not empty.
+If the key is trusted, the command has a 0 exit code and outputs:
 
-{{% /tab %}}
-{{% tab "SUSE" %}}
-
-Run the following commands on the host:
-
-```bash
-$ grep DATADOG_RPM_KEY_FD4BF915.public /etc/zypp/repos.d/datadog.repo
+```
+gpg-pubkey-e09422b3-57744e9e
 ```
 
-And check the output is not empty.
+Otherwise, the command returns a non-0 exit code and the following output:
+
+```
+package gpg-pubkey-e09422b3 is not installed
+```
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -121,4 +108,5 @@ And check the output is not empty.
 [7]: https://github.com/DataDog/ansible-datadog
 [8]: https://github.com/DataDog/puppet-datadog-agent
 [9]: https://github.com/DataDog/datadog-formula
-[10]: https://docs.datadoghq.com/integrations/amazon_elasticbeanstalk
+[10]: https://github.com/DataDog/heroku-buildpack-datadog
+[11]: https://docs.datadoghq.com/integrations/amazon_elasticbeanstalk

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -23,7 +23,7 @@ If you're using one of the following install methods, your hosts trust the key a
 * [Ansible role][7] v4.10.0 or later (released May 25, 2021)
 * [Puppet module][8] v3.13.0 or later (released Aug 11, 2021)
 * [SaltStack formula][9] v3.4 or later (released Aug 12, 2021)
-* [Heroku buildpack][10] v1.26  or later (released May 26, 2021)
+* [Heroku buildpack][10] v1.26 or later (released May 26, 2021)
 * [Elastic Beanstalk][11] config templates updated as of Mar 29, 2021 or later (should contain `DATADOG_RPM_KEY_FD4BF915.public` under `gpgkey`)
 * Containerized Agents (Docker/Kubernetes): No action needed on any version
 * Windows/MacOS Agents: No action needed on any version.

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -14,6 +14,8 @@ Customers using Datadog's RPM or DEB packages might require a manual action to i
 <strong>Note</strong>: This DOES NOT affect the functionality of already running Agents, and only limits the ability to install or upgrade to a newer version of the Agent. This also doesn't affect Windows or MacOS Agents, nor Dockerized Linux Agents.
 </div>
 
+## Install methods that automatically trust the new GPG key
+
 If you're using one of the following install methods, your hosts trust the key automatically and no further action is needed:
 
 * [Agent install script][5] v1.6.0 or later (released Jul 26, 2021)
@@ -28,13 +30,13 @@ If you're using one of the following install methods, your hosts trust the key a
 
 Additionally, if you are using the DEB version of the Agent version 7.31.0 or greater, your hosts should have the `datadog-signing-keys` package installed, which will make APT recognize the signature by the new key on the Datadog APT repository.
 
-If unsure, read the steps in [Check if a host trusts the new GPG key](#check-if-a-host-trusts-the-new-gpg-key).
+If you're unsure if a host trusts the new signing key, you can [check](#check-if-a-host-trusts-the-new-gpg-key).
 
 Trying to install or upgrade the Agent package without trusting the new key results in `NOKEY` errors when installing the RPM package and `NO_PUBKEY` errors when installing the DEB package.
 
-For hosts running older versions of the install methods listed above or older versions of the DEB package, Datadog recommends updating the install method to the latest version. Alternatively Debian and Ubuntu users can update the Agent to version 7.31.0 or greater. Otherwise, the keys can be manually updated on host by following these instructions:
+For hosts running older versions of the install methods listed above or older versions of the DEB package, Datadog recommends updating the install method to the latest version. Alternatively Debian and Ubuntu users can update the Agent to version 7.31.0 or greater. Otherwise, the keys can be manually updated:
 
-### Manual update
+## Manual update
 
 {{< tabs >}}
 {{% tab "Debian/Ubuntu" %}}

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -5,34 +5,34 @@ kind: faq
 
 As a common best practice, Datadog periodically rotates the keys and certificates used to sign Datadog's Agent packages. The following GPG keys, used to sign the Agent RPM and DEB packages, reach their end-of-life in June 2022 and will be rotated in April 2022:
 
-- The RPM signing key with hash [`A4C0B90D7443CF6E4E8AA341F1068E14E09422B3`][1] will be rotated in April 11th 2022 and will be replaced by the key with hash [`C6559B690CA882F023BDF3F63F4D1729FD4BF915`][2]
-- The DEB signing key with hash [`A2923DFF56EDA6E76E55E492D3A80E30382E94DE`][3] will be rotated in May 2nd 2022 and will be replaced by the key with hash [`D75CEA17048B9ACBF186794B32637D44F14F620E`][4]
+- The RPM signing key with hash [`A4C0B90D7443CF6E4E8AA341F1068E14E09422B3`][1] will be rotated on April 11, 2022 and replaced by the key with hash [`C6559B690CA882F023BDF3F63F4D1729FD4BF915`][2]
+- The DEB signing key with hash [`A2923DFF56EDA6E76E55E492D3A80E30382E94DE`][3] will be rotated on May 2, 2022 and replaced by the key with hash [`D75CEA17048B9ACBF186794B32637D44F14F620E`][4]
 
-Customers using Datadog's RPM or DEB packages might require a manual action to import the new key on their systems in order to install or upgrade the Agent after the rotation takes place.
+Customers using Datadog's RPM or DEB packages might require a manual action to import the new key on their systems to install or upgrade the Agent after the rotation takes place.
 
 <div class="alert alert-info">
-<strong>Note</strong>: This DOES NOT affect the functionality of already running Agents, and only limits the ability to install the Agent or upgrade to a newer version of the Agent. This also doesn't affect Dockerized Linux Agents nor Windows or MacOS Agents.
+<strong>Note</strong>: This DOES NOT affect the functionality of already running Agents, and only limits the ability to install or upgrade to a newer version of the Agent. Also, this doesn't affect Dockerized Linux Agents, Windows, or macOS Agents.
 </div>
 
 ## Install methods that automatically trust the new GPG key
 
-If you're using one of the following install methods, your hosts trust the key automatically and no further action is needed:
+Your host automatically trusts the new key (no further action is required) if you're using one of the following install methods:
 
-* [Agent install script][5] v1.6.0 or later (released Jul 26, 2021)
-* [Chef cookbook][6] v4.11.0 or later (released Aug 10, 2021)
-* [Ansible role][7] v4.10.0 or later (released May 25, 2021)
-* [Puppet module][8] v3.13.0 or later (released Aug 11, 2021)
-* [SaltStack formula][9] v3.4 or later (released Aug 12, 2021)
-* [Heroku buildpack][10] v1.26 or later (released May 26, 2021)
-* [Elastic Beanstalk][11] config templates updated as of Mar 29, 2021 or later (should contain `DATADOG_RPM_KEY_FD4BF915.public` under `gpgkey`)
-* Containerized Agents (Docker/Kubernetes): No action needed on any version
-* Windows/MacOS Agents: No action needed on any version.
+- [Agent install script][5] v1.6.0+ (released Jul 26, 2021)
+- [Chef cookbook][6] v4.11.0+ (released Aug 10, 2021)
+- [Ansible role][7] v4.10.0+ (released May 25, 2021)
+- [Puppet module][8] v3.13.0+ (released Aug 11, 2021)
+- [SaltStack formula][9] v3.4+ (released Aug 12, 2021)
+- [Heroku buildpack][10] v1.26+ (released May 26, 2021)
+- [Elastic Beanstalk][11] config templates updated as of Mar 29, 2021 or later (should contain `DATADOG_RPM_KEY_FD4BF915.public` under `gpgkey`)
+- Containerized Agents (Docker/Kubernetes) for any version
+- Windows/MacOS Agents for any version
 
-Additionally, if you are using the DEB version of the Agent version 7.31.0 or greater, your hosts should have the `datadog-signing-keys` package installed, which will make APT recognize the signature by the new key on the Datadog APT repository.
+Additionally, if you are using the DEB package and Agent v7.31.0+, your hosts should have the `datadog-signing-keys` package installed, which automatically adds the new key (no further action is needed).
 
 If you're unsure if a host trusts the new signing key, you can [check](#check-if-a-host-trusts-the-new-gpg-key).
 
-For hosts running older versions of the install methods listed above or older versions of the DEB package, Datadog recommends updating the install method to the latest version. Alternatively Debian and Ubuntu users can update the Agent to version 7.31.0 or greater. Otherwise, the key can be [manually updated](#manual-update).
+For hosts running older versions of the install methods listed above or older versions of the DEB package, Datadog recommends updating the install method to the latest version. Alternatively Debian and Ubuntu users can update the Agent to version 7.31.0+. Otherwise, the key can be [manually updated](#manual-update).
 
 ## What happens if I don't trust the new key before it is rotated?
 
@@ -95,7 +95,7 @@ If the file `/usr/share/keyrings/datadog-archive-keyring.gpg` exists, the new ke
 {{% /tab %}}
 {{% tab "RedHat/CentOS/SUSE" %}}
 
-Run the following commands on the host:
+Run the following command on the host:
 
 ```bash
 $ rpm -q gpg-pubkey-fd4bf915
@@ -116,11 +116,11 @@ package gpg-pubkey-fd4bf915 is not installed
 {{% /tab %}}
 {{< /tabs >}}
 
-## Impact for Agent 5 users
+## Impact for Agent v5 users
 
-Agent 5 users on DEB-based systems (Debian/Ubuntu) are also required to trust the new signing key in order to install or upgrade the Agent after the rotation date. Agent 5 users on RPM-based systems (RedHat/CentOS/SUSE) are not affected by this rotation.
+Agent v5 users on DEB-based systems (Debian/Ubuntu) are also required to trust the new signing key to install or upgrade the Agent after the rotation date. Agent v5 users on RPM-based systems (RedHat/CentOS/SUSE) are not affected by this rotation.
 
-Note that Agent 5 uses Python 2 which reached end-of-life on January 1st 2021. We recommend you [upgrade to Agent 7][12].
+**Note**: Agent v5 uses Python 2 which reached end-of-life on January 1, 2021. Datadog recommends [upgrading to Agent v7][12].
 
 [1]: https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
 [2]: https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -121,7 +121,7 @@ package gpg-pubkey-fd4bf915 is not installed
 [2]: https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
 [3]: https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public
 [4]: https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
-[5]: https://app.datadoghq.com/account/settings#agent
+[5]: https://s3.amazonaws.com/dd-agent/scripts/install_script.sh
 [6]: https://github.com/DataDog/chef-datadog
 [7]: https://github.com/DataDog/ansible-datadog
 [8]: https://github.com/DataDog/puppet-datadog-agent

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -68,6 +68,7 @@ Run the following commands on the host:
 ```bash
 $ curl -o /tmp/DATADOG_APT_KEY_F14F620E https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
 $ sudo apt-key add /tmp/DATADOG_APT_KEY_F14F620E
+$ sudo touch /usr/share/keyrings/datadog-archive-keyring.gpg
 $ cat /tmp/DATADOG_APT_KEY_F14F620E | sudo gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg
 $ sudo chmod a+r /usr/share/keyrings/datadog-archive-keyring.gpg
 ```

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -48,9 +48,7 @@ $ wget -qO - https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo a
 {{% /tab %}}
 {{% tab "RedHat/CentOS/SUSE" %}}
 
-Edit the `/etc/yum.repos.d/datadog.repo` and make sure it includes the following list of keys in the `gpgkey` section:
-
-{{% tab "" %}}
+Run the following commands on the host:
 
 ```
 $ curl -o /tmp/DATADOG_RPM_KEY_FD4BF915.public https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -46,6 +46,8 @@ Run the following commands on the host:
 ```bash
 $ curl -o /tmp/DATADOG_APT_KEY_F14F620E https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
 $ sudo apt-key add /tmp/DATADOG_APT_KEY_F14F620E
+$ cat /tmp/DATADOG_APT_KEY_F14F620E | sudo gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg
+$ sudo chmod a+r /usr/share/keyrings/datadog-archive-keyring.gpg
 ```
 
 {{% /tab %}}
@@ -63,17 +65,10 @@ $ sudo rpm --import /tmp/DATADOG_RPM_KEY_FD4BF915
 
 ## Check if a host trusts the new GPG key
 
-
 {{< tabs >}}
 {{% tab "Debian/Ubuntu" %}}
 
-Run the following commands on the host:
-
-```bash
-$ apt-key list
-```
-
-And check the output for Datadog's key fingerprint ending in `F14F620E` or (with a space) `F14F 620E`.
+If the file `/usr/share/keyrings/datadog-archive-keyring.gpg` exists, the new key is trusted and no further action is needed.
 
 {{% /tab %}}
 {{% tab "RedHat/CentOS/SUSE" %}}

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -11,7 +11,7 @@ As a common best practice, Datadog periodically rotates the keys and certificate
 Customers using Datadog's RPM or DEB packages might require a manual action to import the new key on their systems in order to install or upgrade the Agent after the rotation takes place.
 
 <div class="alert alert-info">
-<strong>Note</strong>: This DOES NOT affect the functionality of already running Agents, and only limits the ability to install or upgrade to a newer version of the Agent. This also doesn't affect Windows or MacOS Agents, nor Dockerized Linux Agents.
+<strong>Note</strong>: This DOES NOT affect the functionality of already running Agents, and only limits the ability to install the Agent or upgrade to a newer version of the Agent. This also doesn't affect Dockerized Linux Agents nor Windows or MacOS Agents.
 </div>
 
 ## Install methods that automatically trust the new GPG key


### PR DESCRIPTION
### What does this PR do?
Adds documentation for the upcoming Agent signing key rotation for Linux (deb/rpm) packages.

### Motivation
Will be linked from an email that customers that potentially need to trust the new key will receive.

### Preview
https://docs-staging.datadoghq.com/albertvaka/agent-key-rotation-2022/agent/faq/linux-agent-2022-key-rotation

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
