### PR TITLE
updating postman URLs

### DIFF
--- a/content/en/api/latest/_index.md
+++ b/content/en/api/latest/_index.md
@@ -18,7 +18,7 @@ The Datadog API is an HTTP REST API. The API uses resource-oriented URLs to call
 
 Authenticate to the API with an [API key][1], and depending on the endpoint, an [Application key][2].
 
-To try out the API [![Run in Postman][3]](https://app.getpostman.com/run-collection/b82586cb783eb6f7cf6d?action=collection%2Fimport#?env%5BDatadog%20Authentication%5D=W3sia2V5IjoiYXBwbGljYXRpb25fa2V5IiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlLCJ0eXBlIjoidGV4dCJ9LHsia2V5IjoiYXBpX2tleSIsInZhbHVlIjoiIiwiZW5hYmxlZCI6dHJ1ZSwidHlwZSI6InRleHQifV0=)
+To try out the API [![Run in Postman][3]][3]](https://app.getpostman.com/run-collection/7274195-66ef21d8-e159-4d7d-8ded-c511e1abe189?action=collection%2Ffork&collection-url=entityId%3D7274195-66ef21d8-e159-4d7d-8ded-c511e1abe189%26entityType%3Dcollection%26workspaceId%3Dbf049f54-c695-4e91-b879-0cad1854bafa#?env%5BDatadog%20Authentication%5D=W3sia2V5IjoiYXBpX2tleSIsInZhbHVlIjoiIiwiZW5hYmxlZCI6dHJ1ZX0seyJrZXkiOiJhcHBsaWNhdGlvbl9rZXkiLCJ2YWx1ZSI6IiIsImVuYWJsZWQiOnRydWV9XQ==)
 
 [Using the API][4] is a guide to the endpoints.
 

--- a/content/en/getting_started/api/_index.md
+++ b/content/en/getting_started/api/_index.md
@@ -30,9 +30,10 @@ Start by [logging into Postman][4]. Datadog recommends [downloading the Postman 
 
 </br>
 <div class="postman-run-button"
-data-postman-action="collection/import"
-data-postman-var-1="b82586cb783eb6f7cf6d"
-data-postman-param="env%5BDatadog%20Authentication%5D=W3sia2V5IjoiYXBwbGljYXRpb25fa2V5IiwidmFsdWUiOiIiLCJlbmFibGVkIjp0cnVlLCJ0eXBlIjoidGV4dCJ9LHsia2V5IjoiYXBpX2tleSIsInZhbHVlIjoiIiwiZW5hYmxlZCI6dHJ1ZSwidHlwZSI6InRleHQifV0="></div>
+data-postman-action="collection/fork"
+data-postman-var-1="7274195-66ef21d8-e159-4d7d-8ded-c511e1abe189"
+data-postman-collection-url="entityId=7274195-66ef21d8-e159-4d7d-8ded-c511e1abe189&entityType=collection&workspaceId=bf049f54-c695-4e91-b879-0cad1854bafa"
+data-postman-param="env%5BDatadog%20Authentication%5D=W3sia2V5IjoiYXBpX2tleSIsInZhbHVlIjoiIiwiZW5hYmxlZCI6dHJ1ZX0seyJrZXkiOiJhcHBsaWNhdGlvbl9rZXkiLCJ2YWx1ZSI6IiIsImVuYWJsZWQiOnRydWV9XQ=="></div>
 <script type="text/javascript">
   (function (p,o,s,t,m,a,n) {
     !p[s] && (p[s] = function () { (p[t] || (p[t] = [])).push(arguments); });


### PR DESCRIPTION
Updates to the new postman spec:

- https://docs-staging.datadoghq.com/kaylyn/postman-update/api/latest/
- https://docs-staging.datadoghq.com/kaylyn/postman-update/getting_started/api/

Clicking on the Postman button in each page should now take you to the September 22 version of the Postman spec.


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
