### PR TITLE
[WEB-1764] Updates announcement banner parameters for en and ja sites.

### DIFF
--- a/config/_default/params.en.yaml
+++ b/config/_default/params.en.yaml
@@ -4,8 +4,8 @@ meta_title: Getting Started with Datadog
 meta_description: Datadog, the leading service for cloud-scale monitoring.
 disclaimer: "This page is not yet available in English, we are working on its translation. <br> May you have any questions or feedback about our current translation project, <a href=\"https://docs.datadoghq.com/fr/help/\">feel free to reach out to us!</a>"
 announcement_banner:
-  desktop_message: "2021 State of Serverless Report"
-  mobile_message: "2021 State of Serverless Report"
-  external_link: "https://www.datadoghq.com/state-of-serverless/?utm_source=Advertisement&utm_medium=Advertisement&utm_campaign=Organic-TopBannerServerlessReport"
+  desktop_message: "Join us at the Dash virtual conference! October 26-27"
+  mobile_message: "Register for Dash! Oct 26-27"
+  external_link: "https://www.dashcon.io/?utm_source=Advertisement&utm_medium=Advertisement&utm_campaign=Organic-TopBannerDash"
 exclude: []
 translate_status_banner: "This translation isn't up to date, for the latest english version click here"

--- a/config/_default/params.ja.yaml
+++ b/config/_default/params.ja.yaml
@@ -4,8 +4,8 @@ meta_title: Datadogを始めてみましょう
 meta_description: Datadogが大規模なクラウドのモニタリングサービスをリードします。
 disclaimer: このページは日本語には対応しておりません。随時翻訳に取り組んでいます。翻訳に関してご質問やご意見ございましたら、お気軽にご連絡ください。
 announcement_banner:
-  desktop_message: 2021 State of Serverless レポート
-  mobile_message: 2021 State of Serverless レポート
-  external_link: https://www.datadoghq.com/state-of-serverless/?utm_source=Advertisement&utm_medium=Advertisement&utm_campaign=Organic-TopBannerServerlessReport
+  desktop_message: "Join us at the Dash virtual conference! October 26-27"
+  mobile_message: "Register for Dash! Oct 26-27"
+  external_link: "https://www.dashcon.io/?utm_source=Advertisement&utm_medium=Advertisement&utm_campaign=Organic-TopBannerDash"
 exclude: []
 translate_status_banner: このドキュメントは最新ではありません。最新版はこちらをクリックして英語版をご覧ください。


### PR DESCRIPTION
### What does this PR do?
Updates banner text for EN and JA sites, promoting Dash.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1764

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/update-banner-text/
https://docs-staging.datadoghq.com/brian.deutsch/update-banner-text/ja

Link should direct to the Dash website

Note: it looks like there is a pre-existing vertical alignment issue for the announcement banner text on the JA site.  i'll make a separate card to investigate as it appears to not be using our default JA font.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
