### PR TITLE
correct thresholds evaluation frequency

### DIFF
--- a/content/en/monitors/create/types/metric.md
+++ b/content/en/monitors/create/types/metric.md
@@ -113,8 +113,8 @@ The alert conditions vary slightly based on the chosen detection method.
 The evaluation frequency changes based on the evaluation time frame you select:
 
 * `timeframe < 24h`: evaluation performs every 1 minute.
-* `24h < timeframe < 48h`: evaluation performs every 10 minutes.
-* `timeframe > 48h`: evaluation performs every 30 minutes.
+* `24h <= timeframe < 48h`: evaluation performs every 10 minutes.
+* `timeframe >= 48h`: evaluation performs every 30 minutes.
 
 **Definitions**:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Correct the 24h and 48h evaluation window thresholds for the evaluation frequency of metric monitors

### Motivation
<!-- What inspired you to submit this pull request?-->
Nit in the thresholds

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/antoine.dussault/evaluation_frequency_metric_monitor/monitors/create/types/metric/#set-alert-conditions

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
