### PR TITLE
Updating monitor timeframes to include the behaviour at limits

### DIFF
--- a/content/en/monitors/create/types/metric.md
+++ b/content/en/monitors/create/types/metric.md
@@ -113,8 +113,8 @@ The alert conditions vary slightly based on the chosen detection method.
 The evaluation frequency changes based on the evaluation time frame you select:
 
 * `timeframe < 24h`: evaluation performs every 1 minute.
-* `24h < timeframe < 48h`: evaluation performs every 10 minutes.
-* `timeframe > 48h`: evaluation performs every 30 minutes.
+* `24h <= timeframe < 48h`: evaluation performs every 10 minutes.
+* `timeframe >= 48h`: evaluation performs every 30 minutes.
 
 **Definitions**:
 


### PR DESCRIPTION
### What does this PR do?
Update limites to show when the extreme values are included or not

### Motivation
It felt like 24h and 48h were not part of any group

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/metric-monitor-evaluation/monitors/create/types/metric/?tab=threshold#set-alert-conditions

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
