### PR TITLE
[WEB-1772] Pages with `is_beta: true` front matter should have `noindex,nofollow` meta tag

### DIFF
--- a/layouts/partials/noindex.html
+++ b/layouts/partials/noindex.html
@@ -1,3 +1,3 @@
-{{ if (or (eq .Params.beta true) (eq .Params.private true) (eq .Params.is_public false) (eq .Params.placeholder true) (eq .Site.Params.environment "preview") (eq .Params.noindex true) ) }}
+{{ if (or (eq .Params.beta true) (eq .Params.is_beta true) (eq .Params.private true) (eq .Params.is_public false) (eq .Params.placeholder true) (eq .Site.Params.environment "preview") (eq .Params.noindex true) ) }}
 <meta name="robots" content="noindex, nofollow">
 {{ end }}

--- a/layouts/partials/noindex.html
+++ b/layouts/partials/noindex.html
@@ -1,3 +1,5 @@
-{{ if (or (eq .Params.beta true) (eq .Params.is_beta true) (eq .Params.private true) (eq .Params.is_public false) (eq .Params.placeholder true) (eq .Site.Params.environment "preview") (eq .Params.noindex true) ) }}
+{{ $is_beta := or (eq .Params.beta true) (eq .Params.is_beta true) }}
+
+{{ if (or (eq $is_beta true) (eq .Params.private true) (eq .Params.is_public false) (eq .Params.placeholder true) (eq .Site.Params.environment "preview") (eq .Params.noindex true) ) }}
 <meta name="robots" content="noindex, nofollow">
 {{ end }}


### PR DESCRIPTION
### What does this PR do?
Pages with `is_beta: true` frontmatter should have `noindex,nofollow` meta tag.   Previously we had support for `beta: true` frontmatter only.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1772

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/no-index-beta-pages/.   Nothing to test here as all previews render the `noindex,nofollow` meta tag.   For testing pull down the branch locally and make sure this page has the meta tag: `metrics/faq/updating-to-distribution-metrics-faq/`.

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
