### PR TITLE
[WEB-1783] Updates `Watchdog` to `Datadog Watchdog` on homepage tiles.

### DIFF
--- a/.github/styles/Datadog/headings.yml
+++ b/.github/styles/Datadog/headings.yml
@@ -54,6 +54,7 @@ exceptions:
   - Datadog Lambda Extension
   - Datadog Operator
   - Datadog Plugin
+  - Datadog Watchdog
   - DatadogHook
   - Debian
   - Detection Rules

--- a/data/partials/home.fr.yaml
+++ b/data/partials/home.fr.yaml
@@ -72,7 +72,7 @@ nav_sections:
             link: mobile/
             icon: mobile
             desc: Consultez les alertes et les dashboards Datadog sur votre appareil mobile
-          - title: Watchdog
+          - title: Datadog Watchdog
             link: watchdog/
             icon: watchdog
             desc: Identifiez automatiquement les tendances de vos métriques d'application et d'infrastructure

--- a/data/partials/home.ja.yaml
+++ b/data/partials/home.ja.yaml
@@ -72,7 +72,7 @@ nav_sections:
             link: mobile/
             icon: mobile
             desc: Datadog アラートとダッシュボード をモバイル端末で表示
-          - title: Watchdog
+          - title: Datadog Watchdog
             link: watchdog/
             icon: watchdog
             desc: アプリケーションとインフラストラクチャーメトリクスの傾向を自動的に確認する

--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -80,7 +80,7 @@ nav_sections:
         link: mobile/
         icon: mobile
         desc: View Datadog alerts and dashboards on your mobile device
-      - title: Watchdog
+      - title: Datadog Watchdog
         link: watchdog/
         icon: watchdog
         desc: Automatically see trends in your applications & infrastructure metrics


### PR DESCRIPTION
### What does this PR do?
Updates `Watchdog` to `Datadog Watchdog` on homepage tiles.

### Motivation
legal request: https://datadoghq.atlassian.net/browse/WEB-1783

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/watchdog-name-update/
https://docs-staging.datadoghq.com/brian.deutsch/watchdog-name-update/ja
https://docs-staging.datadoghq.com/brian.deutsch/watchdog-name-update/fr

Tile should be updated from `Watchdog` -> `Datadog Watchdog`.    As per the request no other instances of the name should be changed yet.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
