### PR TITLE
Adding a blog post link

### DIFF
--- a/content/en/serverless/libraries_integrations/extension.md
+++ b/content/en/serverless/libraries_integrations/extension.md
@@ -5,6 +5,9 @@ further_reading:
     - link: 'serverless/custom_metrics'
       tag: 'Documentation'
       text: 'Submitting Custom Metrics from AWS Lambda'
+    - link: 'https://www.datadoghq.com/blog/aws-graviton2-lambda-monitoring/'
+      tag: 'Blog'
+      text: 'AWS Lambda Functions running on AWS Graviton2 processors'
 aliases:
     - /serverless/datadog_lambda_library/extension/
 ---


### PR DESCRIPTION
### What does this PR do?
Adds a blog post into further reading:
- https://docs-staging.datadoghq.com/kaylyn/writing-update/serverless/libraries_integrations/extension/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
