### PR TITLE
submit metrics missing body data

### DIFF
--- a/data/api/v1/translate_actions.json
+++ b/data/api/v1/translate_actions.json
@@ -695,7 +695,8 @@
   "SubmitMetrics": {
     "description": "The metrics end-point allows you to post time-series data that can be graphed on Datadog’s dashboards.\nThe maximum payload size is 3.2 megabytes (3200000 bytes). Compressed payloads must have a decompressed size of less than 62 megabytes (62914560 bytes).\n\nIf you’re submitting metrics directly to the Datadog API without using DogStatsD, expect:\n\n- 64 bits for the timestamp\n- 32 bits for the value\n- 20 bytes for the metric names\n- 50 bytes for the timeseries\n- The full payload is approximately 100 bytes. However, with the DogStatsD API,\ncompression is applied, which reduces the payload size.",
     "summary": "Submit metrics",
-    "request_description": ""
+    "request_description": "",
+    "request_schema_description": "The metrics' payload."
   },
   "ListServiceDependencies": {
     "description": "Get a list of services from APM and their dependencies. The services retrieved are filtered by environment and a\nprimary tag, if one is defined.",

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -39,7 +39,7 @@
             {{- with $requestBody.examples -}}
                 {{- range $exampleId, $exampleDefinition := . -}}
                     {{- $exampleValue := $exampleDefinition.value -}}
-                    {{- if hasPrefix $contentType "application/json" -}}
+                    {{- if (or (hasPrefix $contentType "application/json") (hasPrefix $contentType "text/json")) -}}
                         {{- $exampleValue = $exampleValue | jsonify (dict "indent" "  ") -}}
                     {{- end -}}
 ## {{ default $exampleId $exampleDefinition.summary }}

--- a/layouts/partials/api/request-body.html
+++ b/layouts/partials/api/request-body.html
@@ -16,7 +16,7 @@
 
   <div class="tab-content">
       {{ range $contentType, $content := $body.content }}
-          {{- if hasPrefix $contentType "application/json" -}}
+          {{- if (or (hasPrefix $contentType "application/json") (hasPrefix $contentType "text/json")) -}}
               {{ range $itemKey, $schema := $content }}
                   {{ if eq $itemKey "schema" }}
                       <!-- Get Json and HTML -->

--- a/src/scripts/build-api-pages.js
+++ b/src/scripts/build-api-pages.js
@@ -198,7 +198,7 @@ const getSchema = (content) => {
   const contentTypeKeys = Object.keys(content);
   const [firstContentType] = contentTypeKeys;
   contentTypeKeys.forEach((key) => {
-    if(key.startsWith("application/json")) {
+    if(key.startsWith("application/json") || key.startsWith("text/json")) {
       return content[key].schema;
     }
   });
@@ -895,6 +895,8 @@ const createTranslations = (apiYaml, deref, apiVersion) => {
           item['request_description'] = action.requestBody.description || '';
           if (action.requestBody.content && action.requestBody.content["application/json"]) {
             item['request_schema_description'] = action.requestBody.content["application/json"].schema.description || '';
+          } else if(action.requestBody.content && action.requestBody.content["text/json"]) {
+            item['request_schema_description'] = action.requestBody.content["text/json"].schema.description || '';
           }
         }
         /*


### PR DESCRIPTION
### What does this PR do?

Allow using `text/json` too in processing spec files

### Motivation

api discussions, missing body data in submit metrics page 

### Preview

Compare to same url on production and look at 
- `Body Data (required)` section 
- Curl example body
https://docs-staging.datadoghq.com/david.jones/text-json-fix/api/latest/metrics/#submit-metrics

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
