### PR TITLE
Specify that the Lambda Extension may be used with the Lambda Libraries

### DIFF
--- a/content/en/serverless/libraries_integrations/library.md
+++ b/content/en/serverless/libraries_integrations/library.md
@@ -33,7 +33,7 @@ The Datadog Lambda Library is responsible for:
 - Enabling [Datadog APM and Distributed Tracing][3] for Node.js, Python, and Ruby.
 
 If you are using the Datadog Lambda library for **Ruby** or **Java**, you **must** also install and configure the Datadog Forwarder to ingest traces, enhanced Lambda metrics, or custom metrics (asynchronously) from your Lambda functions.
-If you are using the Datadog Lambda library for **Python**, **Node**, or **Go**, you may use the [Datadog Lambda Extension][9] to ingest traces, enhanced Lambda metrics, or custom metrics; or you may continue to use Datadog Forwarder.
+If you are using the Datadog Lambda library for **Python**, **Node**, or **Go**, you may use the [Datadog Lambda Extension][9] to ingest traces, enhanced Lambda metrics, or custom metrics; or you may continue to use the Datadog Forwarder.
 
 The Datadog Lambda Library is **NOT** responsible for collecting:
 

--- a/content/en/serverless/libraries_integrations/library.md
+++ b/content/en/serverless/libraries_integrations/library.md
@@ -60,4 +60,4 @@ To install the Datadog Lambda library and instrument your serverless application
 [6]: /serverless/forwarder/
 [7]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
 [8]: /serverless/installation/
-[9]: /extension/
+[9]: /serverless/libraries_integrations/extension/

--- a/content/en/serverless/libraries_integrations/library.md
+++ b/content/en/serverless/libraries_integrations/library.md
@@ -32,7 +32,8 @@ The Datadog Lambda Library is responsible for:
 - Submitting [custom metrics][2] (synchronously and asynchronously).
 - Enabling [Datadog APM and Distributed Tracing][3] for Node.js, Python, and Ruby.
 
-You **must** also install and configure the Datadog Forwarder to ingest traces, enhanced Lambda metrics, or custom metrics (asynchronously) from your Lambda functions.
+If you are using the Datadog Lambda library for **Ruby** or **Java**, you **must** also install and configure the Datadog Forwarder to ingest traces, enhanced Lambda metrics, or custom metrics (asynchronously) from your Lambda functions.
+If you are using the Datadog Lambda library for **Python**, **Node**, or **Go**, you may use the [Datadog Lambda Extension][9] to ingest traces, enhanced Lambda metrics, or custom metrics; or you may continue to use Datadog Forwarder.
 
 The Datadog Lambda Library is **NOT** responsible for collecting:
 
@@ -59,3 +60,4 @@ To install the Datadog Lambda library and instrument your serverless application
 [6]: /serverless/forwarder/
 [7]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
 [8]: /serverless/installation/
+[9]: /extension/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Mentions that the Lambda Extension may be used with some Lambda Libraries. 

### Motivation
<!-- What inspired you to submit this pull request?-->
Support found this page contradictory, so I thought I'd clarify.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/chris.agocs/mention-lambda-extension-with-libraries/serverless/libraries_integrations/library/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
