### PR TITLE
Update wording for comparing DD_AGENT_HOST particularly for web servers

### DIFF
--- a/content/en/tracing/troubleshooting/connection_errors.md
+++ b/content/en/tracing/troubleshooting/connection_errors.md
@@ -214,7 +214,7 @@ See the table below for example setups. Some require setting up additional netwo
 | [Datadog Agent and Application Docker Containers][16] | Datadog Agent container |
 
 
-**Note about web servers**: If the `DD_AGENT_HOST` environment variable that you’re passing in is not picked up by the tracing library correctly, review how environment variables are cascaded for that specific server. For example, in PHP, there’s an additional setting to ensure that [Apache][17] or [Nginx][18] pick up the `DD_AGENT_HOST` environment variables correctly.
+**Note about web servers**: If the `agent_url` section in the [tracer startup logs][1] has a mismatch against the `DD_AGENT_HOST` environment variable that was passed in, review how environment variables are cascaded for that specific server. For example, in PHP, there’s an additional setting to ensure that [Apache][17] or [Nginx][18] pick up the `DD_AGENT_HOST` environment variable correctly.
 
 If your tracing library is sending traces correctly based on your setup, then proceed to the next step.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR updates the wording to specify comparing the `agent_url` and `DD_AGENT_HOST` in the case of web servers.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/clarify-web-servers/tracing/troubleshooting/connection_errors/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
