### PR TITLE
local dev fix

### DIFF
--- a/layouts/shortcodes/agent-config.html
+++ b/layouts/shortcodes/agent-config.html
@@ -2,7 +2,7 @@
   {{ errorf "Agent Config shortcode error: Missing value for param 'type': %s" .Position }}
 {{ end }}
 
-{{ $agent_config_data := $.Site.Data.agent_config }}
+{{ $agent_config_data := $.Site.Data.agent_config | default (dict) }}
 {{ $type := (.Get ("type")) | lower }}
 {{ $filename := .Get "filename" | default "Code example" }}
 {{ $collapsible := .Get "collapsible" }}
@@ -11,7 +11,11 @@
 {{ $config_data_string := trim $config_data "\n" }}
 
 {{ if eq $config_data nil }}
-  {{ errorf "Agent Config shortcode error: given 'type' param was not found in Agent config template.  Check agent_config_types_list.txt for list of available configuration types." }}
+  {{ if eq $.Site.Params.environment "development" }}
+    {{ warnf "Agent Config shortcode error: given 'type' param was not found in Agent config template.  Check agent_config_types_list.txt for list of available configuration types." }}
+  {{ else }}
+    {{ errorf "Agent Config shortcode error: given 'type' param was not found in Agent config template.  Check agent_config_types_list.txt for list of available configuration types." }}
+  {{ end }}
 {{ end }}
 
 <div class="code-snippet-wrapper">


### PR DESCRIPTION
### What does this PR do?

`make start-no-pre-build` fails with the following error:

```bash
Error: Error building site: "/Users/username/documentation/content/en/getting_started/logs/_index.md:49:5": failed to render shortcode "agent-config": failed to process shortcode: "/Users/username/documentation/layouts/shortcodes/agent-config.html:10:19": execute of template failed: template: shortcodes/agent-config.html:10:19: executing "shortcodes/agent-config.html" at <index $agent_config_data $type>: error calling index: index of untyped nil
```

Looks like the bug was introduced in #11709 

This PR fixes this by:
- setting default data when the datafile wasn't retrieved 
- switches to a warning on local development and error on other environments so as not to stop the build locally

### Motivation

slack reported

### Preview

Check that the code snippets here are still populating
https://docs-staging.datadoghq.com/david.jones/local-dev/getting_started/logs/

Locally you shouldn't have any build issue

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
