### PR TITLE
[PrivateLink] Remove custom configuration of dd_url and HTTP

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -28,16 +28,6 @@ The overall process consists of configuring an internal endpoint in your VPC tha
 
 ## Setup
 
-### Datadog Agent
-
-Update the `dd_url` parameter in your [datadog.yaml][2]:
-
-```yaml
-dd_url: https://agent.datadoghq.com
-```
-
-### AWS VPC endpoint
-
 1. Connect to the AWS console to region **us-east-1** and create a new VPC endpoint:
    {{< img src="agent/guide/private_link/create_vpc_endpoint.png" alt="Create VPC endpoint" style="width:60%;" >}}
 2. Select **Find service by name**.
@@ -91,7 +81,7 @@ dd_url: https://agent.datadoghq.com
 {{% /tab %}}
 {{< /tabs >}}
 
-4. Hit the _verify_ button. If it does not return _Service name found_, reach out to the [Datadog support team][3].
+4. Hit the _verify_ button. If it does not return _Service name found_, reach out to the [Datadog support team][2].
 5. Choose the VPC and subnets that should be peered with the Datadog VPC service endpoint.
 6. Make sure that for **Enable DNS name** the _Enable for this endpoint_ is checked:
    {{< img src="agent/guide/private_link/enabled_dns_private.png" alt="Enable DNS private" style="width:60%;" >}}
@@ -106,7 +96,7 @@ dd_url: https://agent.datadoghq.com
     {{< img src="agent/guide/private_link/vpc_status.png" alt="VPC status" style="width:60%;" >}}
 
     Once it shows _Available_, the AWS PrivateLink is ready to be used.
-11. If you are collecting logs data, ensure your Agent is configured to send logs over HTTPS. If it's not already there, add the following to the [Agent `datadog.yaml` configuration file][2]:
+11. If you are collecting logs data, ensure your Agent is configured to send logs over HTTPS. If it's not already there, add the following to the [Agent `datadog.yaml` configuration file][3]:
 
     ```yaml
     logs_config:
@@ -119,7 +109,7 @@ dd_url: https://agent.datadoghq.com
     DD_LOGS_CONFIG_USE_HTTP=true
     ```
 
-    This configuration is required when sending logs to Datadog with AWS PrivateLink. See [Agent log collection][4] for more details.
+    This configuration is required when sending logs to Datadog with AWS PrivateLink and the Datadog Agent. See [Agent log collection][4] for more details. This is not required for the Lambda Extension.
 12. [Restart your Agent][5] to send data to Datadog through AWS PrivateLink.
 
 ## Advanced usage
@@ -137,8 +127,8 @@ See [Amazon VPC peering][6] for more details.
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://aws.amazon.com/privatelink/
-[2]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
-[3]: /help/
+[2]: /help/
+[3]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 [4]: /agent/logs/?tab=tailexistingfiles#send-logs-over-https
 [5]: /agent/guide/agent-commands/#restart-the-agent
 [6]: https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html

--- a/content/en/serverless/guide/extension_private_link.md
+++ b/content/en/serverless/guide/extension_private_link.md
@@ -31,17 +31,13 @@ Add Datadog's Private Link endpoints to your VPC, as described in the [PrivateLi
 By default, the Extension uses different API endpoints than the Datadog Agent. Override the endpoints by setting the following environment variables on the Lambda function.
 
 ```
-DD_URL="https://agent.datadoghq.com"
-DD_LOGS_CONFIG_USE_HTTP=true
 DD_LOGS_CONFIG_LOGS_DD_URL="agent-http-intake.logs.datadoghq.com:443"
 ```
 
 Alternatively, you can configure the Extension by adding a [`datadog.yaml`][5] file in the same folder as the Lambda handler code.
 
 ```
-dd_url: https://agent.datadoghq.com
 logs_config:
-    use_http: true
     logs_dd_url: agent-http-intake.logs.datadoghq.com:443
 ```
 


### PR DESCRIPTION
### What does this PR do?

Removes custom configuration of dd_url and HTTP mode with PrivateLink

### Motivation

The Agent and Lambda extension don't require a custom dd_url with the new
metrics PrivateLink endpoint that's documented (`com.amazonaws.vpce.us-east-1.vpce-svc-09a8006e245d1e7b8`).

In addition, the Lambda extension doesn't need to have HTTP mode
explicitly configured (it already defaults to HTTP).

### Preview

https://docs-staging.datadoghq.com/olivier.vielpeau/private-link-no-dd-url/agent/guide/private-link

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
