### PR TITLE
Monitor template variables for all attributes & tags

### DIFF
--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -108,6 +108,8 @@ The message will render the `error.message` attribute of a chosen log matching t
 
 <div class="alert alert-info"><strong>Note</strong>: If the picked event does not contain the attribute or the tag key, the variable will render empty in the notification message. To avoid missing notifications, using these variables for routing notification with {{#is_match}} handles is not recommended.</div>
 
+##### Top level attributes
+
 Logs, spans and RUM events also have some first level attributes, that you can use in variables following the following syntax :
 
 | Monitor type    | Variable syntax                       | First level attributes |
@@ -115,6 +117,8 @@ Logs, spans and RUM events also have some first level attributes, that you can u
 | RUM             | `{{rum.key}}`                         | `service`, `status`, `timestamp` |
 | Trace Analytics | `{{span.key}}`                        | `env`, `operation_name`, `resource_name`, `service`, `status`, `span_id`, `timestamp`, `trace_id`, `type` |
 | Log             | `{{log.key}}`                         | `message`, `service`, `status`, `source`, `span_id`, `timestamp`, `trace_id` |
+
+##### Explorer link
 
 ### Check monitor variables
 

--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -84,9 +84,9 @@ If your facet has periods, use brackets around the facet, for example:
 {{ [@network.client.ip].name }}
 ```
 
-### Attributes and Tag variables
+### Attribute and Tag variables
 
-_Available for Log monitor, Trace Analytics monitor (APM) and RUM monitor_
+_Available for [Log monitor][3], [Trace Analytics monitor][4] (APM) and [RUM monitor][5]_
 
 To include **any** attribute or tag from an event matching the monitor query, use the following variables :
 
@@ -96,9 +96,9 @@ To include **any** attribute or tag from an event matching the monitor query, us
 | Trace Analytics |  `{{span.attributes.key}}` / `{{span.tags.key}}`        |
 | Log             |  `{{log.attributes.key}}` / `{{log.tags.key}}`          |
 
-For any `key:value` pair, the variable `{{log.attributes.key}}` renders `value` in the alert message.
+For any `key:value` pair, the variable `{{log.tags.key}}` renders `value` in the alert message.
 
-**Example**: if a log monitor is grouped by `@error_code`, to include the error message in the notification message, use the variable :
+**Example**: if a log monitor is grouped by `@error.code`, to include the error message in the notification message, use the variable :
 
 ```text
 {{ log.attributes.[error.message] }}
@@ -108,9 +108,9 @@ The message will render the `error.message` attribute of a chosen log matching t
 
 <div class="alert alert-info"><strong>Note</strong>: If the picked event does not contain the attribute or the tag key, the variable will render empty in the notification message. To avoid missing notifications, using these variables for routing notification with {{#is_match}} handles is not recommended.</div>
 
-##### Top level attributes
+#### First level attributes
 
-Logs, spans and RUM events also have some first level attributes, that you can use in variables following the following syntax :
+Logs, spans and RUM events have generic first level attributes, that you can also use in variables following the following syntax :
 
 | Monitor type    | Variable syntax                       | First level attributes |
 |-----------------|---------------------------------------|------------------------|
@@ -118,7 +118,11 @@ Logs, spans and RUM events also have some first level attributes, that you can u
 | Trace Analytics | `{{span.key}}`                        | `env`, `operation_name`, `resource_name`, `service`, `status`, `span_id`, `timestamp`, `trace_id`, `type` |
 | Log             | `{{log.key}}`                         | `message`, `service`, `status`, `source`, `span_id`, `timestamp`, `trace_id` |
 
-##### Explorer link
+If the matching event does not contain the attribute in its definition, the variable is rendered empty.
+
+#### Explorer link
+
+Use `{{log.link}}`, `{{rum.link}}` and `{{span.link}}` to enrich the notification with a link to the log, rum or trace explorer, scoped on the events matching the query.
 
 ### Check monitor variables
 
@@ -436,3 +440,6 @@ If `host.name` matches `<HOST_NAME>`, the template outputs:
 
 [1]: /monitors/guide/template-variable-evaluation/
 [2]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+[3]: /monitors/create/types/log/
+[4]: /monitors/create/types/apm/?tab=analytics
+[5]: /monitors/create/types/real_uscaer_monitoring/

--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -51,11 +51,9 @@ For example, if your monitor triggers for each `env`, then the variable `{{env.n
 
 For any `key:value` tag, the variable `{{key.name}}` renders `value` in the alert message. If a group is tagged with multiple `values` associated with the same `key`, the alert message will render a comma-separated string of all values, in the lexicographic order.
 
-<div class="alert alert-info"><strong>Note</strong>: Tag variables on single alert monitors are not supported. If you want to know the specific tag value that caused the alert, use a multi-alert monitor instead.</div>
-
 Variable content is escaped by default. To prevent content such as JSON or code from being escaped, use triple braces instead of double braces, for example: `{{{event.text}}}`.
 
-### Multi-alert group by host
+#### Multi-alert group by host
 
 If your monitor triggers an alert for each `host`, then the tag variables `{{host.name}}` and `{{host.ip}}` are available as well as any host tag that is available on this host.
 To see a list of tag variables based on your tag selection, click **Use message template variables** in the **Say what's happening** section.
@@ -66,25 +64,9 @@ Some specific host metadata are available as well:
 - Platform      : {{host.metadata_platform}}
 - Processor     : {{host.metadata_processor}}
 
+### Facet variables
 
-### Tag key with period
-
-If your tag's key has a period in it, include brackets around the full key when using a tag variable.
-For example, if your tag is `dot.key.test:five` and your monitor is grouped by `dot.key.test`, use:
-
-```text
-{{[dot.key.test].name}}
-```
-
-If the tag is on an event and you're using an event monitor, use:
-
-```text
-{{ event.tags.[dot.key.test] }}
-```
-
-### Log facet variables
-
-Log monitors can use facets as variables if the monitor is grouped by the facets.
+Log monitors, Trace Analytics monitors, RUM monitors and Event monitors can use facets as variables if the monitor is grouped by the facets.
 For example, if your log monitor is grouped by the `facet`, the variable is:
 
 ```text
@@ -95,13 +77,46 @@ For example, if your log monitor is grouped by the `facet`, the variable is:
 ```text
 This alert was triggered on {{ @machine_id.name }}
 ```
+
 If your facet has periods, use brackets around the facet, for example:
 
 ```text
 {{ [@network.client.ip].name }}
 ```
 
-#### Check monitor variables
+### Attributes and Tag variables
+
+_Available for Log monitor, Trace Analytics monitor (APM) and RUM monitor_
+
+To include **any** attribute or tag from an event matching the monitor query, use the following variables :
+
+| Monitor type    | Variable syntax                                         |
+|-----------------|---------------------------------------------------------|
+| RUM             |  `{{rum.attributes.key}}` / `{{rum.tags.key}}`          |
+| Trace Analytics |  `{{span.attributes.key}}` / `{{span.tags.key}}`        |
+| Log             |  `{{log.attributes.key}}` / `{{log.tags.key}}`          |
+
+For any `key:value` pair, the variable `{{log.attributes.key}}` renders `value` in the alert message.
+
+**Example**: if a log monitor is grouped by `@error_code`, to include the error message in the notification message, use the variable :
+
+```text
+{{ log.attributes.[error.message] }}
+```
+
+The message will render the `error.message` attribute of a chosen log matching the query, **if the attribute exists**
+
+<div class="alert alert-info"><strong>Note</strong>: If the picked event does not contain the attribute or the tag key, the variable will render empty in the notification message. To avoid missing notifications, using these variables for routing notification with {{#is_match}} handles is not recommended.</div>
+
+Logs, spans and RUM events also have some first level attributes, that you can use in variables following the following syntax :
+
+| Monitor type    | Variable syntax                       | First level attributes |
+|-----------------|---------------------------------------|------------------------|
+| RUM             | `{{rum.key}}`                         | `service`, `status`, `timestamp` |
+| Trace Analytics | `{{span.key}}`                        | `env`, `operation_name`, `resource_name`, `service`, `status`, `span_id`, `timestamp`, `trace_id`, `type` |
+| Log             | `{{log.key}}`                         | `message`, `service`, `status`, `source`, `span_id`, `timestamp`, `trace_id` |
+
+### Check monitor variables
 
 For check monitor variables (custom check and integration check), the variable `{{check_message}}` is available and renders the message specified in the custom check or the integration check.
 
@@ -116,6 +131,21 @@ For example, if your composite monitor has sub-monitor `a`, you can include the 
 ```
 
 Composite monitors can also utilize tag variables in the same way as their underlying monitors. They follow the same format as other monitors bearing in mind that the underlying monitors must all be grouped by the same tag/facet.
+
+#### Tag key with period
+
+If your tag's key has a period in it, include brackets around the full key when using a tag variable.
+For example, if your tag is `dot.key.test:five` and your monitor is grouped by `dot.key.test`, use:
+
+```text
+{{[dot.key.test].name}}
+```
+
+If the tag is on an event and you're using an event monitor, use:
+
+```text
+{{ event.tags.[dot.key.test] }}
+```
 
 ## Conditional variables
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update the monitor variables documentation page to add attribute and tag variables syntax guidelines to render all attributes and tags associated with events (for log, rum and trace analytics monitors)

### Motivation
<!-- What inspired you to submit this pull request?-->
Documentation for this [new feature](https://datadoghq.atlassian.net/browse/MNOTIF-989)

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/antoine.dussault/monitor_template_variables_attributes_tags/monitors/notify/variables

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
