### PR TITLE
Add Advanced Configuration Section for Raising Sampling Rate

### DIFF
--- a/content/en/database_monitoring/setup_mysql/advanced_configuration.md
+++ b/content/en/database_monitoring/setup_mysql/advanced_configuration.md
@@ -52,5 +52,20 @@ instances:
     quantize_sql_tables: true
 ```
 
+## Raising the sampling rate
+
+If you have queries that are relatively infrequent or execute very quickly, raising the sampling rate can help get
+samples collected. 
+
+Set the `collection_interval` in your database instance configuration in the Datadog Agent. Note that the default value is 1
+and raising the sampling rate requires _lowering_ this value to a smaller interval:
+
+```yaml
+instances:
+  - dbm: true
+    ...
+    query_samples:        
+        collection_interval: 0.1
+```
 
 [1]: https://dev.mysql.com/doc/refman/8.0/en/performance-schema-system-variables.html#sysvar_performance_schema_digests_size

--- a/content/en/database_monitoring/setup_mysql/advanced_configuration.md
+++ b/content/en/database_monitoring/setup_mysql/advanced_configuration.md
@@ -54,11 +54,9 @@ instances:
 
 ## Raising the sampling rate
 
-If you have queries that are relatively infrequent or execute very quickly, raising the sampling rate can help get
-samples collected. 
+If you have queries that are relatively infrequent or execute very quickly, raise the sampling rate by lowering the `collection_interval` value to collect samples more frequently. 
 
-Set the `collection_interval` in your database instance configuration in the Datadog Agent. Note that the default value is 1
-and raising the sampling rate requires _lowering_ this value to a smaller interval:
+Set the `collection_interval` in your database instance configuration of the Datadog Agent. The default value is 1. Lower the value to a smaller interval:
 
 ```yaml
 instances:

--- a/content/en/database_monitoring/setup_postgres/advanced_configuration.md
+++ b/content/en/database_monitoring/setup_postgres/advanced_configuration.md
@@ -44,11 +44,9 @@ instances:
 
 ## Raising the sampling rate
 
-If you have queries that are relatively infrequent or execute very quickly, raising the sampling rate can help get
-samples collected. 
+If you have queries that are relatively infrequent or execute very quickly, raise the sampling rate by lowering the `collection_interval` value to collect samples more frequently.
 
-Set the `collection_interval` in your database instance configuration in the Datadog Agent. Note that the default value is 1
-and raising the sampling rate requires _lowering_ this value to a smaller interval:
+Set the `collection_interval` in your database instance configuration of the Datadog Agent. The default value is 1. Lower the value to a smaller interval:
 
 ```yaml
 instances:

--- a/content/en/database_monitoring/setup_postgres/advanced_configuration.md
+++ b/content/en/database_monitoring/setup_postgres/advanced_configuration.md
@@ -41,3 +41,19 @@ instances:
     ...
     quantize_sql_tables: true
 ```
+
+## Raising the sampling rate
+
+If you have queries that are relatively infrequent or execute very quickly, raising the sampling rate can help get
+samples collected. 
+
+Set the `collection_interval` in your database instance configuration in the Datadog Agent. Note that the default value is 1
+and raising the sampling rate requires _lowering_ this value to a smaller interval:
+
+```yaml
+instances:
+  - dbm: true
+    ...
+    query_samples:        
+        collection_interval: 0.1
+```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a missing section in the advanced configuration to describe how to raise the sampling rate. This was linked to from the troubleshooting sections without any corresponding content in the advanced configuration pages.

### Motivation
A support question highlighted the gap in the documentation. 

### Preview

https://docs-staging.datadoghq.com/alex.normand/add-sampling-rate-advanced-configuration/database_monitoring/setup_mysql/advanced_configuration

https://docs-staging.datadoghq.com/alex.normand/add-sampling-rate-advanced-configuration/database_monitoring/setup_postgres/advanced_configuration

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
