### PR TITLE
Continuous Integration: add us3 region to docs

### DIFF
--- a/content/en/continuous_integration/_index.md
+++ b/content/en/continuous_integration/_index.md
@@ -12,8 +12,8 @@ further_reading:
 
 <div class="alert alert-info"><p>CI Visibility is in beta. There are no billing implications for tracing pipelines and tests during this period.</p>
 </div>
-{{< site-region region="us3,gov" >}}
-<div class="alert alert-info"><p>CI Visibility is available only on the US1 and EU1 Datadog sites at this time.</p></div>
+{{< site-region region="gov" >}}
+<div class="alert alert-info"><p>CI Visibility is available only on the US1, EU1 and US3 Datadog sites at this time.</p></div>
 {{< /site-region >}}
 
 Datadog Continuous Integration (CI) Visibility brings together information about CI test and pipeline results _plus_ data about CI performance, trends, and reliability, all into one place. Not only does it provide developers with the ability to dig into the reasons for a test or pipeline failure, to monitor trends in test suite execution times, or to see the effect a given commit has on the pipeline, it also gives build engineers visibility into cross-organization CI health and trends in pipeline performance over time.

--- a/content/en/continuous_integration/setup_pipelines/buildkite.md
+++ b/content/en/continuous_integration/setup_pipelines/buildkite.md
@@ -33,6 +33,15 @@ The Datadog integration for [Buildkite][2] works by using [webhooks][1] to send 
 [1]: https://app.datadoghq.eu/organization-settings/api-keys
 {{< /site-region >}}
 
+{{< site-region region="us3" >}}
+1. Go to **Settings > Notification Services** in Buildkite and add a new webhook:
+  * **Webhook URL**: `https://webhook-intake.us3.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
+  * **Events**: Select `job.finished` and `build.finished`.
+  * **Pipelines**: Select all pipelines or the subset of pipelines you want to trace.
+
+[1]: https://us3.datadoghq.com/organization-settings/api-keys
+{{< /site-region >}}
+
 2. Click **Add Webhook Notification** to save the new webhook.
 
 ## Visualize pipeline data in Datadog
@@ -52,6 +61,14 @@ The [Pipelines][1] and [Pipeline Executions][2] pages populate with data after t
 [2]: https://app.datadoghq.eu/ci/pipeline-executions
 {{< /site-region >}}
 
+{{< site-region region="us3" >}}
+
+The [Pipelines][1] and [Pipeline Executions][2] pages populate with data after the pipelines finish.
+
+[1]: https://us3.datadoghq.com/ci/pipelines
+[2]: https://us3.datadoghq.com/ci/pipeline-executions
+{{< /site-region >}}
+
 **Note**: The Pipelines page shows data for only the default branch of each repository.
 
 ## Further reading
@@ -63,6 +80,6 @@ The [Pipelines][1] and [Pipeline Executions][2] pages populate with data after t
 [3]: /getting_started/tagging/unified_service_tagging
 {{< /site-region >}}
 
-{{< site-region region="us3,gov" >}}
+{{< site-region region="gov" >}}
 This feature is not supported for the selected Datadog site ({{< region-param key="dd_site_name" >}}).
 {{< /site-region >}}

--- a/content/en/continuous_integration/setup_pipelines/circleci.md
+++ b/content/en/continuous_integration/setup_pipelines/circleci.md
@@ -39,6 +39,16 @@ The Datadog integration for [CircleCI][1] works by using [webhooks][2] to send d
 [1]: https://app.datadoghq.eu/account/settings#api
 {{< /site-region >}}
 
+{{< site-region region="us3" >}}
+1. For each project, go to **Project Settings > Webhooks** in CircleCI and add a new webhook:
+  * **Webhook URL**: `https://webhook-intake.us3.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
+  * **Name**: `Datadog CI Visibility` or any other identifier name that you want to provide.
+  * **Events**: Select `Workflow Completed` and `Job Completed`.
+  * **Certificate verifications**: Enable this check.
+
+[1]: https://us3.datadoghq.com/account/settings#api
+{{< /site-region >}}
+
 2. Click **Add Webhook** to save the new webhook.
 
 ## Visualize pipeline data in Datadog
@@ -59,6 +69,14 @@ The [Pipelines][1] and [Pipeline Executions][2] pages populate with data after t
 [2]: https://app.datadoghq.eu/ci/pipeline-executions
 {{< /site-region >}}
 
+{{< site-region region="us3" >}}
+
+The [Pipelines][1] and [Pipeline Executions][2] pages populate with data after the workflows finish.
+
+[1]: https://us3.datadoghq.com/ci/pipelines
+[2]: https://us3.datadoghq.com/ci/pipeline-executions
+{{< /site-region >}}
+
 **Note**: The Pipelines page shows data for only the default branch of each repository.
 
 ## Further reading
@@ -69,6 +87,6 @@ The [Pipelines][1] and [Pipeline Executions][2] pages populate with data after t
 [2]: https://circleci.com/docs/2.0/webhooks
 {{< /site-region >}}
 
-{{< site-region region="us3,gov" >}}
+{{< site-region region="gov" >}}
 This feature is not supported for the selected Datadog site ({{< region-param key="dd_site_name" >}}).
 {{< /site-region >}}

--- a/content/en/continuous_integration/setup_pipelines/custom_spans.md
+++ b/content/en/continuous_integration/setup_pipelines/custom_spans.md
@@ -7,7 +7,7 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
-{{< site-region region="us,eu" >}}
+{{< site-region region="us,eu,us3" >}}
 Custom spans provide a way to trace individual commands in your CI pipelines, allowing you to measure the time your command takes without taking into account any setup or teardown actions that the job might have (for example, downloading Docker images or waiting for an available node in a Kubernetes-based infrastructure). These spans appear as part of the pipeline's trace:
 
 {{< img src="ci/ci-custom-spans.png" alt="Details for a single pipeline with custom spans" style="width:100%;">}}
@@ -51,6 +51,14 @@ DATADOG_API_KEY=<api_key> DATADOG_SITE=datadoghq.eu datadog-ci trace \
   --name "Greet" \
   -- \
   echo "Hello World"
+{{< /code-block >}}
+{{< /site-region >}}
+{{< site-region region="us3" >}}
+{{< code-block lang="bash" >}}
+DATADOG_API_KEY=<api_key> DATADOG_SITE=us3.datadoghq.com datadog-ci trace \
+--name "Greet" \
+-- \
+echo "Hello World"
 {{< /code-block >}}
 {{< /site-region >}}
 
@@ -98,6 +106,6 @@ Additionally, configure the Datadog site to use the selected one ({{< region-par
 [1]: https://www.npmjs.com/package/@datadog/datadog-ci
 [2]: https://app.datadoghq.com/account/settings#api
 {{< /site-region >}}
-{{< site-region region="us3,gov" >}}
+{{< site-region region="gov" >}}
 The selected Datadog site ({{< region-param key="dd_site_name" >}}) does not support this feature.
 {{< /site-region >}}

--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -125,6 +125,13 @@ Go to **Settings > Webhooks** in your repository (or GitLab instance settings), 
 
 [1]: https://app.datadoghq.eu/account/settings#api
 {{< /site-region >}}
+{{< site-region region="us3" >}}
+* **URL**: `https://webhook-intake.us3.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is [your Datadog API key][1].
+* **Secret Token**: leave blank
+* **Trigger**: Select `Job events` and `Pipeline events`.
+
+[1]: https://us3.datadoghq.com/account/settings#api
+{{< /site-region >}}
 
 To set custom `env` or `service` parameters, add more query parameters in the webhooks URL: `&env=<YOUR_ENV>&service=<YOUR_SERVICE_NAME>`
 
@@ -148,6 +155,6 @@ After the integration is successfully configured, the [Pipelines][4] and [Pipeli
 [4]: https://app.datadoghq.com/ci/pipelines
 [5]: https://app.datadoghq.com/ci/pipeline-executions
 {{< /site-region >}}
-{{< site-region region="us3,gov" >}}
+{{< site-region region="gov" >}}
 The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported at this time.
 {{< /site-region >}}

--- a/content/en/continuous_integration/setup_tests/agent.md
+++ b/content/en/continuous_integration/setup_tests/agent.md
@@ -11,7 +11,7 @@ further_reading:
 
 ---
 
-{{< site-region region="us,eu" >}}
+{{< site-region region="us,eu,us3" >}}
 To report test results to Datadog, the [Datadog Agent][1] is required.
 
 There are two ways to set up the Agent in a CI environment:
@@ -48,7 +48,7 @@ To run the Datadog Agent as a container acting as a simple results forwarder, us
 **Required value**: `none`
 
 
-{{< site-region region="eu" >}}
+{{< site-region region="eu,us3" >}}
 Additionally, configure the Datadog site to use the selected one ({{< region-param key="dd_site_name" >}}):
 
 `DD_SITE` (Required)
@@ -161,6 +161,22 @@ test:
     - make test
 {{< /code-block >}}
 {{< /site-region >}}
+{{< site-region region="us3" >}}
+{{< code-block lang="yaml" filename=".gitlab-ci.yml" >}}
+variables:
+  DD_API_KEY: $DD_API_KEY
+  DD_INSIDE_CI: "true"
+  DD_HOSTNAME: "none"
+  DD_AGENT_HOST: "datadog-agent"
+  DD_SITE: "us3.datadoghq.com"
+
+test:
+  services:
+    - name: gcr.io/datadoghq/agent:latest
+  script:
+    - make test
+{{< /code-block >}}
+{{< /site-region >}}
 
 Add your [Datadog API key][2] to your [project environment variables][3] with the key `DD_API_KEY`.
 
@@ -204,6 +220,24 @@ jobs:
           DD_INSIDE_CI: "true"
           DD_HOSTNAME: "none"
           DD_SITE: "datadoghq.eu"
+    steps:
+      - run: make test
+{{< /code-block >}}
+{{< /site-region >}}
+{{< site-region region="us3" >}}
+{{< code-block lang="yaml" >}}
+jobs:
+  test:
+    services:
+      datadog-agent:
+        image: gcr.io/datadoghq/agent:latest
+        ports:
+          - 8126:8126
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_INSIDE_CI: "true"
+          DD_HOSTNAME: "none"
+          DD_SITE: "us3.datadoghq.com"
     steps:
       - run: make test
 {{< /code-block >}}
@@ -270,6 +304,31 @@ workflows:
       - test
 {{< /code-block >}}
 {{< /site-region >}}
+{{< site-region region="us3" >}}
+{{< code-block lang="yaml" filename=".circleci/config.yml" >}}
+version: 2.1
+
+orbs:
+  datadog-agent: datadog/agent@0
+
+jobs:
+  test:
+    docker:
+      - image: circleci/<language>:<version_tag>
+    environment:
+      DD_SITE: "us3.datadoghq.com"
+    steps:
+      - checkout
+      - datadog-agent/setup
+      - run: make test
+      - datadog-agent/stop
+
+workflows:
+  test:
+    jobs:
+      - test
+{{< /code-block >}}
+{{< /site-region >}}
 
 Add your [Datadog API key][2] to your [project environment variables][3] with the key `DD_API_KEY`.
 
@@ -323,6 +382,26 @@ services:
       - DD_AGENT_HOST=datadog-agent
 {{< /code-block >}}
 {{< /site-region >}}
+{{< site-region region="us3" >}}
+{{< code-block lang="yaml" filename="docker-compose.yml" >}}
+version: '3'
+services:
+  datadog-agent:
+    image: "gcr.io/datadoghq/agent:latest"
+    environment:
+      - DD_API_KEY
+      - DD_INSIDE_CI=true
+      - DD_HOSTNAME=none
+      - DD_SITE=us3.datadoghq.com
+    ports:
+      - 8126/tcp
+
+  tests:
+    build: .
+    environment:
+      - DD_AGENT_HOST=datadog-agent
+{{< /code-block >}}
+{{< /site-region >}}
 
 Alternatively, share the same network namespace between the Agent container and the tests container:
 
@@ -359,6 +438,23 @@ services:
     network_mode: "service:datadog-agent"
 {{< /code-block >}}
 {{< /site-region >}}
+{{< site-region region="us3" >}}
+{{< code-block lang="yaml" filename="docker-compose.yml" >}}
+version: '3'
+services:
+  datadog-agent:
+    image: "gcr.io/datadoghq/agent:latest"
+    environment:
+      - DD_API_KEY
+      - DD_INSIDE_CI=true
+      - DD_HOSTNAME=none
+      - DD_SITE=us3.datadoghq.com
+
+  tests:
+    build: .
+    network_mode: "service:datadog-agent"
+{{< /code-block >}}
+{{< /site-region >}}
 
 In this case, `DD_AGENT_HOST` is not required because it is `localhost` by default.
 
@@ -383,6 +479,6 @@ DD_API_KEY=<YOUR_DD_API_KEY> docker-compose up \
 [5]: https://docs.docker.com/compose/
 [6]: /continuous_integration/setup_tests/containers/
 {{< /site-region >}}
-{{< site-region region="us3,gov" >}}
+{{< site-region region="gov" >}}
 The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported at this time.
 {{< /site-region >}}

--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -10,7 +10,7 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
-{{< site-region region="us,eu" >}}
+{{< site-region region="us,eu,us3" >}}
 JUnit test report files are XML files that contain test execution information, such as test and suite names, pass/fail status, duration, and sometimes error logs. Although it was introduced by the [JUnit][1] testing framework, many other popular frameworks are able to output results using this format.
 
 As an alternative to instrumenting your tests natively using Datadog tracers, which is the recommended option as it provides the most comprehensive test results, you can also upload JUnit XML test reports.
@@ -47,6 +47,13 @@ DD_ENV=ci DATADOG_API_KEY=<api_key> datadog-ci junit upload \
 DD_ENV=ci DATADOG_API_KEY=<api_key> DATADOG_SITE=datadoghq.eu datadog-ci junit upload \
   --service my-api-service \
   unit-tests/junit-reports e2e-tests/single-report.xml
+{{< /code-block >}}
+{{< /site-region >}}
+{{< site-region region="us3" >}}
+{{< code-block lang="bash" >}}
+DD_ENV=ci DATADOG_API_KEY=<api_key> DATADOG_SITE=us3.datadoghq.com datadog-ci junit upload \
+--service my-api-service \
+unit-tests/junit-reports e2e-tests/single-report.xml
 {{< /code-block >}}
 {{< /site-region >}}
 
@@ -89,7 +96,7 @@ The following environment variables are supported:
 **Default**: (none)
 
 
-{{< site-region region="eu" >}}
+{{< site-region region="eu,us3" >}}
 Additionally, configure the Datadog site to use the selected one ({{< region-param key="dd_site_name" >}}):
 
 `DATADOG_SITE` (Required)
@@ -114,6 +121,6 @@ The Datadog CI CLI tries to extract git repository and commit metadata from CI p
 [3]: https://app.datadoghq.com/account/settings#api
 [4]: https://git-scm.com/downloads
 {{< /site-region >}}
-{{< site-region region="us3,gov" >}}
+{{< site-region region="gov" >}}
 The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported at this time.
 {{< /site-region >}}

--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -117,7 +117,7 @@ Set all these variables in your test target:
 **Recommended**: `$(SRCROOT)`<br/>
 **Example**: `/Users/ci/source/MyApp`
 
-{{< site-region region="eu" >}}
+{{< site-region region="eu,us3" >}}
 Additionally, configure the Datadog site to use the selected one ({{< region-param key="dd_site_name" >}}):
 
 `DD_SITE` (Required)
@@ -196,6 +196,15 @@ DD_TEST_RUNNER=1 DD_ENV=ci xcodebuild \
 {{< site-region region="eu" >}}
 {{< code-block lang="bash" >}}
 DD_TEST_RUNNER=1 DD_ENV=ci DD_SITE=datadoghq.eu xcodebuild \
+  -project "MyProject.xcodeproj" \
+  -scheme "MyScheme" \
+  -destination "platform=macOS,arch=x86_64" \
+  test
+{{< /code-block >}}
+{{< /site-region >}}
+{{< site-region region="us3" >}}
+{{< code-block lang="bash" >}}
+DD_TEST_RUNNER=1 DD_ENV=ci DD_SITE=us3.datadoghq.com xcodebuild \
   -project "MyProject.xcodeproj" \
   -scheme "MyScheme" \
   -destination "platform=macOS,arch=x86_64" \
@@ -542,6 +551,6 @@ Additional Git configuration for physical device testing:
 [1]: https://app.datadoghq.com/organization-settings/client-tokens
 
 {{< /site-region >}}
-{{< site-region region="us3,gov" >}}
+{{< site-region region="gov" >}}
 The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported at this time.
 {{< /site-region >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This PR updates the Continuous Integrations docs to reflect that `us3` is now a supported region for this product. All sections that were previously hidden for this region should be displayed now, and all region-dependent sections should have a `us3` section in addition to `us` and `eu`.

### Motivation

Our team has finished the deployment to this region, this should now be advertised to customers once we enable traffic.

### Preview

https://docs-staging.datadoghq.com/alexc/CIAPP-docs-us3/continuous_integration/

### Additional Notes

N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
