### PR TITLE
Add a clarification note about linking the framework with the app

### DIFF
--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -71,7 +71,7 @@ end
 
 3. If you run UITests, also link the app running the tests with this library.
 
-<div class="alert alert-warning"><strong>Note</strong>:  The framework is only useful for testing and it should only be linked with the application when running tests. The framework should not be distributed to final users. </div>
+<div class="alert alert-warning"><strong>Note</strong>: This framework is useful only for testing and should only be linked with the application when running tests. Do not distribute the framework to your users. </div>
 
 
 [1]: https://github.com/DataDog/dd-sdk-swift-testing/releases

--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -71,6 +71,8 @@ end
 
 3. If you run UITests, also link the app running the tests with this library.
 
+<div class="alert alert-warning"><strong>Note</strong>:  The framework is only useful for testing and it should only be linked with the application when running tests. The framework should not be distributed to final users. </div>
+
 
 [1]: https://github.com/DataDog/dd-sdk-swift-testing/releases
 {{% /tab %}}


### PR DESCRIPTION
### What does this PR do?
Add a clarification note about linking the framework with the app

### Motivation
This question was asked by a client to support team, lets try to avoid another user asking again

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nachoBonafonte/CI-app-Swift-clarify-linking-with-app/continuous_integration/setup_tests/swift

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
