### PR TITLE
APM > .NET > Restructure .NET Framework Setup docs

### DIFF
--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -54,139 +54,194 @@ For a full list of supported libraries and processor architectures, see [Compati
 
 ## Installation and getting started
 
-### Automatic instrumentation
-
 <div class="alert alert-warning">
-  <strong>Notes:</strong><br><ul><li>Datadog automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, APM). To ensure maximum visibility, run only one APM solution in your application environment.</li><li> If you are using both automatic and custom instrumentation, it is important to keep the package versions (for example, MSI and NuGet) in sync.</li></ul>
+  <strong>Note:</strong> Datadog automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, APM). To ensure maximum visibility, run only one APM solution in your application environment.
 </div>
 
-Follow these instructions to begin tracing .NET applications:
+### Installation overview
 
-#### Applications hosted in IIS
+1. [Install the tracer](#install-the-tracer)
+2. [Enable the tracer for your service](#enable-the-tracer-for-your-service)
+3. [Configure the Datadog Agent for APM](#configure-the-datadog-agent-for-apm)
+4. [View your live data](#view-your-live-data)
 
-To start tracing an application hosted in IIS:
+### Install the tracer
 
-1. Install and configure the [Windows Datadog Agent][2].
+You can install the Datadog .NET Tracer machine-wide so that all services on the machine are instrumented, or you can install it on a per-application basis to allow developers to manage the instrumentation through the application’s dependencies. To see machine-wide installation instructions, click the Windows tab. To see per-application installation instructions, click the NuGet tab.
 
-2. Download the .NET Tracer [MSI installer][3]. Select the MSI installer for the architecture that matches the operating system (x64 or x86).
+{{< tabs >}}
 
-3. Run the .NET Tracer MSI installer with administrator privileges.
+{{% tab "Windows" %}}
 
-4. Stop, then start IIS using the following commands as an administrator:
+To install the .NET Tracer machine-wide:
 
-    <div class="alert alert-warning">
-      <strong>Note:</strong> You must use a stop and start command. This is not the same as a reset or restart command.
-    </div>
+1. Download the [.NET Tracer MSI installer][1]. Select the MSI installer for the architecture that matches the operating system (x64 or x86).
 
-    ```text
-    net stop /y was
-    net start w3svc
-    ```
-5. Create application load.
+2. Run the .NET Tracer MSI installer with administrator privileges.
 
-6. Visit [APM Live Traces][4].
 
-#### Applications not hosted in IIS
+[1]: https://github.com/DataDog/dd-trace-dotnet/releases
+{{% /tab %}}
 
-To enable automatic instrumentation on Windows applications not in IIS, you must set two environment variables before starting your application:
-
-| Name                   | Value                                    |
-| ---------------------- | ---------------------------------------- |
-| `COR_ENABLE_PROFILING` | `1`                                      |
-| `COR_PROFILER`         | `{846F5F1C-F9AE-4B07-969E-05C26BC060D8}` |
+{{% tab "NuGet" %}}
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> The .NET runtime tries to load a profiler into any .NET process started with these environment variables set. You should limit instrumentation only to the applications that need to be traced. Don't set these environment variables globally because this causes all .NET processes on the host to load the profiler.
+  <strong>Note:</strong> This installation will not instrument applications running in IIS. To instrument applications running in IIS, follow the Windows machine-wide installation process.
 </div>
 
-##### Windows services
-To automatically instrument a Windows service, set the `COR_ENABLE_PROFILING` and `COR_PROFILER` environment variables:
+To install the .NET Tracer per-application:
 
-1. In the Windows Registry Editor, create a multi-string value named `Environment` in  `HKLM\System\CurrentControlSet\Services\<SERVICE NAME>`
-2. Set the value data to:
+1. Add the `Datadog.Monitoring.Distribution` [NuGet package][1] to your application.
 
-   ```text
+
+[1]: https://www.nuget.org/packages/Datadog.Monitoring.Distribution
+{{% /tab %}}
+
+{{< /tabs >}}
+
+### Enable the tracer for your service
+
+Enabling the .NET Tracer for your service involves setting the required environment variables, and restarting the application. For information about different methods for setting environment variables, see [Configuring process environment variables](#configuring-process-environment-variables).
+
+{{< tabs >}}
+
+{{% tab "Windows" %}}
+
+#### Internet Information Services (IIS)
+
+1. The .NET Tracer MSI installer adds all of the required environment variables, so there are no environment variables to configure.
+
+2. To automatically instrument applications hosted in IIS, completely stop and start IIS by running the following commands as an administrator:
+
+   ```cmd
+   net stop /y was
+   net start w3svc
+   ```
+
+   <div class="alert alert-warning">
+     <strong>Note:</strong> Use <code>stop</code> and <code>start</code> commands. A reset or restart will not always work.
+   </div>
+
+
+#### Services not in IIS
+
+1. Set the following required environment variables for automatic instrumentation to attach to your application:
+
+   ```
    COR_ENABLE_PROFILING=1
    COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
    ```
-     {{< img src="tracing/setup/dotnet/RegistryEditorFramework.png" alt="Registry Editor"  >}}
+2. For standalone applications and Windows services, manually restart the application as you normally would.
 
-Alternatively, you can set the environment variables by using the following PowerShell snippet:
+{{% /tab %}}
 
-   {{< code-block lang="powershell" filename="add-env-var.ps1" >}}
-   [String[]] $v = @("COR_ENABLE_PROFILING=1", "COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}")
-   Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\<NAME> -Name Environment -Value $v
-   {{< /code-block >}}
+{{% tab "NuGet" %}}
 
-##### Console applications
+1. Set the following required environment variables for automatic instrumentation to attach to your application:
 
-To automatically instrument a console application, set the `COR_ENABLE_PROFILING` and `COR_PROFILER` environment variables from a batch file before starting your application:
+   ```
+   COR_ENABLE_PROFILING=1
+   COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+   COR_PROFILER_PATH=<System-dependent path>
+   DD_INTEGRATIONS=<APP_DIRECTORY>/datadog/integrations.json
+   DD_DOTNET_TRACER_HOME=<APP_DIRECTORY>/datadog
+   ```
 
-```bat
-rem Set environment variables
-SET COR_ENABLE_PROFILING=1
-SET COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+   The value for the `COR_PROFILER_PATH` environment variable varies based on the system where the application is running:
 
-rem Start application
-example.exe
-```
+   Operating System and Process Architecture | COR_PROFILER_PATH Value
+   ------------------------------------------|----------------------------
+   Windows x64      | `<APP_DIRECTORY>\datadog\win-x64\Datadog.Trace.ClrProfiler.Native.dll`
+   Windows x86      | `<APP_DIRECTORY>\datadog\win-x86\Datadog.Trace.ClrProfiler.Native.dll`
+
+2. For standalone applications, manually restart the application as you normally would.
+
+
+{{% /tab %}}
+
+{{< /tabs >}}
+
 ### Configure the Datadog Agent for APM
 
-Install and configure the Datadog Agent to receive traces from your instrumented application. By default the Datadog Agent is enabled in your [datadog.yaml][5] file under `apm_config` with `enabled: true` and listens for trace traffic at `receiver_port:8126`.
+[Install and configure the Datadog Agent][2] to receive traces from your instrumented application. By default the Datadog Agent is enabled in your `datadog.yaml` file under `apm_config` with `enabled: true` and listens for trace traffic at `localhost:8126`. For containerized, serverless, and cloud environments:
 
-{{< agent-config type="trace collection configuration" filename="config_template.yaml" collapsible="true">}}
+{{< tabs >}}
 
-For containerized environments, follow the in-app [Quickstart instructions][2] to enable trace collection within the Datadog Agent.
+{{% tab "Containers" %}}
 
-{{< site-region region="us3,eu,gov" >}}
+1. Set `apm_non_local_traffic: true` in the `apm_config` section of your main [`datadog.yaml` configuration file][1].
 
-Ensure you set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" code="true" >}} so that the Agent sends data to the right Datadog location.
+2. See the specific setup instructions to ensure that the Agent is configured to receive traces in a containerized environment:
+
+{{< partial name="apm/apm-containers.html" >}}
+</br>
+
+3. After instrumenting your application, the tracing client sends traces to `localhost:8126` by default.  If this is not the correct host and port change it by setting the `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` environment variables. See [Configuration](#configuration) for more information on how to set these variables.
+
+{{< site-region region="us3,eu,gov" >}} 
+
+4. Set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
 
 {{< /site-region >}}
 
-## Custom instrumentation
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
+{{% /tab %}}
 
-<div class="alert alert-warning">
-  <strong>Note:</strong> If you are using both automatic and custom instrumentation, it is important to keep the package versions (for example, MSI and NuGet) in sync.
-</div>
+{{% tab "AWS Lambda" %}}
 
-To use custom instrumentation in your .NET application:
-1. Add the `Datadog.Trace` [NuGet package][6] to your application.
-2. In your application code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
+To set up Datadog APM in AWS Lambda, see the [Tracing Serverless Functions][1] documentation.
 
-For additional details on custom instrumentation and custom tagging, see the [.NET Custom Instrumentation documentation][7].
+
+
+[1]: /tracing/serverless_functions/
+{{% /tab %}}
+
+{{% tab "Azure App Service" %}}
+
+To set up Datadog APM in Azure App Service, see the [Tracing Azure App Service Extension][1] documentation.
+
+
+[1]: /serverless/azure_app_services/
+{{% /tab %}}
+
+{{% tab "Other Environments" %}}
+
+Tracing is available for a number of other environments, such as [Heroku][1], [Cloud Foundry][2], and [AWS Elastic Beanstalk][3].
+
+For other environments, see the [Integrations][4] documentation for that environment and [contact support][5] if you are encountering setup issues.
+
+
+[1]: /agent/basic_agent_usage/heroku/#installation
+[2]: /integrations/cloud_foundry/#trace-collection
+[3]: /integrations/amazon_elasticbeanstalk/
+[4]: /integrations/
+[5]: /help/
+{{% /tab %}}
+
+{{< /tabs >}}
+
+### View your live data
+
+After enabling the .NET Tracer for your service:
+
+1. Restart your service.
+
+2. Create application load.
+
+3. Visit [APM Live Traces][3].
 
 ## Configuration
 
 {{< img src="tracing/dotnet/diagram_docs_net.png" alt=".NET Tracer configuration setting precedence"  >}}
 
-The .NET Tracer has configuration settings which you can set by any of these methods:
+The .NET Tracer has configuration settings that you can set by any of these methods:
 
 {{< tabs >}}
 
 {{% tab "Environment variables" %}}
 
-To configure the tracer using environment variables, set the variables before launching the instrumented application.
+To configure the tracer using environment variables, set the variables before launching the instrumented application. To learn how to set environment variables in different environments, see [Configuring process environment variables](#configuring-process-environment-variables).
 
-For example:
-
-```cmd
-rem Set environment variables
-SET DD_TRACE_AGENT_URL=http://localhost:8126
-SET DD_ENV=prod
-SET DD_SERVICE=MyService
-SET DD_VERSION=abc123
-
-rem Launch application
-example.exe
-```
-
-<div class="alert alert-warning">
-<strong>Note:</strong> To set environment variables for a Windows Service, use the multi-string key <code>HKLM\System\CurrentControlSet\Services\{service name}\Environment</code> in the Windows Registry, as described above.
-<br />
-<br />
-Because IIS runs all applications under one Windows Service, Datadog recommends you use another configuration option (Code, web.config, or JSON file) for application-specific settings such as <code>DD_SERVICE</code>.
-</div>
 
 {{% /tab %}}
 
@@ -260,7 +315,7 @@ Using the methods described above, customize your tracing configuration with the
 
 #### Unified Service Tagging
 
-To use [Unified Service Tagging][8], configure the following settings for your services:
+To use [Unified Service Tagging][4], configure the following settings for your services:
 
 `DD_ENV`
 : **TracerSettings property**: `Environment`<br>
@@ -294,6 +349,14 @@ Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_T
 `DD_LOGS_INJECTION`
 : **TracerSettings property**: `LogsInjectionEnabled` <br>
 Enables or disables automatic injection of correlation identifiers into application logs.
+
+`DD_MAX_TRACES_PER_SECOND`
+: **TracerSettings property**: `MaxTracesSubmittedPerSecond` <br>
+The number of traces allowed to be submitted per second.
+
+`DD_TRACE_GLOBAL_TAGS`
+: **TracerSettings property**: `GlobalTags`<br>
+If specified, adds all of the specified tags to all generated spans.
 
 `DD_TRACE_DEBUG`
 : **TracerSettings property**: `DebugEnabled` <br>
@@ -359,11 +422,11 @@ The following table lists configuration variables that are available **only** wh
 
 `DD_DISABLED_INTEGRATIONS`
 : **TracerSettings property**: `DisabledIntegrationNames` <br>
-Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][9] section.
+Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][5] section.
 
 `DD_TRACE_<INTEGRATION_NAME>_ENABLED`
 : **TracerSettings property**: `Integrations[<INTEGRATION_NAME>].Enabled` <br>
-Enables or disables a specific integration. Valid values are: `true` or `false`. Integration names are listed in the [Integrations][9] section.<br>
+Enables or disables a specific integration. Valid values are: `true` or `false`. Integration names are listed in the [Integrations][5] section.<br>
 **Default**: `true`
 
 #### Experimental features
@@ -378,16 +441,82 @@ The following configuration variables are for features that are available for us
 : Enables incrementally flushing large traces to the Datadog Agent, reducing the chance of rejection by the Agent. Use only when you have long-lived traces or traces with many spans. Valid values are `true` or `false`. Added in version 1.26.0, only compatible with the Datadog Agent 7.26.0+.<br>
 **Default**: `false`
 
+## Custom instrumentation
+
+Setting up to do custom instrumentation depends first setting up automatic instrumentation, and then these additional steps, depending on which method you used:
+
+{{< tabs >}}
+
+{{% tab "Windows" %}}
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> If you are using both automatic and custom instrumentation, it is important to keep the package versions (for example, MSI and NuGet) in sync.
+</div>
+
+To use custom instrumentation in your .NET application:
+1. Add the `Datadog.Trace` [NuGet package][1] to your application.
+2. In your application code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
+
+
+[1]: https://www.nuget.org/packages/Datadog.Trace
+{{% /tab %}}
+
+{{% tab "NuGet" %}}
+
+To use custom instrumentation in your .NET application:
+1. In your application code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
+
+{{% /tab %}}
+
+{{< /tabs >}}
+
+For additional details on adding spans and tags for custom instrumentation, see the [.NET Custom Instrumentation documentation][6].
+
+## Configuring process environment variables
+
+For automatic instrumentation to attach to your service, you must set required the environment variables before starting the application. Refer back to the [Enable the tracer for your service](#enable-the-tracer-for-your-service) section to identify which environment variables must be set according to your .NET Tracer installation method, and follow the examples below to correctly set the environment variables based on the environment of the instrumented service.
+
+### Windows
+
+#### Windows services
+
+Using the Registry Editor:
+
+In the Registry Editor, create a multi-string value called `Environment` in the `HKLM\System\CurrentControlSet\Services\<SERVICE NAME>` key and set the value data to:
+```text
+COR_ENABLE_PROFILING=1
+COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+```
+
+{{< img src="tracing/setup/dotnet/RegistryEditorCore.png" alt="Using the Registry Editor to create environment variables for a Windows service" >}}
+
+Using PowerShell:
+
+```powershell
+[string[]] $v = @("COR_ENABLE_PROFILING=1", "COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}")
+Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\<SERVICE NAME> -Name Environment -Value $v
+```
+
+#### Console applications
+
+To automatically instrument a console application, set the environment variables from a batch file before starting your application:
+
+```bat
+rem Set environment variables
+SET COR_ENABLE_PROFILING=1
+SET COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+
+rem Start application
+dotnet.exe example.dll
+```
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing/compatibility_requirements/dotnet-framework
-[2]: https://docs.datadoghq.com/agent/basic_agent_usage/windows/?tab=gui
-[3]: https://github.com/datadog/dd-trace-dotnet/releases/latest
-[4]: https://app.datadoghq.com/apm/traces
-[5]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
-[6]: https://www.nuget.org/packages/Datadog.Trace
-[7]: /tracing/custom_instrumentation/dotnet/
-[8]: /getting_started/tagging/unified_service_tagging/
-[9]: /tracing/setup_overview/compatibility_requirements/dotnet-framework/#integrations
+[2]: /agent/
+[3]: https://app.datadoghq.com/apm/traces
+[4]: /getting_started/tagging/unified_service_tagging/
+[5]: /tracing/setup_overview/compatibility_requirements/dotnet-framework/#integrations
+[6]: /tracing/setup_overview/custom_instrumentation/dotnet/


### PR DESCRIPTION
### What does this PR do?
This PR restructures the .NET Framework setup docs to accommodate a new installation mechanism for the .NET Tracer: An app-local NuGet package

### Motivation
PR #11627 modified the .NET Core setup docs to accommodate the new installation mechanism. This PR updates the .NET Framework docs to match the .NET Core docs, with the following changes:
- Removes the Linux steps (.NET Framework is Windows-only)
- Renames the CORECLR* environment variables to COR* environment variables (for .NET Framework)

### Preview
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-framework-nuget-package/tracing/setup_overview/setup/dotnet-framework/?tab=windows

### Additional Notes
The changes look just as large as the .NET Core changes in #11627, but if you compare the two files `/content/en/tracing/setup_overview/setup/dotnet-core.md` and `/content/en/tracing/setup_overview/setup/dotnet-framework.md`, you'll see that the diff is relatively small.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
