### PR TITLE
fix doc

### DIFF
--- a/content/en/security_platform/security_monitoring/log_detection_rules.md
+++ b/content/en/security_platform/security_monitoring/log_detection_rules.md
@@ -240,7 +240,7 @@ This JSON object is an example of event attributes which may be associated with 
 You could use the following in the “say what’s happening” section:
 
 ```
-{{@usr.id}} just logged in without MFA from {@network.client.ip}.
+{{@usr.id}} just logged in without MFA from {{@network.client.ip}}.
 ```
 
 And this would be rendered as the following:


### PR DESCRIPTION
Double brackets should be used in templates, not single ones.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
