### PR TITLE
Fix phrasing for section with variable steps.

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -197,7 +197,7 @@ If you prefer to manually correlate your traces with your logs, you can add corr
 
 **Note:** If you are not using a [Datadog Log Integration][7] to parse your logs, custom log parsing rules must parse `dd.trace_id` and `dd.span_id` as strings. For information, see the [FAQ on this topic][8].
 
-After completing Step 1 and 2 [above](#getting-started), finish your manual log enrichment setup:
+After completing the [getting started steps](#getting-started), finish your manual log enrichment setup:
 
 1. Reference the [`Datadog.Trace` NuGet package][9] in your project.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes phrasing for a sentence

### Motivation
There are some getting started tabs that have more than two steps, and the link text wasn't great for this link.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
