### PR TITLE
DOCS-2600 Getting Started with Session Replay Banner + RUM & Session Replay Product Landing Page Edits

### DIFF
--- a/content/en/real_user_monitoring/_index.md
+++ b/content/en/real_user_monitoring/_index.md
@@ -41,7 +41,7 @@ Datadog's *Real User Monitoring (RUM)* gives you end-to-end visibility into the 
 
 Datadog's _Session Replay_ allows you to capture and visually replay the web browsing experience of your users. Combined with RUM performance data, Session Replay is beneficial for error identification, reproduction, and resolution, and provides insights into your web application’s usage patterns and design pitfalls. For more information, see [Getting Started with Session Replay][1].
 
-<div class="alert alert-info"><p>Session Replay is in beta. There are no billing implications for your Session Replays during this period.</p><p>Session Replay is available only on <a href="/getting_started/site/">the US1 Datadog site</a>. If you're using a different region, sign up with <a href="https://www.datadoghq.com/session-replay-beta-request-form/">this form</a>.</p>
+<div class="alert alert-info"><p>Session Replay is in open beta. There are no billing implications for your Session Replays during this period.</p><p>Session Replay is available on <a href="/getting_started/site/">US1 and EU Datadog sites</a>.</p>
 </div>
 
 ## Get started

--- a/content/en/real_user_monitoring/guide/session-replay-getting-started.md
+++ b/content/en/real_user_monitoring/guide/session-replay-getting-started.md
@@ -11,7 +11,7 @@ further_reading:
       text: 'Use Datadog Session Replay to view real-time user journeys'
 ---
 
-<div class="alert alert-info"><p>Session Replay is in beta. There are no billing implications for the Session Replays during this period. If you have any questions, email <a href="mailto:support@datadoghq.com">support@datadoghq.com</a>.</p><p>Session Replay is available only on <a href="/getting_started/site/">the US1 Datadog site</a>. If you're using a different region, sign up with <a href="https://www.datadoghq.com/session-replay-beta-request-form/">this form</a>.</p>
+<div class="alert alert-info"><p>Session Replay is in open beta. There are no billing implications for the Session Replays during this period. If you have any questions, email <a href="mailto:support@datadoghq.com">support@datadoghq.com</a>.</p><p>Session Replay is available on <a href="/getting_started/site/">US1 and EU Datadog sites</a>.</p>
 </div>
 
 ## What is Session Replay?


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Remove EU beta form from Getting Started with Session Replay and RUM & Session Replay product landing page.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-2600

### Preview

https://docs-staging.datadoghq.com/alai97/session-replay-beta-banner-improvements/real_user_monitoring/guide/session-replay-getting-started/

https://docs-staging.datadoghq.com/alai97/session-replay-beta-banner-improvements/real_user_monitoring/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
