### PR TITLE
Updating Docker deprecation guide

### DIFF
--- a/content/en/agent/guide/docker-deprecation.md
+++ b/content/en/agent/guide/docker-deprecation.md
@@ -9,7 +9,7 @@ Kubernetes is deprecating Docker as a runtime starting after version 1.20, and s
 
 - GKE 1.19 [deprecated Docker and uses containerd by default, on new nodes][2].
 
-- EKS 1.22 [will deprecate Docker and use containerd by default][3].
+- EKS 1.22 [deprecates Docker and uses containerd by default][3].
 
 If you are running a version of Kubernetes where Docker has been deprecated, the Docker socket is no longer present, or has no information about the containers running by Kubernetes, and the Docker check does not work. You can find details about Docker runtime on [kubernetes.io][4]. This means that you must enable either the [containerd][5] or the [CRI-O][6] check depending on the container runtime you are using. The container metrics collected from the new container runtime replace the Docker metrics.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
EKS announced that they are deprecating docker in version 1.22, so it adds this information. Also, adds minor changes about agent version and the relevant helm parameter 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
