### PR TITLE
[privatelink] you don't need to set dd_url for privatelink

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -28,14 +28,6 @@ The overall process consists of configuring an internal endpoint in your VPC tha
 
 ## Setup
 
-### Datadog Agent
-
-Update the `dd_url` parameter in your [datadog.yaml][2]:
-
-```yaml
-dd_url: https://agent.datadoghq.com
-```
-
 ### AWS VPC endpoint
 
 1. Connect to the AWS console to region **us-east-1** and create a new VPC endpoint:


### PR DESCRIPTION
### What does this PR do?
Removes outdated information with regards to agent configuration when using PrivateLink.

### Motivation
While it was true in previous generations of our PrivateLink offering, the current generation of PrivateLink endpoints (as currently documented within this article) do not require you to set the `dd_url` in `datadog.yaml`.  The agent-versioned hostnames work just fine, and calling this out as a requirement to deploy PrivateLink can hinder the adoption of PrivateLink, as orgs think they will need to do a fleet-wide agent change to make use of PrivateLink.

### Preview
Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/rtdean/privatelink-doesnt-need-ddurl/agent/guide/private-link/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.