### PR TITLE
Update logs_config for Vector aggregator for v2 API

### DIFF
--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -46,7 +46,7 @@ logs_config:
   logs_dd_url: "<VECTOR_HOST>:<VECTOR_PORT>"
   logs_no_ssl: true # If TLS/SSL is not enabled on the Vector side
   use_http: true # Vector `datadog_logs` source only supports events over HTTP(S) and not raw TCP
-  # use_v2_api: false # If using Vector < v0.17.0
+  # use_v2_api: false # Uncomment this line if you use a version of Vector before v0.17.0
 ```
 
 Where `VECTOR_HOST` is the hostname of the system running Vector and `VECTOR_PORT` is the TCP port on which


### PR DESCRIPTION
v0.17.0 of Vector supports the v2 logs API now so this option is only
required when using an older version of Vector.

Closes: https://github.com/vectordotdev/vector/issues/9370

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
