### PR TITLE
Fix typo in PHP tracer setup page

### DIFF
--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -779,7 +779,7 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys <SIGNING KEY FROM UBUNT
 apt update
 ```
 
-Try againg the canonical package names for debug symbols. For example, if the package name is `php7.2-fpm` try:
+Try adding the canonical package names for debug symbols. For example, if the package name is `php7.2-fpm` try:
 
 ```
 apt install -y php7.2-fpm-dbgsym


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes typo

### Motivation
Report from translator

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/typo-php/tracing/setup_overview/setup/php/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
