### PR TITLE
Document limits for enrichment table beta

### DIFF
--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -31,7 +31,7 @@ Click **New Enrichment Table +**, then upload a CSV file, name the appropriate c
 
 {{< img src="logs/guide/enrichment-tables/configure-enrichment-table.png" alt="Create an Enrichment Table" style="width:100%;">}}
 
-**Note**: The manual CSV upload method supports files up to 5MB
+**Note**: The manual CSV upload method supports files up to 5MB.
 
 {{% /tab %}}
 
@@ -67,7 +67,7 @@ Click **New Enrichment Table +**, then add a name, select AWS S3, fill out all f
 
 {{< img src="logs/guide/enrichment-tables/configure-s3-enrichment-table.png" alt="Create an Enrichment Table" style="width:100%;">}}
 
-**Note**: The upload from a S3 bucket method supports files up to 3GB
+**Note**: The upload from an S3 bucket method supports files up to 3GB.
 
 [1]: https://app.datadoghq.com/account/settings#integrations/amazon-web-services
 [2]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#installation


### PR DESCRIPTION
### What does this PR do?
Add limits about file size for enrichment table upload as well as max number of tables during the beta

### Motivation
Those limits were not documented and users faced issues when trying to upload bigger files.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/enrichment-beta-limits/logs/guide/enrichment-tables/?tab=awss3upload#overview

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
