### PR TITLE
WEB-1806 - replace relative app links to absolute

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -726,6 +726,12 @@ class Integrations:
             if manifest_json.get("is_public", False):
                 out_name = self.content_integrations_dir + new_file_name
 
+                # lets make relative app links to integrations tile absolute
+                regex = r"(?<!https://app.datadoghq.com)(/account/settings#integrations[^.)\s]*)"
+                regex_result = re.sub(regex, "https://app.datadoghq.com\\1", result, 0, re.MULTILINE)
+                if regex_result:
+                    result = regex_result
+
                 # if the same integration exists in multiple locations try name md file differently
                 # integration_id.md -> name.md -> original_collision_name.md
                 if exist_collision:


### PR DESCRIPTION
### What does this PR do?

This PR will update Integration links that are relative to the app e.g `/account/settings#integrations` to be absolute.

**Why?**
The link needs to stay relative in the source repo however it will be a 404 in the docs like this. So changing it to be absolute means that the link checker no longer fails and we have no 404 anymore.

### Motivation

https://datadoghq.atlassian.net/browse/WEB-1806

### Preview

See click here link on big panda
https://docs-staging.datadoghq.com/david.jones/app-links-integrations/integrations/bigpanda_saas/

Also check other integration detailed pages for any issues

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
