### PR TITLE
Fix a missing redirection (after we merged Timeseries and Network widgets in doc)

### DIFF
--- a/content/en/dashboards/widgets/timeseries.md
+++ b/content/en/dashboards/widgets/timeseries.md
@@ -5,6 +5,7 @@ description: "Display the evolution of one or more metrics, log events, Indexed 
 aliases:
     - /graphing/widgets/timeseries/
     - /dashboards/widgets/network/
+    - /graphing/widgets/network/
 further_reading:
 - link: "/dashboards/timeboards/"
   tag: "Documentation"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fix a missing redirection - after we merged Timeseries and Network widgets in doc, [see PR](https://github.com/DataDog/documentation/pull/11753)

![image](https://user-images.githubusercontent.com/46612673/136808273-a5fad8ca-8498-4023-9249-175fefb3e465.png)
![image](https://user-images.githubusercontent.com/46612673/136808301-90f48b7b-b0bd-4d74-976a-daf2688f8978.png)


### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/pcarioufr/NPM_widget_app2doc/graphing/widgets/network/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
