### PR TITLE
Add link to extension VPC guide from installation instructions for different runtimes

### DIFF
--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -166,6 +166,8 @@ func myHandler(ctx context.Context, event MyEvent) (string, error) {
 
 For more information, see the [Custom Metrics documentation][8].
 
+If your Lambda function is running in a VPC, follow the [Datadog Lambda Extension AWS PrivateLink Setup][9] guide to ensure that the extension can reach Datadog API endpoints.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -178,3 +180,4 @@ For more information, see the [Custom Metrics documentation][8].
 [6]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
 [7]: https://app.datadoghq.com/functions
 [8]: /serverless/custom_metrics?tab=go
+[9]: /serverless/guide/extension_private_link/

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -505,6 +505,8 @@ exports.handler = async (event) => {
 
 For more information on custom metric submission, see [here][6]. For additional details on custom instrumentation, see the Datadog APM documentation for [custom instrumentation][7].
 
+If your Lambda function is running in a VPC, follow the [Datadog Lambda Extension AWS PrivateLink Setup][8] guide to ensure that the extension can reach Datadog API endpoints.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -516,3 +518,4 @@ For more information on custom metric submission, see [here][6]. For additional 
 [5]: /serverless/libraries_integrations/forwarder
 [6]: /serverless/custom_metrics?tab=nodejs
 [7]: /tracing/custom_instrumentation/nodejs/
+[8]: /serverless/guide/extension_private_link/

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -607,6 +607,8 @@ def get_message():
 
 For more information on custom metric submission, see [here][7]. For additional details on custom instrumentation, see the Datadog APM documentation for [custom instrumentation][8].
 
+If your Lambda function is running in a VPC, follow the [Datadog Lambda Extension AWS PrivateLink Setup][9] guide to ensure that the extension can reach Datadog API endpoints.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -619,3 +621,4 @@ For more information on custom metric submission, see [here][7]. For additional 
 [6]: /serverless/libraries_integrations/forwarder
 [7]: /serverless/custom_metrics?tab=python
 [8]: /tracing/custom_instrumentation/python/
+[9]: /serverless/guide/extension_private_link/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add link to extension VPC guide from installation instructions for different runtimes. 

### Motivation
<!-- What inspired you to submit this pull request?-->
This is to avoid the user having to open the guides explicitly to find the extension PrivateLink setup instructions.

### Preview
<!-- Impacted pages preview links-->


<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hghotra/vpc-instructions/serverless/installation/python?tab=datadogcli

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
