### PR TITLE
Update default code snippet for plugin to use extension

### DIFF
--- a/content/fr/serverless/libraries_integrations/plugin.md
+++ b/content/fr/serverless/libraries_integrations/plugin.md
@@ -50,7 +50,7 @@ Pour réaliser une configuration avancée de votre plug-in, utilisez les paramè
 | `injectLogContext`     | Lorsque ce paramètre est défini, la couche Lambda corrige automatiquement console.log avec les ID de tracing de Datadog. Valeur par défaut : `true`.                                                                                                                                                                                                                                                                                                     |
 | `exclude`              | Lorsque ce paramètre est défini, le plug-in ignore toutes les fonctions spécifiées. Utilisez ce paramètre pour exclure des fonctions de votre déploiement Datadog. Valeur par défaut : `[]`.                                                                                                                                                                                                                                            |
 | `enabled`              | Lorsque ce paramètre est défini sur false, le plug-in Datadog reste inactif. Valeur par défaut : `true`. Vous pouvez contrôler cette option à l'aide d'une variable d'environnement (p. ex., `enabled: ${strToBool(${env:DD_PLUGIN_ENABLED, true})}`, afin d'activer ou de désactiver le plug-in lors du déploiement. Il est également possible d'utiliser la valeur transmise avec `--stage` pour contrôler cette option. Pour en savoir plus, consultez [cet exemple](#desactiver-le-plug-in-pour-un-environnement-specifique).
-| `monitors`             | Lorsque ce paramètre est défini, le plug-in Datadog configure des monitors pour la fonction déployée. Vous devez également définir `monitorsApiKey` et `monitorsAppKey`. Pour découvrir comment définir des monitors, consultez la rubrique [Activer et configurer un monitor sans serveur recommandé](#activer-et-configurer-un-monitor-sans-serveur-recommande).  |                                                                                          
+| `monitors`             | Lorsque ce paramètre est défini, le plug-in Datadog configure des monitors pour la fonction déployée. Vous devez également définir `monitorsApiKey` et `monitorsAppKey`. Pour découvrir comment définir des monitors, consultez la rubrique [Activer et configurer un monitor sans serveur recommandé](#activer-et-configurer-un-monitor-sans-serveur-recommande).  |
 
 Pour utiliser n'importe lequel de ces paramètres, ajoutez une section `custom` > `datadog` dans votre fichier `serverless.yml` qui est semblable à l'exemple ci-dessous :
 
@@ -63,11 +63,11 @@ custom:
     monitorsApiKey: "{Clé_API_Datadog}"
     monitorsAppKey: "{Clé_application_Datadog}"
     addLayers: true
+    addExtension: true
     logLevel: "info"
     enableXrayTracing: false
     enableDDTracing: true
     enableAPIGatewayLogs: true
-    forwarderArn: arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder
     enableTags: true
     injectLogContext: true
     exclude:
@@ -165,7 +165,7 @@ Il existe sept monitors recommandés avec des valeurs par défaut prédéfinies.
 
 Pour créer un monitor sans serveur recommandé, vous devez utiliser son ID. Attention : vous devez également définir les paramètres `monitorApiKey` et `monitorAppKey`.
 
-Si vous souhaitez configurer davantage de paramètres pour un monitor recommandé, définissez leur valeur sous l'ID du monitor. Les paramètres qui ne sont pas spécifiés à cet endroit seront définis sur la valeur recommandée par défaut. Le paramètre `query` pour les monitors recommandés ne peut pas être modifié directement. Il prend donc la valeur par défaut, comme les autres paramètres non spécifiés. Toutefois, vous pouvez modifier la valeur seuil de `query` en la redéfinissant dans le paramètre `options`. Pour supprimer un monitor, retirez-le du modèle `serverless.yml`. Pour en savoir plus sur la définition des paramètres de monitor, consultez la documentation relative aux [API Monitors de Datadog](https://docs.datadoghq.com/api/latest/monitors/#creer-un-monitor). 
+Si vous souhaitez configurer davantage de paramètres pour un monitor recommandé, définissez leur valeur sous l'ID du monitor. Les paramètres qui ne sont pas spécifiés à cet endroit seront définis sur la valeur recommandée par défaut. Le paramètre `query` pour les monitors recommandés ne peut pas être modifié directement. Il prend donc la valeur par défaut, comme les autres paramètres non spécifiés. Toutefois, vous pouvez modifier la valeur seuil de `query` en la redéfinissant dans le paramètre `options`. Pour supprimer un monitor, retirez-le du modèle `serverless.yml`. Pour en savoir plus sur la définition des paramètres de monitor, consultez la documentation relative aux [API Monitors de Datadog](https://docs.datadoghq.com/api/latest/monitors/#creer-un-monitor).
 
 La création du monitor a lieu après le déploiement de la fonction. Si jamais elle échoue, le déploiement de la fonction n'est donc pas perturbé.
 

--- a/content/ja/serverless/libraries_integrations/plugin.md
+++ b/content/ja/serverless/libraries_integrations/plugin.md
@@ -50,7 +50,7 @@ Datadog は、サーバーレスフレームワークを使用してサーバー
 | `injectLogContext`     | 設定すると、lambda レイヤーは自動的に console.log に Datadog のトレース ID をパッチします。デフォルトは `true` です。                                                                                                                                                                                                                                                                                                     |
 | `exclude`              | 設定後、このプラグインは指定されたすべての機能を無視します。Datadog の機能に含まれてはならない機能がある場合は、このパラメーターを使用します。デフォルトは `[]` です。                                                                                                                                                                                                                                            |
 | `enabled`              | false に設定すると、Datadog プラグインが非アクティブ状態になります。デフォルトは `true` です。`enabled: ${strToBool(${env:DD_PLUGIN_ENABLED, true})}` などの環境変数を使用してこのオプションを制御し、デプロイ時にプラグインを有効化 / 無効化することができます。また、`--stage` を通じて渡された値を使用してこのオプションを制御することもできます。[こちらの例](#disable-plugin-for-particular-environment)をご覧ください。
-| `monitors`             | 定義すると、Datadog プラグインはデプロイされた関数のモニターを構成します。また、`monitorsApiKey` と `monitorsAppKey` を定義する必要があります。モニターの定義方法については、[推奨されるサーバーレスモニターを有効にして構成するには](#to-enable-and-configure-a-recommended-serverless-monitor)を参照してください。  |                                                                                          
+| `monitors`             | 定義すると、Datadog プラグインはデプロイされた関数のモニターを構成します。また、`monitorsApiKey` と `monitorsAppKey` を定義する必要があります。モニターの定義方法については、[推奨されるサーバーレスモニターを有効にして構成するには](#to-enable-and-configure-a-recommended-serverless-monitor)を参照してください。  |
 
 上記のパラメーターを使用するには、以下の例のように `custom` > `datadog` セクションを `serverless.yml` に追加します。
 
@@ -63,11 +63,11 @@ custom:
     monitorsApiKey: "{Datadog_API_Key}"
     monitorsAppKey: "{Datadog_Application_Key}"
     addLayers: true
+    addExtension: true
     logLevel: "info"
     enableXrayTracing: false
     enableDDTracing: true
     enableAPIGatewayLogs: true
-    forwarderArn: arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder
     enableTags: true
     injectLogContext: true
     exclude:

--- a/content/ja/serverless/serverless_integrations/plugin.md
+++ b/content/ja/serverless/serverless_integrations/plugin.md
@@ -53,13 +53,13 @@ custom:
     apiKey: "{Datadog_API_Key}"
     apiKMSKey: "{Encrypted_Datadog_API_Key}"
     addLayers: true
+    addExtension: true
     logLevel: "info"
     enableXrayTracing: false
     enableDDTracing: true
-    forwarderArn: arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder
     enableTags: true
     injectLogContext: true
-    exclude: 
+    exclude:
       - dd-excluded-function
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update default code snippet for plugin to use extension.

### Motivation
<!-- What inspired you to submit this pull request?-->
Currently, the snippet has the `forwarderArn` but does not add the Extension. Since the Extension is now the preferred method for sending logs, metrics & traces, we should update the snippet to use the Extension instead of the Forwarder. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hghotra/update-serverless-plugin-snippet/serverless/libraries_integrations/plugin/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
