### PR TITLE
[log_collection] clarify the size at which the Agent starts splitting.

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -238,7 +238,7 @@ A TCP endpoint is not supported for this region.
 
 **Notes**:
 
-* The HTTPS API supports logs of sizes up to 1MB. However, for optimal performance, it is recommended that an individual log be no greater than 25K bytes. If you use the Datadog Agent for logging, it is configured to split a log at 256kB (256 000 bytes).
+* The HTTPS API supports logs of sizes up to 1MB. However, for optimal performance, it is recommended that an individual log be no greater than 25K bytes. If you use the Datadog Agent for logging, it is configured to split a log at 256kB (256000 bytes).
 * A log event should not have more than 100 tags, and each tag should not exceed 256 characters for a maximum of 10 million unique tags per day.
 * A log event converted to JSON format should contain less than 256 attributes. Each of those attribute's keys should be less than 50 characters, nested in less than 10 successive levels, and their respective value should be less than 1024 characters if promoted as a facet.
 * Log events can be submitted up to 18h in the past and 2h in the future.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

The documentation is correct, `256KB = 256 000 bytes` (whereas `256KiB = 256*1024 bytes`), however, it can be confusing to some customers.

This PR is offering to go the ugliest but clearest way.

### Motivation

Some customers have already been confused by this.

### Preview

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/remeh/clarify-logs-truncate/logs/log_collection/

### Additional Notes

We could also consider something like:

`to split a log at 256 000 bytes.`

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
