### PR TITLE
[CIAPP-2920] Only Python and Ruby test instrumentation is in beta

### DIFF
--- a/content/en/continuous_integration/_index.md
+++ b/content/en/continuous_integration/_index.md
@@ -11,7 +11,7 @@ further_reading:
 ---
 
 {{< site-region region="us5,gov" >}}
-<div class="alert alert-info"><p>CI Visibility is available only on the US1, EU1, and US3 Datadog sites at this time.</p></div>
+<div class="alert alert-info">CI Visibility is available only on the US1, EU1, and US3 Datadog sites at this time.</div>
 {{< /site-region >}}
 
 Datadog Continuous Integration (CI) Visibility brings together information about CI test and pipeline results _plus_ data about CI performance, trends, and reliability, all into one place. Not only does it provide developers with the ability to dig into the reasons for a test or pipeline failure, to monitor trends in test suite execution times, or to see the effect a given commit has on the pipeline, it also gives build engineers visibility into cross-organization CI health and trends in pipeline performance over time.

--- a/content/en/continuous_integration/setup_tests/python.md
+++ b/content/en/continuous_integration/setup_tests/python.md
@@ -10,7 +10,7 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
-<div class="alert alert-info"><p>Python test instrumentation is in beta. There are no billing implications for instrumenting Python tests during this period.</p>
+<div class="alert alert-info">Python test instrumentation is in beta. There are no billing implications for instrumenting Python tests during this period.
 </div>
 ## Compatibility
 

--- a/content/en/continuous_integration/setup_tests/ruby.md
+++ b/content/en/continuous_integration/setup_tests/ruby.md
@@ -10,7 +10,7 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
-<div class="alert alert-info"><p>Ruby test instrumentation is in beta. There are no billing implications for instrumenting Ruby tests during this period.</p>
+<div class="alert alert-info">Ruby test instrumentation is in beta. There are no billing implications for instrumenting Ruby tests during this period.
 </div>
 ## Compatibility
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Remove the "beta" notice on the CI Visibility landing page, and add it to the Python and Ruby pages.

### Motivation
<!-- What inspired you to submit this pull request?-->

As CI Visibility is going GA soon, excluding Python and Ruby test instrumentation.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fermayo/ciapp-update-for-ga/continuous_integration/
https://docs-staging.datadoghq.com/fermayo/ciapp-update-for-ga/continuous_integration/setup_tests/python/
https://docs-staging.datadoghq.com/fermayo/ciapp-update-for-ga/continuous_integration/setup_tests/ruby/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

⚠️ Cannot be merged until the product goes GA

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
