### PR TITLE
[WEB-1776] Add fixed height to api code snippet wrappers

### DIFF
--- a/assets/styles/pages/_api.scss
+++ b/assets/styles/pages/_api.scss
@@ -78,6 +78,19 @@ $ddpurple: #632ca6;
 
     .code-snippet-wrapper {
         margin-right: 0;
+        height: 475px;
+
+        @include media-breakpoint-up(md) {
+            height: 435px;
+        }
+
+        @include media-breakpoint-up(lg) {
+            height: 420px;
+        }
+
+        @include media-breakpoint-up(xl) {
+            height: 400px;
+        }
     }
 
     .table-request .isReadOnly {


### PR DESCRIPTION
### What does this PR do?
Fixes display bug on API pages where clicking on and away from `Curl` examples causes the page to jump.
This was introduced when the `Instructions` code snippets were added.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1776

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/code-examples-bug/api/latest/events/

- Scroll to the bottom of the page and click into and away from the `Curl` code examples.   The page shouldn't jump.   The bug can be replicated in live here: https://docs.datadoghq.com/api/latest/events/
- There should be no display issues with the code example content being too long at any screen size.

### Additional Notes
---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
