### PR TITLE
Update the page name and URL for changing Billing emails

### DIFF
--- a/content/en/account_management/billing/_index.md
+++ b/content/en/account_management/billing/_index.md
@@ -53,7 +53,7 @@ To change your payment method, contact your [Customer Success][12] Manager.
 
 ### Billing emails
 
-You can set specific email addresses to receive invoices on the [Plan][13] page under **Manage Billing Emails**:
+You can set specific email addresses to receive invoices on the [Biling history][13] page under **Manage Billing Emails**:
 
 {{< img src="account_management/billing/billing01.png" alt="Manage Billing Emails" >}}
 
@@ -102,4 +102,4 @@ You can set specific email addresses to receive invoices on the [Plan][13] page 
 [10]: mailto:billing@datadoghq.com
 [11]: /account_management/billing/credit_card/
 [12]: mailto:success@datadoghq.com
-[13]: https://app.datadoghq.com/account/billing
+[13]: https://app.datadoghq.com/billing/history


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the page name and URL to add billing email addresses.

### Motivation
The original version points readers to the wrong page, billing email addresses are not available at Plan page.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
--

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
