### PR TITLE
[dogstatsd] Remove mentions of Python DogStatsD client buffering

### DIFF
--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -66,19 +66,20 @@ func main() {
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}
 
-By using Datadog's official Python library [datadogpy][1], the example below uses a buffered DogStatsD client that sends metrics in a minimal number of packets. In client versions v0.43.0 and higher, buffering is enabled by default and automatic flushing is performed at packet size limit and every 300ms (configurable).
+By using Datadog's official Python library [datadogpy][1], the example below uses a buffered DogStatsD client that sends metrics in a minimal number of packets. With buffering automatic flushing is performed at packet size limit and every 300ms (configurable).
 
 ```python
 from datadog import DogStatsd
 
-dsd = DogStatsd(host="127.0.0.1", port=8125)
 
-# If using client v0.43.0+, buffering is enabled by default with automatic flushing every 300ms.
+# If using client v0.43.0+
+dsd = DogStatsd(host="127.0.0.1", port=8125, disable_buffering=False)
 dsd.gauge('example_metric.gauge_1', 123, tags=["environment:dev"])
 dsd.gauge('example_metric.gauge_2', 1001, tags=["environment:dev"])
 dsd.flush()  # Optional manual flush
 
 # If using client before v0.43.0, context manager is needed to use buffering
+dsd = DogStatsd(host="127.0.0.1", port=8125)
 with dsd:
     dsd.gauge('example_metric.gauge_1', 123, tags=["environment:dev"])
     dsd.gauge('example_metric.gauge_2', 1001, tags=["environment:dev"])

--- a/content/en/events/guides/dogstatsd.md
+++ b/content/en/events/guides/dogstatsd.md
@@ -57,9 +57,6 @@ options = {
 initialize(**options)
 
 statsd.event('An error occurred', 'Error message', alert_type='error', tags=['env:dev'])
-
-# Optional manual flush (only available in client versions >= 0.43.0)
-statsd.flush()
 ```
 {{< /programming-lang >}}
 


### PR DESCRIPTION
### What does this PR do?

Removes mentions of buffering for default use of Python DogStatsd client

### Motivation

Python DogStatsD client buffering-by-default for v0.43.0 has been
postponed and as such should not be part of the documentation for
the client at this time.

### Preview

https://docs-staging.datadoghq.com/sgnn7/remove-dogstatsd-python-client-buffering-mentions/events/guides/dogstatsd
https://docs-staging.datadoghq.com/sgnn7/remove-dogstatsd-python-client-buffering-mentions/developers/dogstatsd/high_throughput

(not sure why links aren't working)

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
