### PR TITLE
correct dd.trace.methods

### DIFF
--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -329,7 +329,7 @@ A list of method annotations to treat as `@Trace`.
 `dd.trace.methods`
 : **Environment Variable**: `DD_TRACE_METHODS`<br>
 **Default**: `null`<br>
-**Example**: `"package.ClassName[method1,method2,...];AnonymousClass$1[call];package.ClassName[*]"`<br>
+**Example**: `package.ClassName[method1,method2,...];AnonymousClass$1[call];package.ClassName[*]`<br>
 List of class/interface and methods to trace. Similar to adding `@Trace`, but without changing code. **Note:** The wildcard method support (`[*]`) does not accommodate constructors, getters, setters, synthetic, toString, equals, hashcode, or finalizer method calls
 
 `dd.trace.classes.exclude`


### PR DESCRIPTION
### What does this PR do?
The correct way to specify dd.trace.methods does not include quotes, as seen here: https://docs.datadoghq.com/fr/tracing/setup_overview/custom_instrumentation/java/#datadog-trace-methods 

This place in our docs specifies it wrong

### Motivation
This ticket where it tripped up a customer: https://datadog.zendesk.com/agent/tickets/564652


### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
