### PR TITLE
[APM-Int] Update Ruby debug logging instructions

### DIFF
--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -37,13 +37,7 @@ To enable debug mode for the Datadog Python Tracer, set the environment variable
 
 {{< programming-lang lang="ruby" >}}
 
-To enable debug mode for the Datadog Ruby Tracer, set the `debug` option to `true` in the tracer initialization configuration:
-
-```ruby
-Datadog.configure do |c|
-  c.tracer debug: true
-end
-```
+To enable debug mode for the Datadog Ruby Tracer, set the environment variable `DD_TRACE_DEBUG=true`.
 
 **Application Logs**
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

The "Tracer Debug Logs" has become stale, and the way to configure trace debug logs in Ruby has since changed.

This PR updates the configuration instructions for an applications with debug logs enabled to simply use `DD_TRACE_DEBUG=true`, instead of the programmatic configuration.

### Motivation
<!-- What inspired you to submit this pull request?-->

Stale documentation. See https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#tracer-settings for latest (albeit very technical) full configuration API.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ruby-debug-log/tracing/troubleshooting/tracer_debug_logs/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

I believe Go and NodeJS can probably also be simplified to setting `DD_TRACE_DEBUG=true`, like Ruby, Python, Java, PHP and .NET do today.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
