### PR TITLE
Fix Request Body Typo

### DIFF
--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -80,7 +80,7 @@ To create an HTTP request step, click **Create Your First Step**.
 
    {{% tab "Request Body" %}}
 
-   * **Body type**: Select the type of the request body (`text/plain`, `application/json`, `text/xml`, `text/html`, `application/x-www-form-urlendcoded`, or `None`) you want to add to your HTTP request.
+   * **Body type**: Select the type of the request body (`text/plain`, `application/json`, `text/xml`, `text/html`, `application/x-www-form-urlencoded`, or `None`) you want to add to your HTTP request.
    * **Request body**: Add the content of your HTTP request body. **Note**: The request body is limited to a maximum size of 50 kilobytes.
 
    {{% /tab %}}


### PR DESCRIPTION
Change `application/x-www-form-urlendcoded` to `application/x-www-form-urlencoded`.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Fix a typo in the Request Body types on one page.

### Motivation
<!-- What inspired you to submit this pull request?-->

Slack

### Preview

https://docs-staging.datadoghq.com/alai97/synthetics-advanced-options-request-body-typo/synthetics/multistep

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
