### PR TITLE
update config for forwarder on live too

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -225,13 +225,6 @@
       options:
         dest_path: '/serverless/libraries_integrations/'
         file_name: 'forwarder.md'
-        front_matters:
-          dependencies: ["https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/README.md"]
-          title: Datadog Forwarder
-          kind: documentation
-          aliases:
-            - /serverless/troubleshooting/installing_the_forwarder/
-            - /serverless/forwarder/
 
   - repo_name: serverless-plugin-datadog
     contents:


### PR DESCRIPTION
### What does this PR do?

This #11948 was missing the change to the regular pull config too

### Motivation

Issue resolved on previews but not on live

### Preview

https://docs-staging.datadoghq.com/david.jones/update-config/serverless/libraries_integrations/forwarder/

vs

https://docs.datadoghq.com/serverless/libraries_integrations/forwarder/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
