### PR TITLE
revert wrapping css on api

### DIFF
--- a/assets/styles/pages/_api.scss
+++ b/assets/styles/pages/_api.scss
@@ -78,7 +78,7 @@ $ddpurple: #632ca6;
 
     .code-snippet-wrapper {
         margin-right: 0;
-        height: 475px;
+        /*height: 475px;
 
         @include media-breakpoint-up(md) {
             height: 435px;
@@ -90,7 +90,7 @@ $ddpurple: #632ca6;
 
         @include media-breakpoint-up(xl) {
             height: 400px;
-        }
+        }*/
     }
 
     .table-request .isReadOnly {


### PR DESCRIPTION
### What does this PR do?

This PR reverts the changes in #11943 so that https://docs.datadoghq.com/api/latest/?code-lang=java doesn't overlap in a way we don't want.

### Motivation

Slack

### Preview

https://docs-staging.datadoghq.com/david.jones/revert-wrapper-css/api/latest/?code-lang=java

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
