### PR TITLE
[Kubernetes] Correct Event Collection for Operator

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -356,12 +356,12 @@ If you want to collect events from your Kubernetes cluster set the environment v
 {{% /tab %}}
 {{% tab "Operator" %}}
 
-Set `agent.config.collectEvents` to `true` in your `datadog-agent.yaml` manifest.
+Set `clusterAgent.config.collectEvents` to `true` in your `datadog-agent.yaml` manifest.
 
 For example:
 
 ```
-agent:
+clusterAgent:
   config:
     collectEvents: true
 ```


### PR DESCRIPTION
Collecting Operator Events, corrected from agent.config.collectEvents to clusterAgent.config.collectEvents

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Correct the event collection for the Operator from `agent.config.collectEvents` to `clusterAgent.config.collectEvents`

### Motivation
Client feedback

### Preview
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/agent/kubernetes/?tab=operator#event-collection


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
