### PR TITLE
Link to the right doc for trace and log filtering using Lambda Extension

### DIFF
--- a/content/en/serverless/libraries_integrations/extension.md
+++ b/content/en/serverless/libraries_integrations/extension.md
@@ -32,9 +32,15 @@ To install the Datadog Lambda Extension, instrument your AWS serverless applicat
 
 To disable submission of your AWS Lambda logs to Datadog using the extension, set the environment variable `DD_SERVERLESS_LOGS_ENABLED` to `false` in your Lambda function.
 
+To scrub or filter logs before sending them to Datadog, see [Advanced Log Collection][6].
+
 ## Trace collection
 
 To disable submission of your AWS Lambda traces to Datadog using the extension, set the environment variable `DD_TRACE_ENABLED` to `false` in your Lambda function.
+
+To filter traces before sending them to Datadog, see [Ignoring Unwanted Resources in APM][7].
+
+To scrub trace attributes for data security, see [Configure the Datadog Agent or Tracer for Data Security][8].
 
 ## Tagging
 
@@ -42,7 +48,7 @@ When using the Extension, Datadog recommends you apply tags by adding the follow
 
 - `DD_ENV`: This sets the `env` tag in Datadog. Use it to separate out your staging, development, and production environments.
 - `DD_SERVICE`: This sets the `service` tag in Datadog. Use it to group related Lambda functions into a service.
-- `DD_VERSION`: This sets the `version` tag in Datadog. Use it to enable [Deployment Tracking][6].
+- `DD_VERSION`: This sets the `version` tag in Datadog. Use it to enable [Deployment Tracking][9].
 - `DD_TAGS`: This sets custom tags in Datadog. Must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`.
 
 If you have the Datadog AWS integration enabled, any AWS resource tag applied to your AWS Lambda function also gets applied in Datadog automatically.
@@ -51,7 +57,7 @@ If you have the Datadog AWS integration enabled, any AWS resource tag applied to
 
 The Datadog Lambda Extension introduces a small amount of overhead to your Lambda function's cold starts (that is, the higher init duration), as the Extension needs to initialize. Datadog is continuously optimizing the Lambda extension performance and recommend always using the latest release.
 
-You may also notice increase of your Lambda function's reported duration, and this is because the Datadog Lambda Extension needs to flush data back to the Datadog API. Although the time spent by the Extension flushing data is reported as part of the duration, it's done *after* AWS returning your function's response back to the client. In other words, the added duration does not slow down your Lambda function. Additional technical details can be found from this [AWS blog post][7].
+You may also notice increase of your Lambda function's reported duration, and this is because the Datadog Lambda Extension needs to flush data back to the Datadog API. Although the time spent by the Extension flushing data is reported as part of the duration, it's done *after* AWS returning your function's response back to the client. In other words, the added duration does not slow down your Lambda function. Additional technical details can be found from this [AWS blog post][10].
 
 By default, the Extension sends data back to Datadog at the end of each invocation. This avoids delays of data arrival for sporadic invocations from low-traffic applications, cron jobs, and manual tests. Once the Extension detects a steady and frequent invocation pattern (more than once per minute), it batches data from multiple invocations and flushes periodically at the beginning of the invocation when it's due. This means that *the busier your function is, the lower the average duration overhead per invocation*. 
 
@@ -67,5 +73,8 @@ For Lambda functions deployed in a region that is far from the Datadog site, for
 [3]: /serverless/distributed_tracing
 [4]: /serverless/custom_metrics?tab=python#synchronous-vs-asynchronous-custom-metrics
 [5]: /serverless/installation
-[6]: /tracing/deployment_tracking/
-[7]: https://aws.amazon.com/blogs/compute/performance-and-functionality-improvements-for-aws-lambda-extensions/
+[6]: /agent/logs/advanced_log_collection/
+[7]: /tracing/guide/ignoring_apm_resources/
+[8]: /tracing/setup_overview/configure_data_security/
+[9]: /tracing/deployment_tracking/
+[10]: https://aws.amazon.com/blogs/compute/performance-and-functionality-improvements-for-aws-lambda-extensions/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Customers don't normally realize that the trace and log filtering & scrubbing features also work just fine for Lambda Extension, since the Extension is essentially a special flavor of the Datadog agent. People been asking questions about filtering or scrubbing data from traces and logs quite frequently. Mentioning the right docs from the Extension doc should help.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tian.chu/extension-log-tracing-collection-advanced-topics/serverless/libraries_integrations/extension/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
