### PR TITLE
Clarify that the Kubernetes events collection can be done by the cluster agent or by a node agent

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -170,7 +170,7 @@ To install the Datadog Agent on your Kubernetes cluster:
      **Note**: Those manifests are set for the `default` namespace by default. If you are in a custom namespace, update the `metadata.namespace` parameter before applying them.
 
 4. **Set your Datadog site** to {{< region-param key="dd_site" code="true" >}} using the `DD_SITE` environment variable in the `datadog-agent.yaml` manifest.
-    
+
     **Note**: If the `DD_SITE` environment variable is not explicitly set, it defaults to the `US` site `datadog.com`. If you are using one of the other sites (`EU`, `US3`, or `US1-FED`) this will result in an invalid API key message. Use the [documentation site selector][20] to see documentation appropriate for the site you're using.
 
 5. **Deploy the DaemonSet** with the command:
@@ -345,7 +345,9 @@ See the [Live Containers][7] documentation for configuration instructions and ad
 {{< tabs >}}
 {{% tab "Helm" %}}
 
-Set the `datadog.leaderElection`, `datadog.collectEvents` and `agents.rbac.create` options to `true` in your `value.yaml` file in order to enable Kubernetes event collection.
+If you want the Kubernetes events to be collected by the cluster agent, set the `clusterAgent.enabled`, `datadog.collectEvents` and `clusterAgent.rbac.create` options to `true` in your `value.yaml` file.
+
+If you don’t want the cluster agent, you can still have the Kubernetes events be collected by a node agent by setting `datadog.leaderElection`, `datadog.collectEvents` and `agents.rbac.create` options to `true` in your `value.yaml` file.
 
 {{% /tab %}}
 {{% tab "DaemonSet" %}}
@@ -356,7 +358,17 @@ If you want to collect events from your Kubernetes cluster set the environment v
 {{% /tab %}}
 {{% tab "Operator" %}}
 
-Set `agent.config.collectEvents` to `true` in your `datadog-agent.yaml` manifest.
+In order to collect the Kubernetes events with the cluster agent, set `clusterAgent.config.collectEvents` to `true` in your `datadog-agent.yaml` manifest.
+
+For example:
+
+```
+clusterAgent:
+  config:
+    collectEvents: true
+```
+
+Alternatively, in order to collect the Kubernetes events with a node agent, set `agent.config.collectEvents` to `true` in your `datadog-agent.yaml` manifest.
 
 For example:
 

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -345,9 +345,9 @@ See the [Live Containers][7] documentation for configuration instructions and ad
 {{< tabs >}}
 {{% tab "Helm" %}}
 
-If you want the Kubernetes events to be collected by the cluster agent, set the `clusterAgent.enabled`, `datadog.collectEvents` and `clusterAgent.rbac.create` options to `true` in your `value.yaml` file.
+If you want Kubernetes events to be collected by the Datadog Cluster Agent, set the `clusterAgent.enabled`, `datadog.collectEvents` and `clusterAgent.rbac.create` options to `true` in your `value.yaml` file.
 
-If you don’t want the cluster agent, you can still have the Kubernetes events be collected by a node agent by setting `datadog.leaderElection`, `datadog.collectEvents` and `agents.rbac.create` options to `true` in your `value.yaml` file.
+If you don’t want to use the Cluster Agent, you can still have a node Agent collect Kubernetes events by setting `datadog.leaderElection`, `datadog.collectEvents` and `agents.rbac.create` options to `true` in your `value.yaml` file.
 
 {{% /tab %}}
 {{% tab "DaemonSet" %}}
@@ -358,7 +358,7 @@ If you want to collect events from your Kubernetes cluster set the environment v
 {{% /tab %}}
 {{% tab "Operator" %}}
 
-In order to collect the Kubernetes events with the cluster agent, set `clusterAgent.config.collectEvents` to `true` in your `datadog-agent.yaml` manifest.
+To collect the Kubernetes events with the Cluster Agent, set `clusterAgent.config.collectEvents` to `true` in your `datadog-agent.yaml` manifest.
 
 For example:
 
@@ -368,7 +368,7 @@ clusterAgent:
     collectEvents: true
 ```
 
-Alternatively, in order to collect the Kubernetes events with a node agent, set `agent.config.collectEvents` to `true` in your `datadog-agent.yaml` manifest.
+Alternatively, to collect the Kubernetes events with a node Agent, set `agent.config.collectEvents` to `true` in your `datadog-agent.yaml` manifest.
 
 For example:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Clarify that the Kubernetes events collection can be done by the cluster agent or by a node agent

### Motivation
<!-- What inspired you to submit this pull request?-->

Whereas with the `DaemonSet` installation method, it was mentioned that there were two ways to collect Kubernetes events, with the `Helm` and `Operator` installation methods, we were mentioning only the way without the cluster agent whereas we would like to promote it.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/lenaic/clarify_collect_events

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Resolves #11962

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
