### PR TITLE
Fix formatting of document

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -15,21 +15,17 @@ further_reading:
 
 ## Overview
 
-AWS service logs are usually stored in S3 buckets or CloudWatch Log groups. It is possible to subscribe to these logs and forward them to an Amazon Kinesis stream to then forward them to one or multiple destinations. Datadog is one of the default destinations for Amazon Kinesis Delivery streams.
-​
-AWS fully manages Amazon Kinesis Data Firehose, so you don't need to maintain any additional infrastructure or forwarding configurations for streaming logs.
-​
-You can set up a Kinesis Firehose Delivery Stream in the AWS Firehose console, or automatically set up the destination using a CloudFormation template:
+AWS service logs are usually stored in S3 buckets or CloudWatch Log groups. It is possible to subscribe to these logs and forward them to an Amazon Kinesis stream to then forward them to one or multiple destinations. Datadog is one of the default destinations for Amazon Kinesis Delivery streams. 
+
+AWS fully manages Amazon Kinesis Data Firehose, so you don't need to maintain any additional infrastructure or forwarding configurations for streaming logs. You can set up a Kinesis Firehose Delivery Stream in the AWS Firehose console, or automatically set up the destination using a CloudFormation template.
 
 ## Setup
 
 {{< tabs >}}
 {{% tab "Kinesis Firehose Delivery stream" %}}
-​
-Datadog recommends using a Kinesis stream as input when using the Datadog Kinesis destination. It gives you the ability to forward your logs to multiple destinations in case Datadog is not the only consumer for those logs.
-​
-If you only want to send logs to Datadog, or if you already have a Kinesis Datastream with your logs, ignore step 1.
-​
+
+Datadog recommends using a Kinesis stream as input when using the Datadog Kinesis destination. It gives you the ability to forward your logs to multiple destinations in case Datadog is not the only consumer for those logs. If you only want to send logs to Datadog, or if you already have a Kinesis Datastream with your logs, ignore step 1.
+
 1. (Optional) Create a new Kinesis stream (see the [Kinesis documentation][1]). Name the stream something descriptive, like `DatadogLogStream`, and give it a shard count of 1 (increase the shard count for each MB/s throughput that you need).
 2. Create a [new delivery stream][2] and name it `DatadogLogsforwarder`.
 3. Set the source as "Kinesis stream" (or leave the source as `Direct PUT or other sources` if you don’t want to use a Kinesis stream) and select `DatadogLogStream` (or the existing Kinesis stream that already contains your logs).
@@ -54,10 +50,8 @@ To ensure that logs that fail through the Delivery Stream are still sent to Data
 {{% /tab %}}
 
 {{% tab "CloudFormation template" %}}
-​
-Alternatively, customize this CloudFormation template and install it from the AWS Console:
-​
-See the full [Kinesis CloudFormation template][1].
+
+Alternatively, customize this CloudFormation template and install it from the AWS Console. See the full [Kinesis CloudFormation template][1].
 
 [1]: /resources/json/kinesis-logs-cloudformation-template.json
 {{% /tab %}}
@@ -67,14 +61,13 @@ See the full [Kinesis CloudFormation template][1].
 
 1. Check the `Subscriptions` column on the [log groups index page][1] to see current subscriptions to your relevant log groups. Add the new Kinesis stream as a subscriber. Note: CloudWatch Log groups can only have two subscriptions each.
   * **Note**: If you have more than two sources you want to subscribe to, you can subscribe to the new Kinesis stream after completing this setup.
-2. Subscribe your new Kinesis stream to the CloudWatch log groups you want to ingest into Datadog. Refer to [this CloudWatch Logs documentation section][2] (step 3 to 6) to:
-  a. Use the `aws iam create-role` command to create the IAM role that gives CloudWatch Logs permission to put logs data into the Kinesis stream.
-  b. Create a permissions policy allowing the `firehose:PutRecord` `firehose:PutRecordBatch`, `kinesis:PutRecord` and `kinesis:PutRecordBatch` actions.
-  c. Attach the permissions policy to your newly created IAM role using the `aws iam put-role-policy` command.
-  d. Use the `aws logs put-subscription-filter` command to subscribe your Kinesis stream to each CloudWatch log group you want to ingest into Datadog.
-​
-    Example of subscription filter:
-​
+2. Subscribe your new Kinesis stream to the CloudWatch log groups you want to ingest into Datadog. Refer to [this CloudWatch Logs documentation section][2] (step 3 to 6) to:  
+   - Use the `aws iam create-role` command to create the IAM role that gives CloudWatch Logs permission to put logs data into the Kinesis stream.
+   - Create a permissions policy allowing the `firehose:PutRecord` `firehose:PutRecordBatch`, `kinesis:PutRecord`, and `kinesis:PutRecordBatch` actions.
+   - Attach the permissions policy to your newly created IAM role using the `aws iam put-role-policy` command.
+   - Use the `aws logs put-subscription-filter` command to subscribe your Kinesis stream to each CloudWatch log group you want to ingest into Datadog.  
+
+   Example of subscription filter:
     ```
     aws logs put-subscription-filter \
         --log-group-name "MYLOGGROUPNAME" \
@@ -83,10 +76,10 @@ See the full [Kinesis CloudFormation template][1].
         --destination-arn "DESTINATIONARN (data stream or delivery stream)" \
         --role-arn "MYROLEARN"
     ```
-​
     **Important note**: The destination of the subscription filter must be in the same account as the log group, as described in the [AWS documentation][3].
+
 3. Check the `Subscriptions` column in the [log groups index page][1] to confirm that the new Kinesis stream is now subscribed to your log groups.
-​
+
 If you want to push logs directly to the delivery stream without going through a Kinesis data stream, you can subscribe the CloudWatch log groups directly to the Kinesis Firehose Destination by adding the Kinesis Firehose ARN in the `destination-arn` parameter of the subscription filter, as shown in [the AWS Subscription Filters documentation][4] (step 12).
 
 ## Search for AWS Kinesis logs in Datadog


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Added in missing spaces and also fixed the formatting of the document.

Here is the document: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination/?tab=kinesisfirehosedeliverystream#overview
### Motivation
While working on support tickets, this documentation comes up and it doesn't look good.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
