### PR TITLE
fix docs of log collection. `http` sends to only to Datadog.

### DIFF
--- a/content/fr/logs/log_collection/javascript.md
+++ b/content/fr/logs/log_collection/javascript.md
@@ -556,6 +556,10 @@ window.DD_LOGS && DD_LOGS.logger.setLevel('<NIVEAU>')
 
 Par défaut, les loggers créés par le SDK Browser Datadog envoient les logs à Datadog. Une fois le SDK lancé, il est possible de configurer le logger de façon à ce que les logs soient envoyés à la `console` ou qu'ils ne soient pas envoyés du tout (`silent`) avec l'API :
 
+- envoyer les logs vers le Datadog (`http`) seulement
+- envoyer les logs uniquement à la console `console`
+- ne pas envoyer de logs du tout (`silent`)
+
 ```
 setHandler (handler?: 'http' | 'console' | 'silent')
 ```

--- a/content/ja/logs/log_collection/javascript.md
+++ b/content/ja/logs/log_collection/javascript.md
@@ -556,7 +556,7 @@ window.DD_LOGS && DD_LOGS.logger.setLevel('<LEVEL>')
 
 デフォルトでは、Datadog ブラウザログ SDK が作成したロガーは、ログを Datadog に送信します。Datadog ブラウザログ SDK が初期化されると、ロガーを構成して以下のようにすることもできます。
 
-- `console` と Datadog にログを送信する (`http`)
+- Datadog にのみログを送信する (`http`)
 - `console` にのみログを送信する
 - ログをまったく送信しない (`silent`)
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
The documentation was incorrect.
Fixed the documentation as implemented.

### Motivation
<!-- What inspired you to submit this pull request?-->
I would like to get the documentation correct.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
#### Implementation Code
https://github.com/DataDog/browser-sdk/blob/abccf2c48b23a5daa7a7efdc841bf3adcb32eb40/packages/logs/src/domain/logger.ts#L57

#### Actual pages
- https://docs.datadoghq.com/logs/log_collection/javascript/
- https://docs.datadoghq.com/fr/logs/log_collection/javascript/
- https://docs.datadoghq.com/ja/logs/log_collection/javascript/

#### Relation PR
https://github.com/DataDog/browser-sdk/pull/1142

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
