### PR TITLE
Fix example copying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,27 +249,27 @@ EXAMPLES_DIR = $(shell pwd)/examples/content/en/api
 
 examples/go: examples/datadog-api-client-go clean-go-examples
 	echo $(EXAMPLES_DIR)
-	@cd examples/datadog-api-client-go; ./extract-code-blocks.sh $(EXAMPLES_DIR) || (echo "Error copying Go code examples, aborting build."; exit 1); if [ -d examples ]; then cp -R examples/ $(EXAMPLES_DIR); fi
+	@cd examples/datadog-api-client-go; ./extract-code-blocks.sh $(EXAMPLES_DIR) || (echo "Error copying Go code examples, aborting build."; exit 1); if [ -d examples ]; then cp -R examples/* $(EXAMPLES_DIR)/; fi
 
 	-cp -Rn examples/content ./
 
 examples/java: examples/datadog-api-client-java clean-java-examples
-	@cd examples/datadog-api-client-java; ./extract-code-blocks.sh $(EXAMPLES_DIR) || (echo "Error copying Java code examples, aborting build."; exit 1); if [ -d examples ]; then cp -R examples/ $(EXAMPLES_DIR); fi
+	@cd examples/datadog-api-client-java; ./extract-code-blocks.sh $(EXAMPLES_DIR) || (echo "Error copying Java code examples, aborting build."; exit 1); if [ -d examples ]; then cp -R examples/* $(EXAMPLES_DIR)/; fi
 
 	-cp -Rn examples/content ./
 
 examples/python: examples/datadog-api-client-python clean-python-examples
-	@cd examples/datadog-api-client-python; ./extract-code-blocks.sh $(EXAMPLES_DIR) || (echo "Error copying Python code examples, aborting build."; exit 1); if [ -d examples ]; then cp -R examples/ $(EXAMPLES_DIR); fi
+	@cd examples/datadog-api-client-python; ./extract-code-blocks.sh $(EXAMPLES_DIR) || (echo "Error copying Python code examples, aborting build."; exit 1); if [ -d examples ]; then cp -R examples/* $(EXAMPLES_DIR)/; fi
 
 	-cp -Rn examples/content ./
 
 examples/ruby: examples/datadog-api-client-ruby clean-ruby-examples
-	@cd examples/datadog-api-client-ruby; ./extract-code-blocks.sh $(EXAMPLES_DIR) || (echo "Error copying Ruby code examples, aborting build."; exit 1); if [ -d examples ]; then cp -R examples/ $(EXAMPLES_DIR); fi
+	@cd examples/datadog-api-client-ruby; ./extract-code-blocks.sh $(EXAMPLES_DIR) || (echo "Error copying Ruby code examples, aborting build."; exit 1); if [ -d examples ]; then cp -R examples/* $(EXAMPLES_DIR)/; fi
 
 	-cp -Rn examples/content ./
 
 examples/typescript: examples/datadog-api-client-typescript clean-typescript-examples
-	@cd examples/datadog-api-client-typescript; ./extract-code-blocks.sh $(EXAMPLES_DIR) || (echo "Error copying Typescript code examples, aborting build."; exit 1); if [ -d examples ]; then cp -R examples/ $(EXAMPLES_DIR); fi
+	@cd examples/datadog-api-client-typescript; ./extract-code-blocks.sh $(EXAMPLES_DIR) || (echo "Error copying Typescript code examples, aborting build."; exit 1); if [ -d examples ]; then cp -R examples/* $(EXAMPLES_DIR)/; fi
 
 	-cp -Rn examples/content ./
 


### PR DESCRIPTION
### What does this PR do?

Make sure the API code examples that are explicitly overwritten copy successfully to the destination.

### Motivation

slack

### Preview

Compare Ruby code example here to the one in production
https://docs-staging.datadoghq.com/david.jones/clean-examples-ci/api/latest/metrics/#submit-metrics

Also spot check code examples in various parts of the api to ensure they are still the same

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
