### PR TITLE
[Session replay] Change sdk minimal version

### DIFF
--- a/content/en/real_user_monitoring/guide/session-replay-getting-started.md
+++ b/content/en/real_user_monitoring/guide/session-replay-getting-started.md
@@ -30,7 +30,7 @@ Session Replay is available through a dedicated build of the RUM Browser SDK. To
 
 #### npm
 
-Replace the `@datadog/browser-rum package` with a version >3.0.2 of [`@datadog/browser-rum`][2]. To start the recording, call `datadogRum.startSessionReplayRecording()`.
+Replace the `@datadog/browser-rum package` with a version >3.6.0 of [`@datadog/browser-rum`][2]. To start the recording, call `datadogRum.startSessionReplayRecording()`.
 
 ```javascript
 import { datadogRum } from '@datadog/browser-rum';


### PR DESCRIPTION
### What does this PR do?

SDK > 3.6.0 should be used in order to work in EU datacenter

### Motivation

issue in EU since where session replay requests were sent using v1 API

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/bcaudan/sr-doc/real_user_monitoring/guide/session-replay-getting-started/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
