### PR TITLE
[CIAPP-1912] Document configurations tags for junit XML uploads

### DIFF
--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -160,7 +160,7 @@ If you are running tests in non-supported CI providers or with no `.git` folder,
 
 ## Collecting environment configuration metadata
 
-There are some special tags that are used to identify the configuration of the environment where tests run, which include OS, runtime and device information (where applicable). When the same test for the same commit runs in more than one configuration (for example, in both Windows and Linux machines), they are treated as two different tests when it comes to failure and flakiness detection.
+Datadog uses special dedicated tags to identify the configuration of the environment in which tests run, including the operating system, runtime, and device information, if applicable. When the same test for the same commit runs in more than one configuration (for example, on Windows and on Linux), the tags are used to differentiate the test in failure and flakiness detection.
 
 You can specify these special tags using the `--tags` parameter when calling `datadog-ci junit upload`, or by setting the `DD_TAGS` environment variable.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add docs for test configurations tags for junit uploads.

### Motivation
Allowing users of CI Visibility with junit upload to make use of the features for test configuration insights.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/adrian.lopezcalvo%2Fdocument-configuration-tags-for-junit-upload/continuous_integration/setup_tests/junit_upload/#defining-metadata-for-testing-configurations


### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
