### PR TITLE
Include message about required trace attributes

### DIFF
--- a/content/en/tracing/error_tracking/_index.md
+++ b/content/en/tracing/error_tracking/_index.md
@@ -21,7 +21,7 @@ Monitoring the errors collected by Datadog is critical to your system's health, 
 
 ## How Datadog error tracking works
 
-The Datadog tracers collect errors through integrations and manual instrumentation of the source code. Error spans within a trace are processed by Error Tracking __when they are located in the uppermost service span__, which is also called the _service entry span_. The span must also contain the `error.stack`, `error.msg`, and `error.type` [span tags](https://docs.datadoghq.com/tracing/visualization/trace/?tab=spantags#more-information) in order to be tracked.
+The Datadog tracers collect errors through integrations and manual instrumentation of the source code. Error spans within a trace are processed by Error Tracking __when they are located in the uppermost service span__, which is also called the _service entry span_. The span must also contain the `error.stack`, `error.msg`, and `error.type` [span tags][1] in order to be tracked.
 
 {{< img src="tracing/error_tracking/flamegraph_with_errors.png" alt="Flame graph with errors"  >}}
 
@@ -32,3 +32,5 @@ Error Tracking computes a fingerprint for each error span it processes using the
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://docs.datadoghq.com/tracing/visualization/trace/?tab=spantags#more-information


### PR DESCRIPTION

### Motivation
It wasn't clear to me why a certain span wasn't showing up in error tracking, and it was because it didn't have the `error.stack` attribute.

### Additional Notes
![image](https://user-images.githubusercontent.com/38891791/138135702-f1bea92a-8453-4326-abdd-474c40edcbbf.png)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
