### PR TITLE
DOCS-2631 - change `k8s_tagger` to `k8sattributes`

### DIFF
--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -236,7 +236,7 @@ A full example Kubernetes manifest for deploying the OpenTelemetry Collector as 
       # ...
     ```
 
-3. For OpenTelemetry Collectors in standalone collector mode, which receive traces from downstream collectors and export to Datadog's backend, include a `batch` processor configured with a `timeout` of `10s` as well as the `k8sattributes` enabled. These should be included along with the `datadog` exporter and added to the `traces` pipeline.
+3. For OpenTelemetry Collectors in standalone collector mode, which receive traces from downstream collectors and export to Datadog's backend, include a `batch` processor configured with a `timeout` of `10s`, and `k8sattributes` enabled. These should be included along with the `datadog` exporter and added to the `traces` pipeline.
 
     In the `otel-collector-conf` ConfigMap's `data.otel-collector-config` `processors` section:
 
@@ -265,6 +265,7 @@ A full example Kubernetes manifest for deploying the OpenTelemetry Collector as 
       exporters: [datadog]
       # ...
     ```
+<div class="alert alert-warning">If you get the error <code>unknown processors type "k8sattributes" for k8sattributes</code>, upgrade to the latest OpenTelemetry Collector (v0.37.0 or greater).</div>
 
 ##### Example Kubernetes OpenTelemetry application configuration
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates name of k8s_tagger processor to k8sattributes for upcoming OTel Collector 0.37.0 release

### Motivation
https://datadoghq.atlassian.net/browse/DOCS-2631

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/k8sattributes/tracing/setup_overview/open_standards/#example-kubernetes-opentelemetry-collector-configuration

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
