### PR TITLE
Syslog tabbing

### DIFF
--- a/content/en/integrations/syslog_ng.md
+++ b/content/en/integrations/syslog_ng.md
@@ -30,7 +30,7 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
 ### Log collection
 
 {{< site-region region="us3" >}}
-**Log collection is not supported for the Datadog {{< region-param key="dd_site_name" >}}  site**.
+**Log collection is not supported for the Datadog {{< region-param key="dd_site_name" >}} site**.
 {{< /site-region >}}
 
 1. Collect system logs and log files in `/etc/syslog-ng/syslog-ng.conf` and make sure the source is correctly defined:


### PR DESCRIPTION
### What does this PR do?
Updates the Syslog integration docs to exclude region tabs as docs are applicable to all regions

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/sarina/syslog-site-region/integrations/syslog_ng

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
