### PR TITLE
Clarify CSP entries for RUM

### DIFF
--- a/content/en/real_user_monitoring/faq/content_security_policy.md
+++ b/content/en/real_user_monitoring/faq/content_security_policy.md
@@ -19,6 +19,8 @@ Depending on the `site` option used to initialize [Real User Monitoring][2] or [
 connect-src https://*.logs.datadoghq.com https://*.browser-intake-datadoghq.com
 ```
 
+Both entries are required even if you are not using [browser logs collection][3].
+
 {{< /site-region >}}
 
 
@@ -27,6 +29,9 @@ connect-src https://*.logs.datadoghq.com https://*.browser-intake-datadoghq.com
 ```txt
 connect-src https://*.logs.datadoghq.eu https://*.browser-intake-datadoghq.eu
 ```
+
+Both entries are required even if you are not using [browser logs collection][3].
+
 
 {{< /site-region >}}
 


### PR DESCRIPTION
### What does this PR do?

It clarifies that both CSP entries are required, regardless of whether you're using browser logs collection or not.

### Motivation

The docs were a bit ambiguous about whether you needed both entries if you *weren't* using browser logs collection. @bcaudan suggested I propose changes in https://github.com/DataDog/browser-sdk/issues/1137#issuecomment-945779675.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
