### PR TITLE
[CIAPP-2998] Add section about how to configure Git information manually in Jenkins plugin.

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -295,11 +295,11 @@ If the Git information is not detected automatically, you can set the following 
 
 `DD_GIT_COMMIT_AUTHOR_NAME` (Optional)
 : The name of the author of the commit.<br/>
-**Example**: `John Doe`
+**Example**: `John Smith`
 
 `DD_GIT_COMMIT_AUTHOR_EMAIL` (Optional)
 : The email of the author of the commit.<br/>
-**Example**: `john@doe.com`
+**Example**: `john@example.com`
 
 `DD_GIT_COMMIT_AUTHOR_DATE` (Optional)
 : The date when the author submitted the commit expressed in ISO 8601 format.<br/>
@@ -307,11 +307,11 @@ If the Git information is not detected automatically, you can set the following 
 
 `DD_GIT_COMMIT_COMMITTER_NAME` (Optional)
 : The name of the committer of the commit.<br/>
-**Example**: `Jane Doe`
+**Example**: `Jane Smith`
 
 `DD_GIT_COMMIT_COMMITTER_EMAIL` (Optional)
 : The email of the committer of the commit.<br/>
-**Example**: `jane@doe.com`
+**Example**: `jane@example.com`
 
 `DD_GIT_COMMIT_COMMITTER_DATE` (Optional)
 : The date when the committer submitted the commit expressed in ISO 8601 format.<br/>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR adds a new section in the configuration of Jenkins for CI Visibility product.

This section explains how to provide Git information to the plugin manually via environment variables.

### Motivation
<!-- What inspired you to submit this pull request?-->

Sometimes, the Git plugins used by Jenkins do not set this information automatically.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/drodriguezhdez/jenkins_git_user_supplied/continuous_integration/setup_pipelines/jenkins

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
