### PR TITLE
Add a note about uninstrument

### DIFF
--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -70,7 +70,7 @@ export AWS_SECRET_ACCESS_KEY="<ACCESS KEY>"
 
 ### Instrument
 
-**Note**: Please instrument your Lambda functions in a dev or staging environment first! Should the instrumentation result be unsatisfactory, run `uninstrument` with the same arguments to revert the changes.
+**Note**: Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run `uninstrument` with the same arguments to revert the changes.
 
 To instrument the function, run the following command:
 

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -70,6 +70,8 @@ export AWS_SECRET_ACCESS_KEY="<ACCESS KEY>"
 
 ### Instrument
 
+**Note**: Please instrument your Lambda functions in a dev or staging environment first! Should the instrumentation result be unsatisfactory, run `uninstrument` with the same arguments to revert the changes.
+
 To instrument the function, run the following command:
 
 ```sh

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -69,6 +69,9 @@ export AWS_SECRET_ACCESS_KEY="<ACCESS KEY>"
 ```
 
 ### Instrument
+
+**Note**: Please instrument your Lambda functions in a dev or staging environment first! Should the instrumentation result be unsatisfactory, run `uninstrument` with the same arguments to revert the changes.
+
 To instrument your Lambda functions, run the following command:
 
 ```sh

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -70,7 +70,7 @@ export AWS_SECRET_ACCESS_KEY="<ACCESS KEY>"
 
 ### Instrument
 
-**Note**: Please instrument your Lambda functions in a dev or staging environment first! Should the instrumentation result be unsatisfactory, run `uninstrument` with the same arguments to revert the changes.
+**Note**: Instrument your Lambda functions in a dev or staging environment first! Should the instrumentation result be unsatisfactory, run `uninstrument` with the same arguments to revert the changes.
 
 To instrument your Lambda functions, run the following command:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

We are adding an `uninstrument` option to the `datadog-ci lambda` command https://github.com/DataDog/datadog-ci/pull/374. Once that's ready we should mention it in the doc.

### Motivation

For other serverless installation methods, customers can easily "uninstrument" by removing the lines of code added and redeploy, but NOT with the `datadog-ci lambda instrument` command, since it directly makes changes on the Lambda functions.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tian.chu/lambda-uninstrument/serverless/installation/python
https://docs-staging.datadoghq.com/tian.chu/lambda-uninstrument/serverless/installation/nodejs

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
