### PR TITLE
Update automatically set up triggers table for the AWS log forwarder guide

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -38,12 +38,14 @@ Datadog can automatically configure triggers on the Datadog Forwarder Lambda fun
 
 | Source                          | Location       |
 | ------------------------------- | ---------------|
-| S3 Access Logs                  | S3             |
-| Classic ELB Access Logs         | S3             |
+| API Gateway Access Logs         | CloudWatch     |
+| API Gateway Execution Logs      | CloudWatch     |
 | Application ELB Access Logs     | S3             |
+| Classic ELB Access Logs         | S3             |
 | CloudFront Access Logs          | S3             |
-| Redshift Logs                   | S3             |
 | Lambda Logs                     | CloudWatch     |
+| Redshift Logs                   | S3             |
+| S3 Access Logs                  | S3             |
 
 1. If you haven't already, set up the [Datadog log collection AWS Lambda function][1].
 2. Ensure the policy of the IAM role used for [Datadog-AWS integration][3] has the following permissions. Information on how these permissions are used can be found in the descriptions below:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds two new options for the AWS log forwarder guide
- API Gateway Access Logs
- API Gateway Execution Logs

Alphabetizes the table to match how it is displayed in the app

### Motivation
<!-- What inspired you to submit this pull request?-->
These options are now available for all customers

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jcstorms1-patch-1/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md

<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
