### PR TITLE
Remove extra /nextlink in In monitors/create

### DIFF
--- a/content/en/monitors/create/_index.md
+++ b/content/en/monitors/create/_index.md
@@ -25,6 +25,8 @@ Select a [monitor type][5] from the list.
 {{< nextlink href="/monitors/create/types/host" >}}<u>Host</u>: Check if one or more hosts are reporting to Datadog.{{< /nextlink >}}
 {{< nextlink href="/monitors/create/types/metric" >}}<u>Metric</u>: Compare values of a metric with a user-defined threshold.{{< /nextlink >}}
 {{< nextlink href="/monitors/create/types/anomaly" >}}<u>Anomaly</u>: Detect anomalous behavior for a metric based on historical data.{{< /nextlink >}}
+{{< /whatsnext >}}
+
 {{< whatsnext desc="Choose your monitor type:">}}
 {{< nextlink href="/monitors/create/types/audit_logs" >}}<u>Audit Logs</u>: Alert when a specified type of audit log exceeds a user-defined threshold over a given period of time.
 {{< /nextlink >}}
@@ -41,6 +43,7 @@ Select a [monitor type][5] from the list.
 {{< nextlink href="/monitors/create/types/real_user_monitoring" >}}<u>Real User Monitoring</u>: Monitor real user data gathered by Datadog.{{< /nextlink >}}
 {{< nextlink href="/monitors/create/types/watchdog" >}}<u>Watchdog</u>: Get notified when Watchdog detects anomalous behavior.{{< /nextlink >}}
 {{< nextlink href="/monitors/create/types/composite" >}}<u>Composite</u>: Alert on an expression combining multiple monitors.{{< /nextlink >}}
+{{< /whatsnext >}}
 
 ### Import a monitor
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

The _Import a monitor_ section is in raw text on production now because the extra `{{< /nextlink >}}` is messing up the markdown parser.

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
https://docs.datadoghq.com/monitors/create

![Screenshot of garbled text in the monitors/create page linked previously](https://user-images.githubusercontent.com/3335181/138498512-1e0dcb27-185c-44da-863a-248fc328ea3d.png)

### Preview
Not in your org, lmk if you want this filled out 😄 

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes

Lovely docs otherwise, thank you! ❤️‍🔥 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
