### PR TITLE
[doc] Document search on message that allows users to search on the monitor message

### DIFF
--- a/content/en/synthetics/search.md
+++ b/content/en/synthetics/search.md
@@ -49,6 +49,7 @@ Search through your Synthetic tests by clicking on the facets on the left panel 
 * **Search on free text**: Enter your text in the search bar to search on a test name.
 * **Search on a single facet**: Click a facet value to create a search query that includes only that facet value. For example, `type:api`. To add another value of the same facet to your search, click the other value checkbox or add the other value with an `OR` Boolean operator and wrap values with quotes and parentheses. For example, `type:("api" OR "api-ssl")`.
 * **Search on multiple facets and text**: Click on values of different facets to create a search query that includes filtering for multiple facets. For example, `type:api``region:aws:us-east-2`. You can also mix facets and text. For example, `checkout type:browser`. Although invisible, the `AND` Boolean operator is applied when searching on multiple terms.
+* **Search on message**: Use message in your query to search through your tests’ notification messages (found in the **Message** property). For example, `message:testcontent`.
 * **Exclude facets or text**: Click on an existing filled checkbox to deselect a facet value or prepend your term with `-` to exclude it from the search query, e.g. `-state:paused`.
 * **Perform custom matches**: Use wildcards (`*`). For example, `valid*`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update doc to add option to search on Synthetics test message property

### Motivation
https://datadoghq.atlassian.net/wiki/spaces/SYN/pages/711459412

### Preview
https://docs.datadoghq.com/synthetics/search/#create-your-query 

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/papfeiffer-patch-1/synthetics/search/#create-your-query

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
