### PR TITLE
Remove DD_FLUSH_TO_LOG from serverless installation instructions

### DIFF
--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -254,7 +254,6 @@ Replace `<TAG>` with either a specific version number (for example, `{{< latest-
 2. Set the following environment variables in AWS:
   - Set `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
   - Set `DD_TRACE_ENABLED` to `true`.
-  - Set `DD_FLUSH_TO_LOG` to `true`.
   - Set `DD_API_KEY` with your Datadog API key from the [API Management page][2].
 3. Optionally add `service` and `env` tags with appropriate values to your function.
 

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -220,7 +220,6 @@ More information and additional parameters can be found on the [Datadog CDK NPM 
       "aws_environment_variables": {
         "DD_LAMBDA_HANDLER": "handler.lambda_handler",
         "DD_TRACE_ENABLED": "true",
-        "DD_FLUSH_TO_LOG": "true",
         "DD_API_KEY": "<DATADOG_API_KEY>",
       }
     }
@@ -238,7 +237,6 @@ More information and additional parameters can be found on the [Datadog CDK NPM 
       "aws_environment_variables": {
         "DD_LAMBDA_HANDLER": "handler.lambda_handler",
         "DD_TRACE_ENABLED": "true",
-        "DD_FLUSH_TO_LOG": "true",
         "DD_API_KEY": "<DATADOG_API_KEY>"
       },
       }
@@ -294,7 +292,6 @@ arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension-ARM:{{<
         "api_gateway_stage": "api",
         "environment_variables": {
           "DD_TRACE_ENABLED": "true",
-          "DD_FLUSH_TO_LOG": "true",
           "DD_API_KEY": "<DATADOG_API_KEY>",
         },
         "layers": ["arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:<EXTENSION_VERSION>"],
@@ -313,7 +310,6 @@ arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension-ARM:{{<
         "api_gateway_stage": "api",
         "environment_variables": {
           "DD_TRACE_ENABLED": "true",
-          "DD_FLUSH_TO_LOG": "true",
           "DD_API_KEY": "<DATADOG_API_KEY>",
         },
         "layers": ["arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-Extension:<EXTENSION_VERSION>"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

`DD_FLUSH_TO_LOG` is only useful when instrumenting Lambda functions using the Forwarder. When using the Extension (replaces the Forwarder), this env var is ignored. Our instructions are all updated to using the Extension, therefore this env var should be removed to simplify the instructions.

### Motivation
Remove unused env var.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tian.chu/sls-rm-flush-to-log/serverless/installation/python
https://docs-staging.datadoghq.com/tian.chu/sls-rm-flush-to-log/serverless/installation/nodejs

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
