### PR TITLE
Add documentation for b3 header configuration support in python tracelib

### DIFF
--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -179,6 +179,15 @@ Override the port that the default tracer submits DogStatsD metrics to.
 : **Default**: `false`<br>
 Enable [connecting logs and trace injection][9].
 
+`DD_PROPAGATION_STYLE_INJECT`
+: **Default**: `Datadog`<br>
+Propagation styles to use when injecting tracing headers. For example, use `DD_PROPAGATION_STYLE_INJECT=Datadog,B3` to inject both Datadog and B3 format headers.
+
+
+`DD_PROPAGATION_STYLE_EXTRACT`
+: **Default**: Value of `DD_PROPAGATION_STYLE_INJECT` (`Datadog`)<br>
+Propagation styles to use when extracting tracing headers. When multiple values are given, it uses the first header match found. The order of matching is static and unrelated to the order of values given. For example: `DD_PROPAGATION_STYLE_EXTRACT=B3,Datadog` will produce the same behavior as `DD_PROPAGATION_STYLE_EXTRACT=Datadog,B3`.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -186,7 +186,7 @@ Propagation styles to use when injecting tracing headers. For example, use `DD_P
 
 `DD_PROPAGATION_STYLE_EXTRACT`
 : **Default**: Value of `DD_PROPAGATION_STYLE_INJECT` (`Datadog`)<br>
-Propagation styles to use when extracting tracing headers. When multiple values are given, it uses the first header match found. The order of matching is static and unrelated to the order of values given. For example: `DD_PROPAGATION_STYLE_EXTRACT=B3,Datadog` will produce the same behavior as `DD_PROPAGATION_STYLE_EXTRACT=Datadog,B3`.
+Propagation styles to use when extracting tracing headers. When multiple values are given, it uses the first header match found. The order of matching is static and unrelated to the order of values given. For example: `DD_PROPAGATION_STYLE_EXTRACT=B3,Datadog` produces the same behavior as `DD_PROPAGATION_STYLE_EXTRACT=Datadog,B3`.
 
 ## Further Reading
 


### PR DESCRIPTION
Adds documentation for two new configuration parameters in the python trace lib, being added in https://github.com/DataDog/dd-trace-py/pull/2888

* DD_PROPAGATION_STYLE_INJECT
* DD_PROPAGATION_STYLE_EXTRACT

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Documents configurable injectors/extractors in https://github.com/DataDog/dd-trace-py/pull/2888

### Motivation
PR template from https://github.com/DataDog/dd-trace-py/pull/2888 suggested that it was required


### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
