### PR TITLE
artifact too large

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -273,6 +273,7 @@ build_live:
     - in-isolation deploy_live
     - create_artifact
     - create_artifact_untracked
+    - remove_static_from_repo
   artifacts:
     when: on_success
     paths:


### PR DESCRIPTION
### What does this PR do?

Remove images from the public dir thats passed around to avoid

```bash
ERROR: Uploading artifacts as "archive" to coordinator... too large archive  id=12343567 responseStatus=413 Request Entity Too Large status=413 token=123456
```

### Motivation

See above error

### Preview

https://docs-staging.datadoghq.com/david.jones/reduce-artifact/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
