### PR TITLE
Add missing new line to CI App Python and Ruby docs

### DIFF
--- a/content/en/continuous_integration/setup_tests/python.md
+++ b/content/en/continuous_integration/setup_tests/python.md
@@ -12,6 +12,7 @@ further_reading:
 
 <div class="alert alert-info">Python test instrumentation is in beta. There are no billing implications for instrumenting Python tests during this period.
 </div>
+
 ## Compatibility
 
 Supported Python interpreters:

--- a/content/en/continuous_integration/setup_tests/ruby.md
+++ b/content/en/continuous_integration/setup_tests/ruby.md
@@ -12,6 +12,7 @@ further_reading:
 
 <div class="alert alert-info">Ruby test instrumentation is in beta. There are no billing implications for instrumenting Ruby tests during this period.
 </div>
+
 ## Compatibility
 
 Supported Ruby interpreters:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a missing new line that breaks the markdown format

### Motivation
<!-- What inspired you to submit this pull request?-->
Fix the issue

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fermayo/ciapp-fix-python-ruby-doc/continuous_integration/setup_tests/ruby
https://docs-staging.datadoghq.com/fermayo/ciapp-fix-python-ruby-doc/continuous_integration/setup_tests/python

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
