### PR TITLE
[Cloud Workload Security] remove system-probe env variable

### DIFF
--- a/content/en/security_platform/cloud_workload_security/getting_started.md
+++ b/content/en/security_platform/cloud_workload_security/getting_started.md
@@ -79,7 +79,6 @@ docker run -d --name dd-agent \
   -v /sys/kernel/debug:/sys/kernel/debug \
   -v /etc/os-release:/etc/os-release \
   -e DD_RUNTIME_SECURITY_CONFIG_ENABLED=true \
-  -e DD_SYSTEM_PROBE_ENABLED=true \
   -e HOST_ROOT=/host/root \
   -e DD_API_KEY=<API KEY> \
   gcr.io/datadoghq/agent:7


### PR DESCRIPTION
### What does this PR do?

This PR removes an unnecessary environment variable for the Cloud Workload Security product docker setup.

### Motivation

This environment variable is not needed to start CWS and it would actually activate NPM.

### Preview

https://docs-staging.datadoghq.com/will/remove-system-probe-env/security_platform/cloud_workload_security/getting_started?tab=docker

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
