### PR TITLE
Update information about supported SUSE versions

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -142,10 +142,10 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [RedHat/CentOS][4]                       | RedHat/CentOS 6+                                          |
 | [Docker][5]                              | Version 1.12+                                             |
 | [Kubernetes][6]                          | Version 1.3+                                              |
-| [SUSE Enterprise Linux][7] with systemd  | SUSE 11 SP4+ in Agent < 7.33.0                            |
-| [SUSE Enterprise Linux][7] with SysVinit | SUSE 11 SP4 in Agent 7.16.0 - 7.33.0                      |
-| [SUSE Enterprise Linux][7] with systemd  | SUSE 12+ in Agent 7.33.0+                                 |
-| [OpenSUSE][7] with systemd               | OpenSUSE 15+ in Agent 7.33.0+                             |
+| [SUSE Enterprise Linux][7] with systemd  | SUSE 11 SP4+ in Agent < 6.33.0/7.33.0                     |
+| [SUSE Enterprise Linux][7] with SysVinit | SUSE 11 SP4 in Agent 6.16.0/7.16.0 - 6.33.0/7.33.0        |
+| [SUSE Enterprise Linux][7] with systemd  | SUSE 12+ in Agent 6.33.0+/7.33.0+                         |
+| [OpenSUSE][7] with systemd               | OpenSUSE 15+ in Agent 6.33.0+/7.33.0+                     |
 | [Fedora][8]                              | Fedora 26+                                                |
 | [macOS][9]                               | macOS 10.12+                                              |
 | [Windows Server][10]                     | Windows Server 2008 R2+ and Server Core (not Nano Server) |

--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -142,8 +142,10 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [RedHat/CentOS][4]                       | RedHat/CentOS 6+                                          |
 | [Docker][5]                              | Version 1.12+                                             |
 | [Kubernetes][6]                          | Version 1.3+                                              |
-| [SUSE Enterprise Linux][7] with systemd  | SUSE 11 SP4+                                              |
-| [SUSE Enterprise Linux][7] with SysVinit | SUSE 11 SP4 in Agent 7.16.0+                              |
+| [SUSE Enterprise Linux][7] with systemd  | SUSE 11 SP4+ in Agent < 7.33.0                            |
+| [SUSE Enterprise Linux][7] with SysVinit | SUSE 11 SP4 in Agent 7.16.0 - 7.33.0                      |
+| [SUSE Enterprise Linux][7] with systemd  | SUSE 12+ in Agent 7.33.0+                                 |
+| [OpenSUSE][7] with systemd               | OpenSUSE 15+ in Agent 7.33.0+                             |
 | [Fedora][8]                              | Fedora 26+                                                |
 | [macOS][9]                               | macOS 10.12+                                              |
 | [Windows Server][10]                     | Windows Server 2008 R2+ and Server Core (not Nano Server) |

--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -142,9 +142,8 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [RedHat/CentOS][4]                       | RedHat/CentOS 6+                                          |
 | [Docker][5]                              | Version 1.12+                                             |
 | [Kubernetes][6]                          | Version 1.3+                                              |
-| [SUSE Enterprise Linux][7] with systemd  | SUSE 11 SP4+ in Agent < 6.33.0/7.33.0                     |
+| [SUSE Enterprise Linux][7] with systemd  | SUSE 11 SP4+ in Agent < 6.33.0/7.33.0, SUSE 12+ in Agent 6.33.0+/7.33.0+                     |
 | [SUSE Enterprise Linux][7] with SysVinit | SUSE 11 SP4 in Agent 6.16.0/7.16.0 - 6.33.0/7.33.0        |
-| [SUSE Enterprise Linux][7] with systemd  | SUSE 12+ in Agent 6.33.0+/7.33.0+                         |
 | [OpenSUSE][7] with systemd               | OpenSUSE 15+ in Agent 6.33.0+/7.33.0+                     |
 | [Fedora][8]                              | Fedora 26+                                                |
 | [macOS][9]                               | macOS 10.12+                                              |

--- a/content/en/agent/basic_agent_usage/suse.md
+++ b/content/en/agent/basic_agent_usage/suse.md
@@ -22,7 +22,7 @@ This page outlines the basic features of the Datadog Agent for SUSE. If you have
 
 Packages are available for 64-bit x86 architectures. For other architectures, use the source install.
 
-**Note**: SUSE 11 SP4 and above are supported.
+**Note**: SUSE 11 SP4 and above are supported in Agent < 6.33.0/7.33.0. SLES 12 and above and OpenSUSE 15 and above are supported in Agent >= 6.33.0/7.33.0.
 
 ## Commands
 


### PR DESCRIPTION
### What does this PR do?

With the introduction of https://github.com/DataDog/datadog-agent/pull/9660 (to be shipped in 6.33.0/7.33.0), we're dropping support for some older OpenSUSE/SLES versions. This PR updates the docs to reflect this.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
https://docs-staging.datadoghq.com/slavek.kabrda/suse-support-update/agent/basic_agent_usage/?tab=agentv6v7
https://docs-staging.datadoghq.com/slavek.kabrda/suse-support-update/agent/basic_agent_usage/suse/?tab=agentv6v7

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
