### PR TITLE
Fixing host path for logs pointdir

### DIFF
--- a/content/en/agent/amazon_ecs/logs.md
+++ b/content/en/agent/amazon_ecs/logs.md
@@ -101,7 +101,7 @@ To collect all logs written by running applications in your ECS containers and s
           "mountPoints": [
             (...)
             {
-              "containerPath": "/opt/datadog-agent/run",
+              "containerPath": "C:/var/log",
               "sourceVolume": "pointdir",
               "readOnly": false
             },
@@ -132,6 +132,12 @@ To collect all logs written by running applications in your ECS containers and s
       ],
       "volumes": [
         (...)
+        {
+          "host": {
+            "sourcePath": "C:/var/log"
+          },
+          "name": "pointdir"
+        },
         {
           "host": {
             "sourcePath": "c:/programdata/docker/containers"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

fix path for the volume mount for the folder to store the pointers for the logs collection.

### Motivation

Improve the documentation.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/charly/update_windows_ecs_doc

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
