### PR TITLE
Update helm chart registry override instruction

### DIFF
--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -81,7 +81,7 @@ Next, enable the Datadog features that you'd like to use: [APM][5], [Logs][6]
 
 - For a full list of the Datadog chart's configurable parameters and their default values, refer to the [Datadog Helm repository README][7].
 
-### Containers registries
+### Container registries
 
 If Google Container Registry ([gcr.io/datadoghq][8]) is not accessible in your deployment region, use another registry with the following configuration in the `values.yaml` file:
 


### PR DESCRIPTION
### What does this PR do?

Update the Datadog helm chart installation instruction to easily switch to another container registry.
### Motivation

The Datadog helm chart now have a new option that ease the
container registry configuration.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/clamoriniere/update-helm-instruction/agent/kubernetes/?tab=helm

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
