### PR TITLE
DOCS-2642 Synthetics Troubleshooting Edit

### DIFF
--- a/content/en/synthetics/troubleshooting/_index.md
+++ b/content/en/synthetics/troubleshooting/_index.md
@@ -140,7 +140,7 @@ This might mean your private location is unable to reach the endpoint your API t
 
 ### I’m seeing `invalid mount config for type "bind": source path must be a directory` when attempting to run a private location.
 
-This occurs when you attempt to mount a single file in a Windows-based container, which is [not supported][14]. Make sure that the source of the bind mount is a local directory.
+This occurs when you attempt to mount a single file in a Windows-based container, which is not supported. For more information, see the [Docker Mount volume documentation][14]. Ensure that the source of the bind mount is a local directory.
 
 ## CI/CD Testing
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds the following example:
I’m seeing invalid mount config for type "bind": source path must be a directory when attempting to run a private location.

This occurs when a user attempts to mount a single file in a Windows-based container, which is [currently not supported](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v---read-only). Make sure that the source of the bind mount is a local directory instead.

### Motivation
https://datadoghq.atlassian.net/wiki/spaces/SYN/pages/711459412

### Preview
https://docs.datadoghq.com/synthetics/troubleshooting/#private-locations 

https://docs-staging.datadoghq.com/papfeiffer-patch-1/synthetics/troubleshooting/#private-locations 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
