### PR TITLE
Add nuget tracer instructions for Docker

### DIFF
--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -198,11 +198,12 @@ For information about the different methods for setting environment variables, s
    RUN /<APP_DIRECTORY>/datadog/createLogPath.sh
    ```
 
-  Docker examples are available in the dd-trace-dotnet [repository][8].
+  Docker examples are available in the dd-trace-dotnet [repository][1].
 
 3. For standalone applications, manually restart the application.
 
 
+[1]: https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples/NugetDeployment
 {{% /tab %}}
 
 {{< /tabs >}}
@@ -657,4 +658,3 @@ When using `systemctl` to run .NET applications as a service, you can also set e
 [5]: /tracing/setup_overview/compatibility_requirements/dotnet-core#integrations
 [6]: /tracing/setup_overview/custom_instrumentation/dotnet/
 [7]: https://www.freedesktop.org/software/systemd/man/systemctl.html#set-environment%20VARIABLE=VALUE%E2%80%A6
-[8]: https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples/NugetDeployment

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -198,7 +198,7 @@ For information about the different methods for setting environment variables, s
    RUN /<APP_DIRECTORY>/datadog/createLogPath.sh
    ```
 
-  Docker examples are available in the dd-trace-dotnet [repository][1].
+   Docker examples are available in the [`dd-trace-dotnet` repository][1].
 
 3. For standalone applications, manually restart the application.
 

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -192,7 +192,15 @@ For information about the different methods for setting environment variables, s
    Windows x64      | `<APP_DIRECTORY>\datadog\win-x64\Datadog.Trace.ClrProfiler.Native.dll`
    Windows x86      | `<APP_DIRECTORY>\datadog\win-x86\Datadog.Trace.ClrProfiler.Native.dll`
 
-2. For standalone applications, manually restart the application.
+2. For Docker images running on Linux, configure the image to run the `createLogPath.sh` script:
+  
+   ```
+   RUN /<APP_DIRECTORY>/datadog/createLogPath.sh
+   ```
+
+  Docker examples are available in the dd-trace-dotnet [repository][8].
+
+3. For standalone applications, manually restart the application.
 
 
 {{% /tab %}}
@@ -649,3 +657,4 @@ When using `systemctl` to run .NET applications as a service, you can also set e
 [5]: /tracing/setup_overview/compatibility_requirements/dotnet-core#integrations
 [6]: /tracing/setup_overview/custom_instrumentation/dotnet/
 [7]: https://www.freedesktop.org/software/systemd/man/systemctl.html#set-environment%20VARIABLE=VALUE%E2%80%A6
+[8]: https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples/NugetDeployment


### PR DESCRIPTION
### What does this PR do?
Adds instructions for using the `Datadog.Monitoring.Distribution` nuget package with docker images.

### Motivation
Without running the script, APM will not work within Linux images. I got stuck with this yesterday until I looked at the samples in the dd-trace repository.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
