### PR TITLE
Update logs-monitors-on-volumes.md

### DIFF
--- a/content/en/logs/guide/logs-monitors-on-volumes.md
+++ b/content/en/logs/guide/logs-monitors-on-volumes.md
@@ -37,7 +37,7 @@ To define anomaly detection monitors to be alerted of any unexpected indexing lo
 1. [Create a new Anomaly monitor][4]
 2. Select the `datadog.estimated_usage.logs.ingested_events` metric
 3. Add `datadog_is_excluded:false` in the `from` section (to monitor indexed logs and not ingested ones)
-4. Add the tag `service` and `datadog_index` in **group by** (to be notified if a specific service spikes or stops sending logs in any indexes)
+4. Add the tag `service` and `datadog_index` in **count by** (to be notified if a specific service spikes or stops sending logs in any indexes)
 5. Set the alert condition to match your use case (e.g., evaluation window, number of times outside the expected range, etc.)
 6. Set the notification message with actionable instructions:
 


### PR DESCRIPTION
Reflecting "count by" verbiage that appears in the UI, instead of "group by" (as it was before)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates docs to correspond to the current UI

### Motivation
I was following the instructions and hit a snag. i could not find "group by". 

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
