### PR TITLE
Remove overhead sentence for Java tracing

### DIFF
--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -658,7 +658,7 @@ Java APM has minimal impact on the overhead of an application:
 - No collections maintained by Java APM grow unbounded in memory
 - Reporting traces does not block the application thread
 - Java APM loads additional classes for trace collection and library instrumentation
-- If you observe the Java APM frequently adding substantially more than a 3% increase in CPU or JVM heap usage, in a way that degrades your application's performance, contact [the Support team][20].
+
 
 
 ## Further Reading


### PR DESCRIPTION
### Motivation
This sentence has been there for a long time. It is wrong, as we haven't evaluated the overhead, and often source of confusion for our customers and support.
It happens quite often that our library's overhead is bigger than 3%, and it's often expected

### Preview
https://docs-staging.datadoghq.com/hugokash-patch-1/tracing/setup_overview/setup/java/?tab=containers#performance


