### PR TITLE
Add information about AlmaLinux and Rocky support

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -139,7 +139,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [Debian][2] with systemd                 | Debian 7 (wheezy)+                                        |
 | [Debian][2] with SysVinit                | Debian 7 (wheezy)+ in Agent 6.6.0+                        |
 | [Ubuntu][3]                              | Ubuntu 14.04+                                             |
-| [RedHat/CentOS][4]                       | RedHat/CentOS 6+                                          |
+| [RedHat/CentOS/AlmaLinux/Rocky][4]       | RedHat/CentOS 6+, AlmaLinux/Rocky 8+ in Agent 6.33.0+/7.33.0+ |
 | [Docker][5]                              | Version 1.12+                                             |
 | [Kubernetes][6]                          | Version 1.3+                                              |
 | [SUSE Enterprise Linux][7] with systemd  | SUSE 11 SP4+                                              |

--- a/content/en/agent/basic_agent_usage/redhat.md
+++ b/content/en/agent/basic_agent_usage/redhat.md
@@ -22,7 +22,7 @@ This page outlines the basic features of the Datadog Agent for Red Hat. If you h
 
 Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
 
-**Note**: RedHat 6 and above are supported.
+**Note**: RedHat/CentOS 6 and above are supported. Since Agent 6.33.0/7.33.0, AlmaLinux/Rocky 8 and above are supported.
 
 ## Commands
 


### PR DESCRIPTION
### What does this PR do?

Adds AlmaLinux/Rocky to supported RedHat derivatives. To be merged after 6.33.0/7.33.0 is released.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview

https://docs-staging.datadoghq.com/slavek.kabrda/almalinux-rocky/agent/basic_agent_usage/?tab=agentv6v7
https://docs-staging.datadoghq.com/slavek.kabrda/almalinux-rocky/agent/basic_agent_usage/redhat/?tab=agentv6v7

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
