### PR TITLE
[ci-app] Document --ddtrace-patch-all

### DIFF
--- a/content/en/continuous_integration/setup_tests/python.md
+++ b/content/en/continuous_integration/setup_tests/python.md
@@ -44,6 +44,12 @@ To enable instrumentation of `pytest` tests, add the `--ddtrace` option when run
 DD_SERVICE=my-python-app DD_ENV=ci pytest --ddtrace
 {{< /code-block >}}
 
+If you also want to enable the rest of the APM integrations to get more information in your flamegraph, add the `--ddtrace-patch-all` option:
+
+{{< code-block lang="bash" >}}
+DD_SERVICE=my-python-app DD_ENV=ci pytest --ddtrace --ddtrace-patch-all
+{{< /code-block >}}
+
 ## Configuration settings
 
 The following is a list of the most important configuration settings that can be used with the tracer, either in code or using environment variables:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Documents the `--ddtrace-patch-all` option for python's CI Visibility tracer.
<!-- A brief description of the change being made with this pull request.-->

### Motivation
A customer opened a support ticket to get full flamegraphs in CI Visibility.
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->
<img width="681" alt="Screenshot 2021-11-02 at 09 51 26" src="https://user-images.githubusercontent.com/1845771/139815186-a4e856aa-f3ab-45cf-9839-f54fb91ebed2.png">


<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/edrevo/document-patchall/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
