### PR TITLE
DOCS-2154 Move enabling log collection from agent logs to logs collection setup

### DIFF
--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -38,14 +38,6 @@ To send logs with environment variables, configure the following:
 
 After activating log collection, the Agent is ready to forward logs to Datadog. Next, configure the Agent on where to collect logs from.
 
-## Enabling log collection from integrations
-
-To collect logs for a given integration, uncomment the logs section in that integration's `conf.yaml` file and configure it for your environment. If you are running the Agent in a Kubernetes or Docker environment, see the dedicated [Kubernetes Log Collection][6] or [Docker Log Collection][7] documentation.
-
-<div class="alert alert-warning">
-Consult the <a href="/integrations/#cat-log-collection">list of supported integrations</a>  that include out of the box log configurations.
-</div>
-
 ## Custom log collection
 
 Datadog Agent v6 can collect logs and forward them to Datadog from files, the network (TCP or UDP), journald, and Windows channels:
@@ -53,8 +45,8 @@ Datadog Agent v6 can collect logs and forward them to Datadog from files, the ne
 1. Create a new `<CUSTOM_LOG_SOURCE>.d/` folder in the `conf.d/` directory at the root of your [Agent's configuration directory][4].
 2. Create a new `conf.yaml` file in this new folder.
 3. Add a custom log collection configuration group with the parameters below.
-4. [Restart your Agent][8] to take into account this new configuration.
-5. Run the [Agent's status subcommand][9] and look for `<CUSTOM_LOG_SOURCE>` under the Checks section.
+4. [Restart your Agent][6] to take into account this new configuration.
+5. Run the [Agent's status subcommand][7] and look for `<CUSTOM_LOG_SOURCE>` under the Checks section.
 
 Below are examples of custom log collection setup:
 
@@ -160,8 +152,8 @@ List of all available parameters for log collection:
 | `port`           | Yes      | If `type` is **tcp** or **udp**, set the port for listening to logs.                                                                                                                                                                                                                                                                                     |
 | `path`           | Yes      | If `type` is **file** or **journald**, set the file path for gathering logs.                                                                                                                                                                                                                                                                             |
 | `channel_path`   | Yes      | If `type` is **windows_event**, list the Windows event channels for collecting logs.                                                                                                                                                                                                                                                                     |
-| `service`        | Yes      | The name of the service owning the log. If you instrumented your service with [Datadog APM][9], this must be the same service name. Check the [unified service tagging][10] instructions when configuring `service` across multiple data types.                                                                                                          |
-| `source`         | Yes      | The attribute that defines which integration is sending the logs. If the logs do not come from an existing integration, then this field may include a custom source name. However, it is recommended that you match this value to the namespace of any related [custom metrics][11] you are collecting, for example: `myapp` from `myapp.request.count`. |
+| `service`        | Yes      | The name of the service owning the log. If you instrumented your service with [Datadog APM][8], this must be the same service name. Check the [unified service tagging][9] instructions when configuring `service` across multiple data types.                                                                                                          |
+| `source`         | Yes      | The attribute that defines which integration is sending the logs. If the logs do not come from an existing integration, then this field may include a custom source name. However, it is recommended that you match this value to the namespace of any related [custom metrics][10] you are collecting, for example: `myapp` from `myapp.request.count`. |
 | `include_units`  | No       | If `type` is **journald**, list of the specific journald units to include.                                                                                                                                                                                                                                                                               |
 | `exclude_paths`  | No       | If `type` is **file**, and `path` contains a wildcard character, list the matching file or files to exclude from log collection. This is available for Agent version >= 6.18.                                                                                                                                                                            |
 | `exclude_units`  | No       | If `type` is **journald**, list of the specific journald units to exclude.                                                                                                                                                                                                                                                                               |
@@ -179,9 +171,9 @@ List of all available parameters for log collection:
 [3]: /agent/docker/log/
 [4]: /agent/guide/agent-configuration-files/
 [5]: /agent/logs/log_transport/
-[6]: /agent/kubernetes/log/#autodiscovery
-[7]: /agent/docker/log/#log-integrations
-[8]: /agent/guide/agent-commands/#agent-status-and-information
-[9]: /tracing/
-[10]: /getting_started/tagging/unified_service_tagging
+[6]: /agent/guide/agent-commands/#restart-the-agent
+[7]: /agent/guide/agent-commands/#agent-status-and-information
+[8]: /tracing/
+[9]: /getting_started/tagging/unified_service_tagging
+[10]: /metrics/custom_metrics/#overview
 [11]: /getting_started/tagging/

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -90,13 +90,18 @@ Select your Cloud provider below to see how to automatically collect your logs a
 
 Datadog integrations and log collection are tied together. Use an integration default configuration file to enable dedicated [processors][1], [parsing][2], and [facets][3] in Datadog.
 
-Consult the [list of available supported integrations][4].
+## Enabling log collection from integrations
 
+To collect logs for a given integration, uncomment the logs section in that integration's `conf.yaml` file and configure it for your environment. If you are running the Agent in a Kubernetes or Docker environment, see the dedicated [Kubernetes Log Collection][4] or [Docker Log Collection][5] documentation.
+
+Consult the [list of available supported integrations][6].
 
 [1]: /logs/log_configuration/processors
 [2]: /logs/log_configuration/parsing
 [3]: /logs/explorer/facets/
-[4]: /integrations/#cat-log-collection
+[4]: /agent/kubernetes/log/#autodiscovery
+[5]: /agent/docker/log/#log-integrations
+[6]: /integrations/#cat-log-collection
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
### What does this PR do?
- Move "Enabling Log Collection" from Agent logs section to logs collection setup
- Fix "Agent’s status subcommand" link to go to agent status page instead of APM
- Fix "custom metrics" link to go to custom metrics page instead of tagging

### Motivation
DOCS-2154

### Preview
https://docs-staging.datadoghq.com/may.lee/move-enabling-log-collection/logs/log_collection/?tab=cloudintegration

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
