### PR TITLE
[doc] changes to apply kube tags to custom metrics

### DIFF
--- a/content/en/agent/kubernetes/tag.md
+++ b/content/en/agent/kubernetes/tag.md
@@ -61,8 +61,7 @@ The Agent can autodiscover and attach tags to all data emitted by the entire pod
 
 </div>
 
-### Note:
-To apply these [Out-Of-The-Box tags](?tab=containerizedagent#out-of-the-box-tags) to custom metrics sent over UDS, [Origin Detection](?tab=host#origin-detection) needs to be enabled. To properly detect the origin for DogStatsD metrics and to tag appropraitely set  'useHostPID: true' in your deployment file. 
+**Note:** To apply these [Out-Of-The-Box tags](?tab=containerizedagent#out-of-the-box-tags) to custom metrics sent over UDS, [Origin Detection](?tab=host#origin-detection) needs to be enabled. To properly detect the origin for DogStatsD metrics and to tag appropriately set  'useHostPID: true' in your deployment file. 
 
 
 ### Host tag

--- a/content/en/agent/kubernetes/tag.md
+++ b/content/en/agent/kubernetes/tag.md
@@ -61,6 +61,10 @@ The Agent can autodiscover and attach tags to all data emitted by the entire pod
 
 </div>
 
+### Note:
+To apply these [Out-Of-The-Box tags](?tab=containerizedagent#out-of-the-box-tags) to custom metrics sent over UDS, [Origin Detection](?tab=host#origin-detection) needs to be enabled. To properly detect the origin for DogStatsD metrics and to tag appropraitely set  'useHostPID: true' in your deployment file. 
+
+
 ### Host tag
 
 The Agent can attach Kubernetes environment information as "host tags".


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds the following: 
Note: To apply these Out-Of-The-Box tags to custom metrics sent over UDS, Origin Detection needs to be enabled. To properly detect the origin for DogStatsD metrics and to tag appropraitely set  datadog.dogstatsd.useHostPID: true in your deployment file. 


### Motivation
Two tickets that could have been avoided if docs indicated these config requirements
https://datadog.zendesk.com/agent/tickets/565731
https://datadog.zendesk.com/agent/tickets/568137

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
