### PR TITLE
[Okta] Fix How to Configure SAML 2.0 link

### DIFF
--- a/content/en/account_management/saml/okta.md
+++ b/content/en/account_management/saml/okta.md
@@ -22,10 +22,10 @@ Follow the [How to Configure SAML 2.0 for Datadog][1] docs to configure Okta as 
 
 | Okta IDP Input Field        | Expected Value                                                                                                                 |
 |-----------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| Single Sign On URL          | Assertion Consumer Service URL (Find this URL on the [Configure SAML][1] page, in the *Assertion Consumer Service URL* field.) |
+| Single Sign On URL          | Assertion Consumer Service URL (Find this URL on the [Configure SAML][2] page, in the *Assertion Consumer Service URL* field.) |
 | Recipient URL               | Assertion Consumer Service URL (or click the *Use this for Recipient URL and Destination URL* checkbox)                        |
 | Destination URL             | Assertion Consumer Service URL (or click the *Use this for Recipient URL and Destination URL* checkbox)                        |
-| Audience URI (SP Entity ID) | Service Provider Entity ID (Find this URL on the [Configure SAML][1] page, in the *Service Provider Entity ID* field.)         |
+| Audience URI (SP Entity ID) | Service Provider Entity ID (Find this URL on the [Configure SAML][2] page, in the *Service Provider Entity ID* field.)         |
 | Name ID Format              | EmailAddress                                                                                                                   |
 | Response                    | Signed                                                                                                                         |
 | Assertion Signature         | Signed                                                                                                                         |
@@ -46,22 +46,23 @@ Follow the [How to Configure SAML 2.0 for Datadog][1] docs to configure Okta as 
 
 ## Group attribute statements (optional)
 
-This is required only if you are using [AuthN Mapping][2].
+This is required only if you are using [AuthN Mapping][3].
 
 | Name     | Name Format (optional) | Value                                                                                                                     |
 |----------|------------------------|---------------------------------------------------------------------------------------------------------------------------|
 | memberOf | Unspecified            | Matches regex `.*` (This method retrieves all groups. Contact your IDP administrator if this does not fit your use case.) |
 
 
-Additional information on configuring SAML for your Datadog account is available on the [SAML documentation page][3].
+Additional information on configuring SAML for your Datadog account is available on the [SAML documentation page][4].
 
-In the event that you need to upload an `IDP.XML` file to Datadog before being able to fully configure the application in Okta, see [acquiring the idp.xml metadata file for a SAML template App article][4] for field placeholder instructions.
+In the event that you need to upload an `IDP.XML` file to Datadog before being able to fully configure the application in Okta, see [acquiring the idp.xml metadata file for a SAML template App article][5] for field placeholder instructions.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/saml/saml_setup
-[2]: /account_management/saml/#mapping-saml-attributes-to-datadog-roles
-[3]: /account_management/saml/
-[4]: https://support.okta.com/help/s/article/How-do-we-download-the-IDP-XML-metadata-file-from-a-SAML-Template-App
+[1]: https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-DataDog.html
+[2]: https://app.datadoghq.com/saml/saml_setup
+[3]: /account_management/saml/#mapping-saml-attributes-to-datadog-roles
+[4]: /account_management/saml/
+[5]: https://support.okta.com/help/s/article/How-do-we-download-the-IDP-XML-metadata-file-from-a-SAML-Template-App


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR fixes the link in our Okta SAML IdP docs to the **How to Configure SAML 2.0 for Datadog** page.

### Motivation
I noticed that the link was added back [here](https://github.com/DataDog/documentation/blob/f711aa280f521287a8dac8ee626efd7e283b47be/content/en/account_management/saml/okta.md) after being deleted [here](https://github.com/DataDog/documentation/commit/e0f7b21d14bbacca4f4d5531afc7f7ad05e92043#diff-6e25d02b5905436951588d555009e5781757bc8bca05c2335731990bfb2f2799). However, it looks like it currently points to the wrong page.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/victorien-provenzano/fix-how-to-configure-saml-20-link

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
