### PR TITLE
DOCS-1423 Remove link parameter from docker compose example

### DIFF
--- a/content/en/integrations/faq/compose-and-the-datadog-agent.md
+++ b/content/en/integrations/faq/compose-and-the-datadog-agent.md
@@ -38,8 +38,6 @@ services:
     image: redis
   datadog:
     build: datadog
-    links:
-     - redis # Connect the Datadog Agent container to the Redis container
     environment:
      - DD_API_KEY=${DD_API_KEY}
      - DD_SITE={{< region-param key="dd_site" >}}
@@ -80,8 +78,6 @@ services:
       com.datadoghq.ad.logs: '[{"source": "redis", "service": "redis"}]'
   datadog:
     build: datadog
-    links:
-     - redis # Connect the Datadog Agent container to the Redis container
     environment:
      - DD_API_KEY=${DD_API_KEY}
      - DD_SITE={{< region-param key="dd_site" >}}


### PR DESCRIPTION
### What does this PR do?
Remove --link parameter because it's deprecated.

### Motivation
DOCS-1423

### Preview
https://docs-staging.datadoghq.com/may/remove-link-parameter/integrations/faq/compose-and-the-datadog-agent/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
