### PR TITLE
Remove quotes from Java environment variables

### DIFF
--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -71,10 +71,10 @@ Follow these steps to instrument the function:
 2. Configure the following environment variables on your function:
 
     ```yaml
-    JAVA_TOOL_OPTIONS: "-javaagent:\"/opt/java/lib/dd-java-agent.jar\""
-    DD_LOGS_INJECTION: "true"
-    DD_JMXFETCH_ENABLED: "false"
-    DD_TRACE_ENABLED: "true"
+    JAVA_TOOL_OPTIONS: -javaagent:"/opt/java/lib/dd-java-agent.jar"
+    DD_LOGS_INJECTION: true
+    DD_JMXFETCH_ENABLED: false
+    DD_TRACE_ENABLED: true
     ```
 
 3. Wrap your Lambda handler function using the wrapper provided by the Datadog Lambda Library:


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Removes the quotes surrounding the environment variables required by the Java tracer in Lambda functions.

### Motivation
<!-- What inspired you to submit this pull request?-->

I've gotten some feedback that the quotes here cause  confusion when these environment variables are set in the AWS console. I think it's safe enough to assume that if someone is using a tool where they need to escape quotes, they should be able to work it out.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
