### PR TITLE
[CIAPP-2828] Add GitHub CI Visibility docs

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2049,26 +2049,31 @@ main:
     parent: ci
     identifier: setup_pipelines
     weight: 2
-  - name: GitLab
-    url: continuous_integration/setup_pipelines/gitlab/
-    parent: setup_pipelines
-    identifier: ci_gitlab
-    weight: 201
-  - name: Jenkins
-    url: continuous_integration/setup_pipelines/jenkins/
-    parent: setup_pipelines
-    identifier: ci_jenkins
-    weight: 202
   - name: Buildkite
     url: continuous_integration/setup_pipelines/buildkite/
     parent: setup_pipelines
     identifier: ci_buildkite
-    weight: 203
+    weight: 201
   - name: CircleCI
     url: continuous_integration/setup_pipelines/circleci/
     parent: setup_pipelines
     identifier: ci_circleci
+    weight: 202
+  - name: GitHub
+    url: continuous_integration/setup_pipelines/github/
+    parent: setup_pipelines
+    identifier: ci_github
+    weight: 203
+  - name: GitLab
+    url: continuous_integration/setup_pipelines/gitlab/
+    parent: setup_pipelines
+    identifier: ci_gitlab
     weight: 204
+  - name: Jenkins
+    url: continuous_integration/setup_pipelines/jenkins/
+    parent: setup_pipelines
+    identifier: ci_jenkins
+    weight: 205
   - name: Custom Commands
     url: continuous_integration/setup_pipelines/custom_commands/
     parent: setup_pipelines

--- a/content/en/continuous_integration/setup_pipelines/_index.md
+++ b/content/en/continuous_integration/setup_pipelines/_index.md
@@ -6,9 +6,10 @@ disable_sidebar: true
 ---
 
 {{< whatsnext desc="CI pipelines providers:" >}}
-    {{< nextlink href="continuous_integration/setup_pipelines/gitlab" >}}GitLab{{< /nextlink >}}
-    {{< nextlink href="continuous_integration/setup_pipelines/jenkins" >}}Jenkins{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_pipelines/buildkite" >}}Buildkite{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_pipelines/circleci" >}}CircleCI{{< /nextlink >}}
+    {{< nextlink href="continuous_integration/setup_pipelines/github" >}}GitHub{{< /nextlink >}}
+    {{< nextlink href="continuous_integration/setup_pipelines/gitlab" >}}GitLab{{< /nextlink >}}
+    {{< nextlink href="continuous_integration/setup_pipelines/jenkins" >}}Jenkins{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_pipelines/custom_commands" >}}Custom Commands{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/continuous_integration/setup_pipelines/github.md
+++ b/content/en/continuous_integration/setup_pipelines/github.md
@@ -35,7 +35,7 @@ The [GitHub Actions][1] integration uses a private [GitHub App][2] to collect wo
 6. Give the app a name, for example, `Datadog CI Visibility`.
 7. Click **Install GitHub App** and follow the instructions on GitHub.
 
-After the GitHub App is created and installed, recently finished GitHub Actions workflows will appear on CI Visibility.
+After the GitHub App is created and installed, recently finished GitHub Actions workflows appear in CI Visibility pages.
 
 ## Visualize pipeline data in Datadog
 

--- a/content/en/continuous_integration/setup_pipelines/github.md
+++ b/content/en/continuous_integration/setup_pipelines/github.md
@@ -1,0 +1,103 @@
+---
+title: Set up Tracing on a GitHub Actions workflows
+kind: documentation
+further_reading:
+    - link: "/continuous_integration/explore_pipelines"
+      tag: "Documentation"
+      text: "Explore Pipeline Execution Results and Performance"
+    - link: "/continuous_integration/troubleshooting/"
+      tag: "Documentation"
+      text: "Troubleshooting CI"
+---
+
+{{< site-region region="us,eu,us3" >}}
+<div class="alert alert-info">GitHub Actions integration is in beta. There are no billing implications for activating the GitHub Actions integration during this period.
+</div>
+
+## Compatibility
+
+Supported GitHub versions:
+* GitHub.com (SaaS)
+
+GitHub Enterprise is not yet supported.
+
+## Configuring the Datadog integration
+
+The [GitHub Actions][1] integration uses a private [GitHub App][2] to collect workflow information. To create one:
+
+[1]: https://docs.github.com/en/actions
+[2]: https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps
+
+{{< site-region region="us" >}}
+1. Go to the [GitHub Apps Integration tile][1].
+2. Click the `Link GitHub Account` button.
+3. Follow the instructions to configure for a personal or organization account.
+4. In `Edit Permissions`, make sure `Actions: Read` access is granted.
+5. Click `Create App in GitHub` which takes you to GitHub to finish the app creation process.
+6. Give the app a name.
+7. Click the `Install GitHub App` and follow the instructions on GitHub.
+
+[1]: https://app.datadoghq.com/account/settings#integrations/github-apps
+{{< /site-region >}}
+
+{{< site-region region="eu" >}}
+1. Go to the [GitHub Apps Integration tile][1].
+2. Click the `Link GitHub Account` button.
+3. Follow the instructions to configure for a personal or organization account.
+4. In `Edit Permissions`, make sure `Actions: Read` access is granted.
+5. Click `Create App in GitHub` which takes you to GitHub to finish the app creation process.
+6. Give the app a name,
+7. Click the `Install GitHub App` and follow the instructions on GitHub.
+
+[1]: https://app.datadoghq.eu/account/settings#integrations/github-apps
+{{< /site-region >}}
+
+{{< site-region region="us3" >}}
+1. Go to the [GitHub Apps Integration tile][1].
+2. Click the `Link GitHub Account` button.
+3. Follow the instructions to configure for a personal or organization account.
+4. In `Edit Permissions`, make sure `Actions: Read` access is granted.
+5. Click `Create App in GitHub` which takes you to GitHub to finish the app creation process.
+6. Give the app a name.
+7. Click the `Install GitHub App` and follow the instructions on GitHub.
+
+[1]: https://us3.datadoghq.com/account/settings#integrations/github-apps
+{{< /site-region >}}
+
+Once the GitHub App is created and installed, newly finished GitHub Actions workflows will appear on CI Visibility.
+
+## Visualize pipeline data in Datadog
+
+{{< site-region region="us" >}}
+The [Pipelines][1] and [Pipeline Executions][2] pages populate with data after the pipelines finish.
+
+[1]: https://app.datadoghq.com/ci/pipelines
+[2]: https://app.datadoghq.com/ci/pipeline-executions
+{{< /site-region >}}
+
+{{< site-region region="eu" >}}
+
+The [Pipelines][1] and [Pipeline Executions][2] pages populate with data after the pipelines finish.
+
+[1]: https://app.datadoghq.eu/ci/pipelines
+[2]: https://app.datadoghq.eu/ci/pipeline-executions
+{{< /site-region >}}
+
+{{< site-region region="us3" >}}
+
+The [Pipelines][1] and [Pipeline Executions][2] pages populate with data after the pipelines finish.
+
+[1]: https://us3.datadoghq.com/ci/pipelines
+[2]: https://us3.datadoghq.com/ci/pipeline-executions
+{{< /site-region >}}
+
+**Note**: The Pipelines page shows data for only the default branch of each repository.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+{{< /site-region >}}
+
+{{< site-region region="us5,gov" >}}
+This feature is not supported for the selected Datadog site ({{< region-param key="dd_site_name" >}}).
+{{< /site-region >}}

--- a/content/en/continuous_integration/setup_pipelines/github.md
+++ b/content/en/continuous_integration/setup_pipelines/github.md
@@ -1,5 +1,5 @@
 ---
-title: Set up Tracing on a GitHub Actions workflows
+title: Set up Tracing on GitHub Actions Workflows
 kind: documentation
 further_reading:
     - link: "/continuous_integration/explore_pipelines"
@@ -11,31 +11,31 @@ further_reading:
 ---
 
 {{< site-region region="us5,gov" >}}
-<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+<div class="alert alert-warning">The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported.</div>
 {{< /site-region >}}
 
-<div class="alert alert-info">GitHub Actions integration is in beta. There are no billing implications for activating the GitHub Actions integration during this period.</div>
+<div class="alert alert-info">The GitHub Actions integration is in beta. There are no billing implications for activating the GitHub Actions integration during this period.</div>
 
 ## Compatibility
 
 Supported GitHub versions:
 * GitHub.com (SaaS)
 
-GitHub Enterprise is not yet supported.
+GitHub Enterprise is not supported.
 
 ## Configuring the Datadog integration
 
-The [GitHub Actions][1] integration uses a private [GitHub App][2] to collect workflow information. To create one:
+The [GitHub Actions][1] integration uses a private [GitHub App][2] to collect workflow information. To create the app:
 
 1. Go to the [GitHub Apps Integration tile][3].
-2. Click the `Link GitHub Account` button.
-3. Follow the instructions to configure for a personal or organization account.
-4. In `Edit Permissions`, make sure `Actions: Read` access is granted.
-5. Click `Create App in GitHub` which takes you to GitHub to finish the app creation process.
-6. Give the app a name. For example, `Datadog CI Visibility`.
-7. Click the `Install GitHub App` and follow the instructions on GitHub.
+2. Click **Link GitHub Account**.
+3. Follow the instructions to configure the integration for a personal or organization account.
+4. In **Edit Permissions**, grant `Actions: Read` access.
+5. Click **Create App in GitHub** to finish the app creation process GitHub.
+6. Give the app a name, for example, `Datadog CI Visibility`.
+7. Click **Install GitHub App** and follow the instructions on GitHub.
 
-Once the GitHub App is created and installed, newly finished GitHub Actions workflows will appear on CI Visibility.
+After the GitHub App is created and installed, recently finished GitHub Actions workflows will appear on CI Visibility.
 
 ## Visualize pipeline data in Datadog
 
@@ -47,8 +47,8 @@ The [Pipelines][4] and [Pipeline Executions][5] pages populate with data after t
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://docs.github.com/en/actions
-[2]: https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps
+[1]: https://docs.github.com/actions
+[2]: https://docs.github.com/developers/apps/getting-started-with-apps/about-apps
 [3]: https://app.datadoghq.com/account/settings#integrations/github-apps
 [4]: https://app.datadoghq.com/ci/pipelines
 [5]: https://app.datadoghq.com/ci/pipeline-executions

--- a/content/en/continuous_integration/setup_pipelines/github.md
+++ b/content/en/continuous_integration/setup_pipelines/github.md
@@ -10,9 +10,11 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
-{{< site-region region="us,eu,us3" >}}
-<div class="alert alert-info">GitHub Actions integration is in beta. There are no billing implications for activating the GitHub Actions integration during this period.
-</div>
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
+
+<div class="alert alert-info">GitHub Actions integration is in beta. There are no billing implications for activating the GitHub Actions integration during this period.</div>
 
 ## Compatibility
 
@@ -25,79 +27,28 @@ GitHub Enterprise is not yet supported.
 
 The [GitHub Actions][1] integration uses a private [GitHub App][2] to collect workflow information. To create one:
 
-[1]: https://docs.github.com/en/actions
-[2]: https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps
-
-{{< site-region region="us" >}}
-1. Go to the [GitHub Apps Integration tile][1].
+1. Go to the [GitHub Apps Integration tile][3].
 2. Click the `Link GitHub Account` button.
 3. Follow the instructions to configure for a personal or organization account.
 4. In `Edit Permissions`, make sure `Actions: Read` access is granted.
 5. Click `Create App in GitHub` which takes you to GitHub to finish the app creation process.
 6. Give the app a name.
 7. Click the `Install GitHub App` and follow the instructions on GitHub.
-
-[1]: https://app.datadoghq.com/account/settings#integrations/github-apps
-{{< /site-region >}}
-
-{{< site-region region="eu" >}}
-1. Go to the [GitHub Apps Integration tile][1].
-2. Click the `Link GitHub Account` button.
-3. Follow the instructions to configure for a personal or organization account.
-4. In `Edit Permissions`, make sure `Actions: Read` access is granted.
-5. Click `Create App in GitHub` which takes you to GitHub to finish the app creation process.
-6. Give the app a name,
-7. Click the `Install GitHub App` and follow the instructions on GitHub.
-
-[1]: https://app.datadoghq.eu/account/settings#integrations/github-apps
-{{< /site-region >}}
-
-{{< site-region region="us3" >}}
-1. Go to the [GitHub Apps Integration tile][1].
-2. Click the `Link GitHub Account` button.
-3. Follow the instructions to configure for a personal or organization account.
-4. In `Edit Permissions`, make sure `Actions: Read` access is granted.
-5. Click `Create App in GitHub` which takes you to GitHub to finish the app creation process.
-6. Give the app a name.
-7. Click the `Install GitHub App` and follow the instructions on GitHub.
-
-[1]: https://us3.datadoghq.com/account/settings#integrations/github-apps
-{{< /site-region >}}
 
 Once the GitHub App is created and installed, newly finished GitHub Actions workflows will appear on CI Visibility.
 
 ## Visualize pipeline data in Datadog
 
-{{< site-region region="us" >}}
-The [Pipelines][1] and [Pipeline Executions][2] pages populate with data after the pipelines finish.
-
-[1]: https://app.datadoghq.com/ci/pipelines
-[2]: https://app.datadoghq.com/ci/pipeline-executions
-{{< /site-region >}}
-
-{{< site-region region="eu" >}}
-
-The [Pipelines][1] and [Pipeline Executions][2] pages populate with data after the pipelines finish.
-
-[1]: https://app.datadoghq.eu/ci/pipelines
-[2]: https://app.datadoghq.eu/ci/pipeline-executions
-{{< /site-region >}}
-
-{{< site-region region="us3" >}}
-
-The [Pipelines][1] and [Pipeline Executions][2] pages populate with data after the pipelines finish.
-
-[1]: https://us3.datadoghq.com/ci/pipelines
-[2]: https://us3.datadoghq.com/ci/pipeline-executions
-{{< /site-region >}}
+The [Pipelines][4] and [Pipeline Executions][5] pages populate with data after the pipelines finish.
 
 **Note**: The Pipelines page shows data for only the default branch of each repository.
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-{{< /site-region >}}
 
-{{< site-region region="us5,gov" >}}
-This feature is not supported for the selected Datadog site ({{< region-param key="dd_site_name" >}}).
-{{< /site-region >}}
+[1]: https://docs.github.com/en/actions
+[2]: https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps
+[3]: https://app.datadoghq.com/account/settings#integrations/github-apps
+[4]: https://app.datadoghq.com/ci/pipelines
+[5]: https://app.datadoghq.com/ci/pipeline-executions

--- a/content/en/continuous_integration/setup_pipelines/github.md
+++ b/content/en/continuous_integration/setup_pipelines/github.md
@@ -32,7 +32,7 @@ The [GitHub Actions][1] integration uses a private [GitHub App][2] to collect wo
 3. Follow the instructions to configure for a personal or organization account.
 4. In `Edit Permissions`, make sure `Actions: Read` access is granted.
 5. Click `Create App in GitHub` which takes you to GitHub to finish the app creation process.
-6. Give the app a name.
+6. Give the app a name. For example, `Datadog CI Visibility`.
 7. Click the `Install GitHub App` and follow the instructions on GitHub.
 
 Once the GitHub App is created and installed, newly finished GitHub Actions workflows will appear on CI Visibility.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds the documentation for tracing GitHub Action workflows with CI Visibility.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/carlos.gonzalez/ci-gh-docs/continuous_integration/setup_pipelines/github/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
