### PR TITLE
Update cloud-metric-delay.md

### DIFF
--- a/content/en/integrations/faq/cloud-metric-delay.md
+++ b/content/en/integrations/faq/cloud-metric-delay.md
@@ -20,7 +20,7 @@ When using any Datadog cloud integration (AWS, Azure, GCP, etc.), metrics are pu
 |------------|------------------|
 | Alibaba    | Every 10 minutes |
 | AWS        | Every 10 minutes |
-| Azure      | Every 5 minutes  |
+| Azure      | Every 2 minutes  |
 | Cloudflare | Every 15 minutes |
 | GCP        | Every 5 minutes  |
 
@@ -40,7 +40,7 @@ Further, the CloudWatch API only offers a metric-by-metric crawl to pull data. T
 
 ### Azure
 
-Azure emits metrics with 1-minute granularity. Therefore, expect metric delays of ~7-8 minutes.
+Azure emits metrics with 1-minute granularity. Therefore, expect metric delays of ~4-5 minutes.
 
 ### GCP
 


### PR DESCRIPTION
Default interval of Azure crawler updated to 2minutes from 5minutes
Source : cloud-metric-delay.md

Motivation
New Azure crawler interval is confirmed from #support-azure-integration :

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->
https://dd.slack.com/archives/C02FPP4JQHX/p1636013977056500

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
