### PR TITLE
Updating link to MWL doc

### DIFF
--- a/content/en/metrics/types.md
+++ b/content/en/metrics/types.md
@@ -218,12 +218,12 @@ That is, for a distribution metric with added percentile aggregations during a g
 
 #### Customization of tagging
 
-This functionality allows you to control tagging for metrics where host-level granularity is not necessary. See the [Distribution Metric page][1] to learn more about whitelist-based tagging control.
+This functionality allows you to control tagging for metrics where host-level granularity is not necessary. Learn more about [Metrics withhout Limits][1].
 
 **Note**: The exclusion of tags with `!` is not accepted with this feature.
 
 
-[1]: https://app.datadoghq.com/metric/distribution_metrics
+[1]: https://app.datadoghq.com/metric/metrics-without-limits
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/metrics/types.md
+++ b/content/en/metrics/types.md
@@ -223,7 +223,7 @@ This functionality allows you to control tagging for metrics where host-level gr
 **Note**: The exclusion of tags with `!` is not accepted with this feature.
 
 
-[1]: https://app.datadoghq.com/metric/metrics-without-limits
+[1]: /metrics/metrics-without-limits/
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/metrics/types.md
+++ b/content/en/metrics/types.md
@@ -218,7 +218,7 @@ That is, for a distribution metric with added percentile aggregations during a g
 
 #### Customization of tagging
 
-This functionality allows you to control tagging for metrics where host-level granularity is not necessary. Learn more about [Metrics withhout Limits][1].
+This functionality allows you to control tagging for metrics where host-level granularity is not necessary. Learn more about [Metrics withhout Limits™][1].
 
 **Note**: The exclusion of tags with `!` is not accepted with this feature.
 


### PR DESCRIPTION
Just switching out an outdated link on the metric types page

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
