### PR TITLE
[SW-1699] Add new Synthetic test error type

### DIFF
--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -217,7 +217,7 @@ These reasons include the following:
   - `TIMEOUT: Retrieving the response couldn’t be completed in a reasonable time.` indicates that the timeout happened on the overall run (which includes TCP socket connection, data transfer, and assertions).
 
 `MALFORMED_RESPONSE` 
-: The remote server responded with a payload that did not comply with HTTP specifications.
+: The remote server responded with a payload that does not comply with HTTP specifications.
 
 ## Permissions
 

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -216,6 +216,9 @@ These reasons include the following:
   - `TIMEOUT: The request couldn’t be completed in a reasonable time.` indicates that the timeout happened at the TCP socket connection level. 
   - `TIMEOUT: Retrieving the response couldn’t be completed in a reasonable time.` indicates that the timeout happened on the overall run (which includes TCP socket connection, data transfer, and assertions).
 
+`MALFORMED_RESPONSE` 
+: The remote server responded with a payload that did not comply with HTTP specifications.
+
 ## Permissions
 
 By default, only users with the [Datadog Admin and Datadog Standard roles][13] can create, edit, and delete Synthetic HTTP tests. To get create, edit, and delete access to Synthetic HTTP tests, upgrade your user to one of those two [default roles][13].

--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -258,7 +258,7 @@ A test is considered `FAILED` if a step does not satisfy one or several assertio
   - `TIMEOUT: Retrieving the response couldn’t be completed in a reasonable time.` indicates that the timeout happened on the overall run (which includes TCP socket connection, data transfer, and assertions).
 
 `MALFORMED_RESPONSE` 
-: The remote server responded with a payload that did not comply with HTTP specifications.
+: The remote server responded with a payload that does not comply with HTTP specifications.
 
 ## Permissions
 

--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -257,6 +257,9 @@ A test is considered `FAILED` if a step does not satisfy one or several assertio
   - `TIMEOUT: The request couldn’t be completed in a reasonable time.` indicates that the timeout happened at the TCP socket connection level.
   - `TIMEOUT: Retrieving the response couldn’t be completed in a reasonable time.` indicates that the timeout happened on the overall run (which includes TCP socket connection, data transfer, and assertions).
 
+`MALFORMED_RESPONSE` 
+: The remote server responded with a payload that did not comply with HTTP specifications.
+
 ## Permissions
 
 By default, only users with the [Datadog Admin and Datadog Standard roles][16] can create, edit, and delete Synthetic multistep API tests. To get create, edit, and delete access to Synthetic multistep API tests, upgrade your user to one of those two [default roles][16].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/beth.glenfield/synthetic-response-updates/synthetics/api_tests/http_tests/?tab=requestoptions#test-failure

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
