### PR TITLE
Exclude START and END logs from Lambda Extension

### DIFF
--- a/content/en/serverless/libraries_integrations/extension.md
+++ b/content/en/serverless/libraries_integrations/extension.md
@@ -32,7 +32,18 @@ To install the Datadog Lambda Extension, instrument your AWS serverless applicat
 
 To disable submission of your AWS Lambda logs to Datadog using the extension, set the environment variable `DD_SERVERLESS_LOGS_ENABLED` to `false` in your Lambda function.
 
-To scrub or filter logs before sending them to Datadog, see [Advanced Log Collection][6].
+To exclude the `START` and `END` logs, set the environment variable `DD_LOGS_CONFIG_PROCESSING_RULES` to `[{"type": "exclude_at_match", "name": "exclude_start_and_end_logs", "pattern": "(START|END)\\s"}]`. Alternatively, you can add a `datadog.yaml` file in your project root directory with the following content:
+
+```yaml
+logs_config:
+  processing_rules:
+    - type: exclude_at_match
+      name: exclude_start_and_end_logs
+      pattern: (START|END)\s
+```
+
+To scrub or filter other logs before sending them to Datadog, see [Advanced Log Collection][6].
+
 
 ## Trace collection
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Document how to prevent Lambda START and END logs (many consider them as useless) from being collected by the Lambda Extension.

### Motivation 
People often ask for this.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tian.chu/lambda-ext-log-exclusion/serverless/libraries_integrations/extension/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
