### PR TITLE
Fix links and site-region tags on all pages in CI Visibility section

### DIFF
--- a/content/en/continuous_integration/_index.md
+++ b/content/en/continuous_integration/_index.md
@@ -14,7 +14,7 @@ further_reading:
 ---
 
 {{< site-region region="us5,gov" >}}
-<div class="alert alert-info">CI Visibility is available only on the US1, EU1, and US3 Datadog sites at this time.</div>
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
 Datadog Continuous Integration (CI) Visibility brings together information about CI test and pipeline results _plus_ data about CI performance, trends, and reliability, all into one place. Not only does it provide developers with the ability to dig into the reasons for a test or pipeline failure, to monitor trends in test suite execution times, or to see the effect a given commit has on the pipeline, it also gives build engineers visibility into cross-organization CI health and trends in pipeline performance over time.

--- a/content/en/continuous_integration/explore_pipelines.md
+++ b/content/en/continuous_integration/explore_pipelines.md
@@ -7,6 +7,10 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
+
 Your pipelines appear in the [Pipelines][1] page under the CI menu.
 
 ## Pipelines health overview

--- a/content/en/continuous_integration/explore_tests.md
+++ b/content/en/continuous_integration/explore_tests.md
@@ -10,6 +10,10 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
+
 The [Tests][1] page, under the CI menu in Datadog, provides a test-first view into your CI health by showing you important metrics and results from your tests. It can help you drill down into performance problems and test failures that concern you primarily because you work on the related code (and less because you maintain the pipelines they are run in).
 
 ## Explore tests

--- a/content/en/continuous_integration/guides/flaky_test_management.md
+++ b/content/en/continuous_integration/guides/flaky_test_management.md
@@ -4,7 +4,11 @@ kind: guide
 aliases: /continuous_integration/guides/find_flaky_tests/
 ---
 
-_Flaky tests_ are tests that exhibit both a passing and failing status across multiple test runs for the same commit. If you commit some code and run it through CI, and a test fails, and you run it through CI again and the test passes, that test is unreliable as proof of quality code. 
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
+
+_Flaky tests_ are tests that exhibit both a passing and failing status across multiple test runs for the same commit. If you commit some code and run it through CI, and a test fails, and you run it through CI again and the test passes, that test is unreliable as proof of quality code.
 
 Flaky tests introduce risk and unpredictability into your CI system and into your end product. When people have to remember which tests are flaky, they lose trust in their test results, and a tremendous amount of time and resources are wasted on pipeline retries.
 
@@ -32,5 +36,5 @@ If a flaky test has not failed in the past 30 days, it is automatically removed 
 
 2. Filter the table to see branches, services, or commits of interest to you.
 
-3. Look at the **New Flaky** column to see the number of new flaky tests that were introduced by the latest commit. These are tests that exhibit flaky behavior and didn’t previously exist in the Flaky Tests table. 
+3. Look at the **New Flaky** column to see the number of new flaky tests that were introduced by the latest commit. These are tests that exhibit flaky behavior and didn’t previously exist in the Flaky Tests table.
 

--- a/content/en/continuous_integration/setup_pipelines/buildkite.md
+++ b/content/en/continuous_integration/setup_pipelines/buildkite.md
@@ -11,12 +11,9 @@ further_reading:
 ---
 
 {{< site-region region="us5,gov" >}}
-<div class="alert alert-warning">
-The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported.
-</div>
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-{{< site-region region="us,eu,us3" >}}
 ## Configure the Datadog integration
 
 The steps to activate the Datadog integration for [Buildkite][1] are:
@@ -36,11 +33,10 @@ The [Pipelines][3] and [Pipeline Executions][4] pages populate with data after t
 
 **Note**: The Pipelines page shows data for only the default branch of each repository.
 
-{{< /site-region >}}
-
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
 [1]: https://buildkite.com
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 [3]: https://app.datadoghq.com/ci/pipelines

--- a/content/en/continuous_integration/setup_pipelines/circleci.md
+++ b/content/en/continuous_integration/setup_pipelines/circleci.md
@@ -14,12 +14,9 @@ further_reading:
 ---
 
 {{< site-region region="us5,gov" >}}
-<div class="alert alert-warning">
-The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported.
-</div>
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-{{< site-region region="us,eu,us3" >}}
 ## Configure the Datadog integration
 
 The Datadog integration for [CircleCI][1] works by using [webhooks][2] to send data to Datadog.
@@ -37,8 +34,6 @@ The Datadog integration for [CircleCI][1] works by using [webhooks][2] to send d
 The [Pipelines][4] and [Pipeline Executions][5] pages populate with data after the workflows finish.
 
 **Note**: The Pipelines page shows data for only the default branch of each repository.
-
-{{< /site-region >}}
 
 ## Further reading
 

--- a/content/en/continuous_integration/setup_pipelines/custom_commands.md
+++ b/content/en/continuous_integration/setup_pipelines/custom_commands.md
@@ -8,12 +8,9 @@ further_reading:
 ---
 
 {{< site-region region="us5,gov" >}}
-<div class="alert alert-warning">
-The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported.
-</div>
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-{{< site-region region="us,eu,us3" >}}
 Custom commands provide a way to trace individual commands in your CI pipelines, allowing you to measure the time your command takes without taking into account any setup or teardown actions that the job might have (for example, downloading Docker images or waiting for an available node in a Kubernetes-based infrastructure). These spans appear as part of the pipeline's trace:
 
 {{< img src="ci/ci-custom-spans.png" alt="Details for a single pipeline with custom commands" style="width:100%;">}}
@@ -43,14 +40,29 @@ datadog-ci trace [--name <name>] -- <command>
 
 Specify a valid [Datadog API key][2] in the `DATADOG_API_KEY` environment variable. For example:
 
+{{< site-region region="us" >}}
 <pre class="chroma">
 <code class="language-bash" data-lang="bash">
-DATADOG_API_KEY=&lt;api_key&gt; DATADOG_SITE={{< region-param key="dd_site" >}} datadog-ci trace \
+DATADOG_API_KEY=&lt;key&gt; datadog-ci trace \
 --name "Greet" \
 -- \
 echo "Hello World"
 </code>
 </pre>
+{{< /site-region >}}
+{{< site-region region="us3,eu" >}}
+<pre class="chroma">
+<code class="language-bash" data-lang="bash">
+DATADOG_API_KEY=&lt;key&gt; DATADOG_SITE={{< region-param key="dd_site" >}} datadog-ci trace \
+--name "Greet" \
+-- \
+echo "Hello World"
+</code>
+</pre>
+{{< /site-region >}}
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
 
 ## Configuration settings
 
@@ -81,18 +93,18 @@ The following environment variables are supported:
 : [Datadog API key][2] used to authenticate the requests.<br/>
 **Default**: (none)
 
+{{< site-region region="us3,eu" >}}
 Additionally, configure the Datadog site to use the selected one ({{< region-param key="dd_site_name" >}}):
 
 `DATADOG_SITE`
-: The [Datadog site][3] to upload results to.<br/>
+: The Datadog site to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
 **Selected site**: {{< region-param key="dd_site" code="true" >}}
-
 {{< /site-region >}}
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
 [1]: https://www.npmjs.com/package/@datadog/datadog-ci
 [2]: https://app.datadoghq.com/organization-settings/api-keys
-[3]: /getting_started/site/

--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -11,12 +11,9 @@ further_reading:
 ---
 
 {{< site-region region="us5,gov" >}}
-<div class="alert alert-warning">
-The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported.
-</div>
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-{{< site-region region="us,eu,us3" >}}
 ## Compatibility
 
 Supported GitLab versions:
@@ -90,7 +87,6 @@ Fill in the integration configuration settings:
 : Specifies which [Datadog site][1] to send data to.<br/>
 **Default**: `datadoghq.com`<br/>
 **Selected site**: {{< region-param key="dd_site" code="true" >}}<br/>
-**Possible values**: `datadoghq.com`, `datadoghq.eu`
 
 **API URL** (optional)
 : Allows overriding the API URL used for sending data directly, only used in advanced scenarios.<br/>
@@ -128,8 +124,6 @@ To set custom `env` or `service` parameters, add more query parameters in the we
 After the integration is successfully configured, the [Pipelines][4] and [Pipeline Executions][5] pages populate with data after the pipelines finish.
 
 **Note**: The Pipelines page shows data for only the default branch of each repository.
-
-{{< /site-region >}}
 
 ## Further reading
 

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -13,6 +13,10 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
+
 ## Compatibility
 
 Supported Jenkins versions:

--- a/content/en/continuous_integration/setup_tests/agent.md
+++ b/content/en/continuous_integration/setup_tests/agent.md
@@ -11,12 +11,9 @@ further_reading:
 ---
 
 {{< site-region region="us5,gov" >}}
-<div class="alert alert-warning">
-The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported.
-</div>
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-{{< site-region region="us,eu,us3" >}}
 To report test results to Datadog, the [Datadog Agent][1] is required.
 
 There are two ways to set up the Agent in a CI environment:
@@ -52,12 +49,14 @@ To run the Datadog Agent as a container acting as a simple results forwarder, us
 **Default**: (autodetected)<br/>
 **Required value**: `none`
 
+{{< site-region region="us3,eu" >}}
 Additionally, configure the Datadog site to use the selected one ({{< region-param key="dd_site_name" >}}):
 
 `DD_SITE`
-: The [Datadog site][1] to upload results to.<br/>
+: The Datadog site to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
 **Selected site**: {{< region-param key="dd_site" code="true" >}}
+{{< /site-region >}}
 
 ### CI provider configuration examples
 
@@ -66,7 +65,34 @@ The following sections provide CI provider-specific instructions to run and conf
 {{< tabs >}}
 {{% tab "Azure Pipelines" %}}
 
-To run the Datadog Agent in Azure Pipelines, define a new container in the [resources section][1] and link it with the job declaring it as a [service container][2]. Replace `<DD_SITE>` with {{< region-param key="dd_site" code="true" >}} (defaults to `datadoghq.com`).
+To run the Datadog Agent in Azure Pipelines, define a new container in the [resources section][1] and link it with the job declaring it as a [service container][2].
+
+{{< site-region region="us" >}}
+{{< code-block lang="yaml" filename="azure-pipeline.yml" >}}
+variables:
+  ddApiKey: $(DD_API_KEY)
+
+resources:
+  containers:
+    - container: dd_agent
+      image: gcr.io/datadoghq/agent:latest
+      ports:
+        - 8126:8126
+      env:
+        DD_API_KEY: $(ddApiKey)
+        DD_INSIDE_CI: "true"
+        DD_HOSTNAME: "none"
+
+jobs:
+  - job: test
+    services:
+      dd_agent: dd_agent
+    steps:
+      - script: make test
+{{< /code-block >}}
+{{< /site-region >}}
+{{< site-region region="us3,eu" >}}
+Replace `<DD_SITE>` with the selected site: {{< region-param key="dd_site" code="true" >}}.
 
 {{< code-block lang="yaml" filename="azure-pipeline.yml" >}}
 variables:
@@ -91,6 +117,7 @@ jobs:
     steps:
       - script: make test
 {{< /code-block >}}
+{{< /site-region >}}
 
 Add your [Datadog API key][3] to your [project environment variables][4] with the key `DD_API_KEY`.
 
@@ -101,7 +128,26 @@ Add your [Datadog API key][3] to your [project environment variables][4] with th
 {{% /tab %}}
 {{% tab "GitLab CI" %}}
 
-To run the Agent in GitLab, define the Agent container under [services][1]. Replace `<DD_SITE>` with {{< region-param key="dd_site" code="true" >}} (defaults to `datadoghq.com`).
+To run the Agent in GitLab, define the Agent container under [services][1].
+
+{{< site-region region="us" >}}
+{{< code-block lang="yaml" filename=".gitlab-ci.yml" >}}
+variables:
+  DD_API_KEY: $DD_API_KEY
+  DD_INSIDE_CI: "true"
+  DD_HOSTNAME: "none"
+  DD_AGENT_HOST: "datadog-agent"
+
+test:
+  services:
+    - name: gcr.io/datadoghq/agent:latest
+  script:
+    - make test
+{{< /code-block >}}
+{{< /site-region >}}
+{{< site-region region="us3,eu" >}}
+
+Replace `<DD_SITE>` with the selected site: {{< region-param key="dd_site" code="true" >}}.
 
 {{< code-block lang="yaml" filename=".gitlab-ci.yml" >}}
 variables:
@@ -117,6 +163,7 @@ test:
   script:
     - make test
 {{< /code-block >}}
+{{< /site-region >}}
 
 Add your [Datadog API key][2] to your [project environment variables][3] with the key `DD_API_KEY`.
 
@@ -126,7 +173,28 @@ Add your [Datadog API key][2] to your [project environment variables][3] with th
 {{% /tab %}}
 {{% tab "GitHub Actions" %}}
 
-To run the Agent in GitHub Actions, define the Agent container under [services][1]. Replace `<DD_SITE>` with {{< region-param key="dd_site" code="true" >}} (defaults to `datadoghq.com`).
+To run the Agent in GitHub Actions, define the Agent container under [services][1].
+
+{{< site-region region="us" >}}
+{{< code-block lang="yaml" >}}
+jobs:
+  test:
+    services:
+      datadog-agent:
+        image: gcr.io/datadoghq/agent:latest
+        ports:
+          - 8126:8126
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_INSIDE_CI: "true"
+          DD_HOSTNAME: "none"
+    steps:
+      - run: make test
+{{< /code-block >}}
+{{< /site-region >}}
+{{< site-region region="us3,eu" >}}
+
+Replace `<DD_SITE>` with the selected site: {{< region-param key="dd_site" code="true" >}}.
 
 {{< code-block lang="yaml" >}}
 jobs:
@@ -144,6 +212,7 @@ jobs:
     steps:
       - run: make test
 {{< /code-block >}}
+{{< /site-region >}}
 
 Add your [Datadog API key][2] to your [project secrets][3] with the key `DD_API_KEY`.
 
@@ -155,7 +224,32 @@ Add your [Datadog API key][2] to your [project secrets][3] with the key `DD_API_
 
 To run the Agent in CircleCI, launch the Agent container before running tests by using the [datadog/agent CircleCI orb][1], and stop it after to ensure results are sent to Datadog.
 
-For the following example, replace `<DD_SITE>` with {{< region-param key="dd_site" code="true" >}} (defaults to `datadoghq.com`).
+{{< site-region region="us" >}}
+{{< code-block lang="yaml" filename=".circleci/config.yml" >}}
+version: 2.1
+
+orbs:
+  datadog-agent: datadog/agent@0
+
+jobs:
+  test:
+    docker:
+      - image: circleci/<language>:<version_tag>
+    steps:
+      - checkout
+      - datadog-agent/setup
+      - run: make test
+      - datadog-agent/stop
+
+workflows:
+  test:
+    jobs:
+      - test
+{{< /code-block >}}
+{{< /site-region >}}
+{{< site-region region="us3,eu" >}}
+
+Replace `<DD_SITE>` with the selected site: {{< region-param key="dd_site" code="true" >}}.
 
 {{< code-block lang="yaml" filename=".circleci/config.yml" >}}
 version: 2.1
@@ -180,6 +274,7 @@ workflows:
     jobs:
       - test
 {{< /code-block >}}
+{{< /site-region >}}
 
 Add your [Datadog API key][2] to your [project environment variables][3] with the key `DD_API_KEY`.
 
@@ -191,7 +286,30 @@ Add your [Datadog API key][2] to your [project environment variables][3] with th
 
 ### Using Docker Compose
 
-Regardless of which CI provider you use, if tests are run using [Docker Compose][5], the Datadog Agent can be run as one service. Replace `<DD_SITE>` with {{< region-param key="dd_site" code="true" >}} (defaults to `datadoghq.com`).
+Regardless of which CI provider you use, if tests are run using [Docker Compose][5], the Datadog Agent can be run as one service.
+
+{{< site-region region="us" >}}
+{{< code-block lang="yaml" filename="docker-compose.yml" >}}
+version: '3'
+services:
+  datadog-agent:
+    image: "gcr.io/datadoghq/agent:latest"
+    environment:
+      - DD_API_KEY
+      - DD_INSIDE_CI=true
+      - DD_HOSTNAME=none
+    ports:
+      - 8126/tcp
+
+  tests:
+    build: .
+    environment:
+      - DD_AGENT_HOST=datadog-agent
+{{< /code-block >}}
+{{< /site-region >}}
+{{< site-region region="us3,eu" >}}
+
+Replace `<DD_SITE>` with the selected site: {{< region-param key="dd_site" code="true" >}}.
 
 {{< code-block lang="yaml" filename="docker-compose.yml" >}}
 version: '3'
@@ -211,8 +329,29 @@ services:
     environment:
       - DD_AGENT_HOST=datadog-agent
 {{< /code-block >}}
+{{< /site-region >}}
 
 Alternatively, share the same network namespace between the Agent container and the tests container:
+
+{{< site-region region="us" >}}
+{{< code-block lang="yaml" filename="docker-compose.yml" >}}
+version: '3'
+services:
+  datadog-agent:
+    image: "gcr.io/datadoghq/agent:latest"
+    environment:
+      - DD_API_KEY
+      - DD_INSIDE_CI=true
+      - DD_HOSTNAME=none
+
+  tests:
+    build: .
+    network_mode: "service:datadog-agent"
+{{< /code-block >}}
+{{< /site-region >}}
+{{< site-region region="us3,eu" >}}
+
+Replace `<DD_SITE>` with the selected site: {{< region-param key="dd_site" code="true" >}}.
 
 {{< code-block lang="yaml" filename="docker-compose.yml" >}}
 version: '3'
@@ -229,6 +368,7 @@ services:
     build: .
     network_mode: "service:datadog-agent"
 {{< /code-block >}}
+{{< /site-region >}}
 
 In this case, `DD_AGENT_HOST` is not required because it is `localhost` by default.
 
@@ -241,8 +381,6 @@ DD_API_KEY=<YOUR_DD_API_KEY> docker-compose up \
 {{< /code-block >}}
 
 **Note:** In this case, add all the required CI provider environment variables so build information can be attached to each test result, as described in [Tests in containers][6].
-
-{{< /site-region >}}
 
 ## Further reading
 

--- a/content/en/continuous_integration/setup_tests/containers.md
+++ b/content/en/continuous_integration/setup_tests/containers.md
@@ -3,6 +3,10 @@ title: Tests in Containers
 kind: documentation
 ---
 
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
+
 If you run your tests inside a container that you launch yourself within the build (for example, using [`docker run`][1] or [`docker-compose`][2]), forward the following environment variables to the container depending on your CI provider. This enables the Datadog tracer to autodetect the build information.
 
 Additionally, you need to pass in the environment variables required to configure the tracer as described in the [per-language test instrumentation instructions][3] (such as `DD_SERVICE`, `DD_ENV`, and a valid `DD_TRACE_AGENT_URL` that is accessible from within the container).

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -10,6 +10,10 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
+
 ## Compatibility
 
 Supported .NET versions:

--- a/content/en/continuous_integration/setup_tests/java.md
+++ b/content/en/continuous_integration/setup_tests/java.md
@@ -10,6 +10,10 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
+
 ## Compatibility
 
 Supported test frameworks:

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -10,6 +10,10 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
+
 ## Compatibility
 
 Supported test frameworks:

--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -10,7 +10,10 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
-{{< site-region region="us,eu,us3" >}}
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
+
 JUnit test report files are XML files that contain test execution information, such as test and suite names, pass/fail status, duration, and sometimes error logs. Although it was introduced by the [JUnit][1] testing framework, many other popular frameworks are able to output results using this format.
 
 As an alternative to instrumenting your tests natively using Datadog tracers, which is the recommended option as it provides the most comprehensive test results, you can also upload JUnit XML test reports.
@@ -36,25 +39,25 @@ datadog-ci junit upload --service <service_name> <path> [<path> ...]
 Specify a valid [Datadog API key][3] in the `DATADOG_API_KEY` environment variable, and the environment where tests were run (for example, `local` when uploading results from a developer workstation, or `ci` when uploading them from a CI provider) in the `DD_ENV` environment variable. For example:
 
 {{< site-region region="us" >}}
-{{< code-block lang="bash" >}}
-DD_ENV=ci DATADOG_API_KEY=<api_key> datadog-ci junit upload \
+<pre class="chroma">
+<code class="language-bash" data-lang="bash">
+DD_ENV=ci DATADOG_API_KEY=&lt;key&gt; datadog-ci junit upload \
   --service my-api-service \
   unit-tests/junit-reports e2e-tests/single-report.xml
-{{< /code-block >}}
+</code>
+</pre>
 {{< /site-region >}}
-{{< site-region region="eu" >}}
-{{< code-block lang="bash" >}}
-DD_ENV=ci DATADOG_API_KEY=<api_key> DATADOG_SITE=datadoghq.eu datadog-ci junit upload \
+{{< site-region region="eu,us3" >}}
+<pre class="chroma">
+<code class="language-bash" data-lang="bash">
+DD_ENV=ci DATADOG_API_KEY=&lt;key&gt; DATADOG_SITE={{< region-param key="dd_site" >}} datadog-ci junit upload \
   --service my-api-service \
   unit-tests/junit-reports e2e-tests/single-report.xml
-{{< /code-block >}}
+</code>
+</pre>
 {{< /site-region >}}
-{{< site-region region="us3" >}}
-{{< code-block lang="bash" >}}
-DD_ENV=ci DATADOG_API_KEY=<api_key> DATADOG_SITE=us3.datadoghq.com datadog-ci junit upload \
---service my-api-service \
-unit-tests/junit-reports e2e-tests/single-report.xml
-{{< /code-block >}}
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
 ## Configuration settings
@@ -100,11 +103,9 @@ The following environment variables are supported:
 Additionally, configure the Datadog site to use the selected one ({{< region-param key="dd_site_name" >}}):
 
 `DATADOG_SITE` (Required)
-: The [Datadog site][1] to upload results to.<br/>
+: The Datadog site to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
 **Selected site**: {{< region-param key="dd_site" code="true" >}}
-
-[1]: /getting_started/site/
 {{< /site-region >}}
 
 
@@ -208,7 +209,7 @@ For mobile apps (Swift, Android):
 `test.bundle`
 : Used to execute groups of test suites separately.<br/>
 **Examples**: `ApplicationUITests`, `ModelTests` -->
-  
+
 ## Providing metadata through `<property>` elements
 
 In addition to the `--tags` CLI parameter and the `DD_TAGS` environment variable, which apply custom tags globally to all tests included the uploaded XML report, you can provide additional tags to specific tests by including `<property name="dd_tags[key]" value="value">` elements within the `<testsuite>` or `<testcase>` elements. If you add these tags to a `<testcase>` element, they are stored in its test span. If you add the tags to a `<testsuite>` element, they are stored in all of that suite's test spans.
@@ -254,7 +255,3 @@ To be processed, the `name` attribute in the `<property>` element must have the 
 [2]: https://www.npmjs.com/package/@datadog/datadog-ci
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 [4]: https://git-scm.com/downloads
-{{< /site-region >}}
-{{< site-region region="us5,gov" >}}
-The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported at this time.
-{{< /site-region >}}

--- a/content/en/continuous_integration/setup_tests/python.md
+++ b/content/en/continuous_integration/setup_tests/python.md
@@ -10,6 +10,10 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">Python test instrumentation is in beta. There are no billing implications for instrumenting Python tests during this period.
 </div>
 

--- a/content/en/continuous_integration/setup_tests/ruby.md
+++ b/content/en/continuous_integration/setup_tests/ruby.md
@@ -10,6 +10,10 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">Ruby test instrumentation is in beta. There are no billing implications for instrumenting Ruby tests during this period.
 </div>
 

--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -10,7 +10,10 @@ further_reading:
       text: "Troubleshooting CI"
 ---
 
-{{< site-region region="us,eu,us3" >}}
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
+
 ## Compatibility
 
 Supported languages:
@@ -121,11 +124,9 @@ Set all these variables in your test target:
 Additionally, configure the Datadog site to use the selected one ({{< region-param key="dd_site_name" >}}):
 
 `DD_SITE` (Required)
-: The [Datadog site][1] to upload results to.<br/>
+: The Datadog site to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
 **Selected site**: {{< region-param key="dd_site" code="true" >}}
-
-[1]: /getting_started/site/
 {{< /site-region >}}
 
 ### Collecting Git metadata
@@ -185,31 +186,29 @@ If you are running tests in non-supported CI providers or with no `.git` folder,
 After installation, run your tests as you normally do, for example using the `xcodebuild test` command. Tests, network requests, and application logs are instrumented automatically. Pass your environment variables when running your tests in the CI, for example:
 
 {{< site-region region="us" >}}
-{{< code-block lang="bash" >}}
+<pre class="chroma">
+<code class="language-bash" data-lang="bash">
 DD_TEST_RUNNER=1 DD_ENV=ci xcodebuild \
   -project "MyProject.xcodeproj" \
   -scheme "MyScheme" \
   -destination "platform=macOS,arch=x86_64" \
   test
-{{< /code-block >}}
+</code>
+</pre>
 {{< /site-region >}}
-{{< site-region region="eu" >}}
-{{< code-block lang="bash" >}}
-DD_TEST_RUNNER=1 DD_ENV=ci DD_SITE=datadoghq.eu xcodebuild \
+{{< site-region region="eu,us3" >}}
+<pre class="chroma">
+<code class="language-bash" data-lang="bash">
+DD_TEST_RUNNER=1 DD_ENV=ci DD_SITE={{< region-param key="dd_site" >}} xcodebuild \
   -project "MyProject.xcodeproj" \
   -scheme "MyScheme" \
   -destination "platform=macOS,arch=x86_64" \
   test
-{{< /code-block >}}
+</code>
+</pre>
 {{< /site-region >}}
-{{< site-region region="us3" >}}
-{{< code-block lang="bash" >}}
-DD_TEST_RUNNER=1 DD_ENV=ci DD_SITE=us3.datadoghq.com xcodebuild \
-  -project "MyProject.xcodeproj" \
-  -scheme "MyScheme" \
-  -destination "platform=macOS,arch=x86_64" \
-  test
-{{< /code-block >}}
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
 ### UI tests
@@ -549,8 +548,3 @@ Additional Git configuration for physical device testing:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/organization-settings/client-tokens
-
-{{< /site-region >}}
-{{< site-region region="us5,gov" >}}
-The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported at this time.
-{{< /site-region >}}

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -3,6 +3,10 @@ title: Troubleshooting CI Visibility
 kind: documentation
 ---
 
+{{< site-region region="us5,gov" >}}
+<div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
+{{< /site-region >}}
+
 ### Your Jenkins instance is instrumented, but Datadog isn't showing any data
 
 1. Make sure that at least one pipeline has finished executing. Pipeline execution information is only sent after the pipeline has finished.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

- Fixes links in some pages like [Buildkite](https://docs.datadoghq.com/continuous_integration/setup_pipelines/buildkite/)
- Adds a warning message to all pages when selecting a non-supported region, _but_ it does not hide the content, to avoid compatibility issues with the link formatter script: `CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time`
- Updated "Installing the Agent" page removing `DD_SITE` if `us` is selected to improve readability

### Motivation
<!-- What inspired you to submit this pull request?-->

Saw broken links on our docs, due to the fact that the link formatter script that is executed when committing does not support links within `site-region` sections (it messes up everything).

### Preview
<!-- Impacted pages preview links-->
<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->

All pages under:
https://docs-staging.datadoghq.com/fermayo/ciapp-fix-links/continuous_integration/

### Additional Notes
<!-- Anything else we should know when reviewing?-->
We should probably update the `format_link.py` to support `site-region`  and nested sections so these workarounds are not needed.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
