### PR TITLE
Update minimal required ddtrace gem version

### DIFF
--- a/content/en/continuous_integration/setup_tests/ruby.md
+++ b/content/en/continuous_integration/setup_tests/ruby.md
@@ -35,7 +35,7 @@ To install the Ruby tracer:
 
     {{< code-block lang="ruby" filename="Gemfile" >}}
 source 'https://rubygems.org'
-gem 'ddtrace', ">=0.51.0"
+gem 'ddtrace', ">=0.53.0"
 {{< /code-block >}}
 
 2. Install the gem by running `bundle install`

--- a/content/ja/continuous_integration/setup_tests/ruby.md
+++ b/content/ja/continuous_integration/setup_tests/ruby.md
@@ -31,7 +31,7 @@ Ruby トレーサーをインストールするには
 
     {{< code-block lang="ruby" filename="Gemfile" >}}
 ソース 'https://rubygems.org'
-gem 'ddtrace', ">=0.51.0"
+gem 'ddtrace', ">=0.53.0"
 {{< /code-block >}}
 
 2. `bundle install` を実行して gem をインストールします


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the minimal ddtrace gem version required. See See https://github.com/DataDog/dd-trace-rb/issues/1663#issuecomment-938163452


### Motivation
There was a fix recently included in version 0.53.0 of ddtrace gem. Looking at the documentation asking >= 0.51.0 I didn’t think about upgrading my gem to fix the wrong behavior I met. 

### Preview
https://app.datadoghq.eu/ci/setup/test?ciProvider=circleci&ciProviderVersion=cloud&framework=rspec&language=ruby

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
