### PR TITLE
Carlos/fix-glyphter-icons

### DIFF
--- a/assets/styles/_icons.scss
+++ b/assets/styles/_icons.scss
@@ -20,7 +20,7 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-.icon-tick:before{content:'\0061';} //a
+.icon-check-bold:before{content:'\0061';} //a
 .icon-small-bookmark:before{content:'\30';} //b
 .icon-toc-bookmark:before{content:'\0062';} //b
 .icon-small-x:before{content:'\0071';} //q

--- a/assets/styles/_webfonts.scss
+++ b/assets/styles/_webfonts.scss
@@ -25,3 +25,14 @@
   font-style: normal;
   font-stretch: normal;
 }
+
+@font-face {
+    font-family: 'Glyphter';
+    src: url('../fonts/Glyphter.woff') format('woff'),
+         url('../fonts/Glyphter.eot'),
+         url('../fonts/Glyphter.eot?#iefix') format('embedded-opentype'),
+         url('../fonts/Glyphter.ttf') format('truetype'),
+         url('../fonts/Glyphter.svg#Glyphter') format('svg');
+    font-weight: normal;
+    font-style: normal;
+}

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -1,7 +1,6 @@
 // bootstrap customization & font setup
 @import 'bootstrap-custom';
 @import 'webfonts';
-@import 'icons';
 
 // base
 @import 'base/variables';

--- a/content/en/agent/faq/agent_v6_changes.md
+++ b/content/en/agent/faq/agent_v6_changes.md
@@ -229,16 +229,16 @@ If you're unsure which init system your distribution uses by default, see the ta
 
 | distribution \ init system      | upstart                   | systemd                   | sysvinit                                  | Notes                         |
 |---------------------------------|---------------------------|---------------------------|-------------------------------------------|-------------------------------|
-| Amazon Linux (<= 2017.09)       | <i class="icon-tick"></i> |                           |                                           |                               |
-| Amazon Linux 2 (>= 2017.12)     |                           | <i class="icon-tick"></i> |                                           |                               |
-| CentOS/RHEL 6                   | <i class="icon-tick"></i> |                           |                                           |                               |
-| CentOS/RHEL 7                   |                           | <i class="icon-tick"></i> |                                           |                               |
-| Debian 7 (wheezy)               |                           |                           | <i class="icon-tick"></i> (Agent v6.6.0+) |                               |
-| Debian 8 (jessie) & 9 (stretch) |                           | <i class="icon-tick"></i> |                                           |                               |
+| Amazon Linux (<= 2017.09)       | <i class="icon-check-bold"></i> |                           |                                           |                               |
+| Amazon Linux 2 (>= 2017.12)     |                           | <i class="icon-check-bold"></i> |                                           |                               |
+| CentOS/RHEL 6                   | <i class="icon-check-bold"></i> |                           |                                           |                               |
+| CentOS/RHEL 7                   |                           | <i class="icon-check-bold"></i> |                                           |                               |
+| Debian 7 (wheezy)               |                           |                           | <i class="icon-check-bold"></i> (Agent v6.6.0+) |                               |
+| Debian 8 (jessie) & 9 (stretch) |                           | <i class="icon-check-bold"></i> |                                           |                               |
 | SUSE 11                         |                           |                           |                                           | Unsupported without `systemd` |
-| SUSE 12                         |                           | <i class="icon-tick"></i> |                                           |                               |
-| Ubuntu < 15.04                  | <i class="icon-tick"></i> |                           |                                           |                               |
-| Ubuntu >= 15.04                 |                           | <i class="icon-tick"></i> |                                           |                               |
+| SUSE 12                         |                           | <i class="icon-check-bold"></i> |                                           |                               |
+| Ubuntu < 15.04                  | <i class="icon-check-bold"></i> |                           |                                           |                               |
+| Ubuntu >= 15.04                 |                           | <i class="icon-check-bold"></i> |                                           |                               |
 
 #### Agent commands
 

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -163,12 +163,12 @@ To install the Datadog Agent on your Kubernetes cluster:
 
     | Metrics                   | Logs                      | APM                       | Process                   | NPM                       | Security                       | Linux                   | Windows                 |
     |---------------------------|---------------------------|---------------------------|---------------------------|---------------------------|-------------------------|-------------------------|-------------------------|
-    | <i class="icon-tick"></i> | <i class="icon-tick"></i> | <i class="icon-tick"></i> | <i class="icon-tick"></i> |                           | <i class="icon-tick"></i> | [Manifest template][3]  | [Manifest template][4] (no security)  |
-    | <i class="icon-tick"></i> | <i class="icon-tick"></i> | <i class="icon-tick"></i> |                           |                           |                           | [Manifest template][5]  | [Manifest template][6]  |
-    | <i class="icon-tick"></i> | <i class="icon-tick"></i> |                           |                           |                           |                           | [Manifest template][7]  | [Manifest template][8]  |
-    | <i class="icon-tick"></i> |                           | <i class="icon-tick"></i> |                           |                           |                           | [Manifest template][9]  | [Manifest template][10] |
-    |                           |                           |                           |                           | <i class="icon-tick"></i> | <i class="icon-tick"></i> | [Manifest template][11] | no template             |
-    | <i class="icon-tick"></i> |                           |                           |                           |                           |                           | [Manifest template][12] | [Manifest template][13] |
+    | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |                           | <i class="icon-check-bold"></i> | [Manifest template][3]  | [Manifest template][4] (no security)  |
+    | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |                           |                           |                           | [Manifest template][5]  | [Manifest template][6]  |
+    | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |                           |                           |                           |                           | [Manifest template][7]  | [Manifest template][8]  |
+    | <i class="icon-check-bold"></i> |                           | <i class="icon-check-bold"></i> |                           |                           |                           | [Manifest template][9]  | [Manifest template][10] |
+    |                           |                           |                           |                           | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> | [Manifest template][11] | no template             |
+    | <i class="icon-check-bold"></i> |                           |                           |                           |                           |                           | [Manifest template][12] | [Manifest template][13] |
 
      To enable trace collection completely, [extra steps are required on your application Pod configuration][14]. Refer also to the [logs][15], [APM][16], [processes][17], and [Network Performance Monitoring][18], and [Security][19] documentation pages to learn how to enable each feature individually.
 

--- a/content/fr/agent/faq/agent_v6_changes.md
+++ b/content/fr/agent/faq/agent_v6_changes.md
@@ -228,16 +228,16 @@ Si vous ne savez pas quel système init votre distribution utilise par défaut, 
 
 | distribution \ système init      | upstart                   | systemd                   | sysvinit                                  | Remarques                         |
 |---------------------------------|---------------------------|---------------------------|-------------------------------------------|-------------------------------|
-| Amazon Linux (<= 2017.09)       | <i class="icon-tick"></i> |                           |                                           |                               |
-| Amazon Linux 2 (>= 2017.12)     |                           | <i class="icon-tick"></i> |                                           |                               |
-| CentOS/RHEL 6                   | <i class="icon-tick"></i> |                           |                                           |                               |
-| CentOS/RHEL 7                   |                           | <i class="icon-tick"></i> |                                           |                               |
-| Debian 7 (wheezy)               |                           |                           | <i class="icon-tick"></i> (Agent v6.6.0+) |                               |
-| Debian 8 (jessie) et 9 (stretch) |                           | <i class="icon-tick"></i> |                                           |                               |
+| Amazon Linux (<= 2017.09)       | <i class="icon-check-bold"></i> |                           |                                           |                               |
+| Amazon Linux 2 (>= 2017.12)     |                           | <i class="icon-check-bold"></i> |                                           |                               |
+| CentOS/RHEL 6                   | <i class="icon-check-bold"></i> |                           |                                           |                               |
+| CentOS/RHEL 7                   |                           | <i class="icon-check-bold"></i> |                                           |                               |
+| Debian 7 (wheezy)               |                           |                           | <i class="icon-check-bold"></i> (Agent v6.6.0+) |                               |
+| Debian 8 (jessie) et 9 (stretch) |                           | <i class="icon-check-bold"></i> |                                           |                               |
 | SUSE 11                         |                           |                           |                                           | Non pris en charge sans `systemd` |
-| SUSE 12                         |                           | <i class="icon-tick"></i> |                                           |                               |
-| Ubuntu < 15.04                  | <i class="icon-tick"></i> |                           |                                           |                               |
-| Ubuntu >= 15.04                 |                           | <i class="icon-tick"></i> |                                           |                               |
+| SUSE 12                         |                           | <i class="icon-check-bold"></i> |                                           |                               |
+| Ubuntu < 15.04                  | <i class="icon-check-bold"></i> |                           |                                           |                               |
+| Ubuntu >= 15.04                 |                           | <i class="icon-check-bold"></i> |                                           |                               |
 
 #### Commandes de l'Agent
 

--- a/content/ja/agent/faq/agent_v6_changes.md
+++ b/content/ja/agent/faq/agent_v6_changes.md
@@ -228,16 +228,16 @@ Linux 上の Agent v6 の主な変更点は次のとおりです。
 
 | ディストリビューション \ init システム      | upstart                   | systemd                   | sysvinit                                  | 注                         |
 |---------------------------------|---------------------------|---------------------------|-------------------------------------------|-------------------------------|
-| Amazon Linux (<= 2017.09)       | <i class="icon-tick"></i> |                           |                                           |                               |
-| Amazon Linux 2 (>= 2017.12)     |                           | <i class="icon-tick"></i> |                                           |                               |
-| CentOS/RHEL 6                   | <i class="icon-tick"></i> |                           |                                           |                               |
-| CentOS/RHEL 7                   |                           | <i class="icon-tick"></i> |                                           |                               |
-| Debian 7 (wheezy)               |                           |                           | <i class="icon-tick"></i> (Agent v6.6.0+) |                               |
-| Debian 8 (jessie) & 9 (stretch) |                           | <i class="icon-tick"></i> |                                           |                               |
+| Amazon Linux (<= 2017.09)       | <i class="icon-check-bold"></i> |                           |                                           |                               |
+| Amazon Linux 2 (>= 2017.12)     |                           | <i class="icon-check-bold"></i> |                                           |                               |
+| CentOS/RHEL 6                   | <i class="icon-check-bold"></i> |                           |                                           |                               |
+| CentOS/RHEL 7                   |                           | <i class="icon-check-bold"></i> |                                           |                               |
+| Debian 7 (wheezy)               |                           |                           | <i class="icon-check-bold"></i> (Agent v6.6.0+) |                               |
+| Debian 8 (jessie) & 9 (stretch) |                           | <i class="icon-check-bold"></i> |                                           |                               |
 | SUSE 11                         |                           |                           |                                           | `systemd` がないとサポートされません |
-| SUSE 12                         |                           | <i class="icon-tick"></i> |                                           |                               |
-| Ubuntu < 15.04                  | <i class="icon-tick"></i> |                           |                                           |                               |
-| Ubuntu >= 15.04                 |                           | <i class="icon-tick"></i> |                                           |                               |
+| SUSE 12                         |                           | <i class="icon-check-bold"></i> |                                           |                               |
+| Ubuntu < 15.04                  | <i class="icon-check-bold"></i> |                           |                                           |                               |
+| Ubuntu >= 15.04                 |                           | <i class="icon-check-bold"></i> |                                           |                               |
 
 #### Agent のコマンド
 

--- a/content/ja/agent/kubernetes/_index.md
+++ b/content/ja/agent/kubernetes/_index.md
@@ -157,12 +157,12 @@ Datadog Agent を Kubernetes クラスターにインストールするには:
 
     | メトリクス                   | ログ                      | APM                       | Process                   | NPM                       | セキュリティ                       | Linux                   | Windows                 |
     |---------------------------|---------------------------|---------------------------|---------------------------|---------------------------|-------------------------|-------------------------|-------------------------|
-    | <i class="icon-tick"></i> | <i class="icon-tick"></i> | <i class="icon-tick"></i> | <i class="icon-tick"></i> |                           | <i class="icon-tick"></i> | [マニフェストテンプレート][3]  | [マニフェストテンプレート][4] (セキュリティなし)  |
-    | <i class="icon-tick"></i> | <i class="icon-tick"></i> | <i class="icon-tick"></i> |                           |                           |                           | [マニフェストテンプレート][5]  | [マニフェストテンプレート][6]  |
-    | <i class="icon-tick"></i> | <i class="icon-tick"></i> |                           |                           |                           |                           | [マニフェストテンプレート][7]  | [マニフェストテンプレート][8]  |
-    | <i class="icon-tick"></i> |                           | <i class="icon-tick"></i> |                           |                           |                           | [マニフェストテンプレート][9]  | [マニフェストテンプレート][10] |
-    |                           |                           |                           |                           | <i class="icon-tick"></i> | <i class="icon-tick"></i> | [マニフェストテンプレート][11] | テンプレートなし             |
-    | <i class="icon-tick"></i> |                           |                           |                           |                           |                           | [マニフェストテンプレート][12] | [マニフェストテンプレート][13] |
+    | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |                           | <i class="icon-check-bold"></i> | [マニフェストテンプレート][3]  | [マニフェストテンプレート][4] (セキュリティなし)  |
+    | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |                           |                           |                           | [マニフェストテンプレート][5]  | [マニフェストテンプレート][6]  |
+    | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |                           |                           |                           |                           | [マニフェストテンプレート][7]  | [マニフェストテンプレート][8]  |
+    | <i class="icon-check-bold"></i> |                           | <i class="icon-check-bold"></i> |                           |                           |                           | [マニフェストテンプレート][9]  | [マニフェストテンプレート][10] |
+    |                           |                           |                           |                           | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> | [マニフェストテンプレート][11] | テンプレートなし             |
+    | <i class="icon-check-bold"></i> |                           |                           |                           |                           |                           | [マニフェストテンプレート][12] | [マニフェストテンプレート][13] |
 
    トレース収集を完全に有効にするには、[アプリケーションのポッドコンフィギュレーションで追加の手順が必要となります][14]。それぞれの機能を個別に有効にする方法については、[ログ][15]、[APM][16]、[プロセス][17]、[ネットワークパフォーマンスモニタリング][18]、[セキュリティ][19]に関するドキュメントページを参照してください。
 

--- a/layouts/shortcodes/X.html
+++ b/layouts/shortcodes/X.html
@@ -1,1 +1,1 @@
-<i class="icon-tick"></i>
+<i class="icon-check-bold"></i>

--- a/layouts/shortcodes/classic-libraries-table.html
+++ b/layouts/shortcodes/classic-libraries-table.html
@@ -32,9 +32,9 @@
               <tr>
                 <td>{{ if eq $i 0}}<strong>{{ $libName }}</strong>{{ end }}</td>
                 <td><a href="{{ $el.link }}">{{ $el.name }}</a></td>
-                <td>{{ if $el.official}}<i class="icon-tick"></i>{{ end }}</td>
-                <td>{{ if $el.api}}<i class="icon-tick"></i>{{ end }}</td>
-                <td>{{ if $el.dogstatsd }}<i class="icon-tick"></i>{{ end }}</td>
+                <td>{{ if $el.official}}<i class="icon-check-bold"></i>{{ end }}</td>
+                <td>{{ if $el.api}}<i class="icon-check-bold"></i>{{ end }}</td>
+                <td>{{ if $el.dogstatsd }}<i class="icon-check-bold"></i>{{ end }}</td>
                 <td>{{ if $el.authors }}{{ $el.authors }}{{ end }}</td>
                 <td>{{ if $el.notes }}{{ $el.notes }}{{ end }}</td>
               </tr>

--- a/layouts/shortcodes/log-libraries-table.html
+++ b/layouts/shortcodes/log-libraries-table.html
@@ -31,7 +31,7 @@
               <tr>
                 <td>{{ if eq $i 0}}<strong>{{ $libName }}</strong>{{ end }}</td>
                 <td><a href="{{ $el.link }}">{{ $el.name }}</a></td>
-                <td>{{ if $el.official}}<i class="icon-tick"></i>{{ end }}</td>
+                <td>{{ if $el.official}}<i class="icon-check-bold"></i>{{ end }}</td>
                 <td>{{if $el.authors }}{{ $el.authors }}{{ end }}</td>
                 <td>{{ if $el.notes }}{{ $el.notes }}{{ end }}</td>
               </tr>

--- a/layouts/shortcodes/serverless-libraries-table.html
+++ b/layouts/shortcodes/serverless-libraries-table.html
@@ -31,7 +31,7 @@
               <tr>
                 <td>{{ if eq $i 0}}<strong>{{ $libName }}</strong>{{ end }}</td>
                 <td><a href="{{ $el.link }}">{{ $el.name }}</a></td>
-                <td>{{ if $el.official}}<i class="icon-tick"></i>{{ end }}</td>
+                <td>{{ if $el.official}}<i class="icon-check-bold"></i>{{ end }}</td>
                 <td>{{if $el.authors }}{{ $el.authors }}{{ end }}</td>
                 <td>{{ if $el.notes }}{{ $el.notes }}{{ end }}</td>
               </tr>

--- a/layouts/shortcodes/tracing-libraries-table.html
+++ b/layouts/shortcodes/tracing-libraries-table.html
@@ -31,7 +31,7 @@
               <tr>
                 <td>{{ if eq $i 0}}<strong>{{ $libName }}</strong>{{ end }}</td>
                 <td><a href="{{ $el.link }}">{{ $el.name }}</a></td>
-                <td>{{ if $el.official}}<i class="icon-tick"></i>{{ end }}</td>
+                <td>{{ if $el.official}}<i class="icon-check-bold"></i>{{ end }}</td>
                 <td>{{if $el.authors }}{{ $el.authors }}{{ end }}</td>
                 <td>{{ if $el.notes }}{{ $el.notes }}{{ end }}</td>
               </tr>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- fixes broken icons using `icon-tick` by updating them to use iconfont's `icon-check-bold` (same icon)

### Motivation
https://dd.slack.com/archives/C3CT8QA11/p1636470362003900

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/carlos/fix-glyphter-icons/agent/troubleshooting/debug_mode/?tab=agentv6v7#agent-log-level

compare to broken icons on prod: https://docs.datadoghq.com/agent/troubleshooting/debug_mode/?tab=agentv6v7#agent-log-level

### Additional Notes
- [ ] check any other known pages featuring the tick/check-bold icon

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
