### PR TITLE
Fix cardinality defaults

### DIFF
--- a/content/en/agent/kubernetes/tag.md
+++ b/content/en/agent/kubernetes/tag.md
@@ -31,10 +31,10 @@ The Agent can autodiscover and attach tags to all data emitted by the entire pod
   | `display_container_name`      | High         | Pod status                                                              | N/A                                                 |
   | `pod_name`                    | Orchestrator | Pod metadata                                                            | N/A                                                 |
   | `oshift_deployment`           | Orchestrator | Pod annotation `openshift.io/deployment.name`                           | OpenShift environment and pod annotation must exist |
-  | `kube_ownerref_name`          | Orchestrator | Pod ownerref                                                            | Pod must have an owner                              |
-  | `kube_job`                    | Orchestrator | Pod ownerref                                                            | Pod must be attached to a job                       |
-  | `kube_replica_set`            | Orchestrator | Pod ownerref                                                            | Pod must be attached to a replica set               |
-  | `kube_service`                | Orchestrator | Kubernetes service discovery                                            | Pod is behind a Kubernetes service                  |
+  | `kube_ownerref_name`          | Low          | Pod ownerref                                                            | Pod must have an owner                              |
+  | `kube_job`                    | Low          | Pod ownerref                                                            | Pod must be attached to a job                       |
+  | `kube_replica_set`            | Low          | Pod ownerref                                                            | Pod must be attached to a replica set               |
+  | `kube_service`                | Low          | Kubernetes service discovery                                            | Pod is behind a Kubernetes service                  |
   | `kube_daemon_set`             | Low          | Pod ownerref                                                            | Pod must be attached to a DaemonSet                 |
   | `kube_container_name`         | Low          | Pod status                                                              | N/A                                                 |
   | `kube_namespace`              | Low          | Pod metadata                                                            | N/A                                                 |

--- a/content/en/agent/kubernetes/tag.md
+++ b/content/en/agent/kubernetes/tag.md
@@ -31,7 +31,8 @@ The Agent can autodiscover and attach tags to all data emitted by the entire pod
   | `display_container_name`      | High         | Pod status                                                              | N/A                                                 |
   | `pod_name`                    | Orchestrator | Pod metadata                                                            | N/A                                                 |
   | `oshift_deployment`           | Orchestrator | Pod annotation `openshift.io/deployment.name`                           | OpenShift environment and pod annotation must exist |
-  | `kube_ownerref_name`          | Low          | Pod ownerref                                                            | Pod must have an owner                              |
+  | `kube_ownerref_name`          | Orchestrator | Pod ownerref                                                            | Pod must have an owner                              |
+  | `kube_job`                    | Orchestrator | Pod ownerref                                                            | Pod must be attached to a cronjob                   |
   | `kube_job`                    | Low          | Pod ownerref                                                            | Pod must be attached to a job                       |
   | `kube_replica_set`            | Low          | Pod ownerref                                                            | Pod must be attached to a replica set               |
   | `kube_service`                | Low          | Kubernetes service discovery                                            | Pod is behind a Kubernetes service                  |


### PR DESCRIPTION
### What does this PR do?
There are a set of tags that get added when cardinality is "Low", that were categorized as "Orchestrator"

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/arapulido/fix_cardinality_defaults/agent/kubernetes/tag/?tab=containerizedagent#out-of-the-box-tags

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
