### PR TITLE
DOCS-2680 Add table to source code integration overview

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -22,9 +22,9 @@ With the source code and GitHub Apps integrations, you can also see inline code 
 
 | Integration Name            | Stack Trace Links | Issue and PR Previews | Inline Code Snippets |
 |-----------------------------|-------------------|-----------------------|----------------------|
-| Source Code                 | {{< X >}}         | x                     | x                    |
-| GitHub Apps                 | x                 | {{< X >}}             | x                    |
-| Source Code and GitHub Apps | x                 | x                     | {{< X >}}            |
+| Source Code                 | {{< X >}}         | X                     | X                    |
+| GitHub Apps                 | X                 | {{< X >}}             | X                    |
+| Source Code and GitHub Apps | X                 | X                     | {{< X >}}            |
 
 ## Configuration
 

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -20,6 +20,12 @@ The source code integration is an integration with Git that allows you to link y
 
 With the source code and GitHub Apps integrations, you can also see inline code snippets in your errors. For more information, see [Inline Source Code](#inline-source-code).
 
+| Integration Name            | Stack Trace Links | Issue and PR Previews | Inline Code Snippets |
+|-----------------------------|-------------------|-----------------------|----------------------|
+| Source Code                 | {{< X >}}         | x                     | x                    |
+| GitHub Apps                 | x                 | {{< X >}}             | x                    |
+| Source Code and GitHub Apps | x                 | x                     | {{< X >}}            |
+
 ## Configuration
 
 To map telemetry data with your source code, you need to send metadata to Datadog from your CI pipeline.


### PR DESCRIPTION
### What does this PR do?
Add a table to compare features for the integrations.

### Motivation
DOCS-2680

### Preview
https://docs-staging.datadoghq.com/may/add-table/integrations/guide/source-code-integration/?tab=dockerruntime#overview

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
