### PR TITLE
DOCS-2751 Update metrics page for APM

### DIFF
--- a/content/en/tracing/guide/metrics_namespace.md
+++ b/content/en/tracing/guide/metrics_namespace.md
@@ -58,35 +58,14 @@ With the following definitions:
 **Metric type:** [COUNT][5].<br>
 **Tags:** `env`, `service`, `version`, `resource`, `http.status_class`, `http.status_code`, all host tags from the Datadog Host Agent, and [the second primary tag][4].
 
-### Percentile aggregation
+### Latency distribution
 
-`trace.<SPAN_NAME>.duration.by.resource_<2ND_PRIM_TAG>_service.<PERCENTILE_AGGREGATION>`
+`trace.<SPAN_NAME>`
 : **Prerequisite:** This metric exists for any APM service.<br>
-**Description:** Measure the total time spent processing by resource, service, and [2nd primary tag][4].<br>
-**Metric type:** [GAUGE][6].<br>
-**Percentile Aggregations:** `100p`, `50p`, `75p`, `90p`, `95p`, `99p`<br>
-**Tags:** `env`, `service`, `resource`, and [the second primary tag][4].
+**Description:** Represent the latency distribution for all services, resources, and versions across different environments and second primary tags.<br>
+**Metric type:** [DISTRIBUTION][6].<br>
+**Tags:** `env`, `service`, `resource`, `resource_name`, `version`, `synthetics`, and [the second primary tag][4].
 
-`trace.<SPAN_NAME>.duration.by.resource_service.<PERCENTILE_AGGREGATION>`
-: **Prerequisite:** This metric exists for any APM service.<br>
-**Description:** Measure the total time spent processing for each resource and service combination.<br>
-**Metric type:** [GAUGE][6].<br>
-**Percentile Aggregations:** `100p`, `50p`, `75p`, `90p`, `95p`, `99p`<br>
-**Tags:** `env`, `service`, and `resource`.
-
-`trace.<SPAN_NAME>.duration.by.<2ND_PRIM_TAG>_service.<PERCENTILE_AGGREGATION>`
-: **Prerequisite:** This metric exists for any APM service.<br>
-**Description:** Measure the total time spent processing for each [2nd primary tag][4] and service combination.<br>
-**Metric type:** [GAUGE][6].<br>
-**Percentile Aggregations:** `100p`, `50p`, `75p`, `90p`, `95p`, `99p`<br>
-**Tags:** `env`, `service`, and [the second primary tag][4].
-
-`trace.<SPAN_NAME>.duration.by.service.<PERCENTILE_AGGREGATION>`
-: **Prerequisite:** This metric exists for any APM service.<br>
-**Description:** Represents the duration for an individual span. It's used to track latency and answer questions like, "what's the median wait time a user experienced?" or "how long do the slowest 1% of users have to wait?".<br>
-**Metric type:** [GAUGE][6].<br>
-**Percentile Aggregations:** `100p`, `50p`, `75p`, `90p`, `95p`, `99p`<br>
-**Tags:** `env` and `service`.
 
 ### Errors
 
@@ -125,7 +104,7 @@ With the following definitions:
 `trace.<SPAN_NAME>.duration`
 : **Prerequisite:** This metric exists for any APM service.<br>
 **Description:** Measure the total time for a collection of spans. Specifically, it is the total time spent by all spans over an interval - including time spent waiting on child processes.<br>
-**Metric type:** [GAUGE][6].<br>
+**Metric type:** [GAUGE][7].<br>
 **Tags:** `env`, `service`, `resource`, `http.status_code`, all host tags from the Datadog Host Agent, and [the second primary tag][4].
 
 ### Duration by
@@ -133,65 +112,65 @@ With the following definitions:
 `trace.<SPAN_NAME>.duration.by_http_status`
 : **Prerequisite:** This metric exists for HTTP/WEB APM services if http metadata exists.<br>
 **Description:** Measure the total time for a collection of spans for each HTTP status. Specifically, it is the relative share of time spent by all spans over an interval and a given HTTP status - including time spent waiting on child processes.<br>
-**Metric type:** [GAUGE][6].<br>
+**Metric type:** [GAUGE][7].<br>
 **Tags:** `env`, `service`, `resource`, `http.status_class`, `http.status_code`, all host tags from the Datadog Host Agent, and [the second primary tag][4].
 
 `trace.<SPAN_NAME>.duration.by_service`
 : **Prerequisite:** This metric exists for any APM service.<br>
 **Description:** Measure the total time spent actually processing for each service (i.e. it excludes time spent waiting on child processes).<br>
-**Metric type:** [GAUGE][6].<br>
+**Metric type:** [GAUGE][7].<br>
 **Tags:** `env`, `service`, `resource`, `sublayer_service`, `http.status_code`, all host tags from the Datadog Host Agent, and [the second primary tag][4].
 
 `trace.<SPAN_NAME>.duration.by_type`
 : **Prerequisite:** This metric exists for any APM service.<br>
-**Description:** Measure the total time spent actually processing for each [Service type][7].<br>
-**Metric type:** [GAUGE][6].<br>
+**Description:** Measure the total time spent actually processing for each [Service type][8].<br>
+**Metric type:** [GAUGE][7].<br>
 **Tags:** `env`, `service`, `resource`, `sublayer_type`, `http.status_code`, all host tags from the Datadog Host Agent, and [the second primary tag][4].
 
 `trace.<SPAN_NAME>.duration.by_type.by_http_status`
 : **Prerequisite:** This metric exists for HTTP/WEB APM services if http metadata exists.<br>
-**Description:** Measure the total time spent actually processing for each [Service type][7] and HTTP status.<br>
-**Metric type:** [GAUGE][6].<br>
+**Description:** Measure the total time spent actually processing for each [Service type][8] and HTTP status.<br>
+**Metric type:** [GAUGE][7].<br>
 **Tags:** `env`, `service`, `resource`, `sublayer_type`, `http.status_class`, `http.status_code`, all host tags from the Datadog Host Agent, and [the second primary tag][4].
 
 `trace.<SPAN_NAME>.duration.by_service.by_http_status`
 : **Prerequisite:** This metric exists for HTTP/WEB APM services if http metadata exists.<br>
-**Description:** Measure the total time spent actually processing for each [Service][8] and HTTP status.<br>
-**Metric type:** [GAUGE][6].<br>
+**Description:** Measure the total time spent actually processing for each [Service][9] and HTTP status.<br>
+**Metric type:** [GAUGE][7].<br>
 **Tags:** `env`, `service`, `resource`, `sublayer_service`, `http.status_class`, `http.status_code`, all host tags from the Datadog Host Agent, and [the second primary tag][4].
 
 ### Apdex
 
 `trace.<SPAN_NAME>.apdex`
 : **Prerequisite:** This metric exists for any HTTP/WEB APM service.<br>
-**Description:** Measures the [Apdex][9] score for each web service.<br>
-**Metric type:** [GAUGE][6].<br>
+**Description:** Measures the [Apdex][10] score for each web service.<br>
+**Metric type:** [GAUGE][7].<br>
 **Tags:** `env`, `service`, `resource` / `resource_name`, `version`, `synthetics`, and [the second primary tag][4].
 
 **The following legacy apdex metrics are deprecated.**
 
 `trace.<SPAN_NAME>.apdex.by.resource_<2ND_PRIM_TAG>_service`
 : **Prerequisite:** This metric exists for any HTTP/WEB APM service.<br>
-**Description:** Represents the [Apdex][9] score for all combination of resources, [2nd primary tag][4]s and services.<br>
-**Metric type:** [GAUGE][6].<br>
+**Description:** Represents the [Apdex][10] score for all combination of resources, [2nd primary tag][4]s and services.<br>
+**Metric type:** [GAUGE][7].<br>
 **Tags:** `env`, `service`, `resource` / `resource_name`, and [the second primary tag][4].
 
 `trace.<SPAN_NAME>.apdex.by.resource_service`
 : **Prerequisite:** This metric exists for any HTTP/WEB APM service.<br>
-**Description:** Measures the [Apdex][9] score for each combination of resources and web services.<br>
-**Metric type:** [GAUGE][6].<br>
+**Description:** Measures the [Apdex][10] score for each combination of resources and web services.<br>
+**Metric type:** [GAUGE][7].<br>
 **Tags:** `env`, `service`, and `resource` / `resource_name`.
 
 `trace.<SPAN_NAME>.apdex.by.<2ND_PRIM_TAG>_service`
 : **Prerequisite:** This metric exists for any HTTP/WEB APM service.<br>
-**Description:** Measures the [Apdex][9] score for each combination of [2nd primary tag][4] and web services.<br>
-**Metric type:** [GAUGE][6].<br>
+**Description:** Measures the [Apdex][10] score for each combination of [2nd primary tag][4] and web services.<br>
+**Metric type:** [GAUGE][7].<br>
 **Tags:** `env`, `service`, and [the second primary tag][4].
 
 `trace.<SPAN_NAME>.apdex.by.service`
 : **Prerequisite:** This metric exists for any HTTP/WEB APM service.<br>
-**Description:** Measures the [Apdex][9] score for each web service.<br>
-**Metric type:** [GAUGE][6].<br>
+**Description:** Measures the [Apdex][10] score for each web service.<br>
+**Metric type:** [GAUGE][7].<br>
 **Tags:** `env` and `service`.
 
 ## Further Reading
@@ -203,7 +182,8 @@ With the following definitions:
 [3]: /tracing/visualization/#trace-metrics
 [4]: /tracing/guide/setting_primary_tags_to_scope/#add-a-second-primary-tag-in-datadog
 [5]: /metrics/types/?tab=count#metric-types
-[6]: /metrics/types/?tab=gauge#metric-types
-[7]: /tracing/visualization/services_list/#services-types
-[8]: /tracing/visualization/#services
-[9]: /tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm/
+[6]: /metrics/types/?tab=distribution#metric-types
+[7]: /metrics/types/?tab=gauge#metric-types
+[8]: /tracing/visualization/services_list/#services-types
+[9]: /tracing/visualization/#services
+[10]: /tracing/guide/configure_an_apdex_for_your_traces_with_datadog_apm/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes Percentile Aggregation metrics, adds Latency distribution

### Motivation
DOCS-2751 from PM

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/docs-2751-apm-lat-dist/tracing/guide/metrics_namespace

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
