### PR TITLE
Include changes to kubernetes_state_core *.waiting metrics

### DIFF
--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -130,6 +130,9 @@ The Kubernetes State Metrics Core check is not backward compatible, be sure to r
 `kubernetes_state.node.count`
 : The metric is not tagged with `host` anymore. It aggregates the nodes count by `kernel_version` `os_image` `container_runtime_version` `kubelet_version`.
 
+`kubernetes_state.container.waiting` and `kubernetes_state.container.status_report.count.waiting`
+: These metrics will no longer emit a 0 value if no pods are waiting. They will only report non-zero values.
+
 {{< tabs >}}
 {{% tab "Helm" %}}
 

--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -131,7 +131,7 @@ The Kubernetes State Metrics Core check is not backward compatible, be sure to r
 : The metric is not tagged with `host` anymore. It aggregates the nodes count by `kernel_version` `os_image` `container_runtime_version` `kubelet_version`.
 
 `kubernetes_state.container.waiting` and `kubernetes_state.container.status_report.count.waiting`
-: These metrics will no longer emit a 0 value if no pods are waiting. They will only report non-zero values.
+: These metrics no longer emit a 0 value if no pods are waiting. They only report non-zero values.
 
 {{< tabs >}}
 {{% tab "Helm" %}}


### PR DESCRIPTION
### What does this PR do?
Update kubernetes_state_core docs page to reflect different behavior of *.waiting metrics 

### Motivation
Better information for users

### Preview
https://docs-staging.datadoghq.com/celene/update_ksmcore/integrations/kubernetes_state_core/?tab=helm#backward-incompatibility-changes

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
