### PR TITLE
Correct self-contradicting statement

### DIFF
--- a/content/en/agent/amazon_ecs/tags.md
+++ b/content/en/agent/amazon_ecs/tags.md
@@ -38,7 +38,7 @@ If you do not have unified service tagging enabled, complete the following steps
 
 ### Notes
 
-- Ensure the IAM role is associated with your [Amazon ECS container instances][2] and not the underlying EC2 instance.
+- Ensure the IAM role is associated with your [Amazon ECS container instances][2] and not the task role of the Datadog agent container.
 - ECS resource tags can be collected from EC2 instances, but not from AWS Fargate.
 - This feature requires Datadog Agent v6.17+ or v7.17+.
 - The Agent supports ECS tag collection from the `tasks`, `services`, and `container instances` ECS resources.


### PR DESCRIPTION
The role should be on the EC2 instance/container instance, since container instances _are_ EC2 instances

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
