### PR TITLE
Fix inaccuracy about metric-based SLO docs grouping

### DIFF
--- a/content/en/monitors/service_level_objectives/metric.md
+++ b/content/en/monitors/service_level_objectives/metric.md
@@ -24,7 +24,7 @@ On the [SLO status page][1], select **New SLO +**. Then select [**Metric**][2].
 
 1. There are two queries to define. The numerator query defines the sum of the good events, while the denominator query defines the sum of the total events. Your queries must use either COUNT or RATE metrics to ensure the SLO calculation behaves correctly.
 2. Use the `FROM` field to include or exclude specific groups using tags.
-3. Optionally, use the `sum by` aggregator to break your SLI out by specific groups (for tracking and visualization)
+3. Optionally, use the `sum by` aggregator to break your SLI out by specific groups (for tracking and visualization).
 
 **Example:** If you are tracking HTTP return codes, and your metric includes a tag like `code:2xx` || `code:3xx` || `code:4xx`. The sum of good events would be `sum:httpservice.hits{code:2xx} + sum:httpservice.hits{code:4xx}`. And the `total` events would be `sum:httpservice.hits{!code:3xx}`.
 

--- a/content/en/monitors/service_level_objectives/metric.md
+++ b/content/en/monitors/service_level_objectives/metric.md
@@ -24,8 +24,7 @@ On the [SLO status page][1], select **New SLO +**. Then select [**Metric**][2].
 
 1. There are two queries to define. The numerator query defines the sum of the good events, while the denominator query defines the sum of the total events. Your queries must use either COUNT or RATE metrics to ensure the SLO calculation behaves correctly.
 2. Use the `FROM` field to include or exclude specific groups using tags.
-3. Use the `sum by` aggregator to sum up all request counts instead of averaging them, or taking the max or min of all of those requests.
-4. Optionally, break your SLI out by specific groups (for tracking and visualization) or report on an aggregation of everything included in your criteria from steps 1 and 2. 
+3. Optionally, use the `sum by` aggregator to break your SLI out by specific groups (for tracking and visualization)
 
 **Example:** If you are tracking HTTP return codes, and your metric includes a tag like `code:2xx` || `code:3xx` || `code:4xx`. The sum of good events would be `sum:httpservice.hits{code:2xx} + sum:httpservice.hits{code:4xx}`. And the `total` events would be `sum:httpservice.hits{!code:3xx}`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes inaccuracies in the metric-based SLOs docs with regards to grouping

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer ticket

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/markazerdd/metric-based-slo-grouping/monitors/service_level_objectives/metric/#define-queries

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
