### PR TITLE
zachG add UDS setup to Kubernetes trace collection docs

### DIFF
--- a/content/en/agent/kubernetes/apm.md
+++ b/content/en/agent/kubernetes/apm.md
@@ -25,7 +25,7 @@ In order to start collecting your application traces you must be [running the Da
 
 ## Setup
 
-To enable trace collection with your Agent, follow the instructions below. You can configure the agent to intake traces via UDP or Unix Domain Socket:
+To enable trace collection with your Agent, follow the instructions below. You can configure the Agent to intake traces via UDP or Unix Domain Socket:
 
 1. **Configure the Datadog Agent to accept traces**:
     {{< tabs >}}
@@ -232,7 +232,7 @@ If sending traces to the agent via UDP (`<ip_address>:8126`):
 3. **Configure your application tracers to emit traces**: Point your application-level tracers to where the Datadog Agent host is using the environment variable `DD_AGENT_HOST`. Refer to the [language-specific APM instrumentation docs][3] for more examples.
 {{% /tab %}}
 {{% tab "Unix Domain Socket" %}}
-If sending traces to the agent via Unix Domain Socket you need to mount the directory the socket is in to the application container and specify the path with `DD_TRACE_AGENT_URL`.
+If you are sending traces to the Agent by using Unix Domain Socket, mount the directory the socket is in to the application container and specify the path with `DD_TRACE_AGENT_URL`.
 
     ```yaml
         apiVersion: apps/v1
@@ -257,7 +257,7 @@ If sending traces to the agent via Unix Domain Socket you need to mount the dire
                     path: /var/run/datadog/
                   name: apmsocketpath
     ```
-3. **Configure your application tracers to emit traces**: Point your application-level tracers to where the Datadog Agent host is using the environment variable `DD_APM_RECEIVER_SOCKET` or for Helm `apm.socketPath`. For Helm and Operator the default for this value is `"/var/run/datadog/apm.socket"`. Some tracers do not yet support sending via UDS, refer to the [language-specific APM instrumentation docs][3] to see if this is supported for the tracr you're using.
+3. **Configure your application tracers to emit traces**: Point your application-level tracers to where the Datadog Agent host is using the environment variable `DD_APM_RECEIVER_SOCKET` or for Helm `apm.socketPath`. For Helm and Operator the default for this value is `"/var/run/datadog/apm.socket"`. Some tracers do not support Unix Domain Socket. Refer to the [language-specific APM instrumentation docs][3] to see if this is supported for your tracer.
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/agent/kubernetes/apm.md
+++ b/content/en/agent/kubernetes/apm.md
@@ -25,7 +25,7 @@ In order to start collecting your application traces you must be [running the Da
 
 ## Setup
 
-To enable trace collection with your Agent, follow the instructions below. You can configure the Agent to intake traces with UDP or Unix Domain Socket:
+You can configure the Agent to intake traces by using either UDP or Unix Domain Socket. To enable trace collection with your Agent:
 
 1. **Configure the Datadog Agent to accept traces**:
     {{< tabs >}}
@@ -95,7 +95,7 @@ To enable APM trace collection, open the DaemonSet configuration file and edit t
 
 - Set your Datadog site to: {{< region-param key="dd_site" code="true" >}} (defaults to `site: datadoghq.com`).
 
-- **If using an old agent version (7.17 or lower)**, in addition to the steps above, set the `DD_APM_NON_LOCAL_TRAFFIC` and `DD_APM_ENABLED` variable to `true` in your *env* section of the `datadog.yaml` trace Agent manifest:
+- **If using an old agent version (7.17 or lower)**, in addition to the steps above, set the `DD_APM_NON_LOCAL_TRAFFIC` and `DD_APM_ENABLED` variable to `true` in your `env` section of the `datadog.yaml` trace Agent manifest:
 
     ```yaml
      # (...)
@@ -112,8 +112,6 @@ To enable APM trace collection, open the DaemonSet configuration file and edit t
 {{% tab "DaemonSet Unix Domain Socket" %}}
 
 To enable APM trace collection, open the DaemonSet configuration file and edit the following:
-
-- This config creates a directory on the host and mounts it to the agent. Then creates a socket file in that directory with `DD_APM_RECEIVER_SOCKET`. This will allow incoming data from the socket and make it available to the application containers to access on the host:
 
     ```yaml
      # (...)
@@ -133,10 +131,12 @@ To enable APM trace collection, open the DaemonSet configuration file and edit t
      # (...)
     ```
 
+This configuration creates a directory on the host and mounts it to the Agent. It creates a socket file in that directory with the `DD_APM_RECEIVER_SOCKET` value. This allows incoming data from the socket and makes it available to the application containers to access on the host.
+
 {{% /tab %}}
 {{% tab "Operator UDP" %}}
 
-Update your `datadog-agent.yaml` manifest with:
+Update your `datadog-agent.yaml` manifest with the following:
 
 ```
 agent:
@@ -161,7 +161,7 @@ $ kubectl apply -n $DD_NAMESPACE -f datadog-agent.yaml
 {{% /tab %}}
 {{% tab "Operator Unix Domain Socket" %}}
 
-Update your `datadog-agent.yaml` manifest with:
+Update your `datadog-agent.yaml` manifest with the following:
 
 ```
 agent:
@@ -190,80 +190,85 @@ $ kubectl apply -n $DD_NAMESPACE -f datadog-agent.yaml
 [1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-apm.yaml
 {{% /tab %}}
 {{< /tabs >}}
+
    **Note**: On minikube, you may receive an `Unable to detect the kubelet URL automatically` error. In this case, set `DD_KUBELET_TLS_VERIFY=false`.
 
 2. **Configure your application pods in order to communicate with the Datadog Agent**:
     {{< tabs >}}
 {{% tab "UDP" %}}
-If sending traces to the agent via UDP (`<ip_address>:8126`):
-  - Automatically with the [Datadog Admission Controller][2], or
-  - Manually using the downward API to pull the host IP; the application container needs the `DD_AGENT_HOST` environment variable that points to `status.hostIP`.
+If you are sending traces to the Agent by using UDP (`<IP_ADDRESS>:8126`), either automatically with the [Datadog Admission Controller][1], or manually using the downward API to pull the host IP, the application container needs the `DD_AGENT_HOST` environment variable that points to `status.hostIP`:
 
-    ```yaml
-        apiVersion: apps/v1
-        kind: Deployment
-         # ...
-            spec:
-              containers:
-              - name: "<CONTAINER_NAME>"
-                image: "<CONTAINER_IMAGE>"/"<TAG>"
-                env:
-                  - name: DD_AGENT_HOST
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: status.hostIP
-    ```
+```yaml
+    apiVersion: apps/v1
+    kind: Deployment
+      # ...
+        spec:
+          containers:
+          - name: "<CONTAINER_NAME>"
+            image: "<CONTAINER_IMAGE>"/"<TAG>"
+            env:
+              - name: DD_AGENT_HOST
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.hostIP
+```
 
-    ```yaml
-        apiVersion: apps/v1
-        kind: Deployment
-         # ...
-            spec:
-              containers:
-              - name: "<CONTAINER_NAME>"
-                image: "<CONTAINER_IMAGE>"/"<TAG>"
-                env:
-                  - name: DD_AGENT_HOST
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: status.hostIP
-    ```
 
-3. **Configure your application tracers to emit traces**: Point your application-level tracers to where the Datadog Agent host is using the environment variable `DD_AGENT_HOST`. Refer to the [language-specific APM instrumentation docs][3] for more examples.
+
+[1]: /agent/cluster_agent/admission_controller/
 {{% /tab %}}
 {{% tab "Unix Domain Socket" %}}
-If you are sending traces to the Agent by using Unix Domain Socket, mount the directory the socket is in to the application container and specify the path with `DD_TRACE_AGENT_URL`.
+If you are sending traces to the Agent by using Unix Domain Socket, mount the directory the socket is in to the application container and specify the path with `DD_TRACE_AGENT_URL`:
 
-    ```yaml
-        apiVersion: apps/v1
-        kind: Deployment
-        # ...
-            spec:
-              containers:
-              - name: "<CONTAINER_NAME>"
-                image: "<CONTAINER_IMAGE>"/"<TAG>"
-                imagePullPolicy: Never
-                volumeMounts:
-                - name: apmsocketpath
-                  mountPath: /var/run/datadog
-                ports:
-                - containerPort: 9390
-                env:
-                - name: DD_TRACE_AGENT_URL
-                  value: 'unix:///var/run/datadog/apm.socket'
-                # ...
-              volumes:
-                - hostPath:
-                    path: /var/run/datadog/
-                  name: apmsocketpath
-    ```
-3. **Configure your application tracers to emit traces**: Point your application-level tracers to where the Datadog Agent host is using the environment variable `DD_APM_RECEIVER_SOCKET` or for Helm `apm.socketPath`. For Helm and Operator the default for this value is `"/var/run/datadog/apm.socket"`. Some tracers do not support Unix Domain Socket. Refer to the [language-specific APM instrumentation docs][3] to see if this is supported for your tracer.
+```yaml
+    apiVersion: apps/v1
+    kind: Deployment
+    # ...
+        spec:
+          containers:
+          - name: "<CONTAINER_NAME>"
+            image: "<CONTAINER_IMAGE>"/"<TAG>"
+            imagePullPolicy: Never
+            volumeMounts:
+            - name: apmsocketpath
+              mountPath: /var/run/datadog
+            ports:
+            - containerPort: 9390
+            env:
+            - name: DD_TRACE_AGENT_URL
+              value: 'unix:///var/run/datadog/apm.socket'
+            # ...
+          volumes:
+            - hostPath:
+                path: /var/run/datadog/
+              name: apmsocketpath
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+3. **Configure your application tracers to emit traces**:
+    {{< tabs >}}
+{{% tab "UDP" %}}
+
+Point your application-level tracers to where the Datadog Agent host is using the environment variable `DD_AGENT_HOST`. Refer to the [language-specific APM instrumentation docs][1] for more examples.
+
+[1]: /tracing/setup/
+{{% /tab %}}
+{{% tab "Unix Domain Socket" %}}
+
+Point your application-level tracers to where the Datadog Agent host is using the environment variable `DD_APM_RECEIVER_SOCKET` or for Helm `apm.socketPath`. For Helm and Operator the default for this value is `"/var/run/datadog/apm.socket"`. 
+
+Some tracers do not support Unix Domain Socket. Refer to the [language-specific APM instrumentation docs][1] to see if this is supported for your tracer.
+
+
+[1]: /tracing/setup/
 {{% /tab %}}
 {{< /tabs >}}
 
 ## Agent environment variables
 
-**Note**: As a best practice, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][4] documentation.
+**Note**: As a best practice, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][2] documentation.
 
 List of all environment variables available for tracing within the Agent running in Kubernetes:
 
@@ -271,7 +276,7 @@ List of all environment variables available for tracing within the Agent running
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `DD_API_KEY`               | [Datadog API Key][3]                                                                                                                                                                                                                                                                                                        |
 | `DD_PROXY_HTTPS`           | Set up the URL for the proxy to use.                                                                                                                                                                                                                                                                                        |
-| `DD_APM_REPLACE_TAGS`      | [Scrub sensitive data from your span’s tags][5].                                                                                                                                                                                                                                                                            |
+| `DD_APM_REPLACE_TAGS`      | [Scrub sensitive data from your span’s tags][4].                                                                                                                                                                                                                                                                            |
 | `DD_HOSTNAME`              | Manually set the hostname to use for metrics if autodection fails, or when running the Datadog Cluster Agent.                                                                                                                                                                                                               |
 | `DD_DOGSTATSD_PORT`        | Set the DogStatsD port.                                                                                                                                                                                                                                                                                                     |
 | `DD_APM_RECEIVER_SOCKET`  | Collect your traces through a Unix Domain Sockets and takes priority over hostname and port configuration if set. Off by default, when set it must point to a valid sock file.                                                                                                                                            |
@@ -283,17 +288,17 @@ List of all environment variables available for tracing within the Agent running
 | `DD_APM_RECEIVER_PORT`     | Port that the Datadog Agent's trace receiver listens on. Default value is `8126`.                                                                                                                                                                                                                                           |
 | `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when tracing from other containers. Default value is `true` (Agent 7.18+)                                                                                                                                                                                                                               |
 | `DD_APM_IGNORE_RESOURCES`  | Configure resources for the Agent to ignore. Format should be comma separated, regular expressions. Like <code>GET /ignore-me,(GET\|POST) /and-also-me</code>.                                                                                                                                                       |
-| `DD_ENV`                   | Sets the global `env` for all data emitted by the Agent. If `env` is not present in your trace data, this variable is used. See [APM environment setup][6] for more details.  
+| `DD_ENV`                   | Sets the global `env` for all data emitted by the Agent. If `env` is not present in your trace data, this variable is used. See [APM environment setup][5] for more details.  
                         
 
 ### Operator environment variables
 | Environment variable       | Description                                                                                                                                                                                                                                                                                                                 |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent.apm.enabled`                                                                                          | Enable this to enable APM and tracing, on port 8126. See the [Datadog Docker documentation][7].                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `agent.apm.env`                                                                                              | The Datadog Agent supports many [environment variables][8].                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `agent.apm.enabled`                                                                                          | Enable this to enable APM and tracing, on port 8126. See the [Datadog Docker documentation][6].                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `agent.apm.env`                                                                                              | The Datadog Agent supports many [environment variables][7].                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `agent.apm.hostPort`                                                                                         | Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If `HostNetwork` is specified, this must match `ContainerPort`. Most containers do not need this.                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| `agent.apm.resources.limits`                                                                                 | Limits describes the maximum amount of compute resources allowed. For more info, see the [Kubernetes documentation][9].                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| `agent.apm.resources.requests`                                                                               | Requests describes the minimum amount of compute resources required. If `requests` is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. For more info, see the [Kubernetes documentation][9].     |                                                                                                                                                                                                                                                                                                                               |
+| `agent.apm.resources.limits`                                                                                 | Limits describes the maximum amount of compute resources allowed. For more info, see the [Kubernetes documentation][8].                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `agent.apm.resources.requests`                                                                               | Requests describes the minimum amount of compute resources required. If `requests` is omitted for a container, it defaults to `limits` if that is explicitly specified, otherwise to an implementation-defined value. For more info, see the [Kubernetes documentation][8].     |                                                                                                                                                                                                                                                                                                                               |
 
 
 ## Further Reading
@@ -302,11 +307,10 @@ List of all environment variables available for tracing within the Agent running
 
 
 [1]: /agent/kubernetes/
-[2]: /agent/cluster_agent/admission_controller/
+[2]: /getting_started/tagging/unified_service_tagging
 [3]: /tracing/setup/
-[4]: /getting_started/tagging/unified_service_tagging
-[5]: /tracing/guide/security/#replace-rules
-[6]: /tracing/guide/setting_primary_tags_to_scope/#environment
-[7]: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host
-[8]: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables
-[9]: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+[4]: /tracing/guide/security/#replace-rules
+[5]: /tracing/guide/setting_primary_tags_to_scope/#environment
+[6]: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host
+[7]: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables
+[8]: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/

--- a/content/en/agent/kubernetes/apm.md
+++ b/content/en/agent/kubernetes/apm.md
@@ -25,7 +25,7 @@ In order to start collecting your application traces you must be [running the Da
 
 ## Setup
 
-To enable trace collection with your Agent, follow the instructions below. You can configure the Agent to intake traces via UDP or Unix Domain Socket:
+To enable trace collection with your Agent, follow the instructions below. You can configure the Agent to intake traces with UDP or Unix Domain Socket:
 
 1. **Configure the Datadog Agent to accept traces**:
     {{< tabs >}}


### PR DESCRIPTION
### What does this PR do?
Add Unix domain socket configurations to the K8s Tracer setup docs

### Motivation
APM is moving towards using UDS as the default and we're more often recommending that to customers since it's more reliable than UDP. How to set this up is not entirely intuitive to customers.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/add-k8s-apm-uds-configs/agent/kubernetes ?

### Additional Notes
This is for Kari to review since we've chatted about it before.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
