### PR TITLE
Clarify tag cardinality

### DIFF
--- a/content/en/getting_started/tagging/assigning_tags.md
+++ b/content/en/getting_started/tagging/assigning_tags.md
@@ -240,9 +240,9 @@ Either define the variables in your custom `datadog.yaml`, or set them as JSON m
 
 ##### Tags cardinality
 
-There are two environment variables that set tag cardinality: `DD_CHECKS_TAG_CARDINALITY` and `DD_DOGSTATSD_TAG_CARDINALITY`—as DogStatsD is priced differently, its tag cardinality setting is separated in order to provide the opportunity for finer configuration. Otherwise, these variables function the same way: they can have values `low`, `orchestrator`, or `high`. They both default to `low`, which pulls in host-level tags.
+There are two environment variables that set tag cardinality: `DD_CHECKS_TAG_CARDINALITY` and `DD_DOGSTATSD_TAG_CARDINALITY`. Because DogStatsD is priced differently, the DogStatsD tag cardinality setting is separated to provide the opportunity for finer configuration. Otherwise, these variables function the same way: they can have values `low`, `orchestrator`, or `high`. They both default to `low`, which pulls in host-level tags.
 
-Depending on the cardinality, there will be a different set of out-of-the box tags for [Kubernetes and Openshift][7], and for [Docker, Rancher and Mesos][8]. For ECS and Fargate, setting the variable to `orchestrator` adds the `task_arn` tag.
+Depending on the cardinality, there is a different set of out-of-the box tags for [Kubernetes and OpenShift][7], and for [Docker, Rancher, and Mesos][8]. For ECS and Fargate, setting the variable to `orchestrator` adds the `task_arn` tag.
 
 #### Traces
 

--- a/content/en/getting_started/tagging/assigning_tags.md
+++ b/content/en/getting_started/tagging/assigning_tags.md
@@ -164,13 +164,13 @@ After installing the containerized Datadog Agent, you can set your host tags usi
 
 Datadog automatically collects common tags from [Docker, Kubernetes, ECS, Swarm, Mesos, Nomad, and Rancher][6]. To extract even more tags, use the following options:
 
-| Environment Variable               | Description                                    |
-|------------------------------------|------------------------------------------------|
-| `DD_DOCKER_LABELS_AS_TAGS`         | Extract docker container labels                |
-| `DD_DOCKER_ENV_AS_TAGS`            | Extract docker container environment variables |
-| `DD_KUBERNETES_POD_LABELS_AS_TAGS` | Extract pod labels                             |
-| `DD_CHECKS_TAG_CARDINALITY`        | Add tags to check metrics                      |
-| `DD_DOGSTATSD_TAG_CARDINALITY`     | Add tags to custom metrics                     |
+| Environment Variable               | Description                                          |
+|------------------------------------|------------------------------------------------------|
+| `DD_DOCKER_LABELS_AS_TAGS`         | Extract docker container labels                      |
+| `DD_DOCKER_ENV_AS_TAGS`            | Extract docker container environment variables       |
+| `DD_KUBERNETES_POD_LABELS_AS_TAGS` | Extract pod labels                                   |
+| `DD_CHECKS_TAG_CARDINALITY`        | Add tags to check metrics (low, orchestrator, high)  |
+| `DD_DOGSTATSD_TAG_CARDINALITY`     | Add tags to custom metrics (low, orchestrator, high) |
 
 **Examples:**
 
@@ -238,15 +238,15 @@ services:
 
 Either define the variables in your custom `datadog.yaml`, or set them as JSON maps in these environment variables. The map key is the source (`label/envvar`) name, and the map value is the Datadog tag name.
 
+##### Tags cardinality
+
 There are two environment variables that set tag cardinality: `DD_CHECKS_TAG_CARDINALITY` and `DD_DOGSTATSD_TAG_CARDINALITY`—as DogStatsD is priced differently, its tag cardinality setting is separated in order to provide the opportunity for finer configuration. Otherwise, these variables function the same way: they can have values `low`, `orchestrator`, or `high`. They both default to `low`, which pulls in host-level tags.
 
-Setting the variable to `orchestrator` adds the following tags: `pod_name` (Kubernetes), `oshift_deployment` (OpenShift), `task_arn` (ECS and Fargate), `mesos_task` (Mesos).
-
-Setting the variable to `high` additionally adds the following tags: `container_name` (Docker), `container_id` (Docker), `display_container_name` (Kubelet).
+Depending on the cardinality, there will be a different set of out-of-the box tags for [Kubernetes and Openshift][7], and for [Docker, Rancher and Mesos][8]. For ECS and Fargate, setting the variable to `orchestrator` adds the `task_arn` tag.
 
 #### Traces
 
-The Datadog tracer can be configured with environment variables, system properties, or through configuration in code. The [Datadog tracing setup][7] documentation has information on tagging options and configuration for each tracer. You can also follow the [unified service tagging][2] documentation to configure your tracer for unified service tagging.
+The Datadog tracer can be configured with environment variables, system properties, or through configuration in code. The [Datadog tracing setup][9] documentation has information on tagging options and configuration for each tracer. You can also follow the [unified service tagging][2] documentation to configure your tracer for unified service tagging.
 
 Regardless of the tracer used, span metadata must respect a typed tree structure. Each node of the tree is split by a `.` and is of a single type.
 
@@ -379,7 +379,7 @@ sum:page.views{domain:example.com} by {host}
 
 ### DogStatsD
 
-Add tags to any metric, event, or service check you send to [DogStatsD][8]. For example, compare the performance of two algorithms by tagging a timer metric with the algorithm version:
+Add tags to any metric, event, or service check you send to [DogStatsD][9]. For example, compare the performance of two algorithms by tagging a timer metric with the algorithm version:
 
 ```python
 
@@ -392,9 +392,9 @@ def algorithm_two():
     # Do fancy things (maybe faster?) here ...
 ```
 
-**Note**: Tagging is a [Datadog-specific extension][9] to StatsD.
+**Note**: Tagging is a [Datadog-specific extension][10] to StatsD.
 
-Special consideration is necessary when assigning the `host` tag to DogStatsD metrics. For more information on the host tag key, see the [DogStatsD section][10].
+Special consideration is necessary when assigning the `host` tag to DogStatsD metrics. For more information on the host tag key, see the [DogStatsD section][11].
 
 ## Further Reading
 
@@ -406,7 +406,9 @@ Special consideration is necessary when assigning the `host` tag to DogStatsD me
 [4]: /getting_started/agent/#setup
 [5]: /integrations/#cat-web
 [6]: /agent/docker/?tab=standard#tagging
-[7]: /tracing/setup/
-[8]: /developers/dogstatsd/
-[9]: /developers/community/libraries/
-[10]: /metrics/dogstatsd_metrics_submission/#host-tag-key
+[7]: /agent/kubernetes/tag/?tab=containerizedagent#out-of-the-box-tags
+[8]: /agent/docker/tag/?tab=containerizedagent#out-of-the-box-tagging
+[9]: /tracing/setup/
+[10]: /developers/dogstatsd/
+[11]: /developers/community/libraries/
+[12]: /metrics/dogstatsd_metrics_submission/#host-tag-key


### PR DESCRIPTION
### What does this PR do?
Tag cardinality section is a bit confusing. This PR tries to clarify it a bit more by:

* Adding its own subsection
* Instead of listing the tags added by setting to `orchestrator` (which was already outdated), point to the existing documentation with the full list of tags

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/arapulido/clarify_tag_cardinality/getting_started/tagging/assigning_tags
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
