### PR TITLE
Update enrichment-tables.md to correct S3 file size limit

### DIFF
--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -67,7 +67,7 @@ Click **New Enrichment Table +**, then add a name, select AWS S3, fill out all f
 
 {{< img src="logs/guide/enrichment-tables/configure-s3-enrichment-table.png" alt="Create an Enrichment Table" style="width:100%;">}}
 
-**Note**: The upload from an S3 bucket method supports files up to 3GB.
+**Note**: The upload from an S3 bucket method supports files up to 200MB.
 
 [1]: https://app.datadoghq.com/account/settings#integrations/amazon-web-services
 [2]: https://docs.datadoghq.com/integrations/amazon_web_services/?tab=automaticcloudformation#installation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

- corrects file size limit for S3 uploads from 3GB to 200MB.

### Motivation
<!-- What inspired you to submit this pull request?-->
- we had different limits for import (200MB) and refresh (3GB) of files. The higher limit for refresh is meant to be for org 2 only, and this corrects the actual limits in docs.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
