### PR TITLE
Remove `agent.config.securityContext.capabilities`

### DIFF
--- a/content/en/agent/kubernetes/operator_configuration.md
+++ b/content/en/agent/kubernetes/operator_configuration.md
@@ -96,12 +96,6 @@ spec:
 `agent.config.securityContext.allowPrivilegeEscalation`
 : Controls whether a process can gain more privileges than its parent process. This boolean determines whether or not the `no_new_privs` flag is set on the container process. `AllowPrivilegeEscalation` is always true when the container is run as both `Privileged` and has `CAP_SYS_ADMIN`.
 
-`agent.config.securityContext.capabilities.add`
-: Added capabilities.
-
-`agent.config.securityContext.capabilities.drop`
-: Removed capabilities.
-
 `agent.config.securityContext.privileged`
 : Run the container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to `false`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Remove following sections.
- `agent.config.securityContext.capabilities.add`
- `agent.config.securityContext.capabilities.drop`

### Motivation
<!-- What inspired you to submit this pull request?-->

Above two fields does not exist. Besides they are not defined in [DataDog/datadog-operator/apis/datadoghq/v1alpha1/datadogagent_types.go](https://github.com/DataDog/datadog-operator/blob/1953406f4fddfef3bccc4e93a96193b71eacfb0c/apis/datadoghq/v1alpha1/datadogagent_types.go#L1-L1445). Therefore, I think there is incorrect information in [the document](https://docs.datadoghq.com/agent/kubernetes/operator_configuration/#all-configuration-options).

![datadogagent yaml — dogdata 2021-11-14 at 9 34 55 PM](https://user-images.githubusercontent.com/41987730/141681290-9e31cc7a-4964-43f6-b40f-e3efb5b95973.jpg)

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://github.com/DataDog/documentation/blob/kei6u-patch-2/content/en/agent/kubernetes/operator_configuration.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
