### PR TITLE
Move logs transport HTTPS content to HTTPS tab

### DIFF
--- a/content/en/agent/logs/log_transport.md
+++ b/content/en/agent/logs/log_transport.md
@@ -1,5 +1,5 @@
 ---
-title: Agent Transport for logs
+title: Agent Transport for Logs
 kind: documentation
 description: Use the Datadog Agent to collect your logs and send them to Datadog
 further_reading:

--- a/content/en/agent/logs/log_transport.md
+++ b/content/en/agent/logs/log_transport.md
@@ -59,32 +59,6 @@ To send logs with environment variables, configure the following:
 
 By default, the Datadog Agent uses the port `443` to send its logs to Datadog over HTTPS.
 
-[1]: /agent/guide/agent-configuration-files/
-{{% /tab %}}
-{{% tab "TCP" %}}
-
-To enforce TCP transport, update the Agent's [main configuration file][1] (`datadog.yaml`) with:
-
-```yaml
-logs_enabled: true
-logs_config:
-  use_tcp: true
-```
-To send logs with environment variables, configure the following:
-
-* `DD_LOGS_ENABLED=true`
-* `DD_LOGS_CONFIG_USE_TCP=true`
-
-By default, the Datadog Agent sends its logs to Datadog over TLS-encrypted TCP. This requires outbound communication (on port `10516` for Datadog US site and port `443`for Datadog EU site).
-
-
-
-[1]: /agent/guide/agent-configuration-files/
-{{% /tab %}}
-{{< /tabs >}}
-
-**Note**: Setting up a [SOCKS5 proxy][2] server enforces TCP transport because socks5 proxies are not yet supported in HTTPS with compression.
-
 ## HTTPS transport
 
 **HTTPS log forwarding is the recommended configuration** for the best log collection reliability as the`200` status code is returned by the Datadog storage system:
@@ -101,7 +75,7 @@ Using HTTP, the Agent sends log batches with the following limits:
 
 The `compression_level` parameter (or `DD_LOGS_CONFIG_COMPRESSION_LEVEL`) accepts values from `0` (no compression) to `9` (maximum compression but higher resource usage). The default value is `6`.
 
-See the [Datadog Agent overhead section][3] for more information about Agent resource usage when compression is enabled.
+See the [Datadog Agent overhead section][2] for more information about Agent resource usage when compression is enabled.
 
 For Agent versions prior to 6.19 / 7.19, you need to enforce compression by updating the Agent's [main configuration file][1] (`datadog.yaml`) with:
 
@@ -128,10 +102,34 @@ Or use the `DD_LOGS_CONFIG_BATCH_WAIT=2` environment variable. The unit is in se
 
 ### HTTPS proxy configuration
 
-When logs are sent through HTTPS, use the same [set of proxy settings][4] as the other data types to send logs through a web proxy.
-
+When logs are sent through HTTPS, use the same [set of proxy settings][3] as the other data types to send logs through a web proxy.
 
 [1]: /agent/guide/agent-configuration-files/
+[2]: /agent/basic_agent_usage/#agent-overhead
+[3]: /agent/proxy/
+{{% /tab %}}
+{{% tab "TCP" %}}
+
+To enforce TCP transport, update the Agent's [main configuration file][1] (`datadog.yaml`) with:
+
+```yaml
+logs_enabled: true
+logs_config:
+  use_tcp: true
+```
+To send logs with environment variables, configure the following:
+
+* `DD_LOGS_ENABLED=true`
+* `DD_LOGS_CONFIG_USE_TCP=true`
+
+By default, the Datadog Agent sends its logs to Datadog over TLS-encrypted TCP. This requires outbound communication (on port `10516` for Datadog US site and port `443`for Datadog EU site).
+
+[1]: /agent/guide/agent-configuration-files/
+{{% /tab %}}
+{{< /tabs >}}
+
+**Note**: Setting up a [SOCKS5 proxy][2] server enforces TCP transport because socks5 proxies are not yet supported in HTTPS with compression.
+
+
+[1]: /agent/guide/agent-commands/?tab=agentv6v7#service-status
 [2]: /agent/logs/proxy/?tab=socks5
-[3]: /agent/basic_agent_usage/#agent-overhead
-[4]: /agent/proxy/


### PR DESCRIPTION
### What does this PR do?
Move HTTPs content so it's under HTTPS tab

### Motivation
DOCS-1305

### Preview
https://docs-staging.datadoghq.com/may/move-https-content/agent/logs/log_transport/?tab=https

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
