### PR TITLE
explain mysql default database missing schema

### DIFF
--- a/content/en/database_monitoring/troubleshooting.md
+++ b/content/en/database_monitoring/troubleshooting.md
@@ -337,7 +337,7 @@ See the appropriate version of the [Postgres `contrib` documentation][1] for mor
 
 The `schema` tag (also known as "database") is present on MySQL Query Metrics and Samples only when a Default Database is set on the connection that made the query. The Default Database is configured by the application by specifying the "schema" in the database connection parameters, or by executing the [USE Statement][5] on an already existing connection. 
 
-If there is no Default Database configured for a connection then none of the queries made by that connection will have the `schema` tag on them. 
+If there is no default database configured for a connection, then none of the queries made by that connection have the `schema` tag on them. 
 
 ## Need more help?
 

--- a/content/en/database_monitoring/troubleshooting.md
+++ b/content/en/database_monitoring/troubleshooting.md
@@ -333,17 +333,19 @@ See the appropriate version of the [Postgres `contrib` documentation][1] for mor
 {{% /tab %}}
 {{< /tabs >}}
 
+### Schema or Database missing on MySQL Query Metrics & Samples
+
+The `schema` tag (also known as "database") is present on MySQL Query Metrics and Samples only when a Default Database is set on the connection that made the query. The Default Database is configured by the application by specifying the "schema" in the database connection parameters, or by executing the [USE Statement][5] on an already existing connection. 
+
+If there is no Default Database configured for a connection then none of the queries made by that connection will have the `schema` tag on them. 
+
 ## Need more help?
 
 If you are still experiencing problems, contact [Datadog Support][4] for help.
-
-
-
-
-
 
 
 [1]: /database_monitoring/#getting-started
 [2]: /agent/troubleshooting/
 [3]: /agent/guide/agent-log-files
 [4]: /help/
+[5]: https://dev.mysql.com/doc/refman/8.0/en/use.html


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

Explain how mysql default database settings can lead to missing the schema tag on query metrics & samples. 

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/djova/explain-mysql-default-database

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
