### PR TITLE
Add a banner to send people to the latest key rotation docs

### DIFF
--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -4,7 +4,7 @@ kind: faq
 ---
 
 <div class="alert alert-warning">
-This page refers to the key rotation that happened in 2019, there's a separate documentation page for the <a href="agent/faq/linux-agent-2022-key-rotation">2022 Key Rotation</a>.
+This page pertains to the 2019 key rotation. For the 2022 key rotation, consult the <a href="agent/faq/linux-agent-2022-key-rotation">2022 Linux Agent Key Rotation</a> documentation.
 </div>
 
 

--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -3,6 +3,11 @@ title: RPM GPG Key Rotation
 kind: faq
 ---
 
+<div class="alert alert-warning">
+This page refers to the key rotation that happened in 2019, there's a separate documentation page for the <a href="agent/faq/linux-agent-2022-key-rotation">2022 Key Rotation</a>.
+</div>
+
+
 Starting with v6.14.0, the Agent RPM packages are signed with a different GPG key. As a common best practice, Datadog periodically updates the GPG key.
 
 Hosts using RPM packages located in the [Datadog Yum repository][1] are affected by this change and need to trust the key by importing the associated public key in their hosts' keyrings.


### PR DESCRIPTION
### What does this PR do?
Adds a banner to the 2019 key rotation page sending people to the 2022

### Motivation
The old page appears first on google when searching for "datadog key rotation"

### Preview
https://docs-staging.datadoghq.com/albertvaka/rpm-key-rotation-banner-2022/agent/faq/rpm-gpg-key-rotation-agent-6

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
