### PR TITLE
Update Tracing documentation to link to gorm v2.

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/go.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/go.md
@@ -71,6 +71,7 @@ The Go tracer includes support for the following data stores and libraries.
 | [Vault][57]             | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/hashicorp/vault][58]                   |
 | [Consul][59]            | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/hashicorp/consul][60]                  |
 | [Gorm][61]              | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/jinzhu/gorm][62]                       |
+| [Gorm v2][68]           | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/gorm.io/gorm.v1][69]                   |
 | [Kubernetes][63]        | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/k8s.io/client-go/kubernetes][64]       |
 | [Memcache][65]          | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/bradfitz/gomemcache/memcache][66]      |
 
@@ -152,3 +153,5 @@ import "gopkg.in/DataDog/dd-trace-go.v1/contrib/<PACKAGE_DIR>/<PACKAGE_NAME>"
 [65]: https://github.com/bradfitz/gomemcache/memcache
 [66]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/bradfitz/gomemcache/memcache
 [67]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/labstack/echo
+[68]: https://gorm.io/
+[69]: https://gopkg.in/DataDog/dd-trace-go.v1/contrib/gorm.io/gorm.v1


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Links to tracing setup for gorm v2.

### Motivation
<!-- What inspired you to submit this pull request?-->
The docs link to old gorm, so I started looking into implementing support for v2 until I found the new package digging through the code.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
I am not in the Datadog organization.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
