### PR TITLE
DOCS-2403, DOCS-2624, and DOCS-2622 Synthetics CI/CD Testing to CI/CD Integrations Navigation (Take 2)

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2555,37 +2555,53 @@ main:
     parent: synthetics_private_location
     identifier: synthetics_private_location_monitoring
     weight: 403
-  - name: CI/CD Testing
-    url: /synthetics/cicd_testing
+  - name: CI/CD Integrations
+    url: /synthetics/cicd_integrations
     parent: synthetics
-    identifier: synthetics_cicd_testing
+    identifier: synthetics_cicd_integrations
     weight: 5
-  - name: CI Results Explorer
-    url: /synthetics/cicd_testing/ci_results_explorer
-    parent: synthetics_cicd_testing
+  - name: GitHub Actions
+    url: /synthetics/cicd_integrations/github_actions
+    parent: synthetics_cicd_integrations
+    identifier: synthetics_integrations_github_actions
     weight: 501
+  - name: Jenkins
+    url: /synthetics/cicd_integrations/jenkins
+    parent: synthetics_cicd_integrations
+    identifier: synthetics_cicd_integrations_jenkins
+    weight: 502
+  - name: Configuration
+    url: /synthetics/cicd_integrations/configuration
+    parent: synthetics_cicd_integrations
+    identifier: synthetics_cicd_integrations_configuration
+    weight: 503
+  - name: CI Results Explorer
+    url: /synthetics/ci_results_explorer
+    parent: synthetics_ci_results_Explorer
+    identifier: synthetics_ci_results_explorer
+    weight: 6
   - name: Testing Tunnel
     url: /synthetics/testing_tunnel
     parent: synthetics
     identifier: synthetics_testing_tunnel
-    weight: 6
+    weight: 7
   - name: APM Integration
     url: synthetics/apm/
     parent: synthetics
     identifier: synthetics_apm
-    weight: 7
+    weight: 8
   - name: Settings
     url: synthetics/settings/
     parent: synthetics
-    weight: 8
+    weight: 9
   - name: Search and Manage
     url: synthetics/search/
     parent: synthetics
-    weight: 9
+    weight: 10
   - name: Metrics
     url: synthetics/metrics/
     parent: synthetics
-    weight: 10
+    weight: 11
   - name: Guides
     url: synthetics/guide/
     parent: synthetics

--- a/content/en/developers/faq/data-collection-resolution-retention.md
+++ b/content/en/developers/faq/data-collection-resolution-retention.md
@@ -44,5 +44,5 @@ Find below a summary of Datadog data collection, resolution, and retention:
 
 [1]: /tracing/guide/trace_sampling_and_storage/?tab=java#trace-storage
 [2]: /integrations/faq/cloud-metric-delay/#faster-metrics
-[3]: /synthetics/cicd_testing/?tab=apitest#trigger-tests-endpoint
-[4]: /synthetics/cicd_testing/?tab=apitest#cli-usage
+[3]: /synthetics/cicd_integrations/?tab=apitest#trigger-tests-endpoint
+[4]: /synthetics/cicd_integrations/?tab=apitest#cli-usage

--- a/content/en/getting_started/synthetics/_index.md
+++ b/content/en/getting_started/synthetics/_index.md
@@ -55,7 +55,7 @@ If you haven't already, create a [Datadog account][6].
 [2]: /synthetics/multistep
 [3]: /synthetics/browser_tests/
 [4]: /synthetics/private_locations
-[5]: /synthetics/cicd_testing/
+[5]: /synthetics/cicd_integrations
 [6]: https://www.datadoghq.com/
 [7]: /getting_started/synthetics/api_test/
 [8]: /getting_started/synthetics/api_test/#create-a-multistep-api-test

--- a/content/en/getting_started/synthetics/api_test.md
+++ b/content/en/getting_started/synthetics/api_test.md
@@ -14,7 +14,7 @@ further_reading:
     - link: '/getting_started/synthetics/private_location'
       tag: 'Documentation'
       text: 'Learn about private locations'
-    - link: '/synthetics/cicd_testing/'
+    - link: '/synthetics/cicd_integrations/'
       tag: 'Documentation'
       text: 'Learn how to trigger Synthetic tests from your CI/CD pipeline'
     - link: '/synthetics/identify_synthetics_bots'

--- a/content/en/getting_started/synthetics/browser_test.md
+++ b/content/en/getting_started/synthetics/browser_test.md
@@ -11,7 +11,7 @@ further_reading:
     - link: '/getting_started/synthetics/private_location'
       tag: 'Documentation'
       text: 'Learn about private locations'
-    - link: '/synthetics/cicd_testing'
+    - link: '/synthetics/cicd_integrations'
       tag: 'Documentation'
       text: 'Learn how to trigger Synthetic tests from your CI/CD pipeline'
     - link: '/synthetics/identify_synthetics_bots'
@@ -128,7 +128,7 @@ Use Datadog's [APM integration with Synthetic Monitoring][13] to view traces gen
 [2]: https://app.datadoghq.com/synthetics/list
 [3]: https://app.datadoghq.com/synthetics/browser/create
 [4]: /getting_started/synthetics/private_location
-[5]: /synthetics/cicd_testing
+[5]: /synthetics/cicd_integrations
 [6]: /integrations/#cat-notification
 [7]: https://app.datadoghq.com/account/settings
 [8]: https://chrome.google.com/webstore/detail/datadog-test-recorder/kkbncfpddhdmkfmalecgnphegacgejoa

--- a/content/en/getting_started/synthetics/private_location.md
+++ b/content/en/getting_started/synthetics/private_location.md
@@ -24,7 +24,7 @@ Private locations allow you to **monitor internal-facing applications** or priva
 You can also use private locations to:
 
 - **Create custom locations** in mission-critical areas of your business.
-- **Verify the application performance in your internal testing environment** before you release new features to production with [Synthetic CI/CD Testing][1].
+- **Verify the application performance in your internal testing environment** before you release new features to production with [Synthetics and CI/CD][1].
 - **Compare the application performance** from inside and outside your internal network.
 
 Private locations are Docker containers that you can install anywhere inside your private network. You can access the [private location worker image][2] on Google Container Registry.
@@ -77,7 +77,7 @@ You can use your new private location just like a managed location to run Synthe
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /synthetics/cicd_testing
+[1]: /synthetics/cicd_integrations
 [2]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/synthetics-private-location-worker?pli=1
 [3]: /getting_started/synthetics/
 [4]: https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce

--- a/content/en/synthetics/_index.md
+++ b/content/en/synthetics/_index.md
@@ -46,7 +46,7 @@ Use [Synthetic private locations][11] to monitor internal APIs and websites or c
 
 ## Run tests with your integration and deployment processes
 
-Leverage your Synthetic tests as [canaries][12] or run them directly within your [CI pipelines][12] to start shipping without fear that faulty code may impact your customers' experience.
+Leverage your Synthetic tests as [canary deployments][12] or run them directly within your [CI pipelines][12] to start shipping without fear that faulty code may impact your customers' experience.
 
  {{< img src="synthetics/ci.png" alt="CI tests" style="width:100%;">}}
 
@@ -76,7 +76,7 @@ See [Getting Started with Synthetic Monitoring][14] for instructions on creating
 [9]: /synthetics/api_tests/websocket_tests
 [10]: /synthetics/browser_tests
 [11]: /synthetics/private_locations
-[12]: /synthetics/cicd_testing
+[12]: /synthetics/cicd_integrations
 [13]: /synthetics/apm/
 [14]: /getting_started/synthetics
 [15]: /getting_started/synthetics/private_location

--- a/content/en/synthetics/api_tests/_index.md
+++ b/content/en/synthetics/api_tests/_index.md
@@ -42,7 +42,7 @@ API tests run from Datadog [managed locations][3] or [private locations][4], all
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /synthetics/api_tests/http_tests?tab=requestoptions#notify-your-team
-[2]: /synthetics/cicd_testing
+[2]: /synthetics/cicd_integrations
 [3]: /api/v1/synthetics/#get-all-locations-public-and-private
 [4]: /synthetics/private_locations
 [5]: /synthetics/multistep/

--- a/content/en/synthetics/api_tests/dns_tests.md
+++ b/content/en/synthetics/api_tests/dns_tests.md
@@ -165,7 +165,7 @@ If you have access to the [custom role feature][11], add your user to any custom
 
 [1]: /api/v1/synthetics/#get-all-locations-public-and-private
 [2]: /synthetics/private_locations
-[3]: /synthetics/cicd_testing
+[3]: /synthetics/cicd_integrations
 [4]: /synthetics/search/#search
 [5]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 [6]: /monitors/notify/#notify-your-team

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -231,7 +231,7 @@ If you have access to the [custom role feature][14], add your user to any custom
 
 [1]: /api/v1/synthetics/#get-all-locations-public-and-private
 [2]: /synthetics/private_locations
-[3]: /synthetics/cicd_testing
+[3]: /synthetics/cicd_integrations
 [4]: /synthetics/search/#search
 [5]: https://restfulapi.net/json-jsonpath/
 [6]: https://www.w3schools.com/xml/xpath_syntax.asp

--- a/content/en/synthetics/api_tests/icmp_tests.md
+++ b/content/en/synthetics/api_tests/icmp_tests.md
@@ -152,7 +152,7 @@ If you have access to the [custom role feature][10], add your user to any custom
 
 [1]: /api/v1/synthetics/#get-all-locations-public-and-private
 [2]: /synthetics/private_locations
-[3]: /synthetics/cicd_testing
+[3]: /synthetics/cicd_integrations
 [4]: /synthetics/search/#search
 [5]: /monitors/notify/#notify-your-team
 [6]: https://www.markdownguide.org/basic-syntax/

--- a/content/en/synthetics/api_tests/ssl_tests.md
+++ b/content/en/synthetics/api_tests/ssl_tests.md
@@ -176,7 +176,7 @@ If you have access to the [custom role feature][12], add your user to any custom
 
 [1]: /api/v1/synthetics/#get-all-locations-public-and-private
 [2]: /synthetics/private_locations
-[3]: /synthetics/cicd_testing
+[3]: /synthetics/cicd_integrations
 [4]: /synthetics/search/#search
 [5]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 [6]: /monitors/notify/#notify-your-team

--- a/content/en/synthetics/api_tests/tcp_tests.md
+++ b/content/en/synthetics/api_tests/tcp_tests.md
@@ -159,7 +159,7 @@ If you have access to the [custom role feature][10], add your user to any custom
 
 [1]: /api/v1/synthetics/#get-all-locations-public-and-private
 [2]: /synthetics/private_locations
-[3]: /synthetics/cicd_testing
+[3]: /synthetics/cicd_integrations
 [4]: /synthetics/search/#search
 [5]: /monitors/notify/#notify-your-team
 [6]: https://www.markdownguide.org/basic-syntax/

--- a/content/en/synthetics/api_tests/udp_tests.md
+++ b/content/en/synthetics/api_tests/udp_tests.md
@@ -54,7 +54,7 @@ Select the **Locations** to run your UDP test from. UDP tests can run from both 
 UDP tests can run:
 
 - **On a schedule** to ensure your most important services are always accessible to your users. Select the frequency at which you want Datadog to run your UDP test.
-- [**Within your CI/CD pipelines**][6].
+- [**Within your CI/CD pipelines**][3].
 - **On-demand** to run your tests whenever makes the most sense for your team.
 
 ### Define alert conditions
@@ -78,9 +78,9 @@ When you set the alert conditions to `An alert is triggered if your test fails f
 
 A notification is sent by your test based on the [alerting conditions](#define-alert-conditions) previously defined. Use this section to define how and what to message to send to your teams.
 
-1. [Similar to how you configure monitors][7], select **users and/or services** that should receive notifications either by adding an `@notification`to the message or by searching for team members and connected integrations with the drop-down box.
+1. [Similar to how you configure monitors][6], select **users and/or services** that should receive notifications either by adding an `@notification`to the message or by searching for team members and connected integrations with the drop-down box.
 
-2. Enter the notification **message** for your test. This field allows standard [Markdown formatting][8] and supports the following [conditional variables][9]:
+2. Enter the notification **message** for your test. This field allows standard [Markdown formatting][7] and supports the following [conditional variables][8]:
 
     | Conditional Variable       | Description                                                         |
     |----------------------------|---------------------------------------------------------------------|
@@ -118,7 +118,7 @@ When you have entered a name and a value, click **Add Variable**. (standardize t
 
 ### Use variables
 
-You can use the [global variables defined in `Settings`][10] and [locally defined variables](#create-local-variables) in the URL and assertions of your UDP tests.
+You can use the [global variables defined in `Settings`][8] and [locally defined variables](#create-local-variables) in the URL and assertions of your UDP tests.
 
 To display your list of variables, type `{{` in your desired field:
 
@@ -146,9 +146,9 @@ These reasons include the following:
 
 ## Permissions
 
-By default, only users with the Datadog Admin and Datadog Standard roles can create, edit, and delete Synthetic UDP tests. To get create, edit, and delete access to Synthetic UDP tests, upgrade your user to one of those two [default roles][11].
+By default, only users with the Datadog Admin and Datadog Standard roles can create, edit, and delete Synthetic UDP tests. To get create, edit, and delete access to Synthetic UDP tests, upgrade your user to one of those two [default roles][9].
 
-If you have access to the [custom role feature][12], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
+If you have access to the [custom role feature][10], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
 
 ## Further Reading
 
@@ -156,13 +156,11 @@ If you have access to the [custom role feature][12], add your user to any custom
 
 [1]: /api/latest/synthetics/#get-all-locations-public-and-private
 [2]: /synthetics/private_locations/
-[3]: /synthetics/cicd_testing
+[3]: /synthetics/cicd_integrations
 [4]: /synthetics/search/#search
 [5]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-[6]: /synthetics/cicd_testing/
-[7]: /monitors/notify/#notify-your-team
-[8]: https://www.markdownguide.org/basic-syntax/
-[9]: /monitors/notify/variables/?tab=is_alert#conditional-variables
-[10]: /synthetics/settings/#global-variables
-[11]: /account_management/rbac/
-[12]: /account_management/rbac#custom-roles
+[6]: /monitors/notify/#notify-your-team
+[7]: https://www.markdownguide.org/basic-syntax/
+[8]: /synthetics/settings/#global-variables
+[9]: /account_management/rbac/
+[10]: /account_management/rbac#custom-roles

--- a/content/en/synthetics/api_tests/websocket_tests.md
+++ b/content/en/synthetics/api_tests/websocket_tests.md
@@ -179,7 +179,7 @@ If you have access to the [custom role feature][11], add your user to any custom
 
 [1]: /api/latest/synthetics/#get-all-locations-public-and-private
 [2]: /synthetics/private_locations
-[3]: /synthetics/cicd_testing
+[3]: /synthetics/cicd_integrations
 [4]: /synthetics/search/#search
 [5]: /synthetics/settings/#global-variables
 [6]: /monitors/notify/#notify-your-team

--- a/content/en/synthetics/ci_results_explorer.md
+++ b/content/en/synthetics/ci_results_explorer.md
@@ -2,6 +2,8 @@
 title: CI Results Explorer
 kind: documentation
 description: Drill down into CI jobs executing Synthetic tests.
+aliases: 
+  - /synthetics/cicd_testing/ci_results_explorer
 further_reading:
 - link: "https://www.datadoghq.com/blog/datadog-synthetic-ci-cd-testing/"
   tag: "Blog"
@@ -80,5 +82,5 @@ To query the CI Results Explorer data, use the [same query syntax][2] as on the 
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /synthetics/cicd_testing
+[1]: /synthetics/cicd_integrations
 [2]: /synthetics/search/

--- a/content/en/synthetics/cicd_integrations/_index.md
+++ b/content/en/synthetics/cicd_integrations/_index.md
@@ -1,9 +1,10 @@
 ---
-title: Synthetic CI/CD Testing
+title: Synthetics and CI/CD
 kind: documentation
 description: Run Synthetic tests on-demand in your CI/CD pipelines.
 aliases: 
   - /synthetics/ci
+  - /synthetics/cicd_testing
 further_reading:
 - link: "https://www.datadoghq.com/blog/datadog-synthetic-ci-cd-testing/"
   tag: "Blog"
@@ -23,19 +24,19 @@ further_reading:
 
 ---
 
-In addition to running tests at predefined intervals, you can also run Datadog Synthetic tests on-demand using API endpoints. You can run Datadog Synthetic tests in your continuous integration (CI) pipelines, letting you block the deployment of branches that would break your product.
+In addition to running tests at predefined intervals, you can run Datadog Synthetic tests on-demand using API endpoints. Run Datadog Synthetic tests in your continuous integration (CI) pipelines to block branches from being deployed and breaking your application in production.
 
-Synthetic CI/CD testing can also be used to **run tests as part of your CD process**, evaluating the state of your production application immediately after a deployment finishes. This lets you detect potential regressions that could impact your users—and automatically trigger a rollback whenever a critical test fails.
+Use Synthetic CI/CD testing to also run tests as part of your continuous delivery (CD) process and evaluate the state of your applications and services in production immediately after a deployment finishes. You can detect potential regressions that may impact your users and automatically trigger a rollback when a critical test fails.
 
-This function allows you to avoid spending time fixing issues on production, and to catch bugs and regressions earlier in the process.
+This functionality reduces time spent fixing issues in production by proactively catching bugs and regressions earlier in the process, allowing your engineering teams to focus on non-urgent work instead. 
 
-On top of these API endpoints, Datadog provides and maintains a command line interface (CLI), allowing you to easily integrate Datadog Synthetic tests with your CI tooling. Synthetic CI/CD testing is open-source, and its source code is available on GitHub at [DataDog/datadog-ci][1].
+To get started, see [Integrations](#integrations) and [use the API](#use-the-api) or the [open-source CLI package](#use-the-cli). 
 
 ## CLI usage
 
 ### Package installation
 
-The package is published under [@datadog/datadog-ci][2] in the NPM registry.
+The package is published under [@datadog/datadog-ci][1] in the NPM registry.
 
 {{< tabs >}}
 {{% tab "NPM" %}}
@@ -97,7 +98,7 @@ In the global configuration file, you can configure the following options:
 : Overrides of synthetic tests applied to all tests ([see below for description of each field](#configure-tests)).
 
 `proxy`
-: The proxy to be used for outgoing connections to Datadog. `host` and `port` keys are mandatory arguments, `protocol` key defaults to `http`. Supported values for `protocol` key are `http`, `https`, `socks`, `socks4`, `socks4a`, `socks5`, `socks5h`, `pac+data`, `pac+file`, `pac+ftp`, `pac+http`, `pac+https`. The library used to configure the proxy is [proxy-agent][3] library.
+: The proxy to be used for outgoing connections to Datadog. `host` and `port` keys are mandatory arguments, `protocol` key defaults to `http`. Supported values for `protocol` key are `http`, `https`, `socks`, `socks4`, `socks4a`, `socks5`, `socks5h`, `pac+data`, `pac+file`, `pac+ftp`, `pac+http`, `pac+https`. The library used to configure the proxy is [proxy-agent][2] library.
 
 `subdomain`
 : The name of the custom subdomain set to access your Datadog application. If the URL used to access Datadog is `myorg.datadoghq.com` the `subdomain` value then needs to be set to `myorg`.
@@ -160,7 +161,7 @@ By default, the client automatically discovers and runs all tests specified in `
 
 #### Further configuration
 
-The default configurations used for the tests are the original tests' configurations (visible in the UI or when [getting your tests' configurations from the API][4]).
+The default configurations used for the tests are the original tests' configurations (visible in the UI or when [getting your tests' configurations from the API][3]).
 
 However, in the context of your CI deployment, you can optionally decide to override some (or all) of your tests parameters by using the below overrides. If you want to define overrides for all of your tests, these same parameters can be set at the [global configuration file](#setup-the-client) level.
 
@@ -363,9 +364,9 @@ npm run datadog-ci-synthetics
 
 ### Use the testing tunnel
 
-The [@datadog/datadog-ci][2] NPM package also comes with a tunnel functionality allowing you to swiftly trigger Synthetic tests on your internal applications. The testing tunnel creates an end-to-end encrypted HTTP proxy between your infrastructure and Datadog<span class="x x-first x-last">,</span> allowing all test requests sent <span class="x x-first x-last">through</span> the CLI to be <span class="x x-first x-last">automatically </span>routed through the `datadog-ci` client, consequently <span class="x x-first x-last">enabling</span> Datadog to run test on your internal applications.
+The [@datadog/datadog-ci][1] NPM package also comes with a tunnel functionality allowing you to swiftly trigger Synthetic tests on your internal applications. The testing tunnel creates an end-to-end encrypted HTTP proxy between your infrastructure and Datadog<span class="x x-first x-last">,</span> allowing all test requests sent <span class="x x-first x-last">through</span> the CLI to be <span class="x x-first x-last">automatically </span>routed through the `datadog-ci` client, consequently <span class="x x-first x-last">enabling</span> Datadog to run test on your internal applications.
 
-To learn how to get started using the testing tunnel, see the [Synthetics testing tunnel documentation][5].
+To learn how to get started using the testing tunnel, see the [Synthetics testing tunnel documentation][4].
 
 ### Visualize test results
 
@@ -381,7 +382,7 @@ You can identify what caused a test to fail by looking at the execution logs and
 
 #### In Datadog application
 
-You can also see your CI test results listed in the [CI Results Explorer][6] and on test details pages:
+You can also see your CI test results listed in the [CI Results Explorer][5] and on test details pages:
 
 {{< img src="synthetics/ci/ci_results_explorer/ci_results_explorer.png" alt="CI Results Explorer" style="width:100%;">}}
 
@@ -708,9 +709,8 @@ curl -G \
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/datadog-ci
-[2]: https://www.npmjs.com/package/@datadog/datadog-ci
-[3]: https://github.com/TooTallNate/node-proxy-agent
-[4]: /api/v1/synthetics/#get-test
-[5]: /synthetics/testing_tunnel/
-[6]: /synthetics/cicd_testing/ci_results_explorer
+[1]: https://www.npmjs.com/package/@datadog/datadog-ci
+[2]: https://github.com/TooTallNate/node-proxy-agent
+[3]: /api/v1/synthetics/#get-test
+[4]: /synthetics/testing_tunnel/
+[5]: /synthetics/ci_results_explorer

--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -272,7 +272,7 @@ If you have access to the [custom role feature][17], add your user to any custom
 
 [1]: /synthetics/api_tests/http_tests
 [2]: /synthetics/api_tests/http_tests?tab=requestoptions#notify-your-team
-[3]: /synthetics/cicd_testing
+[3]: /synthetics/cicd_integrations
 [4]: /api/v1/synthetics/#get-all-locations-public-and-private
 [5]: /synthetics/private_locations
 [6]: /synthetics/api_tests/

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -26,7 +26,7 @@ The access to this feature is restricted. For access to this feature, or if you 
 Private locations allow you to **monitor internal-facing applications or any private endpoints** that aren’t accessible from the public internet. They can also be used to:
 
 * **Create custom Synthetic locations** in areas that are mission-critical to your business.
-* **Verify application performance in your internal CI environment** before you release new features to production with [Synthetic CI/CD Testing][1].
+* **Verify application performance in your internal CI environment** before you release new features to production with [Synthetics and CI/CD][1].
 * **Compare application performance** from both inside and outside your internal network.
 
 Private locations come as Docker containers that you can install wherever makes sense inside of your private network. Once created and installed, you can assign [Synthetic tests][2] to your private location just like you would with any regular managed location.
@@ -564,7 +564,7 @@ For more information, see [Private Location Monitoring][19].
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /synthetics/cicd_testing
+[1]: /synthetics/cicd_integrations
 [2]: /synthetics/
 [3]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/synthetics-private-location-worker?pli=1
 [4]: https://docs.docker.com/engine/install/

--- a/content/en/synthetics/private_locations/dimensioning.md
+++ b/content/en/synthetics/private_locations/dimensioning.md
@@ -73,5 +73,5 @@ For example, ten tests are scheduled to run simultaneously on a private location
 [1]: /synthetics/api_tests/
 [2]: /synthetics/multistep?tab=requestoptions
 [3]: /synthetics/browser_tests/?tab=requestoptions
-[4]: /synthetics/cicd_testing/
+[4]: /synthetics/cicd_integrations
 [5]: /synthetics/private_locations/configuration#advanced-configuration

--- a/content/en/synthetics/search.md
+++ b/content/en/synthetics/search.md
@@ -12,7 +12,7 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/test-maintenance-best-practices/"
   tag: "Blog"
   text: "Best practices for maintaining end-to-end tests"
-- link: "/synthetics/cicd_testing/ci_results_explorer"
+- link: "/synthetics/ci_results_explorer"
   tag: "Documentation"
   text: CI Results Explorer
 ---
@@ -86,5 +86,5 @@ Find all Synthetic Monitoring related changes by searching the event stream for 
 
 [1]: https://app.datadoghq.com/synthetics/list
 [2]: https://app.datadoghq.com/synthetics/explorer/ci
-[3]: /synthetics/cicd_testing/ci_results_explorer
+[3]: /synthetics/ci_results_explorer
 [4]: /events/

--- a/content/en/synthetics/testing_tunnel.md
+++ b/content/en/synthetics/testing_tunnel.md
@@ -101,4 +101,4 @@ datadog-ci synthetics run-tests --config <GLOBAL_CONFIG_FILE>.json --tunnel
 [1]: /synthetics/private_locations
 [2]: https://www.npmjs.com/package/@datadog/datadog-ci
 [3]: https://github.com/DataDog/datadog-ci/releases/tag/v0.11.0
-[4]: /synthetics/cicd_testing/#cli-usage
+[4]: /synthetics/cicd_integrations/#use-the-cli

--- a/content/en/synthetics/troubleshooting/_index.md
+++ b/content/en/synthetics/troubleshooting/_index.md
@@ -166,4 +166,4 @@ Check whether you are using API endpoints to trigger your CI/CD test runs. To ha
 [12]: /synthetics/api_tests/?tab=httptest#notify-your-team
 [13]: /synthetics/private_locations#private-location-total-hardware-requirements
 [14]: https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v---read-only
-[15]: /synthetics/cicd_testing/?tab=apitest#cli-usage
+[15]: /synthetics/cicd_integrations#use-the-cli


### PR DESCRIPTION
CI/CD Testing --> CI/CD Integrations + created configuration.md, github_actions.md, and jenkins.md.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

We are changing "CI/CD Testing" to "CI/CD Integrations" and preparing the Synthetics CI/CD Integrations content update with a navigational update first. I replaced all English links for `synthetics/cicd_testing` with `synthetics/cicd_integrations `and added three Markdown files for new content.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-2403, DOCS-2624, and DOCS-2622

### Preview

https://docs-staging.datadoghq.com/alai97/synthetics-cicd-testing-doc-navigation-updates/synthetics/cicd_integrations

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
