### PR TITLE
Rename examples .rb to .rbbeta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,7 @@ examples/python: examples/datadog-api-client-python clean-python-examples
 
 examples/ruby: examples/datadog-api-client-ruby clean-ruby-examples
 	@cd examples/datadog-api-client-ruby; ./extract-code-blocks.sh $(EXAMPLES_DIR) || (echo "Error copying Ruby code examples, aborting build."; exit 1); if [ -d examples ]; then cp -R examples/* $(EXAMPLES_DIR)/; fi
+	@find examples/content -iname \*.rb -exec mv {} {}beta \;
 
 	-cp -Rn examples/content ./
 


### PR DESCRIPTION
We need to keep the name to render legacy examples.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation

got removed in https://github.com/DataDog/documentation/commit/88bcd37fd8cc671a282536ddeb4e9960fab77e0a#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/therve/ruby-examples/api/latest/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
