### PR TITLE
DOCS-2750 - fixing duplicate agent keys in aks and eks for operator

### DIFF
--- a/content/en/agent/kubernetes/distributions.md
+++ b/content/en/agent/kubernetes/distributions.md
@@ -72,23 +72,6 @@ spec:
     config:
       criSocket:
         criSocketPath: /run/dockershim.sock
-  agent:
-    image:
-      name: "gcr.io/datadoghq/agent:latest"
-    apm:
-      enabled: false
-    process:
-      enabled: true
-      processCollectionEnabled: false
-    log:
-      enabled: false
-    systemProbe:
-      enabled: false
-    security:
-      compliance:
-        enabled: false
-      runtime:
-        enabled: false
   clusterAgent:
     image:
       name: "gcr.io/datadoghq/cluster-agent:latest"
@@ -146,23 +129,6 @@ spec:
             fieldPath: spec.nodeName
         hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
         # tlsVerify: false # If Kubelet integration fails with provided configuration
-  agent:
-    image:
-      name: "gcr.io/datadoghq/agent:latest"
-    apm:
-      enabled: false
-    process:
-      enabled: true
-      processCollectionEnabled: false
-    log:
-      enabled: false
-    systemProbe:
-      enabled: false
-    security:
-      compliance:
-        enabled: false
-      runtime:
-        enabled: false
   clusterAgent:
     image:
       name: "gcr.io/datadoghq/cluster-agent:latest"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes an erroneous repeated section

### Motivation
it is wrong

### Preview

https://docs-staging.datadoghq.com/cswatt/aks-eks-templatefix/agent/kubernetes/distributions

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
