### PR TITLE
add function invocation in agentless logging sample

### DIFF
--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -312,7 +312,7 @@ Then, initialize the logger directly in your application. Do not forget to [add 
 
 ```csharp
 using (var log = new LoggerConfiguration()
-    .WriteTo.DatadogLogs("<API_KEY>", configuration: new DatadogConfiguration { Url = "https://http-intake.logs.datadoghq.com" })
+    .WriteTo.DatadogLogs("<API_KEY>", configuration: new DatadogConfiguration(){ Url = "https://http-intake.logs.datadoghq.com" })
     .CreateLogger())
 {
     // Some code
@@ -324,7 +324,7 @@ using (var log = new LoggerConfiguration()
 
 ```csharp
 using (var log = new LoggerConfiguration()
-    .WriteTo.DatadogLogs("<API_KEY>", configuration: new DatadogConfiguration { Url = "https://http-intake.logs.datadoghq.eu" })
+    .WriteTo.DatadogLogs("<API_KEY>", configuration: new DatadogConfiguration(){ Url = "https://http-intake.logs.datadoghq.eu" })
     .CreateLogger())
 {
     // Some code


### PR DESCRIPTION
The sample code for agentless logging code sample did not invoke the DatadogConfiguration class method. It was missing parentheses.

### What does this PR do?
Fixes the sample code for agentless logging

### Motivation
(https://datadog.zendesk.com/agent/tickets/583617)

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

