### PR TITLE
Added powershell command that returns .NET framework version

### DIFF
--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -48,7 +48,11 @@ further_reading:
 ## Compatibility requirements
 
 ### Supported .NET Framework runtimes
-The .NET Tracer supports instrumentation on .NET Framework 4.5 and above.
+The .NET Tracer supports instrumentation on .NET Framework 4.5 and above. If you do not know which .NET Framework version you're currently using, you can execute the following Powershell command: 
+
+```cmd
+Get-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\'NET Framework Setup'\NDP\v4\Full -Name "Version"
+```
 
 For a full list of supported libraries and processor architectures, see [Compatibility Requirements][1].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Includes a Powershell users can execute to determine which .NET framework version they have.

### Motivation
Many users do not know off-hand which .NET Framework version they have when trying to set up APM. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
