### PR TITLE
DOCS-2511 Update Envoy tracing config example yaml to 1.19

### DIFF
--- a/content/en/tracing/setup_overview/proxy_setup/_index.md
+++ b/content/en/tracing/setup_overview/proxy_setup/_index.md
@@ -83,21 +83,7 @@ The following settings are required to enable Datadog APM in Envoy:
 
    Change the `address` value if Envoy is running in a container or orchestrated environment.
 
-2. Set Envoy's tracing configuration to use the Datadog APM extension:
-
-   ```yaml
-    tracing:
-      provider:
-        name: envoy.tracers.datadog
-        typed_config:
-          "@type": type.googleapis.com/envoy.config.trace.v3.DatadogConfig
-          collector_cluster: datadog_agent # matched against the named cluster
-          service_name: envoy-v1.19        # user-defined service name
-   ```
-
-   The `collector_cluster` value must match the name provided for the Datadog Agent cluster. The `service_name` can be changed to a meaningful value for your usage of Envoy.
-
-3. Include the following additional configuration in the `http_connection_manager` sections to enable tracing:
+2. Include the following additional configuration in the `http_connection_manager` sections to enable tracing:
 
    ```yaml
     - name: envoy.filters.network.http_connection_manager
@@ -111,8 +97,8 @@ The following settings are required to enable Datadog APM in Envoy:
               "@type": type.googleapis.com/envoy.config.trace.v3.DatadogConfig
               collector_cluster: datadog_agent
               service_name: envoy-v1.19 
-
    ```
+   The `collector_cluster` value must match the name provided for the Datadog Agent cluster. The `service_name` can be changed to a meaningful value for your usage of Envoy.
 
 With this configuration, HTTP requests to Envoy initiate and propagate Datadog traces, and appear in the APM UI.
 

--- a/content/en/tracing/setup_overview/proxy_setup/_index.md
+++ b/content/en/tracing/setup_overview/proxy_setup/_index.md
@@ -90,6 +90,10 @@ The following settings are required to enable Datadog APM in Envoy:
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         generate_request_id: true
+        request_id_extension:
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.request_id.uuid.v3.UuidRequestIdConfig
+            use_request_id_for_trace_sampling: false
         tracing: 
           provider:
             name: envoy.tracers.datadog
@@ -120,6 +124,10 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           generate_request_id: true
+          request_id_extension:
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.request_id.uuid.v3.UuidRequestIdConfig
+              use_request_id_for_trace_sampling: false
           tracing:
           # Use the datadog tracer
             provider:

--- a/content/en/tracing/setup_overview/proxy_setup/_index.md
+++ b/content/en/tracing/setup_overview/proxy_setup/_index.md
@@ -53,66 +53,66 @@ Datadog APM is included in Envoy v1.9.0 and newer.
 
 ## Enabling Datadog APM
 
-**Note**: The example configuration below is for Envoy v1.14.
-Example configurations for older versions can be found [here][1]
+**Note**: The example configuration below is for Envoy v1.19.
+Example configurations for other versions can be found [in the `dd-opentracing-cpp` GitHub repo][1].
 
-Three settings are required to enable Datadog APM in Envoy:
+The following settings are required to enable Datadog APM in Envoy:
 
 - a cluster for submitting traces to the Datadog Agent
 - `tracing` configuration to enable the Datadog APM extension
 - `http_connection_manager` configuration to activate tracing
 
-A cluster for submitting traces to the Datadog Agent needs to be added.
+1. Add a cluster for submitting traces to the Datadog Agent:
 
-```yaml
-  clusters:
-  ... existing cluster configs ...
-  - name: datadog_agent
-    connect_timeout: 1s
-    type: strict_dns
-    lb_policy: round_robin
-    load_assignment:
-      cluster_name: datadog_agent
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: localhost
-                port_value: 8126
-```
+   ```yaml
+    clusters:
+    ... existing cluster configs ...
+    - name: datadog_agent
+      connect_timeout: 1s
+      type: strict_dns
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: datadog_agent
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: dd-agent
+                  port_value: 8126
+   ```
 
-The `address` value may need to be changed if Envoy is running in a container or orchestrated environment.
+   Change the `address` value if Envoy is running in a container or orchestrated environment.
 
-Envoy's tracing configuration needs to use the Datadog APM extension.
+2. Set Envoy's tracing configuration to use the Datadog APM extension:
 
-```yaml
-tracing:
-  http:
-    name: envoy.tracers.datadog
-    typed_config:
-      "@type": type.googleapis.com/envoy.config.trace.v2.DatadogConfig
-      collector_cluster: datadog_agent   # matched against the named cluster
-      service_name: envoy-example        # user-defined service name
-```
-
-The `collector_cluster` value must match the name provided for the Datadog Agent cluster.
-The `service_name` can be changed to a meaningful value for your usage of Envoy.
-
-Finally, the `http_connection_manager` sections need to include additional configuration to enable tracing.
-
-```yaml
-      - name: envoy.http_connection_manager
+   ```yaml
+    tracing:
+      provider:
+        name: envoy.tracers.datadog
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
-          tracing: {}
-```
+          "@type": type.googleapis.com/envoy.config.trace.v3.DatadogConfig
+          collector_cluster: datadog_agent # matched against the named cluster
+          service_name: envoy-v1.19        # user-defined service name
+   ```
 
-After completing this configuration, HTTP requests to Envoy will initiate and propagate Datadog traces, and will appear in the APM UI.
+   The `collector_cluster` value must match the name provided for the Datadog Agent cluster. The `service_name` can be changed to a meaningful value for your usage of Envoy.
 
-## Example Envoy v1.14 configuration
+3. Include the following additional configuration in the `http_connection_manager` sections to enable tracing:
 
-An example configuration is provided here to demonstrate the placement of items required to enable tracing using Datadog APM.
+   ```yaml
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        generate_request_id: true
+        tracing: {}
+   ```
+
+With this configuration, HTTP requests to Envoy initiate and propagate Datadog traces, and appear in the APM UI.
+
+## Example Envoy v1.19 configuration
+
+The following example configuration demonstrates the placement of items required to enable tracing using Datadog APM.
 
 ```yaml
 static_resources:
@@ -124,11 +124,26 @@ static_resources:
     traffic_direction: OUTBOUND
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           generate_request_id: true
-          tracing: {}
+          tracing:
+          # Use the datadog tracer
+            provider:
+              name: envoy.tracers.datadog
+              typed_config:
+                "@type": type.googleapis.com/envoy.config.trace.v3.DatadogConfig
+                collector_cluster: datadog_agent   # matched against the named cluster
+                service_name: envoy-v1.19          # user-defined service name
+          access_log:
+          - name: envoy.access_loggers.file
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              path: /dev/stdout
+              log_format:
+                text_format_source:
+                  inline_string: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH):256% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" \"%RESP(X-AMZN-RequestId)%\" \"%REQ(X-DATADOG-TRACE-ID)%\" \"%REQ(X-DATADOG-PARENT-ID)%\"\n"
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
@@ -142,11 +157,11 @@ static_resources:
                   prefix: "/"
                 route:
                   cluster: service1
-          http_filters:
           # Traces for healthcheck requests should not be sampled.
+          http_filters:
           - name: envoy.filters.http.health_check
             typed_config:
-              "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+              "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
               pass_through_mode: false
               headers:
                 - exact_match: /healthcheck
@@ -159,7 +174,6 @@ static_resources:
     connect_timeout: 0.250s
     type: strict_dns
     lb_policy: round_robin
-    http2_protocol_options: {}
     load_assignment:
       cluster_name: service1
       endpoints:
@@ -169,7 +183,7 @@ static_resources:
               socket_address:
                 address: service1
                 port_value: 80
-  # Configure this cluster with the address of the datadog agent
+  # Configure this cluster with the address of the datadog Agent
   # for sending traces.
   - name: datadog_agent
     connect_timeout: 1s
@@ -182,17 +196,8 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: localhost
+                address: dd-agent
                 port_value: 8126
-
-tracing:
-  # Use the datadog tracer
-  http:
-    name: envoy.tracers.datadog
-    typed_config:
-      "@type": type.googleapis.com/envoy.config.trace.v2.DatadogConfig
-      collector_cluster: datadog_agent   # matched against the named cluster
-      service_name: envoy-example        # user-defined service name
 
 admin:
   access_log_path: "/dev/null"


### PR DESCRIPTION

### What does this PR do?
Updates the sample yaml in the instructions for configuring tracing for an Envoy proxy, some general cleanup of the Envoy instructions

### Motivation
DOCS-2511 (Hotjar customer feedback)

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/docs-2511-envoy-update/tracing/setup_overview/proxy_setup/?tab=envoy

### Additional Notes
Checking with Eng to see if we can update the Envoy-to-C++-library version table

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
