### PR TITLE
DOCS-1612 make link more explicit, call out non local traffic as important

### DIFF
--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -156,13 +156,14 @@ Optional collection Agents are disabled by default for security or performance r
 
 | Env Variable               | Description                                                                                                                                                                                                                                                      |
 |----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DD_APM_ENABLED`           | Enable [trace collection][15] with the Trace Agent.                                                                                                                                                                                                              |
-| `DD_LOGS_ENABLED`          | Enable [log collection][16] with the Logs Agent.                                                                                                                                                                                                                 |
-| `DD_PROCESS_AGENT_ENABLED` | Enable [live process collection][17] with the Process Agent. The [live container view][18] is already enabled by default if the Docker socket is available. If set to `false`, the [live process collection][17] and the [live container view][18] are disabled. |
+| `DD_APM_ENABLED`           | Enable trace collection. Read about additional trace collection environment variables in [Tracing Docker Applications][15].   |
+| `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers][16]. Defaults to `false` for Agent version 6 and before version 7.26.0.   |
+| `DD_LOGS_ENABLED`          | Enable [log collection][17] with the Logs Agent.                                                                                                                                                                                                                 |
+| `DD_PROCESS_AGENT_ENABLED` | Enable [live process collection][18] with the Process Agent. The [live container view][19] is already enabled by default if the Docker socket is available. If set to `false`, the [live process collection][18] and the [live container view][19] are disabled. |
 
 ### DogStatsD (custom metrics)
 
-Send custom metrics with [the StatsD protocol][19]:
+Send custom metrics with [the StatsD protocol][20]:
 
 | Env Variable                     | Description                                                                                                                                                |
 |----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -173,13 +174,13 @@ Send custom metrics with [the StatsD protocol][19]:
 | `DD_DOGSTATSD_ORIGIN_DETECTION`  | Enable container detection and tagging for unix socket metrics.                                                                                            |
 | `DD_DOGSTATSD_TAGS`              | Additional tags to append to all metrics, events, and service checks received by this DogStatsD server, for example: `"env:golden group:retrievers"`. |
 | `DD_DOGSTATSD_DISABLE`           | Disables sending custom metrics from the dogstatsd library.                                                                                                |
-Learn more about [DogStatsD over Unix Domain Sockets][20].
+Learn more about [DogStatsD over Unix Domain Sockets][21].
 
 ### Tagging
 
-As a best practice, Datadog recommends using [unified service tagging][21] when assigning tags.
+As a best practice, Datadog recommends using [unified service tagging][22] when assigning tags.
 
-Datadog automatically collects common tags from [Docker][22], [Kubernetes][23], [ECS][24], [Swarm, Mesos, Nomad, and Rancher][22]. To extract even more tags, use the following options:
+Datadog automatically collects common tags from [Docker][23], [Kubernetes][24], [ECS][25], [Swarm, Mesos, Nomad, and Rancher][23]. To extract even more tags, use the following options:
 
 | Env Variable               | Description                                               |
 |----------------------------|-----------------------------------------------------------|
@@ -187,11 +188,11 @@ Datadog automatically collects common tags from [Docker][22], [Kubernetes][23], 
 | `DD_DOCKER_ENV_AS_TAGS`    | Extract Docker container environment variables            |
 | `DD_COLLECT_EC2_TAGS`      | Extract custom EC2 tags without using the AWS integration |
 
-See the [Docker Tag Extraction][25] documentation to learn more.
+See the [Docker Tag Extraction][26] documentation to learn more.
 
 ### Using secret files
 
-Integration credentials can be stored in Docker or Kubernetes secrets and used in Autodiscovery templates. For more information, see the [Secrets Management documentation][26].
+Integration credentials can be stored in Docker or Kubernetes secrets and used in Autodiscovery templates. For more information, see the [Secrets Management documentation][27].
 
 ### Ignore containers
 
@@ -208,7 +209,7 @@ Exclude containers from logs collection, metrics collection, and Autodiscovery. 
 | `DD_AC_INCLUDE`                | **Deprecated**. Allowlist of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`                                                                                                                                                     |
 | `DD_AC_EXCLUDE`                | **Deprecated**. Blocklist of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*`                                                                                        |
 
-Additional examples are available on the [Container Discover Management][27] page.
+Additional examples are available on the [Container Discover Management][28] page.
 
 **Note**: The `kubernetes.containers.running`, `kubernetes.pods.running`, `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings. All containers are counted. This does not affect your per-container billing.
 
@@ -223,7 +224,7 @@ You can add extra listeners and config providers using the `DD_EXTRA_LISTENERS` 
 
 ## Commands
 
-See the [Agent Commands guides][28] to discover all the Docker Agent commands.
+See the [Agent Commands guides][29] to discover all the Docker Agent commands.
 
 ## Data collected
 
@@ -233,16 +234,16 @@ By default, the Docker Agent collects metrics with the following core checks. To
 
 | Check       | Metrics       |
 |-------------|---------------|
-| CPU         | [System][29]  |
-| Disk        | [Disk][30]    |
-| Docker      | [Docker][31]  |
-| File Handle | [System][29]  |
-| IO          | [System][29]  |
-| Load        | [System][29]  |
-| Memory      | [System][29]  |
-| Network     | [Network][32] |
-| NTP         | [NTP][33]     |
-| Uptime      | [System][29]  |
+| CPU         | [System][30]  |
+| Disk        | [Disk][31]    |
+| Docker      | [Docker][32]  |
+| File Handle | [System][30]  |
+| IO          | [System][30]  |
+| Load        | [System][30]  |
+| Memory      | [System][30]  |
+| Network     | [Network][33] |
+| NTP         | [NTP][34]     |
+| Uptime      | [System][30]  |
 
 ### Events
 
@@ -275,21 +276,22 @@ Returns `CRITICAL` if an Agent check is unable to send metrics to Datadog, other
 [13]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 [14]: /agent/proxy/#agent-v6
 [15]: /agent/docker/apm/
-[16]: /agent/docker/log/
-[17]: /infrastructure/process/
-[18]: /infrastructure/livecontainers/
-[19]: /developers/dogstatsd/
-[20]: /developers/dogstatsd/unix_socket/
-[21]: /getting_started/tagging/unified_service_tagging/
-[22]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/docker_extract.go
-[23]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/kubelet_extract.go
-[24]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/ecs_extract.go
-[25]: /agent/docker/tag/
-[26]: /agent/guide/secrets-management/?tab=linux
-[27]: /agent/guide/autodiscovery-management/
-[28]: /agent/guide/agent-commands/
-[29]: /integrations/system/#metrics
-[30]: /integrations/disk/#metrics
-[31]: /agent/docker/data_collected/#metrics
-[32]: /integrations/network/#metrics
-[33]: /integrations/ntp/#metrics
+[16]: /agent/docker/apm/#tracing-from-other-containers
+[17]: /agent/docker/log/
+[18]: /infrastructure/process/
+[19]: /infrastructure/livecontainers/
+[20]: /developers/dogstatsd/
+[21]: /developers/dogstatsd/unix_socket/
+[22]: /getting_started/tagging/unified_service_tagging/
+[23]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/docker_extract.go
+[24]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/kubelet_extract.go
+[25]: https://github.com/DataDog/datadog-agent/blob/master/pkg/tagger/collectors/ecs_extract.go
+[26]: /agent/docker/tag/
+[27]: /agent/guide/secrets-management/?tab=linux
+[28]: /agent/guide/autodiscovery-management/
+[29]: /agent/guide/agent-commands/
+[30]: /integrations/system/#metrics
+[31]: /integrations/disk/#metrics
+[32]: /agent/docker/data_collected/#metrics
+[33]: /integrations/network/#metrics
+[34]: /integrations/ntp/#metrics


### PR DESCRIPTION

### What does this PR do?
Customers were missing additional APM env var config because they just read the Docker page. Emphasizing that the link has info about more env vars, and adding one key env var to the table because it's frequently missed (although true by default in modern Agents)

### Motivation
DOCS-1612

### Preview

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/docs-1612-apm-env-var/agent/docker/#optional-collection-agents

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
