### PR TITLE
DOCS-2516 clarifying some language for lambda extension

### DIFF
--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -28,7 +28,7 @@ You can also generate metrics from 100% of ingested spans, regardless of whether
 
 Datadog recommends using the [Datadog Lambda Extension][1] to submit custom metrics from supported Lambda runtimes.
 
-1. Follow the general [serverless installation instructions][6] to configure your Lambda function and install the Datadog Lambda Library and Extension.
+1. Follow the general [serverless installation instructions][6] appropriate for your Lambda runtime.
 1. If you are not interested in collecting traces from your Lambda function, set the environment variable `DD_TRACE_ENABLED` to `false`.
 1. If you are not interested in collecting logs from your Lambda function, set the environment variable `DD_SERVERLESS_LOGS_ENABLED` to `false`.
 1. Import and use the helper function from the Datadog Lambda Library, such as `lambda_metric` or `sendDistributionMetric`, to submit your custom metrics following the [sample code](#custom-metrics-sample-code).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
there was some confusion as to what these links were meant to lead to. language changed to make clearer that the current serverless instrumentation instructions involve deploying the extension.

### Motivation
support request

### Preview

https://docs-staging.datadoghq.com/cswatt/extension-clarity/serverless/custom_metrics

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
