### PR TITLE
Add operator tab in `network_monitoring/performance/setup.md`

### DIFF
--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -346,6 +346,7 @@ If you already have the [Agent running with a manifest][4]:
 {{% /tab %}}
 {{% tab "Operator" %}}
 <div class="alert alert-warning">The Datadog Operator is in public beta. If you have any feedback or questions, contact <a href="/help">Datadog support</a>.</div>
+
 [The Datadog Operator][1] is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options.
 
 To enable Network Performance Monitoring in Operator, use the following configuration:

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -361,10 +361,6 @@ spec:
   features:
     networkMonitoring:
       enabled: true
-  agent:
-    # (...)
-    systemProbe:
-      enabled: true
 ```
 
 [1]: https://github.com/DataDog/datadog-operator

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -344,6 +344,44 @@ If you already have the [Agent running with a manifest][4]:
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 [4]: /agent/kubernetes/
 {{% /tab %}}
+{{% tab "Operator" %}}
+[The Datadog Operator][1] is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options.
+
+1. To enable Network Performance Monitoring in Operator, use the following configuration:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+  namespace: datadog
+spec:
+  # (...)
+  features:
+    networkMonitoring:
+      enabled: true
+  agent:
+    # (...)
+    systemProbe:
+      enabled: true
+```
+
+2. Add the following volumes to your manifest:
+
+```yaml
+spec:
+  containers:
+  # (...)
+  volumes:
+      - name: sysprobe-socket-dir
+        emptyDir: {}
+      - name: debugfs
+        hostPath:
+            path: /sys/kernel/debug
+```
+
+[1]: https://github.com/DataDog/datadog-operator
+{{% /tab %}}
 {{% tab "Docker" %}}
 
 To enable Network Performance Monitoring in Docker, use the following configuration when starting the container Agent:

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -345,6 +345,7 @@ If you already have the [Agent running with a manifest][4]:
 [4]: /agent/kubernetes/
 {{% /tab %}}
 {{% tab "Operator" %}}
+<div class="alert alert-warning">The Datadog Operator is in public beta. If you have any feedback or questions, contact <a href="/help">Datadog support</a>.</div>
 [The Datadog Operator][1] is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options.
 
 1. To enable Network Performance Monitoring in Operator, use the following configuration:

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -348,7 +348,7 @@ If you already have the [Agent running with a manifest][4]:
 <div class="alert alert-warning">The Datadog Operator is in public beta. If you have any feedback or questions, contact <a href="/help">Datadog support</a>.</div>
 [The Datadog Operator][1] is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options.
 
-1. To enable Network Performance Monitoring in Operator, use the following configuration:
+To enable Network Performance Monitoring in Operator, use the following configuration:
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -365,20 +365,6 @@ spec:
     # (...)
     systemProbe:
       enabled: true
-```
-
-2. Add the following volumes to your manifest:
-
-```yaml
-spec:
-  containers:
-  # (...)
-  volumes:
-      - name: sysprobe-socket-dir
-        emptyDir: {}
-      - name: debugfs
-        hostPath:
-            path: /sys/kernel/debug
 ```
 
 [1]: https://github.com/DataDog/datadog-operator

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -353,8 +353,8 @@ If you already have the [Agent running with a manifest][4]:
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
 metadata:
-  name: datadog
-  namespace: datadog
+  name: placeholder
+  namespace: placeholder
 spec:
   # (...)
   features:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add operator tab in `network_monitoring/performance/setup.md`.

### Motivation
<!-- What inspired you to submit this pull request?-->

There is no instruction of using operator in `network_monitoring/performance/setup.md`.

### Preview
<!-- Impacted pages preview links-->

https://github.com/kei6u/documentation/blob/kei6u/add_operator_tab_in_network_monitoring_performance/content/en/network_monitoring/performance/setup.md


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
