### PR TITLE
[WEB-1927] Adds default security rules to the list of ignored content for transifex

### DIFF
--- a/translate.yaml
+++ b/translate.yaml
@@ -28,6 +28,7 @@ sources:
 
 ignores:
   - "content/en/**/faq/!(agent_v6_changes|certificate_verify_failed-error).md"
+  - "content/en/security_platform/default_rules/*.md"
   - "**/*.fr.md"
   - "**/*.fr.yaml"
   - "**/*.fr.json"


### PR DESCRIPTION
### What does this PR do?
- Adds new `ignores` pattern entry so Transifex will no remove and no longer translate default security rules content.  This should happen on the next nightly build when the `manage_translations` job runs.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1927

### Preview
n/a

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
