### PR TITLE
updating tagging schema recommendation for python, go, node serverless instructions

### DIFF
--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -115,7 +115,7 @@ Follow these steps to instrument the function:
 
 ### Unified service tagging
 
-Although it is optional, Datadog highly recommends tagging your serverless applications your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension][10] documentation for details.
+Datadog highly recommends tagging your serverless applications your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension][10] documentation for details.
 
 ## Explore
 

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -113,9 +113,9 @@ Follow these steps to instrument the function:
     }
     ```
 
-### Tag
+### Unified service tagging
 
-Optionally, tag your serverless applications with `env`, `service`, and `version`. For more information, see the [Unified Service Tagging documentation][6].
+Although it is optional, Datadog highly recommends tagging your serverless applications your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension][10] documentation for details.
 
 ## Explore
 
@@ -181,3 +181,4 @@ If your Lambda function is running in a VPC, follow the [Datadog Lambda Extensio
 [7]: https://app.datadoghq.com/functions
 [8]: /serverless/custom_metrics?tab=go
 [9]: /serverless/guide/extension_private_link/
+[10]: /serverless/libraries_integrations/extension/#tagging

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -115,7 +115,7 @@ Follow these steps to instrument the function:
 
 ### Unified service tagging
 
-Datadog highly recommends tagging your serverless applications your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension][10] documentation for details.
+Datadog recommends tagging your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension documentation][10] for more details.
 
 ## Explore
 

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -444,7 +444,7 @@ After you have configured your function following the steps above, you can view 
 
 ### Unified service tagging
 
-Although it is optional, Datadog highly recommends tagging your serverless applications your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension][9] documentation for details.
+Datadog highly recommends tagging your serverless applications your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension][9] documentation for details.
 
 ### Collect logs from AWS serverless resources
 

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -444,7 +444,7 @@ After you have configured your function following the steps above, you can view 
 
 ### Unified service tagging
 
-Although it's optional, Datadog highly recommends tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][4].
+Although it is optional, Datadog highly recommends tagging your serverless applications your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension][9] documentation for details.
 
 ### Collect logs from AWS serverless resources
 
@@ -522,3 +522,4 @@ If your Lambda function is running in a VPC, follow the [Datadog Lambda Extensio
 [6]: /serverless/custom_metrics?tab=nodejs
 [7]: /tracing/custom_instrumentation/nodejs/
 [8]: /serverless/guide/extension_private_link/
+[9]: /serverless/libraries_integrations/extension/#tagging

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -444,7 +444,7 @@ After you have configured your function following the steps above, you can view 
 
 ### Unified service tagging
 
-Datadog highly recommends tagging your serverless applications your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension][9] documentation for details.
+Datadog recommends tagging your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension documentation][9] for more details.
 
 ### Collect logs from AWS serverless resources
 

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -556,7 +556,7 @@ After you have configured your function following the steps above, you can view 
 
 ### Unified service tagging
 
-Although it's optional, Datadog highly recommends tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][5].
+Although it is optional, Datadog highly recommends tagging your serverless applications your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension][10] documentation for details.
 
 ### Collect logs from AWS serverless resources
 
@@ -623,3 +623,4 @@ If your Lambda function is running in a VPC, follow the [Datadog Lambda Extensio
 [7]: /serverless/custom_metrics?tab=python
 [8]: /tracing/custom_instrumentation/python/
 [9]: /serverless/guide/extension_private_link/
+[10]: /serverless/libraries_integrations/extension/#tagging

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -556,7 +556,7 @@ After you have configured your function following the steps above, you can view 
 
 ### Unified service tagging
 
-Although it is optional, Datadog highly recommends tagging your serverless applications your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension][10] documentation for details.
+Datadog highly recommends tagging your serverless applications your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension][10] documentation for details.
 
 ### Collect logs from AWS serverless resources
 

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -556,7 +556,7 @@ After you have configured your function following the steps above, you can view 
 
 ### Unified service tagging
 
-Datadog highly recommends tagging your serverless applications your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension][10] documentation for details.
+Datadog recommends tagging your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension documentation][10] for more details.
 
 ### Collect logs from AWS serverless resources
 


### PR DESCRIPTION
### What does this PR do?
previously it was recommended to use the normal Unified Service Tagging `env`, `service`, etc. because these three are using the extension, they should now be using `DD_ENV`, `DD_SERVICE`, etc.

### Motivation
serverless sync

### Preview

https://docs-staging.datadoghq.com/cswatt/serverless-tagging/serverless/installation/go
https://docs-staging.datadoghq.com/cswatt/serverless-tagging/serverless/installation/nodejs
https://docs-staging.datadoghq.com/cswatt/serverless-tagging/serverless/installation/python

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
