### PR TITLE
Fix example for agent 7

### DIFF
--- a/content/en/integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect.md
+++ b/content/en/integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect.md
@@ -74,8 +74,7 @@ instances:
               values:
                 true: 1
                 false: 0
-              # Note: If using Agent 6, boolean keys must be in quotes
-              # values: {"true": 1, "false": 0, default: 0}
+              # Note: If using Agent 6, boolean keys must be in quotes values: {"true": 1, "false": 0, default: 0}
 ```
 
 Jmxfetch then knows it's a string and uses this rule to transform that into a numeric metric.

--- a/content/en/integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect.md
+++ b/content/en/integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect.md
@@ -72,8 +72,10 @@ instances:
               alias: jmx.hadoop.hbase.master.server.tag.isActiveMaster
               metric_type: gauge
               values:
-                "true": 1
-                "false": 0
+                true: 1
+                false: 0
+              # Note: If using Agent 6, boolean keys must be in quotes
+              # values: {"true": 1, "false": 0, default: 0}
 ```
 
 Jmxfetch then knows it's a string and uses this rule to transform that into a numeric metric.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR updates the config example for Agent 7 syntax.

The actual integration example uses a different syntax https://github.com/DataDog/integrations-extras/blob/master/hbase_master/datadog_checks/hbase_master/data/metrics.yaml#L94

### Motivation
customer issue, they were using quotes and wasn't working

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
