### PR TITLE
Update link to the agent repo

### DIFF
--- a/content/en/getting_started/application/_index.md
+++ b/content/en/getting_started/application/_index.md
@@ -133,7 +133,7 @@ Datadog [Security Monitoring][20] automatically detects threats to your applicat
 [1]: https://app.datadoghq.com
 [2]: http://www.datadoghq.com/integrations
 [3]: /api/
-[4]: https://github.com/DataDog/dd-agent
+[4]: https://github.com/DataDog/datadog-agent
 [5]: /logs/
 [6]: /tracing/
 [7]: /infrastructure/


### PR DESCRIPTION
Updated the link to point to the new version of Datadog Agent (datadog-agent repo instead of dd-agent)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
