### PR TITLE
add unit tests for region redirects

### DIFF
--- a/src/scripts/region-redirects.js
+++ b/src/scripts/region-redirects.js
@@ -65,6 +65,10 @@ function regionOnChangeHandler(region) {
     }
 }
 
+function getFormattedDatadogAppUrl(link, region) {
+    return `https://${config.dd_full_site[region]}${link.pathname}${link.search}${link.hash}`;
+}
+
 function showRegionSnippet(newSiteRegion) {
     const regionSnippets = document.querySelectorAll('[data-region]');
     const regionParams = document.querySelectorAll('[data-region-param]');
@@ -109,7 +113,7 @@ function showRegionSnippet(newSiteRegion) {
 
     if (externalLinks) {
         externalLinks.forEach(link => {
-            link.href = `https://${config.dd_full_site[newSiteRegion]}${link.pathname}${link.search}${link.hash}`;
+            link.href = getFormattedDatadogAppUrl(link, newSiteRegion);
         });
     }
 }
@@ -169,4 +173,4 @@ function redirectToRegion(region = '') {
 
 redirectToRegion();
 
-export { redirectToRegion, showRegionSnippet, regionOnChangeHandler };
+export { redirectToRegion, showRegionSnippet, regionOnChangeHandler, getFormattedDatadogAppUrl };

--- a/src/scripts/tests/region-redirects.test.js
+++ b/src/scripts/tests/region-redirects.test.js
@@ -1,4 +1,4 @@
-import { redirectToRegion } from '../region-redirects';
+import { redirectToRegion, getFormattedDatadogAppUrl } from '../region-redirects';
 
 let regionUSSnippet;
 let regionEUSnippet;
@@ -242,4 +242,27 @@ describe(`On main page load (not home or api pages, nor loaded via async)`, () =
             });
         });
     });
+
+    describe('Datadog app links are formatted properly when changing site', () => {
+        it('Retains query string parameter correctly', () => {
+            const anchor = document.createElement('a');
+            const region = 'us';
+            anchor.href = 'https://app.datadoghq.com/infrastructure/map?node_type=container';
+            const expected = 'https://app.datadoghq.com/infrastructure/map?node_type=container'
+            const formatted = getFormattedDatadogAppUrl(anchor, region);
+
+            expect(formatted).toEqual(expected);
+        })
+
+        it('Retains hash correctly', () => {
+            const anchor = document.createElement('a');
+            const region = 'eu';
+            anchor.href = 'https://app.datadoghq.com/account/settings#agent';
+            const expected = 'https://app.datadoghq.eu/account/settings#agent';
+            const formatted = getFormattedDatadogAppUrl(anchor, region);
+
+            
+            expect(formatted).toEqual(expected);
+        })
+    })
 });

--- a/src/scripts/tests/region-redirects.test.js
+++ b/src/scripts/tests/region-redirects.test.js
@@ -246,9 +246,9 @@ describe(`On main page load (not home or api pages, nor loaded via async)`, () =
     describe('Datadog app links are formatted properly when changing site', () => {
         it('Retains query string parameter correctly', () => {
             const anchor = document.createElement('a');
-            const region = 'us';
+            const region = 'us3';
             anchor.href = 'https://app.datadoghq.com/infrastructure/map?node_type=container';
-            const expected = 'https://app.datadoghq.com/infrastructure/map?node_type=container'
+            const expected = 'https://us3.datadoghq.com/infrastructure/map?node_type=container'
             const formatted = getFormattedDatadogAppUrl(anchor, region);
 
             expect(formatted).toEqual(expected);


### PR DESCRIPTION
### What does this PR do?
- small refactor of `region-redirects.js`
- add two unit tests to `region-redirects.test.js`

### Motivation
Recent issue with query strings being stripped from dd app links.

### Preview
- Links to the DD app retain query parameters and hash
- Links retain proper hostname when switching the site dropdown (i.e. when choosing `EU` in the dropdown app urls should begin with `app.datadoghq.eu`...)
- unit tests are all passing (can run from terminal `jest src/scripts/tests/region-redirects.test.js`)

- https://docs-staging.datadoghq.com/brian.deutsch/update-test-region-redirects/tracing/trace_retention_and_ingestion/usage_metrics/
- https://docs-staging.datadoghq.com/brian.deutsch/update-test-region-redirects/account_management/billing/alibaba/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
