### PR TITLE
[documentation]rebecca-rosenberg/clarify-sorting-reliability

### DIFF
--- a/content/en/logs/explorer/visualize.md
+++ b/content/en/logs/explorer/visualize.md
@@ -47,7 +47,7 @@ The default **sort** for logs in the list visualization is by timestamp, with th
 {{< site-region region="us,eu" >}}
 The default **sort** for logs in the list visualization is by timestamp, with the most recent logs on top. This is the fastest and therefore recommended sorting method for general purposes. Surface logs with lowest or highest value for a measure first, or sort your logs lexicographically for the unique value of facet, ordering a column according to that facet.
 
-**Note**: Although any attributes or tags can be added as a column, sorting your table will be most reliable if you [declare a facet][1] beforehand. Non-faceted attributes can be added as columns, but will not produce reliable sorting.
+**Note**: Although any attributes or tags can be added as a column, sorting your table is most reliable if you [declare a facet][1] beforehand. Non-faceted attributes can be added as columns, but will not produce reliable sorting.
 {{< /site-region >}}
 
 The configuration of the log table is stored alongside other elements of your troubleshooting context in [Saved Views][2].

--- a/content/en/logs/explorer/visualize.md
+++ b/content/en/logs/explorer/visualize.md
@@ -47,7 +47,7 @@ The default **sort** for logs in the list visualization is by timestamp, with th
 {{< site-region region="us,eu" >}}
 The default **sort** for logs in the list visualization is by timestamp, with the most recent logs on top. This is the fastest and therefore recommended sorting method for general purposes. Surface logs with lowest or highest value for a measure first, or sort your logs lexicographically for the unique value of facet, ordering a column according to that facet.
 
-**Note**: Although any attributes or tags can be added as a column, sorting your table according to a specific field requires that you [declare a facet][1] beforehand.
+**Note**: Although any attributes or tags can be added as a column, sorting your table will be most reliable if you [declare a facet][1] beforehand. Non-faceted attributes can be added as columns, but will not produce reliable sorting.
 {{< /site-region >}}
 
 The configuration of the log table is stored alongside other elements of your troubleshooting context in [Saved Views][2].

--- a/content/en/logs/explorer/visualize.md
+++ b/content/en/logs/explorer/visualize.md
@@ -47,7 +47,7 @@ The default **sort** for logs in the list visualization is by timestamp, with th
 {{< site-region region="us,eu" >}}
 The default **sort** for logs in the list visualization is by timestamp, with the most recent logs on top. This is the fastest and therefore recommended sorting method for general purposes. Surface logs with lowest or highest value for a measure first, or sort your logs lexicographically for the unique value of facet, ordering a column according to that facet.
 
-**Note**: Although any attributes or tags can be added as a column, sorting your table is most reliable if you [declare a facet][1] beforehand. Non-faceted attributes can be added as columns, but will not produce reliable sorting.
+**Note**: Although any attributes or tags can be added as a column, sorting your table is most reliable if you [declare a facet][1] beforehand. Non-faceted attributes can be added as columns, but it does not produce reliable sorting.
 {{< /site-region >}}
 
 The configuration of the log table is stored alongside other elements of your troubleshooting context in [Saved Views][2].


### PR DESCRIPTION
Clarify sorting reliability.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Edit the note to explain that while you can sort by non-faceted attributes, it will not be reliable.

### Motivation
<!-- What inspired you to submit this pull request?-->

Customer request (see Zendesk ticket)

### Preview
<!-- Impacted pages preview links-->

https://docs.datadoghq.com/logs/explorer/visualize/

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->

https://docs-staging.datadoghq.com/documentation/[documentation]rebecca-rosenberg/clarify-sorting-reliability

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
