### PR TITLE
Fix display bug in Tracer Debug Logs page in Japanese

### DIFF
--- a/content/ja/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/ja/tracing/troubleshooting/tracer_debug_logs.md
@@ -48,14 +48,18 @@ Datadog クライアントのログメッセージは、他のメッセージと
 
 トレーサーの `log` 属性を使用し、デフォルトロガーを上書きしてカスタムロガーに置き換えることができます。
 
-<mrk mid="45" mtype="seg">```ruby
+<mrk mid="45" mtype="seg">
+
+```ruby
 f = File.new(&quot;&lt;FILENAME&gt;.log&quot;, &quot;w+&quot;)           # ログメッセージが書き込まれる場所
 Datadog.configure do |c|
   c.tracer log:</mrk> <mrk mid="46" mtype="seg">Logger.new(f)                 # デフォルトのトレーサーの上書き
 end
 
 Datadog::Tracer.log.info { &quot;this is typically called by tracing code&quot; }
-```</mrk>
+```
+
+</mrk>
 
 詳細については、[API に関するドキュメント][1]を参照してください。
 
@@ -98,7 +102,9 @@ const tracer = require('dd-trace').init({
 
 例:
 
-<mrk mid="59" mtype="seg">```javascript
+<mrk mid="59" mtype="seg">
+
+```javascript
 const bunyan = require('bunyan')
 const logger = bunyan.createLogger({
   name:</mrk> <mrk mid="60" mtype="seg">'dd-trace',
@@ -112,7 +118,9 @@ const tracer = require('dd-trace').init({
   },
   debug: true
 })
-```</mrk>
+```
+
+</mrk>
 
 次に、Agent ログをチェックして、問題に関する詳細情報があるか確認します。
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Fix display bug in tracer_debug_logs in Japanese

### Motivation
<!-- What inspired you to submit this pull request?-->

Ruby and NodeJS tabs displays odd in [Tracer Debug Logs](https://docs.datadoghq.com/ja/tracing/troubleshooting/tracer_debug_logs/) page as following screenshots.

![トレーサーデバッグログ 2021-11-22 at 3 19 08 PM](https://user-images.githubusercontent.com/41987730/142810392-055d0982-b435-4d92-a579-386fb74fa8d1.jpg)

![トレーサーデバッグログ 2021-11-22 at 3 23 02 PM](https://user-images.githubusercontent.com/41987730/142810567-fe6959df-f5bf-4492-87be-7abf55a46dbd.jpg)

### Preview

https://github.com/kei6u/documentation/blob/kei6u/ja_tracer_debug_logs/content/ja/tracing/troubleshooting/tracer_debug_logs.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
