### PR TITLE
APM > .NET > Update to version 2.0

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -77,7 +77,7 @@ Don’t see your desired frameworks? Datadog is continually adding additional su
 
 ## Out of support .NET Core versions
 
-The .NET Tracer works on .NET Core 2.0, 2.1, 2.2, and 3.0, but these versions reached their end of life and are no longer supported by Microsoft. See [Microsoft's support policy][3] for more details. We recommend using the latest patch version of .NET Core 3.1 or .NET 5. Older versions of .NET Core may encounter the following runtime issues when enabling automatic instrumentation:
+The .NET Tracer works on .NET Core 2.0, 2.1, 2.2, and 3.0, but these versions reached their end of life and are no longer supported by Microsoft. See [Microsoft's support policy][3] for more details. Datadog recommends using the latest patch version of .NET Core 3.1, .NET 5, or .NET 6. Older versions of .NET Core may encounter the following runtime issues when enabling automatic instrumentation:
 
 | Issue                                         | Affected .NET Core Versions               | Solution                                                               | More information                        |
 |-----------------------------------------------|-------------------------------------------|------------------------------------------------------------------------|-----------------------------------------|

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -26,6 +26,7 @@ The .NET Tracer supports automatic instrumentation on the following .NET Core ve
 
 | Version              | Microsoft End of Life |
 | -------------------- | --------------------- |
+| .NET 6               |                       |
 | .NET 5               |                       |
 | .NET Core 3.1        | 12/03/2022            |
 | .NET Core 2.1        | 08/21/2021            |
@@ -41,7 +42,7 @@ The .NET Tracer supports automatic instrumentation on the following architecture
 | Windows x64 (`win-x64`)                                                 |
 | Linux x64 (`linux-x64`)                                                 |
 | Alpine Linux x64 (`linux-musl-x64`)                                     |
-| Linux ARM64 (`linux-arm64`)<br><br>.NET 5 only, added in version 1.27.0 |
+| Linux ARM64 (`linux-arm64`)<br><br>.NET 5+ only, added in version 1.27.0|
 
 
 ## Integrations
@@ -50,24 +51,25 @@ The [latest version of the .NET Tracer][4] can automatically instrument the foll
 
 | Framework or library            | NuGet package                                                                             | Integration Name     |
 | ------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
-| ADO.NET                         | `System.Data.Common`</br>`System.Data.SqlClient` 4.0+                                     | `AdoNet`             |
 | Aerospike                       | `Aerospike.Client` 4.0.0+                                                                 | `Aerospike`          |
 | ASP.NET Core                    | `Microsoft.AspNetCore`</br>`Microsoft.AspNetCore.App`</br>2.0+ and 3.0+                   | `AspNetCore`         |
 | AWS SQS                         | `AWSSDK.SQS`  3.0+                                                                        | `AwsSqs`             |
-| CosmosDb                        | `Microsoft.Azure.Cosmos.Client` 3.6.0                                                     | `CosmosDb`           |
+| CosmosDb                        | `Microsoft.Azure.Cosmos.Client` 3.6.0+                                                    | `CosmosDb`           |
+| Couchbase                       | `CouchbaseNetClient` 2.2.8+                                                               | `Couchbase`          |
 | Elasticsearch                   | `Elasticsearch.Net` 5.3.0+                                                                | `ElasticsearchNet`   |
 | GraphQL .NET                    | `GraphQL` 2.3.0+                                                                          | `GraphQL`            |
 | HttpClient / HttpMessageHandler | `System.Net.Http` 4.0+                                                                    | `HttpMessageHandler` |
 | Kafka                           | `Confluent.Kafka` 1.4+                                                                    | `Kafka`              |
 | MongoDB                         | `MongoDB.Driver.Core` 2.1.0+                                                              | `MongoDb`            |
-| MySql                           | `MySql.Data` 6.7.0+                                                                       | `AdoNet`             |
-| Oracle                          | `Oracle.ManagedDataAccess` 4.122.0+                                                       | `AdoNet`             |
-| PostgreSQL                      | `Npgsql` 4.0+                                                                             | `AdoNet`             |
+| MySql                           | `MySql.Data` 6.7.0+</br>`MySqlConnector` 1.0.0+                                           | `MySql`              |
+| Oracle                          | `Oracle.ManagedDataAccess` 4.122.0+                                                       | `Oracle`             |
+| PostgreSQL                      | `Npgsql` 4.0+                                                                             | `Npgsql`             |
 | RabbitMQ                        | `RabbitMQ.Client` 3.6.9+                                                                  | `RabbitMQ`           |
 | Redis (ServiceStack client)     | `ServiceStack.Redis` 4.0.48+                                                              | `ServiceStackRedis`  |
 | Redis (StackExchange client)    | `StackExchange.Redis` 1.0.187+                                                            | `StackExchangeRedis` |
 | Service Fabric Remoting         | `Microsoft.ServiceFabric.Services.Remoting` 4.0.470+                                      | `ServiceRemoting`    |
-| SQL Server                      | `System.Data` 4.0.0+</br>`System.Data.SqlClient` 4.0.0+</br>`Microsoft.Data.SqlClient` 1.0.0+  | `AdoNet`             |
+| SQLite                          | `System.Data.Sqlite` 2.0.0+ </br>`Microsoft.Data.Sqlite` 1.0.0+                           | `Sqlite`             |
+| SQL Server                      | `System.Data` 4.0.0+</br>`System.Data.SqlClient` 4.0.0+</br>`Microsoft.Data.SqlClient` 1.0.0+  | `SqlClient`     |
 | WCF (server)                    | built-in                                                                                  | `Wcf`                |
 | WebClient / WebRequest          | `System.Net.Requests` 4.0+                                                                | `WebRequest`         |
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -51,6 +51,7 @@ The [latest version of the .NET Tracer][4] can automatically instrument the foll
 
 | Framework or library            | NuGet package                                                                             | Integration Name     |
 | ------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
+| ADO.NET                         | All AdoNet integrations                                                                   | `AdoNet`             |
 | Aerospike                       | `Aerospike.Client` 4.0.0+                                                                 | `Aerospike`          |
 | ASP.NET Core                    | `Microsoft.AspNetCore`</br>`Microsoft.AspNetCore.App`</br>2.0+ and 3.0+                   | `AspNetCore`         |
 | AWS SQS                         | `AWSSDK.SQS`  3.0+                                                                        | `AwsSqs`             |

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -22,7 +22,7 @@ further_reading:
 - The .NET Tracer library for Datadog is open source. For more information, see the [.NET Tracer repository][1].
 
 ## Supported .NET Framework runtimes
-The .NET Tracer supports automatic instrumentation on .NET Framework 4.5 and above. It also supports [.NET Core][2].
+The .NET Tracer supports automatic instrumentation on .NET Framework 4.6.1 and above. It also supports [.NET Core][2].
 
 | Version  | Microsoft End of Life |
 | -------- | --------------------- |
@@ -31,10 +31,6 @@ The .NET Tracer supports automatic instrumentation on .NET Framework 4.5 and abo
 | 4.7      |                       |
 | 4.6.2    |                       |
 | 4.6.1    | 04/26/2022            |
-| 4.6      | 04/26/2022            |
-| 4.5.2    | 04/26/2022            |
-| 4.5.1    | 01/12/2016            | 
-| 4.5      | 01/12/2016            |
 
  Additional information on .NET Framework support policy can be found within [Microsoft's .NET Framework Lifecycle Policy][3]. 
 
@@ -52,26 +48,27 @@ The [latest version of the .NET Tracer][4] can automatically instrument the foll
 
 | Framework or library            | NuGet package                                                                             | Integration Name     |
 | ------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
-| ADO.NET                         | built-in                                                                                  | `AdoNet`             |
 | Aerospike                       | `Aerospike.Client` 4.0.0+                                                                 | `Aerospike`          |
 | ASP.NET (including Web Forms)   | built-in                                                                                  | `AspNet`             |
 | ASP.NET MVC                     | `Microsoft.AspNet.Mvc` 4.0+                                                               | `AspNetMvc`          |
 | ASP.NET Web API 2               | `Microsoft.AspNet.WebApi` 5.1+                                                            | `AspNetWebApi2`      |
 | AWS SQS                         | `AWSSDK.SQS`  3.0+                                                                        | `AwsSqs`             |
-| CosmosDb                        | `Microsoft.Azure.Cosmos.Client` 3.6.0                                                     | `CosmosDb`           |
+| CosmosDb                        | `Microsoft.Azure.Cosmos.Client` 3.6.0+                                                    | `CosmosDb`           |
+| Couchbase                       | `CouchbaseNetClient` 2.2.8+                                                               | `Couchbase`          |
 | Elasticsearch                   | `Elasticsearch.Net` 5.3.0+                                                                | `ElasticsearchNet`   |
 | GraphQL .NET                    | `GraphQL` 2.3.0+                                                                          | `GraphQL`            |
 | HttpClient / HttpMessageHandler | built-in                                                                                  | `HttpMessageHandler` |
 | Kafka                           | `Confluent.Kafka` 1.4+                                                                    | `Kafka`              |
 | MongoDB                         | `MongoDB.Driver.Core` 2.1.0+                                                              | `MongoDb`            |
 | MSMQ                            | built-in                                                                                  | `Msmq`               |
-| MySql                           | `MySql.Data` 6.7.0+                                                                       | `AdoNet`             |
-| Oracle                          | `Oracle.ManagedDataAccess` 4.122.0+                                                       | `AdoNet`             |
-| PostgreSQL                      | `Npgsql` 4.0+                                                                             | `AdoNet`             |
+| MySql                           | `MySql.Data` 6.7.0+</br>`MySqlConnector` 1.0.0+                                           | `MySql`              |
+| Oracle                          | `Oracle.ManagedDataAccess` 4.122.0+                                                       | `Oracle`             |
+| PostgreSQL                      | `Npgsql` 4.0+                                                                             | `Npgsql`             |
 | RabbitMQ                        | `RabbitMQ.Client` 3.6.9+                                                                  | `RabbitMQ`           |
 | Redis (ServiceStack client)     | `ServiceStack.Redis` 4.0.48+                                                              | `ServiceStackRedis`  |
 | Redis (StackExchange client)    | `StackExchange.Redis` 1.0.187+                                                            | `StackExchangeRedis` |
-| SQL Server                      | `System.Data` 4.0.0+</br>`System.Data.SqlClient` 4.0.0+</br>`Microsoft.Data.SqlClient` 1.0.0+  | `AdoNet`             |
+| SQLite                          | `System.Data.Sqlite` 2.0.0+ </br>`Microsoft.Data.Sqlite` 1.0.0+                           | `Sqlite`             |
+| SQL Server                      | `System.Data` 4.0.0+</br>`System.Data.SqlClient` 4.0.0+</br>`Microsoft.Data.SqlClient` 1.0.0+  | `SqlClient`     |
 | WCF (server)                    | built-in                                                                                  | `Wcf`                |
 | WebClient / WebRequest          | built-in                                                                                  | `WebRequest`         |
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -48,6 +48,7 @@ The [latest version of the .NET Tracer][4] can automatically instrument the foll
 
 | Framework or library            | NuGet package                                                                             | Integration Name     |
 | ------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
+| ADO.NET                         | built-in                                                                                  | `AdoNet`             |
 | Aerospike                       | `Aerospike.Client` 4.0.0+                                                                 | `Aerospike`          |
 | ASP.NET (including Web Forms)   | built-in                                                                                  | `AspNet`             |
 | ASP.NET MVC                     | `Microsoft.AspNet.Mvc` 4.0+                                                               | `AspNetMvc`          |

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -464,10 +464,6 @@ The following configuration variables are for features that are available for us
 `DD_TRACE_LOG_PATH`
 : Sets the path for the automatic instrumentation log file and determines the directory of all other .NET Tracer log files. Ignored if `DD_TRACE_LOG_DIRECTORY` is set. 
 
-`DD_TRACE_ADONET_EXCLUDED_TYPES`
-: **TracerSettings property**: `AdoNetExcludedTypes` <br>
-Sets a list of `AdoNet` types (for example, `System.Data.SqlClient.SqlCommand`) that will be excluded from automatic instrumentation. Unused in version 2.0+.
-
 `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED`
 : Enables improved resource names for web spans when set to `true`. Uses route template information where available, adds an additional span for ASP.NET Core integrations, and enables additional tags. Added in version 1.26.0. Enabled by default in 2.0.0<br>
 **Default**: `true`

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -42,7 +42,7 @@ further_reading:
 
 ### Supported .NET Core runtimes
 
-The .NET Tracer supports instrumentation on .NET Core 2.1, 3.1, and .NET 5. 
+The .NET Tracer supports instrumentation on .NET Core 2.1, 3.1, .NET 5, and .NET 6. 
 
 For a full list of supported libraries and processor architectures, see [Compatibility Requirements][1].
 
@@ -92,10 +92,10 @@ To install the .NET Tracer machine-wide:
    : `sudo rpm -Uvh datadog-dotnet-apm<TRACER_VERSION>-1.x86_64.rpm && /opt/datadog/createLogPath.sh`
 
    Alpine or other musl-based distributions
-   : `sudo tar -xzf -C /opt/datadog datadog-dotnet-apm<TRACER_VERSION>-musl.tar.gz && sh /opt/datadog/createLogPath.sh`
+   : `sudo tar -C /opt/datadog -xzf datadog-dotnet-apm<TRACER_VERSION>-musl.tar.gz && sh /opt/datadog/createLogPath.sh`
 
    Other distributions
-   : `sudo tar -xzf -C /opt/datadog datadog-dotnet-apm<TRACER_VERSION>-tar.gz && /opt/datadog/createLogPath.sh`
+   : `sudo tar -C /opt/datadog -xzf datadog-dotnet-apm<TRACER_VERSION>-tar.gz && /opt/datadog/createLogPath.sh`
 
 
 [1]: https://github.com/DataDog/dd-trace-dotnet/releases
@@ -162,7 +162,6 @@ For information about the different methods for setting environment variables, s
    CORECLR_ENABLE_PROFILING=1
    CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
    CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
-   DD_INTEGRATIONS=/opt/datadog/integrations.json
    DD_DOTNET_TRACER_HOME=/opt/datadog
    ```
 
@@ -178,7 +177,6 @@ For information about the different methods for setting environment variables, s
    CORECLR_ENABLE_PROFILING=1
    CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
    CORECLR_PROFILER_PATH=<System-dependent path>
-   DD_INTEGRATIONS=<APP_DIRECTORY>/datadog/integrations.json
    DD_DOTNET_TRACER_HOME=<APP_DIRECTORY>/datadog
    ```
 
@@ -294,7 +292,7 @@ To configure the tracer using environment variables, set the variables before la
 
 {{% tab "Code" %}}
 
-To configure the Tracer in application code, create a `TracerSettings` instance from the default configuration sources. Set properties on this `TracerSettings` instance before passing it to a `Tracer` constructor. For example:
+To configure the Tracer in application code, create a `TracerSettings` instance from the default configuration sources. Set properties on this `TracerSettings` instance before calling `Tracer.Configure()`. For example:
 
 <div class="alert alert-warning">
   <strong>Note:</strong> Settings must be set on <code>TracerSettings</code> <em>before</em> creating the <code>Tracer</code>. Changes made to <code>TracerSettings</code> properties after the <code>Tracer</code> is created are ignored.
@@ -313,11 +311,8 @@ settings.ServiceName = "MyService";
 settings.ServiceVersion = "abc123";
 settings.AgentUri = new Uri("http://localhost:8126/");
 
-// create a new Tracer using these settings
-var tracer = new Tracer(settings);
-
-// set the global tracer
-Tracer.Instance = tracer;
+// configure the global Tracer settings
+Tracer.Configure(settings);
 ```
 
 {{% /tab %}}
@@ -411,10 +406,7 @@ Added in version 1.17.0.
 
 `DD_TRACE_LOG_DIRECTORY`
 : Sets the directory for .NET Tracer logs. <br>
-**Default**: `%ProgramData%\Datadog .NET Tracer\logs\`
-
-`DD_TRACE_LOG_PATH`
-: Sets the path for the automatic instrumentation log file and determines the directory of all other .NET Tracer log files. Ignored if `DD_TRACE_LOG_DIRECTORY` is set.
+**Default**: `%ProgramData%\Datadog .NET Tracer\logs\` on Windows, `/var/log/datadog/dotnet` on Linux
 
 `DD_TRACE_LOGGING_RATE`
 : Sets rate limiting for log messages. If set, unique log lines are written once per `x` seconds. For example, to log a given message once per 60 seconds, set to `60`. Setting to `0` disables log rate limiting. Added in version 1.24.0. Disabled by default.
@@ -446,10 +438,6 @@ Enables or disables all automatic instrumentation. Setting the environment varia
 **Default**: `false`<br>
 Added in version 1.23.0.
 
-`DD_TRACE_ADONET_EXCLUDED_TYPES`
-: **TracerSettings property**: `AdoNetExcludedTypes` <br>
-Sets a list of `AdoNet` types (for example, `System.Data.SqlClient.SqlCommand`) that will be excluded from automatic instrumentation.
-
 #### Automatic instrumentation integration configuration
 
 The following table lists configuration variables that are available **only** when using automatic instrumentation and can be set for each integration.
@@ -467,13 +455,22 @@ Enables or disables a specific integration. Valid values are: `true` or `false`.
 
 The following configuration variables are for features that are available for use but may change in future releases.
 
-`DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED`
-: Enables improved resource names for web spans when set to `true`. Uses route template information where available, adds an additional span for ASP.NET Core integrations, and enables additional tags. Added in version 1.26.0.<br>
-**Default**: `false`
-
 `DD_TRACE_PARTIAL_FLUSH_ENABLED`
 : Enables incrementally flushing large traces to the Datadog Agent, reducing the chance of rejection by the Agent. Use only when you have long-lived traces or traces with many spans. Valid values are `true` or `false`. Added in version 1.26.0, only compatible with the Datadog Agent 7.26.0+.<br>
 **Default**: `false`
+
+#### Deprecated settings
+
+`DD_TRACE_LOG_PATH`
+: Sets the path for the automatic instrumentation log file and determines the directory of all other .NET Tracer log files. Ignored if `DD_TRACE_LOG_DIRECTORY` is set. 
+
+`DD_TRACE_ADONET_EXCLUDED_TYPES`
+: **TracerSettings property**: `AdoNetExcludedTypes` <br>
+Sets a list of `AdoNet` types (for example, `System.Data.SqlClient.SqlCommand`) that will be excluded from automatic instrumentation. Unused in version 2.0+.
+
+`DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED`
+: Enables improved resource names for web spans when set to `true`. Uses route template information where available, adds an additional span for ASP.NET Core integrations, and enables additional tags. Added in version 1.26.0. Enabled by default in 2.0.0<br>
+**Default**: `true`
 
 ## Custom instrumentation
 
@@ -579,7 +576,6 @@ To set the required environment variables from a bash file before starting your 
 export CORECLR_ENABLE_PROFILING=1
 export CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 export CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
-export DD_INTEGRATIONS=/opt/datadog/integrations.json
 export DD_DOTNET_TRACER_HOME=/opt/datadog
 
 # Start your application
@@ -595,7 +591,6 @@ To set the required environment variables on a Linux Docker container:
   ENV CORECLR_ENABLE_PROFILING=1
   ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
   ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
-  ENV DD_INTEGRATIONS=/opt/datadog/integrations.json
   ENV DD_DOTNET_TRACER_HOME=/opt/datadog
 
   # Start your application
@@ -612,7 +607,6 @@ When using `systemctl` to run .NET applications as a service, you can add the re
     CORECLR_ENABLE_PROFILING=1
     CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
     CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
-    DD_INTEGRATIONS=/opt/datadog/integrations.json
     DD_DOTNET_TRACER_HOME=/opt/datadog
     # any other environment variable used by the application
     ```
@@ -639,7 +633,6 @@ When using `systemctl` to run .NET applications as a service, you can also set e
     systemctl set-environment CORECLR_ENABLE_PROFILING=1
     systemctl set-environment CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
     systemctl set-environment CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
-    systemctl set-environment DD_INTEGRATIONS=/opt/datadog/integrations.json
     systemctl set-environment DD_DOTNET_TRACER_HOME=/opt/datadog
     ```
 2. Verify that the environment variables were set by running `systemctl show-environment`.

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -374,7 +374,7 @@ Added in version 1.17.0.
 
 `DD_TRACE_LOG_DIRECTORY`
 : Sets the directory for .NET Tracer logs. <br>
-**Default**: `%ProgramData%\Datadog .NET Tracer\logs\` on Windows, `/var/log/datadog/dotnet` on Linux
+**Default**: `%ProgramData%\Datadog .NET Tracer\logs\`
 
 `DD_TRACE_LOGGING_RATE`
 : Sets rate limiting for log messages. If set, unique log lines are written once per `x` seconds. For example, to log a given message once per 60 seconds, set to `60`. Setting to `0` disables log rate limiting. Added in version 1.24.0. Disabled by default.
@@ -431,10 +431,6 @@ The following configuration variables are for features that are available for us
 
 `DD_TRACE_LOG_PATH`
 : Sets the path for the automatic instrumentation log file and determines the directory of all other .NET Tracer log files. Ignored if `DD_TRACE_LOG_DIRECTORY` is set. 
-
-`DD_TRACE_ADONET_EXCLUDED_TYPES`
-: **TracerSettings property**: `AdoNetExcludedTypes` <br>
-Sets a list of `AdoNet` types (for example, `System.Data.SqlClient.SqlCommand`) that will be excluded from automatic instrumentation. Unused in version 2.0+.
 
 `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED`
 : Enables improved resource names for web spans when set to `true`. Uses route template information where available, adds an additional span for ASP.NET Core integrations, and enables additional tags. Added in version 1.26.0. Enabled by default in 2.0.0<br>

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -48,7 +48,7 @@ further_reading:
 ## Compatibility requirements
 
 ### Supported .NET Framework runtimes
-The .NET Tracer supports instrumentation on .NET Framework 4.5 and above.
+The .NET Tracer supports instrumentation on .NET Framework 4.6.1 and above.
 
 For a full list of supported libraries and processor architectures, see [Compatibility Requirements][1].
 
@@ -144,7 +144,6 @@ For information about the different methods for setting environment variables, s
    COR_ENABLE_PROFILING=1
    COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
    COR_PROFILER_PATH=<System-dependent path>
-   DD_INTEGRATIONS=<APP_DIRECTORY>/datadog/integrations.json
    DD_DOTNET_TRACER_HOME=<APP_DIRECTORY>/datadog
    ```
 
@@ -248,7 +247,7 @@ To configure the tracer using environment variables, set the variables before la
 
 {{% tab "Code" %}}
 
-To configure the Tracer in application code, create a `TracerSettings` instance from the default configuration sources. Set properties on this `TracerSettings` instance before passing it to a `Tracer` constructor. For example:
+To configure the Tracer in application code, create a `TracerSettings` instance from the default configuration sources. Set properties on this `TracerSettings` instance before calling `Tracer.Configure()`. For example:
 
 <div class="alert alert-warning">
   <strong>Note:</strong> Settings must be set on <code>TracerSettings</code> <em>before</em> creating the <code>Tracer</code>. Changes made to <code>TracerSettings</code> properties after the <code>Tracer</code> is created are ignored.
@@ -267,11 +266,8 @@ settings.ServiceName = "MyService";
 settings.ServiceVersion = "abc123";
 settings.AgentUri = new Uri("http://localhost:8126/");
 
-// create a new Tracer using these settings
-var tracer = new Tracer(settings);
-
-// set the global tracer
-Tracer.Instance = tracer;
+// configure the global Tracer settings
+Tracer.Configure(settings);
 ```
 
 {{% /tab %}}
@@ -378,10 +374,7 @@ Added in version 1.17.0.
 
 `DD_TRACE_LOG_DIRECTORY`
 : Sets the directory for .NET Tracer logs. <br>
-**Default**: `%ProgramData%\Datadog .NET Tracer\logs\`
-
-`DD_TRACE_LOG_PATH`
-: Sets the path for the automatic instrumentation log file and determines the directory of all other .NET Tracer log files. Ignored if `DD_TRACE_LOG_DIRECTORY` is set.
+**Default**: `%ProgramData%\Datadog .NET Tracer\logs\` on Windows, `/var/log/datadog/dotnet` on Linux
 
 `DD_TRACE_LOGGING_RATE`
 : Sets rate limiting for log messages. If set, unique log lines are written once per `x` seconds. For example, to log a given message once per 60 seconds, set to `60`. Setting to `0` disables log rate limiting. Added in version 1.24.0. Disabled by default.
@@ -413,10 +406,6 @@ Enables or disables all automatic instrumentation. Setting the environment varia
 **Default**: `false`<br>
 Added in version 1.23.0.
 
-`DD_TRACE_ADONET_EXCLUDED_TYPES`
-: **TracerSettings property**: `AdoNetExcludedTypes` <br>
-Sets a list of `AdoNet` types (for example, `System.Data.SqlClient.SqlCommand`) that will be excluded from automatic instrumentation.
-
 #### Automatic instrumentation integration configuration
 
 The following table lists configuration variables that are available **only** when using automatic instrumentation and can be set for each integration.
@@ -434,13 +423,22 @@ Enables or disables a specific integration. Valid values are: `true` or `false`.
 
 The following configuration variables are for features that are available for use but may change in future releases.
 
-`DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED`
-: Enables improved resource names for web spans when set to `true`. Uses route template information where available, adds an additional span for ASP.NET Core integrations, and enables additional tags. Added in version 1.26.0.<br>
-**Default**: `false`
-
 `DD_TRACE_PARTIAL_FLUSH_ENABLED`
 : Enables incrementally flushing large traces to the Datadog Agent, reducing the chance of rejection by the Agent. Use only when you have long-lived traces or traces with many spans. Valid values are `true` or `false`. Added in version 1.26.0, only compatible with the Datadog Agent 7.26.0+.<br>
 **Default**: `false`
+
+#### Deprecated settings
+
+`DD_TRACE_LOG_PATH`
+: Sets the path for the automatic instrumentation log file and determines the directory of all other .NET Tracer log files. Ignored if `DD_TRACE_LOG_DIRECTORY` is set. 
+
+`DD_TRACE_ADONET_EXCLUDED_TYPES`
+: **TracerSettings property**: `AdoNetExcludedTypes` <br>
+Sets a list of `AdoNet` types (for example, `System.Data.SqlClient.SqlCommand`) that will be excluded from automatic instrumentation. Unused in version 2.0+.
+
+`DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED`
+: Enables improved resource names for web spans when set to `true`. Uses route template information where available, adds an additional span for ASP.NET Core integrations, and enables additional tags. Added in version 1.26.0. Enabled by default in 2.0.0<br>
+**Default**: `true`
 
 ## Custom instrumentation
 


### PR DESCRIPTION
### What does this PR do?
Document the latest features and configuration details for .NET tracer

### Motivation
There were a number of breaking changes in version 2.0 of the .NET tracer; we want to make sure we have the correct documentation for the current version of the tracer.

### Preview
https://docs-staging.datadoghq.com/andrewlock/version-2-updates/tracing/setup_overview/compatibility_requirements/dotnet-core
https://docs-staging.datadoghq.com/andrewlock/version-2-updates/tracing/setup_overview/compatibility_requirements/dotnet-framework/
https://docs-staging.datadoghq.com/andrewlock/version-2-updates/tracing/setup_overview/setup/dotnet-core
https://docs-staging.datadoghq.com/andrewlock/version-2-updates/tracing/setup_overview/setup/dotnet-framework/

### Additional Notes
Version 2 has not been finished yet, so we may make additional changes before merging

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.

@DataDog/apm-dotnet 