### PR TITLE
removed extra space before example params [WEB-1935]

### DIFF
--- a/local/bin/py/build/process_agent_config.py
+++ b/local/bin/py/build/process_agent_config.py
@@ -24,7 +24,7 @@ def format_agent_config_string(string):
     if re.match(regex_string, string):
         return string.replace('#', '').replace('\n', '').strip()
     elif '#' in string and '##' not in string:
-        return string.replace('#', '') + '\n'
+        return string.replace('# ', '') + '\n'
     else:
         return string + '\n'
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

removes extra space before `datadog.yaml` configuration code example params.

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/browse/WEB-1935

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->

https://docs-staging.datadoghq.com/stefon.simmons/rm-extra-shortcode-space/agent/logs/?tab=tailfiles
https://docs-staging.datadoghq.com/stefon.simmons/rm-extra-shortcode-space/getting_started/logs/?tab=tailfiles
https://docs-staging.datadoghq.com/stefon.simmons/rm-extra-shortcode-space/ja/agent/logs/?tab=tailfiles

### Additional Notes
<!-- Anything else we should know when reviewing?-->

n/a

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
