### PR TITLE
feat: Add note that trace obfuscation is not supported via the datado…

### DIFF
--- a/content/en/serverless/distributed_tracing/collect_lambda_payloads.md
+++ b/content/en/serverless/distributed_tracing/collect_lambda_payloads.md
@@ -71,6 +71,8 @@ DD_APM_REPLACE_TAGS=[
 ]
 ```
 
+Please note, payload obfuscation is supported only via the Datadog Lambda Extension, and is not available when used in conjunction with the Datadog Forwarder.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/serverless/distributed_tracing/collect_lambda_payloads.md
+++ b/content/en/serverless/distributed_tracing/collect_lambda_payloads.md
@@ -71,7 +71,7 @@ DD_APM_REPLACE_TAGS=[
 ]
 ```
 
-Payload obfuscation is available in when using the Datadog Lambda Extension. It is not available in the Datadog Forwarder.
+Payload obfuscation is available when using the Datadog Lambda Extension. It is not available in the Datadog Forwarder.
 
 ## Further Reading
 

--- a/content/en/serverless/distributed_tracing/collect_lambda_payloads.md
+++ b/content/en/serverless/distributed_tracing/collect_lambda_payloads.md
@@ -71,7 +71,7 @@ DD_APM_REPLACE_TAGS=[
 ]
 ```
 
-Please note, payload obfuscation is supported only via the Datadog Lambda Extension, and is not available when used in conjunction with the Datadog Forwarder.
+Payload obfuscation is available in when using the Datadog Lambda Extension. It is not available in the Datadog Forwarder.
 
 ## Further Reading
 


### PR DESCRIPTION
…g forwarder at this time

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Obfuscation is not supported via the Datadog Forwarder at this time, this was unfortunately not captured when these logs were created.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
