### PR TITLE
Update Agent instructions for the Raspberry Pi

### DIFF
--- a/content/en/developers/faq/deploying-the-agent-on-raspberrypi.md
+++ b/content/en/developers/faq/deploying-the-agent-on-raspberrypi.md
@@ -29,11 +29,30 @@ kind: faq
 Example output after successful installation:
 {{< img src="developers/faq/rasberypi_install.png" alt="rasberypi_install" >}}
 
-The Agent runs in the foreground. Some users find benefit in creating an RC script for it or putting it into the `/etc/rc.local` like this:
+The Agent runs in the foreground. Some users find benefit in creating a systemd service for the agent like this:
 
 ```text
-nohup sh /root/.datadog-agent/bin/agent &
+#/etc/systemd/system/datadog.service
+
+[Unit]
+Description=Datadog Agent
+
+[Service]
+ExecStart=/path/to/.datadog-agent/bin/agent
+
+[Install]
+WantedBy=multi-user.target
 ```
+
+and then running
+
+```shell
+systemctl daemon-reload
+sudo systemctl enable datadog
+systemctl start datadog
+```
+
+n.b. that the Datadog Agent is installed in the working directory where you ran the installation command, e.g. `/home/pi/.datadog-agent/`. 
 
 Example of metrics being ingested from your Raspberry PI device:
 {{< img src="developers/faq/rasberry_dashboard.png" alt="raspberry_dashboard" >}}

--- a/content/en/developers/faq/deploying-the-agent-on-raspberrypi.md
+++ b/content/en/developers/faq/deploying-the-agent-on-raspberrypi.md
@@ -29,7 +29,7 @@ kind: faq
 Example output after successful installation:
 {{< img src="developers/faq/rasberypi_install.png" alt="rasberypi_install" >}}
 
-The Agent runs in the foreground. Some users find benefit in creating a systemd service for the agent like this:
+The Agent runs in the foreground. Some users find benefit in creating a `systemd` service for the Agent like this:
 
 ```text
 #/etc/systemd/system/datadog.service
@@ -44,7 +44,7 @@ ExecStart=/path/to/.datadog-agent/bin/agent
 WantedBy=multi-user.target
 ```
 
-and then running
+Then, run:
 
 ```shell
 systemctl daemon-reload
@@ -52,7 +52,7 @@ sudo systemctl enable datadog
 systemctl start datadog
 ```
 
-Please note that the Datadog Agent is installed in the working directory where you ran the installation command, for example `/home/pi/.datadog-agent/`. 
+The Datadog Agent is installed in the working directory where you ran the installation command, for example: `/home/pi/.datadog-agent/`. 
 
 Example of metrics being ingested from your Raspberry PI device:
 {{< img src="developers/faq/rasberry_dashboard.png" alt="raspberry_dashboard" >}}

--- a/content/en/developers/faq/deploying-the-agent-on-raspberrypi.md
+++ b/content/en/developers/faq/deploying-the-agent-on-raspberrypi.md
@@ -52,7 +52,7 @@ sudo systemctl enable datadog
 systemctl start datadog
 ```
 
-n.b. that the Datadog Agent is installed in the working directory where you ran the installation command, e.g. `/home/pi/.datadog-agent/`. 
+Please note that the Datadog Agent is installed in the working directory where you ran the installation command, for example `/home/pi/.datadog-agent/`. 
 
 Example of metrics being ingested from your Raspberry PI device:
 {{< img src="developers/faq/rasberry_dashboard.png" alt="raspberry_dashboard" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Changes the Raspberry Pi instructions from recommending an RC script to recommending a systemd service for starting the datadog agent.

### Motivation
<!-- What inspired you to submit this pull request?-->
I installed the agent on a Raspberry Pi as part of the Hackathon last week. I ran into some trouble with these instructions, so I decided to update them with a systemd service definition for the Datadog agent.


### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/chris.agocs/systemd-for-agent-on-raspberry-pi/developers/faq/deploying-the-agent-on-raspberrypi/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
