### PR TITLE
Updated OPENTRACING_VERSION variable

### DIFF
--- a/content/en/tracing/setup_overview/setup/cpp.md
+++ b/content/en/tracing/setup_overview/setup/cpp.md
@@ -101,7 +101,7 @@ get_latest_release() {
     sed -E 's/.*"([^"]+)".*/\1/';
 }
 DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)"
-OPENTRACING_VERSION="v1.5.1"
+OPENTRACING_VERSION="$(get_latest_release opentracing/opentracing-cpp)"
 # Download and install OpenTracing-cpp
 wget https://github.com/opentracing/opentracing-cpp/archive/${OPENTRACING_VERSION}.tar.gz -O opentracing-cpp.tar.gz
 mkdir -p opentracing-cpp/.build


### PR DESCRIPTION
OPENTRACING_VERSION was hard-coded for version 1.5.1. This PR updates the OPENTRACING_VERSION variable to grab the latest release version from opentracing/opentracing-cpp via get_latest_release()

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
