### PR TITLE
[WEB-1919] Exclude site-region container from Algolia

### DIFF
--- a/layouts/shortcodes/site-region.html
+++ b/layouts/shortcodes/site-region.html
@@ -4,4 +4,4 @@
 
 {{ $region := .Get "region" }}
 
-<div class="d-none" data-region="{{ $region }}"><p>{{- .Inner | markdownify -}}</p></div>
+<div class="d-none site-region-container" data-region="{{ $region }}"><p>{{- .Inner | markdownify -}}</p></div>

--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -255,7 +255,8 @@
         "#further-reading",
         ".alert-info",
         ".announcement_banner",
-        ".language-region-select-container"
+        ".language-region-select-container",
+        ".site-region-container"
     ],
     "conversation_id": ["620036890"],
     "custom_settings": {

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -255,7 +255,8 @@
         "#further-reading",
         ".alert-info",
         ".announcement_banner",
-        ".language-region-select-container"
+        ".language-region-select-container",
+        ".site-region-container"
     ],
     "conversation_id": ["620036890"],
     "custom_settings": {


### PR DESCRIPTION
### What does this PR do?
Updates Algolia config to exclude specific site-region-container content from being indexed. Adds a custom class name to the site-region shortcode wrapping div so that we can target that for the selectors_exclude config in Algolia's docsearch. 

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1919

### Preview
N/A -- there are no visible changes to review, however, ensure the content is still displayed as expected for the US-FED1 region selection of the reported content:
https://docs-staging.datadoghq.com/nsollecito/algolia-exclude-site/integrations/confluent_cloud/#overview

https://docs-staging.datadoghq.com/nsollecito/algolia-exclude-site/search/?s=confluent

### Additional Notes
This has been confirmed as working in the Algolia backend, but the on-site search for the Preview will not be updated until this is merged and the site is recrawled or updated in the nightly build job 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
