### PR TITLE
fixed styling on further reading list item [WEB-1936]

### DIFF
--- a/assets/styles/components/_whats-next.scss
+++ b/assets/styles/components/_whats-next.scss
@@ -29,9 +29,6 @@ $ddpurple:    #632CA6;
     }
     .badge {
       font-weight: 200;
-      position: absolute;
-      right: 51px;
-      top: 17px;
       font-size: 14px;
       color: #555;
       border-color: transparent;
@@ -44,7 +41,6 @@ $ddpurple:    #632CA6;
       }
     }
     .text {
-      margin-right: 9px;
       &:lang(ja) {
         font-size: 15px;
         line-height: 25px;

--- a/layouts/partials/whats-next/whats-next.html
+++ b/layouts/partials/whats-next/whats-next.html
@@ -23,7 +23,12 @@
       {{- end -}}
       {{- $link := $.Scratch.Get "link" -}}
       <a class="list-group-item list-group-item-action list-group-item-white  d-flex justify-content-between align-items-center" href="{{- $link -}}">
-        <span><span class="text">{{- .text -}}</span>{{- if .tag -}}<span class="badge badge-white">{{- .tag | upper -}}</span>{{- end -}}</span>
+        <span class="w-100 d-flex justify-content-between">
+            <span class="text">{{- .text -}}</span>
+            {{- if .tag -}}
+                <span class="badge badge-white pr-2">{{- .tag | upper -}}</span>
+            {{- end -}}
+        </span>
         {{- partial "img.html" (dict "root" $dot "src" "icons/list-group-whats-next-arrow-1.png" "class" "img-fluid static" "alt" "more") -}}
         {{- partial "img.html" (dict "root" $dot "src" "icons/list-group-whats-next-arrow-2.png" "class" "img-fluid hover" "alt" "more") -}}
       </a>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Fixes the vertical alignment of text in the `Further Reading` section

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-1936

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->

https://docs-staging.datadoghq.com/stefon.simmons/vertical-align-further-reading/agent/troubleshooting/agent_check_status/?tab=agentv6v7#further-reading

### Additional Notes
<!-- Anything else we should know when reviewing?-->

n/a

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
