### PR TITLE
[WEB-1932] Updates FAQ sections to cascade private

### DIFF
--- a/content/en/account_management/faq/_index.md
+++ b/content/en/account_management/faq/_index.md
@@ -1,7 +1,8 @@
 ---
 title: Account Management FAQ
 kind: faq
-private: true
+cascade: 
+  - private: true
 ---
 
 ## Account management

--- a/content/en/agent/faq/_index.md
+++ b/content/en/agent/faq/_index.md
@@ -1,7 +1,8 @@
 ---
 title: Agent FAQ
 kind: faq
-private: true
+cascade: 
+  - private: true
 disable_sidebar: true
 aliases:
 - /agent/faq/agent-5-vs-agent-6-for-docker-kubernetes

--- a/content/en/dashboards/faq/_index.md
+++ b/content/en/dashboards/faq/_index.md
@@ -1,7 +1,8 @@
 ---
 title: Graphing FAQ
 kind: faq
-private: true
+cascade: 
+  - private: true
 aliases:
     - /graphing/faq/how-to-merge-screenboards
     - /graphing/faq/false-spikes-sometimes-appear-on-my-sum-graph

--- a/content/en/developers/faq/_index.md
+++ b/content/en/developers/faq/_index.md
@@ -1,7 +1,8 @@
 ---
 title: Developers FAQ
 kind: faq
-private: true
+cascade: 
+  - private: true
 ---
 
 ## General

--- a/content/en/integrations/faq/_index.md
+++ b/content/en/integrations/faq/_index.md
@@ -1,7 +1,8 @@
 ---
 title: FAQ Integrations
 kind: faq
-private: true
+cascade: 
+  - private: true
 aliases:
     - /integrations/faq/how-can-i-gather-metrics-from-the-unix-shell
     - /integrations/faq/what-is-a-custom-metric-and-what-is-the-limit-on-the-number-of-custom-metrics-i-can-have

--- a/content/en/logs/faq/_index.md
+++ b/content/en/logs/faq/_index.md
@@ -1,7 +1,8 @@
 ---
 title: Logs FAQ
 kind: faq
-private: true
+cascade: 
+  - private: true
 aliases:
     - /logs/faq/instance-initialization-error-while-sending-logs-from-datadog-agent/
 ---

--- a/content/en/metrics/faq/_index.md
+++ b/content/en/metrics/faq/_index.md
@@ -1,7 +1,8 @@
 ---
 title: Metrics FAQ
 kind: faq
-private: true
+cascade:
+  - private: true
 ---
 
 {{< whatsnext desc="List of Frequently Asked Questions:" >}}

--- a/content/en/monitors/faq/_index.md
+++ b/content/en/monitors/faq/_index.md
@@ -1,7 +1,8 @@
 ---
 title: Monitor FAQ
 kind: faq
-private: true
+cascade: 
+  - private: true
 ---
 
 {{< whatsnext desc="List of Frequently Asked Questions:">}}

--- a/content/en/real_user_monitoring/faq/_index.md
+++ b/content/en/real_user_monitoring/faq/_index.md
@@ -1,7 +1,8 @@
 ---
 title: RUM FAQ
 kind: faq
-private: true
+cascade: 
+  - private: true
 ---
 
 {{< whatsnext desc="List of Frequently Asked Questions:" >}}

--- a/content/en/synthetics/faq/_index.md
+++ b/content/en/synthetics/faq/_index.md
@@ -1,7 +1,8 @@
 ---
 title: Synthetic Monitoring FAQ
 kind: faq
-private: true
+cascade: 
+  - private: true
 ---
 
 {{< whatsnext desc="List of Frequently Asked Questions:">}}

--- a/content/en/tracing/faq/_index.md
+++ b/content/en/tracing/faq/_index.md
@@ -1,7 +1,8 @@
 ---
 title: Tracing FAQ
 kind: faq
-private: true
+cascade: 
+  - private: true
 ---
 
 {{< whatsnext desc="List of Frequently Asked Questions:">}}


### PR DESCRIPTION
### What does this PR do?
Updates FAQ sections to cascade private: true. This will include noindex,nofollow meta tags in the template for any child FAQ page so these will no longer appear in the Google search results

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1932

### Preview
Check page source for list and single pages for noindex, nofollow
https://docs-staging.datadoghq.com/nsollecito/cascade-private-faqs/agent/faq/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
