### PR TITLE
[DOCS-2782] Fix link on IM page

### DIFF
--- a/content/en/monitors/incident_management/_index.md
+++ b/content/en/monitors/incident_management/_index.md
@@ -200,7 +200,7 @@ Work through an example workflow in the [Getting Started with Incident Managemen
 [9]: /getting_started/tagging/assigning_tags?tab=noncontainerizedenvironments#overview
 [10]: /tracing/#2-instrument-your-application
 [11]: https://app.datadoghq.com/incidents/settings#Property-Fields
-[12]: /dashboards/querying/#incident-management-analytics
+[12]: /monitors/incident_management/analytics/#overview
 [13]: /integrations/pagerduty/
 [14]: /integrations/jira/
 [15]: /integrations/webhooks/


### PR DESCRIPTION
### What does this PR do?
Fix link on IM page to go to the correct page

### Motivation
DOCS-2782

### Preview
https://docs-staging.datadoghq.com/may/im-fix-link/monitors/incident_management

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
