### PR TITLE
[prod]mike-dessailly/rate-limits-page-edit

### DIFF
--- a/content/en/api/v2/rate-limits/_index.md
+++ b/content/en/api/v2/rate-limits/_index.md
@@ -7,7 +7,7 @@ type: api
 
 All of the API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
 
-If you are rate limited, you will see a 429 in the response code. Datadog recommends to either wait the time designated by the `X-RateLimit-Limit` before making calls again, or you should switch to making calls at a frequency slightly longer than the `X-RateLimit-Limit` / `X-RateLimit-Period`.
+If you are rate limited, you will see a 429 in the response code. Datadog recommends to either wait the time designated by the `X-RateLimit-Period` before making calls again, or you should switch to making calls at a frequency slightly longer than the `X-RateLimit-Limit` / `X-RateLimit-Period`.
 
 Rate limits can be increased from the defaults by [contacting the Datadog support team][1].
 


### PR DESCRIPTION
Changing X-RateLimit-Limit to X-RateLimit-Period for rate-limits page.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Changes the X-RateLimit-Limit to X-RateLimit-Period on the Rate Limits page within the API documentation.

### Motivation
<!-- What inspired you to submit this pull request?-->
Seems like the sentence, "Datadog recommends to either wait the time designated by the X-RateLimit-Limit before making calls again, or you should switch to making calls at a frequency slightly longer than the X-RateLimit-Limit / X-RateLimit-Period" should read, 

"Datadog recommends to either wait the time designated by the **X-RateLimit-Period** before making calls again, or you should switch to making calls at a frequency slightly longer than the X-RateLimit-Limit / X-RateLimit-Period"

### Preview
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/api/latest/rate-limits/

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/farfalle211/rate-limits-edit/<PATH>

^ Not sure what the <PATH> is here.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
