### PR TITLE
DOCS-2827 Tabs for profiler setup options

### DIFF
--- a/content/en/tracing/profiler/enabling/java.md
+++ b/content/en/tracing/profiler/enabling/java.md
@@ -44,33 +44,38 @@ To begin profiling applications:
 
      **Note**: Profiler is available in the `dd-java-agent.jar` library in versions 0.55+.
 
-3. Set `-Ddd.profiling.enabled` flag or `DD_PROFILING_ENABLED` environment variable to `true`. Your service invocation should look like:
+3. Enable the profiler by setting `-Ddd.profiling.enabled` flag or `DD_PROFILING_ENABLED` environment variable to `true`. Specify `dd.service`, `dd.env`, and `dd.version` so you can filter and group your profiles across these dimensions:
+   {{< tabs >}}
+{{% tab "Command arguments" %}}
 
-    ```diff
-    java \
-        -javaagent:dd-java-agent.jar \
-        -Ddd.service=<YOUR_SERVICE> \
-        -Ddd.env=<YOUR_ENVIRONMENT> \
-        -Ddd.version=<YOUR_VERSION> \
-        -Ddd.profiling.enabled=true \
-        -XX:FlightRecorderOptions=stackdepth=256 \
-        -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
-    ```
+Invoke your service: 
+```diff
+java \
+    -javaagent:dd-java-agent.jar \
+    -Ddd.service=<YOUR_SERVICE> \
+    -Ddd.env=<YOUR_ENVIRONMENT> \
+    -Ddd.version=<YOUR_VERSION> \
+    -Ddd.profiling.enabled=true \
+    -XX:FlightRecorderOptions=stackdepth=256 \
+    -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
+```
 
-    **Recommendation**: Specify `dd.service`, `dd.env`, and `dd.version` so you can filter and group your profiles across these dimensions.
+{{% /tab %}}
+{{% tab "Environment variables" %}}
 
-    You can also [use environment variables](#environment-variables) to set the parameters as such:
+```diff
+export DD_SERVICE=<YOUR_SERVICE>
+export DD_ENV=<YOUR_ENV>
+export DD_VERSION=<YOUR_VERSION>
+export DD_PROFILING_ENABLED=true
+java \
+    -javaagent:dd-java-agent.jar \
+    -XX:FlightRecorderOptions=stackdepth=256 \
+    -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
+```
 
-    ```diff
-    export DD_SERVICE=<YOUR_SERVICE>
-    export DD_ENV=<YOUR_ENV>
-    export DD_VERSION=<YOUR_VERSION>
-    export DD_PROFILING_ENABLED=true
-    java \
-        -javaagent:dd-java-agent.jar \
-        -XX:FlightRecorderOptions=stackdepth=256 \
-        -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
-    ```
+{{% /tab %}}
+{{< /tabs >}}
 
     **Note**: The `-javaagent` argument needs to be before `-jar`, adding it as a JVM option rather than an application argument. For more information, see the [Oracle documentation][6]:
 

--- a/content/en/tracing/profiler/enabling/nodejs.md
+++ b/content/en/tracing/profiler/enabling/nodejs.md
@@ -40,37 +40,44 @@ To begin profiling applications:
 
 2. Run `npm install --save dd-trace@latest` to add a dependency on the `dd-trace` module which includes the profiler.
 
-3. You can enable the profiler with environment variables:
+3. Enable the profiler:
 
-    ```shell
-    export DD_PROFILING_ENABLED=true
-    export DD_ENV=prod
-    export DD_SERVICE=my-web-app
-    export DD_VERSION=1.0.3
-    ```
+   {{< tabs >}}
+{{% tab "Environment variables" %}}
 
-    **Note**: If you’re already using Datadog APM, you are already calling `init` and don’t need to do so again. If you are not, ensure the tracer and the profiler are loaded together:
+```shell
+export DD_PROFILING_ENABLED=true
+export DD_ENV=prod
+export DD_SERVICE=my-web-app
+export DD_VERSION=1.0.3
+```
 
-    ```node
-    node -r dd-trace/init app.js
-    ```
+**Note**: If you’re already using Datadog APM, you are already calling `init` and don’t need to do so again. If you are not, ensure the tracer and the profiler are loaded together:
 
-    or
+```node
+node -r dd-trace/init app.js
+```
 
-    ```node
-    const tracer = require('dd-trace/init')
-    ```
+{{% /tab %}}
+{{% tab "In code" %}}
 
-    Or you can enable the profiler in code:
+```js
+const tracer = require('dd-trace').init({
+  profiling: true,
+  env: 'prod',
+  service: 'my-web-app',
+  version: '1.0.3'
+})
+```
 
-    ```js
-    const tracer = require('dd-trace').init({
-      profiling: true,
-      env: 'prod',
-      service: 'my-web-app',
-      version: '1.0.3'
-    })
-    ```
+**Note**: If you’re already using Datadog APM, you are already calling `init` and don’t need to do so again. If you are not, ensure the tracer and the profiler are loaded together:
+
+```node
+const tracer = require('dd-trace/init')
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 4. A minute or two after starting your Node.js application, your profiles will show up on the [APM > Profiler page][4].
 

--- a/content/en/tracing/profiler/enabling/ruby.md
+++ b/content/en/tracing/profiler/enabling/ruby.md
@@ -47,28 +47,34 @@ To begin profiling applications:
 
 2. Install the gems with `bundle install`.
 
-3. You can auto-enable the profiler with environment variables:
+3. Enable the profiler:
 
-    ```shell
-    export DD_PROFILING_ENABLED=true
-    export DD_ENV=prod
-    export DD_SERVICE=my-web-app
-    export DD_VERSION=1.0.3
-    ```
+   {{< tabs >}}
+{{% tab "Environment variables" %}}
 
-    or in code:
+```shell
+export DD_PROFILING_ENABLED=true
+export DD_ENV=prod
+export DD_SERVICE=my-web-app
+export DD_VERSION=1.0.3
+```
 
-    ```ruby
-    Datadog.configure do |c|
-      c.profiling.enabled = true
-      c.env = 'prod'
-      c.service = 'my-web-app'
-      c.version = '1.0.3'
-    end
-    ```
+{{% /tab %}}
+{{% tab "In code" %}}
 
-    **Note**: For Rails applications you can create a `config/initializers/datadog.rb` file with the code configuration above.
+```ruby
+Datadog.configure do |c|
+  c.profiling.enabled = true
+  c.env = 'prod'
+  c.service = 'my-web-app'
+  c.version = '1.0.3'
+end
+```
 
+**Note**: For Rails applications, create a `config/initializers/datadog.rb` file with the code configuration above.
+
+{{% /tab %}}
+{{< /tabs >}}
 
 4. Add the `ddtracerb exec` command to your Ruby application start command:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Puts the options for enabling the profiler onto tabs

### Motivation
DOCS-2827

### Preview
https://docs-staging.datadoghq.com/kari/docs-2827-profiler-setup/tracing/profiler/enabling/java
https://docs-staging.datadoghq.com/kari/docs-2827-profiler-setup/tracing/profiler/enabling/ruby
https://docs-staging.datadoghq.com/kari/docs-2827-profiler-setup/tracing/profiler/enabling/nodejs

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
