### PR TITLE
DOCS-2235 Specify Serverless in titles

### DIFF
--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Custom Metrics
+title: Custom Metrics from Serverless Applications
 kind: documentation
 ---
 

--- a/content/en/serverless/deployment_tracking/_index.md
+++ b/content/en/serverless/deployment_tracking/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Deployment Tracking
+title: Deployment Tracking for Serverless Applications
 kind: documentation
 further_reading:
     - link: '/serverless/distributed_tracing'
@@ -38,4 +38,3 @@ If you have already added the permission, but you still don't see events for any
 
 [1]: https://app.datadoghq.com/functions
 [2]: /integrations/amazon_web_services/#setup
-[3]: /help/

--- a/content/en/serverless/distributed_tracing/_index.md
+++ b/content/en/serverless/distributed_tracing/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Distributed Tracing
+title: Distributed Tracing with Serverless Applications
 kind: documentation
 aliases:
   - /tracing/serverless_functions

--- a/content/en/serverless/installation/dotnet.md
+++ b/content/en/serverless/installation/dotnet.md
@@ -1,5 +1,5 @@
 ---
-title: Instrumenting .NET Applications
+title: Instrumenting .NET Serverless Applications
 kind: documentation
 further_reading:
 - link: 'serverless/serverless_tagging/'

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -1,5 +1,5 @@
 ---
-title: Instrumenting Go Applications
+title: Instrumenting Go Serverless Applications
 kind: documentation
 further_reading:
 - link: 'serverless/datadog_lambda_library/go'
@@ -115,7 +115,7 @@ Follow these steps to instrument the function:
 
 ### Unified service tagging
 
-Datadog recommends tagging your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension documentation][10] for more details.
+Datadog recommends tagging your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension documentation][6] for more details.
 
 ## Explore
 
@@ -177,8 +177,7 @@ If your Lambda function is running in a VPC, follow the [Datadog Lambda Extensio
 [3]: https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-to-al2/
 [4]: https://github.com/DataDog/datadog-lambda-go
 [5]: https://app.datadoghq.com/organization-settings/api-keys
-[6]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
+[6]: /serverless/libraries_integrations/extension/#tagging
 [7]: https://app.datadoghq.com/functions
 [8]: /serverless/custom_metrics?tab=go
 [9]: /serverless/guide/extension_private_link/
-[10]: /serverless/libraries_integrations/extension/#tagging

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -1,5 +1,5 @@
 ---
-title: Instrumenting Java Applications
+title: Instrumenting Java Serverless Applications
 kind: documentation
 further_reading:
 - link: 'serverless/serverless_tagging/'

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -1,5 +1,5 @@
 ---
-title: Instrumenting Node.js Applications
+title: Instrumenting Node.js Serverless Applications
 kind: documentation
 further_reading:
 - link: "/serverless/serverless_integrations/plugin/"
@@ -444,7 +444,7 @@ After you have configured your function following the steps above, you can view 
 
 ### Unified service tagging
 
-Datadog recommends tagging your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension documentation][9] for more details.
+Datadog recommends tagging your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension documentation][4] for more details.
 
 ### Collect logs from AWS serverless resources
 
@@ -517,9 +517,8 @@ If your Lambda function is running in a VPC, follow the [Datadog Lambda Extensio
 [1]: /integrations/amazon_web_services/
 [2]: /serverless/guide/datadog_forwarder_node
 [3]: https://app.datadoghq.com/functions
-[4]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
+[4]: /serverless/libraries_integrations/extension/#tagging
 [5]: /serverless/libraries_integrations/forwarder
 [6]: /serverless/custom_metrics?tab=nodejs
 [7]: /tracing/custom_instrumentation/nodejs/
 [8]: /serverless/guide/extension_private_link/
-[9]: /serverless/libraries_integrations/extension/#tagging

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -1,5 +1,5 @@
 ---
-title: Instrumenting Python Applications
+title: Instrumenting Python Serverless Applications
 kind: documentation
 further_reading:
 - link: "/serverless/serverless_integrations/plugin/"
@@ -556,7 +556,7 @@ After you have configured your function following the steps above, you can view 
 
 ### Unified service tagging
 
-Datadog recommends tagging your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension documentation][10] for more details.
+Datadog recommends tagging your serverless applications with `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, and `DD_TAGS`. See the [Lambda extension documentation][5] for more details.
 
 ### Collect logs from AWS serverless resources
 
@@ -618,9 +618,8 @@ If your Lambda function is running in a VPC, follow the [Datadog Lambda Extensio
 [2]: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html
 [3]: /serverless/guide/datadog_forwarder_python
 [4]: https://app.datadoghq.com/functions
-[5]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
+[5]: /serverless/libraries_integrations/extension/#tagging
 [6]: /serverless/libraries_integrations/forwarder
 [7]: /serverless/custom_metrics?tab=python
 [8]: /tracing/custom_instrumentation/python/
 [9]: /serverless/guide/extension_private_link/
-[10]: /serverless/libraries_integrations/extension/#tagging

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -1,5 +1,5 @@
 ---
-title: Instrumenting Ruby Applications
+title: Instrumenting Ruby Serverless Applications
 kind: documentation
 further_reading:
 - link: 'serverless/serverless_tagging/'

--- a/content/en/serverless/libraries_integrations/_index.md
+++ b/content/en/serverless/libraries_integrations/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Libraries & Integrations
+title: Serverless Libraries and Integrations
 kind: documentation
 further_reading:
 - link: "/serverless/serverless_integrations/plugin/"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds "Serverless" to several page titles so that they're distinguishable in search results from "regular" tracing pages.

### Motivation
DOCS-2235 APM PM request

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/docs-2235-title-clarification/serverless/custom_metrics/
https://docs-staging.datadoghq.com/kari/docs-2235-title-clarification/serverless/deployment_tracking/
https://docs-staging.datadoghq.com/kari/docs-2235-title-clarification/serverless/distributed_tracing/
https://docs-staging.datadoghq.com/kari/docs-2235-title-clarification/serverless/installation/dotnet
https://docs-staging.datadoghq.com/kari/docs-2235-title-clarification/serverless/installation/go
https://docs-staging.datadoghq.com/kari/docs-2235-title-clarification/serverless/installation/java
https://docs-staging.datadoghq.com/kari/docs-2235-title-clarification/serverless/installation/nodejs
https://docs-staging.datadoghq.com/kari/docs-2235-title-clarification/serverless/installation/python
https://docs-staging.datadoghq.com/kari/docs-2235-title-clarification/serverless/installation/ruby
https://docs-staging.datadoghq.com/kari/docs-2235-title-clarification/serverless/libraries_integrations/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
