### PR TITLE
[Windows][Installer] On domain controllers, the password must be specified

### DIFF
--- a/content/en/agent/faq/windows-agent-ddagent-user.md
+++ b/content/en/agent/faq/windows-agent-ddagent-user.md
@@ -75,7 +75,7 @@ It must be separated from the `<USERNAME>` with a backslash `\`.
 
 When installing the Agent on a domain controller, there is no notion of local user account. So if the installer creates a user account, it is a domain user rather than a local one.
 
-If a user account is specified on the command line, but this user account is not found on the system, the installer attempts to create it. If a password was specified, the installer uses that password, otherwise it generate a random password.
+If a user account is specified on the command line, but this user account is not found on the system, the installer attempts to create it. A password must be specified for the installation to succeed.
 
 If the specified user account is from a parent domain, the installer uses that user account.
 If the user account doesn't exist, it creates the user account in the child domain (the domain that the controller is joined to). The installer never creates a user account in the parent domain.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR corrects the documentation for the Windows installer to reflect that it's mandatory to specify the `DDAGENTUSER_PASSWORD` when installing on a Domain Controller.

### Motivation
Prevent support escalations.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/julien.lebot/update_dc_install_pass_doc/agent/faq/windows-agent-ddagent-user/

### Additional Notes
Source: https://github.com/DataDog/datadog-agent/blob/main/tools/windows/install-help/cal/caninstall.cpp#L73-L75

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
