### PR TITLE
DOCS-2810 adding mentions of OKE support where applicable

### DIFF
--- a/content/en/agent/guide/docker-deprecation.md
+++ b/content/en/agent/guide/docker-deprecation.md
@@ -9,9 +9,11 @@ Kubernetes is deprecating Docker as a runtime starting after version 1.20, and s
 
 - GKE 1.19 [deprecated Docker and uses containerd by default, on new nodes][2].
 
-- EKS 1.22 [deprecates Docker and uses containerd by default][3].
+- EKS 1.22 [deprecated Docker and uses containerd by default][3].
 
-If you are running a version of Kubernetes where Docker has been deprecated, the Docker socket is no longer present, or has no information about the containers running by Kubernetes, and the Docker check does not work. You can find details about Docker runtime on [kubernetes.io][4]. This means that you must enable either the [containerd][5] or the [CRI-O][6] check depending on the container runtime you are using. The container metrics collected from the new container runtime replace the Docker metrics.
+- OKE 1.20 [deprecated Docker and uses CRI-O by default][4].
+
+If you are running a version of Kubernetes where Docker has been deprecated, the Docker socket is no longer present, or has no information about the containers running by Kubernetes, and the Docker check does not work. You can find details about Docker runtime on [kubernetes.io][5]. This means that you must enable either the [containerd][6] or the [CRI-O][7] check depending on the container runtime you are using. The container metrics collected from the new container runtime replace the Docker metrics.
 
 With version 7.27+ of the Datadog Agent, the Agent automatically detects the environment you are running, and you do not need to make any configuration changes.
 
@@ -67,6 +69,7 @@ volumes:
 [1]: https://github.com/Azure/AKS/releases/tag/2020-11-16
 [2]: https://cloud.google.com/kubernetes-engine/docs/release-notes#December_08_2020
 [3]: https://aws.amazon.com/blogs/containers/amazon-eks-1-21-released/
-[4]: https://kubernetes.io/docs/tasks/administer-cluster/migrating-from-dockershim/check-if-dockershim-deprecation-affects-you/#role-of-dockershim
-[5]: /integrations/containerd/
-[6]: /integrations/crio/
+[4]: https://docs.oracle.com/en-us/iaas/releasenotes/changes/52d34150-0cb8-4a0f-95f3-924dec5a3c83/
+[5]: https://kubernetes.io/docs/tasks/administer-cluster/migrating-from-dockershim/check-if-dockershim-deprecation-affects-you/#role-of-dockershim
+[6]: /integrations/containerd/
+[7]: /integrations/crio/

--- a/content/en/agent/kubernetes/_index.md
+++ b/content/en/agent/kubernetes/_index.md
@@ -42,7 +42,7 @@ Run the Datadog Agent in your Kubernetes cluster as a DaemonSet in order to star
 ## Installation
 
 **Notes**:
-- Dedicated documentation and examples for [all major Kubernetes distributions][2] (GKE, EKS, AKS, OpenShift, Rancher, etc.) are available.
+- Dedicated documentation and examples for [all major Kubernetes distributions][2] (GKE, EKS, AKS, OpenShift, Rancher, OKE, etc.) are available.
 - Dedicated documentation and examples for [Kubernetes Control Plane monitoring][3] are also available.
 
 {{< tabs >}}

--- a/content/en/agent/kubernetes/distributions.md
+++ b/content/en/agent/kubernetes/distributions.md
@@ -32,6 +32,7 @@ These configuration can then be customized to add any Datadog feature.
 * [Google Kubernetes Engine (GKE)](#GKE)
 * [Red Hat OpenShift](#Openshift)
 * [Rancher](#Rancher)
+* [Oracle Container Engine for Kubernetes (OKE)](#OKE)
 
 ## AWS Elastic Kubernetes Service (EKS) {#EKS}
 
@@ -376,6 +377,58 @@ spec:
       - effect: NoExecute
         key: node-role.kubernetes.io/etcd
         operator: Exists
+  clusterAgent:
+    image:
+      name: "gcr.io/datadoghq/cluster-agent:latest"
+    config:
+      externalMetrics:
+        enabled: false
+      admissionController:
+        enabled: false
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Oracle Container Engine for Kubernetes (OKE) {#OKE}
+
+No specific configuration is required.
+
+To enable container monitoring, add the following (`containerd` check):
+
+{{< tabs >}}
+{{% tab "Helm" %}}
+
+Custom `values.yaml`:
+
+```
+datadog:
+  apiKey: <DATADOG_API_KEY>
+  appKey: <DATADOG_APP_KEY>
+  criSocketPath: /run/dockershim.sock
+  env:
+  - name: DD_AUTOCONFIG_INCLUDE_FEATURES
+    value: "containerd"
+```
+
+{{% /tab %}}
+{{% tab "Operator" %}}
+
+DatadogAgent Kubernetes Resource:
+
+```
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  credentials:
+    apiKey: <DATADOG_API_KEY>
+    appKey: <DATADOG_APP_KEY>
+  agent:
+    config:
+      criSocket:
+        criSocketPath: /run/dockershim.sock
   clusterAgent:
     image:
       name: "gcr.io/datadoghq/cluster-agent:latest"

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -72,7 +72,7 @@
     contents:
 
     - action: integrations
-      branch: cswatt/oke-docs
+      branch: master
       globs:
       - "*/metadata.csv"
       - "*/manifest.json"
@@ -81,7 +81,7 @@
       - "*/datadog_checks/*/__about__.py"
 
     - action: pull-and-push-folder
-      branch: cswatt/oke-docs
+      branch: master
       globs:
       - docs/dev/*.md
       options:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -72,7 +72,7 @@
     contents:
 
     - action: integrations
-      branch: master
+      branch: cswatt/oke-docs
       globs:
       - "*/metadata.csv"
       - "*/manifest.json"
@@ -81,7 +81,7 @@
       - "*/datadog_checks/*/__about__.py"
 
     - action: pull-and-push-folder
-      branch: master
+      branch: cswatt/oke-docs
       globs:
       - docs/dev/*.md
       options:


### PR DESCRIPTION
### What does this PR do?
adds mentions of OKE support alongside eks/gke/etc.

### Motivation
oracle

### Preview

https://docs-staging.datadoghq.com/cswatt/oke-docs/agent/kubernetes/distributions

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
