### PR TITLE
DOCS-1733 Add go runtime metrics page

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1874,6 +1874,11 @@ main:
     parent: tracing_runtime_metrics
     identifier: tracing_runtime_metrics_dotnet
     weight: 1205
+  - name: Go
+    url: tracing/runtime_metrics/go/
+    parent: tracing_runtime_metrics
+    identifier: tracing_runtime_metrics_go
+    weight: 1206
   - name: Continuous Profiler
     url: tracing/profiler/
     parent: tracing

--- a/content/en/tracing/runtime_metrics/go.md
+++ b/content/en/tracing/runtime_metrics/go.md
@@ -1,0 +1,54 @@
+---
+title: Go Runtime Metrics
+kind: documentation
+description: "Gain additional insights into your Go application's performance with the runtime metrics associated to your traces."
+further_reading:
+    - link: 'tracing/connect_logs_and_traces'
+      tag: 'Documentation'
+      text: 'Connect your Logs and Traces'
+    - link: 'tracing/manual_instrumentation'
+      tag: 'Documentation'
+      text: 'Manually instrument your application to create traces.'
+    - link: 'tracing/opentracing'
+      tag: 'Documentation'
+      text: 'Implement Opentracing across your applications.'
+    - link: 'tracing/visualization/'
+      tag: 'Documentation'
+      text: 'Explore your services, resources, and traces'
+---
+
+## Automatic configuration
+
+Enable Go runtime metrics collection, start the tracer using the `WithRuntimeMetrics` option:
+
+```go
+tracer.Start(tracer.WithRuntimeMetrics())
+```
+
+View runtime metrics in correlation with your Go services on the [Service page][1] in Datadog.
+
+By default, runtime metrics from your application are sent every 10 seconds to the Datadog Agent with DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][2]. If your Datadog Agent DogStatsD address differs from the default `localhost:8125`, use the `WithDogstatsdAddress` option or the environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`.
+
+If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][3], and that port `8125` is open on the Agent. Additionally, for:
+
+- **Kubernetes**: You _must_ [bind the DogstatsD port to a host port][4].
+- **ECS**: [Set the appropriate flags in your task definition][5].
+
+## Data Collected
+
+The following metrics are collected by default after enabling Go metrics.
+
+{{< get-metrics-from-git "go" >}}
+
+<!-- Along with displaying these metrics in your APM Service Page, Datadog provides a [default Go Runtime Dashboard][?] with the `service` and `runtime-id` tags that are applied to these metrics.
+-->
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://app.datadoghq.com/apm/services
+[2]: /developers/dogstatsd/#setup
+[3]: /agent/docker/#dogstatsd-custom-metrics
+[4]: /developers/dogstatsd/?tab=kubernetes#agent
+[5]: /integrations/amazon_ecs/#create-an-ecs-task

--- a/content/en/tracing/runtime_metrics/go.md
+++ b/content/en/tracing/runtime_metrics/go.md
@@ -19,7 +19,7 @@ further_reading:
 
 ## Automatic configuration
 
-Enable Go runtime metrics collection, start the tracer using the `WithRuntimeMetrics` option:
+To enable Go runtime metrics collection, start the tracer using the `WithRuntimeMetrics` option:
 
 ```go
 tracer.Start(tracer.WithRuntimeMetrics())

--- a/content/en/tracing/runtime_metrics/go.md
+++ b/content/en/tracing/runtime_metrics/go.md
@@ -40,8 +40,6 @@ The following metrics are collected by default after enabling Go metrics.
 
 {{< get-metrics-from-git "go" >}}
 
-<!-- Along with displaying these metrics in your APM Service Page, Datadog provides a [default Go Runtime Dashboard][?] with the `service` and `runtime-id` tags that are applied to these metrics.
--->
 
 ## Further Reading
 

--- a/layouts/partials/apm/apm-runtime-metrics.html
+++ b/layouts/partials/apm/apm-runtime-metrics.html
@@ -1,6 +1,6 @@
 {{ $dot := . }}
 <div class="apm-languages">
-  <div class="container cards-dd">
+  <div class="container cards-dd col-num-4">
     <div class="card-deck">
       <a class="card" href="java">
         <div class="card-body text-center py-2 px-1">
@@ -17,6 +17,8 @@
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
         </div>
       </a>
+    </div><br/>
+    <div class="card-deck">
       <a class="card" href="nodejs">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
@@ -25,6 +27,11 @@
       <a class="card" href="dotnet">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".NET" "width" "400") }}
+        </div>
+      </a>
+      <a class="card" href="go">
+        <div class="card-body text-center py-2 px-1">
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/golang.png" "class" "img-fluid" "alt" "Go" "width" "400") }}
         </div>
       </a>
     </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds page to Runtime Metrics docs about Go runtime metrics

### Motivation
DOCS-1733

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kari/docs-1733-go-runtime-metrics/tracing/runtime_metrics/go

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
