### PR TITLE
Add missing Latency distribution in Japanese

### DIFF
--- a/content/ja/tracing/guide/metrics_namespace.md
+++ b/content/ja/tracing/guide/metrics_namespace.md
@@ -59,6 +59,14 @@ aliases:
 **メトリクスタイプ:** [COUNT][5]。<br>
 **タグ:** `env`、`service`、`version`、`resource`、`http.status_class`、`http.status_code`、Datadog Host Agent からのすべてのホストタグ、[第 2 プライマリタグ][4]。
 
+### レイテンシ分布
+
+`trace.<SPAN_NAME>`
+: **前提条件:** このメトリクスは、すべての APM サービスに存在します。
+**説明:** 異なる環境や [the second primary tag][4] にまたがるすべてのサービス、リソース、バージョンのレイテンシ分布を表します。<br>
+**メトリクスタイプ:** [DISTRIBUTION][6].<br>
+**タグ:** `env`、 `service`、 `resource`、 `resource_name`、 `version`、 `synthetics`、 [the second primary tag][4].
+
 ### パーセンタイル集計
 
 `trace.<SPAN_NAME>.duration.by.resource_<2ND_PRIM_TAG>_service.<PERCENTILE_AGGREGATION>`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add [Latency distribution](https://docs.datadoghq.com/tracing/guide/metrics_namespace/#latency-distribution) in Japanese.

### Motivation

A part of [Latency distribution](https://docs.datadoghq.com/tracing/guide/metrics_namespace/#latency-distribution) is missing in Japanese page.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kei6u/latency_distribution_ja/content/ja/tracing/guide/metrics_namespace.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
