### PR TITLE
Enable syntax highlight for tracing setup in php

### DIFF
--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -435,7 +435,7 @@ $ export DD_TRACE_AGENT_PORT=8126
 
 For example, assume the following `script.php` runs a Curl request:
 
-```
+```php
 <?php
 
 sleep(1);
@@ -479,7 +479,7 @@ $ export DD_TRACE_AGENT_PORT=8126
 
 For example, assume the following `long_running.php` script:
 
-```
+```php
 <?php
 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Enable syntax highlight for tracing setup in php.

### Motivation

Readability.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kei6u-patch-1/content/en/tracing/setup_overview/setup/php.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
