### PR TITLE
[DOCS-2858] Add Integration instrumentation for Go

### DIFF
--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -180,6 +180,96 @@ If multiple extraction styles are enabled, extraction attempts are made
 in the order that those styles are specified. The first successfully
 extracted value is used.
 
+## Integration instrumentation
+
+Many popular libraries are supported out-of-the-box, which can be auto-instrumented.
+
+### gRPC
+
+The `gRPC` integration adds both client and server interceptors, which run as middleware before executing the service’s remote procedure call. As gRPC applications are often distributed, the integration shares trace information between client and server.
+
+Server side:
+
+```go
+import (
+	dd_grpc "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
+	"google.golang.org/grpc"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+func main() {
+	tracer.Start()
+	defer tracer.Stop()
+
+	// (...)
+
+	s := grpc.NewServer(
+			dd_grpc.UnaryServerInterceptor(),
+			dd_grpc.StreamServerInterceptor(),
+		),
+	)
+
+	// (...)
+}
+```
+
+Client side:
+
+```go
+import (
+	"context"
+
+	dd_grpc "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
+	"google.golang.org/grpc"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+func main() {
+	tracer.Start()
+	defer tracer.Stop()
+
+	// (...)
+
+	conn, err := grpc.DialContext(
+		context.Background(),
+		":8080",
+		dd_grpc.UnaryClientInterceptor(),
+		dd_grpc.StreamClientInterceptor(),
+	)
+
+	// (...)
+}
+```
+
+### net/http
+
+```go
+import (
+	"net/http"
+
+	dd_http "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+func main() {
+	tracer.Start()
+	defer tracer.Stop()
+
+	// (...)
+
+	s := &http.Server{
+		Addr: ":8080",
+		Handler: dd_http.WrapHandler(
+			http.DefaultServeMux,
+			"your_service",
+			"your_resource",
+		),
+	}
+
+	// (...)
+}
+```
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add Integration instrumentation for Go.

### Motivation

Integration instrumentation for Go would be helpful like a [Ruby page](https://docs.datadoghq.com/tracing/setup_overview/setup/ruby#integration-instrumentation).

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
