### PR TITLE
Clarify Dogstatsd origin detection documentation

### DIFF
--- a/content/en/agent/kubernetes/tag.md
+++ b/content/en/agent/kubernetes/tag.md
@@ -62,8 +62,6 @@ The Agent can autodiscover and attach tags to all data emitted by the entire pod
 
 </div>
 
-**Note:** To apply these [Out-Of-The-Box tags](?tab=containerizedagent#out-of-the-box-tags) to custom metrics sent over UDS, [Origin Detection](?tab=host#origin-detection) needs to be enabled. To properly detect the origin for DogStatsD metrics and to tag appropriately set  'useHostPID: true' in your deployment file. 
-
 
 ### Host tag
 

--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -151,9 +151,12 @@ With this, any pod running your application is able to send DogStatsD metrics wi
 
 #### Origin detection over UDP
 
-Origin detection is supported in Agent 6.10.0+ and allows DogStatsD to detect where the container metrics come from, and tag metrics automatically. When this mode is enabled, all metrics received through UDP are tagged by the same container tags as Autodiscovery metrics.
+Origin detection is supported in Agent 6.10.0+ and allows DogStatsD to detect where the container metrics come from, and tag metrics automatically. When this mode is enabled, all metrics received through UDP are tagged by the same pod tags as Autodiscovery metrics.
 
-**Note**: An alternative to UDP is [Unix Domain Sockets][4].
+**Notes**: 
+
+* Origin detection with UDP uses the pod ID as the entity ID, so container-level tags are not emitted.
+* An alternative to UDP is [Unix Domain Sockets][4].
 
 To enable origin detection over UDP, add the following lines to your application manifest:
 

--- a/content/en/developers/dogstatsd/unix_socket.md
+++ b/content/en/developers/dogstatsd/unix_socket.md
@@ -161,7 +161,7 @@ Origin detection allows DogStatsD to detect where the container metrics come fro
 {{% /tab %}}
 {{% tab "Docker" %}}
 
-1. Set the `DD_DOGSTATSD_ORIGIN_DETECTION=true` environement variable for the Agent container.
+1. Set the `DD_DOGSTATSD_ORIGIN_DETECTION=true` environment variable for the Agent container.
 
 2. Optional - To configure [tag cardinality][1] for the metrics collected using origin detection, set the environment variable `DD_DOGSTATSD_TAG_CARDINALITY` to `low` (default), `orchestrator`, or `high`.
 
@@ -183,7 +183,16 @@ When running inside a container, DogStatsD needs to run in the host's PID namesp
           value: 'true'
     ```
 
-2. Optional - To configure [tag cardinality][1] for the metrics collected using origin detection, set the environment variable `DD_DOGSTATSD_TAG_CARDINALITY` to `low` (default), `orchestrator`, or `high`:
+2. Set `hostPID: true` in the pod template spec:
+
+    ```yaml
+    # (...)
+    spec:
+        # (...)
+        hostPID: true
+    ```
+
+3. Optional - To configure [tag cardinality][1] for the metrics collected using origin detection, set the environment variable `DD_DOGSTATSD_TAG_CARDINALITY` to `low` (default), `orchestrator`, or `high`:
 
     ```yaml
     # (...)


### PR DESCRIPTION
### What does this PR do?
- Clarify tags emitted with Origin Detection with UDP
- Move instructions to use `hostPID` parameter to Origin Detection with UDS docs

### Motivation
Better user experience

### Preview
https://docs-staging.datadoghq.com/celene/dsd_fixes/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp
https://docs-staging.datadoghq.com/celene/dsd_fixes/developers/dogstatsd/unix_socket/?tab=kubernetes#origin-detection

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
