### PR TITLE
docs: remove `source` from `addError` calls

### DIFF
--- a/content/fr/real_user_monitoring/browser/collecting_browser_errors.md
+++ b/content/fr/real_user_monitoring/browser/collecting_browser_errors.md
@@ -92,7 +92,7 @@ datadogRum.addError(error, {
 
 // Envoyer une erreur network
 fetch('<UNE_URL>').catch(function(error) {
-    datadogRum.addError(error, undefined);
+    datadogRum.addError(error);
 })
 
 // Envoyer une erreur d'exception gérée

--- a/content/fr/real_user_monitoring/browser/collecting_browser_errors.md
+++ b/content/fr/real_user_monitoring/browser/collecting_browser_errors.md
@@ -71,8 +71,7 @@ Surveillez les exceptions gérées, les objets Promise rejetés et les autres er
 {{< code-block lang="javascript" >}}
 addError(
     error: unknown,
-    context?: Context,
-    source: ErrorSource.CUSTOM | ErrorSource.NETWORK | ErrorSource.SOURCE = ErrorSource.CUSTOM
+    context?: Context
 );
 {{< /code-block >}}
 
@@ -93,14 +92,14 @@ datadogRum.addError(error, {
 
 // Envoyer une erreur network
 fetch('<UNE_URL>').catch(function(error) {
-    datadogRum.addError(error, undefined, 'network');
+    datadogRum.addError(error, undefined);
 })
 
 // Envoyer une erreur d'exception gérée
 try {
     //Logique de code
 } catch (error) {
-    datadogRum.addError(error, undefined, 'source');
+    datadogRum.addError(error, undefined);
 }
 ```
 {{% /tab %}}

--- a/content/fr/real_user_monitoring/browser/collecting_browser_errors.md
+++ b/content/fr/real_user_monitoring/browser/collecting_browser_errors.md
@@ -99,7 +99,7 @@ fetch('<UNE_URL>').catch(function(error) {
 try {
     //Logique de code
 } catch (error) {
-    datadogRum.addError(error, undefined);
+    datadogRum.addError(error);
 }
 ```
 {{% /tab %}}


### PR DESCRIPTION
this argument was removed at https://github.com/DataDog/browser-sdk/pull/936

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
