### PR TITLE
remove outdated further reading

### DIFF
--- a/content/en/monitors/incident_management/analytics.md
+++ b/content/en/monitors/incident_management/analytics.md
@@ -43,10 +43,6 @@ To configure your graph using Incident Management Analytics data, follow these s
 
 {{< img src="monitors/incidents/incident_analytics_query_example.jpeg" alt="Incident Analytics Query Example" style="width:80%;">}}
 
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
-
 [1]: /dashboards/
 [2]: /notebooks/
 [3]: https://app.datadoghq.com/dash/integration/30523/incident-management-overview?from_ts=1632093826308&to_ts=1634685826308&live=true

--- a/content/en/monitors/incident_management/analytics.md
+++ b/content/en/monitors/incident_management/analytics.md
@@ -2,10 +2,6 @@
 title: Incident Management Analytics
 kind: documentation
 description: Track and analyze aggregated incident management statistics in Dashboards and Notebooks
-further_reading:
-- link: "dashboards/querying/#incident-management-analytics"
-  tag: "Documentation"
-  text: "Incident Management Analytics"
 ---
 
 ## Overview


### PR DESCRIPTION
old page that was linked to no longer has relevant section which also may not exist. tldr the further reading link was outdated so now it is gone

https://docs-staging.datadoghq.com/cswatt/im-edit/monitors/incident_management/analytics

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
