### PR TITLE
Fix database monitoring parts of haproxy example configuration

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -306,6 +306,7 @@ backend datadog-logs-http
 
 backend datadog-database-monitoring-metrics
     balance roundrobin
+    mode http
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 dbm-metrics-intake.datadoghq.com:443  check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
@@ -313,6 +314,7 @@ backend datadog-database-monitoring-metrics
 
 backend datadog-database-monitoring-samples
     balance roundrobin
+    mode http
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 dbquery-intake.datadoghq.com:443  check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
@@ -469,6 +471,7 @@ backend datadog-logs-http
 
 backend datadog-database-monitoring-metrics
     balance roundrobin
+    mode http
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 dbm-metrics-intake.datadoghq.eu:443  check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
@@ -476,6 +479,7 @@ backend datadog-database-monitoring-metrics
 
 backend datadog-database-monitoring-samples
     balance roundrobin
+    mode http
     # The following configuration is for HAProxy 1.8 and newer
     server-template mothership 5 dbquery-intake.datadoghq.eu:443  check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
@@ -521,11 +525,14 @@ logs_config:
 
 database_monitoring:
     metrics:
-        dd_url: http://haproxy.example.com:3838
+        logs_dd_url: haproxy.example.com:3838
+        logs_no_ssl: true
     activity:
-        dd_url: http://haproxy.example.com:3838
+        logs_dd_url: haproxy.example.com:3838
+        logs_no_ssl: true
     samples:
-        dd_url: http://haproxy.example.com:3839
+        logs_dd_url: haproxy.example.com:3839
+        logs_no_ssl: true
 ```
 
 Then edit the `datadog.yaml` Agent configuration file and set `skip_ssl_validation` to `true`. This is needed to make the Agent ignore the discrepancy between the hostname on the SSL certificate (`app.datadoghq.com` or `app.datadoghq.eu`) and your HAProxy hostname:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This updates the database monitoring elements of the agent's proxy guide for HA Proxy. There were a few things missing from the first pass and this one was tested locally to confirm that this works end-to-end.

### Motivation
Have a working example of database monitoring data going through HA proxy.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->

https://docs-staging.datadoghq.com/alex.normand/fix-dbm-ha-proxy-configuration/agent/proxy/?tab=agentv6v7#haproxy

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
