### PR TITLE
Update which Agent services run as root/non-root

### DIFF
--- a/content/en/security/agent.md
+++ b/content/en/security/agent.md
@@ -64,7 +64,7 @@ If you believe you've discovered a bug in Datadog's security, get in touch at [s
 
 ## Running as an unprivileged user
 
-By default, the Agent runs as the `dd-agent` user on Linux and as the `ddagentuser` account on [Windows][18]. Note the `system-probe` and `security-agent` services are an exception to this, and still need to run as `root` on Linux and `LOCAL_SYSTEM` on Windows.
+By default, the Agent runs as the `dd-agent` user on Linux and as the `ddagentuser` account on [Windows][18]. Note there are two exceptions to this: the `system-probe` which runs as `root` on Linux and as `LOCAL_SYSTEM` on Windows and the `process-agent` which runs as `LOCAL_SYSTEM` on Windows.
 
 ## Secrets management
 

--- a/content/en/security/agent.md
+++ b/content/en/security/agent.md
@@ -64,7 +64,7 @@ If you believe you've discovered a bug in Datadog's security, get in touch at [s
 
 ## Running as an unprivileged user
 
-By default, the Agent runs as the `dd-agent` user on Linux and as the `ddagentuser` account on [Windows][18]. Note there are two exceptions to this: the `system-probe` which runs as `root` on Linux and as `LOCAL_SYSTEM` on Windows and the `process-agent` which runs as `LOCAL_SYSTEM` on Windows.
+By default, the Agent runs as the `dd-agent` user on Linux and as the `ddagentuser` account on [Windows][18]. Note there are some exceptions to this: the `system-probe` which runs as `root` on Linux and as `LOCAL_SYSTEM` on Windows, the `process-agent` which runs as `LOCAL_SYSTEM` on Windows, and the `security-agent` which runs as `root` on Linux.
 
 ## Secrets management
 

--- a/content/en/security/agent.md
+++ b/content/en/security/agent.md
@@ -64,7 +64,11 @@ If you believe you've discovered a bug in Datadog's security, get in touch at [s
 
 ## Running as an unprivileged user
 
-By default, the Agent runs as the `dd-agent` user on Linux and as the `ddagentuser` account on [Windows][18]. Note there are some exceptions to this: the `system-probe` which runs as `root` on Linux and as `LOCAL_SYSTEM` on Windows, the `process-agent` which runs as `LOCAL_SYSTEM` on Windows, and the `security-agent` which runs as `root` on Linux.
+By default, the Agent runs as the `dd-agent` user on Linux and as the `ddagentuser` account on [Windows][18]. The exceptions are as follows:
+
+- The `system-probe` runs as `root` on Linux and as `LOCAL_SYSTEM` on Windows.
+- The `process-agent` runs as `LOCAL_SYSTEM` on Windows.
+- The `security-agent` runs as `root` on Linux.
 
 ## Secrets management
 

--- a/content/en/security/agent.md
+++ b/content/en/security/agent.md
@@ -66,6 +66,8 @@ If you believe you've discovered a bug in Datadog's security, get in touch at [s
 
 By default, the Agent runs as the `dd-agent` user on Linux and as the `ddagentuser` account on [Windows][18]. Note there are some exceptions to this: the `system-probe` which runs as `root` on Linux and as `LOCAL_SYSTEM` on Windows, the `process-agent` which runs as `LOCAL_SYSTEM` on Windows, and the `security-agent` which runs as `root` on Linux.
 
+The `process-agent` can be configured to run as the unprivileged `ddagentuser` on Windows, but some functionality will be missing. In specific, the command line of each process won't be available in Datadog.
+
 ## Secrets management
 
 Customers with a requirement to avoid storing secrets in plaintext in the Agent's configuration files can leverage the [secrets management][19] package. This package allows the Agent to call a user-provided executable to handle retrieval or decryption of secrets, which are then loaded in memory by the Agent. Users have the flexibility to design their executable according to their preferred key management service, authentication method, and continuous integration workflow.

--- a/content/en/security/agent.md
+++ b/content/en/security/agent.md
@@ -66,8 +66,6 @@ If you believe you've discovered a bug in Datadog's security, get in touch at [s
 
 By default, the Agent runs as the `dd-agent` user on Linux and as the `ddagentuser` account on [Windows][18]. Note there are some exceptions to this: the `system-probe` which runs as `root` on Linux and as `LOCAL_SYSTEM` on Windows, the `process-agent` which runs as `LOCAL_SYSTEM` on Windows, and the `security-agent` which runs as `root` on Linux.
 
-The `process-agent` can be configured to run as the unprivileged `ddagentuser` on Windows, but some functionality will be missing. In specific, the command line of each process won't be available in Datadog.
-
 ## Secrets management
 
 Customers with a requirement to avoid storing secrets in plaintext in the Agent's configuration files can leverage the [secrets management][19] package. This package allows the Agent to call a user-provided executable to handle retrieval or decryption of secrets, which are then loaded in memory by the Agent. Users have the flexibility to design their executable according to their preferred key management service, authentication method, and continuous integration workflow.


### PR DESCRIPTION
### What does this PR do?
Update the "Running as an unprivileged user" about which Agent services run as root/non-root.

### Motivation
The previous docs where incorrect.

### Preview
https://docs-staging.datadoghq.com/albertvaka/process-agent-runs-as-root/security/agent/#running-as-an-unprivileged-user

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
