### PR TITLE
(DOCS-2869) clarify first bucket is the earliest

### DIFF
--- a/content/en/monitors/create/types/metric.md
+++ b/content/en/monitors/create/types/metric.md
@@ -188,7 +188,7 @@ The following logic determines the bucket size:
 
 In order to be considered as a "full window", the monitor requires:
 
-1. At least one data point in the first bucket.
+1. At least one data point in the first bucket. The first bucket is the chronologically earliest bucket in the window.
 2. At most three buckets in total with no data points (including the first one).
 
 If the conditions are met, the monitor is evaluated. Otherwise, the evaluation is canceled and the monitor state is unchanged.

--- a/content/en/monitors/create/types/metric.md
+++ b/content/en/monitors/create/types/metric.md
@@ -188,7 +188,7 @@ The following logic determines the bucket size:
 
 In order to be considered as a "full window", the monitor requires:
 
-1. At least one data point in the first bucket. The first bucket is the chronologically earliest bucket in the window.
+1. At least one data point in the first bucket. The first bucket is chronologically the earliest bucket in the window.
 2. At most three buckets in total with no data points (including the first one).
 
 If the conditions are met, the monitor is evaluated. Otherwise, the evaluation is canceled and the monitor state is unchanged.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Clarify documentation around how `require_full_window` works, specifically that the "first bucket" in an evaluation window is the earliest chronologically. I'm actually *assuming* that this is indeed the case, but would be nice to clarify that behavior before approving this / documenting it.

### Motivation
I frequently have issues with getting the desired behavior when leverage `require_full_window: true` in monitors. I recently stumbled across these docs which are amazing, and this was the one thing that I immediately wanted clarification on.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
I have not confirmed that this is actually true in practice.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
