### PR TITLE
[WEB-1958] Fix Mobile ToC Toggle Visuals

### DIFF
--- a/assets/styles/components/_table-of-contents.scss
+++ b/assets/styles/components/_table-of-contents.scss
@@ -30,6 +30,11 @@ body > header.scrolled ~ .container .mobile-toc-toggle {
 
     cursor: pointer;
     cursor: pointer;
+
+    i {
+        display: flex;
+    }
+
     i.icon-small-bookmark {
         border: 1px solid $ddpurple;
         border-radius: 30px;
@@ -37,10 +42,6 @@ body > header.scrolled ~ .container .mobile-toc-toggle {
         font-size: 25px;
         color: white;
         background-color: $ddpurple;
-        &:before {
-            position: relative;
-            top: 2px;
-        }
     }
     i.icon-small-x-2 {
         border: none;
@@ -235,7 +236,7 @@ body > header.scrolled ~ .container .mobile-toc-toggle {
     }
 
     .toc {
-        padding-top: 60px;
+        padding-top: 70px;
 
         #TableOfContents {
             // open adjacent ul to open link


### PR DESCRIPTION
### What does this PR do?
Fixes ToC mobile button visually:
- button is properly circular, not oblong
- when active, the "X" is aligned vertically
- increase space between "X" button and the ToC content

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1958

### Preview
https://docs-staging.datadoghq.com/davidweid/mobile-menu-button-visual/getting_started/agent/

### Additional Notes
View on table/mobile where mobile ToC button starts to appear.
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.