### PR TITLE
(DOCS-2753) Remove instances of 'easy' and 'easily'

### DIFF
--- a/content/en/account_management/billing/usage_attribution.md
+++ b/content/en/account_management/billing/usage_attribution.md
@@ -60,7 +60,7 @@ Once the reports start being generated, they are updated daily and aggregated mo
 - If multi-org is enabled, usage is summarized across all Datadog organizations at the parent account.
 - Previous months' reports are accessible through the time selector.
 - Monthly reports are not generated until the month is over. Each monthly report should appear by the second day of the following month.
-- Reports are downloadable using the 'Export Current View' option. These `.tsv` reports include both usage numbers and percentages, allowing for easy allocations and chargebacks.
+- Reports are downloadable using the 'Export Current View' option. These `.tsv` reports include both usage numbers and percentages, allowing for simplified allocations and chargebacks.
 
 Monthly data can also be pulled using the tool's public API. (See the [API endpoint documentation][1]).
 

--- a/content/en/account_management/org_settings/sensitive_data_detection.md
+++ b/content/en/account_management/org_settings/sensitive_data_detection.md
@@ -41,7 +41,7 @@ Sensitive data scanner can be found under [Organization Settings][1]. The Scanne
 - **Define scope:** Specify whether you want to scan the entire log event or just specific log attributes. You can also choose to skip specific attributes from the scan.
 - **Add tags:** Specify the tags you want to associate with log events where the values match the specified regex pattern. Datadog recommends using the tag `sensitive_data`. These tags can then be used in searches, dashboards, and monitors.
 - **Process matching values:** Optionally, specify whether you want to redact or hash the matching values. If you choose the redaction option, specify the placeholder text that you would like to replace the matching values so that data is redacted or hashed before it gets stored in Datadog or sent to your archive.
-- **Name the rule:** Provide an easy to understand name for the rule.
+- **Name the rule:** Provide a human-readable name for the rule.
 
 {{< img src="logs/sensitive_data_scanner/scanner_custom_rule2.png" alt="A Sensitive Data Scanner custom rule" style="width:90%;">}}
 

--- a/content/en/account_management/saml/activedirectory.md
+++ b/content/en/account_management/saml/activedirectory.md
@@ -12,7 +12,7 @@ further_reading:
   text: "Configuring Teams & Organizations with Multiple Accounts"
 ---
 
-The Datadog SAML integration for SSO provides an easy pathway for linking an organization to an external user management system so that credentials can be kept and managed in a central system. This doc is meant to be used as an add-on to the main [Single Sign On With SAML][1] documentation, which gives an overview of single sign-on from the Datadog perspective.
+The Datadog SAML integration for SSO provides a pathway for linking an organization to an external user management system so that credentials can be kept and managed in a central system. This doc is meant to be used as an add-on to the main [Single Sign On With SAML][1] documentation, which gives an overview of single sign-on from the Datadog perspective.
 
 To begin configuration of SAML for Active Directory Federation Service (AD FS), see Microsoft's [Configure a SAML 2.0 provider for portals with AD FS][2] docs.
 

--- a/content/en/agent/guide/agent-5-autodiscovery.md
+++ b/content/en/agent/guide/agent-5-autodiscovery.md
@@ -71,7 +71,7 @@ Each **Template Source** section below shows a different way to configure check 
 
 ### Files (auto-conf)
 
-Storing templates as local files is easy to understand and doesn't require an external service or a specific orchestration platform. The downside is that you have to restart your Agent containers each time you change, add, or remove templates.
+Storing templates as local files is doesn't require an external service or a specific orchestration platform. The downside is that you have to restart your Agent containers each time you change, add, or remove templates.
 
 The Agent looks for Autodiscovery templates in its `conf.d/auto_conf` directory, which contains default templates for the following checks:
 

--- a/content/en/agent/guide/agent-5-autodiscovery.md
+++ b/content/en/agent/guide/agent-5-autodiscovery.md
@@ -71,7 +71,7 @@ Each **Template Source** section below shows a different way to configure check 
 
 ### Files (auto-conf)
 
-Storing templates as local files is doesn't require an external service or a specific orchestration platform. The downside is that you have to restart your Agent containers each time you change, add, or remove templates.
+Storing templates as local files doesn't require an external service or a specific orchestration platform. The downside is that you have to restart your Agent containers each time you change, add, or remove templates.
 
 The Agent looks for Autodiscovery templates in its `conf.d/auto_conf` directory, which contains default templates for the following checks:
 

--- a/content/en/agent/troubleshooting/config.md
+++ b/content/en/agent/troubleshooting/config.md
@@ -26,7 +26,7 @@ Use the command `config list-runtime` to list configuration parameters that can 
 | Source     | `sudo datadog-agent config list-runtime`               |
 | Windows    | Consult the dedicated [Windows documentation][1]       |
 
-One parameter that can be changed at runtime is the log level. It is convenient for debug purposes in a containerized environment, where the Agent configuration cannot be changed easily without having to destroy then recreate the container running the Agent. To dynamically set the log level to debug on a Kubernetes deployment, invoke the following command:
+One parameter that can be changed at runtime is the log level. It is convenient for debug purposes in a containerized environment, where the Agent configuration cannot be changed without having to destroy then recreate the container running the Agent. To dynamically set the log level to debug on a Kubernetes deployment, invoke the following command:
 
 ```text
 kubectl exec <POD_NAME> agent config set log_level debug

--- a/content/en/dashboards/faq/there-are-too-many-lines-on-my-graph-can-i-only-display-the-most-important-ones.md
+++ b/content/en/dashboards/faq/there-are-too-many-lines-on-my-graph-can-i-only-display-the-most-important-ones.md
@@ -7,7 +7,7 @@ aliases:
 
 ## Problem
 
-When using a grouped query there are sometimes too many lines displayed on the graph, and you might end up with something not easy to read e.g.:
+When using a grouped query there are sometimes too many lines displayed on the graph, and you might end up with something complicated to read, for example:
 
 {{< img src="dashboards/faq/too_many_metrics_1.png" alt="too_many_metrics_1"  >}}
 

--- a/content/en/dashboards/functions/timeshift.md
+++ b/content/en/dashboards/functions/timeshift.md
@@ -39,7 +39,7 @@ Here is an example of `system.load.1` with the `hour_before()` value shown as a 
 |:---------------|:---------------------------------------------------------------------|:-------------------------------|
 | `day_before()` | Graph values from a day before the current timestamp for the metric. | `day_before(<METRIC_NAME>{*})` |
 
-Here is an example of `nginx.net.connections` with the `day_before()` value shown as a lighter, thinner line. In this example, you can see a week's worth of data, which makes the `day_before()` data easy to identify.
+Here is an example of `nginx.net.connections` with the `day_before()` value shown as a lighter, thinner line. In this example, you can see a week's worth of data, which makes the `day_before()` data easier to identify.
 
 {{< img src="dashboards/functions/timeshift/simple_day_before_example.png" alt="simple day before example" style="width:80%;">}}
 
@@ -49,7 +49,7 @@ Here is an example of `nginx.net.connections` with the `day_before()` value show
 |:----------------|:-------------------------------------------------------------------------------|:--------------------------------|
 | `week_before()` | Graph values from a week (7 days) before the current timestamp for the metric. | `week_before(<METRIC_NAME>{*})` |
 
-Here is an example of `cassandra.db.read_count` with the `week_before()` value shown as a dotted line. In this example, you can see about three weeks' worth of data, which makes the `week_before()` data easy to identify.
+Here is an example of `cassandra.db.read_count` with the `week_before()` value shown as a dotted line. In this example, you can see about three weeks' worth of data, which makes the `week_before()` data easier to identify.
 
 {{< img src="dashboards/functions/timeshift/simple_week_before_example.png" alt="simple week before example" style="width:80%;">}}
 

--- a/content/en/database_monitoring/query_metrics.md
+++ b/content/en/database_monitoring/query_metrics.md
@@ -60,7 +60,7 @@ Select or clear facets to find the list of queries you're interested in.
 
 If you want to filter the contents of the Query Metrics view to just one normalized query, filter on the `query_signature`, not `query`. Tag names are truncated at 200 characters, and because queries can be long, their `query` tags aren't necessarily unique. The `query_signature` is a hash of a normalized query and serves as a unique ID for the normalized query.
 
-An easy way to filter to a specific query (without looking up its query signature value) is to click the query from the list, which opens its [Query Details page](#query-details-page), where you click **Filter to This Query**. This filters the Query Metrics page by the `query_signature` facet.
+One way to filter to a specific query without looking up its query signature value is to click the query from the list. This opens its [Query Details page](#query-details-page), where you click **Filter to This Query**. This filters the Query Metrics page by the `query_signature` facet.
 
 ## Exploring the metrics
 

--- a/content/en/developers/custom_checks/prometheus.md
+++ b/content/en/developers/custom_checks/prometheus.md
@@ -173,7 +173,7 @@ def check(self, instance):
 
 ##### Exceptions
 
-If a check cannot run because of improper configuration, a programming error, or because it could not collect any metrics, it should raise a meaningful exception. This exception is logged and is shown in the Agent [status command][9] for easy debugging. For example:
+If a check cannot run because of improper configuration, a programming error, or because it could not collect any metrics, it should raise a meaningful exception. This exception is logged and is shown in the Agent [status command][9] for debugging. For example:
 
     $ sudo /etc/init.d/datadog-agent info
 

--- a/content/en/developers/faq/legacy-openmetrics.md
+++ b/content/en/developers/faq/legacy-openmetrics.md
@@ -135,7 +135,7 @@ def check(self, instance):
 
 ##### Exceptions
 
-If a check cannot run because of improper configuration, a programming error, or because it could not collect any metrics, it should raise a meaningful exception. This exception is logged and is shown in the Agent [status command][7] for easy debugging. For example:
+If a check cannot run because of improper configuration, a programming error, or because it could not collect any metrics, it should raise a meaningful exception. This exception is logged and is shown in the Agent [status command][7] for debugging. For example:
 
     $ sudo /etc/init.d/datadog-agent info
 

--- a/content/en/developers/faq/use-our-webhook-integration-to-create-a-trello-card.md
+++ b/content/en/developers/faq/use-our-webhook-integration-to-create-a-trello-card.md
@@ -3,7 +3,7 @@ title: Use the webhooks integration to create a Trello card
 kind: faq
 ---
 
-You can easily use the [webhooks integration][1] to instantly create a Trello card using the [@-notification feature][2].
+You can use the [webhooks integration][1] to instantly create a Trello card using the [@-notification feature][2].
 
 This flow uses the Trello REST POST card API endpoint to post an @notification to a relevant Trello list.
 

--- a/content/en/getting_started/database_monitoring/_index.md
+++ b/content/en/getting_started/database_monitoring/_index.md
@@ -14,7 +14,7 @@ further_reading:
 ---
 ## Overview
 
-Datadog Database Monitoring allows you to easily understand the health and performance of your databases, and quickly determine the root cause of any problems.
+Datadog Database Monitoring helps you to better understand the health and performance of your databases, and quickly determine the root cause of any problems.
 
 In one place, you can view:
 

--- a/content/en/getting_started/incident_management/_index.md
+++ b/content/en/getting_started/incident_management/_index.md
@@ -174,7 +174,7 @@ The _Timeline_ shows additions and changes to incident fields and information in
 
     {{< img src="getting_started/incident_management/add_from_slack.png" alt="Add from Slack" responsive="true" style="width:40%;">}}
 
-    You can add any Slack comment in the incident channel to the timeline so that you can easily consolidate important communications related to the investigation and mitigation of the incident.
+    You can add any Slack comment in the incident channel to the timeline so that you can consolidate important communications related to the investigation and mitigation of the incident.
 
 #### Remediation
 

--- a/content/en/getting_started/learning_center.md
+++ b/content/en/getting_started/learning_center.md
@@ -33,7 +33,7 @@ aliases:
   - /videos/weekly_monitor_report/
 ---
 
-Datadog is an extensive, easy-to-use platform for understanding your infrastructure. [The Datadog Learning Center][1] ensures you are able to leverage everything the platform has to offer.
+Datadog is an extensive platform for understanding your infrastructure. [The Datadog Learning Center][1] ensures you are able to leverage everything the platform has to offer.
 
 For a list of available courses, see [Courses][2].
 

--- a/content/en/infrastructure/livecontainers/_index.md
+++ b/content/en/infrastructure/livecontainers/_index.md
@@ -197,7 +197,7 @@ View streaming logs for any container like `docker logs -f` or `kubectl logs -f`
 
 #### Live tail
 
-With live tail, all container logs are streamed. Pausing the stream allows you to easily read logs that are quickly being written; unpause to continue streaming.
+With live tail, all container logs are streamed. Pausing the stream helps you read logs that are quickly being written; unpause to continue streaming.
 
 Streaming logs can be searched with simple string matching. See [Live Tail][13] for more details.
 

--- a/content/en/infrastructure/process.md
+++ b/content/en/infrastructure/process.md
@@ -325,7 +325,7 @@ Hosts that are running the integration, but where the integration is not enabled
 
 {{< img src="infrastructure/process/integration_views.png" alt="Integration Views" >}}
 
-Once a third-party software has been detected, Live Processes makes it quick and easy to analyze the performance of that software.
+After a third-party software has been detected, Live Processes helps to analyze the performance of that software.
 1. To start, click on *Views* at the top right of the page to open a list of pre-set options, including Nginx, Redis, and Kafka.
 2. Select a view to scope the page to only the processes running that software.
 3. When inspecting a heavy process, shift to the *Integration Metrics* tab to analyze the health of the software on the underlying host. If you have already enabled the relevant Datadog integration, you can view all performance metrics collected from the integration to distinguish between a host-level and software-level issue. For instance, seeing correlated spikes in process CPU and MySQL query latency may indicate that an intensive operation, such as a full table scan, is delaying the execution of other MySQL queries relying on the same underlying resources.

--- a/content/en/infrastructure/process/increase_process_retention.md
+++ b/content/en/infrastructure/process/increase_process_retention.md
@@ -17,7 +17,7 @@ further_reading:
 
 ## Overview
 
-While Live Processes data is stored for 36 hours, you can generate global and percentile distribution metrics from your processes to monitor your resource consumption long-term. Process-based metrics are stored for 15 months like any other Datadog metric, making it easy to:
+While Live Processes data is stored for 36 hours, you can generate global and percentile distribution metrics from your processes to monitor your resource consumption long-term. Process-based metrics are stored for 15 months like any other Datadog metric. This can help you:
 
 - Debug past and ongoing infrastructure issues
 - Identify trends in the resource consumption of your critical workloads

--- a/content/en/integrations/faq/how-to-make-trello-card-using-webhooks.md
+++ b/content/en/integrations/faq/how-to-make-trello-card-using-webhooks.md
@@ -3,7 +3,7 @@ title: How to Make a Trello Card using Webhooks
 kind: faq
 ---
 
-You can use our [Webhook Integration][1] to instantly create a trello card using our @-notification feature.
+You can use the Datadog [Webhook Integration][1] to instantly create a Trello card using the `@-notification` feature.
 
 This flow uses the Trello REST POST card api endpoint to post the @notification to a relevant Trello list.
 

--- a/content/en/integrations/faq/how-to-make-trello-card-using-webhooks.md
+++ b/content/en/integrations/faq/how-to-make-trello-card-using-webhooks.md
@@ -3,7 +3,7 @@ title: How to Make a Trello Card using Webhooks
 kind: faq
 ---
 
-You can easily use our [Webhook Integration][1] to instantly create a trello card using our @-notification feature.
+You can use our [Webhook Integration][1] to instantly create a trello card using our @-notification feature.
 
 This flow uses the Trello REST POST card api endpoint to post the @notification to a relevant Trello list.
 

--- a/content/en/integrations/faq/how-to-retrieve-wmi-metrics.md
+++ b/content/en/integrations/faq/how-to-retrieve-wmi-metrics.md
@@ -112,7 +112,7 @@ WorkingSetPeak          : 45273088
 
 This command returns details about the Powershell process. It includes a lot of information including memory usage and I/O operations.
 
-For those who can run third-party applications on their machine the tool WMI Explorer makes it very easy to browse the information exposed by WMI. It's available here https://www.ks-soft.net/hostmon.eng/wmi/, it's a self-contained .exe file so you don't have to install it, and it's virus-free https://www.virustotal.com/en/file/df8e909491da38556a6c9a50abf42b3b906127e0d4b35d0198ef491139d1622c/analysis/.
+For those who can run third-party applications on their machine the tool WMI Explorer is great for browsing the information exposed by WMI. It's available here https://www.ks-soft.net/hostmon.eng/wmi/, it's a self-contained .exe file so you don't have to install it, and it's virus-free https://www.virustotal.com/en/file/df8e909491da38556a6c9a50abf42b3b906127e0d4b35d0198ef491139d1622c/analysis/.
 
 ## Leveraging WMI in Datadog
 

--- a/content/en/integrations/faq/troubleshooting-jmx-integrations.md
+++ b/content/en/integrations/faq/troubleshooting-jmx-integrations.md
@@ -115,7 +115,7 @@ Example:
 
 **Notes**:
 
-- The location to the JRE tools.jar (`/usr/lib/jvm/java-8-oracle/lib/tools.jar` in the example) might reside elsewhere in your system. You should be able to easily find it with `sudo find / -type f -name 'tools.jar'`.
+- The location to the JRE tools.jar (`/usr/lib/jvm/java-8-oracle/lib/tools.jar` in the example) might reside elsewhere in your system. You should be able to find it with `sudo find / -type f -name 'tools.jar'`.
 - You may wish to specify alternative JVM heap parameters `-Xmx`, `-Xms`, the values used in the example correspond to the JMXFetch defaults.
 
 {{% /tab %}}

--- a/content/en/integrations/guide/prometheus-metrics.md
+++ b/content/en/integrations/guide/prometheus-metrics.md
@@ -46,7 +46,7 @@ For [Prometheus/OpenMetrics `histogram`][6], the `_count` and `_sum` values of t
 
 If the parameter `send_histograms_buckets` is `true`, each `_bucket` value is also mapped to Datadog's `gauge`.
 
-If the parameter `send_distribution_buckets` is `true`, each `_bucket` is mapped to Datadog's `distribution`. Prometheus/OpenMetrics histogram data is converted to Datadog distribution metrics to allow for easily monitoring Kubernetes metrics as percentiles in Datadog. Datadog distribution metrics are based on the [DDSketch algorithm][7]. For more information, see the relevant Datadog [blog post on OpenMetrics and distribution metrics][8].
+If the parameter `send_distribution_buckets` is `true`, each `_bucket` is mapped to Datadog's `distribution`. Prometheus/OpenMetrics histogram data is converted to Datadog distribution metrics to allow for monitoring Kubernetes metrics as percentiles in Datadog. Datadog distribution metrics are based on the [DDSketch algorithm][7]. For more information, see the relevant Datadog [blog post on OpenMetrics and distribution metrics][8].
 
 If the parameter `send_distribution_counts_as_monotonic` is `true`, each metric ending in `_count` is submitted as `monotonic_count`. [Read more about monotonic counters][4].
 

--- a/content/en/logs/explorer/saved_views.md
+++ b/content/en/logs/explorer/saved_views.md
@@ -15,7 +15,7 @@ further_reading:
 
 Efficient troubleshooting requires your data to be in the proper **scope** to permit exploration, have access to **visualization options** to surface meaningful information, and have relevant **[facets][1]** listed to enable analysis.
 
-Troubleshooting is highly contextual, and Saved Views enable you and your teammates to easily switch between different troubleshooting contexts. You can access Saved Views in the upper left corner of the [Log Explorer][2].
+Troubleshooting is highly contextual, and Saved Views make it easier for you and your teammates to switch between different troubleshooting contexts. You can access Saved Views in the upper left corner of the [Log Explorer][2].
 
 {{< img src="logs/explorer/saved_views/overview.gif" alt="Saved Views selection"  style="width:90%;" >}}
 

--- a/content/en/logs/faq/how-to-investigate-a-log-parsing-issue.md
+++ b/content/en/logs/faq/how-to-investigate-a-log-parsing-issue.md
@@ -19,7 +19,7 @@ Here are some guidelines on how to find the root cause of the issue and correct 
 Before troubleshooting your parser, read the Datadog log [processors][1] and [parsing][2] documentation, and the [parsing best practice article][3].
 
 1. **Identify your log's pipeline**:
-    Thanks to the Pipeline filters, you can easily find the processing Pipeline your log went through. Integration Pipeline take the source as filter, so check that your log source is correctly set.
+    Because of the Pipeline filters, you can find the processing Pipeline that your log went through. Integration Pipeline takes the source as filter, so check that your log source is correctly set.
 
     {{< img src="logs/faq/integrationpipeline.png" alt="integrationpipeline"  >}}
 

--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -33,7 +33,7 @@ We strongly encourage setting up your logging library to produce your logs in JS
 {{< tabs >}}
 {{% tab "Serilog" %}}
 
-Like many other libraries for .NET, Serilog provides diagnostic logging into files, console, and elsewhere. It has a simple set up, has a clean API, and is portable between recent .NET platforms.
+Like many other libraries for .NET, Serilog provides diagnostic logging into files, the console, and elsewhere. It has a clean API and is portable between recent .NET platforms.
 
 Unlike other logging libraries, Serilog is built with powerful structured event data in mind.
 

--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -33,11 +33,11 @@ We strongly encourage setting up your logging library to produce your logs in JS
 {{< tabs >}}
 {{% tab "Serilog" %}}
 
-Like many other libraries for .NET, Serilog provides diagnostic logging into files, console, and elsewhere. It is easy to set up, has a clean API, and is portable between recent .NET platforms.
+Like many other libraries for .NET, Serilog provides diagnostic logging into files, console, and elsewhere. It has a simple set up, has a clean API, and is portable between recent .NET platforms.
 
 Unlike other logging libraries, Serilog is built with powerful structured event data in mind.
 
-Install Serilog via NuGet. Run the following command in the Package Manager Console:
+Install Serilog with NuGet. Run the following command in the Package Manager Console:
 
 ```text
 PM> Install-Package Serilog.Sinks.File

--- a/content/en/logs/log_collection/go.md
+++ b/content/en/logs/log_collection/go.md
@@ -49,7 +49,7 @@ func main() {
 }
 ```
 
-It's very easy to add metas to any log if you provide a JSON object that you want to see in the log event.
+You can add metas to any log if you provide a JSON object that you want to see in the log event.
 
 These metas can be `hostname`, `username`, `customers`, `metric` or any information that help you troubleshoot and understand what happens in your Go application.
 

--- a/content/en/monitors/faq/i-have-a-downtime-scheduled-on-my-monitor-why-did-it-still-alert.md
+++ b/content/en/monitors/faq/i-have-a-downtime-scheduled-on-my-monitor-why-did-it-still-alert.md
@@ -17,7 +17,7 @@ When you [schedule a downtime][1] over a specific tag scope, the downtime will a
 
 If you want to schedule a downtime over a subset of hosts, a good way to do so is to find a host-tag common to all those hosts and scope the downtime by that tag.
 
-One way you can take advantage of this is to create new host-tags directly in the Datadog UI from your [Infrastructure List][2] and [Host Map][3] by selecting a host and hitting the **Edit Tags** button (shown below), or via [our API][4].
+One way you can take advantage of this is to create new host-tags directly in the Datadog UI from your [Infrastructure List][2] and [Host Map][3] by selecting a host and hitting the **Edit Tags** button (shown below), or with the [Datadog API][4].
 
 {{< img src="monitors/faq/edit_tag.png" alt="edit tag"  >}}
 

--- a/content/en/monitors/faq/i-have-a-downtime-scheduled-on-my-monitor-why-did-it-still-alert.md
+++ b/content/en/monitors/faq/i-have-a-downtime-scheduled-on-my-monitor-why-did-it-still-alert.md
@@ -17,7 +17,7 @@ When you [schedule a downtime][1] over a specific tag scope, the downtime will a
 
 If you want to schedule a downtime over a subset of hosts, a good way to do so is to find a host-tag common to all those hosts and scope the downtime by that tag.
 
-One easy way you can take advantage of this is to create new host-tags directly in the Datadog UI from your [Infrastructure List][2] and [Host Map][3] by selecting a host and hitting the **Edit Tags** button (shown below), or via [our API][4].
+One way you can take advantage of this is to create new host-tags directly in the Datadog UI from your [Infrastructure List][2] and [Host Map][3] by selecting a host and hitting the **Edit Tags** button (shown below), or via [our API][4].
 
 {{< img src="monitors/faq/edit_tag.png" alt="edit tag"  >}}
 

--- a/content/en/network_monitoring/performance/guide/manage_traffic_costs_with_npm.md
+++ b/content/en/network_monitoring/performance/guide/manage_traffic_costs_with_npm.md
@@ -55,10 +55,10 @@ You can edit your preferences using the **Filter traffic** button. In larger env
 
 ## Graphing traffic costs 
 
-Datadog recommends tracking traffic volume metrics over time in dashboards and notebooks. You can graph traffic between any two endpoints using the same queries you would make on the Network page. Create a **Timeseries Widget** and select the **Network Traffic** source from the dropdown menu.  
+Datadog recommends tracking traffic volume metrics over time in dashboards and notebooks. You can graph traffic between any two endpoints using the same queries you would make on the Network page. To do this, create a **Timeseries Widget** and select the **Network Traffic** source from the dropdown menu.  
 
 {{< img src="network_performance_monitoring/guide/manage_traffic_costs_with_npm/timeseries.png" alt="Create a Timeseries">}}
 
-Dashboards and Notebooks make it easy for you to share any issues with your teammates.
+Then share these results and any issues with your teammates using Dashboards and Notebooks. 
 
 {{< img src="network_performance_monitoring/guide/manage_traffic_costs_with_npm/network-traffic.png" alt="View your network traffic">}}

--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -311,7 +311,7 @@ window.DD_RUM &&
 
 ## Identify user sessions
 
-Adding user information to your RUM sessions makes it easy to:
+Adding user information to your RUM sessions can help you:
 * Follow the journey of a given user
 * Know which users are the most impacted by errors
 * Monitor performance for your most important users

--- a/content/en/real_user_monitoring/guide/send-rum-custom-actions.md
+++ b/content/en/real_user_monitoring/guide/send-rum-custom-actions.md
@@ -29,7 +29,7 @@ All RUM context will be automatically attached (current page view information, g
 ## Create facets and measures on your new attributes
 Once you have deployed the code that creates your custom actions, you will start seeing actions appear in the [RUM Explorer][3], in the **Actions** tab.
 
-To filter on your new custom Actions, use the `Action Target Name` attribute as follow: `@action.target.name:<ACTION_NAME>`. In the example, we use the following filter: `@action.target.name:checkout`
+To filter on your new custom Actions, use the `Action Target Name` attribute as follow: `@action.target.name:<ACTION_NAME>`. The example uses the following filter: `@action.target.name:checkout`
 
 Once you click on the action, all metadata is available in the side panel. You can find your action attributes in the Custom Attributes sections. The next step is to create facets or measures for these attributes by clicking on them. For example, create a facet for the cart items and a measure for the cart value.
 

--- a/content/en/real_user_monitoring/guide/send-rum-custom-actions.md
+++ b/content/en/real_user_monitoring/guide/send-rum-custom-actions.md
@@ -29,7 +29,7 @@ All RUM context will be automatically attached (current page view information, g
 ## Create facets and measures on your new attributes
 Once you have deployed the code that creates your custom actions, you will start seeing actions appear in the [RUM Explorer][3], in the **Actions** tab.
 
-To easily filter on your new custom Actions, use the `Action Target Name` attribute as follow: `@action.target.name:<ACTION_NAME>`. In the example, we use the following filter: `@action.target.name:checkout`
+To filter on your new custom Actions, use the `Action Target Name` attribute as follow: `@action.target.name:<ACTION_NAME>`. In the example, we use the following filter: `@action.target.name:checkout`
 
 Once you click on the action, all metadata is available in the side panel. You can find your action attributes in the Custom Attributes sections. The next step is to create facets or measures for these attributes by clicking on them. For example, create a facet for the cart items and a measure for the cart value.
 

--- a/content/en/security_platform/guide/monitor-authentication-logs-for-security-threats.md
+++ b/content/en/security_platform/guide/monitor-authentication-logs-for-security-threats.md
@@ -75,7 +75,7 @@ It's important to use a [standard naming convention][4] for the attributes in yo
 
 Use the same format across all of your authentication logs so you can properly use log attributes to filter and organize log data in Datadog. For example, with standard attributes you can look for which users (`usr.id`) have the highest number of failed logins (`evt.outcome:failure`).
 
-A key-value format also makes it easy to add custom attributes to logs. For example, adding a [reCAPTCHA v3][9] score to identify possible bot activity. Use quotes to wrap any attribute values that may contain spaces. This ensures that you capture the full value in a way that is easily parsable.
+A key-value format also simplifies the process to add custom attributes to logs. For example, you could add a [reCAPTCHA v3][9] score to identify possible bot activity. Use quotes to wrap any attribute values that may contain spaces. This ensures that you capture the full value in a way that is parsable.
 
 ## Monitor and detect security threats
 

--- a/content/en/security_platform/guide/monitor-authentication-logs-for-security-threats.md
+++ b/content/en/security_platform/guide/monitor-authentication-logs-for-security-threats.md
@@ -39,7 +39,7 @@ Logs that contain the "who" (John Doe), "what" (login success), and when (2020-0
 
 ### Log in a standard, parsable format
 
-Ensure your application writes logs in a key-value format using `=` as a separator. Using this format means that a key-value parser, such as Datadog's [Grok Parser][3], can easily process them. For example, if a log is in the following format:
+Ensure your application writes logs in a key-value format using `=` as a separator. Using this format means that a key-value parser, such as Datadog's [Grok Parser][3], can process them. For example, if a log is in the following format:
 
 {{< code-block lang="bash" >}}
 INFO 2020-01-01 12:00:01 usr.id="John Doe" evt.category=authentication evt.name="google oauth" evt.outcome=success network.client.ip=1.2.3.4

--- a/content/en/serverless/distributed_tracing/serverless_trace_propagation.md
+++ b/content/en/serverless/distributed_tracing/serverless_trace_propagation.md
@@ -35,7 +35,7 @@ The following code samples outline how to pass trace context in outgoing events 
 {{< tabs >}}
 {{% tab "Python" %}}
 
-In Python, you can use the `get_dd_trace_context` helper function to easily pass tracing context to outgoing events in a Lambda functions:
+In Python, you can use the `get_dd_trace_context` helper function to pass tracing context to outgoing events in a Lambda functions:
 
 ```py
 import json
@@ -81,7 +81,7 @@ def handler(event, context):
 {{% /tab %}}
 {{% tab "Node.js" %}}
 
-In Node, you can use the `getTraceHeaders` helper function to easily pass tracing context to outgoing events in a Lambda function:
+In Node, you can use the `getTraceHeaders` helper function to pass tracing context to outgoing events in a Lambda function:
 
 ```js
 const AWS = require('aws-sdk');

--- a/content/en/serverless/guide/extension_motivation.md
+++ b/content/en/serverless/guide/extension_motivation.md
@@ -33,7 +33,7 @@ The Lambda extension has full feature parity with the Forwarder for Python, Node
 
 The Datadog Lambda Extension offers the following advantages over the Datadog Forwarder:
 
-- **Simple to set up**: The Forwarder requires that triggers need be set up for every new Lambda function. The Datadog Lambda extension can be easily added as a Lambda layer. Unlike with the Forwarder, configuring the Lambda extension does not require permissions to install third-party AWS CloudFormation stacks. Also, the Lambda extension sends telemetry directly to Datadog, so you do not need to manage CloudWatch Log group subscriptions for your Lambda functions.
+- **Simple to set up**: The Forwarder requires that triggers need be set up for every new Lambda function. The Datadog Lambda extension can be added as a Lambda layer. Unlike with the Forwarder, configuring the Lambda extension does not require permissions to install third-party AWS CloudFormation stacks. Also, the Lambda extension sends telemetry directly to Datadog, so you do not need to manage CloudWatch Log group subscriptions for your Lambda functions.
 - **Less infrastructure to manage**: The simpler configuration of the Lambda extension saves time on infrastructure management. For non-Lambda AWS integrations, the Forwarder is still required.
 - **Skip CloudWatch Logs**: The Forwarder converts logs to metrics and traces, which are then sent to Datadog. The Datadog Lambda Extension sends traces, metrics, and logs directly to Datadog, enabling you to reduce the cost associated with CloudWatch Logs.
 

--- a/content/en/serverless/guide/extension_motivation.md
+++ b/content/en/serverless/guide/extension_motivation.md
@@ -33,7 +33,7 @@ The Lambda extension has full feature parity with the Forwarder for Python, Node
 
 The Datadog Lambda Extension offers the following advantages over the Datadog Forwarder:
 
-- **Simple to set up**: The Forwarder requires that triggers need be set up for every new Lambda function. The Datadog Lambda extension can be added as a Lambda layer. Unlike with the Forwarder, configuring the Lambda extension does not require permissions to install third-party AWS CloudFormation stacks. Also, the Lambda extension sends telemetry directly to Datadog, so you do not need to manage CloudWatch Log group subscriptions for your Lambda functions.
+- **Simple to set up**: The Forwarder requires triggers to be set up for every new Lambda function. The Datadog Lambda extension can be added as a Lambda layer. Unlike with the Forwarder, configuring the Lambda extension does not require permissions to install third-party AWS CloudFormation stacks. Also, the Lambda extension sends telemetry directly to Datadog, so you do not need to manage CloudWatch Log group subscriptions for your Lambda functions.
 - **Less infrastructure to manage**: The simpler configuration of the Lambda extension saves time on infrastructure management. For non-Lambda AWS integrations, the Forwarder is still required.
 - **Skip CloudWatch Logs**: The Forwarder converts logs to metrics and traces, which are then sent to Datadog. The Datadog Lambda Extension sends traces, metrics, and logs directly to Datadog, enabling you to reduce the cost associated with CloudWatch Logs.
 

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -35,7 +35,7 @@ If you previously set up Datadog Serverless using the Datadog Forwarder, see the
 
 ## Configuration
 
-Datadog offers many different ways to enable instrumentation for your serverless applications. Choose a method below that best suits your needs. Datadog generally recommends using the Datadog CLI, which does not require redeploying your whole application. The CLI can also be easily added to your CI/CD pipelines to enable instrumentation for applications across your entire organization.
+Datadog offers many different ways to enable instrumentation for your serverless applications. Choose a method below that best suits your needs. Datadog generally recommends using the Datadog CLI, which does not require redeploying your whole application. The CLI can also be added to your CI/CD pipelines to enable instrumentation for applications across your entire organization.
 
 
 {{< tabs >}}

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -35,7 +35,7 @@ If your Python Lambda functions are written in [Python 3.6 or less][2] or you pr
 
 ## Configuration
 
-Datadog offers many different ways to enable instrumentation for your serverless applications. Choose a method below that best suits your needs. Datadog generally recommends using the Datadog CLI, which does not require redeploying your whole application. The CLI can also be easily added to your CI/CD pipelines to enable instrumentation for applications across your entire organization.
+Datadog offers many different ways to enable instrumentation for your serverless applications. Choose a method below that best suits your needs. Datadog generally recommends using the Datadog CLI, which does not require redeploying your whole application. The CLI can also be added to your CI/CD pipelines to enable instrumentation for applications across your entire organization.
 
 
 {{< tabs >}}

--- a/content/en/serverless/troubleshooting/connect_invoking_resources.md
+++ b/content/en/serverless/troubleshooting/connect_invoking_resources.md
@@ -5,7 +5,7 @@ kind: documentation
 
 {{< img src="serverless/serverless-view.png" alt="Serverless View" >}}
 
-By default, the Serverless View groups your serverless resources by service to help you easily visualize how each part of your application is performing. For each service, you see the functions that belong to it, along with the resources (Amazon API Gateway, SNS, SQS, DynamoDB, S3, EventBridge, Kinesis) that invoked them. 
+By default, the Serverless View groups your serverless resources by service to help you visualize how each part of your application is performing. For each service, you see the functions that belong to it, along with the resources (Amazon API Gateway, SNS, SQS, DynamoDB, S3, EventBridge, Kinesis) that invoked them. 
 
 While grouping by service is the default, you can also group your resources by AWS CloudFormation stack name, as well as any other tags you've configured (such as team, project, or environment).
 

--- a/content/en/synthetics/api_tests/icmp_tests.md
+++ b/content/en/synthetics/api_tests/icmp_tests.md
@@ -19,7 +19,7 @@ further_reading:
 
 ## Overview
 
-ICMP tests allow you to easily monitor the availability of your hosts and diagnose network communication issues. By asserting on the values received from one or more ICMP pings to your endpoint, Datadog can help detect connectivity issues, above-quota latency for round trip times, and unexpected changes in security firewall configuration. The tests can also track the number of network hops (TTL) required to connect to your host and view traceroute results to discover details on each network hop along the path.
+ICMP tests allow you to monitor the availability of your hosts and diagnose network communication issues. By asserting on the values received from one or more ICMP pings to your endpoint, Datadog can help detect connectivity issues, above-quota latency for round trip times, and unexpected changes in security firewall configuration. The tests can also track the number of network hops (TTL) required to connect to your host and view traceroute results to discover details on each network hop along the path.
 
 ICMP tests can run from both [managed][1] and [private locations][2] depending on whether you want to trigger ICMP pings to your endpoints from outside or inside your network. You can run ICMP tests on a defined schedule, on demand, or from within your [CI/CD pipelines][3].
 

--- a/content/en/synthetics/api_tests/udp_tests.md
+++ b/content/en/synthetics/api_tests/udp_tests.md
@@ -15,7 +15,7 @@ further_reading:
 ---
 ## Overview
 
-UDP tests allow you to easily monitor that low-level UDP connections can be established on the ports of given hosts, ensuring availability of any services living on UDP ports. With built-in response time data, you can keep track of the performance of your network applications and be alerted in case of unexpected slowness.
+UDP tests allow you to monitor that low-level UDP connections can be established on the ports of given hosts, ensuring availability of any services living on UDP ports. With built-in response time data, you can keep track of the performance of your network applications and be alerted in case of unexpected slowness.
 
 UDP tests can run from both [managed][1] and [private locations][2] depending on your preference for running the test from outside or inside your network. UDP tests can run on a schedule, on-demand, or directly within your [CI/CD pipelines][3].
 

--- a/content/en/synthetics/guide/manage-browser-tests-through-the-api.md
+++ b/content/en/synthetics/guide/manage-browser-tests-through-the-api.md
@@ -12,7 +12,7 @@ further_reading:
 
 ## Overview
 
-Monitoring your application end-to-end is crucial to understanding your users' experience. The [Datadog test recorder][1] allows you to easily configure these complex testing workflows. However, you may want to manage your Synthetics resources programmatically and define browser tests with the API.
+Monitoring your application end-to-end is crucial to understanding your users' experience. The [Datadog test recorder][1] allows you to simplify configuration for these complex testing workflows. However, you may want to manage your Synthetics resources programmatically and define browser tests with the API.
 
 ## Manage your browser tests with the API
 

--- a/content/en/tracing/guide/add_span_md_and_graph_it.md
+++ b/content/en/tracing/guide/add_span_md_and_graph_it.md
@@ -231,7 +231,7 @@ The Datadog UI uses tags to set span level metadata. Custom tags may be set for 
 
 {{< img src="tracing/guide/add_span_md_and_graph_it/span_md_3.png" alt="Resource Page"  style="width:90%;">}}
 
-The Trace table shows you both the overall latency distribution of all traces in the current scope (service, resource and timeframe) and links to individual traces. You can sort this table by duration or error code to easily identify erroneous operation or opportunities for optimization.
+The Trace table shows you both the overall latency distribution of all traces in the current scope (service, resource and timeframe) and links to individual traces. You can sort this table by duration or error code to identify erroneous operation or opportunities for optimization.
 
 3) **Click into one of your traces**
 

--- a/content/en/tracing/guide/add_span_md_and_graph_it.md
+++ b/content/en/tracing/guide/add_span_md_and_graph_it.md
@@ -231,7 +231,7 @@ The Datadog UI uses tags to set span level metadata. Custom tags may be set for 
 
 {{< img src="tracing/guide/add_span_md_and_graph_it/span_md_3.png" alt="Resource Page"  style="width:90%;">}}
 
-The Trace table shows you both the overall latency distribution of all traces in the current scope (service, resource and timeframe) and links to individual traces. You can sort this table by duration or error code to identify erroneous operation or opportunities for optimization.
+The Trace table shows you both the overall latency distribution of all traces in the current scope (service, resource, and timeframe) and links to individual traces. You can sort this table by duration or error code to identify erroneous operation or opportunities for optimization.
 
 3) **Click into one of your traces**
 

--- a/content/en/tracing/guide/apm_dashboard.md
+++ b/content/en/tracing/guide/apm_dashboard.md
@@ -119,7 +119,7 @@ This guides walks you through adding trace metrics to a dashboard, correlating t
 
     {{< img src="tracing/guide/apm_dashboard/dashboard_10.mp4" alt="dashboard 10" video="true"  style="width:90%;">}}
 
-    Be sure to explore all the metrics available to you and take full advantage of the Datadog 3 pillars of observability. You can easily turn this basic dashboard into a powerful tool that is a one-stop-shop for monitoring and observability in your organization:
+    Be sure to explore all the metrics available to you and take full advantage of the Datadog 3 pillars of observability. You can turn this basic dashboard into a powerful tool that is a one-stop-shop for monitoring and observability in your organization:
 
     {{< img src="tracing/guide/apm_dashboard/dashboard_7.mp4" alt="dashboard 7" video="true"  style="width:90%;">}}
 

--- a/content/en/tracing/guide/slowest_request_daily.md
+++ b/content/en/tracing/guide/slowest_request_daily.md
@@ -23,7 +23,7 @@ _3 minutes to complete_
 
 {{< img src="tracing/guide/slowest_request_daily/slowest_trace_1.mp4" video="true" alt="Identifying the slowest trace and finding the Host metrics for it"  style="width:90%;">}}
 
-With Datadog APM, you can easily investigate the performance of your endpoints, identify slow requests, and investigate the root cause of latency issues. This example shows the slowest [trace][1] of the day for an e-commerce checkout endpoint and how it slows down because of high CPU usage.
+With Datadog APM, you can investigate the performance of your endpoints, identify slow requests, and investigate the root cause of latency issues. This example shows the slowest [trace][1] of the day for an e-commerce checkout endpoint and how it slows down because of high CPU usage.
 
 1. **Open the [Services page][2]**.
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/ruby.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/ruby.md
@@ -59,7 +59,7 @@ The Ruby Datadog Trace library is open source - view the [Github repository][1] 
 
 ## Integration instrumentation
 
-Many popular libraries and frameworks are supported out-of-the-box, which can be auto-instrumented. Although they are not activated automatically, they can be easily activated and configured by using the `Datadog.configure` API:
+Many popular libraries and frameworks are supported out-of-the-box, which can be auto-instrumented. Although they are not activated automatically, they can be activated and configured by using the `Datadog.configure` API:
 
 ```ruby
 Datadog.configure do |c|

--- a/content/en/tracing/setup_overview/custom_instrumentation/ruby.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/ruby.md
@@ -165,7 +165,7 @@ end
 
 ## Adding spans
 
-If you aren't using supported library instrumentation (see [library compatibility][4]), you may want to to manually instrument your code. Adding tracing to your code is easy using the `Datadog.tracer.trace` method, which you can wrap around any Ruby code:
+If you aren't using supported library instrumentation (see [library compatibility][4]), you may want to to manually instrument your code. Add tracing to your code by using the `Datadog.tracer.trace` method, which you can wrap around any Ruby code:
 
 To trace any Ruby code, you can use the `Datadog.tracer.trace` method:
 

--- a/content/en/tracing/setup_overview/custom_instrumentation/ruby.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/ruby.md
@@ -165,7 +165,7 @@ end
 
 ## Adding spans
 
-If you aren't using supported library instrumentation (see [library compatibility][4]), you may want to to manually instrument your code. Add tracing to your code by using the `Datadog.tracer.trace` method, which you can wrap around any Ruby code:
+If you aren't using supported library instrumentation (see [library compatibility][4]), you can manually instrument your code. Add tracing to your code by using the `Datadog.tracer.trace` method, which you can wrap around any Ruby code:
 
 To trace any Ruby code, you can use the `Datadog.tracer.trace` method:
 

--- a/content/en/tracing/troubleshooting/tracer_startup_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_startup_logs.md
@@ -8,7 +8,7 @@ further_reading:
 ---
 ## Startup logs
 
-Tracer startup logs capture all obtainable information at startup and log it either as `DATADOG TRACER CONFIGURATION` or `DATADOG TRACER DIAGNOSTICS` to simplify searching within your logs. Some languages may log to a separate file depending on language conventions and the safety of accessing `Stdout` or equivalent.  In those cases, the location of logs are noted in the language tab below.
+Tracer startup logs capture all obtainable information at startup and log it either as `DATADOG TRACER CONFIGURATION` or `DATADOG TRACER DIAGNOSTICS` to simplify searching within your logs. Some languages may log to a separate file depending on language conventions and the safety of accessing `Stdout` or equivalent. In those cases, the location of logs are noted in the language tab below.
 
 `DIAGNOSTICS` log entries happen when the tracer encounters an error during application startup, while  `CONFIGURATION` logs are a JSON formatted representation of settings applied to your tracer. In languages where an Agent connectivity check is performed, the configuration JSON will also include an 'agent_error' key, which indicates whether the Agent is reachable.
 

--- a/content/en/tracing/troubleshooting/tracer_startup_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_startup_logs.md
@@ -8,7 +8,7 @@ further_reading:
 ---
 ## Startup logs
 
-Tracer startup logs capture all obtainable information at startup and log it either as `DATADOG TRACER CONFIGURATION` or `DATADOG TRACER DIAGNOSTICS` for easy searching within your logs.  Some languages may log to a separate file depending on language conventions and the safety of accessing `Stdout` or equivalent.  In those cases, the location of logs are noted in the language tab below.
+Tracer startup logs capture all obtainable information at startup and log it either as `DATADOG TRACER CONFIGURATION` or `DATADOG TRACER DIAGNOSTICS` to simplify searching within your logs. Some languages may log to a separate file depending on language conventions and the safety of accessing `Stdout` or equivalent.  In those cases, the location of logs are noted in the language tab below.
 
 `DIAGNOSTICS` log entries happen when the tracer encounters an error during application startup, while  `CONFIGURATION` logs are a JSON formatted representation of settings applied to your tracer. In languages where an Agent connectivity check is performed, the configuration JSON will also include an 'agent_error' key, which indicates whether the Agent is reachable.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Where possible, this removes all instances of "easy" and "easily" from the docs. We don't want to assume anything is easy for our users or readers. Places where these terms might be acceptable are when you're making a direct comparison, which is why all instances of "easier" were left, and some instances of "easy" or "easier" were modified to use "easier" instead.

### Motivation

OKR

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
