### PR TITLE
DOCS-2831 - aws batch not supported

### DIFF
--- a/content/en/agent/amazon_ecs/_index.md
+++ b/content/en/agent/amazon_ecs/_index.md
@@ -27,7 +27,7 @@ This page covers Amazon ECS setup with the [Datadog Container Agent v6][1]. For 
 - [Datadog Container Agent v5 setup for Amazon ECS][2]
 - [Datadog Host Agent setup with Autodiscovery][3]
 
-**Note**: **If you are looking to set up ECS on Fargate, follow [this doc instead][4].** AWS Batch is not supported.
+**Note**: **If you are looking to set up ECS on Fargate, see [Amazon ECS on AWS Fargate][4].** AWS Batch is not supported.
 
 ## Setup
 

--- a/content/en/agent/amazon_ecs/_index.md
+++ b/content/en/agent/amazon_ecs/_index.md
@@ -27,7 +27,7 @@ This page covers Amazon ECS setup with the [Datadog Container Agent v6][1]. For 
 - [Datadog Container Agent v5 setup for Amazon ECS][2]
 - [Datadog Host Agent setup with Autodiscovery][3]
 
-**Note**: **If you are looking to set up ECS on Fargate, follow [this doc instead][4].**
+**Note**: **If you are looking to set up ECS on Fargate, follow [this doc instead][4].** AWS Batch is not supported.
 
 ## Setup
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
adds note to ECS docs that AWS batch is not supported

### Motivation
jira

### Preview

https://docs-staging.datadoghq.com/cswatt/ecs_batch/agent/amazon_ecs

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
