### PR TITLE
Obfuscation options can't be set as env vars

### DIFF
--- a/content/en/tracing/setup_overview/configure_data_security/_index.md
+++ b/content/en/tracing/setup_overview/configure_data_security/_index.md
@@ -38,36 +38,7 @@ Datadog enforces several filtering mechanisms on spans as a baseline, to provide
 
 ## Agent trace obfuscation
 
-Agent [trace][2] obfuscation is disabled by default. Enable it in your `datadog.yaml` configuration file to obfuscate information attached to your traces.
-
-List of all environment variables available for Agent trace obfuscation:
-
-`DD_APM_CONFIG_OBFUSCATION_ELASTICSEARCH_ENABLED`
-: Whether or not to enable obfuscation in Elasticsearch.
-
-`DD_APM_CONFIG_OBFUSCATION_ELASTICSEARCH_KEEP_VALUES`
-: Whether or not to store obfuscated values from Elasticsearch.
-
-`DD_APM_CONFIG_OBFUSCATION_HTTP_REMOVE_PATHS_WITH_DIGITS`
-: A string containing values to remove from HTTP paths for obfuscation.
-
-`DD_APM_CONFIG_OBFUSCATION_HTTP_REMOVE_QUERY_STRING`
-: A string containing one or more query strings to remove for obfuscation.
-
-`DD_APM_CONFIG_OBFUSCATION_MEMCACHED_ENABLED`
-: Whether or not to enable obfuscation of `memcached`.
-
-`DD_APM_CONFIG_OBFUSCATION_MONGODB_ENABLED`
-: Whether or not to enable obfuscation of `mongodb`. 
-
-`DD_APM_CONFIG_OBFUSCATION_MONGODB_KEEP_VALUES`
-: Whether or not to store obfuscated values from `mongodb`.
-
-`DD_APM_CONFIG_OBFUSCATION_REDIS_ENABLED`
-: Whether or not to enable obfuscation for `redis`.
-
-`DD_APM_CONFIG_OBFUSCATION_REMOVE_STACK_TRACES`
-: Whether or not to remove stack traces for obfuscation.
+Agent [trace][2] obfuscation is disabled by default. Enable it in your `datadog.yaml` configuration file to obfuscate all information attached to your traces.
 
 This option works with the following services:
 


### PR DESCRIPTION
### What does this PR do?
Obfuscation options on the trace agent can't be set as env vars
It's a revert of [PR11684](https://github.com/DataDog/documentation/pull/11684)

### Motivation
APMS-6466

### Preview
https://docs-staging.datadoghq.com/cecile/removeobfuscationenvvars/tracing/setup_overview/configure_data_security/?tab=mongodb#agent-trace-obfuscation

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
