### PR TITLE
DOCS-1926 Move Gov note for Browser Tests

### DIFF
--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -64,7 +64,7 @@ Define the configuration of your browser test.
 3. **Name**: The name of your browser test.
 4. **Select your tags**: The tags attached to your browser test. Use the `<KEY>:<VALUE>` format to filter on a `<VALUE>` for a given `<KEY>` on the Synthetic tests page.
 5. **Browsers & Devices**: The browsers (`Chrome`, `Firefox`, `Edge`) and devices (`Laptop Large`, `Tablet`, `Mobile Small`) to run your test on. 
-6. **Locations**: The Datadog managed locations to run your test from. Many AWS locations from around the world are available for each site. For the Datadog for Government site, the West US (AWS GovCloud) location is supported. You can also set up [private locations][1] to run your browser test from custom locations or from inside private networks. See a full list of locations in the [Datadog app][2] or use the [API][3].
+6. **Locations**: The Datadog managed locations to run your test from. Many AWS locations from around the world are available for each site. You can also set up [private locations][1] to run your browser test from custom locations or from inside private networks. See a full list of locations in the [Datadog app][2] or use the [API][3]. {{< site-region region="gov" >}}**Note**: The West US (AWS GovCloud) location is supported on the Datadog for Government site.{{< /site-region >}}
 7. **How often should Datadog run the test?** Intervals are available between every five minutes to once per week. The one minute frequency is available [upon request][4].
 
 ### Use global variables


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Move Gov note for Browser Tests inside region-selector.

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/ruth/docs-1926/synthetics/browser_tests/#test-configuration

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
