### PR TITLE
(DOCS-2753) Remove instances of let's and we

### DIFF
--- a/content/en/account_management/billing/custom_metrics.md
+++ b/content/en/account_management/billing/custom_metrics.md
@@ -61,7 +61,7 @@ The count of custom metrics reporting from `temperature` scales with the most gr
 
 Suppose you also wanted to tag your temperature metric by `state` (which has two values: `NY` and `Florida`). This means you are tagging temperature by the tags: `country`, `region`, `state`, and `city`. Adding the state tag doesn't increase the level of granularity already present in your dataset provided by the city tag.
 
-To obtain the temperature in Florida, you can simply recombine the custom metrics of:
+To obtain the temperature in Florida, you can recombine the custom metrics of:
 
 - `temperature{country:USA, state:Florida, city:Orlando}`
 - `temperature{country:USA, state:Florida, city:Miami}`

--- a/content/en/account_management/billing/pricing.md
+++ b/content/en/account_management/billing/pricing.md
@@ -77,7 +77,7 @@ You can put controls in place for both Indexed and Ingested span volumes. For mo
 ## Incident Management
 
 * Datadog tracks the number of monthly active users who participate in incident management and response.
- * An **active user** is only counted if they contribute comments or signals (graphs, links, etc.) to an incident. Anyone who only opens/closes an incident or simply views the incident are not counted. Additionally, these are not named seats, so you do not need to determine which specific users have access.
+ * An **active user** is only counted if they contribute comments or signals (graphs, links, etc.) to an incident. Anyone who only opens or closes an incident or anyone who only views the incident are not counted. Additionally, these are not named seats, so you do not need to determine which specific users have access.
 
 
 ## Troubleshooting

--- a/content/en/account_management/saml/_index.md
+++ b/content/en/account_management/saml/_index.md
@@ -157,7 +157,7 @@ You can make your organization SAML Strict by disabling other login method types
 
 ### Self-updating Datadog SP Metadata
 
-Certain Identity Providers (such as Microsoft's ADFS) can be configured to pull the latest SAML service provider metadata from Datadog. After you configure SAML in Datadog, you can get the metadata URL for your organization from the SAML Configuration page and use that with your Identity Provider to get the latest service provider metadata whenever we publish changes.
+Certain Identity Providers (such as Microsoft's ADFS) can be configured to pull the latest SAML service provider metadata from Datadog. After you configure SAML in Datadog, you can get the metadata URL for your organization from the SAML Configuration page and use that with your Identity Provider to get the latest service provider metadata whenever changes are published.
 
 {{< img src="account_management/saml/saml_metadata_url.png" alt="SAML Metadata URL" style="width:50%;" >}}
 

--- a/content/en/agent/guide/agent-configuration-files.md
+++ b/content/en/agent/guide/agent-configuration-files.md
@@ -81,7 +81,7 @@ An example for each Agent check configuration file is found in the `conf.yaml.ex
 └── frontend.yaml
 ```
 
-A special case are YAML files with the suffix `.default`. These files are loaded by the Agent by default and help define the core set of checks that are always enabled (CPU, memory, uptime ...). They are ignored if any other configuration are found for that check, therefore you can safely ignore them. If you want to disable one of the default checks simply remove that file. To configure these checks, `conf.yaml.example` should be use as a base.
+A special case are YAML files with the suffix `.default`. These files are loaded by the Agent by default and help define the core set of checks that are always enabled (CPU, memory, uptime ...). They are ignored if any other configuration are found for that check, therefore you can safely ignore them. If you want to disable one of the default checks, remove that file. To configure these checks, `conf.yaml.example` should be use as a base.
 
 Autodiscovery template files are stored in the configuration folder with the `auto_conf.yaml` file. For example, for the Redis check, here is the configuration in `redisdb.d/`:
 

--- a/content/en/agent/guide/dogstream.md
+++ b/content/en/agent/guide/dogstream.md
@@ -82,7 +82,7 @@ Custom parsing functions must:
 
 ### Metrics collection
 
-Let's imagine that you're collecting metrics from logs that are not canonically formatted, but which are intelligently delimited by a unique character, logged as the following:
+Imagine that you're collecting metrics from logs that are not canonically formatted, but which are intelligently delimited by a unique character, logged as the following:
 
 ```text
 user.crashes|2016-05-28 20:24:43.463930|24|LotusNotes,Outlook,Explorer

--- a/content/en/dashboards/functions/exclusion.md
+++ b/content/en/dashboards/functions/exclusion.md
@@ -11,9 +11,7 @@ aliases:
 | ---------------- | -------------------------------------------------------------- | ---------------------------------------------- |
 | `exclude_null()` | Remove groups with N/A tag values from your graph or top list. | `exclude_null(avg:system.load.1{*} by {host})` |
 
-Example:
-
-Let's say you have a metric with two tags: `account` and `region`. `account` has three possible values (`prod`, `build` and `N/A`) while `region` has four possible values (`us-east-1`, `us-west-1`, `eu-central-1`, and `N/A`).
+For example, say you have a metric with two tags: `account` and `region`. `account` has three possible values (`prod`, `build` and `N/A`) while `region` has four possible values (`us-east-1`, `us-west-1`, `eu-central-1`, and `N/A`).
 
 When you graph this metric as a timeseries, you would have 3 x 4 = 12 lines on your graph. Applying `exclude_null()` removes lines with tag combinations containing _any_ N/A values, leaving you with 2 x 3 = 6 groups.
 

--- a/content/en/database_monitoring/troubleshooting.md
+++ b/content/en/database_monitoring/troubleshooting.md
@@ -278,7 +278,7 @@ Some or all queries may not have plans available. This can be due to unsupported
 
 | Possible cause                         | Solution                                  |
 |----------------------------------------|-------------------------------------------|
-| The Agent is running an unsupported version. | Ensure that the Agent is running version 7.30.0 or greater. We recommend regular updates of the Agent to take advantage of new features, performance improvements, and security updates. |
+| The Agent is running an unsupported version. | Ensure that the Agent is running version 7.30.0 or greater. Datadog recommends regular updates of the Agent to take advantage of new features, performance improvements, and security updates. |
 | The Agent is not able to execute a required function in the `datadog` schema of the database. | The Agent requires the function `datadog.explain_statement(...)` to exist in **all databases** the Agent can collect queries from. Ensure this function was created by the root user according to the [setup instructions][1] and that the `datadog` user has permission to execute it. |
 | Queries are truncated. | See the section on [truncated query samples](#query-samples-are-truncated) for instructions on how to increase the size of sample query text. |
 | The application client used to execute the query is using the Postgres extended query protocol or prepared statements. | Some client applications using the Postgres [extended query protocol][2] do not support the collection of explain plans due to the separation of the parsed query and raw bind parameters. For instance, the Python client [asyncpg][3] and the Go client [pgx][4] use the extended query protocol by default. To work around this limitation, you can configure your database client to use the simple query protocol. For example: set `preferQueryMode = simple` for the [Postgres JDBC Client][5] or set `PreferSimpleProtocol` on the [pgx][4] connection config. |
@@ -299,7 +299,7 @@ Some or all queries may not have plans available. This can be due to unsupported
 
 | Possible cause                         | Solution                                  |
 |----------------------------------------|-------------------------------------------|
-| The Agent is running an unsupported version. | Ensure that the Agent is running version 7.30.0 or greater. We recommend regular updates of the Agent to take advantage of new features, performance improvements, and security updates. |
+| The Agent is running an unsupported version. | Ensure that the Agent is running version 7.30.0 or greater. Datadog recommends regular updates of the Agent to take advantage of new features, performance improvements, and security updates. |
 | The Agent is not able to execute a required function in this schema of the database. | The Agent requires the function `explain_statement(...)` to exist in **all schemas** the Agent can collect samples from. Ensure this function was created by the root user according to the [setup instructions][1] and that the `datadog` user has permission to execute it. |
 | Queries are truncated. | See the section on [truncated query samples](#query-samples-are-truncated) for instructions on how to increase the size of sample query text. |
 | The query cannot be explained. | Some queries such as BEGIN, COMMIT, SHOW, USE, and ALTER queries cannot yield a valid explain plan from the database. Only SELECT, UPDATE, INSERT, DELETE, and REPLACE queries have support for explain plans. |
@@ -337,17 +337,17 @@ See the appropriate version of the [Postgres `contrib` documentation][1] for mor
 
 ### Schema or Database missing on MySQL Query Metrics & Samples
 
-The `schema` tag (also known as "database") is present on MySQL Query Metrics and Samples only when a Default Database is set on the connection that made the query. The Default Database is configured by the application by specifying the "schema" in the database connection parameters, or by executing the [USE Statement][5] on an already existing connection.
+The `schema` tag (also known as "database") is present on MySQL Query Metrics and Samples only when a Default Database is set on the connection that made the query. The Default Database is configured by the application by specifying the "schema" in the database connection parameters, or by executing the [USE Statement][4] on an already existing connection.
 
 If there is no default database configured for a connection, then none of the queries made by that connection have the `schema` tag on them.
 
 ## Need more help?
 
-If you are still experiencing problems, contact [Datadog Support][4] for help.
+If you are still experiencing problems, contact [Datadog Support][5] for help.
 
 
 [1]: /database_monitoring/#getting-started
 [2]: /agent/troubleshooting/
 [3]: /agent/guide/agent-log-files
-[4]: /help/
-[5]: https://dev.mysql.com/doc/refman/8.0/en/use.html
+[4]: https://dev.mysql.com/doc/refman/8.0/en/use.html
+[5]: /help/

--- a/content/en/integrations/faq/can-i-use-a-named-instance-in-the-sql-server-integration.md
+++ b/content/en/integrations/faq/can-i-use-a-named-instance-in-the-sql-server-integration.md
@@ -3,7 +3,7 @@ title: Can I use a named instance in the SQL Server integration?
 kind: faq
 ---
 
-When connecting to a default instances in SQL Server, users specify the host name with the port (1433 by default) as the host value in the sqlserver.yaml file. When [troubleshooting connection issues with SQL Server][1], make sure we are connecting to a default instance or a named instance. Named instances can be connected using the $SERVER\$INSTANCE_NAME syntax, but only if the SQL Server Browser service is enabled since this service provides the port the instance is on.
+When connecting to a default instance in SQL Server, users specify the host name with the port (1433 by default) as the host value in the sqlserver.yaml file. When [troubleshooting connection issues with SQL Server][1], determine whether you are connecting to a default instance or a named instance. Named instances can be connected using the $SERVER\$INSTANCE_NAME syntax, but only if the SQL Server Browser service is enabled since this service provides the port the instance is on.
 
 Here are the docs from Microsoft with more about the SQL Server Browser service:
 
@@ -11,7 +11,7 @@ Here are the docs from Microsoft with more about the SQL Server Browser service:
 https://technet.microsoft.com/en-us/library/ms181087(v=sql.105).aspx#Anchor_2
 ```
 
-The SQL Server Browser service is required to use named instances and this service is disabled by default. We highly recommend the approval of a sys admin before enabling [this service][2]).
+The SQL Server Browser service is required to use named instances and this service is disabled by default. Datadog highly recommends the approval of a system admin before enabling [this service][2]).
 
 Once the SQL Server Browser service has been enabled, you can configure the [sqlserver.yaml][3] file to connect to a named instance by designating the named instance in the host value. For example:
 

--- a/content/en/integrations/faq/cloud-metric-delay.md
+++ b/content/en/integrations/faq/cloud-metric-delay.md
@@ -54,7 +54,7 @@ When creating monitors in Datadog, a warning message displays if you choose a de
 
 To obtain metrics with virtually zero delay, install the Datadog Agent on your cloud hosts when possible. Refer to the documentation on [installing the Datadog Agent on your cloud instances][1].
 
-On the Datadog side for the AWS, Azure, and GCP integrations, we may be able to speed up the default metric crawler for all metrics. Additionally, for AWS, Datadog has namespace specific crawlers. Contact [Datadog support][2] for more information.
+On the Datadog side for the AWS, Azure, and GCP integrations, Datadog may be able to speed up the default metric crawler for all metrics. Additionally, for AWS, Datadog has namespace specific crawlers. Contact [Datadog support][2] for more information.
 
 ## Further Reading
 

--- a/content/en/integrations/faq/how-to-retrieve-wmi-metrics.md
+++ b/content/en/integrations/faq/how-to-retrieve-wmi-metrics.md
@@ -36,7 +36,7 @@ PS C:\> (Get-WmiObject -List).count
 931
 ```
 
-We can find classes about a specific topic by using the where statement. To display classes that hold processes information, run:
+You can find classes about a specific topic by using the `where` statement. To display classes that hold processes information, run:
 
 ```text
 PS C:\> Get-WmiObject -List | where {$_.name -match "process"} | select Name
@@ -55,9 +55,9 @@ Win32_PerfFormattedData_PerfProc_Process
 [...]
 ```
 
-To browse the data exposed by a class, we can use a syntax similar to SQL called [WQL][1].
+To browse the data exposed by a class, you can use a syntax similar to SQL called [WQL][1].
 
-Many performance related metrics are reported by the PerfMon tool, and are called `Win32_PerfFormattedData_`. In this example we want to look at processes information so we query the `Win32_PerfFormattedData_PerfProc_Process` class:
+Many performance related metrics are reported by the PerfMon tool, and are called `Win32_PerfFormattedData_`. In this example, look at the processes information so you can query the `Win32_PerfFormattedData_PerfProc_Process` class:
 
 ```text
 PS C:\> Get-WmiObject -Query "select * from Win32_PerfFormattedData_PerfProc_Process where Name = 'Powershell'"
@@ -116,9 +116,9 @@ For those who can run third-party applications on their machine the tool WMI Exp
 
 ## Leveraging WMI in Datadog
 
-Now that we understand WMI better, let's see how we can get this data into Datadog. Open the Datagog Agent Manager and click on the WMI Check integration in the left panel.
+After understanding a little bit about how WMI works, you can get this data into Datadog. Open the Datadog Agent Manager and click on the WMI Check integration in the left panel.
 
-Let's start with a simple example: monitoring the number of processes on the machine:
+Start with a simple example: monitoring the number of processes on the machine:
 
 ```yaml
 init_config:
@@ -142,7 +142,7 @@ Save the configuration, enable the integration and restart then go to 'Logs and 
 wmi_check Instance #0 OK Collected 1 metrics, 0 events and 1 service check
 ```
 
-Now let's monitor the Windows Powershell process we were looking at earlier:
+Monitor the Windows Powershell process you were looking at earlier:
 
 ```yaml
 init_config:
@@ -174,7 +174,7 @@ wmi_check
   Collected 0 metrics, 0 events and 1 service check
 ```
 
-This is because the Agent cannot report on 2 different metrics that have the same set of name and tags. To be able to differentiate between the 2 we can use the `tag_by: Instance_Property_Name statement` to use the value of an instance's property as an additional tag:
+This is because the Agent cannot report on 2 different metrics that have the same set of name and tags. To be able to differentiate between the 2 you can use the `tag_by: Instance_Property_Name statement` to use the value of an instance's property as an additional tag:
 
 ```yaml
 init_config:
@@ -193,7 +193,7 @@ instances:
 # values for your WMI query. The examples below show how you can tag your
 # process metrics with the process name (giving a tag of "name:app_name").
     tag_by: Name
-# Note that bellow works on Window >= 2008, as process names are appended a `#XYZ` where `XYZ` is an incremental numebr
+# Note that bellow works on Window >= 2008, as process names are appended a `#XYZ` where `XYZ` is an incremental number
 # If running on Windows 2003, use a different uniq value like `tag_by: IDProcess`
 ```
 
@@ -208,7 +208,7 @@ wmi_check
 
 If the information that you would like to use as a tag is not part of the class you're getting the data from, you have the possibility to use the tag_queries list to link data from different tables.
 
-Let's say I want to report on PoolNonPagedBytes from Win32_PerfFormattedData_PerfProc_Process and I want to addCreationDate from Win32_Process as a tag. These 2 classes expose the PID with different names: IDProcess inWin32_PerfFormattedData_PerfProc_Process and Handle in Win32_Process. So the former is thelink source property and the later the target property:
+Say you want to report on PoolNonPagedBytes from Win32_PerfFormattedData_PerfProc_Process and you want to addCreationDate from Win32_Process as a tag. These 2 classes expose the PID with different names: IDProcess inWin32_PerfFormattedData_PerfProc_Process and Handle in Win32_Process. So the former is the link source property and the later the target property:
 
 ```yaml
 # `tag_queries` optionally lets you specify a list of queries, to tag metrics

--- a/content/en/integrations/faq/how-to-use-bean-regexes-to-filter-your-jmx-metrics-and-supply-additional-tags.md
+++ b/content/en/integrations/faq/how-to-use-bean-regexes-to-filter-your-jmx-metrics-and-supply-additional-tags.md
@@ -16,7 +16,7 @@ Capture groups from the provided regex can be used to supply additional tag valu
 
 This article provides one example of how to use the `bean_regex` from the [Java integration][2], and how to reference such capture groups to set additional tags.
 
-Suppose you have the following Mbean name: `domain.example.com:name=my.metric.name.env.dev.region.eu-central-1.method.GET.status.200`. There is some information we could use as tags once the Agent has collected the metric. For instance, we could export such metric with the following tags:
+Suppose you have the following Mbean name: `domain.example.com:name=my.metric.name.env.dev.region.eu-central-1.method.GET.status.200`. There is some information you could use as tags once the Agent has collected the metric. For instance, you could export a metric with the following tags:
 
 * `env`: `dev`
 * `region`: `eu-central-1`

--- a/content/en/logs/faq/how-to-investigate-a-log-parsing-issue.md
+++ b/content/en/logs/faq/how-to-investigate-a-log-parsing-issue.md
@@ -29,59 +29,60 @@ Before troubleshooting your parser, read the Datadog log [processors][1] and [pa
     In most of the cases, you should have examples or log samples in your parsers. Compare your log with the sample to find simple differences such as a missing element, a different order or extra elements.
     Also check the timestamp format as this is very often the culprit.
 
-    Let's illustrate this with an apache log. In your integration parser you have examples such as:
+    You can illustrate this with an apache log. In your integration parser you have examples such as:
     ```
     127.0.0.1 - frank [13/Jul/2016:10:55:36 +0000] "GET /apache_pb.gif HTTP/1.0" 200 2326
     ```
 
-    Let's say that your log is:
+    Say that your log is:
     ```
     [13/Jul/2016:10:55:36 +0000] 127.0.0.1 - frank "GET /apache_pb.gif HTTP/1.0" 200 2326
     ```
 
-    We can see that the timestamp is not at the same place. Therefore we need to change the parsing rule to reflect that difference.
+    The timestamp is not at the same place. Therefore, you need to change the parsing rule to reflect that difference.
 
 3. **Find the culprit attribute**:
-    There are no obvious differences in the format? Let's start the actual troubleshooting on the parsing rule. Let's use a shortened format of an ELB log to illustrate a real case.
+    There are no obvious differences in the format? Start the actual troubleshooting on the parsing rule. Here is a shortened format of an ELB log to illustrate a real case.
 
     The parsing rule is the following:
     ```
     elb.http %{date("yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ"):date_access} %{notSpace:elb.name} "(?>%{word:http.method} |- )%{notSpace:http.url:nullIf("-")}(?> HTTP\/%{regex("\\d+\\.\\d+"):http.version}| - )" "%{notSpace:http.useragent:nullIf("-")}" %{notSpace:elb.ssl.cipher} %{notSpace:elb.ssl.protocol}
     ```
 
-    And we have the following log:
+    It contains the following log:
     ```
     2015-05-13T23:39:43.945958Z my-loadbalancer "GET http://www.example.com:80/ HTTP/1.1" "Mozilla/5.0 (Windows NT 5.1; rv:52.0) Gecko/20100101 Firefox/52.0" - -
     ```
 
-    From the provided sample we can see that there are no obvious differences and that the parser works fine for the sample:
+    From the provided sample, there are no obvious differences and the parser works fine for the sample:
     {{< img src="logs/faq/sampleparsing.png" alt="sampleparsing"  >}}
 
-    But when we test with our log, it is not working. So let's start to remove attribute one by one from the end until we find the culprit. To do so, we add `.*` at the end of the rule and then we remove the attributes.
+    But when tested with the log, it is not working. The next step is to start to remove attributes one by one from the end until you find the culprit. To do so, add `.*` at the end of the rule and then remove the attributes.
 
-    On the below image, we can see that the rule starts working once we have remove everything up to the user Agent:
+   The image below illustrates the rule starting to work after you have removed everything up to the user Agent:
     {{< img src="logs/faq/Troubleshootparsing.png" alt="Troubleshootparsing"  >}}
 
     This means that the issue is in the user Agent attribute.
 
 4. **Fix the issue**:
-    Now that the culprit attribute is identified, let's look at it more closely.
+    Now that the culprit attribute is identified, look at it more closely.
 
-    The user Agent we have in our log is:
+    The user Agent in the log is:
 
     * Mozilla/5.0 (Windows NT 5.1; rv:52.0) Gecko/20100101 Firefox/52.0.
 
-    And our parsing rule is using:
+    And the parsing rule is using:
 
     * `%{notSpace:http.useragent:nullIf("-")}`
 
-    The first thing to check is the matcher (as a reminder a matcher describes what element the rule expects such as integer, notSpace, regex, ...). Here we have notSpace. But our useragent contains spaces and even specific characeters. Therefore notSpace is not going to work here.
+    The first thing to check is the matcher (as a reminder, a matcher describes what element the rule expects such as integer, notSpace, regex, ...). Here, it expects `notSpace`. But the useragent contains spaces and even specific characters. Therefore `notSpace` is not going to work here.
+    
     The matcher to use is: regex("[^\\\"]*")
 
     In other situation it might be the rule expecting an "integer" whereas the values are double so the matcher should be changed to "number".
 
 5. **Ask for help**:
-    We are always here to help you! If you did not manage to find the cause of the parsing error, [contact us][4].
+    Datadog is always here to help you! If you did not manage to find the cause of the parsing error, [contact us][4].
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/content/en/logs/faq/how-to-remap-custom-severity-values-to-the-official-log-status.md
+++ b/content/en/logs/faq/how-to-remap-custom-severity-values-to-the-official-log-status.md
@@ -17,7 +17,7 @@ By default, the [Log Status Remapper][1] relies on the [Syslog severity standard
 However there might be other systems having different severity values that you might want to remap on the official log status.
 This is possible thanks to the [Category Processor][3] that defines a mapping between your custom values and the expected ones.
 
-In this article, we show how to do this with 2 examples: Bunyan levels and web access logs.
+This page describes how to do this with 2 examples: Bunyan levels and web access logs.
 
 ## Web access logs
 
@@ -28,7 +28,7 @@ The status code of the request can be used to determine the log status. Our inte
 * 4xx: Warning
 * 5xx: Error
 
-Let's assume the status code of your log is stored in the `http.status_code` attribute.
+Assume the status code of your log is stored in the `http.status_code` attribute.
 Add a Category Processor in your Pipeline that creates a new attribute to reflect the above mapping:
 
 {{< img src="logs/faq/category_processor.png" alt="Category Processor "  >}}
@@ -48,7 +48,7 @@ Bunyan levels are similar to those of Syslog, but their values are multiplied by
 * 50 = ERROR
 * 60 = FATAL
 
-Let's assume the bunyan level is stored in the `bunyan_level` attribute.
+Assume the bunyan level is stored in the `bunyan_level` attribute.
 Add a Category Processor in your Pipeline that creates a new attribute to reflect the above mapping:
 
 {{< img src="logs/faq/category_processor_bunyan.png" alt="category Processor  bunyan"  >}}

--- a/content/en/logs/faq/why-do-my-logs-not-have-the-expected-timestamp.md
+++ b/content/en/logs/faq/why-do-my-logs-not-have-the-expected-timestamp.md
@@ -27,13 +27,13 @@ However, this default timestamp does not always reflect the actual value that mi
 
     Check your [user settings][1] to understand if this could be linked to a bad timezone on your profile:
     {{< img src="logs/faq/log_timestamp_2.png" alt="User setting"  style="width:75%;">}}
-    But we can extract the timestamp from the message to override the actual log date for both raw and JSON logs.
+    But you can extract the timestamp from the message to override the actual log date for both raw and JSON logs.
 
 2. **Raw logs**.
 
     2.1 **Extract the timestamp value with a parser**.
         While writing a parsing rule for your logs, you need to extract the timestamp in a specific attribute. [Refer to some specific date parsing examples to help you][2].
-        For the above log, we would use the following rule with the `date()` [matcher][3] to extract the date and pass it into a custom date attribute:
+        For the above log, you would use the following rule with the `date()` [matcher][3] to extract the date and pass it into a custom date attribute:
         {{< img src="logs/faq/log_timestamp_3.png" alt="Parsing date"  style="width:75%;">}}
 
     2.2 **Define a Log Date Remapper**.
@@ -49,10 +49,10 @@ However, this default timestamp does not always reflect the actual value that mi
     3.1 **Supported Date formats**.
         JSON logs are automatically parsed in Datadog.
         The log `date` attribute is one of the [reserved attributes][5] in Datadog which means JSON logs that use those attributes have their values treated specially - in this case to derive the log's date. Change the default remapping for these attributes at the top of your [Pipeline][6].
-        So let's imagine that the actual timestamp of the log is contained in the attribute mytimestamp.
+        Imagine that the actual timestamp of the log is contained in the attribute mytimestamp.
         {{< img src="logs/faq/log_timestamp_6.png" alt="log with mytimestamp attribute"  style="width:75%;">}}
-        To make sure this attribute value is taken to override the log date, we would simply need to add it in the list of Date attributes.
-        The date remapper looks for each of the reserved attributes in the order in which they are configured in the reserved attribute mapping, so to be 100% sure that our `mytimestamp` attribute is used to derive the date, we can place it first in the list.
+        To make sure this attribute value is taken to override the log date, you must add it in the list of Date attributes.
+        The date remapper looks for each of the reserved attributes in the order in which they are configured in the reserved attribute mapping, so to be 100% sure that our `mytimestamp` attribute is used to derive the date, you can place it first in the list.
         **Note**: Any modification on the Pipeline only impacts new logs as all the processing is done at ingestion.
         There are specific date formats to respect for the remapping to work. The recognized date formats are: [ISO8601][7], [UNIX (the milliseconds EPOCH format)][8] and [RFC3164][9].
         If the format is different from one of the above (so if your logs still do not have the right timestamp), there is a solution.

--- a/content/en/logs/faq/why-do-my-logs-show-up-with-an-info-status-even-for-warnings-or-errors.md
+++ b/content/en/logs/faq/why-do-my-logs-show-up-with-an-info-status-even-for-warnings-or-errors.md
@@ -47,7 +47,7 @@ All new logs processed by this Pipeline should now have the correct status.
 
 **JSON logs are automatically parsed in Datadog.**
 The log `status` attribute is one of the [reserved attributes][3] in Datadog which means JSON logs that use those attributes have their values treated specially - in this case to derive the log's status. Change the default remapping for these attributes at the top of your [Pipeline][4].
-So let's imagine that the actual status of the log is contained in the attribute `logger_severity`.
+Imagine that the actual status of the log is contained in the attribute `logger_severity`.
 
 {{< img src="logs/faq/new_log.png" alt="new log"  style="width:50%;">}}
 

--- a/content/en/logs/guide/log-collection-troubleshooting-guide.md
+++ b/content/en/logs/guide/log-collection-troubleshooting-guide.md
@@ -58,7 +58,7 @@ The Datadog Agent only collects logs that have been written after it has started
 
 ## Permission issues tailing log files
 
-The `datadog-agent` does not run as root (and we do not recommend that you make it run as root, as a general best-practice). For this reason, when you configure your `datadog-agent` to tail log files (for custom logs or for integrations) you need to take special care to ensure the `datadog-agent` user has read access to tail the log files you want to collect from.
+The `datadog-agent` does not run as root (and running as root is not recommended, as a general best-practice). For this reason, when you configure your `datadog-agent` to tail log files (for custom logs or for integrations) you need to take special care to ensure the `datadog-agent` user has read access to tail the log files you want to collect from.
 
 In that case, you should see an error message when checking the [Agent status][5]:
 

--- a/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
+++ b/content/en/logs/guide/setting-file-permissions-for-rotating-logs.md
@@ -106,7 +106,7 @@ The easiest path here is to give everyone read access to the file in the logrota
 }
 ```
 
-Each common off-the-shelf application will follow a similar nomenclature. The advantage is that we avoid providing privileged access to an individual account and use a standardized practice. This will keep your audit rules in check.
+Each common off-the-shelf application will follow a similar nomenclature. The advantage is that you avoid providing privileged access to an individual account and use a standardized practice. This keeps your audit rules in check.
 
 ## Further Reading
 

--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -24,9 +24,9 @@ further_reading:
   text: "Log Collection Troubleshooting Guide"
 ---
 
-To send your C# logs to Datadog, we recommend logging to a file and then tailing that file with your Datadog Agent. Here are setup examples for the `Serilog`, `NLog`, and `log4net` logging libraries
+To send your C# logs to Datadog, log to a file and then tail that file with your Datadog Agent. This page details setup examples for the `Serilog`, `NLog`, and `log4net` logging libraries.
 
-We strongly encourage setting up your logging library to produce your logs in JSON format to avoid the need for [custom parsing rules][1].
+Datadog strongly encourages setting up your logging library to produce your logs in JSON format to avoid the need for [custom parsing rules][1].
 
 ## Configure your logger
 
@@ -251,7 +251,7 @@ If you have followed the instructions you should see in your file (for example `
 }
 ```
 
-If, despite the benefits of logging in JSON, you wish to log in raw string format, we recommend you update the `log4net conversion pattern` to automatically parse your logs with the C# integration Pipeline as follows:
+If, despite the benefits of logging in JSON, you wish to log in raw string format, try updating the `log4net conversion pattern` to automatically parse your logs with the C# integration Pipeline as follows:
 
 ```text
 <param name="ConversionPattern" value="%date{yyyy-MM-dd HH:mm:ss.SSS} %level [%thread] %logger %method:%line - %message%n" />

--- a/content/en/logs/log_collection/go.md
+++ b/content/en/logs/log_collection/go.md
@@ -24,9 +24,9 @@ further_reading:
   text: "Log Collection Troubleshooting Guide"
 ---
 
-To send your go logs to Datadog, we recommend logging to a file and then tailing that file with your Datadog Agent. To achieve that we suggest the following setup with the open source logging library called [logrus][1]
+To send your go logs to Datadog, log to a file and then tail that file with your Datadog Agent. To achieve that, the following setup with the open source logging library called [logrus][1] is preferred.
 
-We strongly encourage setting up your logging library to produce your logs in JSON format to avoid the need for [custom parsing rules][2].
+Datadog strongly encourages setting up your logging library to produce your logs in JSON format to avoid the need for [custom parsing rules][2].
 
 ## Configure your logger
 

--- a/content/en/logs/log_configuration/indexes.md
+++ b/content/en/logs/log_configuration/indexes.md
@@ -83,7 +83,7 @@ You might not need your DEBUG logs until you actually need them when your platfo
 
 #### Keep an eye on trends
 
-Let's say now you don't want to keep all logs from your web access server requests. You could choose to index all 3xx, 4xx, and 5xx logs, but exclude 95% of the 2xx logs: `source:nginx AND http.status_code:[200 TO 299]` to keep track of the trends.
+What if you don't want to keep all logs from your web access server requests? You could choose to index all 3xx, 4xx, and 5xx logs, but exclude 95% of the 2xx logs: `source:nginx AND http.status_code:[200 TO 299]` to keep track of the trends.
 **Tip**: Transform web access logs into meaningful KPIs with a [metric generated from your logs][9], counting number of requests and tagged by status code, [browser][13] and [country][14].
 
 {{< img src="logs/indexes/sample_200.png" alt="enable index filters"  style="width:80%;">}}

--- a/content/en/metrics/powershell_metrics_submission.md
+++ b/content/en/metrics/powershell_metrics_submission.md
@@ -44,7 +44,7 @@ $url_signature = "api/v1/series"
 $url = $url_base + $url_signature + "?api_key=$api_key" + "&" + "application_key=$app_key"
 $tags = "[env:test]" #optional parameter
 
-# Select what to send to Datadog. In this example we send the number of handles opened by process "mmc"
+# Select what to send to Datadog. In this example, the number of handles opened by process "mmc" is being sent
 $metric_ns = "ps1." # your desired metric namespace
 $temp = Get-Process mmc
 $metric = @{"name"=$metric_ns + $temp.Name; "amount"=$temp.Handles}

--- a/content/en/monitors/create/types/anomaly.md
+++ b/content/en/monitors/create/types/anomaly.md
@@ -117,7 +117,7 @@ This example shows how the algorithms react to an hour-long anomaly. `Robust` do
 
 {{< img src="monitors/monitor_types/anomaly/alg_comparison_3.png" alt="algorithm comparison 3"  style="width:90%;">}}
 
-The algorithms deal with scale differently. `Basic` and `robust` are scale-insensitive, while `agile` is not. The graphs on the left below show `agile` and `robust` mark the level-shift as being anomalous. On the right, we add 1000 to the same metric, and `agile` no longer calls out the level-shift as being anomalous whereas `robust` continues do so.
+The algorithms deal with scale differently. `Basic` and `robust` are scale-insensitive, while `agile` is not. The graphs on the left below show `agile` and `robust` mark the level-shift as being anomalous. On the right, 1000 is added to the same metric, and `agile` no longer calls out the level-shift as being anomalous whereas `robust` continues do so.
 
 {{< img src="monitors/monitor_types/anomaly/alg_comparison_scale.png" alt="algorithm comparison scale"  style="width:90%;">}}
 
@@ -168,7 +168,7 @@ avg(<query_window>):anomalies(<metric_query>, '<algorithm>', <deviations>, direc
 : The timeframe which will be checked for anomalies (e.g., `last_5m`, `last_1h`).
 
 `interval`
-: A positive integer representing the number of seconds in the rollup interval. We recommend that the `interval` be at least a fifth of the `alert_window` duration.
+: A positive integer representing the number of seconds in the rollup interval. The `interval` should be at least a fifth of the `alert_window` duration.
 
 `count_default_zero`
 : Use `true` for most monitors. Set to `false` only if submitting a count metric in which the lack of a value should _not_ be interpreted as a zero.

--- a/content/en/monitors/faq/why-am-i-getting-so-many-no-data-alerts-for-my-metric-monitor.md
+++ b/content/en/monitors/faq/why-am-i-getting-so-many-no-data-alerts-for-my-metric-monitor.md
@@ -20,7 +20,7 @@ There are a couple Monitor configuration options that can be edited to properly 
 This is due to the limitations on how soon this metric is available from Cloudwatch.
 
 2. This option is the [Require a Full Window of Data][3] (or the ability to not require).
-This option is typically recommended for metrics being reported by the Datadog Agent and ones that are coming in with the current timestamp. For slightly backfilled metrics, this option can cause No Data events or have the Monitor skip the current evaluation period due to the values not being present at the time the monitor evaluates. For this reason we recommend all sparse metrics or metrics that don't report at the same frequency to use the option "Do Not [Require a Full Window of Data][3]".
+This option is typically recommended for metrics being reported by the Datadog Agent and ones that are coming in with the current timestamp. For slightly backfilled metrics, this option can cause No Data events or have the Monitor skip the current evaluation period due to the values not being present at the time the monitor evaluates. For this reason all sparse metrics or metrics that don't report at the same frequency should use the option "Do Not [Require a Full Window of Data][3]".
 
 3. The last option here is the Delay Evaluation.
 Since Monitors perform an evaluation every minute, it is looking back on the past X minutes of data. For backfilled metrics, like those coming from AWS, the monitor may be looking at a period of time when the data is not in Datadog. This causes false No Data alerts. Setting this field allows you to have the monitor wait, 900 seconds, so that the AWS metrics have 900 seconds to be available within Datadog before the monitor begins evaluation.

--- a/content/en/monitors/guide/monitor_api_options.md
+++ b/content/en/monitors/guide/monitor_api_options.md
@@ -21,7 +21,7 @@ kind: guide
 - **`renotify_interval`** the number of minutes after the last notification before a monitor re-notifies on the current status. It only re-notifies if it's not resolved. Default: **None**.
 - **`renotify_statuses`** the states from which a monitor re-notifies. It can only be set if `renotify_interval` is set. Default: **None**. Without `renotify_states` set, it renotifies from `Alert` and `No Data` states.
 - **`renotify_occurrences`** the number of times a monitor re-notifies. It can only be set if `renotify_interval` is set. Default: **None**, it renotifies without a limit.
-- **`escalation_message`** a message to include with a re-notification. Supports the '@username' notification we allow elsewhere. Not applicable if `renotify_interval` is `None`. Default: **None**.
+- **`escalation_message`** a message to include with a re-notification. Supports the '@username' notification that is allowed elsewhere. Not applicable if `renotify_interval` is `None`. Default: **None**.
 - **`notify_audit`** a Boolean indicating whether tagged users is notified on changes to this monitor. Default: **False**
 - **`locked`** a Boolean indicating whether changes to to this monitor should be restricted to the creator or admins. Default: **False**
 - **`include_tags`** a Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title. Default: **True**. Examples:
@@ -54,7 +54,7 @@ Example: `{'critical': 90, 'warning': 80,  'critical_recovery': 70, 'warning_rec
 
 _These options only apply to service checks and are ignored for other monitor types._
 
-- **`thresholds`** a dictionary of thresholds by status. Because service checks can have multiple thresholds, we don't define them directly in the query.
+- **`thresholds`** a dictionary of thresholds by status. Because service checks can have multiple thresholds, they aren't defined directly in the query.
 
 Example: `{'ok': 1, 'critical': 1, 'warning': 1}`
 

--- a/content/en/monitors/guide/suppress-alert-with-downtimes.md
+++ b/content/en/monitors/guide/suppress-alert-with-downtimes.md
@@ -166,7 +166,7 @@ RRULE - or recurrence rule - is a property name from [iCalendar RFC][4], which i
 
 Attributes specifying the duration in `RRULE` are not supported (for example, `DTSTART`, `DTEND`, `DURATION`), see the [RFC][4] for the possible attributes. You can use [this tool][5] to generate RRULEs and paste them into your API call.
 
-**Example**: The ERP app is updated every 2nd Tuesday of the month to apply patches and fixes between 8AM and 10AM. Monitors for this are scoped with `app:erp`, so we use this in the downtime scope.
+**Example**: The ERP app is updated every 2nd Tuesday of the month to apply patches and fixes between 8AM and 10AM. Monitors for this are scoped with `app:erp`, so this is used in the downtime scope.
 
 {{< tabs >}}
 {{% tab "API " %}}

--- a/content/en/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel.md
+++ b/content/en/tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel.md
@@ -10,7 +10,7 @@ further_reading:
   text: 'Ease troubleshooting with cross product correlation.'
 ---
 
-Clicking on a [trace][1] opens a contextual panel that contains information about the trace, about the host and the correlated logs. However the log panel can be empty in some specific cases. Let's review how this can be fixed.
+Clicking on a [trace][1] opens a contextual panel that contains information about the trace, about the host and the correlated logs. However the log panel can be empty in some specific cases. This page reviews how this can be fixed.
 
 {{< img src="tracing/faq/tracing_no_logs_in_trace.png" alt="Tracing missing logs"  style="width:90%;">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes/replaces instances of "let's" and "we" in the docs. This started getting a little long, so this is just part 1 of the "we" removal. 

### Motivation
OKR!

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
