### PR TITLE
code lang order

### DIFF
--- a/layouts/partials/code-lang-tabs.html
+++ b/layouts/partials/code-lang-tabs.html
@@ -11,7 +11,19 @@
         {{ $codeLangs = .codeLangs }}
     {{ end }}
 
+    <!-- Make sure lang[legacy] items are at the end -->
+    {{ $codeLangsWithoutLegacy := slice }}
+    {{ $legacy := slice }}
     {{ range $codeLangs }}
+      {{ if in . "legacy" }}
+        {{ $legacy = $legacy | append . }}
+      {{ else }}
+        {{ $codeLangsWithoutLegacy = $codeLangsWithoutLegacy | append . }}
+      {{ end }}
+    {{ end }}
+    {{ $finalCodeLangs := ($codeLangsWithoutLegacy | append $legacy) }}
+
+    {{ range $finalCodeLangs }}
         <li class="nav-item" style="margin-bottom: 6px;">
             <a class="nav-link mr-1 js-code-example-link" data-code-lang-trigger="{{ . }}" href="#">{{ index $.context.Site.Params.code_language_ids . }}</a>
         </li>


### PR DESCRIPTION
### What does this PR do?

Ensures that code lang tabs with "legacy" appear at the end.

### Motivation

 Recent hugo updates appears to have sorted this differently than before

### Preview

compare the same url on production
https://docs-staging.datadoghq.com/david.jones/legacy-order/api/latest/metrics/#submit-metrics

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
