### PR TITLE
Bump datadog-lambda-extension layer to version 16

### DIFF
--- a/layouts/shortcodes/latest-lambda-layer-version.html
+++ b/layouts/shortcodes/latest-lambda-layer-version.html
@@ -21,7 +21,7 @@
 
 <!-- Lambda Extension -->
 {{- if eq (.Get "layer") "extension" -}}
-    15
+    16
 {{- end -}}
 
 <!-- dd-trace-java Layer -->


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Bump layer version to 16

---

### Reviewer checklist
- [x] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
