### PR TITLE
Fix where 'windows systems' header appears

### DIFF
--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -166,13 +166,15 @@ If you need to use Network Performance Monitoring on other systems with SELinux 
 
 If these utilities do not exist in your distribution, follow the same procedure but using the utilities provided by your distribution instead.
 
-### Windows systems
 
 [1]: /infrastructure/process/?tab=linuxwindows#installation
 [2]: /agent/guide/agent-commands/#restart-the-agent
 [3]: https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/selinux/system_probe_policy.te
 {{% /tab %}}
 {{% tab "Agent (Windows)" %}}
+
+### Windows systems
+
 Data collection for Windows relies on a filter driver for collecting network data.
 
 To enable Network Performance Monitoring for Windows hosts:

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -173,8 +173,6 @@ If these utilities do not exist in your distribution, follow the same procedure 
 {{% /tab %}}
 {{% tab "Agent (Windows)" %}}
 
-### Windows systems
-
 Data collection for Windows relies on a filter driver for collecting network data.
 
 To enable Network Performance Monitoring for Windows hosts:


### PR DESCRIPTION
### What does this PR do?

This is a small bugfix which makes the windows systems header appear at the top of the windows section in the NPM installation docs.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
