### PR TITLE
[WEB-1968] Adds CI alias to continuous-integration

### DIFF
--- a/content/en/continuous_integration/_index.md
+++ b/content/en/continuous_integration/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Continuous Integration Visibility
 kind: documentation
+aliases:
+  - /CI
 further_reading:
     - link: "/continuous_integration/explore_pipelines/"
       tag: "Documentation"

--- a/content/en/continuous_integration/_index.md
+++ b/content/en/continuous_integration/_index.md
@@ -2,7 +2,7 @@
 title: Continuous Integration Visibility
 kind: documentation
 aliases:
-  - /CI
+  - /ci
 further_reading:
     - link: "/continuous_integration/explore_pipelines/"
       tag: "Documentation"


### PR DESCRIPTION
### What does this PR do?
Adds CI alias to continuous-integration section

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1968

### Preview
https://docs-staging.datadoghq.com/nsollecito/ci-alias/ci/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
