### PR TITLE
Suggest checking permissions on sqlserver logfile

### DIFF
--- a/content/en/database_monitoring/setup_sql_server/selfhosted.md
+++ b/content/en/database_monitoring/setup_sql_server/selfhosted.md
@@ -157,6 +157,7 @@ If you haven't already installed the Agent for your SQL Server database host, se
     ```
 
     Change the `path` parameter value to be the file path of your SQL Server log file.
+    Ensure that the user account under which the Datadog agent is running can access this file.
 
     The `service` parameter allows you to tie your logs to other telemetry through a common `service` tag. To learn more about how `service` is used throughout Datadog, read the documentation on [unified service tagging][8].
 

--- a/content/en/database_monitoring/setup_sql_server/selfhosted.md
+++ b/content/en/database_monitoring/setup_sql_server/selfhosted.md
@@ -156,8 +156,7 @@ If you haven't already installed the Agent for your SQL Server database host, se
         service: "<SERVICE_NAME>"
     ```
 
-    Change the `path` parameter value to be the file path of your SQL Server log file.
-    Ensure that the user account under which the Datadog agent is running can access this file.
+    Change the `path` parameter value to be the file path of your SQL Server log file. Ensure that the user account running the Datadog Agent can access this file.
 
     The `service` parameter allows you to tie your logs to other telemetry through a common `service` tag. To learn more about how `service` is used throughout Datadog, read the documentation on [unified service tagging][8].
 


### PR DESCRIPTION
### What does this PR do?

Suggests checking/updating permissions on log files when setting up the sqlserver integration

### Motivation

I spent an hour or so trying to figure this out!  See also https://github.com/DataDog/datadog-agent/pull/10134

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/dustin.mitchell/sqlserver-log-file-permissions/content/en/database_monitoring/setup_sql_server/selfhosted

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
