### PR TITLE
US3 note for Log Collection index.md

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -27,7 +27,7 @@ further_reading:
 {{< site-region region="us3" >}}
 
 <div class="alert alert-warning">
-Log collection is currently not supported for the Datadog US3 site. For more information, contact <a href="https://help.datadoghq.com/hc/en-us">Support</a>.
+Log collection is not supported for the Datadog US3 site. For more information, contact <a href="https://help.datadoghq.com/hc/en-us">Support</a>.
 </div>
 
 {{< /site-region >}}

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -24,6 +24,14 @@ further_reading:
   text: "Logging Without Limits*"
 ---
 
+{{< site-region region="us3" >}}
+
+<div class="alert alert-warning">
+Log collection is currently not supported for the Datadog US3 site. For more information, contact <a href="https://help.datadoghq.com/hc/en-us">Support</a>.
+</div>
+
+{{< /site-region >}}
+
 ## Overview
 
 Choose a configuration option below to begin ingesting your logs. If you are already using a log-shipper daemon, refer to the dedicated documentation for [Rsyslog][1], [Syslog-ng][2], [NXlog][3], [FluentD][4], or [Logstash][5].


### PR DESCRIPTION
### What does this PR do?
Adds a note that log collection is currently not available for US3.

### Motivation
It's not available yet

### Preview
https://docs-staging.datadoghq.com/sarina/us3-log-collection/logs/log_collection

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
