### PR TITLE
Update logs/explorer and logs/faq pages according to linter rules

### DIFF
--- a/content/en/logs/explorer/saved_views.md
+++ b/content/en/logs/explorer/saved_views.md
@@ -27,7 +27,7 @@ Technically, a Saved View keeps track of:
 
 ## Default view
 
-{{< img src="logs/explorer/saved_views/default.png" alt="Default view"  style="width:50%;" >}}
+{{< img src="logs/explorer/saved_views/default.png" alt="Default view" style="width:50%;" >}}
 
 Your existing Log Explorer view is your default saved view. This configuration is only accessible and viewable to you and updating this configuration does not have any impact on your organization.
 
@@ -41,14 +41,14 @@ At any moment, from the default view entry in the Views panel:
 
 ## Saved views
 
-{{< img src="logs/explorer/saved_views/custom.png" alt="Saved views across organizations"  style="width:50%;" >}}
+{{< img src="logs/explorer/saved_views/custom.png" alt="Saved views across organizations" style="width:50%;" >}}
 
 All saved views, that are not your default saved view, are shared across your organization:
 
 * **Integration saved views** come out-of-the-box with most Datadog [Log Management Integrations][7]. These are read-only, and identified by the logo of the integration.
 * **Custom saved views** are created by users. They are editable by any user in your organization (excepting [Read Only users][8]), and identified with the avatar of the user who created it. Hit the **save** button to create a new custom saved view from the current content of your explorer.
 
-{{< img src="logs/explorer/saved_views/save.png" alt="Logs -- Save"  style="width:30%;" >}}
+{{< img src="logs/explorer/saved_views/save.png" alt="Logs -- Save" style="width:30%;" >}}
 
 At any moment, from the saved view entry in the Views panel:
 
@@ -58,7 +58,7 @@ At any moment, from the saved view entry in the Views panel:
 * **Share** a saved view through a short-link.
 * **Star** (turn into a favorite) a saved view so that it appears on top of your saved view list, and is accessible directly from the navigation menu.
 
-{{< img src="logs/explorer/saved_views/star.png" alt="Starred views"  style="width:50%;" >}}
+{{< img src="logs/explorer/saved_views/star.png" alt="Starred views" style="width:50%;" >}}
 
 *Note*: Update, rename, and delete actions are disabled for integration saved views and [Read Only users][8].
 

--- a/content/en/logs/explorer/search.md
+++ b/content/en/logs/explorer/search.md
@@ -19,11 +19,11 @@ further_reading:
 
 ## Overview
 
-Log Explorer search consists of a timerange and a search query, mixing `key:value` and full-text search.
+Log Explorer search consists of a time range and a search query, mixing `key:value` and full-text search.
 
 ### Search query
 
-For example, to filter on logs produced by a specific service, with a specific status, over the past five minutes, you can create a custom query such as `service:payment status:error rejected` and set the timerange to the `Past 5 minutes`:
+For example, to filter on logs produced by a specific service, with a specific status, over the past five minutes, you can create a custom query such as `service:payment status:error rejected` and set the time range to the `Past 5 minutes`:
 
 {{< img src="logs/explorer/search_filter.jpg" alt="Search Filter" style="width:100%;" >}}
 
@@ -43,7 +43,7 @@ For example, to filter on logs produced by a specific service, with a specific s
 
 ### Search syntax
 
-To begin searching for logs in Log Explorer, see the [Log Search Syntax documentation][1] and read the [timerange documentation][2] for more details on advanced timerange use cases.
+To begin searching for logs in Log Explorer, see the [Log Search Syntax documentation][1] and read the [time frame documentation][2] for more details on custom time frames.
 
 ## Further Reading
 

--- a/content/en/logs/explorer/search_syntax.md
+++ b/content/en/logs/explorer/search_syntax.md
@@ -45,11 +45,11 @@ To combine multiple terms into a complex query, you can use any of the following
 
 Use the search bar's autocomplete feature to complete your query using existing values:
 
-{{< img src="logs/explorer/search/search_bar_autocomplete.jpg" alt="search bar autocomplete "  style="width:80%;">}}
+{{< img src="logs/explorer/search/search_bar_autocomplete.jpg" alt="search bar autocomplete " style="width:80%;">}}
 
 ## Escaping of special characters
 
-The following characters are considered special: `+` `-` `=` `&&` `||` `>` `<` `!` `(` `)` `{` `}` `[` `]` `^` `"` `“` `”` `~` `*` `?` `:` `\`, and `/` require escaping with the `\` character. You can’t search for special characters in a log message. However, you can search for special characters when they’re inside of  an attribute. To search for special characters, parse them into an attribute with the [grok parser][1], and then search for logs that contain the attribute.
+The following characters are considered special: `+` `-` `=` `&&` `||` `>` `<` `!` `(` `)` `{` `}` `[` `]` `^` `"` `“` `”` `~` `*` `?` `:` `\`, and `/` require escaping with the `\` character. You can’t search for special characters in a log message. However, you can search for special characters when they’re inside of an attribute. To search for special characters, parse them into an attribute with the [grok parser][1], and then search for logs that contain the attribute.
 
 
 ## Attributes search
@@ -184,7 +184,7 @@ You can add facets on arrays of strings or numbers. All values included in the a
 
 In the below example, clicking on the `Peter` value in the facet returns all the logs that contains a `users.names` attribute, whose value is either `Peter` or an array that contains `Peter`:
 
-{{< img src="logs/explorer/search/array_search.png" alt="Array and Facets"  style="width:80%;">}}
+{{< img src="logs/explorer/search/array_search.png" alt="Array and Facets" style="width:80%;">}}
 
 {{< site-region region="us,eu" >}}
 
@@ -194,7 +194,7 @@ In the following example, CloudWatch logs for Windows contain an array of JSON o
 
 * `@Event.EventData.Data.Name:ObjectServer` matches all logs with the key `Name` and value `ObjectServer`.
 
-{{< img src="logs/explorer/search/facetless_query_json_arrray2.png" alt="Facetless query on array of JSON objects"  style="width:80%;">}}
+{{< img src="logs/explorer/search/facetless_query_json_arrray2.png" alt="Facetless query on array of JSON objects" style="width:80%;">}}
 <p> </p>
 {{< /site-region >}}
 

--- a/content/en/logs/explorer/side_panel.md
+++ b/content/en/logs/explorer/side_panel.md
@@ -19,7 +19,7 @@ further_reading:
 ## Overview
 Datadog displays individual logs following this general side panel layout:
 
-{{< img src="logs/explorer/side_panel/overview.png" alt="Log Explorer side panel"  style="width:60%;">}}
+{{< img src="logs/explorer/side_panel/overview.png" alt="Log Explorer side panel" style="width:60%;">}}
 
 - The upper part of the panel displays general **context** information
 - The lower part of the panel displays the actual **content** of the log
@@ -39,7 +39,7 @@ Some standard fields, for instance `error.stack`, `http.method`, or `duration`, 
 
 The **View in context** button updates the search request in order to show you the log lines dated just before and after a selected log, even if they don't match your filter. This context is different according to the situation, as Datadog uses the `Hostname`, `Service`, `filename`, and `container_id` attributes, along with tags, in order find the appropriate context for your logs.
 
-Click on the **Metrics** tab and access underlying infrastructure metrics in a 30 minutes timeframe around the log.
+Click on the **Metrics** tab and access underlying infrastructure metrics in a 30 minutes time frame around the log.
 
 Interact with **Host** in the upper reserved attributes section, the related [host dashboard][5], or [network page][6]. Interact with **Container** sections to jump to the [container page][7] scoped with the underlying parameters.
 
@@ -66,7 +66,7 @@ Interact with the attributes names and values in the lower JSON section to:
 - Add or remove a column from the logs table
 - Append the search request with specific values (include or exclude)
 
-{{< img src="logs/explorer/side_panel/context.jpg" alt="Side Panel context"  style="width:50%;">}} {{< img src="logs/explorer/side_panel/context2.jpg" alt="Side Panel context"  style="width:50%;">}}
+{{< img src="logs/explorer/side_panel/context.jpg" alt="Side Panel context" style="width:50%;">}} {{< img src="logs/explorer/side_panel/context2.jpg" alt="Side Panel context" style="width:50%;">}}
 
 - Build or edit a facet or measure from an attribute. See [Log Facets][12].
 

--- a/content/en/logs/faq/how-to-investigate-a-log-parsing-issue.md
+++ b/content/en/logs/faq/how-to-investigate-a-log-parsing-issue.md
@@ -65,7 +65,7 @@ Before troubleshooting your parser, read the Datadog log [processors][1] and [pa
     This means that the issue is in the user Agent attribute.
 
 4. **Fix the issue**:
-    Now that the culprit attribute is identified, look at it more closely.
+    After identifying the culprit attribute, look at it more closely.
 
     The user Agent in the log is:
 
@@ -82,7 +82,7 @@ Before troubleshooting your parser, read the Datadog log [processors][1] and [pa
     In other situation it might be the rule expecting an "integer" whereas the values are double so the matcher should be changed to "number".
 
 5. **Ask for help**:
-    Datadog is always here to help you! If you did not manage to find the cause of the parsing error, [contact us][4].
+    Datadog is always here to help you! If you did not manage to find the cause of the parsing error, [contact the support team][4].
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/content/en/logs/faq/how-to-remap-custom-severity-values-to-the-official-log-status.md
+++ b/content/en/logs/faq/how-to-remap-custom-severity-values-to-the-official-log-status.md
@@ -21,7 +21,7 @@ This page describes how to do this with 2 examples: Bunyan levels and web access
 
 ## Web access logs
 
-The status code of the request can be used to determine the log status. Our integrations use the following mapping:
+The status code of the request can be used to determine the log status. Datadog integrations use the following mapping:
 
 * 2xx: OK
 * 3xx: Notice
@@ -51,7 +51,7 @@ Bunyan levels are similar to those of Syslog, but their values are multiplied by
 Assume the bunyan level is stored in the `bunyan_level` attribute.
 Add a Category Processor in your Pipeline that creates a new attribute to reflect the above mapping:
 
-{{< img src="logs/faq/category_processor_bunyan.png" alt="category Processor  bunyan"  >}}
+{{< img src="logs/faq/category_processor_bunyan.png" alt="category Processor bunyan"  >}}
 
 Then add a status remapper that uses the newly created attribute:
 

--- a/content/en/logs/faq/how-to-tail-logs-from-host-using-a-container-agent.md
+++ b/content/en/logs/faq/how-to-tail-logs-from-host-using-a-container-agent.md
@@ -17,7 +17,7 @@ further_reading:
 
 ## Overview
 
-Pods/containers have no access to host files by default, which also applies to the Agent. If you try to configure your container Agent to collect logs from host files, you will see a similar error message to the one below:
+Pods/containers have no access to host files by default, which also applies to the Agent. If you try to configure your container Agent to collect logs from host files, an error message similar to the one below appears:
 
 ```
   syslog
@@ -133,7 +133,7 @@ docker run -d --name datadog-agent \
 
 ## Verification
 
-After you have set this all up, you can now deploy the Agent. You should be able to see something like the below when you run `docker exec -it datadog-agent agent status`:
+After you have set this all up, you can deploy the Agent. You should be able to see something like the below when you run `docker exec -it datadog-agent agent status`:
 
 ```
 ==========

--- a/content/en/logs/faq/i-have-a-custom-log-file-with-heightened-read-permissions.md
+++ b/content/en/logs/faq/i-have-a-custom-log-file-with-heightened-read-permissions.md
@@ -5,9 +5,6 @@ further_reading:
 - link: "/logs/log_collection/"
   tag: "Documentation"
   text: "Learn how to collect your logs"
-- link: "/logs/log_collection/"
-  tag: "Documentation"
-  text: "How to Send Logs to Datadog via External Log Shippers?"
 - link: "/logs/explorer/"
   tag: "Documentation"
   text: "Learn how to explore your logs"
@@ -19,8 +16,12 @@ There are three potential solutions to get around this:
 
 * (Not Recommended) Give the Agent root access so it can tail those files. Datadog strongly recommends against going this route.
 * Change the file permission to let the Agent access it.
-* Configure an open source log shipper (such as Rsyslog, NXLog, ...) that has root access to send those logs either directly to your Datadog platform or locally to a running Datadog Agent. All configuration are explained in the [How to Send Logs to Datadog via External Log Shippers?][1] article.
+* Configure an open source log shipper (such as Rsyslog, NXLog, ...) that has root access to send those logs either directly to your Datadog platform or locally to a running Datadog Agent. For instructions, read the dedicated documentation for [Rsyslog][1], [Syslog-ng][2], [NXlog][3], [FluentD][4], or [Logstash][5].
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /logs/faq/how-to-send-logs-to-datadog-via-external-log-shippers/
+[1]: /integrations/rsyslog/
+[2]: /integrations/syslog_ng/
+[3]: /integrations/nxlog/
+[4]: /integrations/fluentd/#log-collection
+[5]: /integrations/logstash/#log-collection

--- a/content/en/logs/faq/why-do-my-logs-not-have-the-expected-timestamp.md
+++ b/content/en/logs/faq/why-do-my-logs-not-have-the-expected-timestamp.md
@@ -13,36 +13,35 @@ further_reading:
   text: "How to investigate a log parsing issue?"
 ---
 
-By default Datadog generates a timestamp and appends it in a date attribute when logs are received on our intake API.
+By default, Datadog generates a timestamp and appends it in a date attribute when logs are received on the intake API.
 
-However, this default timestamp does not always reflect the actual value that might be contained in the log itself; this article describes how to override this default value.
+However, this default timestamp does not always reflect the actual value that might be contained in the log itself. This article describes how to override the default timestamp.
 
-{{< img src="logs/faq/log_timestamp_1.png" alt="Example of log with timestamp"  style="width:75%;">}}
+{{< img src="logs/faq/log_timestamp_1.png" alt="Example of log with timestamp" style="width:75%;">}}
 
 1. **Displayed timestamp**.
     The first thing to understand is how the log timestamp (visible from the Log Explorer and at the top section of the contextual panel) is generated.
 
     Timestamps are stored in UTC and displayed in the user local timezone.
-    On the above screenshot my local profile is set to `UTC+1` therefore the reception time of my log was `11:06:16.807 UTC`.
+    On the above screenshot, the local profile is set to `UTC+1`, therefore the reception time of the log is `11:06:16.807 UTC`.
 
     Check your [user settings][1] to understand if this could be linked to a bad timezone on your profile:
-    {{< img src="logs/faq/log_timestamp_2.png" alt="User setting"  style="width:75%;">}}
+    {{< img src="logs/faq/log_timestamp_2.png" alt="User setting" style="width:75%;">}}
     But you can extract the timestamp from the message to override the actual log date for both raw and JSON logs.
 
 2. **Raw logs**.
 
     2.1 **Extract the timestamp value with a parser**.
-        While writing a parsing rule for your logs, you need to extract the timestamp in a specific attribute. [Refer to some specific date parsing examples to help you][2].
+        While writing a parsing rule for your logs, you need to extract the timestamp in a specific attribute. [See specific date parsing examples][2].
         For the above log, you would use the following rule with the `date()` [matcher][3] to extract the date and pass it into a custom date attribute:
-        {{< img src="logs/faq/log_timestamp_3.png" alt="Parsing date"  style="width:75%;">}}
+        {{< img src="logs/faq/log_timestamp_3.png" alt="Parsing date" style="width:75%;">}}
 
     2.2 **Define a Log Date Remapper**.
-        The value is now stored in a `date` attribute. [Add a Log Date remapper][4] to make sure the official log timestamp is overridden with the value in the `date` attribute.
-        {{< img src="logs/faq/log_timestamp_4.png" alt="Log date remapper"  style="width:75%;" >}}
-        All new logs that are processed by that Pipeline should now have the correct timestamp.
+        A `date` attribute stores the timestamp value. [Add a Log Date remapper][4] to make sure the value in the `date` attribute overrides the official log timestamp.
+        {{< img src="logs/faq/log_timestamp_4.png" alt="Log date remapper" style="width:75%;" >}}
         **Note**: Any modification on a Pipeline only impacts new logs as all the processing is done at ingestion.
-        The following log generated at `06:01:03 EST`, which correspond to `11:01:03 UTC`, is correctly displayed as 12:01:03 (display timezone is UTC+1 in my case).
-        {{< img src="logs/faq/log_timestamp_5.png" alt="Log post processing with new timestamp"  style="width:70%;" >}}
+        The following log generated at `06:01:03 EST`, which correspond to `11:01:03 UTC`, is correctly displayed as 12:01:03 (display timezone is UTC+1 in this case).
+        {{< img src="logs/faq/log_timestamp_5.png" alt="Log post processing with new timestamp" style="width:70%;" >}}
 
 3. **JSON logs**.
 
@@ -50,22 +49,22 @@ However, this default timestamp does not always reflect the actual value that mi
         JSON logs are automatically parsed in Datadog.
         The log `date` attribute is one of the [reserved attributes][5] in Datadog which means JSON logs that use those attributes have their values treated specially - in this case to derive the log's date. Change the default remapping for these attributes at the top of your [Pipeline][6].
         Imagine that the actual timestamp of the log is contained in the attribute mytimestamp.
-        {{< img src="logs/faq/log_timestamp_6.png" alt="log with mytimestamp attribute"  style="width:75%;">}}
+        {{< img src="logs/faq/log_timestamp_6.png" alt="log with mytimestamp attribute" style="width:75%;">}}
         To make sure this attribute value is taken to override the log date, you must add it in the list of Date attributes.
-        The date remapper looks for each of the reserved attributes in the order in which they are configured in the reserved attribute mapping, so to be 100% sure that our `mytimestamp` attribute is used to derive the date, you can place it first in the list.
+        The date remapper looks for each of the reserved attributes in the order in which they are configured in the reserved attribute mapping. To ensure the date comes from the `mytimestamp` attribute, place it first in the list.
         **Note**: Any modification on the Pipeline only impacts new logs as all the processing is done at ingestion.
         There are specific date formats to respect for the remapping to work. The recognized date formats are: [ISO8601][7], [UNIX (the milliseconds EPOCH format)][8] and [RFC3164][9].
         If the format is different from one of the above (so if your logs still do not have the right timestamp), there is a solution.
 
     3.2 **Custom Date format**.
-        If the format is not supported by the remapper by default, parse this format and convert it to a supported format. To do this use a [parser Processor][4] that applies only on our attribute.
+        If the format is not supported by the remapper by default, parse this format and convert it to a supported format. To do this use a [parser Processor][4] that applies only on the attribute.
         If you do not have a Pipeline filtered on those logs yet, create a new one and add a Processor.
         **Note**: Set this Processor only to apply to the custom `mytimestamp` attribute under the **advanced** settings.
-        {{< img src="logs/faq/log_timestamp_7.png" alt="Advanced settings date Processor"  style="width:75%;">}}
+        {{< img src="logs/faq/log_timestamp_7.png" alt="Advanced settings date Processor" style="width:75%;">}}
         Then define the right parsing rule depending on your date format. See the [parsing dates examples][2].
         Add a Log Date Remapper and to have the correct timestamp on new logs.
-        {{< img src="logs/faq/log_timestamp_8.png" alt="Pipeline example"  style="width:75%;">}}
-        {{< img src="logs/faq/log_timestamp_9.png" alt="Log post processing after previous pipeline"  style="width:75%;">}}
+        {{< img src="logs/faq/log_timestamp_8.png" alt="Pipeline example" style="width:75%;">}}
+        {{< img src="logs/faq/log_timestamp_9.png" alt="Log post processing after previous pipeline" style="width:75%;">}}
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/content/en/logs/faq/why-do-my-logs-show-up-with-an-info-status-even-for-warnings-or-errors.md
+++ b/content/en/logs/faq/why-do-my-logs-show-up-with-an-info-status-even-for-warnings-or-errors.md
@@ -19,7 +19,7 @@ further_reading:
 By default, Datadog generates a status (*Info*) and appends it in the `status` attribute when logs are received on Datadog's intake API.
 However, this default `status` does not always reflect the actual value that might be contained in the log itself; this article describes how to override this default value.
 
-{{< img src="logs/faq/original_log.png" alt="Original log"  style="width:50%;">}}
+{{< img src="logs/faq/original_log.png" alt="Original log" style="width:50%;">}}
 
 ## Raw logs
 
@@ -29,19 +29,17 @@ While writing a parsing rule for your logs, extract the `status` in a specific a
 
 For the log above, use the following rule with the `word()` [matcher][1] to extract the status and pass it into a custom `log_status` attribute:
 
-{{< img src="logs/faq/processor.png" alt="Processor"  style="width:50%;">}}
+{{< img src="logs/faq/processor.png" alt="Processor" style="width:50%;">}}
 
 ### Define a log status remapper
 
-The value is now stored in a `log_status` attribute. [Add a Log Status remapper][2] to make sure the official log status is overridden with the value in the `log_status` attribute.
+The `log_status` attribute contains the correct status. [Add a Log Status remapper][2] to make sure the status value in the `log_status` attribute overrides the official log status.
 
-{{< img src="logs/faq/source_attribute.png" alt="Source attribute"  style="width:50%;">}}
-
-All new logs processed by this Pipeline should now have the correct status.
+{{< img src="logs/faq/source_attribute.png" alt="Source attribute" style="width:50%;">}}
 
 **Note**: Any modification on a Pipeline only impacts new logs as all the processing is done during the intake process.
 
-{{< img src="logs/faq/log_post_processing.png" alt="log post processing"  style="width:50%;">}}
+{{< img src="logs/faq/log_post_processing.png" alt="log post processing" style="width:50%;">}}
 
 ## JSON logs
 
@@ -49,19 +47,19 @@ All new logs processed by this Pipeline should now have the correct status.
 The log `status` attribute is one of the [reserved attributes][3] in Datadog which means JSON logs that use those attributes have their values treated specially - in this case to derive the log's status. Change the default remapping for these attributes at the top of your [Pipeline][4].
 Imagine that the actual status of the log is contained in the attribute `logger_severity`.
 
-{{< img src="logs/faq/new_log.png" alt="new log"  style="width:50%;">}}
+{{< img src="logs/faq/new_log.png" alt="new log" style="width:50%;">}}
 
 To make sure this attribute value is taken to override the log status, add it in the list of Status attributes.
 
-The status remapper looks for each of the reserved attributes in the order in which they are configured in the reserved attribute mapping, so to be 100% sure that our `logger_severity` attribute is used to derive the status, place it first in the list.
+The status remapper looks for each of the reserved attributes in the order in which they are configured in the reserved attribute mapping. To ensure that the status derives from the `logger_severity` attribute, place it first in the list.
 
-{{< img src="logs/faq/reserved_attribute.png" alt="reserved attribute"  style="width:50%;">}}
+{{< img src="logs/faq/reserved_attribute.png" alt="reserved attribute" style="width:50%;">}}
 
 **Note**: Any modification on the Pipeline only impacts new logs as all the processing is done at ingestion.
 
 There are specific status formats that must be adhered to for the remapping to work. The recognized status formats are explained in the [status remapper description][2]. In this specific case, by adding some host and service remapping new logs are correctly configured:
 
-{{< img src="logs/faq/new_log_remapped.png" alt="New log remapped"  style="width:50%;">}}
+{{< img src="logs/faq/new_log_remapped.png" alt="New log remapped" style="width:50%;">}}
 
 {{< partial name="whats-next/whats-next.html" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Ran the Vale linter on the logs/explorer and logs/faq directories.

### Motivation
<!-- What inspired you to submit this pull request?-->
Wanted to learn how to use the Vale linter for Docs Hackday and help Ruth with her project.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/uchen/lint-logs/explorer/ and child pages
https://docs-staging.datadoghq.com/uchen/lint-logs/logs/faq/ and child pages

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
