### PR TITLE
Upgrades algoliasearch javascript package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ public/
 data/service_checks/
 data/npm
 integrations_data
+.hugo_build.lock
 
 # htmltest tmp files
 bin/htmltest

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "@datadog/browser-logs": "^3.6.4",
         "@datadog/browser-rum": "^3.6.4",
         "a11y": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/a11y-v1.0.1.tgz",
-        "algoliasearch": "^3.35.1",
+        "algoliasearch": "4.11.0",
         "bootstrap": "4.3.1",
         "del": "4.1.1",
         "docsearch.js": "^2.6.3",

--- a/src/scripts/components/search.js
+++ b/src/scripts/components/search.js
@@ -3,8 +3,6 @@ import algoliasearch from 'algoliasearch';
 import configDocs from '../config/config-docs';
 import { getQueryParameterByName } from '../helpers/browser';
 
-let indexName = '';
-
 const getAlgoliaConfig = () => {
     const siteEnv = document.querySelector('html').dataset.env;
     return configDocs[siteEnv].algoliaConfig;
@@ -47,35 +45,357 @@ const appendSearchResultCountString = (count) => {
     tipueSearchContentElement.prepend(tipueSearchResultCountDiv);
 }
 
-const renderHit = (hit) => {
-    formatted_results += '<div class="hit">';
-    formatted_results += `${
-        '<div class="tipue_search_content_title">' +
-        '<a href="'
-    }${hit['url']}">${getTitle(hit)}</a></div>`;
-    formatted_results += `${
-        '<div class="tipue_search_content_url">' +
-        '<a href="'
-    }${hit['url']}">${hit['url'].replace(
-        'https://docs.datadoghq.com',
-        ''
-    )}</a></div>`;
-    const text = hit._snippetResult.content.value;
-    formatted_results += `<div class="tipue_search_content_text">${text}</div>`;
-    formatted_results += '</div>';
-    $('#tipue_search_content .content').html(formatted_results);
-}
-
 const renderResults = (query, hits) => {
-    // $('#tipue_search_input').val(query);
-    let formatted_results = '';
+    $('#tipue_search_input').val(query);
     appendSearchResultCountString(hits.length);
+    let formatted_results = '';
 
     if (hits.length) {
-        for (const index in hits) {
-            const hit = hits[index];
-            renderHit(hit)
+        for (const i in hits) {
+            const hit = hits[i];
+            formatted_results += '<div class="hit">';
+            formatted_results += `${
+                '<div class="tipue_search_content_title">' +
+                '<a href="'
+            }${hit['url']}">${getTitle(hit)}</a></div>`;
+            formatted_results += `${
+                '<div class="tipue_search_content_url">' +
+                '<a href="'
+            }${hit['url']}">${hit['url'].replace(
+                'https://docs.datadoghq.com',
+                ''
+            )}</a></div>`;
+            const text = hit._snippetResult.content.value;
+            formatted_results += `<div class="tipue_search_content_text">${text}</div>`;
+            formatted_results += '</div>';
         }
+    }
+
+    $('#tipue_search_content .content').html(formatted_results);
+
+    // load pagination
+    if (hits.length) {
+        let current_page = 1;
+        const num_page_links_to_display = 9;
+        const items_per_page = 7;
+        let page_nums = [];
+        let btn_next = document.getElementById('btn_next');
+        let btn_prev = document.getElementById('btn_prev');
+        let btn_more;
+        let btn_less;
+        const listing_table = document.getElementsByClassName(
+            'content'
+        )[0];
+        const page_navigation = document.getElementsByClassName(
+            'page_navigation'
+        )[0];
+        let page_span = document.getElementById('page');
+
+        function numPages() {
+            return Math.ceil(hits.length / items_per_page);
+        }
+
+        function initPageNums() {
+            const count = Math.min(
+                numPages(),
+                num_page_links_to_display
+            );
+            page_nums = [];
+            for (let i = 1; i < count + 1; i++) {
+                page_nums.push(i);
+            }
+        }
+
+        function prevPage() {
+            if (current_page > 1) {
+                current_page--;
+                if (current_page < page_nums[0]) {
+                    less(null);
+                } else {
+                    addHistory(current_page);
+                    changePage(current_page);
+                }
+            }
+        }
+
+        function nextPage() {
+            if (current_page < numPages()) {
+                current_page++;
+                if (
+                    current_page >
+                    page_nums[page_nums.length - 1]
+                ) {
+                    more(null);
+                } else {
+                    addHistory(current_page);
+                    changePage(current_page);
+                }
+            }
+        }
+
+        function less(e) {
+            if (e) e.preventDefault();
+            // get last in range
+            const first = page_nums[0];
+            const last = page_nums[page_nums.length - 1];
+            page_nums = [];
+            for (
+                let i = first - num_page_links_to_display;
+                i < first;
+                i++
+            ) {
+                page_nums.push(i);
+            }
+            current_page = page_nums[page_nums.length - 1];
+            addHistory(current_page);
+            changePage(current_page);
+            return false;
+        }
+
+        function more(e) {
+            if (e) e.preventDefault();
+            // get last in range
+            const last = page_nums[page_nums.length - 1];
+            // go from next number to num_page_links_to_display or however many are left
+            const remaining_pages = numPages() - last;
+            const count = Math.min(
+                remaining_pages,
+                num_page_links_to_display
+            );
+            page_nums = [];
+            for (
+                let i = last + 1;
+                i < last + (count + 1);
+                i++
+            ) {
+                page_nums.push(i);
+            }
+            current_page = page_nums[0];
+            addHistory(current_page);
+            changePage(current_page);
+            return false;
+        }
+
+        function cleanHandlers() {
+            if (btn_next) {
+                btn_next.removeEventListener(
+                    'click',
+                    btnHandler
+                );
+            }
+            if (btn_prev) {
+                btn_prev.removeEventListener(
+                    'click',
+                    btnHandler
+                );
+            }
+            const pagebtns = document.getElementsByClassName(
+                'page-num'
+            );
+            for (let i = 0; i < pagebtns.length; i++) {
+                pagebtns[i].removeEventListener(
+                    'click',
+                    btnHandlerPage
+                );
+            }
+            if (btn_more) {
+                btn_more.removeEventListener('click', more);
+            }
+            if (btn_less) {
+                btn_less.removeEventListener('click', less);
+            }
+        }
+
+        function btnHandler(e) {
+            e.preventDefault();
+            if (e.target.getAttribute('id') === 'btn_prev') {
+                prevPage();
+            } else if (
+                e.target.getAttribute('id') === 'btn_next'
+            ) {
+                nextPage();
+            }
+            return false;
+        }
+
+        function btnHandlerPage(e) {
+            e.preventDefault();
+            let page = parseInt(
+                e.target.getAttribute('data-pagenum')
+            );
+            if (page > numPages()) {
+                page = numPages();
+            } else if (page <= 0) {
+                page = 1;
+            }
+            current_page = page;
+            addHistory(current_page);
+            changePage(current_page);
+            return false;
+        }
+
+        function setHandlers() {
+            // remove any existing handlers
+            btn_next = document.getElementById('btn_next');
+            btn_prev = document.getElementById('btn_prev');
+            if (btn_prev) {
+                btn_prev.addEventListener('click', btnHandler);
+            }
+            if (btn_next) {
+                btn_next.addEventListener('click', btnHandler);
+            }
+            const pagebtns = document.getElementsByClassName(
+                'page-num'
+            );
+            if (pagebtns) {
+                for (let i = 0; i < pagebtns.length; i++) {
+                    pagebtns[i].addEventListener(
+                        'click',
+                        btnHandlerPage
+                    );
+                }
+            }
+            btn_more = document.getElementsByClassName(
+                'more'
+            )[0];
+            btn_less = document.getElementsByClassName(
+                'less'
+            )[0];
+            if (btn_more) {
+                btn_more.addEventListener('click', more);
+            }
+            if (btn_less) {
+                btn_less.addEventListener('click', less);
+            }
+        }
+
+        function setNavigation() {
+            let html = '';
+            let cls = '';
+            cleanHandlers();
+            html +=
+                '<a class="mr-1 btn btn-sm-tag btn-outline-secondary" href="#" id="btn_prev">Prev</a>';
+            if (page_nums[0] > 1) {
+                html +=
+                    '<a class="mr-1 btn btn-sm-tag btn-outline-secondary less" href="#">...</a>';
+            }
+            for (let i = 0; i < page_nums.length; i++) {
+                cls =
+                    current_page === page_nums[i]
+                        ? 'active'
+                        : '';
+                html += `<a class="mr-1 page-num btn btn-sm-tag btn-outline-secondary ${cls}" href="#" data-pagenum="${page_nums[i]}">${page_nums[i]}</a>`;
+            }
+            if (page_nums[page_nums.length - 1] < numPages()) {
+                html +=
+                    '<a class="mr-1 btn btn-sm-tag btn-outline-secondary more" href="#">...</a>';
+            }
+            html +=
+                '<a class="mr-1 btn btn-sm-tag btn-outline-secondary" href="#" id="btn_next">Next</a>';
+            if (page_navigation) {
+                page_navigation.innerHTML = html;
+            }
+            setHandlers();
+        }
+
+        window.onpopstate = function (event) {
+            if (event.state) {
+                current_page = event.state.page;
+                changePage(current_page);
+            }
+        };
+
+        function addHistory(page) {
+            let pageName = `?s=${query}`;
+            if (page !== 1) pageName += `&p=${page}`;
+            window.history.pushState({ page }, '', pageName);
+        }
+
+        function changePage(page) {
+            page_span = document.getElementById('page');
+
+            // Validate page
+            if (page < 1) page = 1;
+            if (page > numPages()) page = numPages();
+
+            if (listing_table) {
+                listing_table.innerHTML = '';
+            }
+
+            // output our slice of formatted results
+            for (
+                let i = (page - 1) * items_per_page;
+                i < page * items_per_page && i < hits.length;
+                i++
+            ) {
+                let formatted_results = '';
+                formatted_results += '<div class="hit row">';
+                formatted_results += '<div class="col-12">';
+
+                formatted_results += `${
+                    '<div class="tipue_search_content_title">' +
+                    '<a href="'
+                }${hits[i]['url']}">${getTitle(
+                    hits[i]
+                )}</a></div>`;
+                const text =
+                    hits[i]._snippetResult.content.value;
+                formatted_results += `<div class="tipue_search_content_text">${text}</div>`;
+
+                formatted_results += '</div>';
+                formatted_results += '</div>';
+                if (listing_table) {
+                    listing_table.innerHTML += formatted_results;
+                }
+            }
+            if (page_span) {
+                page_span.innerHTML = `${page}/${numPages()}`;
+            }
+
+            setNavigation();
+
+            // set previous and next buttons class
+            if (btn_prev) {
+                btn_prev.classList[
+                    page === 1 ? 'add' : 'remove'
+                ]('disabled');
+            }
+            if (btn_next) {
+                btn_next.classList[
+                    page === numPages() ? 'add' : 'remove'
+                ]('disabled');
+            }
+
+            // set active button class
+            const pagebtns = document.getElementsByClassName(
+                'page-num'
+            );
+            for (let i = 0; i < pagebtns.length; i++) {
+                const page = parseInt(
+                    pagebtns[i].getAttribute('data-pagenum')
+                );
+                pagebtns[i].classList[
+                    current_page === page ? 'add' : 'remove'
+                ]('active');
+            }
+
+            // scroll to top only if there is no hash
+            if (!window.location.hash) {
+                $('html, body').scrollTop(0);
+            }
+        }
+
+        // init page nums
+        initPageNums();
+
+        // set initial page
+        const searchParams = new URLSearchParams(
+            window.location.search
+        );
+        if (searchParams.get('p') !== null)
+            current_page = parseInt(searchParams.get('p'));
+            window.history.replaceState({ page: current_page }, '', '');
+        changePage(current_page);
     }
 }
 
@@ -92,391 +412,15 @@ const handleSearch = () => {
         .then(({ hits }) => {
             renderResults(query, hits);
         })
-        .catch(error => console.error(error))
+        .catch(() => {
+            const content = document.getElementsByClassName(
+                'content'
+            )[0];
+            if (content) {
+                content.innerHTML = '0 results';
+            }
+        })
     }
 }
 
 window.addEventListener('DOMContentLoaded', handleSearch)
-//   // get results from algolia
-//   client.search(
-//       [
-//           {
-//               indexName,
-//               query: decodeURIComponent(query),
-//               params: {
-//                   hitsPerPage: 200,
-//                   attributesToRetrieve: '*',
-//                   facetFilters: [`language:${lang}`]
-//               }
-//           }
-//       ],
-//       function (err, results) {
-//           if (!err) {
-//               // format and populate results
-//               $('#tipue_search_input').val(decodeURIComponent(query));
-//               const hits = results['results'][0]['hits'];
-//               let formatted_results = '';
-//               if (hits.length) {
-//                   $('#tipue_search_content').prepend(
-//                       `<div id="tipue_search_results_count">${hits.length} results</div>`
-//                   );
-//                   for (const i in hits) {
-//                       const hit = hits[i];
-//                       formatted_results += '<div class="hit">';
-//                       formatted_results += `${
-//                           '<div class="tipue_search_content_title">' +
-//                           '<a href="'
-//                       }${hit['url']}">${getTitle(hit)}</a></div>`;
-//                       formatted_results += `${
-//                           '<div class="tipue_search_content_url">' +
-//                           '<a href="'
-//                       }${hit['url']}">${hit['url'].replace(
-//                           'https://docs.datadoghq.com',
-//                           ''
-//                       )}</a></div>`;
-//                       const text = hit._snippetResult.content.value;
-//                       formatted_results += `<div class="tipue_search_content_text">${text}</div>`;
-//                       formatted_results += '</div>';
-//                   }
-//               } else {
-//                   $('#tipue_search_content').prepend(
-//                       `<div id="tipue_search_results_count">${hits.length} results</div>`
-//                   );
-//               }
-//               $('#tipue_search_content .content').html(formatted_results);
-
-//               // load pagination
-//               if (hits.length) {
-//                   let current_page = 1;
-//                   const num_page_links_to_display = 9;
-//                   const items_per_page = 7;
-//                   let page_nums = [];
-//                   let btn_next = document.getElementById('btn_next');
-//                   let btn_prev = document.getElementById('btn_prev');
-//                   let btn_more;
-//                   let btn_less;
-//                   const listing_table = document.getElementsByClassName(
-//                       'content'
-//                   )[0];
-//                   const page_navigation = document.getElementsByClassName(
-//                       'page_navigation'
-//                   )[0];
-//                   let page_span = document.getElementById('page');
-
-//                   function numPages() {
-//                       return Math.ceil(hits.length / items_per_page);
-//                   }
-
-//                   function initPageNums() {
-//                       const count = Math.min(
-//                           numPages(),
-//                           num_page_links_to_display
-//                       );
-//                       page_nums = [];
-//                       for (let i = 1; i < count + 1; i++) {
-//                           page_nums.push(i);
-//                       }
-//                   }
-
-//                   function prevPage() {
-//                       if (current_page > 1) {
-//                           current_page--;
-//                           if (current_page < page_nums[0]) {
-//                               less(null);
-//                           } else {
-//                               addHistory(current_page);
-//                               changePage(current_page);
-//                           }
-//                       }
-//                   }
-
-//                   function nextPage() {
-//                       if (current_page < numPages()) {
-//                           current_page++;
-//                           if (
-//                               current_page >
-//                               page_nums[page_nums.length - 1]
-//                           ) {
-//                               more(null);
-//                           } else {
-//                               addHistory(current_page);
-//                               changePage(current_page);
-//                           }
-//                       }
-//                   }
-
-//                   function less(e) {
-//                       if (e) e.preventDefault();
-//                       // get last in range
-//                       const first = page_nums[0];
-//                       const last = page_nums[page_nums.length - 1];
-//                       page_nums = [];
-//                       for (
-//                           let i = first - num_page_links_to_display;
-//                           i < first;
-//                           i++
-//                       ) {
-//                           page_nums.push(i);
-//                       }
-//                       current_page = page_nums[page_nums.length - 1];
-//                       addHistory(current_page);
-//                       changePage(current_page);
-//                       return false;
-//                   }
-
-//                   function more(e) {
-//                       if (e) e.preventDefault();
-//                       // get last in range
-//                       const last = page_nums[page_nums.length - 1];
-//                       // go from next number to num_page_links_to_display or however many are left
-//                       const remaining_pages = numPages() - last;
-//                       const count = Math.min(
-//                           remaining_pages,
-//                           num_page_links_to_display
-//                       );
-//                       page_nums = [];
-//                       for (
-//                           let i = last + 1;
-//                           i < last + (count + 1);
-//                           i++
-//                       ) {
-//                           page_nums.push(i);
-//                       }
-//                       current_page = page_nums[0];
-//                       addHistory(current_page);
-//                       changePage(current_page);
-//                       return false;
-//                   }
-
-//                   function cleanHandlers() {
-//                       if (btn_next) {
-//                           btn_next.removeEventListener(
-//                               'click',
-//                               btnHandler
-//                           );
-//                       }
-//                       if (btn_prev) {
-//                           btn_prev.removeEventListener(
-//                               'click',
-//                               btnHandler
-//                           );
-//                       }
-//                       const pagebtns = document.getElementsByClassName(
-//                           'page-num'
-//                       );
-//                       for (let i = 0; i < pagebtns.length; i++) {
-//                           pagebtns[i].removeEventListener(
-//                               'click',
-//                               btnHandlerPage
-//                           );
-//                       }
-//                       if (btn_more) {
-//                           btn_more.removeEventListener('click', more);
-//                       }
-//                       if (btn_less) {
-//                           btn_less.removeEventListener('click', less);
-//                       }
-//                   }
-
-//                   function btnHandler(e) {
-//                       e.preventDefault();
-//                       if (e.target.getAttribute('id') === 'btn_prev') {
-//                           prevPage();
-//                       } else if (
-//                           e.target.getAttribute('id') === 'btn_next'
-//                       ) {
-//                           nextPage();
-//                       }
-//                       return false;
-//                   }
-
-//                   function btnHandlerPage(e) {
-//                       e.preventDefault();
-//                       let page = parseInt(
-//                           e.target.getAttribute('data-pagenum')
-//                       );
-//                       if (page > numPages()) {
-//                           page = numPages();
-//                       } else if (page <= 0) {
-//                           page = 1;
-//                       }
-//                       current_page = page;
-//                       addHistory(current_page);
-//                       changePage(current_page);
-//                       return false;
-//                   }
-
-//                   function setHandlers() {
-//                       // remove any existing handlers
-//                       btn_next = document.getElementById('btn_next');
-//                       btn_prev = document.getElementById('btn_prev');
-//                       if (btn_prev) {
-//                           btn_prev.addEventListener('click', btnHandler);
-//                       }
-//                       if (btn_next) {
-//                           btn_next.addEventListener('click', btnHandler);
-//                       }
-//                       const pagebtns = document.getElementsByClassName(
-//                           'page-num'
-//                       );
-//                       if (pagebtns) {
-//                           for (let i = 0; i < pagebtns.length; i++) {
-//                               pagebtns[i].addEventListener(
-//                                   'click',
-//                                   btnHandlerPage
-//                               );
-//                           }
-//                       }
-//                       btn_more = document.getElementsByClassName(
-//                           'more'
-//                       )[0];
-//                       btn_less = document.getElementsByClassName(
-//                           'less'
-//                       )[0];
-//                       if (btn_more) {
-//                           btn_more.addEventListener('click', more);
-//                       }
-//                       if (btn_less) {
-//                           btn_less.addEventListener('click', less);
-//                       }
-//                   }
-
-//                   function setNavigation() {
-//                       let html = '';
-//                       let cls = '';
-//                       cleanHandlers();
-//                       html +=
-//                           '<a class="mr-1 btn btn-sm-tag btn-outline-secondary" href="#" id="btn_prev">Prev</a>';
-//                       if (page_nums[0] > 1) {
-//                           html +=
-//                               '<a class="mr-1 btn btn-sm-tag btn-outline-secondary less" href="#">...</a>';
-//                       }
-//                       for (let i = 0; i < page_nums.length; i++) {
-//                           cls =
-//                               current_page === page_nums[i]
-//                                   ? 'active'
-//                                   : '';
-//                           html += `<a class="mr-1 page-num btn btn-sm-tag btn-outline-secondary ${cls}" href="#" data-pagenum="${page_nums[i]}">${page_nums[i]}</a>`;
-//                       }
-//                       if (page_nums[page_nums.length - 1] < numPages()) {
-//                           html +=
-//                               '<a class="mr-1 btn btn-sm-tag btn-outline-secondary more" href="#">...</a>';
-//                       }
-//                       html +=
-//                           '<a class="mr-1 btn btn-sm-tag btn-outline-secondary" href="#" id="btn_next">Next</a>';
-//                       if (page_navigation) {
-//                           page_navigation.innerHTML = html;
-//                       }
-//                       setHandlers();
-//                   }
-
-//                   window.onpopstate = function (event) {
-//                       if (event.state) {
-//                           current_page = event.state.page;
-//                           changePage(current_page);
-//                       }
-//                   };
-
-//                   function addHistory(page) {
-//                       let pageName = `?s=${query}`;
-//                       if (page !== 1) pageName += `&p=${page}`;
-//                       window.history.pushState({ page }, '', pageName);
-//                   }
-
-//                   function changePage(page) {
-//                       page_span = document.getElementById('page');
-
-//                       // Validate page
-//                       if (page < 1) page = 1;
-//                       if (page > numPages()) page = numPages();
-
-//                       if (listing_table) {
-//                           listing_table.innerHTML = '';
-//                       }
-
-//                       // output our slice of formatted results
-//                       for (
-//                           let i = (page - 1) * items_per_page;
-//                           i < page * items_per_page && i < hits.length;
-//                           i++
-//                       ) {
-//                           let formatted_results = '';
-//                           formatted_results += '<div class="hit row">';
-//                           formatted_results += '<div class="col-12">';
-
-//                           formatted_results += `${
-//                               '<div class="tipue_search_content_title">' +
-//                               '<a href="'
-//                           }${hits[i]['url']}">${getTitle(
-//                               hits[i]
-//                           )}</a></div>`;
-//                           const text =
-//                               hits[i]._snippetResult.content.value;
-//                           formatted_results += `<div class="tipue_search_content_text">${text}</div>`;
-
-//                           formatted_results += '</div>';
-//                           formatted_results += '</div>';
-//                           if (listing_table) {
-//                               listing_table.innerHTML += formatted_results;
-//                           }
-//                       }
-//                       if (page_span) {
-//                           page_span.innerHTML = `${page}/${numPages()}`;
-//                       }
-
-//                       setNavigation();
-
-//                       // set previous and next buttons class
-//                       if (btn_prev) {
-//                           btn_prev.classList[
-//                               page === 1 ? 'add' : 'remove'
-//                           ]('disabled');
-//                       }
-//                       if (btn_next) {
-//                           btn_next.classList[
-//                               page === numPages() ? 'add' : 'remove'
-//                           ]('disabled');
-//                       }
-
-//                       // set active button class
-//                       const pagebtns = document.getElementsByClassName(
-//                           'page-num'
-//                       );
-//                       for (let i = 0; i < pagebtns.length; i++) {
-//                           const page = parseInt(
-//                               pagebtns[i].getAttribute('data-pagenum')
-//                           );
-//                           pagebtns[i].classList[
-//                               current_page === page ? 'add' : 'remove'
-//                           ]('active');
-//                       }
-
-//                       // scroll to top only if there is no hash
-//                       if (!window.location.hash) {
-//                           $('html, body').scrollTop(0);
-//                       }
-//                   }
-
-//                   // init page nums
-//                   initPageNums();
-
-//                   // set initial page
-//                   const searchParams = new URLSearchParams(
-//                       window.location.search
-//                   );
-//                   if (searchParams.get('p') !== null)
-//                       current_page = parseInt(searchParams.get('p'));
-//                       window.history.replaceState({ page: current_page }, '', '');
-//                   changePage(current_page);
-//               }
-//           } else {
-//               const content = document.getElementsByClassName(
-//                   'content'
-//               )[0];
-//               if (content) {
-//                   content.innerHTML = '0 results';
-//               }
-//           }
-//       }
-//   );
-// }

--- a/src/scripts/components/search.js
+++ b/src/scripts/components/search.js
@@ -39,19 +39,42 @@ const getTitle = (hit) => {
     return title;
 }
 
-const populateAndFormatResults = (query, hits) => {
+const appendSearchResultCountString = (count) => {
+    const tipueSearchResultCountDiv = document.createElement('div');
+    tipueSearchResultCountDiv.setAttribute('id', 'tipue_search_results_count');
+    tipueSearchResultCountDiv.innerText = `${count} results`;
+    const tipueSearchContentElement = document.getElementById('tipue_search_content');
+    tipueSearchContentElement.prepend(tipueSearchResultCountDiv);
+}
+
+const renderHit = (hit) => {
+    formatted_results += '<div class="hit">';
+    formatted_results += `${
+        '<div class="tipue_search_content_title">' +
+        '<a href="'
+    }${hit['url']}">${getTitle(hit)}</a></div>`;
+    formatted_results += `${
+        '<div class="tipue_search_content_url">' +
+        '<a href="'
+    }${hit['url']}">${hit['url'].replace(
+        'https://docs.datadoghq.com',
+        ''
+    )}</a></div>`;
+    const text = hit._snippetResult.content.value;
+    formatted_results += `<div class="tipue_search_content_text">${text}</div>`;
+    formatted_results += '</div>';
+    $('#tipue_search_content .content').html(formatted_results);
+}
+
+const renderResults = (query, hits) => {
     // $('#tipue_search_input').val(query);
     let formatted_results = '';
+    appendSearchResultCountString(hits.length);
 
     if (hits.length) {
-        const tipueSearchResultCountDiv = document.createElement('div');
-        tipueSearchResultCountDiv.setAttribute('id', 'tipue_search_results_count');
-        tipueSearchResultCountDiv.innerText = `${hits.length} results`;
-        const tipueSearchContentElement = document.getElementById('tipue_search_content');
-        tipueSearchContentElement.prepend(tipueSearchResultCountDiv);
-
-        for (hit in hits) {
-            console.log(hit);
+        for (const index in hits) {
+            const hit = hits[index];
+            renderHit(hit)
         }
     }
 }
@@ -67,7 +90,7 @@ const handleSearch = () => {
             filters: `language:${getSiteLang()}`
         })
         .then(({ hits }) => {
-            populateAndFormatResults(query, hits);
+            renderResults(query, hits);
         })
         .catch(error => console.error(error))
     }

--- a/src/scripts/components/search.js
+++ b/src/scripts/components/search.js
@@ -1,436 +1,459 @@
 /* eslint-disable */
 import algoliasearch from 'algoliasearch';
 import configDocs from '../config/config-docs';
+import { getQueryParameterByName } from '../helpers/browser';
 
-const siteEnv = document.querySelector('html').dataset.env;
 let indexName = '';
 
-if (window.location.href.indexOf('/search/') > -1) {
-  if (siteEnv === 'preview' || siteEnv === 'development') {
-    indexName = 'docsearch_docs_preview';
-  } else if (siteEnv === 'live') {
-    indexName = 'docsearch_docs_prod';
-  }
-  
-  const client = algoliasearch(
-      configDocs.live.algoliaConfig.appId,
-      configDocs.live.algoliaConfig.apiKey
-  );
-  const results = new RegExp('[?&]' + 's' + '=([^&#]*)').exec(
-      window.location.href
-  );
-  
-  let query = '';
-  try {
-      query = results[1];
-  } catch (e) {}
-
-  let lang = 'en';
-  if (window.location.pathname.indexOf('/fr/') > -1) {
-      lang = 'fr';
-  }
-  if (window.location.pathname.indexOf('/ja/') > -1) {
-      lang = 'ja';
-  }
-
-  function getTitle(hit) {
-      let title = '';
-      title = hit['hierarchy']['lvl0'];
-      if (hit['hierarchy'].hasOwnProperty('lvl1')) {
-          if (hit['hierarchy']['lvl1'] !== null)
-              title += ` &raquo; ${hit['hierarchy']['lvl1']}`;
-      }
-      if (hit['hierarchy'].hasOwnProperty('lvl2')) {
-          if (hit['hierarchy']['lvl2'] !== null)
-              title += ` &raquo; ${hit['hierarchy']['lvl2']}`;
-      }
-      if (hit['hierarchy'].hasOwnProperty('lvl3')) {
-          if (hit['hierarchy']['lvl3'] !== null)
-              title += ` &raquo; ${hit['hierarchy']['lvl3']}`;
-      }
-      return title;
-  }
-
-  // get results from algolia
-  client.search(
-      [
-          {
-              indexName,
-              query: decodeURIComponent(query),
-              params: {
-                  hitsPerPage: 200,
-                  attributesToRetrieve: '*',
-                  facetFilters: [`language:${lang}`]
-              }
-          }
-      ],
-      function (err, results) {
-          if (!err) {
-              // format and populate results
-              $('#tipue_search_input').val(decodeURIComponent(query));
-              const hits = results['results'][0]['hits'];
-              let formatted_results = '';
-              if (hits.length) {
-                  $('#tipue_search_content').prepend(
-                      `<div id="tipue_search_results_count">${hits.length} results</div>`
-                  );
-                  for (const i in hits) {
-                      const hit = hits[i];
-                      formatted_results += '<div class="hit">';
-                      formatted_results += `${
-                          '<div class="tipue_search_content_title">' +
-                          '<a href="'
-                      }${hit['url']}">${getTitle(hit)}</a></div>`;
-                      formatted_results += `${
-                          '<div class="tipue_search_content_url">' +
-                          '<a href="'
-                      }${hit['url']}">${hit['url'].replace(
-                          'https://docs.datadoghq.com',
-                          ''
-                      )}</a></div>`;
-                      const text = hit._snippetResult.content.value;
-                      formatted_results += `<div class="tipue_search_content_text">${text}</div>`;
-                      formatted_results += '</div>';
-                  }
-              } else {
-                  $('#tipue_search_content').prepend(
-                      `<div id="tipue_search_results_count">${hits.length} results</div>`
-                  );
-              }
-              $('#tipue_search_content .content').html(formatted_results);
-
-              // load pagination
-              if (hits.length) {
-                  let current_page = 1;
-                  const num_page_links_to_display = 9;
-                  const items_per_page = 7;
-                  let page_nums = [];
-                  let btn_next = document.getElementById('btn_next');
-                  let btn_prev = document.getElementById('btn_prev');
-                  let btn_more;
-                  let btn_less;
-                  const listing_table = document.getElementsByClassName(
-                      'content'
-                  )[0];
-                  const page_navigation = document.getElementsByClassName(
-                      'page_navigation'
-                  )[0];
-                  let page_span = document.getElementById('page');
-
-                  function numPages() {
-                      return Math.ceil(hits.length / items_per_page);
-                  }
-
-                  function initPageNums() {
-                      const count = Math.min(
-                          numPages(),
-                          num_page_links_to_display
-                      );
-                      page_nums = [];
-                      for (let i = 1; i < count + 1; i++) {
-                          page_nums.push(i);
-                      }
-                  }
-
-                  function prevPage() {
-                      if (current_page > 1) {
-                          current_page--;
-                          if (current_page < page_nums[0]) {
-                              less(null);
-                          } else {
-                              addHistory(current_page);
-                              changePage(current_page);
-                          }
-                      }
-                  }
-
-                  function nextPage() {
-                      if (current_page < numPages()) {
-                          current_page++;
-                          if (
-                              current_page >
-                              page_nums[page_nums.length - 1]
-                          ) {
-                              more(null);
-                          } else {
-                              addHistory(current_page);
-                              changePage(current_page);
-                          }
-                      }
-                  }
-
-                  function less(e) {
-                      if (e) e.preventDefault();
-                      // get last in range
-                      const first = page_nums[0];
-                      const last = page_nums[page_nums.length - 1];
-                      page_nums = [];
-                      for (
-                          let i = first - num_page_links_to_display;
-                          i < first;
-                          i++
-                      ) {
-                          page_nums.push(i);
-                      }
-                      current_page = page_nums[page_nums.length - 1];
-                      addHistory(current_page);
-                      changePage(current_page);
-                      return false;
-                  }
-
-                  function more(e) {
-                      if (e) e.preventDefault();
-                      // get last in range
-                      const last = page_nums[page_nums.length - 1];
-                      // go from next number to num_page_links_to_display or however many are left
-                      const remaining_pages = numPages() - last;
-                      const count = Math.min(
-                          remaining_pages,
-                          num_page_links_to_display
-                      );
-                      page_nums = [];
-                      for (
-                          let i = last + 1;
-                          i < last + (count + 1);
-                          i++
-                      ) {
-                          page_nums.push(i);
-                      }
-                      current_page = page_nums[0];
-                      addHistory(current_page);
-                      changePage(current_page);
-                      return false;
-                  }
-
-                  function cleanHandlers() {
-                      if (btn_next) {
-                          btn_next.removeEventListener(
-                              'click',
-                              btnHandler
-                          );
-                      }
-                      if (btn_prev) {
-                          btn_prev.removeEventListener(
-                              'click',
-                              btnHandler
-                          );
-                      }
-                      const pagebtns = document.getElementsByClassName(
-                          'page-num'
-                      );
-                      for (let i = 0; i < pagebtns.length; i++) {
-                          pagebtns[i].removeEventListener(
-                              'click',
-                              btnHandlerPage
-                          );
-                      }
-                      if (btn_more) {
-                          btn_more.removeEventListener('click', more);
-                      }
-                      if (btn_less) {
-                          btn_less.removeEventListener('click', less);
-                      }
-                  }
-
-                  function btnHandler(e) {
-                      e.preventDefault();
-                      if (e.target.getAttribute('id') === 'btn_prev') {
-                          prevPage();
-                      } else if (
-                          e.target.getAttribute('id') === 'btn_next'
-                      ) {
-                          nextPage();
-                      }
-                      return false;
-                  }
-
-                  function btnHandlerPage(e) {
-                      e.preventDefault();
-                      let page = parseInt(
-                          e.target.getAttribute('data-pagenum')
-                      );
-                      if (page > numPages()) {
-                          page = numPages();
-                      } else if (page <= 0) {
-                          page = 1;
-                      }
-                      current_page = page;
-                      addHistory(current_page);
-                      changePage(current_page);
-                      return false;
-                  }
-
-                  function setHandlers() {
-                      // remove any existing handlers
-                      btn_next = document.getElementById('btn_next');
-                      btn_prev = document.getElementById('btn_prev');
-                      if (btn_prev) {
-                          btn_prev.addEventListener('click', btnHandler);
-                      }
-                      if (btn_next) {
-                          btn_next.addEventListener('click', btnHandler);
-                      }
-                      const pagebtns = document.getElementsByClassName(
-                          'page-num'
-                      );
-                      if (pagebtns) {
-                          for (let i = 0; i < pagebtns.length; i++) {
-                              pagebtns[i].addEventListener(
-                                  'click',
-                                  btnHandlerPage
-                              );
-                          }
-                      }
-                      btn_more = document.getElementsByClassName(
-                          'more'
-                      )[0];
-                      btn_less = document.getElementsByClassName(
-                          'less'
-                      )[0];
-                      if (btn_more) {
-                          btn_more.addEventListener('click', more);
-                      }
-                      if (btn_less) {
-                          btn_less.addEventListener('click', less);
-                      }
-                  }
-
-                  function setNavigation() {
-                      let html = '';
-                      let cls = '';
-                      cleanHandlers();
-                      html +=
-                          '<a class="mr-1 btn btn-sm-tag btn-outline-secondary" href="#" id="btn_prev">Prev</a>';
-                      if (page_nums[0] > 1) {
-                          html +=
-                              '<a class="mr-1 btn btn-sm-tag btn-outline-secondary less" href="#">...</a>';
-                      }
-                      for (let i = 0; i < page_nums.length; i++) {
-                          cls =
-                              current_page === page_nums[i]
-                                  ? 'active'
-                                  : '';
-                          html += `<a class="mr-1 page-num btn btn-sm-tag btn-outline-secondary ${cls}" href="#" data-pagenum="${page_nums[i]}">${page_nums[i]}</a>`;
-                      }
-                      if (page_nums[page_nums.length - 1] < numPages()) {
-                          html +=
-                              '<a class="mr-1 btn btn-sm-tag btn-outline-secondary more" href="#">...</a>';
-                      }
-                      html +=
-                          '<a class="mr-1 btn btn-sm-tag btn-outline-secondary" href="#" id="btn_next">Next</a>';
-                      if (page_navigation) {
-                          page_navigation.innerHTML = html;
-                      }
-                      setHandlers();
-                  }
-
-                  window.onpopstate = function (event) {
-                      if (event.state) {
-                          current_page = event.state.page;
-                          changePage(current_page);
-                      }
-                  };
-
-                  function addHistory(page) {
-                      let pageName = `?s=${query}`;
-                      if (page !== 1) pageName += `&p=${page}`;
-                      window.history.pushState({ page }, '', pageName);
-                  }
-
-                  function changePage(page) {
-                      page_span = document.getElementById('page');
-
-                      // Validate page
-                      if (page < 1) page = 1;
-                      if (page > numPages()) page = numPages();
-
-                      if (listing_table) {
-                          listing_table.innerHTML = '';
-                      }
-
-                      // output our slice of formatted results
-                      for (
-                          let i = (page - 1) * items_per_page;
-                          i < page * items_per_page && i < hits.length;
-                          i++
-                      ) {
-                          let formatted_results = '';
-                          formatted_results += '<div class="hit row">';
-                          formatted_results += '<div class="col-12">';
-
-                          formatted_results += `${
-                              '<div class="tipue_search_content_title">' +
-                              '<a href="'
-                          }${hits[i]['url']}">${getTitle(
-                              hits[i]
-                          )}</a></div>`;
-                          const text =
-                              hits[i]._snippetResult.content.value;
-                          formatted_results += `<div class="tipue_search_content_text">${text}</div>`;
-
-                          formatted_results += '</div>';
-                          formatted_results += '</div>';
-                          if (listing_table) {
-                              listing_table.innerHTML += formatted_results;
-                          }
-                      }
-                      if (page_span) {
-                          page_span.innerHTML = `${page}/${numPages()}`;
-                      }
-
-                      setNavigation();
-
-                      // set previous and next buttons class
-                      if (btn_prev) {
-                          btn_prev.classList[
-                              page === 1 ? 'add' : 'remove'
-                          ]('disabled');
-                      }
-                      if (btn_next) {
-                          btn_next.classList[
-                              page === numPages() ? 'add' : 'remove'
-                          ]('disabled');
-                      }
-
-                      // set active button class
-                      const pagebtns = document.getElementsByClassName(
-                          'page-num'
-                      );
-                      for (let i = 0; i < pagebtns.length; i++) {
-                          const page = parseInt(
-                              pagebtns[i].getAttribute('data-pagenum')
-                          );
-                          pagebtns[i].classList[
-                              current_page === page ? 'add' : 'remove'
-                          ]('active');
-                      }
-
-                      // scroll to top only if there is no hash
-                      if (!window.location.hash) {
-                          $('html, body').scrollTop(0);
-                      }
-                  }
-
-                  // init page nums
-                  initPageNums();
-
-                  // set initial page
-                  const searchParams = new URLSearchParams(
-                      window.location.search
-                  );
-                  if (searchParams.get('p') !== null)
-                      current_page = parseInt(searchParams.get('p'));
-                      window.history.replaceState({ page: current_page }, '', '');
-                  changePage(current_page);
-              }
-          } else {
-              const content = document.getElementsByClassName(
-                  'content'
-              )[0];
-              if (content) {
-                  content.innerHTML = '0 results';
-              }
-          }
-      }
-  );
+const getAlgoliaConfig = () => {
+    const siteEnv = document.querySelector('html').dataset.env;
+    return configDocs[siteEnv].algoliaConfig;
 }
+
+const initializeAlgoliaIndex = () => {
+    const { index, appId, apiKey } = getAlgoliaConfig();
+    const client = algoliasearch(appId, apiKey);
+    return client.initIndex(index);
+}
+
+const getSiteLang = () => {
+    return document.querySelector('html').lang;
+}
+
+const getTitle = (hit) => {
+    let title = '';
+    title = hit['hierarchy']['lvl0'];
+    if (hit['hierarchy'].hasOwnProperty('lvl1')) {
+        if (hit['hierarchy']['lvl1'] !== null)
+            title += ` &raquo; ${hit['hierarchy']['lvl1']}`;
+    }
+    if (hit['hierarchy'].hasOwnProperty('lvl2')) {
+        if (hit['hierarchy']['lvl2'] !== null)
+            title += ` &raquo; ${hit['hierarchy']['lvl2']}`;
+    }
+    if (hit['hierarchy'].hasOwnProperty('lvl3')) {
+        if (hit['hierarchy']['lvl3'] !== null)
+            title += ` &raquo; ${hit['hierarchy']['lvl3']}`;
+    }
+
+    return title;
+}
+
+const populateAndFormatResults = (query, hits) => {
+    // $('#tipue_search_input').val(query);
+    let formatted_results = '';
+
+    if (hits.length) {
+        const tipueSearchResultCountDiv = document.createElement('div');
+        tipueSearchResultCountDiv.setAttribute('id', 'tipue_search_results_count');
+        tipueSearchResultCountDiv.innerText = `${hits.length} results`;
+        const tipueSearchContentElement = document.getElementById('tipue_search_content');
+        tipueSearchContentElement.prepend(tipueSearchResultCountDiv);
+
+        for (hit in hits) {
+            console.log(hit);
+        }
+    }
+}
+
+const handleSearch = () => {
+    if (window.location.href.indexOf('/search/') > -1) {
+        const index = initializeAlgoliaIndex();
+        const query = getQueryParameterByName('s', window.location.href);
+
+        index.search(decodeURIComponent(query), {
+            hitsPerPage: 200,
+            attributesToRetrieve: ['*'],
+            filters: `language:${getSiteLang()}`
+        })
+        .then(({ hits }) => {
+            populateAndFormatResults(query, hits);
+        })
+        .catch(error => console.error(error))
+    }
+}
+
+window.addEventListener('DOMContentLoaded', handleSearch)
+//   // get results from algolia
+//   client.search(
+//       [
+//           {
+//               indexName,
+//               query: decodeURIComponent(query),
+//               params: {
+//                   hitsPerPage: 200,
+//                   attributesToRetrieve: '*',
+//                   facetFilters: [`language:${lang}`]
+//               }
+//           }
+//       ],
+//       function (err, results) {
+//           if (!err) {
+//               // format and populate results
+//               $('#tipue_search_input').val(decodeURIComponent(query));
+//               const hits = results['results'][0]['hits'];
+//               let formatted_results = '';
+//               if (hits.length) {
+//                   $('#tipue_search_content').prepend(
+//                       `<div id="tipue_search_results_count">${hits.length} results</div>`
+//                   );
+//                   for (const i in hits) {
+//                       const hit = hits[i];
+//                       formatted_results += '<div class="hit">';
+//                       formatted_results += `${
+//                           '<div class="tipue_search_content_title">' +
+//                           '<a href="'
+//                       }${hit['url']}">${getTitle(hit)}</a></div>`;
+//                       formatted_results += `${
+//                           '<div class="tipue_search_content_url">' +
+//                           '<a href="'
+//                       }${hit['url']}">${hit['url'].replace(
+//                           'https://docs.datadoghq.com',
+//                           ''
+//                       )}</a></div>`;
+//                       const text = hit._snippetResult.content.value;
+//                       formatted_results += `<div class="tipue_search_content_text">${text}</div>`;
+//                       formatted_results += '</div>';
+//                   }
+//               } else {
+//                   $('#tipue_search_content').prepend(
+//                       `<div id="tipue_search_results_count">${hits.length} results</div>`
+//                   );
+//               }
+//               $('#tipue_search_content .content').html(formatted_results);
+
+//               // load pagination
+//               if (hits.length) {
+//                   let current_page = 1;
+//                   const num_page_links_to_display = 9;
+//                   const items_per_page = 7;
+//                   let page_nums = [];
+//                   let btn_next = document.getElementById('btn_next');
+//                   let btn_prev = document.getElementById('btn_prev');
+//                   let btn_more;
+//                   let btn_less;
+//                   const listing_table = document.getElementsByClassName(
+//                       'content'
+//                   )[0];
+//                   const page_navigation = document.getElementsByClassName(
+//                       'page_navigation'
+//                   )[0];
+//                   let page_span = document.getElementById('page');
+
+//                   function numPages() {
+//                       return Math.ceil(hits.length / items_per_page);
+//                   }
+
+//                   function initPageNums() {
+//                       const count = Math.min(
+//                           numPages(),
+//                           num_page_links_to_display
+//                       );
+//                       page_nums = [];
+//                       for (let i = 1; i < count + 1; i++) {
+//                           page_nums.push(i);
+//                       }
+//                   }
+
+//                   function prevPage() {
+//                       if (current_page > 1) {
+//                           current_page--;
+//                           if (current_page < page_nums[0]) {
+//                               less(null);
+//                           } else {
+//                               addHistory(current_page);
+//                               changePage(current_page);
+//                           }
+//                       }
+//                   }
+
+//                   function nextPage() {
+//                       if (current_page < numPages()) {
+//                           current_page++;
+//                           if (
+//                               current_page >
+//                               page_nums[page_nums.length - 1]
+//                           ) {
+//                               more(null);
+//                           } else {
+//                               addHistory(current_page);
+//                               changePage(current_page);
+//                           }
+//                       }
+//                   }
+
+//                   function less(e) {
+//                       if (e) e.preventDefault();
+//                       // get last in range
+//                       const first = page_nums[0];
+//                       const last = page_nums[page_nums.length - 1];
+//                       page_nums = [];
+//                       for (
+//                           let i = first - num_page_links_to_display;
+//                           i < first;
+//                           i++
+//                       ) {
+//                           page_nums.push(i);
+//                       }
+//                       current_page = page_nums[page_nums.length - 1];
+//                       addHistory(current_page);
+//                       changePage(current_page);
+//                       return false;
+//                   }
+
+//                   function more(e) {
+//                       if (e) e.preventDefault();
+//                       // get last in range
+//                       const last = page_nums[page_nums.length - 1];
+//                       // go from next number to num_page_links_to_display or however many are left
+//                       const remaining_pages = numPages() - last;
+//                       const count = Math.min(
+//                           remaining_pages,
+//                           num_page_links_to_display
+//                       );
+//                       page_nums = [];
+//                       for (
+//                           let i = last + 1;
+//                           i < last + (count + 1);
+//                           i++
+//                       ) {
+//                           page_nums.push(i);
+//                       }
+//                       current_page = page_nums[0];
+//                       addHistory(current_page);
+//                       changePage(current_page);
+//                       return false;
+//                   }
+
+//                   function cleanHandlers() {
+//                       if (btn_next) {
+//                           btn_next.removeEventListener(
+//                               'click',
+//                               btnHandler
+//                           );
+//                       }
+//                       if (btn_prev) {
+//                           btn_prev.removeEventListener(
+//                               'click',
+//                               btnHandler
+//                           );
+//                       }
+//                       const pagebtns = document.getElementsByClassName(
+//                           'page-num'
+//                       );
+//                       for (let i = 0; i < pagebtns.length; i++) {
+//                           pagebtns[i].removeEventListener(
+//                               'click',
+//                               btnHandlerPage
+//                           );
+//                       }
+//                       if (btn_more) {
+//                           btn_more.removeEventListener('click', more);
+//                       }
+//                       if (btn_less) {
+//                           btn_less.removeEventListener('click', less);
+//                       }
+//                   }
+
+//                   function btnHandler(e) {
+//                       e.preventDefault();
+//                       if (e.target.getAttribute('id') === 'btn_prev') {
+//                           prevPage();
+//                       } else if (
+//                           e.target.getAttribute('id') === 'btn_next'
+//                       ) {
+//                           nextPage();
+//                       }
+//                       return false;
+//                   }
+
+//                   function btnHandlerPage(e) {
+//                       e.preventDefault();
+//                       let page = parseInt(
+//                           e.target.getAttribute('data-pagenum')
+//                       );
+//                       if (page > numPages()) {
+//                           page = numPages();
+//                       } else if (page <= 0) {
+//                           page = 1;
+//                       }
+//                       current_page = page;
+//                       addHistory(current_page);
+//                       changePage(current_page);
+//                       return false;
+//                   }
+
+//                   function setHandlers() {
+//                       // remove any existing handlers
+//                       btn_next = document.getElementById('btn_next');
+//                       btn_prev = document.getElementById('btn_prev');
+//                       if (btn_prev) {
+//                           btn_prev.addEventListener('click', btnHandler);
+//                       }
+//                       if (btn_next) {
+//                           btn_next.addEventListener('click', btnHandler);
+//                       }
+//                       const pagebtns = document.getElementsByClassName(
+//                           'page-num'
+//                       );
+//                       if (pagebtns) {
+//                           for (let i = 0; i < pagebtns.length; i++) {
+//                               pagebtns[i].addEventListener(
+//                                   'click',
+//                                   btnHandlerPage
+//                               );
+//                           }
+//                       }
+//                       btn_more = document.getElementsByClassName(
+//                           'more'
+//                       )[0];
+//                       btn_less = document.getElementsByClassName(
+//                           'less'
+//                       )[0];
+//                       if (btn_more) {
+//                           btn_more.addEventListener('click', more);
+//                       }
+//                       if (btn_less) {
+//                           btn_less.addEventListener('click', less);
+//                       }
+//                   }
+
+//                   function setNavigation() {
+//                       let html = '';
+//                       let cls = '';
+//                       cleanHandlers();
+//                       html +=
+//                           '<a class="mr-1 btn btn-sm-tag btn-outline-secondary" href="#" id="btn_prev">Prev</a>';
+//                       if (page_nums[0] > 1) {
+//                           html +=
+//                               '<a class="mr-1 btn btn-sm-tag btn-outline-secondary less" href="#">...</a>';
+//                       }
+//                       for (let i = 0; i < page_nums.length; i++) {
+//                           cls =
+//                               current_page === page_nums[i]
+//                                   ? 'active'
+//                                   : '';
+//                           html += `<a class="mr-1 page-num btn btn-sm-tag btn-outline-secondary ${cls}" href="#" data-pagenum="${page_nums[i]}">${page_nums[i]}</a>`;
+//                       }
+//                       if (page_nums[page_nums.length - 1] < numPages()) {
+//                           html +=
+//                               '<a class="mr-1 btn btn-sm-tag btn-outline-secondary more" href="#">...</a>';
+//                       }
+//                       html +=
+//                           '<a class="mr-1 btn btn-sm-tag btn-outline-secondary" href="#" id="btn_next">Next</a>';
+//                       if (page_navigation) {
+//                           page_navigation.innerHTML = html;
+//                       }
+//                       setHandlers();
+//                   }
+
+//                   window.onpopstate = function (event) {
+//                       if (event.state) {
+//                           current_page = event.state.page;
+//                           changePage(current_page);
+//                       }
+//                   };
+
+//                   function addHistory(page) {
+//                       let pageName = `?s=${query}`;
+//                       if (page !== 1) pageName += `&p=${page}`;
+//                       window.history.pushState({ page }, '', pageName);
+//                   }
+
+//                   function changePage(page) {
+//                       page_span = document.getElementById('page');
+
+//                       // Validate page
+//                       if (page < 1) page = 1;
+//                       if (page > numPages()) page = numPages();
+
+//                       if (listing_table) {
+//                           listing_table.innerHTML = '';
+//                       }
+
+//                       // output our slice of formatted results
+//                       for (
+//                           let i = (page - 1) * items_per_page;
+//                           i < page * items_per_page && i < hits.length;
+//                           i++
+//                       ) {
+//                           let formatted_results = '';
+//                           formatted_results += '<div class="hit row">';
+//                           formatted_results += '<div class="col-12">';
+
+//                           formatted_results += `${
+//                               '<div class="tipue_search_content_title">' +
+//                               '<a href="'
+//                           }${hits[i]['url']}">${getTitle(
+//                               hits[i]
+//                           )}</a></div>`;
+//                           const text =
+//                               hits[i]._snippetResult.content.value;
+//                           formatted_results += `<div class="tipue_search_content_text">${text}</div>`;
+
+//                           formatted_results += '</div>';
+//                           formatted_results += '</div>';
+//                           if (listing_table) {
+//                               listing_table.innerHTML += formatted_results;
+//                           }
+//                       }
+//                       if (page_span) {
+//                           page_span.innerHTML = `${page}/${numPages()}`;
+//                       }
+
+//                       setNavigation();
+
+//                       // set previous and next buttons class
+//                       if (btn_prev) {
+//                           btn_prev.classList[
+//                               page === 1 ? 'add' : 'remove'
+//                           ]('disabled');
+//                       }
+//                       if (btn_next) {
+//                           btn_next.classList[
+//                               page === numPages() ? 'add' : 'remove'
+//                           ]('disabled');
+//                       }
+
+//                       // set active button class
+//                       const pagebtns = document.getElementsByClassName(
+//                           'page-num'
+//                       );
+//                       for (let i = 0; i < pagebtns.length; i++) {
+//                           const page = parseInt(
+//                               pagebtns[i].getAttribute('data-pagenum')
+//                           );
+//                           pagebtns[i].classList[
+//                               current_page === page ? 'add' : 'remove'
+//                           ]('active');
+//                       }
+
+//                       // scroll to top only if there is no hash
+//                       if (!window.location.hash) {
+//                           $('html, body').scrollTop(0);
+//                       }
+//                   }
+
+//                   // init page nums
+//                   initPageNums();
+
+//                   // set initial page
+//                   const searchParams = new URLSearchParams(
+//                       window.location.search
+//                   );
+//                   if (searchParams.get('p') !== null)
+//                       current_page = parseInt(searchParams.get('p'));
+//                       window.history.replaceState({ page: current_page }, '', '');
+//                   changePage(current_page);
+//               }
+//           } else {
+//               const content = document.getElementsByClassName(
+//                   'content'
+//               )[0];
+//               if (content) {
+//                   content.innerHTML = '0 results';
+//               }
+//           }
+//       }
+//   );
+// }

--- a/src/scripts/components/search.js
+++ b/src/scripts/components/search.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import algoliasearch from 'algoliasearch';
-import configDocs from '../config/config-docs';
 import { getQueryParameterByName } from '../helpers/browser';
+import configDocs from '../config/config-docs';
 
 const getAlgoliaConfig = () => {
     const siteEnv = document.querySelector('html').dataset.env;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,110 @@
 # yarn lockfile v1
 
 
+"@algolia/cache-browser-local-storage@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.11.0.tgz#1c168add00b398a860db6c86039e33b2843a9425"
+  integrity sha512-4sr9vHIG1fVA9dONagdzhsI/6M5mjs/qOe2xUP0yBmwsTsuwiZq3+Xu6D3dsxsuFetcJgC6ydQoCW8b7fDJHYQ==
+  dependencies:
+    "@algolia/cache-common" "4.11.0"
+
+"@algolia/cache-common@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.11.0.tgz#066fe6d58b18e4b028dbef9bb8de07c5e22a3594"
+  integrity sha512-lODcJRuPXqf+6mp0h6bOxPMlbNoyn3VfjBVcQh70EDP0/xExZbkpecgHyyZK4kWg+evu+mmgvTK3GVHnet/xKw==
+
+"@algolia/cache-in-memory@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-in-memory/-/cache-in-memory-4.11.0.tgz#763c8cb655e6fd2261588e04214fca0959ac07c1"
+  integrity sha512-aBz+stMSTBOBaBEQ43zJXz2DnwS7fL6dR0e2myehAgtfAWlWwLDHruc/98VOy1ZAcBk1blE2LCU02bT5HekGxQ==
+  dependencies:
+    "@algolia/cache-common" "4.11.0"
+
+"@algolia/client-account@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-account/-/client-account-4.11.0.tgz#67fadd3b0802b013ebaaa4b47bb7babae892374e"
+  integrity sha512-jwmFBoUSzoMwMqgD3PmzFJV/d19p1RJXB6C1ADz4ju4mU7rkaQLtqyZroQpheLoU5s5Tilmn/T8/0U2XLoJCRQ==
+  dependencies:
+    "@algolia/client-common" "4.11.0"
+    "@algolia/client-search" "4.11.0"
+    "@algolia/transporter" "4.11.0"
+
+"@algolia/client-analytics@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-4.11.0.tgz#cbdc8128205e2da749cafc79e54708d14c413974"
+  integrity sha512-v5U9585aeEdYml7JqggHAj3E5CQ+jPwGVztPVhakBk8H/cmLyPS2g8wvmIbaEZCHmWn4TqFj3EBHVYxAl36fSA==
+  dependencies:
+    "@algolia/client-common" "4.11.0"
+    "@algolia/client-search" "4.11.0"
+    "@algolia/requester-common" "4.11.0"
+    "@algolia/transporter" "4.11.0"
+
+"@algolia/client-common@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.11.0.tgz#9a2d1f6f8eaad25ba5d6d4ce307ba5bd84e6f999"
+  integrity sha512-Qy+F+TZq12kc7tgfC+FM3RvYH/Ati7sUiUv/LkvlxFwNwNPwWGoZO81AzVSareXT/ksDDrabD4mHbdTbBPTRmQ==
+  dependencies:
+    "@algolia/requester-common" "4.11.0"
+    "@algolia/transporter" "4.11.0"
+
+"@algolia/client-personalization@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-personalization/-/client-personalization-4.11.0.tgz#d3bf0e760f85df876b4baf5b81996f0aa3a59940"
+  integrity sha512-mI+X5IKiijHAzf9fy8VSl/GTT67dzFDnJ0QAM8D9cMPevnfX4U72HRln3Mjd0xEaYUOGve8TK/fMg7d3Z5yG6g==
+  dependencies:
+    "@algolia/client-common" "4.11.0"
+    "@algolia/requester-common" "4.11.0"
+    "@algolia/transporter" "4.11.0"
+
+"@algolia/client-search@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.11.0.tgz#c1105d715a2a04ba27231eca86f5d6620f68f4ae"
+  integrity sha512-iovPLc5YgiXBdw2qMhU65sINgo9umWbHFzInxoNErWnYoTQWfXsW6P54/NlKx5uscoLVjSf+5RUWwFu5BX+lpw==
+  dependencies:
+    "@algolia/client-common" "4.11.0"
+    "@algolia/requester-common" "4.11.0"
+    "@algolia/transporter" "4.11.0"
+
+"@algolia/logger-common@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-common/-/logger-common-4.11.0.tgz#bac1c2d59d29dee378b57412c8edd435b97de663"
+  integrity sha512-pRMJFeOY8hoWKIxWuGHIrqnEKN/kqKh7UilDffG/+PeEGxBuku+Wq5CfdTFG0C9ewUvn8mAJn5BhYA5k8y0Jqg==
+
+"@algolia/logger-console@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-console/-/logger-console-4.11.0.tgz#ced19e3abb22eb782ed5268d51efb5aa9ef109ef"
+  integrity sha512-wXztMk0a3VbNmYP8Kpc+F7ekuvaqZmozM2eTLok0XIshpAeZ/NJDHDffXK2Pw+NF0wmHqurptLYwKoikjBYvhQ==
+  dependencies:
+    "@algolia/logger-common" "4.11.0"
+
+"@algolia/requester-browser-xhr@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.11.0.tgz#f9e1ad56f185432aa8dde8cad53ae271fd5d6181"
+  integrity sha512-Fp3SfDihAAFR8bllg8P5ouWi3+qpEVN5e7hrtVIYldKBOuI/qFv80Zv/3/AMKNJQRYglS4zWyPuqrXm58nz6KA==
+  dependencies:
+    "@algolia/requester-common" "4.11.0"
+
+"@algolia/requester-common@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.11.0.tgz#d16de98d3ff72434bac39e4d915eab08035946a9"
+  integrity sha512-+cZGe/9fuYgGuxjaBC+xTGBkK7OIYdfapxhfvEf03dviLMPmhmVYFJtJlzAjQ2YmGDJpHrGgAYj3i/fbs8yhiA==
+
+"@algolia/requester-node-http@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-4.11.0.tgz#beb2b6b68d5f4ce15aec80ede623f0ac96991368"
+  integrity sha512-qJIk9SHRFkKDi6dMT9hba8X1J1z92T5AZIgl+tsApjTGIRQXJLTIm+0q4yOefokfu4CoxYwRZ9QAq+ouGwfeOg==
+  dependencies:
+    "@algolia/requester-common" "4.11.0"
+
+"@algolia/transporter@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/transporter/-/transporter-4.11.0.tgz#a8de3c173093ceceb02b26b577395ce3b3d4b96f"
+  integrity sha512-k4dyxiaEfYpw4UqybK9q7lrFzehygo6KV3OCYJMMdX0IMWV0m4DXdU27c1zYRYtthaFYaBzGF4Kjcl8p8vxCKw==
+  dependencies:
+    "@algolia/cache-common" "4.11.0"
+    "@algolia/logger-common" "4.11.0"
+    "@algolia/requester-common" "4.11.0"
+
 "@apidevtools/json-schema-ref-parser@^8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz#9eb749499b3f8d919e90bb141e4b6f67aee4692d"
@@ -1692,7 +1796,27 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-algoliasearch@^3.24.5, algoliasearch@^3.35.1:
+algoliasearch@4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.11.0.tgz#234befb3ac355c094077f0edf3777240b1ee013c"
+  integrity sha512-IXRj8kAP2WrMmj+eoPqPc6P7Ncq1yZkFiyDrjTBObV1ADNL8Z/KdZ+dWC5MmYcBLAbcB/mMCpak5N/D1UIZvsA==
+  dependencies:
+    "@algolia/cache-browser-local-storage" "4.11.0"
+    "@algolia/cache-common" "4.11.0"
+    "@algolia/cache-in-memory" "4.11.0"
+    "@algolia/client-account" "4.11.0"
+    "@algolia/client-analytics" "4.11.0"
+    "@algolia/client-common" "4.11.0"
+    "@algolia/client-personalization" "4.11.0"
+    "@algolia/client-search" "4.11.0"
+    "@algolia/logger-common" "4.11.0"
+    "@algolia/logger-console" "4.11.0"
+    "@algolia/requester-browser-xhr" "4.11.0"
+    "@algolia/requester-common" "4.11.0"
+    "@algolia/requester-node-http" "4.11.0"
+    "@algolia/transporter" "4.11.0"
+
+algoliasearch@^3.24.5:
   version "3.35.1"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.35.1.tgz#297d15f534a3507cab2f5dfb996019cac7568f0c"
   integrity sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==


### PR DESCRIPTION
### What does this PR do?
Upgrades `algoliasearch` JS package from v3 to v4, updates some code accordingly, and a small refactor of some code in `search.js`

### Motivation
Previous version was way out of date, this will also help make upcoming algolia insights work easier.

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/upgrade-algoliasearch/search/?s=synthetics
Search page continues to work as expected, including pagination.

https://docs-staging.datadoghq.com/brian.deutsch/upgrade-algoliasearch/
Searching from the home page and the sidebar continues to work as expected, including using the autocomplete dropdown.

Search results themselves should be unaffected, and there should be no console errors.


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
