### PR TITLE
[DOCS-2906] Indicate deprecation of opentelemetry-exporters-datadog

### DIFF
--- a/content/en/tracing/setup_overview/open_standards/ruby.md
+++ b/content/en/tracing/setup_overview/open_standards/ruby.md
@@ -41,7 +41,7 @@ However, additional instrumentation provided by Datadog can be activated alongsi
 OpenTelemetry support is available by using the `opentelemetry-exporters-datadog` gem to export traces from OpenTelemetry to Datadog.
 
 <div class="alert alert-warning">
-This feature is currently in beta. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> if it doesn't work as you expect.
+This feature is deprecated. For OpenTelemetry integration we recommend using <a href="https://github.com/open-telemetry/opentelemetry-collector">OpenTelemetry collector</a> with <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter">DataDog exporter</a>.
 </div>
 
 ### Installation


### PR DESCRIPTION
### What does this PR do?
Updates the documentation to indicate that `opentelemetry-exporters-datadog` gem is deprecated

### Motivation
The documentation states that it's in `beta`, which conflicts with the [gem's Readme](https://github.com/DataDog/dd-opentelemetry-exporter-ruby#readme).

### Preview
- [content/en/tracing/setup_overview/open_standards/ruby.md#opentelemetry](https://github.com/DataDog/documentation/blob/91a7bcf35f88d5166d5be92060e9df3f5144fbcc/content/en/tracing/setup_overview/open_standards/ruby.md#opentelemetry)

### Notes
- [deprecation PR](https://github.com/DataDog/dd-opentelemetry-exporter-ruby/pull/14/files)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
