### PR TITLE
[DOCS-2763] Match API tests list and tiles to UI order

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2508,20 +2508,20 @@ main:
     url: synthetics/api_tests/dns_tests
     parent: api_tests
     weight: 103
+  - name: WebSocket
+    url: synthetics/api_tests/websocket_tests
+    parent: api_tests
+    weight: 104
   - name: TCP
     url: synthetics/api_tests/tcp_tests
     parent: api_tests
-    weight: 104
+    weight: 105
   - name: UDP
     url: synthetics/api_tests/udp_tests
     parent: api_tests
-    weight: 105
+    weight: 106
   - name: ICMP
     url: synthetics/api_tests/icmp_tests
-    parent: api_tests
-    weight: 106
-  - name: WebSocket
-    url: synthetics/api_tests/websocket_tests
     parent: api_tests
     weight: 107
   - name: Multistep API Tests

--- a/layouts/partials/synthetics/network-layers.html
+++ b/layouts/partials/synthetics/network-layers.html
@@ -17,6 +17,11 @@
                     {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/dns-test1.png" "class" "img-fluid" "alt" "DNS" "width" "400") }}
                 </div>
             </a>
+            <a class="card" href="/synthetics/api_tests/websocket_tests">
+                <div class="card-body text-center py-2 px-1">
+                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/websocket-test1.png" "class" "img-fluid" "alt" "WebSocket" "width" "400") }}
+                </div>
+            </a>
             <a class="card" href="/synthetics/api_tests/tcp_tests">
                 <div class="card-body text-center py-2 px-1">
                     {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/tcp-test1.png" "class" "img-fluid" "alt" "TCP" "width" "400") }}
@@ -30,11 +35,6 @@
             <a class="card" href="/synthetics/api_tests/icmp_tests">
                 <div class="card-body text-center py-2 px-1">
                     {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/icmp-test2.png" "class" "img-fluid" "alt" "ICMP" "width" "400") }}
-                </div>
-            </a>
-            <a class="card" href="/synthetics/api_tests/websocket_tests">
-                <div class="card-body text-center py-2 px-1">
-                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/websocket-test1.png" "class" "img-fluid" "alt" "WebSocket" "width" "400") }}
                 </div>
             </a>
         </div>


### PR DESCRIPTION
### What does this PR do?
Matches the API tests nav bar list and the integration tiles on the doc to the order as shown in the UI. 

### Motivation

DOCS-2763

### Preview

https://docs-staging.datadoghq.com/may/api-tests-list-order/synthetics/api_tests/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
