### PR TITLE
Indicate that the regimport command is deprecated

### DIFF
--- a/content/en/agent/guide/agent-commands.md
+++ b/content/en/agent/guide/agent-commands.md
@@ -267,7 +267,7 @@ Some options have flags and options detailed under `--help`. For example, use he
 | `installservice`  | Install the Agent within the service control manager. Windows only.         |
 | `jmx`             | JMX troubleshooting.                                                        |
 | `launch-gui`      | Start the Datadog Agent GUI.                                                |
-| `regimport`       | Import the registry settings into `datadog.yaml`. Windows only.             |
+| `regimport`       | Import the registry settings into `datadog.yaml`. Windows only. Deprecated since 7.27.0             |
 | `remove-service`  | Remove the Agent from the service control manager. Windows only.            |
 | `restart-service` | Restart the Agent within the service control manager. Windows only.         |
 | `start-service`   | Start the Agent within the service control manager. Windows only.           |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds a note to the `regimport` command doc, indicating that it's been removed in 7.27.0.

### Motivation
Correctly document the Agent commands.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/julien.lebot/update_agent_commands_doc/agent/guide/agent-commands/?tab=agentv6v7#other-commands

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
