### PR TITLE
[OpenTelemetry] Recommend `resourcedetection` processor and clarify hostname usage

### DIFF
--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -121,7 +121,7 @@ Run an Opentelemetry Collector container to receive traces either from the [inst
 
 2. Choose a published Docker image such as [`otel/opentelemetry-collector-contrib:latest`][13].
 
-3.  Determine which ports to open on your container. OpenTelemetry traces are sent to the OpenTelemetry Collector over TCP or UDP on a number of ports, which must be exposed on the container.  By default, traces are sent over OTLP/gRPC on port `55680`, but common protocols and their ports include:
+3.  Determine which ports to open on your container. OpenTelemetry traces are sent to the OpenTelemetry Collector over TCP or UDP on several ports, which must be exposed on the container. By default, traces are sent over OTLP/gRPC on port `55680`, but common protocols and their ports include:
 
       - Zipkin/HTTP on port `9411`
       - Jaeger/gRPC on port `14250`


### PR DESCRIPTION
### What does this PR do?

- Update OpenTelemetry Collector suggested configuration to include `resourcedetectionprocessor`
- Update documentation on hostname resolution
- Remove `hostname` field usage in the suggested configuration

### Motivation

In general we want to rely on the resource detection processor for semantic conventions, since this is the only way to have a correct hostname resolution in multi-Collector setups. 

While the `hostname` option is supported and its behavior is the same than in the Datadog Agent, we want to promote the usage of resource attributes instead, since these provide a more granular configuration and are more consisten with the rest of the OpenTelemetry ecosystem.

 
### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

An update to the OpenTelemetry Collector configuration example may also be beneficial, to ensure people use the batch processor and the resource detection processor.

The resourcedetection processor is available in the contrib and AWS distros and is widely used and supported.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
