### PR TITLE
Load missing tag descriptions from v2

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -55,8 +55,8 @@
 <!-- get this translate tag -->
 {{ $translate_tag := (index $translate_tags $tagSlug) | default (dict) }}
 
-<!-- lets show the intro text, shall we use v1 or v2 text. Lets try v1 for now.. -->
-{{ partial "api/intro.html" (dict "tags" $dot.Site.Data.api.v1.full_spec_deref.tags "title" $ParamTitleEn "translate_tag" $translate_tag) }}
+<!-- lets show the intro text -->
+{{ partial "api/intro.html" (dict "api" $dot.Site.Data.api "title" $ParamTitleEn "translate_tag" $translate_tag) }}
 
 <!-- Loop over the menu to determine what to pull in -->
 {{ range (where .Sites.First.Menus.api ".Name" "==" $ParamTitleEn) }}

--- a/layouts/partials/api/intro.html
+++ b/layouts/partials/api/intro.html
@@ -1,7 +1,8 @@
-{{ $tags := .tags }}
+{{ $tagsV1 := .api.v1.full_spec_deref.tags }}
+{{ $tagsV2 := .api.v2.full_spec_deref.tags }}
 {{ $title := .title }}
 {{ $translate_tag := .translate_tag }}
-{{ range $tag := first 1 (where $tags ".name" "==" $title) }}
+{{ range $tag := first 1 (where ($tagsV1 | append $tagsV2) ".name" "==" $title) }}
 <h1>{{ $translate_tag.name | default $tag.name }}</h1>
 <div class="row">
     <div class="col-12 col-lg-9">


### PR DESCRIPTION
### What does this PR do?

Adds missing descriptions for v2 only tags.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jirikuncar/missing-tags-descriptions/api/latest/incidents/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
