### PR TITLE
Update _index.md

### DIFF
--- a/content/en/getting_started/integrations/_index.md
+++ b/content/en/getting_started/integrations/_index.md
@@ -95,7 +95,7 @@ If you define tags in the `datadog.yaml` file, the tags are applied to all of yo
 
 For example, setting `service` in your config file is the recommended [Agent setup][26] for monitoring separate, independent systems.
 
-To better unify your environment, it is also recommended to configure the `env` tag in the Agent. To learn more, see [Unified Service Tagging][12].
+To better unify your environment, it is also recommended to configure the `env` tag in the Agent. To learn more, see [Unified Service Tagging][44].
 
 ### Validation
 

--- a/content/en/getting_started/integrations/_index.md
+++ b/content/en/getting_started/integrations/_index.md
@@ -187,7 +187,7 @@ tagging
 [9]: /integrations/python/
 [10]: /developers/custom_checks/write_agent_check/
 [11]: https://github.com/DataDog/integrations-core
-[12]: https://github.com/DataDog/integrations-extras
+[12]: /getting_started/tagging/unified_service_tagging/
 [13]: /developers/integrations/new_check_howto/#developer-toolkit
 [14]: /agent/guide/integration-management/
 [15]: https://app.datadoghq.com/account/settings#agent

--- a/content/en/getting_started/integrations/_index.md
+++ b/content/en/getting_started/integrations/_index.md
@@ -187,7 +187,7 @@ tagging
 [9]: /integrations/python/
 [10]: /developers/custom_checks/write_agent_check/
 [11]: https://github.com/DataDog/integrations-core
-[12]: /getting_started/tagging/unified_service_tagging/
+[12]: https://github.com/DataDog/integrations-extras
 [13]: /developers/integrations/new_check_howto/#developer-toolkit
 [14]: /agent/guide/integration-management/
 [15]: https://app.datadoghq.com/account/settings#agent
@@ -219,3 +219,4 @@ tagging
 [41]: /metrics/
 [42]: /metrics/custom_metrics/
 [43]: /monitors/guide/visualize-your-service-check-in-the-datadog-ui/
+[44]: /getting_started/tagging/unified_service_tagging/


### PR DESCRIPTION
### What does this PR do?
Updates the unified service tagging link as it's pointing to the wrong path

### Motivation
It's the incorrect path

### Preview
https://docs-staging.datadoghq.com/sarina/ust-wrong-link/getting_started/integrations/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
