### PR TITLE
Note re: Upload step supported from managed location

### DIFF
--- a/content/en/synthetics/browser_tests/actions.md
+++ b/content/en/synthetics/browser_tests/actions.md
@@ -51,7 +51,7 @@ You can record the uploading of files as a step. To record an **Upload** step yo
 
 {{< img src="synthetics/browser_tests/upload_file_step.png" alt="Create an upload file step" style="width:60%;">}}
 
-This is limited to 10 files with a limit of 5MB each.
+This is limited to 10 files with a limit of 5MB each. The Upload step is supported by browser tests running from managed locations.
 
 ## Manually added steps
 


### PR DESCRIPTION
### What does this PR do?
This PR adds a note to clarify that the Upload step is supported from managed locations.

### Motivation
Customer request.

### Preview
https://docs-staging.datadoghq.com/cynthia.dominguez/upload_step_note/synthetics/browser_tests/actions/#upload-file

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
