### PR TITLE
DOCS-2678 Update datadog-agent repo links

### DIFF
--- a/content/en/agent/_index.md
+++ b/content/en/agent/_index.md
@@ -73,4 +73,4 @@ Datadog Agent release numbering follows <a href="https://semver.org/">SemVer</a>
 
 [1]: https://github.com/DataDog/datadog-agent
 [2]: https://app.datadoghq.com/account/settings#agent/aws
-[3]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/dogstatsd/alpine
+[3]: https://github.com/DataDog/datadog-agent/tree/main/Dockerfiles/dogstatsd/alpine

--- a/content/en/agent/amazon_ecs/_index.md
+++ b/content/en/agent/amazon_ecs/_index.md
@@ -313,7 +313,7 @@ Need help? Contact [Datadog support][20].
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent
+[1]: https://github.com/DataDog/datadog-agent/tree/main/Dockerfiles/agent
 [2]: https://docs.datadoghq.com/integrations/faq/agent-5-amazon-ecs/
 [3]: https://docs.datadoghq.com/agent/docker/integrations/?tab=docker
 [4]: https://docs.datadoghq.com/integrations/ecs_fargate/

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -181,7 +181,7 @@ In your existing `Daemonset` [manifest file][2] set the environment variable `DD
 
 After redeploying your `Daemonset` with these configurations in place, the Datadog Agent is able to communicate with the Cluster Agent.
 
-[1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/cluster-agent
+[1]: https://github.com/DataDog/datadog-agent/tree/main/Dockerfiles/manifests/cluster-agent
 [2]: /agent/kubernetes/?tab=daemonset
 [3]: /agent/faq/rbac-for-dca-running-on-aks-with-helm/
 [4]: /agent/cluster_agent/setup/?tab=daemonset#configure-the-datadog-agent

--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -6,7 +6,7 @@ aliases:
     - /tracing/setup/docker/
     - /agent/apm/docker
 further_reading:
-    - link: 'https://github.com/DataDog/datadog-agent/tree/master/pkg/trace'
+    - link: 'https://github.com/DataDog/datadog-agent/tree/main/pkg/trace'
       tag: 'Github'
       text: Source code
     - link: '/integrations/amazon_ecs/#trace-collection'

--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -100,7 +100,7 @@ The commands related to log collection are:
 : To collect containers logs from files. Available in the Datadog Agent 6.27.0/7.27.0+
 
 
-[1]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent
+[1]: https://github.com/DataDog/datadog-agent/tree/main/Dockerfiles/agent
 [2]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/agent
 {{% /tab %}}
 {{% tab "Host Agent" %}}

--- a/content/en/agent/faq/agent_v6_changes.md
+++ b/content/en/agent/faq/agent_v6_changes.md
@@ -569,4 +569,4 @@ Similarly, you may have added a PIP package to meet a requirement for a custom c
 [6]: /agent/guide/agent-commands/
 [7]: /getting_started/agent/autodiscovery/
 [8]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_base
-[9]: https://github.com/DataDog/datadog-agent/tree/master/docs/dev/checks
+[9]: https://github.com/DataDog/datadog-agent/tree/main/docs/dev/checks

--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -15,7 +15,7 @@ further_reading:
     - link: 'developers/libraries'
       tag: 'Documentation'
       text: 'Official and Community created API and DogStatsD client libraries'
-    - link: 'https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd'
+    - link: 'https://github.com/DataDog/datadog-agent/tree/main/pkg/dogstatsd'
       tag: 'GitHub'
       text: 'DogStatsD source code'
 ---

--- a/content/en/developers/dogstatsd/data_aggregation.md
+++ b/content/en/developers/dogstatsd/data_aggregation.md
@@ -11,7 +11,7 @@ further_reading:
     - link: 'developers/libraries'
       tag: 'Documentation'
       text: 'Official and Community created API and DogStatsD client libraries'
-    - link: 'https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd'
+    - link: 'https://github.com/DataDog/datadog-agent/tree/main/pkg/dogstatsd'
       tag: 'GitHub'
       text: 'DogStatsD source code'
 ---

--- a/content/en/developers/dogstatsd/datagram_shell.md
+++ b/content/en/developers/dogstatsd/datagram_shell.md
@@ -11,7 +11,7 @@ further_reading:
     - link: 'developers/libraries'
       tag: 'Documentation'
       text: 'Official and Community created API and DogStatsD client libraries'
-    - link: 'https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd'
+    - link: 'https://github.com/DataDog/datadog-agent/tree/main/pkg/dogstatsd'
       tag: 'GitHub'
       text: 'DogStatsD source code'
 ---

--- a/content/en/developers/dogstatsd/dogstatsd_mapper.md
+++ b/content/en/developers/dogstatsd/dogstatsd_mapper.md
@@ -9,7 +9,7 @@ further_reading:
     - link: 'developers/libraries'
       tag: 'Documentation'
       text: 'Official and Community created API and DogStatsD client libraries'
-    - link: 'https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd'
+    - link: 'https://github.com/DataDog/datadog-agent/tree/main/pkg/dogstatsd'
       tag: 'GitHub'
       text: 'DogStatsD source code'
 ---

--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -9,7 +9,7 @@ further_reading:
     - link: 'developers/libraries'
       tag: 'Documentation'
       text: 'Official and Community created API and DogStatsD client libraries'
-    - link: 'https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd'
+    - link: 'https://github.com/DataDog/datadog-agent/tree/main/pkg/dogstatsd'
       tag: 'GitHub'
       text: 'DogStatsD source code'
 ---

--- a/content/en/developers/dogstatsd/unix_socket.md
+++ b/content/en/developers/dogstatsd/unix_socket.md
@@ -11,7 +11,7 @@ further_reading:
     - link: 'developers/libraries'
       tag: 'Documentation'
       text: 'Official and Community created API and DogStatsD client libraries'
-    - link: 'https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd'
+    - link: 'https://github.com/DataDog/datadog-agent/tree/main/pkg/dogstatsd'
       tag: 'GitHub'
       text: 'DogStatsD source code'
 ---

--- a/content/en/developers/service_checks/dogstatsd_service_checks_submission.md
+++ b/content/en/developers/service_checks/dogstatsd_service_checks_submission.md
@@ -9,7 +9,7 @@ further_reading:
 - link: "/developers/community/libraries/"
   tag: "Documentation"
   text: "Official and Community created API and DogStatsD client libraries"
-- link: "https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd"
+- link: "https://github.com/DataDog/datadog-agent/tree/main/pkg/dogstatsd"
   tag: "GitHub"
   text: "DogStatsD source code"
 ---

--- a/content/en/events/guides/dogstatsd.md
+++ b/content/en/events/guides/dogstatsd.md
@@ -9,7 +9,7 @@ further_reading:
 - link: "/developers/community/libraries/"
   tag: "Documentation"
   text: "Official and Community created API and DogStatsD client libraries"
-- link: "https://github.com/DataDog/datadog-agent/tree/master/pkg/dogstatsd"
+- link: "https://github.com/DataDog/datadog-agent/tree/main/pkg/dogstatsd"
   tag: "GitHub"
   text: "DogStatsD source code"
 aliases:

--- a/content/en/getting_started/agent/_index.md
+++ b/content/en/getting_started/agent/_index.md
@@ -117,11 +117,11 @@ For help troubleshooting the Agent:
 [5]: /logs/
 [6]: /tracing/
 [7]: https://www.datadoghq.com
-[8]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent
+[8]: https://github.com/DataDog/datadog-agent/tree/main/Dockerfiles/agent
 [9]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 [10]: https://app.datadoghq.com/organization-settings/api-keys
 [11]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
-[12]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent#environment-variables
+[12]: https://github.com/DataDog/datadog-agent/tree/main/Dockerfiles/agent#environment-variables
 [13]: /agent/guide/agent-commands/#agent-status-and-information
 [14]: /agent/guide/agent-commands/
 [15]: /agent/guide/agent-commands/#start-the-agent

--- a/content/en/tracing/guide/agent-5-tracing-setup.md
+++ b/content/en/tracing/guide/agent-5-tracing-setup.md
@@ -70,8 +70,8 @@ Trace search is available for Agent 5.25.0+. For more information, see the set u
 
 Need help? Contact [Datadog support][12].
 
-[1]: https://github.com/DataDog/datadog-agent/tree/master/docs/trace-agent#run-on-macos
-[2]: https://github.com/DataDog/datadog-agent/tree/master/docs/trace-agent#run-on-windows
+[1]: https://github.com/DataDog/datadog-agent/tree/main/docs/trace-agent#run-on-macos
+[2]: https://github.com/DataDog/datadog-agent/tree/main/docs/trace-agent#run-on-windows
 [3]: /agent/faq/where-is-the-configuration-file-for-the-agent/
 [4]: /tracing/visualization/#trace-metrics
 [5]: https://app.datadoghq.com/account/settings#agent


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update datadog-agent repo links

### Motivation
datadog-agent master branch changed to main

### Preview
N/A

### Additional Notes
Reference: https://github.com/DataDog/dogweb/pull/68155

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
