### PR TITLE
[ja] `Serverless function` is missing in `service types`

### DIFF
--- a/content/ja/tracing/visualization/services_list.md
+++ b/content/ja/tracing/visualization/services_list.md
@@ -44,6 +44,7 @@ further_reading:
 *  Cache
 *  Custom
 *  DB
+*  Serverless function
 *  Web
 
 また、たとえば Postgre、MySQL、Cassandra のインテグレーションでは、エイリアスが Type: "DB" にマッピングされ、Redis や Memcache のインテグレーションでは Type: "Cache" にマッピングされます。


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add `Serverless function` to [サービスタイプ](https://docs.datadoghq.com/ja/tracing/visualization/services_list/#%E3%82%B5%E3%83%BC%E3%83%93%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%97).

### Motivation

In English page, `Serverless function` is listed up in [Service types](https://docs.datadoghq.com/tracing/visualization/services_list/#services-types).
However, it is missing on Japanese page. It would make Japanese customers be confused.

![Services List 2021-12-13 at 2 56 23 PM](https://user-images.githubusercontent.com/41987730/145760240-1a3fc462-2092-4b58-871a-4a307d0265ce.jpg)

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
