### PR TITLE
Use log4j 2.15.0 whenever log4j-core is mentioned

### DIFF
--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -118,22 +118,22 @@ Log4j 2 includes a JSON layout.
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.7</version>
+        <version>2.15.0</version>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.8.3</version>
+        <version>2.13.0</version>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.8.3</version>
+        <version>2.13.0</version>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.8.3</version>
+        <version>2.13.0</version>
     </dependency>
     ```
 
@@ -338,7 +338,7 @@ Log4j 2 allows logging to a remote host, but it does not offer the ability to pr
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.11.0</version>
+        <version>2.15.0</version>
     </dependency>
     <dependency>
         <groupId>ch.qos.logback</groupId>

--- a/content/fr/logs/log_collection/java.md
+++ b/content/fr/logs/log_collection/java.md
@@ -117,22 +117,22 @@ Log4j 2 intègre une structure JSON.
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.7</version>
+        <version>2.15.0</version>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.8.3</version>
+        <version>2.13.0</version>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.8.3</version>
+        <version>2.13.0</version>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.8.3</version>
+        <version>2.13.0</version>
     </dependency>
     ```
 
@@ -337,7 +337,7 @@ Log4j 2 permet la journalisation sur un host à distance, mais n'offre pas la p
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.11.0</version>
+        <version>2.15.0</version>
     </dependency>
     <dependency>
         <groupId>net.logstash.logback</groupId>

--- a/content/ja/logs/log_collection/java.md
+++ b/content/ja/logs/log_collection/java.md
@@ -117,22 +117,22 @@ Log4j 2 には JSON レイアウトが含まれています。
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.7</version>
+        <version>2.15.0</version>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.8.3</version>
+        <version>2.13.0</version>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.8.3</version>
+        <version>2.13.0</version>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.8.3</version>
+        <version>2.13.0</version>
     </dependency>
     ```
 
@@ -337,7 +337,7 @@ Log4j 2 では、リモートホストへのログ記録が可能ですが、ロ
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-to-slf4j</artifactId>
-        <version>2.11.0</version>
+        <version>2.15.0</version>
     </dependency>
     <dependency>
         <groupId>net.logstash.logback</groupId>


### PR DESCRIPTION
### What does this PR do?

Updates our references to log4j v2 to 2.15.0.

### Preview

https://docs-staging.datadoghq.com/olivielpeau/log4j-2-15-0/logs/log_collection/java/?tab=log4j2#json-format

### Additional Notes

Took the opportunity to also update the jackson version we document. And updated the version for `log4j-to-slf4j` as well, although it's not strictly necessary.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
