### PR TITLE
DOCS-2465 Synthetic Monitoring Terraform Link Update

### DIFF
--- a/content/en/synthetics/_index.md
+++ b/content/en/synthetics/_index.md
@@ -26,57 +26,62 @@ Synthetic tests allow you to observe how your systems and applications are perfo
 
 With **end-to-end testing in production and CI environments**, your development teams can proactively ensure that no defective code makes it to production. **Computing SLOs** on your key endpoints and user journeys makes it easier to stick to your application performance targets and ultimately provide a consistent customer experience.
 
+You can create Synthetic tests in the [Datadog application][1], with the [API][2], or with [Terraform][3].
+
 ## Set up API tests and multistep API tests
 
-API tests allow you to launch [single][1] or [chained][2] requests to perform verifications on your key systems at various network levels: [HTTP test][3], [SSL test][4], [DNS test][5], [TCP test][6], [UDP test][7], [ICMP test][8], and [WebSocket test][9]. 
+API tests allow you to launch [single][4] or [chained][5] requests to perform verifications on your key systems at various network levels: [HTTP test][6], [SSL test][7], [DNS test][8], [TCP test][9], [UDP test][10], [ICMP test][11], and [WebSocket test][12]. 
 
 {{< img src="synthetics/api_test.png" alt="API tests" style="width:100%;">}}
 
 ## Record browser tests
 
-Use [Synthetic browser tests][10] to monitor how your customers experience your webpages from around the world with end-to-end tests.
+Use [Synthetic browser tests][13] to monitor how your customers experience your webpages from around the world with end-to-end tests.
 
 {{< img src="synthetics/browser_test.mp4" alt="Browser tests" video=true style="width:100%;">}}
 
 ## Launch private locations
 
-Use [Synthetic private locations][11] to monitor internal APIs and websites or create custom locations in areas that are mission-critical to your business.
+Use [Synthetic private locations][14] to monitor internal APIs and websites or create custom locations in areas that are mission-critical to your business.
 
 {{< img src="synthetics/private_locations.png" alt="Private locations" style="width:100%;">}}
 
 ## Run tests with your integration and deployment processes
 
-Leverage your Synthetic tests as [canary deployments][12] or run them directly within your [CI pipelines][12] to start shipping without fear that faulty code may impact your customers' experience.
+Leverage your Synthetic tests as [canary deployments][15] or run them directly within your [CI pipelines][15] to start shipping without fear that faulty code may impact your customers' experience.
 
  {{< img src="synthetics/ci.png" alt="CI tests" style="width:100%;">}}
 
 ## Connect data and traces
 
-Use the [out of the box integration between Synthetic tests and APM traces][13] to find the root cause of failures across frontend, network, and backend requests.
+Use the [out of the box integration between Synthetic tests and APM traces][16] to find the root cause of failures across frontend, network, and backend requests.
 
 {{< img src="synthetics/synthetics_traces.mp4" alt="Synthetic Monitoring" video=true style="width:100%;">}}
 
 ## Ready to start?
 
-See [Getting Started with Synthetic Monitoring][14] for instructions on creating your first Synthetic test and monitoring your web applications. Then, explore [Getting Started with Private Locations][15] for instructions on creating your private location and running Synthetic tests with your private location.
+See [Getting Started with Synthetic Monitoring][17] for instructions on creating your first Synthetic test and monitoring your web applications. Then, explore [Getting Started with Private Locations][18] for instructions on creating your private location and running Synthetic tests with your private location.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: /synthetics/api_tests/
-[2]: /synthetics/multistep
-[3]: /synthetics/api_tests/http_tests
-[4]: /synthetics/api_tests/ssl_tests
-[5]: /synthetics/api_tests/dns_tests
-[6]: /synthetics/api_tests/tcp_tests
-[7]: /synthetics/api_tests/udp_tests
-[8]: /synthetics/api_tests/icmp_tests
-[9]: /synthetics/api_tests/websocket_tests
-[10]: /synthetics/browser_tests
-[11]: /synthetics/private_locations
-[12]: /synthetics/cicd_testing
-[13]: /synthetics/apm/
-[14]: /getting_started/synthetics
-[15]: /getting_started/synthetics/private_location
+[1]: https://app.datadoghq.com/synthetics/create#
+[2]: /api/latest/synthetics/#create-an-api-test
+[3]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_test
+[4]: /synthetics/api_tests/
+[5]: /synthetics/multistep
+[6]: /synthetics/api_tests/http_tests
+[7]: /synthetics/api_tests/ssl_tests
+[8]: /synthetics/api_tests/dns_tests
+[9]: /synthetics/api_tests/tcp_tests
+[10]: /synthetics/api_tests/udp_tests
+[11]: /synthetics/api_tests/icmp_tests
+[12]: /synthetics/api_tests/websocket_tests
+[13]: /synthetics/browser_tests
+[14]: /synthetics/private_locations
+[15]: /synthetics/cicd_testing
+[16]: /synthetics/apm/
+[17]: /getting_started/synthetics
+[18]: /getting_started/synthetics/private_location

--- a/content/en/synthetics/_index.md
+++ b/content/en/synthetics/_index.md
@@ -30,7 +30,7 @@ You can create Synthetic tests in the [Datadog application][1], with the [API][2
 
 ## Set up API tests and multistep API tests
 
-API tests allow you to launch [single][4] or [chained][5] requests to perform verifications on your key systems at various network levels: [HTTP test][6], [SSL test][7], [DNS test][8], [TCP test][9], [UDP test][10], [ICMP test][11], and [WebSocket test][12]. 
+API tests allow you to launch [single][4] or [chained][5] requests to perform verifications on your key systems at various network levels: [HTTP test][6], [SSL test][7], [DNS test][8], [WebSocket test][9], [TCP test][10], [UDP test][11], and [ICMP test][12]. 
 
 {{< img src="synthetics/api_test.png" alt="API tests" style="width:100%;">}}
 
@@ -75,10 +75,10 @@ See [Getting Started with Synthetic Monitoring][17] for instructions on creating
 [6]: /synthetics/api_tests/http_tests
 [7]: /synthetics/api_tests/ssl_tests
 [8]: /synthetics/api_tests/dns_tests
-[9]: /synthetics/api_tests/tcp_tests
-[10]: /synthetics/api_tests/udp_tests
-[11]: /synthetics/api_tests/icmp_tests
-[12]: /synthetics/api_tests/websocket_tests
+[9]: /synthetics/api_tests/websocket_tests
+[10]: /synthetics/api_tests/tcp_tests
+[11]: /synthetics/api_tests/udp_tests
+[12]: /synthetics/api_tests/icmp_tests
 [13]: /synthetics/browser_tests
 [14]: /synthetics/private_locations
 [15]: /synthetics/cicd_testing

--- a/content/en/synthetics/api_tests/_index.md
+++ b/content/en/synthetics/api_tests/_index.md
@@ -21,6 +21,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/monitor-apis-with-datadog"
   tag: "Blog"
   text: "Monitor your workflows with Datadog SSL, TLS, and Multistep API tests"
+- link: 'https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_test'
+  tag: 'Terraform'
+  text: 'Create and manage Synthetic API Tests with Terraform'
 ---
 
 ## Overview

--- a/content/en/synthetics/api_tests/websocket_tests.md
+++ b/content/en/synthetics/api_tests/websocket_tests.md
@@ -10,9 +10,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/udp-websocket-api-tests/"
   tag: "Blog"
   text: "Run UDP and WebSocket tests to monitor latency-critical applications"
-- link: 'https://learn.datadoghq.com/course/view.php?id=39'
-  tag: 'Learning Center'
-  text: 'Introduction to Synthetic Tests'
+- link: "https://learn.datadoghq.com/course/view.php?id=39"
+  tag: "Learning Center"
+  text: "Introduction to Synthetic Tests"
 ---
 ## Overview
 

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -21,6 +21,9 @@ further_reading:
 - link: "/synthetics/guide/"
   tag: "Documentation"
   text: "Synthetic Monitoring Guides"
+- link: 'https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_test'
+  tag: 'Terraform'
+  text: 'Create and manage Synthetic Browser Tests with Terraform'
 ---
 
 ## Overview

--- a/content/en/synthetics/browser_tests/actions.md
+++ b/content/en/synthetics/browser_tests/actions.md
@@ -5,7 +5,10 @@ description: Record Steps for a Synthetic Browser Test
 further_reading:
 - link: "/synthetics/browser_tests/advanced_options/"
   tag: "Documentation"
-  text: "Learn how to configure advanced options for steps"
+  text: "Learn how to configure Advanced Options for your browser test"
+- link: "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_global_variable"
+  tag: "Terraform"
+  text: "Create and manage Synthetic Global Variables with Terraform"
 ---
 
 ## Overview

--- a/content/en/synthetics/guide/create-api-test-with-the-api.md
+++ b/content/en/synthetics/guide/create-api-test-with-the-api.md
@@ -8,6 +8,9 @@ further_reading:
 - link: "/synthetics/"
   tag: "Documentation"
   text: "Manage your checks"
+- link: "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_test"
+  tag: "Terraform"
+  text: "Create and manage Synthetic API tests with Terraform"
 ---
 
 ## Overview
@@ -187,6 +190,55 @@ For more information, see [Create an API test][1] in the API documentation.
 }
 {{< /code-block >}}
 
+### WebSocket test
+
+{{< code-block lang="json" disable_copy="false" collapsible="true" >}}
+{
+    "status": "live",
+    "tags": [
+        "env:prod"
+    ],
+    "locations": [
+        "aws:eu-west-3"
+    ],
+    "message": "<NOTIFICATION MESSAGE>",
+    "name": "<TEST NAME>",
+    "type": "api",
+    "subtype": "websocket",
+    "config": {
+        "request": {
+            "url": "ws://example.com:8081",
+            "message": "websocket message"
+        },
+        "assertions": [
+            {
+                "operator": "lessThan",
+                "type": "responseTime",
+                "target": 1000
+            },
+            {
+                "operator": "is",
+                "type": "receivedMessage",
+                "target": "connected!"
+            }
+        ]
+    },
+    "options": {
+        "monitor_options": {
+            "notify_audit": false,
+            "locked": false,
+            "include_tags": true,
+            "new_host_delay": 300,
+            "notify_no_data": false,
+            "renotify_interval": 0
+        },
+        "tick_every": 60,
+        "min_failure_duration": 0,
+        "min_location_failed": 1
+    }
+}
+{{< /code-block >}}
+
 ### TCP test
 
 {{< code-block lang="json" disable_copy="false" collapsible="true" >}}
@@ -319,55 +371,6 @@ For more information, see [Create an API test][1] in the API documentation.
                 "operator": "moreThanOrEqual",
                 "type": "packetsReceived",
                 "target": 1
-            }
-        ]
-    },
-    "options": {
-        "monitor_options": {
-            "notify_audit": false,
-            "locked": false,
-            "include_tags": true,
-            "new_host_delay": 300,
-            "notify_no_data": false,
-            "renotify_interval": 0
-        },
-        "tick_every": 60,
-        "min_failure_duration": 0,
-        "min_location_failed": 1
-    }
-}
-{{< /code-block >}}
-
-### WebSocket test
-
-{{< code-block lang="json" disable_copy="false" collapsible="true" >}}
-{
-    "status": "live",
-    "tags": [
-        "env:prod"
-    ],
-    "locations": [
-        "aws:eu-west-3"
-    ],
-    "message": "<NOTIFICATION MESSAGE>",
-    "name": "<TEST NAME>",
-    "type": "api",
-    "subtype": "websocket",
-    "config": {
-        "request": {
-            "url": "ws://example.com:8081",
-            "message": "websocket message"
-        },
-        "assertions": [
-            {
-                "operator": "lessThan",
-                "type": "responseTime",
-                "target": 1000
-            },
-            {
-                "operator": "is",
-                "type": "receivedMessage",
-                "target": "connected!"
             }
         ]
     },

--- a/content/en/synthetics/guide/manage-browser-tests-through-the-api.md
+++ b/content/en/synthetics/guide/manage-browser-tests-through-the-api.md
@@ -8,6 +8,9 @@ further_reading:
     - link: '/api/latest/synthetics'
       tag: 'API'
       text: 'Synthetics API'
+    - link: 'https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_test'
+      tag: 'Terraform'
+      text: 'Create and manage Synthetic Browser Tests with Terraform'
 ---
 
 ## Overview

--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -15,6 +15,9 @@ further_reading:
 - link: "/synthetics/private_locations"
   tag: "Documentation"
   text: "Run Multistep API tests on internal endpoints"
+- link: "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_test"
+  tag: "Terraform"
+  text: "Create and manage Synthetic Multistep API Tests with Terraform"
 ---
 
 ## Overview

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -3,9 +3,9 @@ title: Run Synthetic Tests from Private Locations
 kind: documentation
 description: Run Synthetic API and browser tests from private locations
 further_reading:
-    - link: "https://www.datadoghq.com/blog/synthetic-private-location-monitoring-datadog/"
-      tag: "Blog"
-      text: "Monitor your Synthetic private locations with Datadog"
+    - link: 'https://www.datadoghq.com/blog/synthetic-private-location-monitoring-datadog/'
+      tag: 'Blog'
+      text: 'Monitor your Synthetic private locations with Datadog'
     - link: /getting_started/synthetics/private_location
       tag: 'Documentation'
       text: 'Getting Started with Private Locations'
@@ -18,6 +18,9 @@ further_reading:
     - link: '/synthetics/api_tests'
       tag: 'Documentation'
       text: 'Configure an API Test'
+    - link: 'https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_private_location'
+      tag: 'Terraform'
+      text: 'Create and manage Synthetic Private Locations with Terraform'
 ---
 
 <div class="alert alert-warning">

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -17,6 +17,9 @@ further_reading:
 - link: "/synthetics/guide/browser-tests-totp"
   tag: "Documentation"
   text: "TOTPs For Multi-Factor Authentication (MFA) in Browser Test"
+- link: "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_global_variable"
+  tag: "Terraform"
+  text: "Create and manage Synthetic Global Variables with Terraform"
 ---
 
 On the [Synthetic Monitoring Settings page][1], you can adjust the following settings:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add mention of three Synthetic test creation methods (UI, API, and Terraform) to Synthetic Monitoring product landing page and links to Terraform resource docs (`datadog_synthetics_global_variable`, `datadog_synthetics_private_location`, and `datadog_synthetics_test`) in API, multistep API, and browser test doc pages..

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-2465

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/synthetics-terraform-further-reading-links/synthetics

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
