### PR TITLE
(DOCS-2753) Remove instances of 'hit'

### DIFF
--- a/content/en/agent/cluster_agent/metadata_provider.md
+++ b/content/en/agent/cluster_agent/metadata_provider.md
@@ -26,7 +26,7 @@ To enable the cluster metadata provider feature:
 3. [Ensure an auth_token is properly shared between the Agents][1].
 4. [Confirm the RBAC rules are properly set][1].
 5. In the Node Agent, set the environment variable `DD_CLUSTER_AGENT_ENABLED` to `true`.
-6. *Optional* - The environment variable `DD_KUBERNETES_METADATA_TAG_UPDATE_FREQ` can be set to specify how often the Node Agents hit the Datadog Cluster Agent.
+6. *Optional* - The environment variable `DD_KUBERNETES_METADATA_TAG_UPDATE_FREQ` can be set to specify how often the Node Agents ping the Datadog Cluster Agent.
 7. *Optional* - Disable the Kubernetes metadata tag collection with `DD_KUBERNETES_COLLECT_METADATA_TAGS=false`.
 
 ## Further Reading

--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -124,7 +124,7 @@ However, to route traffic to Datadog's PrivateLink offering in `us-east-1` from 
 
     **Note**: **The security group must accept inbound traffic on TCP port `443`**.
 
-7. Hit **Create endpoint** at the bottom of the screen. If successful, the following is displayed:
+7. Click **Create endpoint** at the bottom of the screen. If successful, the following is displayed:
 
 {{< img src="agent/guide/private_link/vpc_endpoint_created.png" alt="VPC endpoint created" style="width:80%;" >}}
 

--- a/content/en/dashboards/template_variables.md
+++ b/content/en/dashboards/template_variables.md
@@ -129,7 +129,7 @@ For example, searching for `tags:region:$region.value` with a value of `us-east1
 
 Use commas to search using multiple template variables, for example: `tags:role:$role.value,env:$env.value`
 
-**Note**: Once you hit *enter* to search, `$region.value` updates to the value in the template variable drop-down.
+**Note**: Once you press *enter* to search, `$region.value` updates to the value in the template variable drop-down.
 
 #### Widgets
 

--- a/content/en/developers/guide/query-data-to-a-text-file-step-by-step.md
+++ b/content/en/developers/guide/query-data-to-a-text-file-step-by-step.md
@@ -21,7 +21,7 @@ Prerequisite: Python and `pip` installed on your localhost. Windows users see [I
 
     c. Optionally, replace `*` with a host to filter the data. A list of your hosts is displayed in the [Datadog Infrastructure List][6].
 
-    d. Optionally, change the time period to collect the data. The current setting is 3600 seconds (one hour). **Note**: If you run this too aggressively, you may hit the [Datadog API limits][7].
+    d. Optionally, change the time period to collect the data. The current setting is 3600 seconds (one hour). **Note**: If you run this too aggressively, you may reach the [Datadog API limits][7].
 
     e. Save your file and confirm its location.
 

--- a/content/en/logs/explorer/saved_views.md
+++ b/content/en/logs/explorer/saved_views.md
@@ -46,7 +46,7 @@ At any moment, from the default view entry in the Views panel:
 All saved views, that are not your default saved view, are shared across your organization:
 
 * **Integration saved views** come out-of-the-box with most Datadog [Log Management Integrations][7]. These are read-only, and identified by the logo of the integration.
-* **Custom saved views** are created by users. They are editable by any user in your organization (excepting [Read Only users][8]), and identified with the avatar of the user who created it. Hit the **save** button to create a new custom saved view from the current content of your explorer.
+* **Custom saved views** are created by users. They are editable by any user in your organization (excepting [Read Only users][8]), and identified with the avatar of the user who created it. Click the **save** button to create a new custom saved view from the current content of your explorer.
 
 {{< img src="logs/explorer/saved_views/save.png" alt="Logs -- Save" style="width:30%;" >}}
 

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -29,7 +29,7 @@ Datadog recommends using a Kinesis stream as input when using the Datadog Kinesi
 1. (Optional) Create a new Kinesis stream (see the [Kinesis documentation][1]). Name the stream something descriptive, like `DatadogLogStream`, and give it a shard count of 1 (increase the shard count for each MB/s throughput that you need).
 2. Create a [new delivery stream][2] and name it `DatadogLogsforwarder`.
 3. Set the source as "Kinesis stream" (or leave the source as `Direct PUT or other sources` if you don’t want to use a Kinesis stream) and select `DatadogLogStream` (or the existing Kinesis stream that already contains your logs).
-4. Disable the data transformation and record transformation and hit `next`.
+4. Disable the data transformation and record transformation and click `next`.
 5. Select the `Datadog` destination and select the `Datadog US` or `Datadog EU` region, depending on the Datadog Region of your account.
   {{< img src="logs/guide/choose-destination.png" alt="Choose your destination" style="width:100%;">}}
 6. Paste your `APIKEY` into the `AccessKey` box. (You can get your API key from [your Datadog API settings page][3]).

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -91,7 +91,7 @@ Datadog can automatically configure triggers on the Datadog Forwarder Lambda fun
 3. Navigate to the _Collect Logs_ tab in the [AWS Integration tile][4].
 4. Select the AWS Account from where you want to collect logs, and enter the ARN of the Lambda created in the previous section.
    {{< img src="logs/aws/AWSLogStep1.png" alt="Enter Lambda" popup="true" style="width:80%;" >}}
-5. Select the services from which you'd like to collect logs and hit save. To stop collecting logs from a particular service, uncheck it.
+5. Select the services from which you'd like to collect logs and click save. To stop collecting logs from a particular service, uncheck it.
    {{< img src="logs/aws/AWSLogStep2.png" alt="Select services" popup="true" style="width:80%;" >}}
 6. If you have logs across multiple regions, you must create additional Lambda functions in those regions and enter them in this tile.
 7. To stop collecting all AWS logs, press the _x_ next to each Lambda ARN. All triggers for that function are removed.

--- a/content/en/real_user_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/browser/tracking_user_actions.md
@@ -95,7 +95,7 @@ Starting with [version 2.16.0][3], with the `actionNameAttribute` initialization
 
 ## Custom actions
 
-Custom actions are user actions declared and sent manually by using the `addAction` API. They are used to send information relative to an event occurring during a user journey. In the following example, the RUM SDK collects a visitor's cart data when they hit the checkout button. The number of items within the cart, the list of items, and how much the cart is worth overall are collected.
+Custom actions are user actions declared and sent manually by using the `addAction` API. They are used to send information relative to an event occurring during a user journey. In the following example, the RUM SDK collects a visitor's cart data when they click the checkout button. The number of items within the cart, the list of items, and how much the cart is worth overall are collected.
 
 {{< tabs >}}
 {{% tab "NPM" %}}

--- a/content/en/synthetics/guide/app-that-requires-login.md
+++ b/content/en/synthetics/guide/app-that-requires-login.md
@@ -27,7 +27,7 @@ You can also ensure your credentials are securely stored and obfuscated across t
 
 ## Include the login steps in your recording
 
-The first method is to record the steps that are needed to perform the login at the beginning of your browser tests: input your username, input your password, hit log in. You can then go on and [start recording subsequent steps][1].
+The first method is to record the steps that are needed to perform the login at the beginning of your browser tests: input your username, input your password, and click log in. You can then go on and [start recording subsequent steps][1].
 At test execution, the browser test systematically executes the first login steps before going through the rest of the journey.
 
 {{< img src="synthetics/guide/app_that_requires_login/login_test.mp4" video="true" alt="Demo of recording a login">}}

--- a/content/en/synthetics/guide/email-validation.md
+++ b/content/en/synthetics/guide/email-validation.md
@@ -35,7 +35,7 @@ In the above example, an email variable called `EMAIL` is created. The newly cre
 
 ## Record steps
 
-In the upper left corner of the UI, hit the **Start Recording** button and record the steps leading to the email being triggered using your freshly created email variable. Use the hand icon to input variables in the text inputs of the form.
+In the upper left corner of the UI, click the **Start Recording** button and record the steps leading to the email being triggered using your freshly created email variable. Use the hand icon to input variables in the text inputs of the form.
 
 {{< img src="synthetics/guide/email-validation/record-steps.mp4" alt="Record your steps" video="true"  width="100%">}}
 
@@ -59,7 +59,7 @@ To do this, create a **Navigation** step, choose `Go to email and click link`, p
 
 {{< img src="synthetics/guide/email-validation/navigation-step.mp4" alt="Add a navigation step" video="true"  width="100%">}}
 
-In the above example, the browser test looks into the “Welcome to Shopist” email to hit a verification link in order to confirm the user registration mechanism is working as expected. The “Welcome to Shopist” email is selected and the “Verify your email by clicking here” link is chosen. As soon as the step is saved, the iframe is redirected to the associated page.
+In the above example, the browser test looks into the “Welcome to Shopist” email to click a verification link in order to confirm the user registration mechanism is working as expected. The “Welcome to Shopist” email is selected and the “Verify your email by clicking here” link is chosen. As soon as the step is saved, the iframe is redirected to the associated page.
 
 You can now go ahead and create a final assertion to test the `div` content to make sure this triggered a proper account verification (page contains `Your account is now verified.`).
 

--- a/content/en/synthetics/guide/manually-adding-chrome-extension.md
+++ b/content/en/synthetics/guide/manually-adding-chrome-extension.md
@@ -15,7 +15,7 @@ If you are unable to download applications directly from the Chrome Web Store fo
 1. Download the [Datadog test recorder extension][1] CRX file.
 2. Upload this CRX file to your internal application store and repackage it. The icon of your new extension should appear in your Chrome browser, next to your other Chrome extensions.
   {{< img src="synthetics/guide/manually_adding_chrome_extension/icon.png" alt="the icon that appears in your browser">}}
-3. Start creating your [browser test][2]: [define your test configuration][3] (test name, tags, locations, frequency, etc.), then hit `Save Details & Record Test`. You are on the recorder page: you should see a message asking you to download the [Datadog test recorder extension][1] to get started with your recording.
+3. Start creating your [browser test][2]: [define your test configuration][3] (test name, tags, locations, frequency, etc.), then click `Save Details & Record Test`. You are on the recorder page: you should see a message asking you to download the [Datadog test recorder extension][1] to get started with your recording.
 4. Click the icon that just appeared at the top right hand corner of your browser. The [Datadog test recorder extension][1] automatically detects the extension that was uploaded to your internal application store and you’re now able to [start recording your browser test’ steps][4].
   {{< img src="synthetics/guide/manually_adding_chrome_extension/record_test.png" alt="record your browser tests">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Replaces the word "hit" with appropriate alternatives. The remaining instances of "hit" in the docs pertain to hit rates, so they have not been removed. 

### Motivation
OKR!

### Additional Notes
I kept this solely to card edits, to avoid rabbit-holing a big PR full of style edits.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
