### PR TITLE
Fix Build with a Colon

### DIFF
--- a/content/en/logs/log_collection/ruby.md
+++ b/content/en/logs/log_collection/ruby.md
@@ -13,7 +13,7 @@ further_reading:
 - link: "/logs/faq/log-collection-troubleshooting-guide/"
   tag: "FAQ"
   text: "Log Collection Troubleshooting Guide"
-- link "https://www.datadoghq.com/blog/managing-rails-application-logs/"
+- link: "https://www.datadoghq.com/blog/managing-rails-application-logs/"
   tag: "Blog"
   text: "How to collect, customize, and manage Rails application logs"
 ---


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds a colon in the Further Reading section.

### Motivation
<!-- What inspired you to submit this pull request?-->

Docs Build

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
