### PR TITLE
DOCS-2832 Aggregating Multiple Agents Using Vector Edit

### DIFF
--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -60,7 +60,6 @@ If you are using Docker, add the following to your Agent configuration file.
 -e DD_LOGS_CONFIG_LOGS_DD_URL=<VECTOR_HOST>:<VECTOR_PORT>
 -e DD_LOGS_CONFIG_LOGS_NO_SSL=true
 -e DD_LOGS_CONFIG_USE_HTTP=true
--e DD_LOGS_CONFIG_USE_V2_API=false
 ```
 
 ### Vector configuration


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Removes `DD_LOGS_CONFIG_USE_V2_API` from the Docker configuration following the Vector 0.17 release.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-2832

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/vector-release-parameter-update/agent/vector_aggregation/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
