### PR TITLE
Update mistype command in log4j_mitigation doc

### DIFF
--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -23,7 +23,7 @@ On Linux, the instructions depend on the init system and on the distribution:
     Environment="LOG4J_FORMAT_MSG_NO_LOOKUPS=true"
     ```
 2. Reload the systemd service definitions: `sudo systemctl daemon-reload`
-3. Restart the datadog-agent service: `sudo systemctl datadog-agent restart`
+3. Restart the datadog-agent service: `sudo systemctl restart datadog-agent`
 
 
 ### Upstart-based systems 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update mistyped command in log4j_mitigation doc

Source : content/en/agent/faq/log4j_mitigation.md 

- wrong order in systemctl command
Restart the datadog-agent service: sudo systemctl datadog-agent `restart`

- update
Restart the datadog-agent service: sudo systemctl `restart` datadog-agent

### Motivation
<!-- What inspired you to submit this pull request?-->
- log4j2 issue


### Preview
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/agent/faq/log4j_mitigation/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
