### PR TITLE
updates translation config

### DIFF
--- a/translate.yaml
+++ b/translate.yaml
@@ -28,7 +28,8 @@ sources:
 
 ignores:
   - "content/en/**/faq/!(agent_v6_changes|certificate_verify_failed-error).md"
-  - "content/en/(security_platform|security_monitoring)/default_rules/*.md"
+  - "content/en/security_platform/default_rules/*.md"
+  - "content/en/security_monitoring/default_rules/*.md"
   - "**/*.fr.md"
   - "**/*.fr.yaml"
   - "**/*.fr.json"


### PR DESCRIPTION
### What does this PR do?
updates the translation config so default rules content will be deleted from Transifex following the nightly sync.

### Motivation
the changes to `translate.yaml` in [this commit](https://github.com/DataDog/documentation/commit/6837025ca38e4f4d3bcafd9e681c5669215fb9db#diff-ddb89f2051a9e3c7709b2105b4546b350152bedf949de94e3bd2b4a3619f27a2) may be preventing default rules content files from being deleted out of Transifex.  this commit updates the translation config.

https://datadoghq.atlassian.net/browse/WEB-1927

### Preview
no preview to QA for this.  after the nightly translation job runs we should check the logs to see these default_rules content files being marked for delete.

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
