### PR TITLE
Clarify deployment annotations for Istio

### DIFF
--- a/content/en/tracing/setup_overview/proxy_setup/_index.md
+++ b/content/en/tracing/setup_overview/proxy_setup/_index.md
@@ -441,7 +441,9 @@ of the higher-level `CronJob`.
 Environment variables for Istio sidecars can be set on a per-deployment basis using the `apm.datadoghq.com/env` annotation. This is unique for deployments employing Istio sidecars and is set in addition to the [labels for unified service tagging][11].
 ```yaml
 apiVersion: apps/v1
+...
 kind: Deployment
+...
 spec:
   template:
     metadata:
@@ -510,6 +512,7 @@ If using Kubernetes 1.18+, `appProtocol: tcp` can be added to the port specifica
 [8]: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
 [9]: /tracing/setup/cpp/#environment-variables
 [10]: https://istio.io/docs/ops/configuration/traffic-management/protocol-selection/#manual-protocol-selection
+[11]: /getting_started/tagging/unified_service_tagging/?tab=kubernetes#configuration-1
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/tracing/setup_overview/proxy_setup/_index.md
+++ b/content/en/tracing/setup_overview/proxy_setup/_index.md
@@ -438,11 +438,15 @@ of the higher-level `CronJob`.
 
 ### Environment variables
 
-Environment variables for Istio sidecars can be set on a per-deployment basis using the `apm.datadoghq.com/env` annotation.
+Environment variables for Istio sidecars can be set on a per-deployment basis using the `apm.datadoghq.com/env` annotation.  This is unique for deployments employing Istio sidecars and is set in addition to [the labels for unified service tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#configuration-1).
 ```yaml
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
     metadata:
       annotations:
-        apm.datadoghq.com/env: '{ "DD_ENV": "prod", "DD_TRACE_ANALYTICS_ENABLED": "true" }'
+        apm.datadoghq.com/env: '{ "DD_ENV": "prod", "DD_SERVICE": "my-service", "DD_VERSION": "v1.1"}'
 ```
 
 The available [environment variables][9] depend on the version of the C++ tracer embedded in the Istio sidecar's proxy.

--- a/content/en/tracing/setup_overview/proxy_setup/_index.md
+++ b/content/en/tracing/setup_overview/proxy_setup/_index.md
@@ -438,7 +438,7 @@ of the higher-level `CronJob`.
 
 ### Environment variables
 
-Environment variables for Istio sidecars can be set on a per-deployment basis using the `apm.datadoghq.com/env` annotation.  This is unique for deployments employing Istio sidecars and is set in addition to [the labels for unified service tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#configuration-1).
+Environment variables for Istio sidecars can be set on a per-deployment basis using the `apm.datadoghq.com/env` annotation. This is unique for deployments employing Istio sidecars and is set in addition to the [labels for unified service tagging][11].
 ```yaml
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Customer brought it to our attention that this was confusing.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Clarify the annotations that are used to tag istio sidecars are in addition to the labels applied for unified service tagging.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
