### PR TITLE
add instructions for deleting jndilookup.class

### DIFF
--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -69,15 +69,20 @@ exit 0;
 
 ```
 
+Make the script executable:
+```bash
+chmod +x ./jndi_cleanup.sh
+```
+
 Remove the JndiLogger.class from the jmxfetch.jar by running:
 
-```powershell
+```bash
 sudo ./jndi_cleanup.sh
 ```
 
 Validate the JndiLogger.class was removed by running:
 
-```powershell
+```bash
 .\jndi_cleanup.sh -c
 ```
 

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -135,13 +135,7 @@ $stream.Close()
 $stream.Dispose()
 ```
 
-Stop the Datadog Agent service.
-
-```powershell
-"$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" stopservice
-```
-
-Remove the JndiLogger.class from the jmxfetch.jar by running:
+Remove the JndiLogger.class from the jmxfetch.jar. Please note that this step will stop the Datadog Agent service to apply the patch. To remove the vulnerable code please run:
 
 ```powershell
 .\jndi_cleanup.ps1

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -45,6 +45,13 @@ fi
 zip -q -d $TARGET $JNDI_CLASS
 ```
 
+Check to see that the above step was successful by running. The command below should return no output if the class has successfully been removed.
+
+```bash
+jar tvf /opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.jar | grep JndiLookup.class
+```
+
+
 Finally, restart the Datadog Agent service with `sudo systemctl restart datadog-agent` (Linux systemd-based systems), `sudo restart datadog-agent` (Linux upstart-based systems) or from the Datadog Agent app in the menu bar (macOS).
 
 ### Windows

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -7,7 +7,71 @@ If you are using the Datadog Agent between versions v7.17.0/v6.17.0 and v7.32.2/
 
 **If you are on an impacted version, to mitigate the vulnerability, the best option is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
 
-If you are not able to upgrade your Agent at this time, use these instructions to implement an environment variable (`LOG4J_FORMAT_MSG_NO_LOOKUPS="true"` on the JMXFetch process or the Agent process) to partially mitigate the vulnerability: 
+If you are not able to upgrade your Agent at this time, you can use these instructions either [delete the JndiLookup.class](#delete-jndilookupclass) or to [implement an environment variable](#set-log4j_format_msg_no_lookups-environment-variable) (`LOG4J_FORMAT_MSG_NO_LOOKUPS="true"` on the JMXFetch process or the Agent process) to partially mitigate the vulnerability. 
+
+# Delete JndiLookup.class
+
+**If you are on an impacted version, to mitigate the vulnerability, the best option is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
+
+**Note**: This mitigation is not needed for 7.32.3/6.32.3 since in these versions, JMXFetch uses log4j v2.12.2, which is not affected by CVE-2021-45046 or CVE-2021-44228.
+
+### Linux and MACOS
+
+Save the following code as a bash script, then run the script to patch the provided jmxfetch.jar in place. 
+
+```bash
+#!/bin/bash
+
+YUM_CMD=$(which yum)
+APT_GET_CMD=$(which apt-get)
+
+TARGET="/opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.jar"
+JNDI_CLASS="org/apache/logging/log4j/core/lookup/JndiLookup.class"
+
+set -e
+
+if ! command -v zip &> /dev/null;
+then
+    if [[ ! -z $YUM_CMD ]]; then
+       yum install zip
+    elif [[ ! -z $APT_GET_CMD ]]; then
+       apt-get update
+       apt-get -y install zip
+    fi
+fi
+
+zip -q -d $TARGET $JNDI_CLASS
+```
+
+### Windows
+
+Save the following code as a powershell script, then run the script to patch the provided jmxfetch.jar in place. 
+
+
+```powershell
+[Reflection.Assembly]::LoadWithPartialName('System.IO.Compression')
+
+$zipfile = "C:\Program Files\Datadog\Datadog Agent\embedded\agent\dist\jmx\jmxfetch.jar"
+$files   = "JndiLookup.class"
+
+$stream = New-Object IO.FileStream($zipfile, [IO.FileMode]::Open)
+$mode   = [IO.Compression.ZipArchiveMode]::Update
+$zip    = New-Object IO.Compression.ZipArchive($stream, $mode)
+
+($zip.Entries | ? { $files -contains $_.Name }) | % { $_.Delete() }
+
+$zip.Dispose()
+$stream.Close()
+$stream.Dispose()
+```
+
+### AIX
+
+`Jmxfetch.jar` is included in the AIX agent install bundle, but there is no code in the AIX agent that runs the `jmxfetch` code. If you are not manually starting the `jmxfetch` process, the `jmxfetch.jar` is not used and can be deleted from `/opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.jar`.
+
+# Set LOG4J_FORMAT_MSG_NO_LOOKUPS Environment Variable
+
+**If you are on an impacted version, to mitigate the vulnerability, the best option is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
 
 **Note**: If you are running v7.32.2 or v6.32.2, you do not need to perform these steps. The Agent v7.32.2 (and v6.32.2) [starts jmxfetch with a property](https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7322--6322) that achieves the same result. In all cases, the best option is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.
 

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -101,6 +101,12 @@ $stream.Close()
 $stream.Dispose()
 ```
 
+Stop the Datadog Agent service.
+
+```powershell
+"$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" stopservice	
+```
+
 Remove the JndiLogger.class from the jmxfetch.jar by running:
 
 ```powershell
@@ -119,7 +125,11 @@ If the operation was successful the expected out is:
 The C:\Program Files\Datadog\Datadog Agent\embedded\agent\dist\jmx\jmxfetch.jar is now safe to run.
 ```
 
-Finally, restart the Datadog Agent service to apply the changes.
+Finally, start the Datadog Agent service to apply the changes.
+
+```powershell
+"$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" start-service
+```
 
 ### AIX
 

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -90,7 +90,7 @@ if ($Validate -eq $true) {
     if ($found.Count -eq 0) { 
         Write-Output "The $zipfile is now safe to run." 
     } else { 
-        Write-Output "Dangerous file strill present, something failed during the JNDI cleanup."
+        Write-Output "Dangerous file still present, something failed during the JNDI cleanup."
     }
 } else {
 	($zip.Entries | ? { $files -contains $_.Name }) | % { $_.Delete() }

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -3,17 +3,19 @@ title: Mitigating the Risk of Remote Code Execution Due to Log4Shell
 kind: faq
 ---
 
-If you are using the Datadog Agent between versions v7.17.0/v6.17.0 and v7.32.2/v6.32.2, you may be impacted by the vulnerability presented by Log4Shell (CVE-2021-44228). If you are using an Agent earlier than v7.17.0/v6.17.0, you should not be impacted by the vulnerability unless you configured log4j to log with the JMS Appender (an option that is not supported by the Agent, but if you did it, disable the appender).
+If you are using the Datadog Agent between versions v7.17.0/v6.17.0 and v7.32.2/v6.32.2, you may be impacted by the vulnerability presented by Log4Shell (CVE-2021-44228 and CVE-2021-45046). If you are using an Agent earlier than v7.17.0/v6.17.0, you should not be impacted by the vulnerability unless you configured log4j to log with the JMS Appender (an option that is not supported by the Agent, but if you did it, disable the appender).
 
-**If you are on an impacted version, to mitigate the vulnerability, the best option is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
+**If you are running an impacted version, the best option to mitigate the vulnerability is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
 
 If you are not able to upgrade your Agent at this time, you can use these instructions either [delete the JndiLookup.class](#delete-jndilookupclass) or to [implement an environment variable](#set-log4j_format_msg_no_lookups-environment-variable) (`LOG4J_FORMAT_MSG_NO_LOOKUPS="true"` on the JMXFetch process or the Agent process) to partially mitigate the vulnerability. 
 
 # Delete JndiLookup.class
 
-**If you are on an impacted version, to mitigate the vulnerability, the best option is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
+**If you are running an impacted version, the best option to mitigate the vulnerability is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
 
-**Note**: This mitigation is not needed for 7.32.3/6.32.3 since in these versions, JMXFetch uses log4j v2.12.2, which is not affected by CVE-2021-45046 or CVE-2021-44228.
+Removing the JndiLookup.class will fully mitigate CVE-2021-44228 and CVE-2021-45046.
+
+**Note**: This mitigation is not needed for 7.32.3/6.32.3. In these versions, JMXFetch uses log4j v2.12.2, which is not affected by CVE-2021-45046 or CVE-2021-44228.
 
 ### Linux and MACOS
 
@@ -69,9 +71,9 @@ $stream.Dispose()
 
 `Jmxfetch.jar` is included in the AIX agent install bundle, but there is no code in the AIX agent that runs the `jmxfetch` code. If you are not manually starting the `jmxfetch` process, the `jmxfetch.jar` is not used and can be deleted from `/opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.jar`.
 
-# Set LOG4J_FORMAT_MSG_NO_LOOKUPS Environment Variable
+# Set LOG4J_FORMAT_MSG_NO_LOOKUPS environment variable
 
-**If you are on an impacted version, to mitigate the vulnerability, the best option is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
+**If you are running an impacted version, the best option to mitigate the vulnerability is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
 
 **Note**: If you are running v7.32.2 or v6.32.2, you do not need to perform these steps. The Agent v7.32.2 (and v6.32.2) [starts jmxfetch with a property](https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7322--6322) that achieves the same result. In all cases, the best option is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.
 

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -17,7 +17,7 @@ Removing the JndiLookup.class [fully mitigates CVE-2021-44228 and CVE-2021-45046
 
 **Note**: This mitigation is not needed for 7.32.3/6.32.3. In these versions, JMXFetch uses log4j v2.12.2, which is not affected by CVE-2021-45046 or CVE-2021-44228.
 
-### Linux and MACOS
+### Linux and macOS
 
 Save the following code as a bash script, then run the script to patch the provided jmxfetch.jar in place. 
 

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -45,6 +45,8 @@ fi
 zip -q -d $TARGET $JNDI_CLASS
 ```
 
+Finally, restart the Datadog Agent service with `sudo systemctl restart datadog-agent` (Linux systemd-based systems), `sudo restart datadog-agent` (Linux upstart-based systems) or from the Datadog Agent app in the menu bar (macOS).
+
 ### Windows
 
 Save the following code as a powershell script, then run the script to patch the provided jmxfetch.jar in place. 

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -69,6 +69,8 @@ $stream.Close()
 $stream.Dispose()
 ```
 
+Finally, restart the Datadog Agent service to apply the changes.
+
 ### AIX
 
 `Jmxfetch.jar` is included in the AIX agent install bundle, but there is no code in the AIX agent that runs the `jmxfetch` code. If you are not manually starting the `jmxfetch` process, the `jmxfetch.jar` is not used and can be deleted from `/opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.jar`.

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -5,15 +5,15 @@ kind: faq
 
 If you are using the Datadog Agent between versions v7.17.0/v6.17.0 and v7.32.2/v6.32.2, you may be impacted by the vulnerability presented by Log4Shell (CVE-2021-44228 and CVE-2021-45046). If you are using an Agent earlier than v7.17.0/v6.17.0, you should not be impacted by the vulnerability unless you configured log4j to log with the JMS Appender (an option that is not supported by the Agent, but if you did it, disable the appender).
 
-**If you are running an impacted version, the best option to mitigate the vulnerability is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
+**The best way to mitigate the vulnerability is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
 
 If you are not able to upgrade your Agent at this time, you can use these instructions either [delete the JndiLookup.class](#delete-jndilookupclass) or to [implement an environment variable](#set-log4j_format_msg_no_lookups-environment-variable) (`LOG4J_FORMAT_MSG_NO_LOOKUPS="true"` on the JMXFetch process or the Agent process) to partially mitigate the vulnerability. 
 
 # Delete JndiLookup.class
 
-**If you are running an impacted version, the best option to mitigate the vulnerability is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
+**The best way to mitigate the vulnerability is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
 
-Removing the JndiLookup.class will fully mitigate CVE-2021-44228 and CVE-2021-45046.
+Removing the JndiLookup.class [fully mitigates CVE-2021-44228 and CVE-2021-45046](https://logging.apache.org/log4j/2.x/security.html).
 
 **Note**: This mitigation is not needed for 7.32.3/6.32.3. In these versions, JMXFetch uses log4j v2.12.2, which is not affected by CVE-2021-45046 or CVE-2021-44228.
 
@@ -73,7 +73,7 @@ $stream.Dispose()
 
 # Set LOG4J_FORMAT_MSG_NO_LOOKUPS environment variable
 
-**If you are running an impacted version, the best option to mitigate the vulnerability is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
+**The best way to mitigate the vulnerability is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.** 
 
 **Note**: If you are running v7.32.2 or v6.32.2, you do not need to perform these steps. The Agent v7.32.2 (and v6.32.2) [starts jmxfetch with a property](https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7322--6322) that achieves the same result. In all cases, the best option is to upgrade your Datadog Agent to v7.32.3 (v6.32.3) or later.
 

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -36,10 +36,10 @@ VALIDATE=0
 if [ $# -eq 1 ]; then
 	case "$1" in
 		-c)
-            VALIDATE=1 ;;
+			VALIDATE=1 ;;
 		*)
-            echo "$1 is not a supported option"
-            exit 1 ;;
+			echo "$1 is not a supported option"
+			exit 1 ;;
 	esac
 fi
 


### PR DESCRIPTION
### What does this PR do?
Add instructions for another way to mitigate log4shell by deleting a clasee

### Motivation
Document this workaround in a customer facing place.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->

[Changes rendered in markdown](https://github.com/DataDog/documentation/blob/dcoleman17-deletejndi/content/en/agent/faq/log4j_mitigation.md) (I'm not sure the preview link below works)
https://docs-staging.datadoghq.com/dcoleman17-deletejndi/agent/faq/log4j_mitigation

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
