### PR TITLE
Add instructions for mitigating log4j vuln in datadog-lambda-java

### DIFF
--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -25,10 +25,6 @@ Some versions of `datadog-lambda-java` include a transitive dependency on log4j 
 -  `<=0.3.3`
 -  `1.4.0`
 
-<details>
-<summary>
-Instructions for upgrading `datadog-lambda-java`
-</summary>
 
 The version of the `datadog-lambda-java` dependency in your Lambda function is set in `pom.xml` or `build.gradle` depending on whether you are using Maven or Gradle, respectively.
 
@@ -75,8 +71,6 @@ If you are upgrading from 0.3.x to 1.4.x and you wish to use the `dd-trace-java`
 ```
 arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-java:4`
 ````
-
-</details>
 
 ## Required setup
 

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -20,10 +20,16 @@ aliases:
 ## Upgrading
 
 <div class="alert alert-warning">
-As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is <a href="https://www.datadoghq.com/log4j-vulnerability/
+  As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is <a href="https://www.datadoghq.com/log4j-vulnerability/
 "> vulnerable to remote code execution</a>.
+  Some versions of `datadog-lambda-java` include a transitive dependency on log4j that may be vulnerable. The vulnerable versions are:
 
-Some versions of `datadog-lambda-java` include a transitive dependency on log4j that may be vulnerable. The vulnerable versions are `<=0.3.3` and `1.4.0`. See below for instructions for upgrading to the latest versions of `datadog-lambda-java`.
+<ul>
+<li>`<=0.3.3`</li>
+<li>`1.4.0`</li>
+</ul>
+
+See below for instructions for upgrading to the latest versions of `datadog-lambda-java`.
 </div>
 
 <details>

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -41,7 +41,7 @@ Your `pom.xml` file will contain a section like this.
 </dependency>
 ```
 
-Find this section and change the `VERSION` to the latest release (omitting the preceeding `v`) ![Maven Central][4]
+Find this section and change the `VERSION` to the latest release (omitting the preceeding `v`) ![Maven Cental][4]
 Then redeploy your lambda function.
 
 If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. You can find the latest `0.3.x` release [here][13]. 
@@ -58,7 +58,7 @@ dependencies {
 }
 ```
 
-Find this section and change the `VERSION` to the latest release (omitting the preceeding `v`) ![Maven Central][4]
+Find this section and change the `VERSION` to the latest release (omitting the preceeding `v`) ![Maven Cental][4]
 Then redeploy your lambda function.
 
 If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. You can find the latest `0.3.x` release [here][13]. 

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -194,7 +194,7 @@ Then redeploy your lambda function.
 
 {{% tab "Gradle" %}}
 
-Your `build.gradle` file contains a section like similar to the following:
+Your `build.gradle` file contains a section similar to the following:
 
 ```groovy
 dependencies {

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -20,13 +20,16 @@ aliases:
 ## Upgrading
 
 <div class="alert alert-warning">
-  As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is [vulnerable to remote code execution][12].
+  As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is <a href="https://www.datadoghq.com/log4j-vulnerability/
+"> vulnerable to remote code execution</a>.
   Some versions of `datadog-lambda-java` include a transitive dependency on log4j that may be vulnerable. The vulnerable versions are:
 
--  `<=0.3.3`
--  `1.4.0`
+<ul>
+<li>`<=0.3.3`</li>
+<li>`1.4.0`</li>
+</ul>
 
-  See below for instructions for upgrading to the latest versions of `datadog-lambda-java`.
+See below for instructions for upgrading to the latest versions of `datadog-lambda-java`.
 </div>
 
 <details>

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -20,16 +20,13 @@ aliases:
 ## Upgrading
 
 <div class="alert alert-warning">
-  As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is <a href="https://www.datadoghq.com/log4j-vulnerability/
-"> vulnerable to remote code execution</a>.
+  As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is [vulnerable to remote code execution][12].
   Some versions of `datadog-lambda-java` include a transitive dependency on log4j that may be vulnerable. The vulnerable versions are:
 
-<ul>
-<li>`<=0.3.3`</li>
-<li>`1.4.0`</li>
-</ul>
+-  `<=0.3.3`
+-  `1.4.0`
 
-See below for instructions for upgrading to the latest versions of `datadog-lambda-java`.
+  See below for instructions for upgrading to the latest versions of `datadog-lambda-java`.
 </div>
 
 <details>

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -20,16 +20,10 @@ aliases:
 ## Upgrading
 
 <div class="alert alert-warning">
-  As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is <a href="https://www.datadoghq.com/log4j-vulnerability/
+As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is <a href="https://www.datadoghq.com/log4j-vulnerability/
 "> vulnerable to remote code execution</a>.
-  Some versions of `datadog-lambda-java` include a transitive dependency on log4j that may be vulnerable. The vulnerable versions are:
 
-<ul>
-<li>`<=0.3.3`</li>
-<li>`1.4.0`</li>
-</ul>
-
-See below for instructions for upgrading to the latest versions of `datadog-lambda-java`.
+Some versions of `datadog-lambda-java` include a transitive dependency on log4j that may be vulnerable. The vulnerable versions are `<=0.3.3` and `1.4.0`. See below for instructions for upgrading to the latest versions of `datadog-lambda-java`.
 </div>
 
 <details>

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -18,7 +18,7 @@ aliases:
 {{< img src="serverless/java-lambda-tracing.png" alt="Monitor Java Lambda Functions with Datadog"  style="width:100%;">}}
 
 <div class="alert alert-danger">
-There are versions of `datadog-lambda-java` that import `log4j <=2.14.0` as a transitive dependency. Upgrade instructions are [here](#upgrading). 
+There are versions of datadog-lambda-java that import log4j <=2.14.0 as a transitive dependency. Upgrade instructions are <a href="#upgrading">here</a>. 
 </div>
 
 ## Required setup
@@ -161,7 +161,7 @@ To automatically connect Java Lambda function logs and traces, see [Connecting J
 
 ## Upgrading
 
-As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is [vulnerable to remote code execution][12].
+Apache Foundation has announced that log4j, a popular Java logging library, is [vulnerable to remote code execution][12].
 Some versions of `datadog-lambda-java` include a transitive dependency on log4j that may be vulnerable. The vulnerable versions are:
 
 -  `<=0.3.3`
@@ -169,14 +169,15 @@ Some versions of `datadog-lambda-java` include a transitive dependency on log4j 
 
 The latest version of datadog-lambda java is ![Maven Cental][4]. Use this version (omitting the preceeding `v`) when following the upgrading instructions below.
 
-If you are currently running `0.3.x` and do not wish to upgrade to `1.4.x`, you may find the latest version of `0.3.x` [here][13]
+If you do not wish to upgrade to `1.4.x`, `0.3.x` is updated with the latest log4j security patches as well. 
+If you are currently running `0.3.x` and do not wish to upgrade to `1.4.x`, you may find the latest version of `0.3.x` in the [datadog-lambda-java repository][13]
 
 The version of the `datadog-lambda-java` dependency in your Lambda function is set in `pom.xml` or `build.gradle` depending on whether you are using Maven or Gradle, respectively.
 
 {{< tabs >}}
 {{% tab "Maven" %}}
 
-Your `pom.xml` file will contain a section like this.
+Your `pom.xml` file contains a section similar to the following:
 
 ```xml
 <dependency>
@@ -186,15 +187,16 @@ Your `pom.xml` file will contain a section like this.
 </dependency>
 ```
 
+Replace `VERSION` with the latest version of `datadog-lambda-java` (available above). 
 Then redeploy your lambda function.
 
-If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. 
+If you do not wish to upgrade to `v1.4.x`, `0.3.x` is also updated with the latest log4j security patches. 
 
 {{% /tab %}}
 
 {{% tab "Gradle" %}}
 
-Your `build.gradle` file will contain a section like this.
+Your `build.gradle` file contains a section like similar to the following:
 
 ```groovy
 dependencies {
@@ -202,9 +204,10 @@ dependencies {
 }
 ```
 
+Replace `VERSION` with the latest version of `datadog-lambda-java` (available above). 
 Then redeploy your lambda function.
 
-If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. 
+If you do not wish to upgrade to `v1.4.x`, `0.3.x` is also updated with the latest log4j security patches. 
 
 {{% /tab %}}
 {{< /tabs>}}

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -19,15 +19,11 @@ aliases:
 
 ## Upgrading
 
-<div class="alert alert-warning">
-  As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is [vulnerable to remote code execution][12].
-  Some versions of `datadog-lambda-java` include a transitive dependency on log4j that may be vulnerable. The vulnerable versions are:
+As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is [vulnerable to remote code execution][12].
+Some versions of `datadog-lambda-java` include a transitive dependency on log4j that may be vulnerable. The vulnerable versions are:
 
 -  `<=0.3.3`
 -  `1.4.0`
-
-  See below for instructions for upgrading to the latest versions of `datadog-lambda-java`.
-</div>
 
 <details>
 <summary>

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -23,60 +23,62 @@ aliases:
   As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is [vulnerable to remote code execution][12].
   Some versions of `datadog-lambda-java` include a transitive dependency on log4j that may be vulnerable. The vulnerable versions are:
 
-  `<=0.3.3`
-  `<=1.4.0`
+-  `<=0.3.3`
+-  `1.4.0`
 
   See below for instructions for upgrading to the latest versions of `datadog-lambda-java`.
 </div>
 
 <details>
-  <summary>
-    Instructions for upgrading `datadog-lambda-java`
-  </summary>
+<summary>
+Instructions for upgrading `datadog-lambda-java`
+</summary>
 
-  The version of the `datadog-lambda-java` dependency in your Lambda function is set in `pom.xml` or `build.gradle` depending on whether you are using Maven or Gradle, respectively.
+The version of the `datadog-lambda-java` dependency in your Lambda function is set in `pom.xml` or `build.gradle` depending on whether you are using Maven or Gradle, respectively.
 
-  {{< tabs >}}
-    {{% tab "Maven" %}}
-      Your `pom.xml` file will contain a section like this.
+{{< tabs >}}
+{{% tab "Maven" %}}
 
-      ```xml
-      <dependency>
-        <groupId>com.datadoghq</groupId>
-        <artifactId>datadog-lambda-java</artifactId>
-        <version>VERSION</version>
-      </dependency>
-      ```
+Your `pom.xml` file will contain a section like this.
 
-      Find this section and change the `VERSION` to the latest release (omitting the preceeding `v`) ![Maven Central][4]
-      Then redeploy your lambda function.
+```xml
+<dependency>
+  <groupId>com.datadoghq</groupId>
+  <artifactId>datadog-lambda-java</artifactId>
+  <version>VERSION</version>
+</dependency>
+```
 
-      If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. You can find the latest `0.3.x` release [here][13]. 
+Find this section and change the `VERSION` to the latest release (omitting the preceeding `v`) ![Maven Central][4]
+Then redeploy your lambda function.
 
-    {{% /tab %}}
+If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. You can find the latest `0.3.x` release [here][13]. 
 
-    {{% tab "Gradle" %}}
-      Your `build.gradle` file will contain a section like this.
+{{% /tab %}}
 
-      ```groovy
-      dependencies {
-        implementation 'com.datadoghq:datadog-lambda-java:VERSION'
-      }
-      ```
+{{% tab "Gradle" %}}
 
-      Find this section and change the `VERSION` to the latest release (omitting the preceeding `v`) ![Maven Central][4]
-      Then redeploy your lambda function.
+Your `build.gradle` file will contain a section like this.
 
-      If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. You can find the latest `0.3.x` release [here][13]. 
+```groovy
+dependencies {
+  implementation 'com.datadoghq:datadog-lambda-java:VERSION'
+}
+```
 
-    {{% /tab %}}
-  {{< /tabs>}}
+Find this section and change the `VERSION` to the latest release (omitting the preceeding `v`) ![Maven Central][4]
+Then redeploy your lambda function.
 
-  If you are upgrading from 0.3.x to 1.4.x and you wish to use the `dd-trace-java` tracer, find the reference to the `dd-trace-java` lambda layer and change it to 
-  
-  ```
-  arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-java:4`
-  ````
+If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. You can find the latest `0.3.x` release [here][13]. 
+
+{{% /tab %}}
+{{< /tabs>}}
+
+If you are upgrading from 0.3.x to 1.4.x and you wish to use the `dd-trace-java` tracer, find the reference to the `dd-trace-java` lambda layer and change it to 
+
+```
+arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-java:4`
+````
 
 </details>
 

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -17,60 +17,9 @@ aliases:
 
 {{< img src="serverless/java-lambda-tracing.png" alt="Monitor Java Lambda Functions with Datadog"  style="width:100%;">}}
 
-## Upgrading
-
-As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is [vulnerable to remote code execution][12].
-Some versions of `datadog-lambda-java` include a transitive dependency on log4j that may be vulnerable. The vulnerable versions are:
-
--  `<=0.3.3`
--  `1.4.0`
-
-
-The version of the `datadog-lambda-java` dependency in your Lambda function is set in `pom.xml` or `build.gradle` depending on whether you are using Maven or Gradle, respectively.
-
-{{< tabs >}}
-{{% tab "Maven" %}}
-
-Your `pom.xml` file will contain a section like this.
-
-```xml
-<dependency>
-  <groupId>com.datadoghq</groupId>
-  <artifactId>datadog-lambda-java</artifactId>
-  <version>VERSION</version>
-</dependency>
-```
-
-Find this section and change the `VERSION` to the latest release (omitting the preceeding `v`) ![Maven Cental][4]
-Then redeploy your lambda function.
-
-If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. You can find the latest `0.3.x` release [here][13]. 
-
-{{% /tab %}}
-
-{{% tab "Gradle" %}}
-
-Your `build.gradle` file will contain a section like this.
-
-```groovy
-dependencies {
-  implementation 'com.datadoghq:datadog-lambda-java:VERSION'
-}
-```
-
-Find this section and change the `VERSION` to the latest release (omitting the preceeding `v`) ![Maven Cental][4]
-Then redeploy your lambda function.
-
-If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. You can find the latest `0.3.x` release [here][13]. 
-
-{{% /tab %}}
-{{< /tabs>}}
-
-If you are upgrading from 0.3.x to 1.4.x and you wish to use the `dd-trace-java` tracer, find the reference to the `dd-trace-java` lambda layer and change it to 
-
-```
-arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-java:4`
-````
+<div class="alert alert-danger">
+There are versions of `datadog-lambda-java` that import `log4j <=2.14.0` as a transitive dependency. Upgrade instructions are [here](#upgrading). 
+</div>
 
 ## Required setup
 
@@ -209,6 +158,64 @@ See the [custom metrics documentation][10] for more information on custom metric
 To automatically connect Java Lambda function logs and traces, see [Connecting Java Logs and Traces][11] for instructions.
 
 <div class="alert alert-info"> Failing to use the correct Java runtime can result in errors like, "Error opening zip file or JAR manifest missing : /opt/java/lib/dd-java-agent.jar" Make sure to use java8.al2 or java11 as runtime as described above. </div>
+
+## Upgrading
+
+As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is [vulnerable to remote code execution][12].
+Some versions of `datadog-lambda-java` include a transitive dependency on log4j that may be vulnerable. The vulnerable versions are:
+
+-  `<=0.3.3`
+-  `1.4.0`
+
+The latest version of datadog-lambda java is ![Maven Cental][4]. Use this version (omitting the preceeding `v`) when following the upgrading instructions below.
+
+If you are currently running `0.3.x` and do not wish to upgrade to `1.4.x`, you may find the latest version of `0.3.x` [here][13]
+
+The version of the `datadog-lambda-java` dependency in your Lambda function is set in `pom.xml` or `build.gradle` depending on whether you are using Maven or Gradle, respectively.
+
+{{< tabs >}}
+{{% tab "Maven" %}}
+
+Your `pom.xml` file will contain a section like this.
+
+```xml
+<dependency>
+  <groupId>com.datadoghq</groupId>
+  <artifactId>datadog-lambda-java</artifactId>
+  <version>VERSION</version>
+</dependency>
+```
+
+Then redeploy your lambda function.
+
+If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. 
+
+{{% /tab %}}
+
+{{% tab "Gradle" %}}
+
+Your `build.gradle` file will contain a section like this.
+
+```groovy
+dependencies {
+  implementation 'com.datadoghq:datadog-lambda-java:VERSION'
+}
+```
+
+Then redeploy your lambda function.
+
+If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. 
+
+{{% /tab %}}
+{{< /tabs>}}
+
+If you are upgrading from 0.3.x to 1.4.x and you wish to use the `dd-trace-java` tracer, find the reference to the `dd-trace-java` lambda layer and change it to 
+
+```
+arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-java:4`
+````
+
+
 
 ## Further Reading
 

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -170,7 +170,7 @@ Some versions of `datadog-lambda-java` include a transitive dependency on log4j 
 The latest version of datadog-lambda java is ![Maven Cental][4]. Use this version (omitting the preceeding `v`) when following the upgrading instructions below.
 
 If you do not wish to upgrade to `1.4.x`, `0.3.x` is updated with the latest log4j security patches as well. 
-If you are currently running `0.3.x` and do not wish to upgrade to `1.4.x`, you may find the latest version of `0.3.x` in the [datadog-lambda-java repository][13]
+You may find the latest version of `0.3.x` in the [datadog-lambda-java repository][13]
 
 The version of the `datadog-lambda-java` dependency in your Lambda function is set in `pom.xml` or `build.gradle` depending on whether you are using Maven or Gradle, respectively.
 
@@ -190,8 +190,6 @@ Your `pom.xml` file contains a section similar to the following:
 Replace `VERSION` with the latest version of `datadog-lambda-java` (available above). 
 Then redeploy your lambda function.
 
-If you do not wish to upgrade to `v1.4.x`, `0.3.x` is also updated with the latest log4j security patches. 
-
 {{% /tab %}}
 
 {{% tab "Gradle" %}}
@@ -206,8 +204,6 @@ dependencies {
 
 Replace `VERSION` with the latest version of `datadog-lambda-java` (available above). 
 Then redeploy your lambda function.
-
-If you do not wish to upgrade to `v1.4.x`, `0.3.x` is also updated with the latest log4j security patches. 
 
 {{% /tab %}}
 {{< /tabs>}}

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -208,7 +208,7 @@ Then redeploy your lambda function.
 {{% /tab %}}
 {{< /tabs>}}
 
-If you are upgrading from 0.3.x to 1.4.x and you wish to use the `dd-trace-java` tracer, find the reference to the `dd-trace-java` lambda layer and change it to 
+If you are upgrading from 0.3.x to 1.4.x and you wish to use the `dd-trace-java` tracer, find the reference to the `dd-trace-java` lambda layer and change it to:
 
 ```
 arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-java:4`

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -17,6 +17,69 @@ aliases:
 
 {{< img src="serverless/java-lambda-tracing.png" alt="Monitor Java Lambda Functions with Datadog"  style="width:100%;">}}
 
+## Upgrading
+
+<div class="alert alert-warning">
+  As you may be aware, it was recently announced by the Apache Foundation that log4j, a popular Java logging library, is [vulnerable to remote code execution][12].
+  Some versions of `datadog-lambda-java` include a transitive dependency on log4j that may be vulnerable. The vulnerable versions are:
+
+  `<=0.3.3`
+  `<=1.4.0`
+
+  See below for instructions for upgrading to the latest versions of `datadog-lambda-java`.
+</div>
+
+<details>
+  <summary>
+    Instructions for upgrading `datadog-lambda-java`
+  </summary>
+
+  The version of the `datadog-lambda-java` dependency in your Lambda function is set in `pom.xml` or `build.gradle` depending on whether you are using Maven or Gradle, respectively.
+
+  {{< tabs >}}
+    {{% tab "Maven" %}}
+      Your `pom.xml` file will contain a section like this.
+
+      ```xml
+      <dependency>
+        <groupId>com.datadoghq</groupId>
+        <artifactId>datadog-lambda-java</artifactId>
+        <version>VERSION</version>
+      </dependency>
+      ```
+
+      Find this section and change the `VERSION` to the latest release (omitting the preceeding `v`) ![Maven Central][4]
+      Then redeploy your lambda function.
+
+      If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. You can find the latest `0.3.x` release [here][13]. 
+
+    {{% \tab %}}
+
+    {{% tab "Gradle" %}}
+      Your `build.gradle` file will contain a section like this.
+
+      ```groovy
+      dependencies {
+        implementation 'com.datadoghq:datadog-lambda-java:VERSION'
+      }
+      ```
+
+      Find this section and change the `VERSION` to the latest release (omitting the preceeding `v`) ![Maven Central][4]
+      Then redeploy your lambda function.
+
+      If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. You can find the latest `0.3.x` release [here][13]. 
+
+    {{% \tab %}}
+  {{< \tabs>}}
+
+  If you are upgrading from 0.3.x to 1.4.x and you wish to use the `dd-trace-java` tracer, find the reference to the `dd-trace-java` lambda layer and change it to 
+  
+  ```
+  arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-java:4`
+  ````
+
+</details>
+
 ## Required setup
 
 If not already configured:
@@ -170,3 +233,5 @@ To automatically connect Java Lambda function logs and traces, see [Connecting J
 [9]: https://app.datadoghq.com/functions
 [10]: /serverless/custom_metrics?tab=java
 [11]: /tracing/connect_logs_and_traces/java/
+[12]: https://www.datadoghq.com/log4j-vulnerability/
+[13]: https://github.com/DataDog/datadog-lambda-java/releases

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -170,7 +170,7 @@ Some versions of `datadog-lambda-java` include a transitive dependency on log4j 
 The latest version of datadog-lambda java is ![Maven Cental][4]. Use this version (omitting the preceeding `v`) when following the upgrading instructions below.
 
 If you do not wish to upgrade to `1.4.x`, `0.3.x` is updated with the latest log4j security patches as well. 
-You may find the latest version of `0.3.x` in the [datadog-lambda-java repository][13]
+You may find the latest version of `0.3.x` in the [datadog-lambda-java repository][13].
 
 The version of the `datadog-lambda-java` dependency in your Lambda function is set in `pom.xml` or `build.gradle` depending on whether you are using Maven or Gradle, respectively.
 
@@ -211,7 +211,7 @@ Then redeploy your lambda function.
 If you are upgrading from 0.3.x to 1.4.x and you wish to use the `dd-trace-java` tracer, find the reference to the `dd-trace-java` lambda layer and change it to:
 
 ```
-arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-java:4`
+arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-java:4
 ````
 
 

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -53,7 +53,7 @@ aliases:
 
       If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. You can find the latest `0.3.x` release [here][13]. 
 
-    {{% \tab %}}
+    {{% /tab %}}
 
     {{% tab "Gradle" %}}
       Your `build.gradle` file will contain a section like this.
@@ -69,8 +69,8 @@ aliases:
 
       If you do not wish to upgrade to `v1.4.x`, we are also updating `0.3.x` with the latest log4j security patches. You can find the latest `0.3.x` release [here][13]. 
 
-    {{% \tab %}}
-  {{< \tabs>}}
+    {{% /tab %}}
+  {{< /tabs>}}
 
   If you are upgrading from 0.3.x to 1.4.x and you wish to use the `dd-trace-java` tracer, find the reference to the `dd-trace-java` lambda layer and change it to 
   

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -18,7 +18,7 @@ aliases:
 {{< img src="serverless/java-lambda-tracing.png" alt="Monitor Java Lambda Functions with Datadog"  style="width:100%;">}}
 
 <div class="alert alert-danger">
-There are versions of datadog-lambda-java that import log4j <=2.14.0 as a transitive dependency. Upgrade instructions are <a href="#upgrading">here</a>. 
+There are versions of datadog-lambda-java that import log4j <=2.14.0 as a transitive dependency. <a href="#upgrading">Upgrade instructions</a> are below. 
 </div>
 
 ## Required setup

--- a/layouts/shortcodes/latest-lambda-layer-version.html
+++ b/layouts/shortcodes/latest-lambda-layer-version.html
@@ -26,5 +26,5 @@
 
 <!-- dd-trace-java Layer -->
 {{- if eq (.Get "layer") "dd-trace-java" -}}
-    3
+    4
 {{- end -}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This adds an **Upgrading** section to the datadog-lambda-java installation instructions with an alert box discussing the log4j vulnerability and a description box with upgrade instructions. Also while I'm at it, I bump the latest dd-trace-java layer version to 4 (unrelated to log4j, just housekeeping).

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/chris.agocs/add_log4j_mitigation_instructions/serverless/installation/java/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
