### PR TITLE
Remove deprecated helm parameter in example

### DIFF
--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -192,7 +192,6 @@ Alternatively, you can set `agents.containers.traceAgent.env` in the `helm insta
 {{< code-block lang="bash" >}}
 helm install dd-agent -f values.yaml \
   --set datadog.apiKeyExistingSecret="datadog-secret" \
-  --set datadog.apm.enabled=true \
   --set agents.containers.traceAgent.env[0].name=DD_APM_IGNORE_RESOURCES, \
     agents.containers.traceAgent.env[0].value="Api::HealthchecksController#index$" \
   datadog/datadog


### PR DESCRIPTION
datadog.apm.enabled is deprecated now, so it should be removed from our examples. 

datadog.apm.socketEnabled is now enabled by default, which sets up unix socket communication with the tracer. Customers can set datadog.apm.portEnabled if they want to override this, and use TCP communication instead.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kaitlavs-doc-update/tracing/guide/ignoring_apm_resources/?tab=kuberneteshelm#example

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
