### PR TITLE
Fix product dropdow menu height

### DIFF
--- a/assets/styles/components/_header.scss
+++ b/assets/styles/components/_header.scss
@@ -169,7 +169,7 @@ body > header {
                 // product menu
                 &.product-menu {
                     column-count: 2;
-                    height: 495px;
+                    height: 523px;
                     column-fill: auto;
 
                     i[class*='icon-'] {


### PR DESCRIPTION
### What does this PR do?
Increases product menu dropdown height so all items fit inside menu

### Motivation
Product menu doesn't fit all items

### Preview
https://docs-staging.datadoghq.com/ccole/nav-fix/

Please confirm Nav -> Product Menu dropdown looks good in both FF and Chrome

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
