### PR TITLE
Oauth scopes

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3257,10 +3257,15 @@ api:
     url: /api/latest/using-the-api/
     parent: API overview
     weight: 5
+  - name: Authorization Scopes
+    url: /api/latest/scopes/
+    identifier: API Scopes
+    parent: API overview
+    weight: 6
   - name: Rate Limits
     url: /api/latest/rate-limits/
     parent: API overview
-    weight: 6
+    weight: 7
     identifier: rate-limits
   - name: AWS Integration
     url: /api/latest/aws-integration/

--- a/content/en/api/latest/_index.md
+++ b/content/en/api/latest/_index.md
@@ -5,6 +5,9 @@ further_reading:
   - link: /api/latest/using-the-api/
     tag: Documentation
     text: Using the API
+  - link: /api/latest/scopes/
+    tag: Documentation
+    text: Authorization Scopes
   - link: /api/latest/rate-limits/
     tag: Documentation
     text: Rate Limits

--- a/content/en/api/latest/scopes/_index.md
+++ b/content/en/api/latest/scopes/_index.md
@@ -1,0 +1,18 @@
+---
+title: Authorization Scopes
+disable_sidebar: true
+---
+## Authorization Scopes
+
+Scope is an authorization mechanism that allows you to limit and define the granular access that applications have to an organization’s Datadog data. When authorized access on behalf of a user or service account, applications can access only the information explicitly requested and nothing more.
+
+The best practice for scoping applications is to maintain the minimal privileges and most restrictive scopes necessary for an application to function as intended. This gives users fine-grained access control of applications and transparency into how an application is using their data. For example, a third-party application that only reads dashboard data does not need permissions to delete or manage users in an organization.
+
+You may use scopes two ways with Datadog:
+- Scope OAuth2 clients for your [Datadog Apps][1]
+- Scope your [application keys][2] 
+
+{{< api-scopes >}}
+
+[1]: https://docs.datadoghq.com/developers/datadog_apps/#oauth-api-access
+[2]: https://docs.datadoghq.com/account_management/api-app-keys/

--- a/content/en/api/latest/scopes/_index.md
+++ b/content/en/api/latest/scopes/_index.md
@@ -2,7 +2,7 @@
 title: Authorization Scopes
 disable_sidebar: true
 ---
-## Authorization Scopes
+## Authorization scopes
 
 Scope is an authorization mechanism that allows you to limit and define the granular access that applications have to an organization’s Datadog data. When authorized access on behalf of a user or service account, applications can access only the information explicitly requested and nothing more.
 

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -1,9 +1,11 @@
 {{ define "api-main" }}
 
+    {{ $dot := . }}
+
     {{ with .Content}}
-        <div class="col-12 col-lg-9 pl-0">
-            {{ . }}
-        </div>
+       <div class="col-12 {{if ne $dot.RelPermalink "/api/latest/scopes/"}}col-lg-9{{ end }} pl-0">
+        {{ . }}
+       </div>
     {{ end }}
 
     {{ $dot := . }}
@@ -152,7 +154,12 @@
 
                     <h3 class="mt-2">{{ i18n "overview" }}</h3>
                     <p>{{ $translate_action.description | default $endpoint.action.description | markdownify }}</p>
-
+                    <p>
+                      {{ $translate_action.description | default $endpoint.action.description | markdownify }}
+                      <!-- required scopes -->
+                      {{ partial "api/scopes.html" (dict "context" $dot "endpoint" $endpoint "securitySchemes" $adat.components.securitySchemes "tag" $tag) }}
+                    </p>
+                    
                     <!-- querystring, path params, header params -->
                     {{ partial "api/arguments.html" (dict "context" $dot "endpoint" $endpoint) }}
 

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -153,7 +153,6 @@
                     </p>
 
                     <h3 class="mt-2">{{ i18n "overview" }}</h3>
-                    <p>{{ $translate_action.description | default $endpoint.action.description | markdownify }}</p>
                     <p>
                       {{ $translate_action.description | default $endpoint.action.description | markdownify }}
                       <!-- required scopes -->

--- a/layouts/partials/api/scopes.html
+++ b/layouts/partials/api/scopes.html
@@ -1,0 +1,18 @@
+{{ $context := .context }}
+{{ $endpoint := .endpoint }}
+{{ $securitySchemes := .securitySchemes }}
+{{ $tag := .tag }}
+
+{{ $authZ := slice }}
+{{ range $endpoint.action.security }}
+  {{ range $sec_key, $sec_val := . }}
+    {{ if eq $sec_key "AuthZ" }}
+      {{ $authZ = . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ with $authZ }}
+  {{ $slug := (replaceRE " " "-" ($tag.name | humanize | lower)) }}
+  This endpoint requires the <code>{{ delimit . ", "}}</code> authorization <a href="{{ "api/latest/scopes/" | absLangURL }}#{{ $slug }}">scope</a>.
+{{ end }}

--- a/layouts/shortcodes/api-scopes.html
+++ b/layouts/shortcodes/api-scopes.html
@@ -1,0 +1,98 @@
+{{ $dot := . }}
+
+{{ $s := newScratch }}
+
+{{ range $versionIndex, $versionNum := (slice "v1" "v2") }}
+  {{ with (index $dot.Site.Data.api $versionNum).full_spec_deref }}
+    {{ $spec := . }}
+    {{ range $path_key, $path_object := $spec.paths }}
+      {{ range $action_type, $action := $path_object }}
+          {{ $tag := index $action.tags 0 }}
+            {{ range $sec := ($action.security | default slice) }}
+                {{ range $k, $v := $sec }}
+                    {{ if eq $k "AuthZ" }}
+                      {{ range $scope := $v }}
+                        {{ $scopeMap := index ($s.Get "scopes" | default dict) $scope | default dict }}
+                        {{ $tags := ($scopeMap.tags | default slice) }}
+                        {{ if not (in $tags $tag) }}
+                            {{ $tags = $tags | append $tag }}
+                        {{ end }}
+                        {{ $endpoints := ($scopeMap.endpoints | default slice) }}
+                        {{ $slug := (replaceRE " " "-" ($action.summary | humanize | lower)) }}
+                        {{ $url := (printf "api/latest/%s/" (replaceRE " " "-" ($tag | humanize | lower))) | absLangURL }}
+                        {{ $endpoints = $endpoints | append (dict "url" (printf "%s#%s" $url $slug) "summary" $action.summary) }}
+                        {{ $updateMap := (dict "endpoints" $endpoints "tags" $tags "desc" (index $spec.components.securitySchemes.AuthZ.flows.authorizationCode.scopes $scope)) }}
+                        {{ $scopeMap = merge $scopeMap $updateMap }}
+                        {{ $s.SetInMap "scopes" $scope $scopeMap }}
+                      {{ end }}
+                    {{ end }}
+                {{ end }}
+            {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+<!--
+For each scope find the common tags and group them together
+-->
+{{ $tagGroups := slice }}
+{{ $scopeGroups := slice }}
+{{ range $scope, $scope_obj := ($s.Get "scopes") }}
+  {{ $intersect := len (intersect $tagGroups $scope_obj.tags) }}
+  {{ if eq $intersect 0 }}
+    {{ if $tagGroups}}
+      {{ $tagStr := (print (delimit $tagGroups ", ")) }}
+      {{ $s.SetInMap "tags" $tagStr $scopeGroups }}
+    {{ end }}
+    {{ $tagGroups = slice }}
+    {{ $scopeGroups = slice }}
+  {{ end }}
+  {{ $tagGroups = ($tagGroups | append $scope_obj.tags) | uniq }}
+  {{ $scopeGroups = ($scopeGroups | append $scope) | uniq }}
+{{ end }}
+
+{{ range $tagString, $scopeSlice := ($s.Get "tags") }}
+    <h4>{{ $tagString }}</h4>
+    {{ range $tag := (split $tagString ", ") }}
+      {{ $slug := (replaceRE " " "-" ($tag | humanize | lower)) }}
+      <a id="{{ $slug }}"></a>
+    {{ end }}
+    <div class="table-request schema-table row has-no-expands">
+        <div class="col-12">
+            <!-- Header -->
+            <div class="row table-header">
+                <div class="col-4 pl-2 column">
+                    <p class="font-semibold">Scope name</p>
+                </div>
+                <div class="col-3 pl-2 column">
+                    <p class="font-semibold">Description</p>
+                </div>
+                <div class="col-5 pl-2 column">
+                    <p class="font-semibold">Endpoints that require this scope</p>
+                </div>
+            </div>
+            <!-- Detail -->
+            {{ range $scope := $scopeSlice }}
+            {{ $scope_obj := index ($s.Get "scopes") $scope }}
+            <div class="row">
+                <div class="col-12 first-column">
+                    <div class="row first-row">
+                        <div class="col-4 p-2 column">
+                            <p>{{ $scope }}</p>
+                        </div>
+                        <div class="col-3 p-2 column">
+                            <p>{{ $scope_obj.desc }}</p>
+                        </div>
+                        <div class="col-5 p-2 column">
+                            {{ range $endpoint := $scope_obj.endpoints }}
+                              <a href="{{ $endpoint.url }}">{{ $endpoint.summary }}</a><br/>
+                            {{ end }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {{ end }}
+        </div>
+    </div>
+{{ end }}


### PR DESCRIPTION
### What does this PR do?
This replaces https://github.com/DataDog/documentation/pull/12498 because #12498 looks like it got into a fight with an accidental rebase pushed to master and came out the loser. 

View scopes here:
https://docs-staging.datadoghq.com/kaylyn/scopes/api/latest/scopes/

View links back to scopes on api endpoints e.g:
https://docs-staging.datadoghq.com/kaylyn/scopes/api/latest/dashboards/#create-a-shared-dashboard

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
