### PR TITLE
APM > .NET > Update .NET compatibility and usage for new 2.x Tracer releases

### DIFF
--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -239,7 +239,6 @@ Set the environment variables before running your instrumented app:
 export CORECLR_ENABLE_PROFILING=1
 export CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 export CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
-export DD_INTEGRATIONS=/opt/datadog/integrations.json
 export DD_DOTNET_TRACER_HOME=/opt/datadog
 
 # For containers

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -24,12 +24,12 @@ further_reading:
 ## Supported .NET Core runtimes
 The .NET Tracer supports automatic instrumentation on the following .NET Core versions. It also supports [.NET Framework][2].
 
-| Version              | Microsoft End of Life |
-| -------------------- | --------------------- |
-| .NET 6               |                       |
-| .NET 5               |                       |
-| .NET Core 3.1        | 12/03/2022            |
-| .NET Core 2.1        | 08/21/2021            |
+| Version              | Microsoft End of Life | APM Supported in 1.x | APM Supported in 2.x |
+| -------------------- | --------------------- | -------------------- | -------------------- |
+| .NET 6               |                       | No                   | Yes                  |
+| .NET 5               |                       | Yes                  | Yes                  |
+| .NET Core 3.1        | 12/03/2022            | Yes                  | Yes                  |
+| .NET Core 2.1        | 08/21/2021            | Yes                  | Yes                  |
 
  Additional information on .NET Core support policy can be found within [Microsoft's .NET Core Lifecycle Policy][3]. 
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -22,15 +22,19 @@ further_reading:
 - The .NET Tracer library for Datadog is open source. For more information, see the [.NET Tracer repository][1].
 
 ## Supported .NET Framework runtimes
-The .NET Tracer supports automatic instrumentation on .NET Framework 4.6.1 and above. It also supports [.NET Core][2].
+The .NET Tracer supports automatic instrumentation on the following .NET Framework versions. It also supports [.NET Core][2].
 
-| Version  | Microsoft End of Life |
-| -------- | --------------------- |
-| 4.8      |                       |
-| 4.7.2    |                       |
-| 4.7      |                       |
-| 4.6.2    |                       |
-| 4.6.1    | 04/26/2022            |
+| .NET Framework Version  | Microsoft End of Life | APM Supported in 1.x | APM Supported in 2.x |
+| ----------------------- | --------------------- | -------------------- | -------------------- |
+| 4.8                     |                       | Yes                  | Yes                  |
+| 4.7.2                   |                       | Yes                  | Yes                  |
+| 4.7                     |                       | Yes                  | Yes                  |
+| 4.6.2                   |                       | Yes                  | Yes                  |
+| 4.6.1                   | 04/26/2022            | Yes                  | Yes                  |
+| 4.6                     | 04/26/2022            | Yes                  | No                   |
+| 4.5.2                   | 04/26/2022            | Yes                  | No                   |
+| 4.5.1                   | 01/12/2016            | Yes                  | No                   |
+| 4.5                     | 01/12/2016            | Yes                  | No                   |
 
  Additional information on .NET Framework support policy can be found within [Microsoft's .NET Framework Lifecycle Policy][3]. 
 

--- a/content/en/tracing/troubleshooting/tracer_startup_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_startup_logs.md
@@ -72,7 +72,6 @@ DATADOG TRACER DIAGNOSTICS - Profiler disabled: {process_name} found in DD_PROFI
 DATADOG TRACER DIAGNOSTICS - Failed to attach profiler: interface ICorProfilerInfo3 not found
 DATADOG TRACER DIAGNOSTICS - Profiler disabled: {application_pool} is recognized as an Azure App Services infrastructure process
 DATADOG TRACER DIAGNOSTICS - Profiler disabled: {application_pool} is recognized as Kudu, an Azure App Services reserved process
-DATADOG TRACER DIAGNOSTICS - Profiler disabled: DD_INTEGRATIONS environment variable not set
 DATADOG TRACER DIAGNOSTICS - Profiler disabled: no enabled integrations found
 DATADOG TRACER DIAGNOSTICS - Failed to attach profiler: unable to set event mask
 DATADOG TRACER DIAGNOSTICS - Error fetching configuration {exception}


### PR DESCRIPTION
### What does this PR do?
Updates the compatibility for .NET APM because there are differences between the old 1.X .NET Tracer releases and the new 2.x .NET Tracer releases.

### Motivation
We are going to be releasing the 2.x .NET Tracer soon and this requires updated guidance.

### Preview
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-update-compatibility/tracing/setup_overview/compatibility_requirements/dotnet-core
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-update-compatibility/tracing/setup_overview/compatibility_requirements/dotnet-framework

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
