### PR TITLE
Update agent manifests based on helm chart 2.27.8

### DIFF
--- a/static/resources/yaml/datadog-agent-aks.yaml
+++ b/static/resources/yaml/datadog-agent-aks.yaml
@@ -1,11 +1,10 @@
----
 # Source: datadog/templates/cluster-agent-rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.22.15"
+    chart: "datadog-2.27.8"
     heritage: "Helm"
     release: "datadog-agent"
   name: datadog-agent-cluster-agent
@@ -228,7 +227,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -280,6 +279,8 @@ spec:
               value: "/var/run/datadog/dsd.socket"
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: "clusterchecks endpointschecks"
+            - name: DD_EXPVAR_PORT
+              value: "6000"
             - name: DD_KUBELET_CLIENT_CA
               value: /etc/kubernetes/certs/kubeletserver.crt
           volumeMounts:
@@ -332,13 +333,12 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
           ports:
             - containerPort: 8126
-              hostPort: 8126
               name: traceport
               protocol: TCP
           env:
@@ -401,7 +401,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -429,6 +429,8 @@ spec:
                 secretKeyRef:
                   name: datadog-agent-cluster-agent
                   key: token
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
@@ -440,15 +442,15 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
-            - name: runtimesocketdir
-              mountPath: /host/var/run
-              mountPropagation: None
-              readOnly: true
             - name: logdatadog
               mountPath: /var/log/datadog
             - name: tmpdir
               mountPath: /tmp
               readOnly: false
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              mountPropagation: None
+              readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
@@ -468,7 +470,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -478,7 +480,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -518,9 +520,6 @@ spec:
             name: datadog-agent-installinfo
         - name: config
           emptyDir: {}
-        - hostPath:
-            path: /var/run
-          name: runtimesocketdir
         - name: logdatadog
           emptyDir: {}
         - name: tmpdir
@@ -544,6 +543,9 @@ spec:
         - hostPath:
             path: /etc/passwd
           name: passwd
+        - hostPath:
+            path: /var/run
+          name: runtimesocketdir
         - hostPath:
             path: /etc/kubernetes/certs
           name: kubeletserver
@@ -584,12 +586,15 @@ spec:
       serviceAccountName: datadog-agent-cluster-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:1.15.1"
+          image: "gcr.io/datadoghq/cluster-agent:1.16.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
             - containerPort: 5005
               name: agentport
+              protocol: TCP
+            - containerPort: 5000
+              name: agentmetrics
               protocol: TCP
           env:
             - name: DD_HEALTH_PORT
@@ -610,8 +615,6 @@ spec:
               value: "INFO"
             - name: DD_LEADER_ELECTION
               value: "true"
-            - name: DD_LEADER_LEASE_DURATION
-              value: "15"
             - name: DD_COLLECT_KUBERNETES_EVENTS
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -1,11 +1,10 @@
----
 # Source: datadog/templates/cluster-agent-rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.22.15"
+    chart: "datadog-2.27.8"
     heritage: "Helm"
     release: "datadog-agent"
   name: datadog-agent-cluster-agent
@@ -72,6 +71,8 @@ data:
     network_config:
       enabled: true
       conntrack_init_timeout: 10s
+    service_monitoring_config:
+      enabled: false
     runtime_security_config:
       enabled: true
       debug: false
@@ -484,7 +485,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -536,6 +537,8 @@ spec:
               value: "/var/run/datadog/dsd.socket"
             - name: DD_EXTRA_CONFIG_PROVIDERS
               value: "clusterchecks endpointschecks"
+            - name: DD_EXPVAR_PORT
+              value: "6000"
           volumeMounts:
             - name: installinfo
               subPath: install_info
@@ -604,7 +607,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -670,7 +673,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -700,6 +703,8 @@ spec:
                   key: token
             - name: DD_PROCESS_AGENT_ENABLED
               value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
@@ -713,15 +718,15 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
-            - name: runtimesocketdir
-              mountPath: /host/var/run
-              mountPropagation: None
-              readOnly: true
             - name: logdatadog
               mountPath: /var/log/datadog
             - name: tmpdir
               mountPath: /tmp
               readOnly: false
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              mountPropagation: None
+              readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
@@ -743,7 +748,7 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -800,7 +805,7 @@ spec:
               mountPropagation: None
               readOnly: true
         - name: security-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -857,11 +862,12 @@ spec:
             - name: tmpdir
               mountPath: /tmp
               readOnly: false
-            - name: runtimesocketdir
-              mountPath: /host/var/run
-              readOnly: true
             - name: dsdsocket
               mountPath: /var/run/datadog
+              readOnly: true
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              mountPropagation: None
               readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
@@ -875,9 +881,6 @@ spec:
             - name: hostroot
               mountPath: /host/root
               readOnly: true
-            - name: runtimesocketdir
-              mountPath: /host/root/var/run
-              readOnly: true
             - name: procdir
               mountPath: /host/proc
               readOnly: true
@@ -889,7 +892,7 @@ spec:
               subPath: system-probe.yaml
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -899,7 +902,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -937,7 +940,7 @@ spec:
               value: "yes"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json
@@ -955,9 +958,6 @@ spec:
             name: datadog-agent-installinfo
         - name: config
           emptyDir: {}
-        - hostPath:
-            path: /var/run
-          name: runtimesocketdir
         - name: logdatadog
           emptyDir: {}
         - name: tmpdir
@@ -996,11 +996,11 @@ spec:
             path: /etc/passwd
           name: passwd
         - hostPath:
-            path: /etc/group
-          name: group
-        - hostPath:
             path: /
           name: hostroot
+        - hostPath:
+            path: /etc/group
+          name: group
         - hostPath:
             path: /etc/os-release
           name: os-release
@@ -1016,6 +1016,9 @@ spec:
         - hostPath:
             path: /var/lib/docker/containers
           name: logdockercontainerpath
+        - hostPath:
+            path: /var/run
+          name: runtimesocketdir
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"
@@ -1053,12 +1056,15 @@ spec:
       serviceAccountName: datadog-agent-cluster-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:1.15.1"
+          image: "gcr.io/datadoghq/cluster-agent:1.16.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
             - containerPort: 5005
               name: agentport
+              protocol: TCP
+            - containerPort: 5000
+              name: agentmetrics
               protocol: TCP
           env:
             - name: DD_HEALTH_PORT
@@ -1079,8 +1085,6 @@ spec:
               value: "INFO"
             - name: DD_LEADER_ELECTION
               value: "true"
-            - name: DD_LEADER_LEASE_DURATION
-              value: "15"
             - name: DD_COLLECT_KUBERNETES_EVENTS
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -1,4 +1,3 @@
----
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -46,7 +45,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -91,6 +90,8 @@ spec:
               value: "5555"
             - name: DD_DOGSTATSD_SOCKET
               value: "/var/run/datadog/dsd.socket"
+            - name: DD_EXPVAR_PORT
+              value: "6000"
           volumeMounts:
             - name: installinfo
               subPath: install_info
@@ -138,7 +139,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -197,7 +198,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -218,6 +219,8 @@ spec:
               value: "yes"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "false"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
@@ -229,15 +232,15 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
-            - name: runtimesocketdir
-              mountPath: /host/var/run
-              mountPropagation: None
-              readOnly: true
             - name: logdatadog
               mountPath: /var/log/datadog
             - name: tmpdir
               mountPath: /tmp
               readOnly: false
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              mountPropagation: None
+              readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
@@ -254,7 +257,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -264,7 +267,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -306,9 +309,6 @@ spec:
             name: datadog-agent-installinfo
         - name: config
           emptyDir: {}
-        - hostPath:
-            path: /var/run
-          name: runtimesocketdir
         - name: logdatadog
           emptyDir: {}
         - name: tmpdir
@@ -332,6 +332,9 @@ spec:
         - hostPath:
             path: /etc/passwd
           name: passwd
+        - hostPath:
+            path: /var/run
+          name: runtimesocketdir
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -1,4 +1,3 @@
----
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -46,7 +45,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -93,6 +92,8 @@ spec:
               value: "5555"
             - name: DD_DOGSTATSD_SOCKET
               value: "/var/run/datadog/dsd.socket"
+            - name: DD_EXPVAR_PORT
+              value: "6000"
           volumeMounts:
             - name: installinfo
               subPath: install_info
@@ -155,7 +156,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -216,7 +217,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -239,6 +240,8 @@ spec:
               value: "name:datadog-agent"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "false"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
@@ -250,15 +253,15 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
-            - name: runtimesocketdir
-              mountPath: /host/var/run
-              mountPropagation: None
-              readOnly: true
             - name: logdatadog
               mountPath: /var/log/datadog
             - name: tmpdir
               mountPath: /tmp
               readOnly: false
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              mountPropagation: None
+              readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
@@ -275,7 +278,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -285,7 +288,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -329,9 +332,6 @@ spec:
             name: datadog-agent-installinfo
         - name: config
           emptyDir: {}
-        - hostPath:
-            path: /var/run
-          name: runtimesocketdir
         - name: logdatadog
           emptyDir: {}
         - name: tmpdir
@@ -367,6 +367,9 @@ spec:
         - hostPath:
             path: /var/lib/docker/containers
           name: logdockercontainerpath
+        - hostPath:
+            path: /var/run
+          name: runtimesocketdir
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -1,4 +1,3 @@
----
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -46,7 +45,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -93,6 +92,8 @@ spec:
               value: "5555"
             - name: DD_DOGSTATSD_SOCKET
               value: "/var/run/datadog/dsd.socket"
+            - name: DD_EXPVAR_PORT
+              value: "6000"
           volumeMounts:
             - name: installinfo
               subPath: install_info
@@ -155,13 +156,12 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
           ports:
             - containerPort: 8126
-              hostPort: 8126
               name: traceport
               protocol: TCP
           env:
@@ -216,7 +216,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -239,6 +239,8 @@ spec:
               value: "name:datadog-agent"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "false"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
@@ -250,15 +252,15 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
-            - name: runtimesocketdir
-              mountPath: /host/var/run
-              mountPropagation: None
-              readOnly: true
             - name: logdatadog
               mountPath: /var/log/datadog
             - name: tmpdir
               mountPath: /tmp
               readOnly: false
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              mountPropagation: None
+              readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
@@ -275,7 +277,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -285,7 +287,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -329,9 +331,6 @@ spec:
             name: datadog-agent-installinfo
         - name: config
           emptyDir: {}
-        - hostPath:
-            path: /var/run
-          name: runtimesocketdir
         - name: logdatadog
           emptyDir: {}
         - name: tmpdir
@@ -367,6 +366,9 @@ spec:
         - hostPath:
             path: /var/lib/docker/containers
           name: logdockercontainerpath
+        - hostPath:
+            path: /var/run
+          name: runtimesocketdir
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -1,4 +1,3 @@
----
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -49,6 +48,8 @@ data:
     network_config:
       enabled: true
       conntrack_init_timeout: 10s
+    service_monitoring_config:
+      enabled: false
     runtime_security_config:
       enabled: false
       debug: false
@@ -273,7 +274,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -318,6 +319,8 @@ spec:
               value: "5555"
             - name: DD_DOGSTATSD_SOCKET
               value: "/var/run/datadog/dsd.socket"
+            - name: DD_EXPVAR_PORT
+              value: "6000"
           volumeMounts:
             - name: installinfo
               subPath: install_info
@@ -371,13 +374,12 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
           ports:
             - containerPort: 8126
-              hostPort: 8126
               name: traceport
               protocol: TCP
           env:
@@ -430,7 +432,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -451,6 +453,8 @@ spec:
               value: "yes"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "false"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
@@ -464,15 +468,15 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
-            - name: runtimesocketdir
-              mountPath: /host/var/run
-              mountPropagation: None
-              readOnly: true
             - name: logdatadog
               mountPath: /var/log/datadog
             - name: tmpdir
               mountPath: /tmp
               readOnly: false
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              mountPropagation: None
+              readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
@@ -494,7 +498,7 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -548,7 +552,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -558,7 +562,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -598,7 +602,7 @@ spec:
               value: "true"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json
@@ -616,9 +620,6 @@ spec:
             name: datadog-agent-installinfo
         - name: config
           emptyDir: {}
-        - hostPath:
-            path: /var/run
-          name: runtimesocketdir
         - name: logdatadog
           emptyDir: {}
         - name: tmpdir
@@ -656,6 +657,9 @@ spec:
         - hostPath:
             path: /etc/passwd
           name: passwd
+        - hostPath:
+            path: /var/run
+          name: runtimesocketdir
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -1,4 +1,3 @@
----
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -46,7 +45,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -91,6 +90,8 @@ spec:
               value: "5555"
             - name: DD_DOGSTATSD_SOCKET
               value: "/var/run/datadog/dsd.socket"
+            - name: DD_EXPVAR_PORT
+              value: "6000"
           volumeMounts:
             - name: installinfo
               subPath: install_info
@@ -138,13 +139,12 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
           ports:
             - containerPort: 8126
-              hostPort: 8126
               name: traceport
               protocol: TCP
           env:
@@ -197,7 +197,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -218,6 +218,8 @@ spec:
               value: "yes"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "false"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
@@ -229,15 +231,15 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
-            - name: runtimesocketdir
-              mountPath: /host/var/run
-              mountPropagation: None
-              readOnly: true
             - name: logdatadog
               mountPath: /var/log/datadog
             - name: tmpdir
               mountPath: /tmp
               readOnly: false
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              mountPropagation: None
+              readOnly: true
             - name: cgroups
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
@@ -254,7 +256,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -264,7 +266,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -306,9 +308,6 @@ spec:
             name: datadog-agent-installinfo
         - name: config
           emptyDir: {}
-        - hostPath:
-            path: /var/run
-          name: runtimesocketdir
         - name: logdatadog
           emptyDir: {}
         - name: tmpdir
@@ -332,6 +331,9 @@ spec:
         - hostPath:
             path: /etc/passwd
           name: passwd
+        - hostPath:
+            path: /var/run
+          name: runtimesocketdir
       tolerations:
       affinity: {}
       serviceAccountName: "datadog-agent"

--- a/static/resources/yaml/datadog-agent-windows-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-windows-all-features.yaml
@@ -1,4 +1,3 @@
----
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -46,7 +45,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -91,18 +90,22 @@ spec:
               value: "true"
             - name: DD_HEALTH_PORT
               value: "5555"
+            - name: DD_EXPVAR_PORT
+              value: "6000"
           volumeMounts:
             - name: config
               mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
             - name: pointerdir
               mountPath: C:/var/log
             - name: logpodpath
               mountPath: C:/var/log/pods
               readOnly: true
             - name: logdockercontainerpath
-              mountPath: C:/ProgramData/docker/containers
+              mountPath: C:/ProgramData
               readOnly: true
           livenessProbe:
             failureThreshold: 6
@@ -125,7 +128,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -166,6 +169,8 @@ spec:
               mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
           livenessProbe:
             initialDelaySeconds: 15
             periodSeconds: 15
@@ -173,7 +178,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -198,6 +203,8 @@ spec:
               value: "false"
             - name: DD_PROCESS_AGENT_ENABLED
               value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
@@ -209,9 +216,11 @@ spec:
               mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -225,7 +234,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -235,6 +244,8 @@ spec:
               mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
           env:
             # Needs to be removed when Agent N-2 is built with Golang 1.17
             - name: GODEBUG
@@ -260,17 +271,23 @@ spec:
         - name: config
           emptyDir: {}
         - hostPath:
-            path: \\.\pipe\docker_engine
-          name: runtimesocket
-        - hostPath:
             path: C:/var/log
           name: pointerdir
         - hostPath:
             path: C:/var/log/pods
           name: logpodpath
         - hostPath:
-            path: C:/ProgramData/docker/containers
+            path: C:/ProgramData
           name: logdockercontainerpath
+        - hostPath:
+            path: \\.\pipe\docker_engine
+          name: runtimesocket
+        # if the CRI or is not provived we should try to mount the default containerd pipe.
+        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
+        # so with this additional hostPath, by default both are mounted.
+        - hostPath:
+            path: \\.\pipe\containerd-containerd
+          name: containerdsocket
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/os

--- a/static/resources/yaml/datadog-agent-windows-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-windows-all-features.yaml
@@ -282,9 +282,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # if the CRI or is not provived we should try to mount the default containerd pipe.
-        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
-        # so with this additional hostPath, by default both are mounted.
+        # If the CRI is not provided, try to mount the default containerd pipe.
+        # By default, datadog.dockerOrCriSocketPath mounts the Docker pipe.
+        # With this additional hostPath, both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket

--- a/static/resources/yaml/datadog-agent-windows-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm.yaml
@@ -218,9 +218,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # if the CRI or is not provived we should try to mount the default containerd pipe.
-        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
-        # so with this additional hostPath, by default both are mounted.
+        # If the CRI is not provided, try to mount the default containerd pipe.
+        # By default, datadog.dockerOrCriSocketPath mounts the Docker pipe.
+        # With this additional hostPath, both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket

--- a/static/resources/yaml/datadog-agent-windows-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm.yaml
@@ -1,4 +1,3 @@
----
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -46,7 +45,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -89,11 +88,15 @@ spec:
               value: "true"
             - name: DD_HEALTH_PORT
               value: "5555"
+            - name: DD_EXPVAR_PORT
+              value: "6000"
           volumeMounts:
             - name: config
               mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -115,7 +118,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -154,6 +157,8 @@ spec:
               mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
           livenessProbe:
             initialDelaySeconds: 15
             periodSeconds: 15
@@ -162,7 +167,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -176,7 +181,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -186,6 +191,8 @@ spec:
               mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
           env:
             # Needs to be removed when Agent N-2 is built with Golang 1.17
             - name: GODEBUG
@@ -211,6 +218,12 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
+        # if the CRI or is not provived we should try to mount the default containerd pipe.
+        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
+        # so with this additional hostPath, by default both are mounted.
+        - hostPath:
+            path: \\.\pipe\containerd-containerd
+          name: containerdsocket
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/os

--- a/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
@@ -1,4 +1,3 @@
----
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -46,7 +45,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -91,18 +90,22 @@ spec:
               value: "true"
             - name: DD_HEALTH_PORT
               value: "5555"
+            - name: DD_EXPVAR_PORT
+              value: "6000"
           volumeMounts:
             - name: config
               mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
             - name: pointerdir
               mountPath: C:/var/log
             - name: logpodpath
               mountPath: C:/var/log/pods
               readOnly: true
             - name: logdockercontainerpath
-              mountPath: C:/ProgramData/docker/containers
+              mountPath: C:/ProgramData
               readOnly: true
           livenessProbe:
             failureThreshold: 6
@@ -125,7 +128,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -166,6 +169,8 @@ spec:
               mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
           livenessProbe:
             initialDelaySeconds: 15
             periodSeconds: 15
@@ -174,7 +179,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -188,7 +193,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -198,6 +203,8 @@ spec:
               mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
           env:
             # Needs to be removed when Agent N-2 is built with Golang 1.17
             - name: GODEBUG
@@ -223,17 +230,23 @@ spec:
         - name: config
           emptyDir: {}
         - hostPath:
-            path: \\.\pipe\docker_engine
-          name: runtimesocket
-        - hostPath:
             path: C:/var/log
           name: pointerdir
         - hostPath:
             path: C:/var/log/pods
           name: logpodpath
         - hostPath:
-            path: C:/ProgramData/docker/containers
+            path: C:/ProgramData
           name: logdockercontainerpath
+        - hostPath:
+            path: \\.\pipe\docker_engine
+          name: runtimesocket
+        # if the CRI or is not provived we should try to mount the default containerd pipe.
+        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
+        # so with this additional hostPath, by default both are mounted.
+        - hostPath:
+            path: \\.\pipe\containerd-containerd
+          name: containerdsocket
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/os

--- a/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
@@ -241,9 +241,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # if the CRI or is not provived we should try to mount the default containerd pipe.
-        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
-        # so with this additional hostPath, by default both are mounted.
+        # If the CRI is not provided, try to mount the default containerd pipe.
+        # By default, datadog.dockerOrCriSocketPath mounts the Docker pipe.
+        # With this additional hostPath, both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket

--- a/static/resources/yaml/datadog-agent-windows-logs.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs.yaml
@@ -191,9 +191,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # if the CRI or is not provived we should try to mount the default containerd pipe.
-        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
-        # so with this additional hostPath, by default both are mounted.
+        # If the CRI is not provided, try to mount the default containerd pipe.
+        # By default, datadog.dockerOrCriSocketPath mounts the Docker pipe.
+        # With this additional hostPath, both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket

--- a/static/resources/yaml/datadog-agent-windows-logs.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs.yaml
@@ -1,4 +1,3 @@
----
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -46,7 +45,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -91,18 +90,22 @@ spec:
               value: "true"
             - name: DD_HEALTH_PORT
               value: "5555"
+            - name: DD_EXPVAR_PORT
+              value: "6000"
           volumeMounts:
             - name: config
               mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
             - name: pointerdir
               mountPath: C:/var/log
             - name: logpodpath
               mountPath: C:/var/log/pods
               readOnly: true
             - name: logdockercontainerpath
-              mountPath: C:/ProgramData/docker/containers
+              mountPath: C:/ProgramData
               readOnly: true
           livenessProbe:
             failureThreshold: 6
@@ -126,7 +129,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -140,7 +143,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -150,6 +153,8 @@ spec:
               mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
           env:
             # Needs to be removed when Agent N-2 is built with Golang 1.17
             - name: GODEBUG
@@ -175,17 +180,23 @@ spec:
         - name: config
           emptyDir: {}
         - hostPath:
-            path: \\.\pipe\docker_engine
-          name: runtimesocket
-        - hostPath:
             path: C:/var/log
           name: pointerdir
         - hostPath:
             path: C:/var/log/pods
           name: logpodpath
         - hostPath:
-            path: C:/ProgramData/docker/containers
+            path: C:/ProgramData
           name: logdockercontainerpath
+        - hostPath:
+            path: \\.\pipe\docker_engine
+          name: runtimesocket
+        # if the CRI or is not provived we should try to mount the default containerd pipe.
+        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
+        # so with this additional hostPath, by default both are mounted.
+        - hostPath:
+            path: \\.\pipe\containerd-containerd
+          name: containerdsocket
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/os

--- a/static/resources/yaml/datadog-agent-windows-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla.yaml
@@ -1,4 +1,3 @@
----
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -46,7 +45,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -89,11 +88,15 @@ spec:
               value: "true"
             - name: DD_HEALTH_PORT
               value: "5555"
+            - name: DD_EXPVAR_PORT
+              value: "6000"
           volumeMounts:
             - name: config
               mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -116,7 +119,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -130,7 +133,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.31.1"
+          image: "gcr.io/datadoghq/agent:7.32.3"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -140,6 +143,8 @@ spec:
               mountPath: C:/ProgramData/Datadog
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
           env:
             # Needs to be removed when Agent N-2 is built with Golang 1.17
             - name: GODEBUG
@@ -165,6 +170,12 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
+        # if the CRI or is not provived we should try to mount the default containerd pipe.
+        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
+        # so with this additional hostPath, by default both are mounted.
+        - hostPath:
+            path: \\.\pipe\containerd-containerd
+          name: containerdsocket
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/os

--- a/static/resources/yaml/datadog-agent-windows-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla.yaml
@@ -170,9 +170,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # if the CRI or is not provived we should try to mount the default containerd pipe.
-        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
-        # so with this additional hostPath, by default both are mounted.
+        # If the CRI is not provided, try to mount the default containerd pipe.
+        # By default, datadog.dockerOrCriSocketPath mounts the Docker pipe.
+        # With this additional hostPath, both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update the manifests documented on this page https://docs.datadoghq.com/agent/kubernetes/?tab=daemonset#installation

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
