### PR TITLE
List of Integrations that use jmxfetch

### DIFF
--- a/content/en/agent/faq/jmx_integrations.md
+++ b/content/en/agent/faq/jmx_integrations.md
@@ -1,0 +1,47 @@
+---
+title: Which Integrations use Jmxfetch?
+kind: faq
+---
+
+## Default Integrations
+
+The following integrations use [jmxfetch](https://github.com/DataDog/jmxfetch) and are included by default in the Datadog Agent:
+* [ActiveMQ](https://docs.datadoghq.com/integrations/activemq/)
+* [Cassandra](https://docs.datadoghq.com/integrations/cassandra/)
+* [Confluent Platform](https://docs.datadoghq.com/integrations/confluent_platform/)
+* [Hazelcast](https://docs.datadoghq.com/integrations/hazelcast/)
+* [Hive](https://docs.datadoghq.com/integrations/hive/)
+* [HiveMQ](https://docs.datadoghq.com/integrations/hivemq/)
+* [Hudi](https://docs.datadoghq.com/integrations/hudi/)
+* [ignite](https://docs.datadoghq.com/integrations/ignite/)
+* [Java/JMX](https://docs.datadoghq.com/integrations/java)
+* [JBoss/WildFly](https://docs.datadoghq.com/integrations/jboss_wildfly/)
+* [Kafka](https://docs.datadoghq.com/integrations/kafka/)
+* [Presto](https://docs.datadoghq.com/integrations/presto/)
+* [Solr](https://docs.datadoghq.com/integrations/solr/)
+* [SonarQube](https://docs.datadoghq.com/integrations/sonarqube/)
+* [Tomcat](https://docs.datadoghq.com/integrations/tomcat/)
+
+**Note**: These integrations will **not** run by default. Each integration must be confugured to run on a host.
+
+## Community Integrations
+
+The following [Community Integrations](/agent/guide/use-community-integrations/?tab=agentv721v621) use jmxfetch and are **not** included by default in the Datadog Agent. 
+* [nextcloud](https://github.com/DataDog/integrations-extras/tree/master/nextcloud)
+* [flume](https://github.com/DataDog/integrations-extras/tree/master/flume)
+* [stardog](https://github.com/DataDog/integrations-extras/tree/master/stardog)
+* [hbase_regionserver](https://github.com/DataDog/integrations-extras/tree/master/hbase_regionserver)
+* [eventstore](https://github.com/DataDog/integrations-extras/tree/master/eventstore)
+* [riak_repl](https://github.com/DataDog/integrations-extras/tree/master/riak_repl)
+* [aqua](https://github.com/DataDog/integrations-extras/tree/master/aqua)
+* [snmpwalk](https://github.com/DataDog/integrations-extras/tree/master/snmpwalk)
+* [resin](https://github.com/DataDog/integrations-extras/tree/master/resin)
+* [zabbix](https://github.com/DataDog/integrations-extras/tree/master/zabbix)
+* [hbase_master](https://github.com/DataDog/integrations-extras/tree/master/hbase_master)
+* [neutrona](https://github.com/DataDog/integrations-extras/tree/master/neutrona)
+
+**Note**: These integrations will **not** run by default. Each integration must be installed and confugured to run on a host.
+
+## Custom Checks
+
+Datadog users can monitor any Java Application by configuring the [Java/JMX](https://docs.datadoghq.com/integrations/java) check.

--- a/content/en/agent/faq/jmx_integrations.md
+++ b/content/en/agent/faq/jmx_integrations.md
@@ -3,7 +3,7 @@ title: Which Integrations use Jmxfetch?
 kind: faq
 ---
 
-## Default Integrations
+## Default integrations
 
 The following integrations use [jmxfetch](https://github.com/DataDog/jmxfetch) and are included by default in the Datadog Agent:
 * [ActiveMQ](https://docs.datadoghq.com/integrations/activemq/)
@@ -22,9 +22,9 @@ The following integrations use [jmxfetch](https://github.com/DataDog/jmxfetch) a
 * [SonarQube](https://docs.datadoghq.com/integrations/sonarqube/)
 * [Tomcat](https://docs.datadoghq.com/integrations/tomcat/)
 
-**Note**: These integrations will **not** run by default. Each integration must be confugured to run on a host.
+**Note**: These integrations do **not** run by default. Each integration must be confugured to run on a host.
 
-## Community Integrations
+## Community integrations
 
 The following [Community Integrations](/agent/guide/use-community-integrations/?tab=agentv721v621) use jmxfetch and are **not** included by default in the Datadog Agent. 
 * [nextcloud](https://github.com/DataDog/integrations-extras/tree/master/nextcloud)
@@ -40,8 +40,8 @@ The following [Community Integrations](/agent/guide/use-community-integrations/?
 * [hbase_master](https://github.com/DataDog/integrations-extras/tree/master/hbase_master)
 * [neutrona](https://github.com/DataDog/integrations-extras/tree/master/neutrona)
 
-**Note**: These integrations will **not** run by default. Each integration must be installed and confugured to run on a host.
+**Note**: These integrations do **not** run by default. Each integration must be installed and confugured to run on a host.
 
-## Custom Checks
+## Custom checks
 
 Datadog users can monitor any Java Application by configuring the [Java/JMX](https://docs.datadoghq.com/integrations/java) check.

--- a/content/en/agent/faq/jmx_integrations.md
+++ b/content/en/agent/faq/jmx_integrations.md
@@ -46,7 +46,7 @@ The following [Community Integrations][17] use jmxfetch and are **not** included
 
 ## Custom checks
 
-Datadog users can monitor any Java Application by configuring the [Java/JMX][10] check.
+Datadog users can monitor any Java Application by configuring the [Java/JMX][10] check. The name of these checks is determined by the user who creates the check.
 [1]: https://github.com/DataDog/jmxfetch
 [2]: https://docs.datadoghq.com/integrations/activemq/
 [3]: https://docs.datadoghq.com/integrations/cassandra/

--- a/content/en/agent/faq/jmx_integrations.md
+++ b/content/en/agent/faq/jmx_integrations.md
@@ -5,7 +5,7 @@ kind: faq
 
 ## Default integrations
 
-The following integrations use [jmxfetch][1] and are included by default in the Datadog Agent:
+The following integrations use [JMXFetch][1] and are included by default in the Datadog Agent:
 
 * [ActiveMQ][2]
 * [Cassandra][3]

--- a/content/en/agent/faq/jmx_integrations.md
+++ b/content/en/agent/faq/jmx_integrations.md
@@ -5,43 +5,74 @@ kind: faq
 
 ## Default integrations
 
-The following integrations use [jmxfetch](https://github.com/DataDog/jmxfetch) and are included by default in the Datadog Agent:
-* [ActiveMQ](https://docs.datadoghq.com/integrations/activemq/)
-* [Cassandra](https://docs.datadoghq.com/integrations/cassandra/)
-* [Confluent Platform](https://docs.datadoghq.com/integrations/confluent_platform/)
-* [Hazelcast](https://docs.datadoghq.com/integrations/hazelcast/)
-* [Hive](https://docs.datadoghq.com/integrations/hive/)
-* [HiveMQ](https://docs.datadoghq.com/integrations/hivemq/)
-* [Hudi](https://docs.datadoghq.com/integrations/hudi/)
-* [ignite](https://docs.datadoghq.com/integrations/ignite/)
-* [Java/JMX](https://docs.datadoghq.com/integrations/java)
-* [JBoss/WildFly](https://docs.datadoghq.com/integrations/jboss_wildfly/)
-* [Kafka](https://docs.datadoghq.com/integrations/kafka/)
-* [Presto](https://docs.datadoghq.com/integrations/presto/)
-* [Solr](https://docs.datadoghq.com/integrations/solr/)
-* [SonarQube](https://docs.datadoghq.com/integrations/sonarqube/)
-* [Tomcat](https://docs.datadoghq.com/integrations/tomcat/)
+The following integrations use [jmxfetch][1] and are included by default in the Datadog Agent:
+
+* [ActiveMQ][2]
+* [Cassandra][3]
+* [Confluent Platform][4]
+* [Hazelcast][5]
+* [Hive][6]
+* [HiveMQ][7]
+* [Hudi][8]
+* [ignite][9]
+* [Java/JMX][10]
+* [JBoss/WildFly][11]
+* [Kafka][12]
+* [Presto][13]
+* [Solr][14]
+* [SonarQube][15]
+* [Tomcat][16]
 
 **Note**: These integrations do **not** run by default. Each integration must be confugured to run on a host.
 
 ## Community integrations
 
-The following [Community Integrations](/agent/guide/use-community-integrations/?tab=agentv721v621) use jmxfetch and are **not** included by default in the Datadog Agent. 
-* [nextcloud](https://github.com/DataDog/integrations-extras/tree/master/nextcloud)
-* [flume](https://github.com/DataDog/integrations-extras/tree/master/flume)
-* [stardog](https://github.com/DataDog/integrations-extras/tree/master/stardog)
-* [hbase_regionserver](https://github.com/DataDog/integrations-extras/tree/master/hbase_regionserver)
-* [eventstore](https://github.com/DataDog/integrations-extras/tree/master/eventstore)
-* [riak_repl](https://github.com/DataDog/integrations-extras/tree/master/riak_repl)
-* [aqua](https://github.com/DataDog/integrations-extras/tree/master/aqua)
-* [snmpwalk](https://github.com/DataDog/integrations-extras/tree/master/snmpwalk)
-* [resin](https://github.com/DataDog/integrations-extras/tree/master/resin)
-* [zabbix](https://github.com/DataDog/integrations-extras/tree/master/zabbix)
-* [hbase_master](https://github.com/DataDog/integrations-extras/tree/master/hbase_master)
-* [neutrona](https://github.com/DataDog/integrations-extras/tree/master/neutrona)
+The following [Community Integrations][17] use jmxfetch and are **not** included by default in the Datadog Agent:
+
+* [nextcloud][18]
+* [flume][19]
+* [stardog][20]
+* [hbase_regionserver][21]
+* [eventstore][22]
+* [riak_repl][23]
+* [aqua][24]
+* [snmpwalk][25]
+* [resin][26]
+* [zabbix][27]
+* [hbase_master][28]
+* [neutrona][29]
 
 **Note**: These integrations do **not** run by default. Each integration must be installed and confugured to run on a host.
 
 ## Custom checks
 
-Datadog users can monitor any Java Application by configuring the [Java/JMX](https://docs.datadoghq.com/integrations/java) check.
+Datadog users can monitor any Java Application by configuring the [Java/JMX][10] check.
+[1]: https://github.com/DataDog/jmxfetch
+[2]: https://docs.datadoghq.com/integrations/activemq/
+[3]: https://docs.datadoghq.com/integrations/cassandra/
+[4]: https://docs.datadoghq.com/integrations/confluent_platform/
+[5]: https://docs.datadoghq.com/integrations/hazelcast/
+[6]: https://docs.datadoghq.com/integrations/hive/
+[7]: https://docs.datadoghq.com/integrations/hivemq/
+[8]: https://docs.datadoghq.com/integrations/hudi/
+[9]: https://docs.datadoghq.com/integrations/ignite/
+[10]: https://docs.datadoghq.com/integrations/java
+[11]: https://docs.datadoghq.com/integrations/jboss_wildfly/
+[12]: https://docs.datadoghq.com/integrations/kafka/
+[13]: https://docs.datadoghq.com/integrations/presto/
+[14]: https://docs.datadoghq.com/integrations/solr/
+[15]: https://docs.datadoghq.com/integrations/sonarqube/
+[16]: https://docs.datadoghq.com/integrations/tomcat/
+[17]: /agent/guide/use-community-integrations/?tab=agentv721v621
+[18]: https://github.com/DataDog/integrations-extras/tree/master/nextcloud
+[19]: https://github.com/DataDog/integrations-extras/tree/master/flume
+[20]: https://github.com/DataDog/integrations-extras/tree/master/stardog
+[21]: https://github.com/DataDog/integrations-extras/tree/master/hbase_regionserver
+[22]: https://github.com/DataDog/integrations-extras/tree/master/eventstore
+[23]: https://github.com/DataDog/integrations-extras/tree/master/riak_repl
+[24]: https://github.com/DataDog/integrations-extras/tree/master/aqua
+[25]: https://github.com/DataDog/integrations-extras/tree/master/snmpwalk
+[26]: https://github.com/DataDog/integrations-extras/tree/master/resin
+[27]: https://github.com/DataDog/integrations-extras/tree/master/zabbix
+[28]: https://github.com/DataDog/integrations-extras/tree/master/hbase_master
+[29]: https://github.com/DataDog/integrations-extras/tree/master/neutrona

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -1,6 +1,10 @@
 ---
 title: Mitigating the Risk of Remote Code Execution Due to Log4Shell
 kind: faq
+further_reading:
+- link: "/agent/faq/jmx_integrations/"
+  tag: "Documentation"
+  text: "Which Integrations use Jmxfetch?"
 ---
 
 If you are using the Datadog Agent between versions v7.17.0/v6.17.0 and v7.32.2/v6.32.2, you may be impacted by the vulnerability presented by Log4Shell (CVE-2021-44228 and CVE-2021-45046). If you are using an Agent earlier than v7.17.0/v6.17.0, you should not be impacted by the vulnerability unless you configured log4j to log with the JMS Appender (an option that is not supported by the Agent, but if you did it, disable the appender).
@@ -290,6 +294,10 @@ curl -X POST "https://api.datadoghq.com/api/v1/dashboard" \
 ### With the CLI
 
 You can also check specific Agent version information with the Agent CLI `version` subcommand. For more information, see the [Agent CLI documentation][6].
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://logging.apache.org/log4j/2.x/security.html


### PR DESCRIPTION
### What does this PR do?
Create a new (unlinked) page on the Agent FAQ to list integrations that use jmxfetch

### Motivation
For log4shell CVEs, it helps customers to know which integrations use jmxfetch

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
Should we include a link to this page from https://docs.datadoghq.com/agent/guide/ ?

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
