### PR TITLE
Fix PHP global tags documentation

### DIFF
--- a/content/en/tracing/setup_overview/custom_instrumentation/php.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/php.md
@@ -61,12 +61,9 @@ For example, the following snippet traces the `CustomDriver::doWork()` method an
         $span->resource = 'CustomDriver.doWork';
         $span->service = 'php';
 
-        $span->meta = [
-            // If an exception was thrown from the instrumented call, return value is null
-            'doWork.size' => $exception ? 0 : count($retval),
-            // Access object members via $this
-            'doWork.thing' => $this->workToDo,
-        ];
+        // If an exception was thrown from the instrumented call, return value is null
+        $span->meta['doWork.size'] = $exception ? 0 : count($retval),
+        $span->meta['doWork.thing'] = $this->workToDo;
 
         // The span will automatically close
     }
@@ -194,10 +191,8 @@ Add tags to a span via the `DDTrace\SpanData::$meta` array.
     'myRandFunc',
     function(\DDTrace\SpanData $span, array $args, $retval) {
         // ...
-        $span->meta = [
-            'rand.range' => $args[0] . ' - ' . $args[1],
-            'rand.value' => $retval,
-        ];
+        $span->meta['rand.range'] = $args[0] . ' - ' . $args[1];
+        $span->meta['rand.value'] = $retval;
     }
 );
 ```
@@ -246,12 +241,9 @@ function doRiskyThing() {
     'doRiskyThing',
     function(\DDTrace\SpanData $span, $args, $retval) {
         if ($retval === SOME_ERROR_CODE) {
-            $span->meta = [
-                'error.msg' => 'Foo error',
-                // Optional:
-                'error.type' => 'CustomError',
-                'error.stack' => my_get_backtrace(),
-            ];
+            $span->meta['error.msg'] = 'Foo error';
+            $span->meta['error.type'] = 'CustomError';
+            $span->meta['error.stack'] = my_get_backtrace();
         }
     }
 );
@@ -316,10 +308,8 @@ function myRandFunc($min, $max) {
         $span->service = 'php';
         // The following are optional
         $span->type = 'web';
-        $span->meta = [
-            'rand.range' => $args[0] . ' - ' . $args[1],
-            'rand.value' => $retval,
-        ];
+        $span->meta['rand.range'] = $args[0] . ' - ' . $args[1];
+        $span->meta['rand.value'] = $retval;
         $span->metrics = [
             '_sampling_priority_v1' => 0.9,
         ];
@@ -619,12 +609,10 @@ dd_trace('CustomDriver', 'doWork', function (...$args) {
         $span->resource = 'CustomDriver.doWork';
         $span->service = 'php';
 
-        $span->meta = [
-            // If an exception was thrown from the instrumented call, return value is null
-            'doWork.size' => $exception ? 0 : count($retval),
-            // Access object members via $this
-            'doWork.thing' => $this->workToDo,
-        ];
+        // If an exception was thrown from the instrumented call, return value is null
+        $span->meta['doWork.size'] = $exception ? 0 : count($retval);
+        // Access object members via $this
+        $span->meta['doWork.thing'] = $this->workToDo;
 
         // No need to explicitly forward the call with dd_trace_forward_call()
         // No need to explicitly catch/attach exceptions

--- a/content/en/tracing/setup_overview/custom_instrumentation/php.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/php.md
@@ -63,6 +63,7 @@ For example, the following snippet traces the `CustomDriver::doWork()` method an
 
         // If an exception was thrown from the instrumented call, return value is null
         $span->meta['doWork.size'] = $exception ? 0 : count($retval),
+        // Access object members via $this
         $span->meta['doWork.thing'] = $this->workToDo;
 
         // The span will automatically close
@@ -242,6 +243,7 @@ function doRiskyThing() {
     function(\DDTrace\SpanData $span, $args, $retval) {
         if ($retval === SOME_ERROR_CODE) {
             $span->meta['error.msg'] = 'Foo error';
+            // Optional:
             $span->meta['error.type'] = 'CustomError';
             $span->meta['error.stack'] = my_get_backtrace();
         }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Changes the docs to remove outdated syntax when defining global tags

### Motivation
<!-- What inspired you to submit this pull request?-->
Misleading documentation since it's no longer recommended to replace `$span->meta`

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
This Breaking Change was done in [dd-trace-php 0.66.0 release](https://github.com/DataDog/dd-trace-php/releases/tag/0.66.0)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
