### PR TITLE
Add configuration for Jboss in domain mode for Java tracer

### DIFF
--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -164,16 +164,26 @@ If a `setenv` file does not exist, create it in the `./bin` directory of the Tom
 {{% /tab %}}
 {{% tab "JBoss" %}}
 
-Add the following line to the end of `standalone.conf`:
+- In standalone mode:
+
+  Add the following line to the end of `standalone.conf`:
 
 ```text
 JAVA_OPTS="$JAVA_OPTS -javaagent:/path/to/dd-java-agent.jar"
 ```
 
-On Windows, add the following line to the end of `standalone.conf.bat`:
+- In standalone mode and on Windows, add the following line to the end of `standalone.conf.bat`:
 
 ```text
 set "JAVA_OPTS=%JAVA_OPTS% -javaagent:X:/path/to/dd-java-agent.jar"
+```
+
+- In domain mode:
+
+  Add the following line in the file `domain.xml`, under the tag server-groups.server-group.jvm.jvm-options:
+ 
+```text
+<option value="-javaagent:/path/to/dd-java-agent.jar"/>
 ```
 
 For more details, see the [JBoss documentation][1].


### PR DESCRIPTION
### What does this PR do?
Add the configuration to use for the java tracer if your application is running in Jboss, in domain mode.

### Motivation
Some customers were asking for this configuration

### Preview

https://docs-staging.datadoghq.com/cecile/jbossapmdomainmode/tracing/setup_overview/setup/java/?tab=jboss#add-the-java-tracer-to-the-jvm

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
