### PR TITLE
DOCS-2882 Migrate retention faq to guide

### DIFF
--- a/content/en/developers/faq/_index.md
+++ b/content/en/developers/faq/_index.md
@@ -5,34 +5,30 @@ cascade:
   - private: true
 ---
 
-## General
-
-* [Datadog Data Collection, Resolution, and Retention][1]
 
 ## APIs, libraries, and community contributions
 
 ### API
 
-* [Use the webhooks integration to create a Trello card][2]
-* [Post AppDynamics Events to Datadog][3]
-* [Data aggregation with DogStatsD/Threadstats][4]
-* [Submit Metrics to Datadog with Threadstats][5]
+* [Use the webhooks integration to create a Trello card][1]
+* [Post AppDynamics Events to Datadog][2]
+* [Data aggregation with DogStatsD/Threadstats][3]
+* [Submit Metrics to Datadog with Threadstats][4]
 
 ### Libraries and community contributions
 
-* [OmniOS Install From Source][6]
-* [Is it possible to integrate with ThousandEyes?][7]
-* [Deploying the Agent on RaspberryPI][8]
-* [Hubot Script - Request snapshots in chat using the Datadog API][9]
-* [Custom Legacy OpenMetrics Check][10]
+* [OmniOS Install From Source][5]
+* [Is it possible to integrate with ThousandEyes?][6]
+* [Deploying the Agent on RaspberryPI][7]
+* [Hubot Script - Request snapshots in chat using the Datadog API][8]
+* [Custom Legacy OpenMetrics Check][9]
 
-[1]: /developers/faq/data-collection-resolution-retention/
-[2]: /developers/faq/use-our-webhook-integration-to-create-a-trello-card/
-[3]: /developers/faq/how-to-post-appdynamics-events-to-datadog/
-[4]: /developers/faq/data-aggregation-with-dogstatsd-threadstats/
-[5]: /developers/faq/is-there-an-alternative-to-dogstatsd-and-the-api-to-submit-metrics-threadstats/
-[6]: /developers/faq/omnios-and-possibly-smartos-openindiana-nexenta-install-from-source-by-tweaking-the-agent-install-script/
-[7]: /developers/faq/is-it-possible-to-integrate-with-thousandeyes/
-[8]: /developers/faq/deploying-the-agent-on-raspberrypi/
-[9]: /developers/faq/hubot-script-request-snapshots-in-chat-using-the-datadog-api/
-[10]: /developers/faq/legacy-openmetrics/
+[1]: /developers/faq/use-our-webhook-integration-to-create-a-trello-card/
+[2]: /developers/faq/how-to-post-appdynamics-events-to-datadog/
+[3]: /developers/faq/data-aggregation-with-dogstatsd-threadstats/
+[4]: /developers/faq/is-there-an-alternative-to-dogstatsd-and-the-api-to-submit-metrics-threadstats/
+[5]: /developers/faq/omnios-and-possibly-smartos-openindiana-nexenta-install-from-source-by-tweaking-the-agent-install-script/
+[6]: /developers/faq/is-it-possible-to-integrate-with-thousandeyes/
+[7]: /developers/faq/deploying-the-agent-on-raspberrypi/
+[8]: /developers/faq/hubot-script-request-snapshots-in-chat-using-the-datadog-api/
+[9]: /developers/faq/legacy-openmetrics/

--- a/content/en/developers/guide/_index.md
+++ b/content/en/developers/guide/_index.md
@@ -4,6 +4,10 @@ kind: guide
 private: true
 ---
 
+{{< whatsnext desc="General:" >}}
+    {{< nextlink href="developers/guide/data-collection-resolution-retention" tag="General" >}}Datadog Data Collection, Resolution, and Retention{{< /nextlink >}}
+{{< /whatsnext >}}
+
 {{< whatsnext desc="Useful Guides to interact with Datadog APIs:" >}}
     {{< nextlink href="developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags" tag="General" >}}What best practices are recommended for naming metrics and tags?{{< /nextlink >}}
     {{< nextlink href="developers/guide/query-the-infrastructure-list-via-the-api" tag="API">}}Query the Infrastructure List with the API{{< /nextlink >}}

--- a/content/en/developers/guide/data-collection-resolution-retention.md
+++ b/content/en/developers/guide/data-collection-resolution-retention.md
@@ -2,6 +2,8 @@
 title: Datadog Data Collection, Resolution, and Retention
 kind: guide
 disable_sidebar: true
+aliases:
+  - /developers/faq/data-collection-resolution-retention/
 ---
 
 Find below a summary of Datadog data collection, resolution, and retention:

--- a/content/en/developers/guide/data-collection-resolution-retention.md
+++ b/content/en/developers/guide/data-collection-resolution-retention.md
@@ -1,6 +1,6 @@
 ---
 title: Datadog Data Collection, Resolution, and Retention
-kind: faq
+kind: guide
 disable_sidebar: true
 ---
 

--- a/content/en/tracing/visualization/_index.md
+++ b/content/en/tracing/visualization/_index.md
@@ -187,7 +187,7 @@ The active spans for a given time, for a given trace, are all of the leaf spans 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /monitors/create/types/apm/
-[2]: /developers/faq/data-collection-resolution-retention/
+[2]: /developers/guide/data-collection-resolution-retention/
 [3]: /tracing/setup/
 [4]: /tracing/visualization/services_list/
 [5]: /tracing/visualization/services_map/


### PR DESCRIPTION
### What does this PR do?
Converts an existing FAQ to a guide so it's more findable.

### Motivation
DOCS-2882, request from Solutions

### Preview

https://docs-staging.datadoghq.com/kari/docs-2882-retention-info/developers/guide/data-collection-resolution-retention

and this should redirect to that page: https://docs-staging.datadoghq.com/kari/docs-2882-retention-info/developers/faq/data-collection-resolution-retention

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
