### PR TITLE
[rss.md update] add links to event stream and event explorer

### DIFF
--- a/content/en/integrations/rss.md
+++ b/content/en/integrations/rss.md
@@ -37,3 +37,17 @@ Configuration requires:
 **Optional**: Enter a username and a password to access the RSS feed
 
 {{< img src="integrations/rss/rss_setup.png" alt="RSS setup"  >}}
+
+### Validation
+
+Check the [Events Stream][1] and [Events Explorer][2] to view RSS feed activity in Datadog.
+
+## Further Reading
+
+### Documentation
+
+- [Exploring Datadog Events][3]
+
+[1]: https://app.datadoghq.com/event/stream
+[2]: https://app.datadoghq.com/event/explorer
+[3]: https://docs.datadoghq.com/events/#exploring-datadog-events


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds Clarification on where to view RSS feed activity in the Datadog UI
Adds a link to Datadog Events documentation

### Motivation
<!-- What inspired you to submit this pull request?-->
A customer reached out with a request to update our RSS documentation: "Installation was documented and super easy but where to go from there was dropped like a baby on its head it seems."

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
