### PR TITLE
modify cardinality configuration link

### DIFF
--- a/content/en/agent/kubernetes/tag.md
+++ b/content/en/agent/kubernetes/tag.md
@@ -354,6 +354,6 @@ container_env_as_tags:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent/docker/tag/#extract-environment-variables-as-tags
+[1]: /getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
 [2]: /getting_started/tagging/unified_service_tagging
 [3]: /agent/kubernetes/tag/?tab=agent#extract-labels-as-tags


### PR DESCRIPTION
This link: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables has more information on tags cardinality than this link: https://docs.datadoghq.com/agent/docker/tag/?tab=containerizedagent#extract-environment-variables-as-tags.

This should help customers understand the different options they can use to configure their tags.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
