### PR TITLE
Update DD_TAGS delimiter

### DIFF
--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -370,8 +370,8 @@ Added in version 1.18.3. Response header support and entries without tag names a
 : **TracerSettings property**: `GlobalTags`<br>
 If specified, adds all of the specified tags to all generated spans. <br>
 **Example**: `layer:api, team:intake` <br>
-Added in version 1.17.0.
-Note that the delimiter is a comma and a whitespace i.e. ', '.
+Added in version 1.17.0. <br>
+Note that the delimiter is a comma and a whitespace i.e. `, `.
 
 `DD_TRACE_LOG_DIRECTORY`
 : Sets the directory for .NET Tracer logs. <br>

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -369,8 +369,9 @@ Added in version 1.18.3. Response header support and entries without tag names a
 `DD_TAGS`
 : **TracerSettings property**: `GlobalTags`<br>
 If specified, adds all of the specified tags to all generated spans. <br>
-**Example**: `layer:api,team:intake` <br>
+**Example**: `layer:api, team:intake` <br>
 Added in version 1.17.0.
+Note that the delimiter is a comma and a whitespace i.e. ', '.
 
 `DD_TRACE_LOG_DIRECTORY`
 : Sets the directory for .NET Tracer logs. <br>

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -371,7 +371,7 @@ Added in version 1.18.3. Response header support and entries without tag names a
 If specified, adds all of the specified tags to all generated spans. <br>
 **Example**: `layer:api, team:intake` <br>
 Added in version 1.17.0. <br>
-Note that the delimiter is a comma and a whitespace i.e. `, `.
+Note that the delimiter is a comma and a whitespace: `, `.
 
 `DD_TRACE_LOG_DIRECTORY`
 : Sets the directory for .NET Tracer logs. <br>


### PR DESCRIPTION
For compatibility with the DD Agent there also needs to be a whitespace after the comma.

### Preview
https://docs-staging.datadoghq.com/julian.kozianski/update_dd_tags_delimiter_core/tracing/setup_overview/setup/dotnet-framework/?tab=windows

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
