### PR TITLE
Add section for Datadog Agent OTLP ingestion support

### DIFF
--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -303,9 +303,9 @@ Since versions 6.32.0 and 7.32.0, the Datadog Agent supports OTLP traces and met
 
 To connect OpenTelemetry traces and logs so that your application logs monitoring and analysis has the additional context provided by the OpenTelemetry traces, see [Connect OpenTelemetry Traces and Logs][18] for language specific instructions and example code.
 
-## Alternatives to the OpenTelemetry Collector Datadog exporter
+## Other alternatives
 
-Datadog recommends you use the OpenTelemetry Collector Datadog exporter in conjunction with OpenTelemetry tracing clients. However, if that doesn't work for you:
+Datadog recommends you use the OpenTelemetry Collector Datadog exporter or the experimental Datadog Agent OTLP ingestion support in conjunction with OpenTelemetry tracing clients. However, if that doesn't work for you:
 
   - Each of the supported languages also has support for [sending OpenTracing data to Datadog][19].
 

--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -295,7 +295,18 @@ To see more information and additional examples of how you might configure your 
 
 <div class="alert alert-warning">This functionality is experimental and its behavior and configuration may change.</div>
 
-Since versions 6.32.0 and 7.32.0, the Datadog Agent supports OTLP traces and metrics ingestion through both gRPC and HTTP. 
+Since versions 6.32.0 and 7.32.0, the Datadog Agent supports OTLP traces and metrics ingestion through both gRPC and HTTP.
+
+The OTLP ingestion is configured through the `datadog.yaml` file. The following configuration enables the HTTP and gRPC endpoints on the default ports (4317 for gRPC and 4318 for HTTP):
+
+```yaml
+experimental:
+  otlp:
+    grpc_port: 4317
+    http_port: 4318
+```
+
+You can also configure the endpoints by providing the port through the `DD_OTLP_GRPC_PORT` and `DD_OTLP_HTTP_PORT` environment variables. These must be available to both the core Agent and trace Agent.
 
 [Contact Datadog support][23] to get more information on this feature and provide feedback.
 
@@ -338,3 +349,4 @@ Datadog recommends you use the OpenTelemetry Collector Datadog exporter or the e
 [21]: /tracing/setup_overview/open_standards/ruby#opentelemetry
 [22]: /tracing/setup_overview/open_standards/nodejs#opentelemetry
 [23]: https://docs.datadoghq.com/help/
+[24]: https://github.com/open-telemetry/opentelemetry-collector/blob/v0.38.0/receiver/otlpreceiver/config.md

--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -291,6 +291,14 @@ spec:
 
 To see more information and additional examples of how you might configure your collector, see [the OpenTelemetry Collector configuration documentation][5].
 
+## Datadog Agent OTLP ingestion support
+
+<div class="alert alert-warning">This functionality is experimental and its behavior and configuration may change.</div>
+
+Since versions 6.32.0 and 7.32.0, the Datadog Agent supports OTLP traces and metrics ingestion through both gRPC and HTTP. 
+
+[Contact Datadog support][23] to get more information on this feature and provide feedback.
+
 ## Connect OpenTelemetry traces and logs
 
 To connect OpenTelemetry traces and logs so that your application logs monitoring and analysis has the additional context provided by the OpenTelemetry traces, see [Connect OpenTelemetry Traces and Logs][18] for language specific instructions and example code.
@@ -329,3 +337,4 @@ Datadog recommends you use the OpenTelemetry Collector Datadog exporter in conju
 [20]: /tracing/setup_overview/open_standards/python#opentelemetry
 [21]: /tracing/setup_overview/open_standards/ruby#opentelemetry
 [22]: /tracing/setup_overview/open_standards/nodejs#opentelemetry
+[23]: https://docs.datadoghq.com/help/

--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -291,7 +291,7 @@ spec:
 
 To see more information and additional examples of how you might configure your collector, see [the OpenTelemetry Collector configuration documentation][5].
 
-## Datadog Agent OTLP ingestion support
+## OTLP ingest in Datadog Agent
 
 <div class="alert alert-warning">This functionality is beta and its behavior and configuration may change.</div>
 
@@ -316,7 +316,7 @@ To connect OpenTelemetry traces and logs so that your application logs monitorin
 
 ## Other alternatives
 
-Datadog recommends you use the OpenTelemetry Collector Datadog exporter or the experimental Datadog Agent OTLP ingestion support in conjunction with OpenTelemetry tracing clients. However, if that doesn't work for you:
+Datadog recommends you use the OpenTelemetry Collector Datadog exporter or the OTLP Ingest in the Datadog Agent in conjunction with OpenTelemetry tracing clients. However, if that doesn't work for you:
 
   - Each of the supported languages also has support for [sending OpenTracing data to Datadog][19].
 

--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -293,7 +293,7 @@ To see more information and additional examples of how you might configure your 
 
 ## Datadog Agent OTLP ingestion support
 
-<div class="alert alert-warning">This functionality is experimental and its behavior and configuration may change.</div>
+<div class="alert alert-warning">This functionality is beta and its behavior and configuration may change.</div>
 
 Since versions 6.32.0 and 7.32.0, the Datadog Agent supports OTLP traces and metrics ingestion through both gRPC and HTTP.
 
@@ -306,9 +306,9 @@ experimental:
     http_port: 4318
 ```
 
-You can also configure the endpoints by providing the port through the `DD_OTLP_GRPC_PORT` and `DD_OTLP_HTTP_PORT` environment variables. These must be available to both the core Agent and trace Agent.
+You can also configure the endpoints by providing the port through the `DD_OTLP_GRPC_PORT` and `DD_OTLP_HTTP_PORT` environment variables. These must be passed to both the core Agent and trace Agent. 
 
-[Contact Datadog support][23] to get more information on this feature and provide feedback.
+Check [the OpenTelemetry instrumentation documentation][24] to understand how to point your instrumentation to the Agent, and [contact Datadog support][23] to get more information on this feature and provide feedback.
 
 ## Connect OpenTelemetry traces and logs
 
@@ -349,4 +349,4 @@ Datadog recommends you use the OpenTelemetry Collector Datadog exporter or the e
 [21]: /tracing/setup_overview/open_standards/ruby#opentelemetry
 [22]: /tracing/setup_overview/open_standards/nodejs#opentelemetry
 [23]: https://docs.datadoghq.com/help/
-[24]: https://github.com/open-telemetry/opentelemetry-collector/blob/v0.38.0/receiver/otlpreceiver/config.md
+[24]: https://opentelemetry.io/docs/instrumentation/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add section for Datadog Agent OTLP ingestion support.

### Motivation
<!-- What inspired you to submit this pull request?-->

Document in the docs that we have this (experimental) feature

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mx-psi/otlp-section/tracing/setup_overview/open_standards/#datadog-agent-otlp-ingestion-support
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
