### PR TITLE
[agent/kubernetes/tag] Document container labels as tags

### DIFF
--- a/content/en/agent/kubernetes/tag.md
+++ b/content/en/agent/kubernetes/tag.md
@@ -350,6 +350,50 @@ container_env_as_tags:
 {{% /tab %}}
 {{< /tabs >}}
 
+## Container labels as tags
+
+Starting with Agent v7.33+, the Agent can collect container labels and use them as tags to attach to all the metrics corresponding to the container.
+Both `docker` and `containerd` containers are supported. In the case of `containerd` the minimum supported version is v1.5.6 because previous releases didn't propagate labels correctly.
+
+{{< tabs >}}
+{{% tab "Containerized Agent" %}}
+
+To extract a given container label `<CONTAINER_LABEL>` and transform it to a tag key `<TAG_KEY>`, add the following environment variable to the Datadog Agent:
+
+```shell
+DD_CONTAINER_LABELS_AS_TAGS='{"<CONTAINER_LABEL>":"<TAG_KEY>"}'
+```
+
+For example:
+
+```shell
+DD_CONTAINER_LABELS_AS_TAGS='{"app":"kube_app"}'
+```
+
+**Note**: Custom metrics may impact billing. See [Custom Metrics Billing][1] for more details.
+
+[1]: /account_management/billing/custom_metrics
+{{% /tab %}}
+{{% tab "Agent" %}}
+
+To extract a given container label `<CONTAINER_LABEL>` and transform it to a tag key `<TAG_KEY>`, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
+
+```yaml
+container_labels_as_tags:
+  <CONTAINER_LABEL>: <TAG_KEY>
+```
+
+For example:
+
+```yaml
+container_labels_as_tags:
+  app: kube_app
+```
+
+[1]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Documents the "container labels as tags" agent option.


### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/davidor/container-labels-as-tags/agent/kubernetes/tag

### Additional Notes

- This feature is similar to the "container env as tags" documented in previous section of the same file.
- Do not merge before releasing Agent 7.33.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
