### PR TITLE
Add mention about `Global OID reference database` to `NDM Data Collected` page

### DIFF
--- a/content/en/network_monitoring/devices/data.md
+++ b/content/en/network_monitoring/devices/data.md
@@ -8,6 +8,7 @@ aliases:
 ## Metrics
 
 Network Device Monitoring submits specified metrics under the `snmp.*` namespace. The metrics collected are determined by the `[configured profile]`.
+If metrics you want is not on the following list, you can search OID and its name from [Global OID reference database](http://oidref.com/) and add your profiles.
 
 {{< get-metrics-from-git "snmp" >}}
 

--- a/content/en/network_monitoring/devices/data.md
+++ b/content/en/network_monitoring/devices/data.md
@@ -8,7 +8,7 @@ aliases:
 ## Metrics
 
 Network Device Monitoring submits specified metrics under the `snmp.*` namespace. The metrics collected are determined by the `[configured profile]`.
-If metrics you want is not on the following list, you can search OID and its name from [Global OID reference database](http://oidref.com/) and add your profiles.
+If the metrics you want are not on the following list, search for the OID and its name from the [Global OID reference database][1] to add to your profiles.
 
 {{< get-metrics-from-git "snmp" >}}
 
@@ -19,3 +19,5 @@ Network Device Monitoring does not include any events.
 ## Service checks
 
 {{< get-service-checks-from-git "snmp" >}}
+
+[1]: http://oidref.com


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add mention about [Global OID reference database](http://oidref.com/) to [NDM Data Collected](https://docs.datadoghq.com/network_monitoring/devices/data/#metrics) page.

### Motivation

This document looks that we can’t get metrics which is not on the list.
It should clarify that we can get metrics if we add OID and its name to a profile.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
