### PR TITLE
Make the Agent benchmarks more generic

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -256,24 +256,18 @@ Enabling JMX Checks forces the Agent to use more memory depending on the number 
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
 
-* Agent Test version: 6.7.0
 * CPU: ~ 0.12% of the CPU used on average
 * Memory: ~ 60MB of RAM used (RSS memory)
 * Network bandwidth: ~ 86 B/s ▼ | 260 B/s ▲
-* Disk:
-  * Linux 350MB to 400MB depending on the distribution
-  * Windows: 260MB
+* Disk: Up to 1GB
 
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 
-* Agent Test version: 5.24.0
 * CPU: ~ 0.35% of the CPU used on average
 * Memory: ~ 115MB of RAM used.
 * Network bandwidth: ~ 1900 B/s ▼ | 800 B/s ▲
-* Disk:
-  * Linux 312MB
-  * Windows: 295MB
+* Disk: Up to 350MB
 
 **Note**: Since v5.15 of the container Agent, it is recommended to set container resources to at least 256MB due to an added memory cache -- upping the limit is not to account for baseline usage but rather to accommodate temporary spikes. Agent 6 has a much more limited memory footprint.
 
@@ -287,35 +281,23 @@ The results below are obtained from a collection of *110KB of logs per seconds* 
 {{< tabs >}}
 {{% tab "HTTP compression level 6" %}}
 
-* Agent Test version: 6.15.0
 * CPU: ~ 1.5% of the CPU used on average
 * Memory: ~ 95MB of RAM used.
 * Network bandwidth: ~ 14 KB/s ▲
-* Disk:
-  * Linux 350MB to 400MB depending on the distribution
-  * Windows: 260MB
 
 {{% /tab %}}
 {{% tab "HTTP compression level 1" %}}
 
-* Agent Test version: 6.15.0
 * CPU: ~ 1% of the CPU used on average
 * Memory: ~ 95MB of RAM used.
 * Network bandwidth: ~ 20 KB/s ▲
-* Disk:
-  * Linux 350MB to 400MB depending on the distribution
-  * Windows: 260MB
 
 {{% /tab %}}
 {{% tab "HTTP Uncompressed" %}}
 
-* Agent Test version: 6.15.0
 * CPU: ~ 0.7% of the CPU used on average
 * Memory: ~ 90MB of RAM used (RSS memory)
 * Network bandwidth: ~ 200 KB/s ▲
-* Disk:
-  * Linux 350MB to 400MB depending on the distribution
-  * Windows: 260MB
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
### What does this PR do?
Make the Agent disk benchmarks generic since we haven't updated them in 3 years

### Motivation
The specified disk size was way off.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
