### PR TITLE
Document running the OpenTelemetry Collector alongside the Datadog Agent

### DIFF
--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -307,7 +307,18 @@ If running the OpenTelemetry Collector on a host with an existing Datadog Agent,
    ```
    When running in a containerized environment, ensure the `endpoint` setting is configured to use the appropriate hostname for the Datadog Agent.
 
-3. On the OpenTelemetry collector config, replace uses of the Datadog exporter in your metrics and traces pipelines by the OTLP exporter.
+3. On the OpenTelemetry collector config, replace uses of the Datadog exporter in your metrics and traces pipelines by the OTLP exporter. For example, if you have one metrics and one traces pipeline with the Datadog exporter:
+   ```yaml
+   pipelines:
+     metrics:
+      receivers: [...]
+      processors: [...]
+      exporters: [nop/1, nop/2, otlp] # replaced 'datadog' by 'otlp'
+    traces:
+      receivers: [...]
+      processors: [...]
+      exporters: [nop/3, nop/4, otlp] # replaced 'datadog' by 'otlp'
+   ```
 
 This configuration ensures consistent host metadata and centralizes the configuration for host tags and host aliases.
 

--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -297,7 +297,7 @@ If running the OpenTelemetry Collector on a host with an existing Datadog Agent,
 
 1. Enable the Datadog Agent OTLP ingest through gRPC by following the instructions in the [dedicated section][25].
 
-2. Define an OTLP exporter to your metrics and traces pipelines, pointing to the Datadog Agent endpoint. For example, if your Datadog Agent is listening on port 4317 and you are running on the same host, you may define the exporter as:
+2. On the OpenTelemetry collector config, define an OTLP exporter pointing to the Datadog Agent endpoint. For example, if your Datadog Agent is listening on port 4317 and you are running on the same host, you may define the exporter as:
    ```yaml
    exporters:
      otlp:
@@ -307,7 +307,7 @@ If running the OpenTelemetry Collector on a host with an existing Datadog Agent,
    ```
    When running in a containerized environment, ensure the `endpoint` setting is configured to use the appropriate hostname for the Datadog Agent.
 
-3. Replace the Datadog exporter in your metrics and traces pipelines by the OTLP exporter.
+3. On the OpenTelemetry collector config, replace uses of the Datadog exporter in your metrics and traces pipelines by the OTLP exporter.
 
 This configuration ensures consistent host metadata and centralizes the configuration for host tags and host aliases.
 

--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -291,6 +291,26 @@ spec:
 
 To see more information and additional examples of how you might configure your collector, see [the OpenTelemetry Collector configuration documentation][5].
 
+#### Running alongside the Datadog Agent
+
+If running the OpenTelemetry Collector on a host with an existing Datadog Agent, replace the Datadog exporter by an OTLP exporter pointing to the Datadog Agent:
+
+1. Enable the Datadog Agent OTLP ingest through gRPC by following the instructions in the [dedicated section][25].
+
+2. Define an OTLP exporter to your metrics and traces pipelines, pointing to the Datadog Agent endpoint. For example, if your Datadog Agent is listening on port 4317 and you are running on the same host, you may define the exporter as:
+   ```yaml
+   exporters:
+     otlp:
+       endpoint: "0.0.0.0:4317"
+       tls:
+        insecure: true
+   ```
+   When running in a containerized environment, ensure the `endpoint` setting is configured to use the appropriate hostname for the Datadog Agent.
+
+3. Replace the Datadog exporter in your metrics and traces pipelines by the OTLP exporter.
+
+This configuration ensures consistent host metadata and centralizes the configuration for host tags and host aliases.
+
 ## OTLP ingest in Datadog Agent
 
 <div class="alert alert-warning">This functionality is beta and its behavior and configuration may change.</div>
@@ -350,3 +370,4 @@ Datadog recommends you use the OpenTelemetry Collector Datadog exporter or the O
 [22]: /tracing/setup_overview/open_standards/python#opentelemetry
 [23]: /tracing/setup_overview/open_standards/ruby#opentelemetry
 [24]: /tracing/setup_overview/open_standards/nodejs#opentelemetry
+[25]: #otlp-ingest-in-datadog-agent

--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -293,7 +293,7 @@ To see more information and additional examples of how you might configure your 
 
 #### Running alongside the Datadog Agent
 
-If running the OpenTelemetry Collector on a host with an existing Datadog Agent, replace the Datadog exporter by an OTLP exporter pointing to the Datadog Agent:
+If running the OpenTelemetry Collector on a host with an existing Datadog Agent, replace the Datadog exporter with an OTLP exporter pointing to the Datadog Agent:
 
 1. Enable the Datadog Agent OTLP ingest through gRPC by following the instructions in the [dedicated section][25].
 
@@ -307,7 +307,7 @@ If running the OpenTelemetry Collector on a host with an existing Datadog Agent,
    ```
    When running in a containerized environment, ensure the `endpoint` setting is configured to use the appropriate hostname for the Datadog Agent.
 
-3. On the OpenTelemetry collector config, replace uses of the Datadog exporter in your metrics and traces pipelines by the OTLP exporter. For example, if you have one metrics and one traces pipeline with the Datadog exporter:
+3. On the OpenTelemetry collector config, replace uses of the Datadog exporter in your metrics and traces pipelines with the OTLP exporter. For example, if you have one metrics and one traces pipeline with the Datadog exporter, use the following configuration:
    ```yaml
    pipelines:
      metrics:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Document our recommended approach when running the OpenTelemetry Collector alongside the Datadog Agent.

### Motivation
<!-- What inspired you to submit this pull request?-->

This approach avoids some issues that may happen when the host metadata from the Datadog Agent is inconsistent with the OpenTelemetry Collector.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mx-psi/document-agent-collector-setup/tracing/setup_overview/open_standards/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
