### PR TITLE
[DOCS-2953] Include AWS S3 required parameter on policy

### DIFF
--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -116,7 +116,7 @@ Go to your [GCP account][1] and [create a GCS bucket][2] to send your archives t
 {{< tabs >}}
 {{% tab "AWS S3" %}}
 
-Add the following two permission statements to your IAM policies. Edit the bucket names and, if desired, specify the paths that contain your log archives.
+Add the following two permission statements to your IAM policies attached to the role for the AWS Integration. Edit the bucket names and, if desired, specify the paths that contain your log archives. 
 
 **Notes**:
 

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -132,6 +132,9 @@ Add the following two permission statements to your IAM policies. Edit the bucke
       "Sid": "DatadogUploadAndRehydrateLogArchives",
       "Effect": "Allow",
       "Action": ["s3:PutObject", "s3:GetObject"],
+       "Principal": {
+          "AWS": "arn:aws:iam::MY_AWS_ACCOUNTID:role/<MY_ROLE_NAME>"
+       },
       "Resource": [
         "arn:aws:s3:::<MY_BUCKET_NAME_1_/_MY_OPTIONAL_BUCKET_PATH_1>/*",
         "arn:aws:s3:::<MY_BUCKET_NAME_2_/_MY_OPTIONAL_BUCKET_PATH_2>/*"
@@ -141,6 +144,9 @@ Add the following two permission statements to your IAM policies. Edit the bucke
       "Sid": "DatadogRehydrateLogArchivesListBucket",
       "Effect": "Allow",
       "Action": "s3:ListBucket",
+      "Principal": {
+          "AWS": "arn:aws:iam::MY_AWS_ACCOUNTID:role/<MY_ROLE_NAME>"
+       },
       "Resource": [
         "arn:aws:s3:::<MY_BUCKET_NAME_1>",
         "arn:aws:s3:::<MY_BUCKET_NAME_2>"


### PR DESCRIPTION
Now the parameter "Principal" is required by AWS S3 Policies

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Include the Principal parameter on AWS S3 Policy for Log Archives

### Motivation
Now the "Principal" parameter is required by Amazon S3 when we need to create a bucket policy

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
