### PR TITLE
Update V5 Live Processes doc

### DIFF
--- a/content/en/agent/faq/agent-5-process-collection.md
+++ b/content/en/agent/faq/agent-5-process-collection.md
@@ -8,7 +8,7 @@ private: true
 
 **Live Processes is available in Datadog Agent version 5.16.0 and above.**
 See the instructions for standard [Agent installation][1] for platform-specific details. **Note**: the Live Processes is
-not available for the source install method of the Agent.
+Not available for the source install method of the Agent.
 
 Once the Datadog Agent is installed, enable Live Processes collection by editing the [configuration file][2] at:
 

--- a/content/en/agent/faq/agent-5-process-collection.md
+++ b/content/en/agent/faq/agent-5-process-collection.md
@@ -6,8 +6,9 @@ private: true
 
 ## Standard Agent configuration
 
-**Live Processes is available in Datadog Agent version 5.16.0.**
-See the instructions for standard [Agent installation][1] for platform-specific details.
+**Live Processes is available in Datadog Agent version 5.16.0 and above.**
+See the instructions for standard [Agent installation][1] for platform-specific details. **Note**: the Live Processes is
+not available for the source install method of the Agent.
 
 Once the Datadog Agent is installed, enable Live Processes collection by editing the [configuration file][2] at:
 
@@ -57,7 +58,7 @@ In the [dd-agent.yaml][5] manifest used to create the DaemonSet, add the followi
 
 See the standard [DaemonSet installation][6] and the [docker-dd-agent][4] information pages for further documentation.
 
-[1]: https://app.datadoghq.com/account/settings#agent
+[1]: https://app.datadoghq.com/account/settings?agent_version=5#agent
 [2]: /agent/faq/where-is-the-configuration-file-for-the-agent/
 [3]: /agent/guide/agent-commands/#start-stop-restart-the-agent
 [4]: https://github.com/DataDog/docker-dd-agent


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

The source install of the V5 agent doesn't ship the process-agent. Also
the install link was pointing to V7 instructions.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/maxime/fix-v5-process/agent/faq/agent-5-process-collection/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
