### PR TITLE
Update incorrect data access page link

### DIFF
--- a/content/en/logs/guide/logs-rbac.md
+++ b/content/en/logs/guide/logs-rbac.md
@@ -282,7 +282,7 @@ Use the [Data Access page][1] in the Datadog App to:
 
 Refer to the [`logs_read_data` permission section][1] for more information.
 
-[1]: /account_management/rbac/permissions?tab=ui#logs_read_data
+[1]: https://app.datadoghq.com/logs/pipelines/data-access
 {{% /tab %}}
 {{% tab "API" %}}
 


### PR DESCRIPTION
### What does this PR do?
Updates an incorrect data access page link in the logs RBAC docs

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/sarina/data-access-pg/logs/guide/logs-rbac

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
