### PR TITLE
Updating Promises Example

### DIFF
--- a/content/en/tracing/setup_overview/custom_instrumentation/nodejs.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/nodejs.md
@@ -161,10 +161,16 @@ API details for `tracer.trace()` can be found [here][1].
 Promises can be traced with `tracer.trace()` which will automatically finish the span when the returned promise resolves and capture any rejection error automatically.
 
 ```javascript
+const getIngredients = () => {
+    return new Promise((resolve, reject) => {
+        resolve('Salami');
+    });
+};
+
 app.get('/make-sandwich', (req, res) => {
   return tracer.trace('sandwich.make', () => {
     return tracer.trace('get_ingredients', () => getIngredients())
-      .then(() => {
+      .then((ingredients) => {
         return tracer.trace('assemble_sandwich', () => {
           return assembleSandwich(ingredients)
         })


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updated the promises example so it includes an example of `getIngredients` that returns a promise and passing the `ingredients` param to the function.

### Motivation
Providing an example that non JS developers could easily follow.

### Preview
https://docs-staging.datadoghq.com/maximo.bautista/updating-promises-example/tracing/setup_overview/custom_instrumentation/nodejs/?tab=promises#creating-spans

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
