### PR TITLE
[DBM] Enable support for us3

### DIFF
--- a/content/en/database_monitoring/_index.md
+++ b/content/en/database_monitoring/_index.md
@@ -17,7 +17,7 @@ further_reading:
 
 {{< img src="database_monitoring/dbm-main.png" alt="Database Monitoring" style="width:100%;">}}
 
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 

--- a/content/en/database_monitoring/data_collected.md
+++ b/content/en/database_monitoring/data_collected.md
@@ -5,7 +5,7 @@ description: Information about the data that Database Monitoring collects.
 further_reading:
 
 ---
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 

--- a/content/en/database_monitoring/query_metrics.md
+++ b/content/en/database_monitoring/query_metrics.md
@@ -22,7 +22,7 @@ further_reading:
 
 ---
 
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 

--- a/content/en/database_monitoring/query_samples.md
+++ b/content/en/database_monitoring/query_samples.md
@@ -15,7 +15,7 @@ further_reading:
 
 ---
 
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 

--- a/content/en/database_monitoring/setup_mysql/_index.md
+++ b/content/en/database_monitoring/setup_mysql/_index.md
@@ -5,7 +5,7 @@ description: Setting up Database Monitoring on a MySQL database
 disable_sidebar: true
 ---
 
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 

--- a/content/en/database_monitoring/setup_mysql/advanced_configuration.md
+++ b/content/en/database_monitoring/setup_mysql/advanced_configuration.md
@@ -4,7 +4,7 @@ kind: documentation
 description: Advanced Configuration for MySQL Database Monitoring
 
 ---
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 
@@ -54,7 +54,7 @@ instances:
 
 ## Raising the sampling rate
 
-If you have queries that are relatively infrequent or execute quickly, raise the sampling rate by lowering the `collection_interval` value to collect samples more frequently. 
+If you have queries that are relatively infrequent or execute quickly, raise the sampling rate by lowering the `collection_interval` value to collect samples more frequently.
 
 Set the `collection_interval` in your database instance configuration of the Datadog Agent. The default value is 1. Lower the value to a smaller interval:
 
@@ -62,7 +62,7 @@ Set the `collection_interval` in your database instance configuration of the Dat
 instances:
   - dbm: true
     ...
-    query_samples:        
+    query_samples:
         collection_interval: 0.1
 ```
 

--- a/content/en/database_monitoring/setup_mysql/aurora.md
+++ b/content/en/database_monitoring/setup_mysql/aurora.md
@@ -9,7 +9,7 @@ further_reading:
 
 ---
 
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 

--- a/content/en/database_monitoring/setup_mysql/gcsql.md
+++ b/content/en/database_monitoring/setup_mysql/gcsql.md
@@ -9,7 +9,7 @@ further_reading:
 
 ---
 
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 

--- a/content/en/database_monitoring/setup_mysql/rds.md
+++ b/content/en/database_monitoring/setup_mysql/rds.md
@@ -9,7 +9,7 @@ further_reading:
 
 ---
 
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 

--- a/content/en/database_monitoring/setup_mysql/selfhosted.md
+++ b/content/en/database_monitoring/setup_mysql/selfhosted.md
@@ -9,7 +9,7 @@ further_reading:
 
 ---
 
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 

--- a/content/en/database_monitoring/setup_postgres/_index.md
+++ b/content/en/database_monitoring/setup_postgres/_index.md
@@ -5,7 +5,7 @@ description: Setting up Database Monitoring on a Postgres database
 disable_sidebar: true
 ---
 
-{{< site-region region="us3,us5,gov" >}} 
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 
@@ -19,7 +19,7 @@ disable_sidebar: true
 | Postgres 12 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
 | Postgres 13 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
 
-For setup instructions, select your hosting type: 
+For setup instructions, select your hosting type:
 
-{{< partial name="dbm/dbm-setup-postgres" >}} 
+{{< partial name="dbm/dbm-setup-postgres" >}}
 

--- a/content/en/database_monitoring/setup_postgres/advanced_configuration.md
+++ b/content/en/database_monitoring/setup_postgres/advanced_configuration.md
@@ -4,7 +4,7 @@ kind: documentation
 description: Advanced Configuration for Postgres Database Monitoring
 
 ---
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 
@@ -52,6 +52,6 @@ Set the `collection_interval` in your database instance configuration of the Dat
 instances:
   - dbm: true
     ...
-    query_samples:        
+    query_samples:
         collection_interval: 0.1
 ```

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -8,7 +8,7 @@ further_reading:
   text: "Basic Postgres Integration"
 ---
 
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 

--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -8,7 +8,7 @@ further_reading:
   text: "Basic Postgres Integration"
 ---
 
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 

--- a/content/en/database_monitoring/setup_postgres/rds.md
+++ b/content/en/database_monitoring/setup_postgres/rds.md
@@ -8,7 +8,7 @@ further_reading:
   text: "Basic Postgres Integration"
 ---
 
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 

--- a/content/en/database_monitoring/setup_postgres/selfhosted.md
+++ b/content/en/database_monitoring/setup_postgres/selfhosted.md
@@ -9,7 +9,7 @@ further_reading:
 
 ---
 
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 
@@ -238,7 +238,7 @@ PostgreSQL default logging is to `stderr`, and logs do not include detailed info
      #log_destination = 'eventlog'
    ```
 2. To gather detailed duration metrics and make them searchable in the Datadog interface, they should be configured inline with the statement themselves. See below for the recommended configuration differences from above and note that both `log_statement` and `log_duration` options are commented out. See discussion on this topic [here][12].
- 
+
  This config logs all statements, but to reduce the output to those which have a certain duration, set the `log_min_duration_statement` value to the desired minimum duration in milliseconds (check that logging the full SQL statement complies with your organization's privacy requirements):
    ```conf
      log_min_duration_statement = 0    # -1 is disabled, 0 logs all statements

--- a/content/en/database_monitoring/setup_sql_server/selfhosted.md
+++ b/content/en/database_monitoring/setup_sql_server/selfhosted.md
@@ -9,7 +9,7 @@ further_reading:
 
 ---
 
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 

--- a/content/en/database_monitoring/troubleshooting.md
+++ b/content/en/database_monitoring/troubleshooting.md
@@ -4,7 +4,7 @@ kind: documentation
 description: Troubleshoot Database Monitoring setup
 
 ---
-{{< site-region region="us3,us5,gov" >}}
+{{< site-region region="us5,gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
 {{< /site-region >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

We are adding US3 as an officially-supported site for Database Monitoring products.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/justindd/enable-dbm-us3/database_monitoring

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
