### PR TITLE
Update out of date references to admin permissions

### DIFF
--- a/content/en/account_management/billing/custom_metrics.md
+++ b/content/en/account_management/billing/custom_metrics.md
@@ -170,7 +170,7 @@ For metrics not configured with Metrics without Limits™, you pay for for index
 
 |                                      | Indexed Custom Metrics<br>(based on monthly average number of Custom Metrics per hour)                                        |
 |--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
-| Account allotment                    | - Pro: 100 indexed Custom Metrics per host <br>- Enterprise: 200 indexed Custom Metrics  per host                             |
+| Account allotment                    | - Pro: 100 indexed Custom Metrics per host <br>- Enterprise: 200 indexed Custom Metrics per host                             |
 | Usage greater than account allotment | For each 100 indexed custom metrics over the account allotment, you pay an amount that is specified in your current contract. |
 
 For metrics configured with Metrics without Limits™ (tags/aggregations are configured), you pay for ingested custom metrics and indexed custom metrics.
@@ -252,7 +252,7 @@ For metrics not configured with Metrics without Limits™, you pay for for index
 
 |                                      | Indexed Custom Metrics<br>(based on monthly average number of Custom Metrics per hour)                                        |
 |--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
-| Account allotment                    | - Pro: 100 indexed Custom Metrics per host <br>- Enterprise: 200 indexed Custom Metrics  per host                             |
+| Account allotment                    | - Pro: 100 indexed Custom Metrics per host <br>- Enterprise: 200 indexed Custom Metrics per host                             |
 | Usage greater than account allotment | For each 100 indexed custom metrics over the account allotment, you pay an amount that is specified in your current contract. |
 
 For metrics configured with Metrics without Limits™ (tags/aggregations are configured), you pay for ingested custom metrics and indexed custom metrics.
@@ -279,7 +279,7 @@ Learn more about [Metrics without Limits™][2].
 
 ## Tracking custom metrics
 
-Administrative users (those with [Datadog Admin roles][5]) can see the monthly average number of **ingested** and **indexed** custom metrics per hour. The top custom metrics table also lists the average number of **indexed** custom metrics  on the [usage details page][6]. See the [Usage Details][7] documentation for more information.
+Administrative users (those with [Datadog Admin roles][5]) can see the monthly average number of **ingested** and **indexed** custom metrics per hour. The top custom metrics table also lists the average number of **indexed** custom metrics on the [usage details page][6]. See the [Usage Details][7] documentation for more information.
 
 For more real-time tracking of the count of custom metrics for a particular metric name, click into the metric name on the [Metrics Summary page][8]. You can view the number of **ingested** custom metrics and **indexed** custom metrics on the metric's details sidepanel. 
 {{< img src="account_management/billing/custom_metrics/mwl_sidepanel_ingested.jpg" alt="Metrics Summary sidepanel" style="width:80%;">}}
@@ -321,7 +321,7 @@ For billing questions, contact your [Customer Success][10] Manager.
 [3]: /metrics/metrics-without-limits
 [4]: /metrics/types/#metric-types
 [5]: /account_management/users/default_roles/
-[6]: https://app.datadoghq.com/account/usage/hourly
+[6]: https://app.datadoghq.com/billing/usage
 [7]: /account_management/billing/usage_details/
 [8]: https://app.datadoghq.com/metric/summary
 [9]: mailto:sales@datadoghq.com

--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -107,7 +107,7 @@ Use the pop up to restrict access to you, everyone in your organization with you
 
 Creators are always able to edit the dashboard, but other users who are allowed to edit the dashboard can add or remove any role from the access control list (ACL) so long as the final ACL includes one of their roles. For more information about roles, see the [RBAC documentation][10].
 
-If you used the deprecated "read only" check box, the access control list is pre-populated with a list of Admin roles with the "Privileged Access" permission.
+If the dashboard was created with the deprecated "read only" setting, the access control list pre-populates with a list of roles with the User Access Manage permission.
 
 If you manage your Dashboards with Terraform, you can use the latest version of the Datadog Terraform provider to control which roles can edit your Dashboards. For more information, see the [Terraform Dashboard role restriction guide][11].
 

--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -107,7 +107,7 @@ Use the pop up to restrict access to you, everyone in your organization with you
 
 Creators are always able to edit the dashboard, but other users who are allowed to edit the dashboard can add or remove any role from the access control list (ACL) so long as the final ACL includes one of their roles. For more information about roles, see the [RBAC documentation][10].
 
-If the dashboard was created with the deprecated "read only" setting, the access control list pre-populates with a list of roles with the User Access Manage permission.
+If the dashboard was created with the deprecated "read only" setting, the access control list pre-populates with a list of roles that have the Access Management (`user_access_manage`) permission.
 
 If you manage your Dashboards with Terraform, you can use the latest version of the Datadog Terraform provider to control which roles can edit your Dashboards. For more information, see the [Terraform Dashboard role restriction guide][11].
 

--- a/content/en/dashboards/graphing_json/_index.md
+++ b/content/en/dashboards/graphing_json/_index.md
@@ -40,7 +40,7 @@ DASHBOARD_SCHEMA = {
 | `title`              | string           | Title of your dashboard.                                                                                                                  |
 | `description`        | string           | Description of the dashboard.                                                                                                             |
 | `layout_type`        | enum             | Layout type of the dashboard. Available values are: `ordered` or `free`               |
-| `is_read_only`       | Boolean          | Whether this dashboard is read-only. If `true`, only the dashboard author and administrators can apply changes to it.                     |
+| `is_read_only`       | Boolean          | Whether this dashboard is read-only. If `true`, only the dashboard author and users with the User Access Manage permission can modify it.                     |
 | `template_variables` | array of object  | List of template variables for this dashboard. See the [template variable schema documentation](#template-variable-schema) for more details. |
 | `notify_list`        | array of strings | List of handles of users to notify when changes are made to this dashboard.                                                               |
 | `widgets`            | array of object  | List of widgets to display on the dashboard. See the dedicated [Widget JSON schema documentation][3] to build the `WIDGET_SCHEMA`.        |

--- a/content/en/dashboards/graphing_json/_index.md
+++ b/content/en/dashboards/graphing_json/_index.md
@@ -40,7 +40,7 @@ DASHBOARD_SCHEMA = {
 | `title`              | string           | Title of your dashboard.                                                                                                                  |
 | `description`        | string           | Description of the dashboard.                                                                                                             |
 | `layout_type`        | enum             | Layout type of the dashboard. Available values are: `ordered` or `free`               |
-| `is_read_only`       | Boolean          | Whether this dashboard is read-only. If `true`, only the dashboard author and users with the User Access Manage permission can modify it.                     |
+| `is_read_only`       | Boolean          | Whether this dashboard is read-only. If `true`, only the dashboard author and users with the Access Management (`user_access_manage`) permission can modify it.                     |
 | `template_variables` | array of object  | List of template variables for this dashboard. See the [template variable schema documentation](#template-variable-schema) for more details. |
 | `notify_list`        | array of strings | List of handles of users to notify when changes are made to this dashboard.                                                               |
 | `widgets`            | array of object  | List of widgets to display on the dashboard. See the dedicated [Widget JSON schema documentation][3] to build the `WIDGET_SCHEMA`.        |

--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -9,7 +9,7 @@ aliases:
 
 ## Introduction
 
-Previously when you wanted to restrict editing of dashboards created and managed by [Terraform][1], you would use the `is_read_only` attribute to define that editing the dashboard is restricted to the creator or users with the User Access Manage permission in your organization. With the introduction of `restricted_roles`, you can list specific roles that can edit this dashboard within your organization.
+Previously when you wanted to restrict editing of dashboards created and managed by [Terraform][1], you would use the `is_read_only` attribute to define that editing the dashboard is restricted to the creator or users with the Access Management (`user_access_manage`) permission in your organization. With the introduction of `restricted_roles`, you can list specific roles that can edit this dashboard within your organization.
 
 ## Restricting a dashboard
 

--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -9,7 +9,7 @@ aliases:
 
 ## Introduction
 
-Previously when you wanted to restrict editing of dashboards created and managed by [Terraform][1], you would use the `is_read_only` attribute to define that editing the dashboard is restricted to the creator or users with the Privileged Access (Admin) permission in your organization. With the introduction of `restricted_roles`, you can list specific roles that can edit this dashboard within your organization.
+Previously when you wanted to restrict editing of dashboards created and managed by [Terraform][1], you would use the `is_read_only` attribute to define that editing the dashboard is restricted to the creator or users with the User Access Manage permission in your organization. With the introduction of `restricted_roles`, you can list specific roles that can edit this dashboard within your organization.
 
 ## Restricting a dashboard
 

--- a/content/en/monitors/guide/monitor_api_options.md
+++ b/content/en/monitors/guide/monitor_api_options.md
@@ -23,7 +23,7 @@ kind: guide
 - **`renotify_occurrences`** the number of times a monitor re-notifies. It can only be set if `renotify_interval` is set. Default: **None**, it renotifies without a limit.
 - **`escalation_message`** a message to include with a re-notification. Supports the '@username' notification that is allowed elsewhere. Not applicable if `renotify_interval` is `None`. Default: **None**.
 - **`notify_audit`** a Boolean indicating whether tagged users is notified on changes to this monitor. Default: **False**
-- **`locked`** a Boolean indicating whether changes to to this monitor should be restricted to the creator or users with the `user_access_manage` permission. Default: **False**
+- **`locked`** a Boolean indicating whether changes to to this monitor should be restricted to the creator or admins. Default: **False**
 - **`include_tags`** a Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title. Default: **True**. Examples:
 
   - `True`: `[Triggered on {host:h1}] Monitor Title`

--- a/content/en/monitors/guide/monitor_api_options.md
+++ b/content/en/monitors/guide/monitor_api_options.md
@@ -23,7 +23,7 @@ kind: guide
 - **`renotify_occurrences`** the number of times a monitor re-notifies. It can only be set if `renotify_interval` is set. Default: **None**, it renotifies without a limit.
 - **`escalation_message`** a message to include with a re-notification. Supports the '@username' notification that is allowed elsewhere. Not applicable if `renotify_interval` is `None`. Default: **None**.
 - **`notify_audit`** a Boolean indicating whether tagged users is notified on changes to this monitor. Default: **False**
-- **`locked`** a Boolean indicating whether changes to to this monitor should be restricted to the creator or admins. Default: **False**
+- **`locked`** a Boolean indicating whether changes to to this monitor should be restricted to the creator or users with the `user_access_manage` permission. Default: **False**
 - **`include_tags`** a Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title. Default: **True**. Examples:
 
   - `True`: `[Triggered on {host:h1}] Monitor Title`
@@ -68,7 +68,7 @@ Example: `{'ok': 1, 'critical': 1, 'warning': 1}`
 
 - **`aggregation`** A dictionary of `type`, `metric`, and `groupBy`.
   - `type`: Three types are supported: `count`, `cardinality`, and `avg`.
-  - `metric`:  For `cardinality`, use the name of the facet. For `avg`, use the name of the metric. For `count`, put `count` as metric.
+  - `metric`: For `cardinality`, use the name of the facet. For `avg`, use the name of the metric. For `count`, put `count` as metric.
   - `groupBy`: Name of the facet on which you want to group by.
 
 Example: `{"metric": "count","type": "count","groupBy": "core_service"}`

--- a/content/en/monitors/notify/_index.md
+++ b/content/en/monitors/notify/_index.md
@@ -130,7 +130,7 @@ An [event][16] is created anytime a monitor is created, modified, silenced, or d
 
 ### Edit restrictions
 
-If changes are restricted, only the monitor's creator or an administrator can change the monitor. Changes include any updates to the monitor definition and muting for any amount of time.
+If changes are restricted, only the monitor's creator or a user with the User Access Manage permission can change the monitor. Changes include any updates to the monitor definition and muting for any amount of time.
 
 **Note**: The limitations are applied both in the UI and API.
 

--- a/content/en/monitors/notify/_index.md
+++ b/content/en/monitors/notify/_index.md
@@ -130,7 +130,7 @@ An [event][16] is created anytime a monitor is created, modified, silenced, or d
 
 ### Edit restrictions
 
-If changes are restricted, only the monitor's creator or a user with the User Access Manage permission can change the monitor. Changes include any updates to the monitor definition and muting for any amount of time.
+If changes are restricted, only the monitor's creator or an administrator can change the monitor. Changes include any updates to the monitor definition and muting for any amount of time.
 
 **Note**: The limitations are applied both in the UI and API.
 


### PR DESCRIPTION
### What does this PR do?
Update references to the Datadog Admin role or Admin users that are already out of date according to our working spreadsheet: https://docs.google.com/spreadsheets/d/1qAFjGVoxZusiOP8Qlevj5mCvELGuU4BYYc0OiZWLfAA/edit#gid=1935103315

### Motivation
Update the docs that are already out of date due to changes in permissions and access roles. The Datadog Admin role is going away, replaced by more specific roles.

### Preview
https://docs-staging.datadoghq.com/uchen/admin-role/account_management/billing/custom_metrics/?tab=countrate
https://docs-staging.datadoghq.com/uchen/admin-role/dashboards/
https://docs-staging.datadoghq.com/uchen/admin-role/dashboards/graphing_json/
https://docs-staging.datadoghq.com/uchen/admin-role/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit/
https://docs-staging.datadoghq.com/uchen/admin-role/monitors/guide/monitor_api_options/

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
