### PR TITLE
Re-generate the sample kubernetes manifests from the Helm chart 2.28.13

### DIFF
--- a/static/resources/yaml/datadog-agent-aks.yaml
+++ b/static/resources/yaml/datadog-agent-aks.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.28.11"
+    chart: "datadog-2.28.13"
     heritage: "Helm"
     release: "datadog-agent"
   name: datadog-agent-cluster-agent
@@ -216,7 +216,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.28.11"
+    chart: "datadog-2.28.13"
     release: "datadog-agent"
     heritage: "Helm"
 spec:
@@ -552,18 +552,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - hostPath:
-            path: /etc/os-release
-          name: etc-os-release
-        - hostPath:
-            path: /etc/redhat-release
-          name: etc-redhat-release
-        - hostPath:
-            path: /etc/fedora-release
-          name: etc-fedora-release
-        - hostPath:
-            path: /etc/lsb-release
-          name: etc-lsb-release
         - hostPath:
             path: /var/run/datadog/
             type: DirectoryOrCreate

--- a/static/resources/yaml/datadog-agent-aks.yaml
+++ b/static/resources/yaml/datadog-agent-aks.yaml
@@ -1,10 +1,11 @@
+---
 # Source: datadog/templates/cluster-agent-rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.27.8"
+    chart: "datadog-2.28.11"
     heritage: "Helm"
     release: "datadog-agent"
   name: datadog-agent-cluster-agent
@@ -207,6 +208,27 @@ spec:
       name: agentport
       protocol: TCP
 ---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent
+  namespace: default
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.28.11"
+    release: "datadog-agent"
+    heritage: "Helm"
+spec:
+  selector:
+    app: datadog-agent
+  ports:
+    - protocol: UDP
+      port: 8125
+      targetPort: 8125
+      name: dogstatsd
+  internalTrafficPolicy: Local
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -227,7 +249,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -282,7 +304,7 @@ spec:
             - name: DD_EXPVAR_PORT
               value: "6000"
             - name: DD_KUBELET_CLIENT_CA
-              value: /etc/kubernetes/certs/kubeletserver.crt
+              value: "/etc/kubernetes/certs/kubeletserver.crt"
           volumeMounts:
             - name: installinfo
               subPath: install_info
@@ -333,7 +355,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -401,7 +423,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -470,7 +492,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -480,7 +502,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -530,6 +552,18 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
+        - hostPath:
+            path: /etc/os-release
+          name: etc-os-release
+        - hostPath:
+            path: /etc/redhat-release
+          name: etc-redhat-release
+        - hostPath:
+            path: /etc/fedora-release
+          name: etc-fedora-release
+        - hostPath:
+            path: /etc/lsb-release
+          name: etc-lsb-release
         - hostPath:
             path: /var/run/datadog/
             type: DirectoryOrCreate

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -1,10 +1,11 @@
+---
 # Source: datadog/templates/cluster-agent-rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.27.8"
+    chart: "datadog-2.28.11"
     heritage: "Helm"
     release: "datadog-agent"
   name: datadog-agent-cluster-agent
@@ -68,6 +69,12 @@ data:
       collect_dns_stats: true
       max_tracked_connections: 131072
       conntrack_max_state_size: 131072
+      enable_runtime_compiler: false
+      runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build
+      kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers
+      apt_config_dir: /host/etc/apt
+      yum_repos_dir: /host/etc/yum.repos.d
+      zypper_repos_dir: /host/etc/zypp/repos.d
     network_config:
       enabled: true
       conntrack_init_timeout: 10s
@@ -135,6 +142,7 @@ data:
             "fchownat",
             "fcntl",
             "fcntl64",
+            "flock",
             "fstat",
             "fstat64",
             "fstatfs",
@@ -199,6 +207,7 @@ data:
             "recvmmsg",
             "recvmsg",
             "rename",
+            "renameat",
             "restart_syscall",
             "rmdir",
             "rt_sigaction",
@@ -239,6 +248,7 @@ data:
             "stat64",
             "statfs",
             "sysinfo",
+            "symlinkat",
             "tgkill",
             "umask",
             "uname",
@@ -462,6 +472,31 @@ spec:
       name: agentport
       protocol: TCP
 ---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent
+  namespace: default
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.28.11"
+    release: "datadog-agent"
+    heritage: "Helm"
+spec:
+  selector:
+    app: datadog-agent
+  ports:
+    - protocol: UDP
+      port: 8125
+      targetPort: 8125
+      name: dogstatsd
+    - protocol: TCP
+      port: 8126
+      targetPort: 8126
+      name: apm
+  internalTrafficPolicy: Local
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -485,7 +520,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -607,7 +642,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -673,7 +708,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -748,7 +783,7 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -801,12 +836,24 @@ spec:
               mountPath: /host/proc
               mountPropagation: None
               readOnly: true
-            - name: os-release
+            - name: etc-os-release
               mountPath: /host/etc/os-release
               mountPropagation: None
               readOnly: true
+            - name: etc-redhat-release
+              mountPath: /host/etc/redhat-release
+              mountPropagation: None
+              readOnly: true
+            - name: etc-fedora-release
+              mountPath: /host/etc/fedora-release
+              mountPropagation: None
+              readOnly: true
+            - name: etc-lsb-release
+              mountPath: /host/etc/lsb-release
+              mountPropagation: None
+              readOnly: true
         - name: security-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -893,7 +940,7 @@ spec:
               subPath: system-probe.yaml
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -903,7 +950,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -941,7 +988,7 @@ spec:
               value: "yes"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json
@@ -969,6 +1016,18 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
+        - hostPath:
+            path: /etc/os-release
+          name: etc-os-release
+        - hostPath:
+            path: /etc/redhat-release
+          name: etc-redhat-release
+        - hostPath:
+            path: /etc/fedora-release
+          name: etc-fedora-release
+        - hostPath:
+            path: /etc/lsb-release
+          name: etc-lsb-release
         - hostPath:
             path: /var/run/datadog/
             type: DirectoryOrCreate
@@ -1002,9 +1061,6 @@ spec:
         - hostPath:
             path: /etc/group
           name: group
-        - hostPath:
-            path: /etc/os-release
-          name: os-release
         - hostPath:
             path: /var/lib/datadog-agent/logs
           name: pointerdir

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.28.11"
+    chart: "datadog-2.28.13"
     heritage: "Helm"
     release: "datadog-agent"
   name: datadog-agent-cluster-agent
@@ -480,7 +480,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.28.11"
+    chart: "datadog-2.28.13"
     release: "datadog-agent"
     heritage: "Helm"
 spec:

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -34,7 +34,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.28.11"
+    chart: "datadog-2.28.13"
     release: "datadog-agent"
     heritage: "Helm"
 spec:
@@ -345,18 +345,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - hostPath:
-            path: /etc/os-release
-          name: etc-os-release
-        - hostPath:
-            path: /etc/redhat-release
-          name: etc-redhat-release
-        - hostPath:
-            path: /etc/fedora-release
-          name: etc-fedora-release
-        - hostPath:
-            path: /etc/lsb-release
-          name: etc-lsb-release
         - hostPath:
             path: /var/run/datadog/
             type: DirectoryOrCreate

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -1,3 +1,4 @@
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -25,6 +26,31 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent
+  namespace: default
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.28.11"
+    release: "datadog-agent"
+    heritage: "Helm"
+spec:
+  selector:
+    app: datadog-agent
+  ports:
+    - protocol: UDP
+      port: 8125
+      targetPort: 8125
+      name: dogstatsd
+    - protocol: TCP
+      port: 8126
+      targetPort: 8126
+      name: apm
+  internalTrafficPolicy: Local
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -45,7 +71,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -139,7 +165,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -198,7 +224,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -257,7 +283,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -267,7 +293,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -319,6 +345,18 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
+        - hostPath:
+            path: /etc/os-release
+          name: etc-os-release
+        - hostPath:
+            path: /etc/redhat-release
+          name: etc-redhat-release
+        - hostPath:
+            path: /etc/fedora-release
+          name: etc-fedora-release
+        - hostPath:
+            path: /etc/lsb-release
+          name: etc-lsb-release
         - hostPath:
             path: /var/run/datadog/
             type: DirectoryOrCreate

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -1,3 +1,4 @@
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -25,6 +26,31 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent
+  namespace: default
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.28.11"
+    release: "datadog-agent"
+    heritage: "Helm"
+spec:
+  selector:
+    app: datadog-agent
+  ports:
+    - protocol: UDP
+      port: 8125
+      targetPort: 8125
+      name: dogstatsd
+    - protocol: TCP
+      port: 8126
+      targetPort: 8126
+      name: apm
+  internalTrafficPolicy: Local
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -45,7 +71,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -156,7 +182,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -217,7 +243,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -278,7 +304,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -288,7 +314,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -342,6 +368,18 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
+        - hostPath:
+            path: /etc/os-release
+          name: etc-os-release
+        - hostPath:
+            path: /etc/redhat-release
+          name: etc-redhat-release
+        - hostPath:
+            path: /etc/fedora-release
+          name: etc-fedora-release
+        - hostPath:
+            path: /etc/lsb-release
+          name: etc-lsb-release
         - hostPath:
             path: /var/run/datadog/
             type: DirectoryOrCreate

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -34,7 +34,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.28.11"
+    chart: "datadog-2.28.13"
     release: "datadog-agent"
     heritage: "Helm"
 spec:
@@ -368,18 +368,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - hostPath:
-            path: /etc/os-release
-          name: etc-os-release
-        - hostPath:
-            path: /etc/redhat-release
-          name: etc-redhat-release
-        - hostPath:
-            path: /etc/fedora-release
-          name: etc-fedora-release
-        - hostPath:
-            path: /etc/lsb-release
-          name: etc-lsb-release
         - hostPath:
             path: /var/run/datadog/
             type: DirectoryOrCreate

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -1,3 +1,4 @@
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -25,6 +26,27 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent
+  namespace: default
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.28.11"
+    release: "datadog-agent"
+    heritage: "Helm"
+spec:
+  selector:
+    app: datadog-agent
+  ports:
+    - protocol: UDP
+      port: 8125
+      targetPort: 8125
+      name: dogstatsd
+  internalTrafficPolicy: Local
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -45,7 +67,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -156,7 +178,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -216,7 +238,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -277,7 +299,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -287,7 +309,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -341,6 +363,18 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
+        - hostPath:
+            path: /etc/os-release
+          name: etc-os-release
+        - hostPath:
+            path: /etc/redhat-release
+          name: etc-redhat-release
+        - hostPath:
+            path: /etc/fedora-release
+          name: etc-fedora-release
+        - hostPath:
+            path: /etc/lsb-release
+          name: etc-lsb-release
         - hostPath:
             path: /var/run/datadog/
             type: DirectoryOrCreate

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -34,7 +34,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.28.11"
+    chart: "datadog-2.28.13"
     release: "datadog-agent"
     heritage: "Helm"
 spec:
@@ -363,18 +363,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - hostPath:
-            path: /etc/os-release
-          name: etc-os-release
-        - hostPath:
-            path: /etc/redhat-release
-          name: etc-redhat-release
-        - hostPath:
-            path: /etc/fedora-release
-          name: etc-fedora-release
-        - hostPath:
-            path: /etc/lsb-release
-          name: etc-lsb-release
         - hostPath:
             path: /var/run/datadog/
             type: DirectoryOrCreate

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -1,3 +1,4 @@
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -45,6 +46,12 @@ data:
       collect_dns_stats: true
       max_tracked_connections: 131072
       conntrack_max_state_size: 131072
+      enable_runtime_compiler: false
+      runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build
+      kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers
+      apt_config_dir: /host/etc/apt
+      yum_repos_dir: /host/etc/yum.repos.d
+      zypper_repos_dir: /host/etc/zypp/repos.d
     network_config:
       enabled: true
       conntrack_init_timeout: 10s
@@ -112,6 +119,7 @@ data:
             "fchownat",
             "fcntl",
             "fcntl64",
+            "flock",
             "fstat",
             "fstat64",
             "fstatfs",
@@ -176,6 +184,7 @@ data:
             "recvmmsg",
             "recvmsg",
             "rename",
+            "renameat",
             "restart_syscall",
             "rmdir",
             "rt_sigaction",
@@ -216,6 +225,7 @@ data:
             "stat64",
             "statfs",
             "sysinfo",
+            "symlinkat",
             "tgkill",
             "umask",
             "uname",
@@ -252,6 +262,27 @@ data:
       ]
     }
 ---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent
+  namespace: default
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.28.11"
+    release: "datadog-agent"
+    heritage: "Helm"
+spec:
+  selector:
+    app: datadog-agent
+  ports:
+    - protocol: UDP
+      port: 8125
+      targetPort: 8125
+      name: dogstatsd
+  internalTrafficPolicy: Local
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -274,7 +305,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -374,7 +405,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -432,7 +463,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -498,7 +529,7 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -551,9 +582,25 @@ spec:
               mountPath: /host/proc
               mountPropagation: None
               readOnly: true
+            - name: etc-os-release
+              mountPath: /host/etc/os-release
+              mountPropagation: None
+              readOnly: true
+            - name: etc-redhat-release
+              mountPath: /host/etc/redhat-release
+              mountPropagation: None
+              readOnly: true
+            - name: etc-fedora-release
+              mountPath: /host/etc/fedora-release
+              mountPropagation: None
+              readOnly: true
+            - name: etc-lsb-release
+              mountPath: /host/etc/lsb-release
+              mountPropagation: None
+              readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -563,7 +610,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -603,7 +650,7 @@ spec:
               value: "true"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json
@@ -631,6 +678,18 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
+        - hostPath:
+            path: /etc/os-release
+          name: etc-os-release
+        - hostPath:
+            path: /etc/redhat-release
+          name: etc-redhat-release
+        - hostPath:
+            path: /etc/fedora-release
+          name: etc-fedora-release
+        - hostPath:
+            path: /etc/lsb-release
+          name: etc-lsb-release
         - hostPath:
             path: /var/run/datadog/
             type: DirectoryOrCreate

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -270,7 +270,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.28.11"
+    chart: "datadog-2.28.13"
     release: "datadog-agent"
     heritage: "Helm"
 spec:

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -1,3 +1,4 @@
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -25,6 +26,27 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent
+  namespace: default
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.28.11"
+    release: "datadog-agent"
+    heritage: "Helm"
+spec:
+  selector:
+    app: datadog-agent
+  ports:
+    - protocol: UDP
+      port: 8125
+      targetPort: 8125
+      name: dogstatsd
+  internalTrafficPolicy: Local
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -45,7 +67,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -139,7 +161,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -197,7 +219,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -256,7 +278,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -266,7 +288,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -318,6 +340,18 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
+        - hostPath:
+            path: /etc/os-release
+          name: etc-os-release
+        - hostPath:
+            path: /etc/redhat-release
+          name: etc-redhat-release
+        - hostPath:
+            path: /etc/fedora-release
+          name: etc-fedora-release
+        - hostPath:
+            path: /etc/lsb-release
+          name: etc-lsb-release
         - hostPath:
             path: /var/run/datadog/
             type: DirectoryOrCreate

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -34,7 +34,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.28.11"
+    chart: "datadog-2.28.13"
     release: "datadog-agent"
     heritage: "Helm"
 spec:
@@ -340,18 +340,6 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        - hostPath:
-            path: /etc/os-release
-          name: etc-os-release
-        - hostPath:
-            path: /etc/redhat-release
-          name: etc-redhat-release
-        - hostPath:
-            path: /etc/fedora-release
-          name: etc-fedora-release
-        - hostPath:
-            path: /etc/lsb-release
-          name: etc-lsb-release
         - hostPath:
             path: /var/run/datadog/
             type: DirectoryOrCreate

--- a/static/resources/yaml/datadog-agent-windows-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-windows-all-features.yaml
@@ -308,9 +308,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # if the CRI or is not provived we should try to mount the default containerd pipe.
-        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
-        # so with this additional hostPath, by default both are mounted.
+        # If the CRI is not provided, try to mount the default containerd pipe.
+        # By default, "datadog.dockerOrCriSocketPath" mounts the Docker pipe.
+        # So with this additional hostPath, by default, both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket

--- a/static/resources/yaml/datadog-agent-windows-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-windows-all-features.yaml
@@ -34,7 +34,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.28.11"
+    chart: "datadog-2.28.13"
     release: "datadog-agent"
     heritage: "Helm"
 spec:

--- a/static/resources/yaml/datadog-agent-windows-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-windows-all-features.yaml
@@ -1,3 +1,4 @@
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -25,6 +26,31 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent
+  namespace: default
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.28.11"
+    release: "datadog-agent"
+    heritage: "Helm"
+spec:
+  selector:
+    app: datadog-agent
+  ports:
+    - protocol: UDP
+      port: 8125
+      targetPort: 8125
+      name: dogstatsd
+    - protocol: TCP
+      port: 8126
+      targetPort: 8126
+      name: apm
+  internalTrafficPolicy: Local
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -45,7 +71,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -128,7 +154,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -178,7 +204,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -220,7 +246,7 @@ spec:
               mountPath: \\.\pipe\containerd-containerd
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -234,7 +260,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -282,9 +308,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # If the CRI is not provided, try to mount the default containerd pipe.
-        # By default, datadog.dockerOrCriSocketPath mounts the Docker pipe.
-        # With this additional hostPath, both are mounted.
+        # if the CRI or is not provived we should try to mount the default containerd pipe.
+        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
+        # so with this additional hostPath, by default both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket

--- a/static/resources/yaml/datadog-agent-windows-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm.yaml
@@ -244,7 +244,7 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # if the CRI is not provided, try to mount the default containerd pipe.
+        # If the CRI is not provided, try to mount the default containerd pipe.
         # By default, "datadog.dockerOrCriSocketPath" mounts the Docker pipe.
         # So with this additional hostPath, by default, both are mounted.
         - hostPath:

--- a/static/resources/yaml/datadog-agent-windows-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm.yaml
@@ -34,7 +34,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.28.11"
+    chart: "datadog-2.28.13"
     release: "datadog-agent"
     heritage: "Helm"
 spec:

--- a/static/resources/yaml/datadog-agent-windows-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm.yaml
@@ -1,3 +1,4 @@
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -25,6 +26,31 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent
+  namespace: default
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.28.11"
+    release: "datadog-agent"
+    heritage: "Helm"
+spec:
+  selector:
+    app: datadog-agent
+  ports:
+    - protocol: UDP
+      port: 8125
+      targetPort: 8125
+      name: dogstatsd
+    - protocol: TCP
+      port: 8126
+      targetPort: 8126
+      name: apm
+  internalTrafficPolicy: Local
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -45,7 +71,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -118,7 +144,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -167,7 +193,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -181,7 +207,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -218,9 +244,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # If the CRI is not provided, try to mount the default containerd pipe.
-        # By default, datadog.dockerOrCriSocketPath mounts the Docker pipe.
-        # With this additional hostPath, both are mounted.
+        # if the CRI or is not provived we should try to mount the default containerd pipe.
+        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
+        # so with this additional hostPath, by default both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket

--- a/static/resources/yaml/datadog-agent-windows-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm.yaml
@@ -244,9 +244,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # if the CRI or is not provived we should try to mount the default containerd pipe.
-        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
-        # so with this additional hostPath, by default both are mounted.
+        # if the CRI is not provided, try to mount the default containerd pipe.
+        # By default, "datadog.dockerOrCriSocketPath" mounts the Docker pipe.
+        # So with this additional hostPath, by default, both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket

--- a/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
@@ -267,9 +267,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # if the CRI or is not provived we should try to mount the default containerd pipe.
-        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
-        # so with this additional hostPath, by default both are mounted.
+        # If the CRI is not provided, try to mount the default containerd pipe.
+        # By default, "datadog.dockerOrCriSocketPath" mounts the Docker pipe.
+        # So with this additional hostPath, by default, both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket

--- a/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
@@ -1,3 +1,4 @@
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -25,6 +26,31 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent
+  namespace: default
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.28.11"
+    release: "datadog-agent"
+    heritage: "Helm"
+spec:
+  selector:
+    app: datadog-agent
+  ports:
+    - protocol: UDP
+      port: 8125
+      targetPort: 8125
+      name: dogstatsd
+    - protocol: TCP
+      port: 8126
+      targetPort: 8126
+      name: apm
+  internalTrafficPolicy: Local
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -45,7 +71,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -128,7 +154,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -179,7 +205,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -193,7 +219,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -241,9 +267,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # If the CRI is not provided, try to mount the default containerd pipe.
-        # By default, datadog.dockerOrCriSocketPath mounts the Docker pipe.
-        # With this additional hostPath, both are mounted.
+        # if the CRI or is not provived we should try to mount the default containerd pipe.
+        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
+        # so with this additional hostPath, by default both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket

--- a/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
@@ -34,7 +34,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.28.11"
+    chart: "datadog-2.28.13"
     release: "datadog-agent"
     heritage: "Helm"
 spec:

--- a/static/resources/yaml/datadog-agent-windows-logs.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs.yaml
@@ -34,7 +34,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.28.11"
+    chart: "datadog-2.28.13"
     release: "datadog-agent"
     heritage: "Helm"
 spec:

--- a/static/resources/yaml/datadog-agent-windows-logs.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs.yaml
@@ -213,9 +213,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # if the CRI or is not provived we should try to mount the default containerd pipe.
-        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
-        # so with this additional hostPath, by default both are mounted.
+        # If the CRI is not provided, try to mount the default containerd pipe.
+        # By default, "datadog.dockerOrCriSocketPath" mounts the Docker pipe.
+        # So with this additional hostPath, by default, both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket

--- a/static/resources/yaml/datadog-agent-windows-logs.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs.yaml
@@ -1,3 +1,4 @@
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -25,6 +26,27 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent
+  namespace: default
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.28.11"
+    release: "datadog-agent"
+    heritage: "Helm"
+spec:
+  selector:
+    app: datadog-agent
+  ports:
+    - protocol: UDP
+      port: 8125
+      targetPort: 8125
+      name: dogstatsd
+  internalTrafficPolicy: Local
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -45,7 +67,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -129,7 +151,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -143,7 +165,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -191,9 +213,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # If the CRI is not provided, try to mount the default containerd pipe.
-        # By default, datadog.dockerOrCriSocketPath mounts the Docker pipe.
-        # With this additional hostPath, both are mounted.
+        # if the CRI or is not provived we should try to mount the default containerd pipe.
+        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
+        # so with this additional hostPath, by default both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket

--- a/static/resources/yaml/datadog-agent-windows-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla.yaml
@@ -34,7 +34,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog-agent"
-    chart: "datadog-2.28.11"
+    chart: "datadog-2.28.13"
     release: "datadog-agent"
     heritage: "Helm"
 spec:

--- a/static/resources/yaml/datadog-agent-windows-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla.yaml
@@ -192,7 +192,7 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # if the CRI is not provided, try to mount the default containerd pipe.
+        # If the CRI is not provided, try to mount the default containerd pipe.
         # By default, "datadog.dockerOrCriSocketPath" mounts the Docker pipe.
         # So with this additional hostPath, by default, both are mounted.
         - hostPath:

--- a/static/resources/yaml/datadog-agent-windows-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla.yaml
@@ -1,3 +1,4 @@
+---
 # Source: datadog/templates/secret-api-key.yaml
 apiVersion: v1
 kind: Secret
@@ -25,6 +26,27 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-agent
+  namespace: default
+  labels:
+    app: "datadog-agent"
+    chart: "datadog-2.28.11"
+    release: "datadog-agent"
+    heritage: "Helm"
+spec:
+  selector:
+    app: datadog-agent
+  ports:
+    - protocol: UDP
+      port: 8125
+      targetPort: 8125
+      name: dogstatsd
+  internalTrafficPolicy: Local
+---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -45,7 +67,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -119,7 +141,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -133,7 +155,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.32.3"
+          image: "gcr.io/datadoghq/agent:7.32.4"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -170,9 +192,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # If the CRI is not provided, try to mount the default containerd pipe.
-        # By default, datadog.dockerOrCriSocketPath mounts the Docker pipe.
-        # With this additional hostPath, both are mounted.
+        # if the CRI or is not provived we should try to mount the default containerd pipe.
+        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
+        # so with this additional hostPath, by default both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket

--- a/static/resources/yaml/datadog-agent-windows-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla.yaml
@@ -192,9 +192,9 @@ spec:
         - hostPath:
             path: \\.\pipe\docker_engine
           name: runtimesocket
-        # if the CRI or is not provived we should try to mount the default containerd pipe.
-        # by default "datadog.dockerOrCriSocketPath" mount the docker pipe.
-        # so with this additional hostPath, by default both are mounted.
+        # if the CRI is not provided, try to mount the default containerd pipe.
+        # By default, "datadog.dockerOrCriSocketPath" mounts the Docker pipe.
+        # So with this additional hostPath, by default, both are mounted.
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket


### PR DESCRIPTION
### What does this PR do?

Regenerate the sample kubernetes manifests from the latest version of the Helm chart.

### Motivation

Keep those kubernetes manifests up-to-date

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

This PR has been fully generated by the execution of the [`generate.sh` script](https://github.com/DataDog/documentation/blob/master/static/resources/yaml/generate.sh).

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
