### PR TITLE
Remove gov note from GS with sites

### DIFF
--- a/content/en/getting_started/site/_index.md
+++ b/content/en/getting_started/site/_index.md
@@ -25,8 +25,6 @@ Since the Datadog sites may support different Datadog functionalities depending 
 
 ## The Datadog for Government site
 
-<div class="alert alert-warning">The Datadog for Government Site is in early access. To request early access, contact fedramp@datadoghq.com</div>
-
 The Datadog for Government site (US1-FED) is meant to allow US government agencies and partners to monitor their applications and infrastructure. For information about the Datadog for Government site's security and compliance controls and frameworks, as well as how it supports FedRAMP, see the [security page][1].
 
 [1]: https://www.datadoghq.com/security/


### PR DESCRIPTION
### What does this PR do?
Removes the early access note from the Getting Started with Sites guide

### Motivation
No longer early access

### Preview
https://docs-staging.datadoghq.com/sarina/gov-site-note/getting_started/site/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
