### PR TITLE
Include shift-jis as a logfile encoding option

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -567,9 +567,13 @@ The example above will match `/var/log/myapp/log/myfile.log` but `/var/log/myapp
 
 **Note**: The Agent requires read and execute permissions on a directory to list all the available files in it.
 
-## Encode UTF-16 format logs
+## Logfile Encodings
 
-If applications logs are written in UTF-16 format, starting with Datadog Agent **v6.23/v7.23**, users can encode these logs so that they are parsed as expected in the [Logs Explorer][4]. Use the `encoding` parameter in the logs configuration section. Set it to `utf-16-le` for UTF16 little-endian and `utf-16-be` for UTF16 big-endian. Any other value will be ignored and the Agent will read the file as UTF8.
+Without other configuration, the the Datadog Agent assumes that logs are encoded in UTF-8. If application logs are written in a different encoding, users can configure the encoding so that the logs are parsed as expected in the [Logs Explorer][4]. Use the `encoding` parameter in the logs configuration section. The supported values are given below. Any other value will be ignored and the Agent will read the file as UTF8.
+
+ * `utf-16-le` - UTF-16 little-endian (Datadog Agent **v6.23/v7.23**)
+ * `utf-16-be` - UTF-16 big-endian (Datadog Agent **v6.23/v7.23**)
+ * `shift-jis` - Shift-JIS (Datadog Agent **v6.34/v7.34**)
 
 Configuration example:
 

--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -569,8 +569,9 @@ The example above will match `/var/log/myapp/log/myfile.log` but `/var/log/myapp
 
 ## Logfile Encodings
 
-Without other configuration, the the Datadog Agent assumes that logs are encoded in UTF-8. If application logs are written in a different encoding, users can configure the encoding so that the logs are parsed as expected in the [Logs Explorer][4]. Use the `encoding` parameter in the logs configuration section. The supported values are given below. Any other value will be ignored and the Agent will read the file as UTF8.
+By default, the Datadog Agent assumes that logs use UTF-8 encoding. If your application logs use a different encoding, specify the `encoding` parameter in the logs configuration setting.
 
+The list below gives the supported encoding values. If you provide an unsupported value, the Agent ignores the value and reads the file as UTF-8.
  * `utf-16-le` - UTF-16 little-endian (Datadog Agent **v6.23/v7.23**)
  * `utf-16-be` - UTF-16 big-endian (Datadog Agent **v6.23/v7.23**)
  * `shift-jis` - Shift-JIS (Datadog Agent **v6.34/v7.34**)


### PR DESCRIPTION
### What does this PR do?

Adds documentation for a new supported encoding.

### Motivation
https://github.com/DataDog/datadog-agent/pull/10371

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/dustin.mitchell/shift-jis/agent/logs/advanced_log_collection/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
