### PR TITLE
Fix typo - remove 'not'.

### DIFF
--- a/content/en/getting_started/profiler/_index.md
+++ b/content/en/getting_started/profiler/_index.md
@@ -33,7 +33,7 @@ A profiler shows how much "work" each function is doing by collecting data about
 | `renderGraph` | 19%       |
 | Other         | 13%       |
 
-When working on performance problems, this information is important because many programs spend a lot of time in a few places, which may not not be obvious. Guessing at which parts of a program to optimize causes engineers to spend a lot of time with little results. By using a profiler, you can find exactly which parts of the code to optimize.
+When working on performance problems, this information is important because many programs spend a lot of time in a few places, which may not be obvious. Guessing at which parts of a program to optimize causes engineers to spend a lot of time with little results. By using a profiler, you can find exactly which parts of the code to optimize.
 
 If you've used an APM tool, you might think of profiling like a "deeper" tracer that provides a fine grained view of your code without needing any instrumentation.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes a typo where the word `not` is repeated twice:

![image](https://user-images.githubusercontent.com/1835893/148098924-3d055ba1-277d-4b66-a445-eefd3a4156b4.png)

### Motivation
Easy fix.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
