### PR TITLE
Override official service of logs with labels/annotations

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -26,9 +26,7 @@ With these three tags you can:
 
 {{< img src="tagging/unified_service_tagging/overview.mp4" alt="Unified Service Tagging" video=true >}}
 
-### Note:
-The official service of a log can default to the container short-image if no AD logs configuration is present. To override the official service of a log add AD [docker labels/pod annotations][6]: 
-``` "com.datadoghq.ad.logs"='[{"service": "service-name"}]' ```
+**Note**: The official service of a log defaults to the container short-image if no Autodiscovery logs configuration is present. To override the official service of a log, add Autodiscovery [Docker labels/pod annotations][6]. For example: `"com.datadoghq.ad.logs"='[{"service": "service-name"}]'`
 
 ### Requirements
 

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -26,6 +26,10 @@ With these three tags you can:
 
 {{< img src="tagging/unified_service_tagging/overview.mp4" alt="Unified Service Tagging" video=true >}}
 
+### Note:
+The official service of a log can default to the container short-image if no AD logs configuration is present. To override the official service of a log add AD [docker labels/pod annotations][6]: 
+``` "com.datadoghq.ad.logs"='[{"service": "service-name"}]' ```
+
 ### Requirements
 
 - Unified service tagging requires setup of a [Datadog Agent][2] that is 6.19.x/7.19.x or higher.
@@ -182,6 +186,7 @@ containers:
 [3]: https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example#L70
 [4]: /tracing/send_traces/
 [5]: /integrations/statsd/
+[6]: /agent/docker/log/?tab=containerinstallation#examples
 {{% /tab %}}
 
 {{% tab "Docker" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Specifies that the way to override the official service of a log is to add AD docker labels/pod annotations like so: "com.datadoghq.ad.logs"='[{"service": "payment-wstage"}]'
This also includes a link to a different page: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#examples

### Motivation
https://datadog.zendesk.com/agent/tickets/621178
https://datadoghq.atlassian.net/browse/CONS-4408

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
