### PR TITLE
(DOCS-27453) remove non-global english from docs, assorted

### DIFF
--- a/content/en/agent/basic_agent_usage/osx.md
+++ b/content/en/agent/basic_agent_usage/osx.md
@@ -21,7 +21,7 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent for macOS. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
-By default, the Agent is installed in a sandbox located at `/opt/datadog-agent`. You can move this folder wherever you like; however, this documentation assumes a default installation location.
+By default, the Agent is installed in a sandbox located at `/opt/datadog-agent`. You can move this folder anywhere; however, this documentation assumes a default installation location.
 
 **Note**: macOS 10.12 and above are supported by the Agent v6, macOS 10.10 and above by the Agent v5.
 

--- a/content/en/agent/basic_agent_usage/source.md
+++ b/content/en/agent/basic_agent_usage/source.md
@@ -19,7 +19,7 @@ further_reading:
 
 This page outlines the basic features of the Datadog Agent. If you haven't installed the Agent yet, instructions can be found [in the Datadog Agent Integration page][1].
 
-By default, your Agent is installed in its own sandbox at `~/.datadog-agent`. You're free to move this folder wherever you like. However, this article assumes that the Agent is installed in its default location, so be sure to modify the instructions accordingly if you decide to move them.
+By default, your Agent is installed in its own sandbox at `~/.datadog-agent`. You're free to move this folder anywhere. However, this article assumes that the Agent is installed in its default location, so be sure to modify the instructions accordingly if you decide to move them.
 
 ## Commands
 

--- a/content/en/dashboards/screenboards.md
+++ b/content/en/dashboards/screenboards.md
@@ -25,14 +25,14 @@ Screenboards are dashboards with free-form layouts which can include a variety o
 
 Click on any screenboard graph to open an options menu:
 
-| Option                 | Description                                                   |
-|------------------------|---------------------------------------------------------------|
-| View in full screen    | View the graph in [full screen mode][1].                     |
-| View related processes | Jump to the [Live Processes][2] page scoped to your graph.   |
-| View related hosts     | Jump to the [Host Map][3] page scoped to your graph.         |
-| View related logs      | Populate a [Logs][4] panel scoped to your graph.             |
-| View related traces    | Populate a [Traces][5] panel scoped to your graph.          |
-| View related profiles  | Jump to the [Profiling][6] page scoped to your graph.       |
+| Option                 | Description                                                      |
+|------------------------|------------------------------------------------------------------|
+| View in full screen    | View the graph in [full screen mode][1].                         |
+| View related processes | Navigate to the [Live Processes][2] page scoped to your graph.   |
+| View related hosts     | Navigate to the [Host Map][3] page scoped to your graph.         |
+| View related logs      | Populate a [Logs][4] panel scoped to your graph.                 |
+| View related traces    | Populate a [Traces][5] panel scoped to your graph.               |
+| View related profiles  | Navigate to the [Profiling][6] page scoped to your graph.        |
 
 ## Further Reading
 

--- a/content/en/database_monitoring/query_metrics.md
+++ b/content/en/database_monitoring/query_metrics.md
@@ -104,13 +104,13 @@ Datadog collects explain plans continuously, so a given query can have multiple 
 
 {{< img src="database_monitoring/dbm_qd_explain_plans.png" alt="Explain plans information for a query" style="width:100%;">}}
 
-Select a plan to see cost metrics or its JSON. Click **View All Samples for This Plan** to jump over to Query Samples view for [the samples associated with it][4].
+Select a plan to see cost metrics or its JSON. Click **View All Samples for This Plan** to navigate to Query Samples view for [the samples associated with it][4].
 
 Not all queries have explain plans, for various reasons, including what type of query it is, or various configuration settings. See [Troubleshooting][5] for more details.
 
 ### Hosts running this query
 
-The **Hosts Running This Query** tab lists the hosts that run this query, with a context menu that lets you jump to related information for the hosts, such as logs or the network data, which can be useful for troubleshooting where latency problems are coming from.
+The **Hosts Running This Query** tab lists the hosts that run this query, with a context menu that lets you navigate to related information for the hosts, such as logs or the network data, which can be useful for troubleshooting where latency problems are coming from.
 
 {{< img src="database_monitoring/dbm_qd_hosts_running_query_menu.png" alt="Host action menu for pivoting to more information" style="width:100%;">}}
 

--- a/content/en/database_monitoring/query_samples.md
+++ b/content/en/database_monitoring/query_samples.md
@@ -42,7 +42,7 @@ Click **Options** to add columns to the table. Click on column headers to sort b
 
 Explain plan cost is a unitless measure that the database uses to compare two plans with each other. It roughly corresponds to number of _things_ on the database---blocks or pages---but it is primarily useful for relative comparisons of two plans, not in absolute terms for a single plan. Explain plan cost calculation helps the database choose which plan it's going to use.
 
-The Query Samples page lets you filter, sort, and compare the explain plan costs of multiple queries. In this context, explain plan cost is not to be taken absolutely. A query with an explain plan cost of 8.5 is not necessarily performing better than one with a cost of 8.7. But if two queries have vastly different costs when you'd expect them to be similar, it can be fruitful to investigate why. Also, you can sort your queries by cost to see what your expensive queries are, separate from external factors like network latency.
+The Query Samples page lets you filter, sort, and compare the explain plan costs of multiple queries. In this context, explain plan cost is not to be taken absolutely. A query with an explain plan cost of 8.5 is not necessarily performing better than one with a cost of 8.7. But if two queries have vastly different costs when you'd expect them to be similar, it can be beneficial to investigate why. Also, you can sort your queries by cost to see what your expensive queries are, separate from external factors like network latency.
 
 ### Indexes
 
@@ -58,7 +58,7 @@ Filter or sort to find queries that take the longest to run over the time frame 
 
 ### Sample details
 
-Click on a query in the table to open its Sample Details page. Use the Source, Host, and Client IP tiles at the top to filter the Sample Queries page by the values for this sample, or to jump to other Datadog information such as the host's dashboard or Network traffic metrics for the client IP.
+Click on a query in the table to open its Sample Details page. Use the Source, Host, and Client IP tiles at the top to filter the Sample Queries page by the values for this sample, or to navigate to other Datadog information such as the host's dashboard or Network traffic metrics for the client IP.
 
 {{< img src="database_monitoring/dbm_sd_actions.png" alt="Sample details action tiles" style="width:100%;">}}
 

--- a/content/en/developers/_index.md
+++ b/content/en/developers/_index.md
@@ -42,7 +42,7 @@ Still not seeing the type of data that you need? Developers have several choices
 
 ### Custom check versus integration
 
-The primary difference between custom checks and integrations is that integrations are reusable components that can become part of the Datadog's ecosystem. They generally take more effort (time to develop) and are best suited for general use-cases such as application frameworks, open source projects, or commonly used software. For more niche scenarios, such as monitoring services that are not widely used outside your team or organization, writing a custom check may be the most efficient option. 
+The primary difference between custom checks and integrations is that integrations are reusable components that can become part of the Datadog's ecosystem. They generally take more effort (time to develop) and are best suited for general use-cases such as application frameworks, open source projects, or commonly used software. For more unique scenarios, such as monitoring services that are not widely used outside your team or organization, writing a custom check may be the most efficient option. 
 
 However, you may choose to write an integration instead of a custom check if your particular use-case requires you to publish and deploy your solution as a Python wheel (`.whl`). Metrics emitted through custom checks are considered custom metrics, which have a cost associated based on your subscription plan. However, once an integration gets accepted into the Datadog ecosystem, metrics that it emits are no longer considered custom metrics, and do not count against your custom metric count. For more information about how this might impact cost, see [Datadog Pricing][8].
 
@@ -57,7 +57,7 @@ When deciding how to send unsupported data to Datadog, the main considerations a
 | Private integration | Medium | Yes            | Python   |
 | Public integration  | High   | No             | Python   |
 
-If you are a partner developing for the Datadog Marketplace or community integrations, jump straight to the [Marketplace][10] and [building an integration][6] docs.
+If you are a partner developing for the Datadog Marketplace or community integrations, navigate directly to the [Marketplace][10] and [building an integration][6] docs.
 
 ### What's the difference between a custom check and a service check?
 

--- a/content/en/developers/guide/calling-on-datadog-s-api-with-the-webhooks-integration.md
+++ b/content/en/developers/guide/calling-on-datadog-s-api-with-the-webhooks-integration.md
@@ -13,7 +13,7 @@ You can also set up webhook notifications to call on [Datadog's API][3] if, for 
 
 Each webhook must be set up with a name (to be referenced in monitors) and a URL (to be pinged by the webhook). For submitting a call to the Datadog API, select "Use custom payload" and add your custom payload to the subsequent field.
 
-* The **name field**: whatever you like, as long as it is unique among all the other webhook name fields.
+* The **name field**: anything, as long as it is unique among all the other webhook name fields.
 
 * The **url field**: the URL used when pinging the API. It looks like this:
 `https://api.datadoghq.com/api/v1/<API_ENDPOINT>?api_key=<DATADOG_API_KEY>`

--- a/content/en/getting_started/tagging/_index.md
+++ b/content/en/getting_started/tagging/_index.md
@@ -100,7 +100,7 @@ After you have [assigned tags][3] at the host and [integration][9] level, start 
 | [Monitors][13]       | Manage monitors, create monitors, or manage downtime                                             |
 | [Metrics][14]        | Filter and group with the metric explorer                                                        |
 | [Integrations][15]   | Optionally limit metrics for AWS, Google Cloud, and Azure                                        |
-| [APM][16]            | Filter Analytics or jump to other areas with the service map                                 |
+| [APM][16]            | Filter Analytics or navigate to other areas with the service map                                 |
 | [Notebooks][17]      | Filter and group metrics on graphs                                                               |
 | [Logs][18]           | Filter logs search, analytics, patterns, live tail, and pipelines                                |
 | [SLOs][19]           | Search for SLOs, grouped metric-based SLOs, grouped monitor-based SLOs                           |

--- a/content/en/getting_started/tagging/using_tags.md
+++ b/content/en/getting_started/tagging/using_tags.md
@@ -243,7 +243,7 @@ For [Trace Search][1], filter traces with tags using the search bar or facet che
 {{% /tab %}}
 {{% tab "Service Map" %}}
 
-After [assigning tags][1], use the Service Map to jump to different areas of the application by clicking on a particular service. In the example below, view [Analytics][2], [Monitors][3], [Logs][4], and the [Host Map][5] filtered by the tag `service:coffee-house`.
+After [assigning tags][1], use the Service Map to navigate to different areas of the application by clicking on a particular service. In the example below, view [Analytics][2], [Monitors][3], [Logs][4], and the [Host Map][5] filtered by the tag `service:coffee-house`.
 
 {{< img src="tagging/using_tags/servicemaptags.png" alt="Service Map Tags" style="width:80%;">}}
 

--- a/content/en/logs/explorer/facets.md
+++ b/content/en/logs/explorer/facets.md
@@ -153,7 +153,7 @@ Hidden facets have no impact aside from the log explorer (for instance: live tai
 
 #### Hidden facets and teammates
 
-Hiding facets is specific to your own troubleshooting context and won't impact your teammates' view, unless you update a [Saved View][24]. Hidden facets is part of the context saved in a saved view.
+Hiding facets is specific to your own troubleshooting context and does not impact your teammates' view, unless you update a [Saved View][24]. Hidden facets is part of the context saved in a saved view.
 
 ### Group facets
 
@@ -163,7 +163,7 @@ Facets are grouped into meaningful themes, to ease navigation in the facet list.
 
 ### Filter facets
 
-Use the search box on facets to scope down the whole facet list and jump more quickly to the one you need to interact with. Facet search uses both facet display name and facet field name to scope results.
+Use the search box on facets to scope down the whole facet list and navigate more quickly to the one you need to interact with. Facet search uses both facet display name and facet field name to scope results.
 
 {{< img src="logs/explorer/facet/search_facet.png" alt="Search Facet" style="width:30%;">}}
 

--- a/content/en/logs/explorer/side_panel.md
+++ b/content/en/logs/explorer/side_panel.md
@@ -41,11 +41,11 @@ The **View in context** button updates the search request in order to show you t
 
 Click on the **Metrics** tab and access underlying infrastructure metrics in a 30 minutes time frame around the log.
 
-Interact with **Host** in the upper reserved attributes section, the related [host dashboard][5], or [network page][6]. Interact with **Container** sections to jump to the [container page][7] scoped with the underlying parameters.
+Interact with **Host** in the upper reserved attributes section, the related [host dashboard][5], or [network page][6]. Interact with **Container** sections to navigate to the [container page][7] scoped with the underlying parameters.
 
 {{< img src="logs/explorer/side_panel/infra.mp4" alt="Hub to Infra" video=true style="width:100%;">}}
 
-In case logs comes from a serverless source, the Host Section is replaced with a Serverless section that links jump to the corresponding [serverless page][8].
+When logs come from a serverless source, the Host Section is replaced with a Serverless section that links to the corresponding [serverless page][8].
 
 {{< img src="logs/explorer/side_panel/infra-serverless.png" alt="Hub to Serverless" style="width:80%;">}}
 

--- a/content/en/mobile/_index.md
+++ b/content/en/mobile/_index.md
@@ -87,7 +87,7 @@ On the Incidents page, you can view, search and filter all incidents that you ha
 
 {{< img src="mobile/incident_widget.png" alt="Datadog incident mobile widget displayed on Android and iOS devices" responsive="true" style="width:100%; background:none; border:none; box-shadow:none;">}}
 
-View your [open incidents][13] from your mobile home screen with Datadog widgets.
+View your [open incidents][12] from your mobile home screen with Datadog widgets.
 
 To dive deeper into issues, tap any open incident displayed in the widget to have it open with more details in the Datadog mobile app. 
 
@@ -196,7 +196,7 @@ Delete a widget by long pressing, dragging, and dropping the widget to the **Rem
 
 {{< img src="mobile/slo_widget.png" alt="Application Uptime SLO widgets displayed on Android and iOS devices" responsive="true" style="width:100%; background:none; border:none; box-shadow:none;">}}
 
-View your [SLOs][14] from your mobile home screen with Datadog widgets. You can add any SLOs from your organization as a widget, along with a timeframe.
+View your [SLOs][13] from your mobile home screen with Datadog widgets. You can add any SLOs from your organization as a widget, along with a timeframe.
 
 Timeframe options are:
 - 7 days
@@ -207,7 +207,7 @@ Timeframe options are:
 - Week to date
 - Month to date
 
-You can also specify a dashboard that opens by default when you tap on an SLOs widget, allowing you to quickly dig deeper into your metrics.
+You can also specify a dashboard that opens by default when you tap on an SLOs widget, allowing you to quickly investigate further into your metrics.
 
 **Note**: If you do not specify a dashboard that opens by default, tapping an SLOs widget opens the Datadog app.
 
@@ -306,7 +306,7 @@ Delete a widget by long pressing, dragging, and dropping the widget to the "Remo
 
 {{< img src="mobile/monitor_widget.png" alt="Configured monitor widgets displayed on Android and iOS screens" responsive="true" style="width:100%; background:none; border:none; box-shadow:none;">}}
 
-View your [monitors][15] from your home screen with Datadog widgets. Tap any cell to open the **Monitor Search** screen in the app, with your monitors already filled in.
+View your [monitors][14] from your home screen with Datadog widgets. Tap any cell to open the **Monitor Search** screen in the app, with your monitors already filled in.
 
 **Note**: If you do not have any monitor saved views, the widget shows you all monitors by default.
 
@@ -404,7 +404,7 @@ Delete a widget by long pressing, dragging, and dropping the widget on the "Remo
 
 {{< img src="mobile/shortcut_shadow.png" style="width:100%; background:none; border:none; box-shadow:none;" alt="Quick Actions">}}
 
-Long-press the app icon to display a quick-action sheet of your top five [Frequently Viewed By Me][16] dashboards for iOS (measured by view count and recency), or your five most opened dashboards on mobile for Android. Tap a result to open the dashboard in-app.
+Long-press the app icon to display a quick-action sheet of your top five [Frequently Viewed By Me][15] dashboards for iOS (measured by view count and recency), or your five most opened dashboards on mobile for Android. Tap a result to open the dashboard in-app.
 
 ## Search from home screen
 
@@ -426,7 +426,7 @@ With the shortcut, you can access your dashboards and monitors through three key
 
 {{< img src="mobile/siri_shadow.png" style="width:100%; background:none; border:none; box-shadow:none;" alt="Shortcuts">}}
 
-For more information about Siri shortcuts and suggestions, read the [Apple Siri documentation][17].
+For more information about Siri shortcuts and suggestions, read the [Apple Siri documentation][16].
 
 ## Handoff
 
@@ -439,7 +439,7 @@ For Handoff to work, each device must:
 - Have Wi-Fi enabled
 - Have Handoff enabled
 
-For more information about Handoff, read the [Apple Handoff documentation][18].
+For more information about Handoff, read the [Apple Handoff documentation][17].
 
 ## Account
 
@@ -447,7 +447,7 @@ Switch organizations or log out from the Account page.
 
 ## Troubleshooting
 
-For help with troubleshooting, [contact Datadog support][19]. You can also send a message in the [Datadog public Slack][20] [#mobile-app][21] channel.
+For help with troubleshooting, [contact Datadog support][18]. You can also send a message in the [Datadog public Slack][19] [#mobile-app][20] channel.
 
 ### Further Reading
 
@@ -465,12 +465,11 @@ For help with troubleshooting, [contact Datadog support][19]. You can also send 
 [10]: https://app.datadoghq.com/dashboard/lists
 [11]: /dashboards/
 [12]: /monitors/incident_management
-[13]: /monitors/incident_management
-[14]: /dashboards/widgets/slo/#setup
-[15]: /logs/explorer/saved_views/
-[16]: https://app.datadoghq.com/dashboard/lists/preset/5
-[17]: https://support.apple.com/en-us/HT209055
-[18]: https://support.apple.com/en-us/HT209455
-[19]: /help/
-[20]: https://chat.datadoghq.com/
-[21]: https://datadoghq.slack.com/archives/C0114D5EHNG
+[13]: /dashboards/widgets/slo/#setup
+[14]: /logs/explorer/saved_views/
+[15]: https://app.datadoghq.com/dashboard/lists/preset/5
+[16]: https://support.apple.com/en-us/HT209055
+[17]: https://support.apple.com/en-us/HT209455
+[18]: /help/
+[19]: https://chat.datadoghq.com/
+[20]: https://datadoghq.slack.com/archives/C0114D5EHNG

--- a/content/en/monitors/manage/search.md
+++ b/content/en/monitors/manage/search.md
@@ -67,9 +67,9 @@ Check any number of boxes to find your monitors. The following rules apply:
 
 ## Saved view
 
-Leverage saved views to quickly jump to pre-set views in order to find monitors relevant to a given context like the monitors for your team or muted for more than 60 days:
+Leverage saved views to quickly navigate to pre-set views in order to find monitors relevant to a given context like the monitors for your team or muted for more than 60 days:
 
-{{< img src="monitors/manage_monitor/overview.jpg" alt="Saved Views selection"  style="width:90%;" >}}
+{{< img src="monitors/manage_monitor/overview.jpg" alt="Saved Views selection" style="width:90%;" >}}
 
 Saved views are visible by everyone in your organization.
 Technically, a saved view keeps track of:
@@ -78,7 +78,7 @@ Technically, a saved view keeps track of:
 
 ### Default view
 
-{{< img src="monitors/manage_monitor/default.jpg" alt="Default view"  style="width:50%;" >}}
+{{< img src="monitors/manage_monitor/default.jpg" alt="Default view" style="width:50%;" >}}
 
 Your existing Manage Monitor view is your default saved view. This configuration is only accessible and viewable to you and updating this configuration does not have any impact on your organization.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes some colloquialisms/phraseology/not global english friendly stuff from the docs, including:

* "whatever/wherever you like"
* "fruitful"
* "niche"
* "dig deeper" (famous cousin of "drill down")
* "jump"

![kitten-jump](https://user-images.githubusercontent.com/605271/148138508-d381ec12-07a6-4737-af8f-9310ca8d8dbc.gif)


### Motivation
OKR wrap up!


### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
