### PR TITLE
DOCS-2773 Synthetics HTTP Tests and Multistep API Tests Edits

### DIFF
--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -199,6 +199,9 @@ A test is considered `FAILED` if it does not satisfy one or more assertions or i
 
 These reasons include the following:
 
+`CONNREFUSED`
+: No connection could be made because the target machine actively refused it.
+
 `CONNRESET`
 : The connection was abruptly closed by the remote server. Possible causes include the web server encountering an error or crashing while responding, or loss of connectivity of the web server.
 

--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -243,6 +243,9 @@ To display your list of variables, type `{{` in your desired field.
 
 A test is considered `FAILED` if a step does not satisfy one or several assertions or if a step's request prematurely failed. In some cases, the test can indeed fail without being able to test the assertions against the endpoint, these reasons include:
 
+`CONNREFUSED`
+: No connection could be made because the target machine actively refused it.
+
 `CONNRESET`
 : The connection was abruptly closed by the remote server. Possible causes include the webserver encountering an error or crashing while responding, or loss of connectivity of the webserver.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds `CONNREFUSED` to the table of error messages for test failures.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-2773

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/synthetics-connrefused-error-message/synthetics/api_tests/http_tests/?tab=requestoptions#test-failure

https://docs-staging.datadoghq.com/alai97/synthetics-connrefused-error-message/synthetics/multistep#test-failure

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
