### PR TITLE
Fix duplicate words "Would would" on Autodiscovery Auto-Configuration

### DIFF
--- a/content/en/agent/faq/auto_conf.md
+++ b/content/en/agent/faq/auto_conf.md
@@ -56,7 +56,7 @@ To disable the Agent from using the `auto_conf.yaml` configuration you can add t
 ```
 DD_IGNORE_AUTOCONF="redisdb istio"
 ```
-Would would have the Agent ignore the [`redisdb.d/auto_conf.yaml`][38] and [`istio.d/auto_conf.yaml`][22] file and avoid automatically setting up these integrations.
+would have the Agent ignore the [`redisdb.d/auto_conf.yaml`][38] and [`istio.d/auto_conf.yaml`][22] file and avoid automatically setting up these integrations.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes typo "Would would" on page https://docs.datadoghq.com/agent/faq/auto_conf/#disabling-auto-configuration

### Motivation
I really like proper grammar.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ben.streeter/autoconftypo-1/agent/faq/auto_conf/#disabling-auto-configuration

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
