### PR TITLE
[DOCS-2982] Add datadog-agent install instructions for macOS

### DIFF
--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -43,7 +43,9 @@ Configuring log collection depends on your current environment. Choose one of th
 {{< tabs >}}
 {{% tab "Container Installation" %}}
 
-To run a [Docker container][1] that embeds the Datadog Agent to monitor your host, use the following command:
+To run a [Docker container][1] that embeds the Datadog Agent to monitor your host, use the following command for your respective operating system:
+
+### Linux
 
 ```shell
 docker run -d --name datadog-agent \
@@ -60,7 +62,7 @@ docker run -d --name datadog-agent \
            gcr.io/datadoghq/agent:latest
 ```
 
-**Note**: On Windows systems, run this command without any volume mounts. That is:
+### Windows
 
 ```shell
 docker run -d --name datadog-agent \
@@ -71,6 +73,23 @@ docker run -d --name datadog-agent \
            -e DD_CONTAINER_EXCLUDE="name:datadog-agent" \
            -v \\.\pipe\docker_engine:\\.\pipe\docker_engine \
            -v c:\programdata\docker\containers:c:\programdata\docker\containers:ro
+           gcr.io/datadoghq/agent:latest
+```
+
+### macOS
+
+Note: Add the path `/opt/datadog-agent/run` under Docker Desktop -> Settings -> Resources -> File sharing.
+
+```shell
+docker run -d --name datadog-agent \
+           -e DD_API_KEY=<DATADOG_API_KEY> \
+           -e DD_LOGS_ENABLED=true \
+           -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
+           -e DD_LOGS_CONFIG_DOCKER_CONTAINER_USE_FILE=true \
+           -e DD_CONTAINER_EXCLUDE="name:datadog-agent" \
+           -v /var/run/docker.sock:/var/run/docker.sock:ro \
+           -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
+           -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
            gcr.io/datadoghq/agent:latest
 ```
 

--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -78,7 +78,7 @@ docker run -d --name datadog-agent \
 
 ### macOS
 
-Note: Add the path `/opt/datadog-agent/run` under Docker Desktop -> Settings -> Resources -> File sharing.
+Add the path `/opt/datadog-agent/run` under Docker Desktop -> Settings -> Resources -> File sharing.
 
 ```shell
 docker run -d --name datadog-agent \


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

- Add instructions on how to run the `datadog-agent` container directly on macOS.

### Motivation
<!-- What inspired you to submit this pull request?-->

When setting up reporting from our apps into DD at work, I had issues getting this to work on my macOS (M1) laptop. I resorted to running an Ubuntu VM, where the `datadog-agent` worked straight away as expected. 

After reaching out to you [in Slack](https://datadoghq.slack.com/archives/C4JREERCY/p1640010574176000) and after having tinkered on my own and with my colleague @rbuzu, which finally got the `datadog-agent` to run as expected in macOS without the use of a VM, I figured the docs could need some updating to help others who are attempting the same thing.

This entailed registering a path in Docker Desktop and I also believe the following mounts can be removed (as they do not exist on macOS):

```
    -v /proc/:/host/proc/:ro \
    -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
```
### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fredrikaverpil:patch-1/agent/docker/log/?tab=containerinstallation

### Additional Notes
<!-- Anything else we should know when reviewing?-->

- One concern I have is I am not sure exactly if the `/var/lib/docker/containers` mount actually works on macOS, as I haven't attempted to make use of it. Perhaps this path also must be entered into Docker Desktop's settings under Resources/File Sharing? Either way, I wouldn't expect any containers running on macOS to write logs to that location by default, since that path does not exist on my system.
- Since some mounts do not exist on macOS, perhaps it would be good to mention that metrics taken from these mounts won't work in macOS. Perhaps it would even be good to put in a notice on that it's not recommended to run datadog-agent in production on anything other than Linux?

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
