### PR TITLE
Mention the existence of the CURRENT key file

### DIFF
--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -116,7 +116,7 @@ Otherwise, the command returns a non-0 exit code and the following output:
 package gpg-pubkey-fd4bf915 is not installed
 ```
 
-Alternatively, you can check if you `datadog.repo` file contains https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public as one of the `gpgkey` entries. This key file will be updated with the new key as soon as it is rotated.
+Alternatively, you can check if you `datadog.repo` file contains https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public as one of the `gpgkey` entries. This key file will be updated with the new key as soon as it is in use.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -116,7 +116,7 @@ Otherwise, the command returns a non-0 exit code and the following output:
 package gpg-pubkey-fd4bf915 is not installed
 ```
 
-Alternatively, you can check if you `datadog.repo` file contains https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public as one of the `gpgkey` entries. This key file will be updated with the new key as soon as it is in use.
+Alternatively, check if your `datadog.repo` file contains `https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public` as one of the `gpgkey` entries. This key file will be updated with the new key as soon as it is in use.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -116,6 +116,8 @@ Otherwise, the command returns a non-0 exit code and the following output:
 package gpg-pubkey-fd4bf915 is not installed
 ```
 
+Alternatively, you can check if you `datadog.repo` file contains https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public as one of the `gpgkey` entries. This key file will be updated with the new key as soon as it is rotated.
+
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
### What does this PR do?

Add a note about the `DATADOG_RPM_KEY_CURRENT.public` file.

### Motivation
On RPM-based distros we point to this file since yum/dnf re-download
the key files each time a signature doesn't match the existing keys.

### Preview
https://docs-staging.datadoghq.com/albertvaka/agent-key-rotation-current/agent/faq/linux-agent-2022-key-rotation/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
