### PR TITLE
Add eks_fargate_node to agent tags on k8s

### DIFF
--- a/content/en/agent/kubernetes/tag.md
+++ b/content/en/agent/kubernetes/tag.md
@@ -59,6 +59,7 @@ The Agent can autodiscover and attach tags to all data emitted by the entire pod
   | `image_name`                  | Low          | Pod spec                                                                | N/A                                                 |
   | `short_image`                 | Low          | Pod spec                                                                | N/A                                                 |
   | `image_tag`                   | Low          | Pod spec                                                                | N/A                                                 |
+  | `eks_fargate_node`            | Low          | Pod spec                                                                | EKS Fargate environment                                       |
 
 </div>
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add eks_fargate_node to the ootb agent tags on k8s

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ahmed/eks-fargate-node/agent/kubernetes/tag/?tab=containerizedagent#out-of-the-box-tags

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
