### PR TITLE
support path changes for security monitoring

### DIFF
--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -96,7 +96,7 @@ def security_rules(content, content_dir):
         if data and message_file_name.exists():
             # delete file or skip if staged
             # any() will return True when at least one of the elements is Truthy
-            if 'restrictedToOrgs' in data or data.get('isStaged', False) or data.get('isDeleted', False) or not data.get('isEnabled', True):
+            if len(data.get('restrictedToOrgs', [])) > 0 or data.get('isStaged', False) or data.get('isDeleted', False) or not data.get('isEnabled', True):
                 if p.exists():
                     logger.info(f"removing file {p.name}")
                     global_aliases.append(f"/security_monitoring/default_rules/{p.stem}")
@@ -128,15 +128,17 @@ def security_rules(content, content_dir):
                     # we need to get the path relative to the repo root for comparisons
                     extract_dir, relative_path = str(p.parent).split(f"/{content['repo_name']}/")
                     # lets build up this categorization for filtering purposes
-                    if 'configuration' in relative_path:
-                        page_data['rule_category'].append('Cloud Configuration')
                     if 'security-monitoring' in relative_path:
                         page_data['rule_category'].append('Log Detection')
-                    if 'runtime' in relative_path:
-                        if 'compliance' in relative_path:
+
+                    if 'posture-management' in relative_path:
+                        if 'cloud-configuration' in relative_path:
+                            page_data['rule_category'].append('Cloud Configuration')
+                        if 'infrastructure-configuration' in relative_path:
                             page_data['rule_category'].append('Infrastructure Configuration')
-                        else:
-                            page_data['rule_category'].append('Workload Security')
+
+                    if 'workload-security' in relative_path:
+                        page_data['rule_category'].append('Workload Security')
 
                     tags = data.get('tags', [])
                     if tags:
@@ -148,94 +150,13 @@ def security_rules(content, content_dir):
                                 page_data[key] = value
                     else:
                         # try build up manually
-                        if content['action'] == 'compliance-rules':
-                            source = data.get('source', None)
-                            tech = data.get('framework', {}).get('name', '').replace('cis-', '')
-                            page_data["source"] = source or tech
-                            page_data["security"] = "compliance"
-                            page_data["framework"] = data.get('framework', {}).get('name', '')
-                            page_data["control"] = data.get('control', '')
-                            page_data["scope"] = tech
-
-                    # lowercase them
-                    if page_data.get("source", None):
-                        page_data["source"] = page_data["source"].lower()
-                    if page_data.get("scope", None):
-                        page_data["scope"] = page_data["scope"].lower()
-
-                    # integration id
-                    page_data["integration_id"] = page_data.get("scope", None) or page_data.get("source", "")
-                    cloud = page_data.get("cloud", None)
-                    if cloud and cloud == 'aws':
-                        page_data["integration_id"] = "amazon-{}".format(page_data["integration_id"])
-
-                    front_matter = yaml.dump(page_data, default_flow_style=False).strip()
-                    output_content = TEMPLATE.format(front_matter=front_matter, content=message.strip())
-
-                    dest_dir = Path(f"{content_dir}{content['options']['dest_path']}")
-                    dest_dir.mkdir(exist_ok=True)
-                    dest_file = dest_dir.joinpath(p.name).with_suffix('.md')
-                    logger.info(dest_file)
-                    with open(dest_file, mode='w', encoding='utf-8') as out_file:
-                        out_file.write(output_content)
-
-    # add global aliases from deleted files to _index.md
-    if os.environ.get('CI_ENVIRONMENT_NAME', '') in ('live', 'preview'):
-        index_path = Path(f"{content_dir}{content['options']['dest_path']}_index.md")
-        update_global_aliases(index_path, global_aliases)
-
-
-def compliance_rules(content, content_dir):
-    """
-    Takes the content from a file from a github repo and
-    pushed it to the doc
-    See https://github.com/DataDog/documentation/wiki/Documentation-Build#pull-and-push-files to learn more
-    :param content: object with a file_name, a file_path, and options to apply
-    :param content_dir: The directory where content should be put
-    """
-    global_aliases = []
-    logger.info("Starting compliance rules action...")
-    for file_name in chain.from_iterable(glob.glob(pattern, recursive=True) for pattern in content["globs"]):
-        # Only loop over rules JSON files (not eg. Markdown files containing the messages)
-        if not file_name.endswith(".json"):
-            continue
-        with open(file_name, mode="r+") as f:
-            try:
-                json_data = json.loads(f.read())
-            except:
-                logger.warn(f"Error parsing {file_name}")
-            p = Path(f.name)
-
-            # delete file or skip if staged
-            if 'restrictedToOrgs' in json_data or json_data.get('isStaged', False) or json_data.get('isDeleted', False) or not json_data.get('enabled', True):
-                if p.exists():
-                    logger.info(f"removing file {p.name}")
-                    global_aliases.append(f"/security_monitoring/default_rules/{p.stem}")
-                    global_aliases.append(f"/security_platform/default_rules/{p.stem}")
-                    p.unlink()
-                else:
-                    logger.info(f"skipping file {p.name}")
-            else:
-                # The message of a detection rule is located in a Markdown file next to the rule definition
-                message_file_name = file_name.rsplit(".", 1)[0] + ".md"
-
-                with open(message_file_name, mode="r+") as message_file:
-                    message = message_file.read()
-
-                    parsed_title = re.sub(r"\[.+\]\s?(.*)", "\\1", json_data.get('name', ''), 0, re.MULTILINE)
-                    page_data = {
-                        "title": f"{parsed_title}",
-                        "kind": "documentation",
-                        "type": "security_rules",
-                        "disable_edit": True,
-                        "aliases": [f"{json_data.get('defaultRuleId', '').strip()}"],
-                        "source": f"{json_data.get('framework', {}).get('name', '').replace('cis-','')}",
-                        "integration_id": ""
-                    }
-
-                    for tag in json_data.get('tags', []):
-                        key, value = tag.split(':')
-                        page_data[key] = value
+                        source = data.get('source', None)
+                        tech = data.get('framework', {}).get('name', '').replace('cis-', '')
+                        page_data["source"] = source or tech
+                        page_data["security"] = "compliance"
+                        page_data["framework"] = data.get('framework', {}).get('name', '')
+                        page_data["control"] = data.get('control', '')
+                        page_data["scope"] = tech
 
                     # lowercase them
                     if page_data.get("source", None):

--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -128,6 +128,17 @@ def security_rules(content, content_dir):
                     # we need to get the path relative to the repo root for comparisons
                     extract_dir, relative_path = str(p.parent).split(f"/{content['repo_name']}/")
                     # lets build up this categorization for filtering purposes
+
+                    # previous categorization
+                    if relative_path.startswith('configuration'):
+                        page_data['rule_category'].append('Cloud Configuration')
+                    elif relative_path.startswith('runtime'):
+                        if 'compliance' in relative_path:
+                            page_data['rule_category'].append('Infrastructure Configuration')
+                        else:
+                            page_data['rule_category'].append('Workload Security')
+
+                    # new categorization
                     if 'security-monitoring' in relative_path:
                         page_data['rule_category'].append('Log Detection')
 

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -601,6 +601,16 @@
     - action: security-rules
       branch: main
       globs:
+        # old
+        - "configuration/*.json"
+        - "configuration/*.yaml"
+        - "configuration/*.yml"
+        - "configuration/*.md"
+        - "runtime/**/*.json"
+        - "runtime/**/*.yaml"
+        - "runtime/**/*.yml"
+        - "runtime/**/*.md"
+        # new
         - "workload-security/signal-rules/*.yaml"
         - "workload-security/signal-rules/*.md"
         - "security-monitoring/*.json"

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -601,21 +601,14 @@
     - action: security-rules
       branch: main
       globs:
+        - "workload-security/signal-rules/*.yaml"
+        - "workload-security/signal-rules/*.md"
         - "security-monitoring/*.json"
         - "security-monitoring/*.md"
-      options:
-        dest_path: '/security_platform/default_rules/'
-    - action: compliance-rules
-      branch: main
-      globs:
-        - "configuration/*.json"
-        - "configuration/*.yaml"
-        - "configuration/*.yml"
-        - "configuration/*.md"
-        - "runtime/**/*.json"
-        - "runtime/**/*.yaml"
-        - "runtime/**/*.yml"
-        - "runtime/**/*.md"
+        - "posture-management/**/*.json"
+        - "posture-management/**/*.yaml"
+        - "posture-management/**/*.yml"
+        - "posture-management/**/*.md"
       options:
         dest_path: '/security_platform/default_rules/'
 

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -600,23 +600,16 @@
   - repo_name: security-monitoring
     contents:
     - action: security-rules
-      branch: main
+      branch: andrea.piccione/add-new-cws-signal-rules
       globs:
+        - "workload-security/signal-rules/*.yaml"
+        - "workload-security/signal-rules/*.md"
         - "security-monitoring/*.json"
         - "security-monitoring/*.md"
-      options:
-        dest_path: '/security_platform/default_rules/'
-    - action: compliance-rules
-      branch: main
-      globs:
-        - "configuration/*.json"
-        - "configuration/*.yaml"
-        - "configuration/*.yml"
-        - "configuration/*.md"
-        - "runtime/**/*.json"
-        - "runtime/**/*.yaml"
-        - "runtime/**/*.yml"
-        - "runtime/**/*.md"
+        - "posture-management/**/*.json"
+        - "posture-management/**/*.yaml"
+        - "posture-management/**/*.yml"
+        - "posture-management/**/*.md"
       options:
         dest_path: '/security_platform/default_rules/'
 

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -600,8 +600,18 @@
   - repo_name: security-monitoring
     contents:
     - action: security-rules
-      branch: andrea.piccione/add-new-cws-signal-rules
+      branch: main
       globs:
+        # old
+        - "configuration/*.json"
+        - "configuration/*.yaml"
+        - "configuration/*.yml"
+        - "configuration/*.md"
+        - "runtime/**/*.json"
+        - "runtime/**/*.yaml"
+        - "runtime/**/*.yml"
+        - "runtime/**/*.md"
+        # new
         - "workload-security/signal-rules/*.yaml"
         - "workload-security/signal-rules/*.md"
         - "security-monitoring/*.json"

--- a/local/bin/py/build/update_pre_build.py
+++ b/local/bin/py/build/update_pre_build.py
@@ -7,7 +7,7 @@ from pull_and_push_file import pull_and_push_file
 from pull_and_push_folder import pull_and_push_folder
 from content_manager import prepare_content
 from integrations import Integrations
-from security_rules import security_rules, compliance_rules
+from security_rules import security_rules
 
 from collections import OrderedDict
 from optparse import OptionParser


### PR DESCRIPTION
### What does this PR do?

- Update to support path changes for security monitoring
- Remove older duplicate function and duplicate yaml entry to reduce confusion

### Motivation

https://github.com/DataDog/security-monitoring/pull/710

### Preview

This should render the same as production now and after sec mon pr is merged it should also work too without extra changes.

https://docs-staging.datadoghq.com/david.jones/wls-signals/security_platform/default_rules/#cat-workload-security

### Additional Notes

we should remove the "old" configuration parts after the security monitoring changes is merged at somepoint

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
