### PR TITLE
DOCS-2984 Dimensioning Private Locations Anchor Link Fix

### DIFF
--- a/content/en/synthetics/private_locations/dimensioning.md
+++ b/content/en/synthetics/private_locations/dimensioning.md
@@ -6,9 +6,6 @@ further_reading:
 - link: "/synthetics/private_locations/monitoring"
   tag: "Documentation"
   text: "Monitor your Private Locations"
-- link: "synthetics/private_locations/dimensioning"
-  tag: "Documentation"
-  text: "Dimension your Private Locations"
 ---
 
 ## Overview 
@@ -46,10 +43,10 @@ For example, Datadog recommends ~ 1.5 core CPU `(150mCores + (150mCores*10 test 
 
 ### Assign resources to your private location
 
-Once you have determined the [total requirements for your private location](#private-location-total-hardware-requirements), decide how you want these resources to be distributed: by assigning all resources to a single worker or by distributing all resources across multiple workers.
+Once you have determined the [total requirements for your private location](#define-your-total-hardware-requirements), decide how you want these resources to be distributed: by assigning all resources to a single worker or by distributing all resources across multiple workers.
 To assign all resources to a single worker, run one container for a private location with a configuration file.
 1. Set the [`concurrency` parameter][5] to `maximum number of test runs that can be executed in parallel on your private location`.
-2. Assign your [total private location resource requirements](#private-location-total-hardware-requirements) to your unique container.
+2. Assign your [total private location resource requirements](#define-your-total-hardware-requirements) to your unique container.
   
 To distribute resources across multiple workers, run multiple containers for a private location with a configuration file.
  
@@ -68,7 +65,6 @@ For example, ten tests are scheduled to run simultaneously on a private location
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-
 
 [1]: /synthetics/api_tests/
 [2]: /synthetics/multistep?tab=requestoptions


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Quick anchor link fix.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-2984

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/transifex-anchor-link-fix/synthetics/private_locations/dimensioning

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
