### PR TITLE
📝 remove legacy intake URL from CSP rules

### DIFF
--- a/content/en/real_user_monitoring/faq/content_security_policy.md
+++ b/content/en/real_user_monitoring/faq/content_security_policy.md
@@ -16,10 +16,8 @@ Depending on the `site` option used to initialize [Real User Monitoring][2] or [
 {{< site-region region="us" >}}
 
 ```txt
-connect-src https://*.logs.datadoghq.com https://*.browser-intake-datadoghq.com
+connect-src https://*.browser-intake-datadoghq.com
 ```
-
-Both entries are required even if you are not using [browser logs collection][3].
 
 {{< /site-region >}}
 
@@ -27,11 +25,8 @@ Both entries are required even if you are not using [browser logs collection][3]
 {{< site-region region="eu" >}}
 
 ```txt
-connect-src https://*.logs.datadoghq.eu https://*.browser-intake-datadoghq.eu
+connect-src https://*.browser-intake-datadoghq.eu
 ```
-
-Both entries are required even if you are not using [browser logs collection][3].
-
 
 {{< /site-region >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Remove the legacy "logs" intake URL from RUM CSP rules.

### Motivation

 With the newly released SDK, we are now using only `https://*.browser-intake-datadoghq.com` intake URLs.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/benoit/remove-legacy-intake-url/real_user_monitoring/faq/content_security_policy

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
