### PR TITLE
Add the ECS metrics table to ECS metrics doc

### DIFF
--- a/content/en/agent/amazon_ecs/data_collected.md
+++ b/content/en/agent/amazon_ecs/data_collected.md
@@ -17,7 +17,11 @@ further_reading:
 
 ### Metrics
 
-Amazon ECS on EC2 is a container management service for Docker containers running on EC2 instances. Metrics collected by the Agent when deployed in a Docker container are the same metrics collected by the Docker integration. See the [Docker integration metrics][1] for a complete list of metrics.
+Amazon ECS on EC2 is a container management service for Docker containers running on EC2 instances. Metrics collected by the Agent for Amazon ECS:
+
+{{< get-metrics-from-git "amazon_ecs" >}}
+
+Metrics collected by the Agent when deployed in a Docker container also include the same metrics collected by the Docker integration. See the [Docker integration metrics][1] for a complete list of metrics.
 
 **Note**: Docker metrics are tagged accordingly with the following tags: `container_name`, `task_arn`, `task_family`, `task_name`, `task_version`. No further configuration is required.
 


### PR DESCRIPTION
### What does this PR do?
Adds the ECS metrics table to the ECS metrics doc as the table was missing; updates the language around ECS and Docker metrics.

### Motivation
Jira request

### Preview
https://docs-staging.datadoghq.com/sarina/ecs-metrics/agent/amazon_ecs/data_collected

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
