### PR TITLE
Agent key rotation: Recommend grepping for the pubkey

### DIFF
--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -101,7 +101,7 @@ If the file `/usr/share/keyrings/datadog-archive-keyring.gpg` exists, the new ke
 Run the following command on the host:
 
 ```bash
-$ rpm -q gpg-pubkey-fd4bf915
+$ rpm -qa | grep gpg-pubkey-fd4bf915
 ```
 
 If the key is trusted, the command has a 0 exit code and outputs:
@@ -110,11 +110,7 @@ If the key is trusted, the command has a 0 exit code and outputs:
 gpg-pubkey-fd4bf915-5f573efe
 ```
 
-Otherwise, the command returns a non-0 exit code and the following output:
-
-```
-package gpg-pubkey-fd4bf915 is not installed
-```
+Otherwise, the command returns a non-0 exit code and prints nothing.
 
 Alternatively, check if your `datadog.repo` file contains `https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public` as one of the `gpgkey` entries. This key file will be updated with the new key as soon as it is in use.
 

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -110,7 +110,7 @@ If the key is trusted, the command has a 0 exit code and outputs:
 gpg-pubkey-fd4bf915-5f573efe
 ```
 
-Otherwise, the command returns a non-0 exit code and has no output.
+Otherwise, the command returns a non-0 exit code with no output.
 
 Alternatively, check if your `datadog.repo` file contains `https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public` as one of the `gpgkey` entries. This key file will be updated with the new key as soon as it is in use.
 

--- a/content/en/agent/faq/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/faq/linux-agent-2022-key-rotation.md
@@ -110,7 +110,7 @@ If the key is trusted, the command has a 0 exit code and outputs:
 gpg-pubkey-fd4bf915-5f573efe
 ```
 
-Otherwise, the command returns a non-0 exit code and prints nothing.
+Otherwise, the command returns a non-0 exit code and has no output.
 
 Alternatively, check if your `datadog.repo` file contains `https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public` as one of the `gpgkey` entries. This key file will be updated with the new key as soon as it is in use.
 


### PR DESCRIPTION
### What does this PR do?
Update the recommended command to check if the key is trusted.

### Motivation
Passing the key name directly to `rpm -q` had inconsistent results across `rpm` versions.

### Preview
https://docs-staging.datadoghq.com/albertvaka/agent-key-rpm-grep/agent/faq/linux-agent-2022-key-rotation/?tab=redhatcentossuse#check-if-a-host-trusts-the-new-gpg-key

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
