### PR TITLE
Update Missing Metrics script

### DIFF
--- a/local/bin/py/missing_metrics.py
+++ b/local/bin/py/missing_metrics.py
@@ -45,6 +45,7 @@ def get_dd_metrics(csv_metrics, keys, t):
             'gcp.logging.user.',
             'gcp.custom.',
             'isatap',
+            'spark_extended',
             'vsphere.',
             'zookeeper.avg_',
             'zookeeper.cnt_',


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update Missing Metrics script to ignore `spark_extended`

### Motivation
Custom metrics reported as missing:
![image](https://user-images.githubusercontent.com/19349244/148829658-3a194857-ad3f-40e0-b9fe-2e138afc427c.png)

### Preview
N/A

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
