### PR TITLE
Mention support for PHP 8 in PHPRedis integration

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/php.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/php.md
@@ -102,7 +102,7 @@ To request support for additional CLI libraries, contact our awesome [support te
 | MongoDB - via [mongo][3] extension                                      | 1.4.x                      | Fully Supported |
 | MySQLi                                                                  | *(Any Supported PHP)*      | Fully Supported |
 | PDO (MySQL, PostgreSQL, MariaDB)                                        | *(Any Supported PHP)*      | Fully Supported |
-| PhpRedis                                                                | 3, 4, 5                    | PHP 7           |
+| PhpRedis                                                                | 3, 4, 5                    | PHP 7, 8        |
 | Predis                                                                  | 1.1                        | Fully Supported |
 
 To request support for additional datastores, contact our awesome [support team][2].

--- a/content/fr/tracing/compatibility_requirements/php.md
+++ b/content/fr/tracing/compatibility_requirements/php.md
@@ -91,7 +91,7 @@ Pour demander la prise en charge d'une autre bibliothèque CLI, contactez notre 
 | MongoDB - via l'extension [mongodb][4]                                    | *(Toute version de PHP prise en charge)*      | _Disponible prochainement_   |
 | MySQLi                                                                  | *(Toute version de PHP prise en charge)*      | Prise en charge complète |
 | PDO (MySQL, PostgreSQL, MariaDB)                                        | *(Toute version de PHP prise en charge)*      | Prise en charge complète |
-| PhpRedis                                                                | 3, 4, 5                    | Prise en charge complète |
+| PhpRedis                                                                | 3, 4, 5                    | PHP 7, 8 |
 | Predis                                                                  | 1.1                        | Prise en charge complète |
 | AWS Couchbase                                                           | AWS PHP SDK 3              | _Disponible prochainement_   |
 | AWS DynamoDB                                                            | AWS PHP SDK 3              | _Disponible prochainement_   |


### PR DESCRIPTION
Version compatibility was not up to date for PHPRedis support in PHP, which is supported not only on PHP 7 but on PHP 8 as well.

### Preview
[Preview](https://docs-staging.datadoghq.com/apm/php/phpredis-support-php8/tracing/setup_overview/compatibility_requirements/php/)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
