### PR TITLE
[WEB-2029] - querystrings table on api if enum show list of options

### DIFF
--- a/layouts/partials/api/arguments.html
+++ b/layouts/partials/api/arguments.html
@@ -64,10 +64,13 @@
                                 <p>{{- .name -}}{{- with .required -}}{{- cond (eq . false) "" "&nbsp;[<em>required</em>]" | safeHTML -}}{{- end -}}</p>
                             </div>
                             <div class="col-2 column">
-                                <p>{{ .schema.type }}</p>
+                                <p>{{ with .schema }}{{ with .enum }}enum{{ else }}{{ .type }}{{ end }}{{ end }}</p>
                             </div>
                             <div class="col-6 column">
-                                <p>{{ .description | markdownify }}</p>
+                                <p>
+                                  {{ .description | markdownify }}
+                                  {{ with .schema }}{{ with .enum }}<br/>Allowed enum values: <code>{{ delimit . ", " }}</code>{{ end }}{{ end }}
+                                </p>
                             </div>
                         </div>
                         </div>


### PR DESCRIPTION
### What does this PR do?

Makes sure that on api pages the querystring table shows enums correctly

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2029

### Preview

https://docs-staging.datadoghq.com/david.jones/enum-querystring/api/latest/usage-metering/#get-hourly-usage-attribution

vs live

https://docs.datadoghq.com/api/latest/usage-metering/#get-hourly-usage-attribution

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
