### PR TITLE
use sandwich analogy in c++ custom instrumentation example

### DIFF
--- a/content/en/tracing/setup_overview/custom_instrumentation/cpp.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/cpp.md
@@ -69,7 +69,6 @@ To manually instrument your code, install the tracer as in the [setup examples][
 
 ```cpp
 {
-  // The tracer is already configured to use the service "recipesvc".
   // Create a root span for the request we're current processing.
   auto root_span = tracer->StartSpan("get_ingredients");
   // Set a resource name for the root span.

--- a/content/en/tracing/setup_overview/custom_instrumentation/cpp.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/cpp.md
@@ -69,7 +69,7 @@ To manually instrument your code, install the tracer as in the [setup examples][
 
 ```cpp
 {
-  // Create a root span for the request we're current processing.
+  // Create a root span for the request we're currently processing.
   auto root_span = tracer->StartSpan("get_ingredients");
   // Set a resource name for the root span.
   root_span->SetTag(datadog::tags::resource_name, "bologna_sandwich");

--- a/content/en/tracing/setup_overview/custom_instrumentation/cpp.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/cpp.md
@@ -69,19 +69,21 @@ To manually instrument your code, install the tracer as in the [setup examples][
 
 ```cpp
 {
-  // Create a root span.
-  auto root_span = tracer->StartSpan("operation_name");
-  // Set a resource name for the root span
-  root_span->SetTag(datadog::tags::resource_name, "resource_name");
-  // Create a child span.
+  // The tracer is already configured to use the service "recipesvc".
+  // Create a root span for the request we're current processing.
+  auto root_span = tracer->StartSpan("get_ingredients");
+  // Set a resource name for the root span.
+  root_span->SetTag(datadog::tags::resource_name, "bologna_sandwich");
+  // Create a child span, with the root span as its parent.
   auto child_span = tracer->StartSpan(
-      "operation_name",
+      "cache_lookup",
       {opentracing::ChildOf(&root_span->context())});
-  // Set a resource name for the child span
-  child_span->SetTag(datadog::tags::resource_name, "resource_name");
-  // Spans can be finished at a specific time ...
+  // Set a resource name for the child span.
+  child_span->SetTag(datadog::tags::resource_name, "ingredients.bologna_sandwich");
+  // Spans can be finished at an explicit time ...
   child_span->Finish();
-} // ... or when they are destructed (root_span finishes here).
+} // ... or otherwise implicitly when their destructor is invoked.
+  // For example, root_span finishes here implicitly.
 ```
 
 ### Inject and extract context for distributed tracing


### PR DESCRIPTION
In addition to Wan's proposed update for setting-resource-name, use this opportunity to make some sense of the example values for operation name and resource name.