### PR TITLE
kelly/update-log-collection-and-integrations-doc

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -24,14 +24,6 @@ further_reading:
   text: "Logging Without Limits*"
 ---
 
-{{< site-region region="us3" >}}
-
-<div class="alert alert-warning">
-Log collection is not supported for the Datadog US3 site. For more information, contact <a href="https://help.datadoghq.com/hc/en-us">Support</a>.
-</div>
-
-{{< /site-region >}}
-
 ## Overview
 
 Choose a configuration option below to begin ingesting your logs. If you are already using a log-shipper daemon, refer to the dedicated documentation for [Rsyslog][1], [Syslog-ng][2], [NXlog][3], [FluentD][4], or [Logstash][5].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Removes the warning for US3 site stating:
"Log collection is not supported for the Datadog US3 site. For more information, contact Support."

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer reached out complaining this is misleading as customers are able to ship logs via the Agent when in a US3 site.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Confirmed in this customers account and another account in US3 that they are able to ship logs.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
