### PR TITLE
DOCS-2583 Move Datadog Serverless Macro front matter

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -249,12 +249,8 @@
       options:
         dest_path: '/serverless/libraries_integrations/'
         file_name: 'macro.md'
-        front_matters:
-          dependencies: ["https://github.com/DataDog/datadog-cloudformation-macro/blob/master/serverless/README.md"]
-          title: Datadog Serverless Macro
-          kind: documentation
-          aliases:
-            - /serverless/serverless_integrations/macro/
+        # front_matters:
+        #   dependencies: ["https://github.com/DataDog/datadog-cloudformation-macro/blob/master/serverless/README.md"]
 
   - repo_name: datadog-ci
     contents:
@@ -272,7 +268,7 @@
           aliases:
             - /serverless/datadog_lambda_library/
             - /serverless/serverless_integrations/cli/
-  
+
   - repo_name: synthetics-ci-github-action
     contents:
     - action: pull-and-push-file

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -250,12 +250,8 @@
       options:
         dest_path: '/serverless/libraries_integrations/'
         file_name: 'macro.md'
-        front_matters:
-          dependencies: ["https://github.com/DataDog/datadog-cloudformation-macro/blob/master/serverless/README.md"]
-          title: Datadog Serverless Macro
-          kind: documentation
-          aliases:
-            - /serverless/serverless_integrations/macro/
+        # front_matters:
+        #   dependencies: ["https://github.com/DataDog/datadog-cloudformation-macro/blob/master/serverless/README.md"]
 
   - repo_name: datadog-ci
     contents:
@@ -273,7 +269,7 @@
           aliases:
             - /serverless/datadog_lambda_library/
             - /serverless/serverless_integrations/cli/
-  
+
   - repo_name: synthetics-ci-github-action
     contents:
     - action: pull-and-push-file
@@ -287,7 +283,7 @@
           dependencies: ["https://github.com/DataDog/synthetics-ci-github-action/blob/main/README.md"]
           title: Synthetics CI GitHub Actions
           kind: documentation
-          
+
   - repo_name: dd-sdk-android
     contents:
     - action: pull-and-push-file


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Move Datadog Serverless Macro front matter

### Motivation
Front matter should live with the README

### Preview
https://docs-staging.datadoghq.com/ruth/docs-2583c/serverless/libraries_integrations/macro/

### Additional Notes
Merge after: https://github.com/DataDog/datadog-cloudformation-macro/pull/57

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
