### PR TITLE
[log4j mitigation] Update Windows instructions

### DIFF
--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -152,7 +152,13 @@ $stream.Close()
 $stream.Dispose()
 ```
 
-Remove the JndiLogger.class from the jmxfetch.jar. Note that this step will stop the Datadog Agent service to apply the patch. To remove the vulnerable code run:
+Stop the Datadog Agent service before applying the patch:
+
+```powershell
+"$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" stopservice
+```
+
+Apply the patch to remove the JndiLogger.class from the jmxfetch.jar:
 
 ```powershell
 .\jndi_cleanup.ps1


### PR DESCRIPTION
### What does this PR do?

Update Windows log4j mitigation instructions with correct instructions to stop the service first.

### Motivation

The script doesn't actually stop the agent service,
so document that the service needs to be stopped first.

### Preview
Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/olivielpeau/log4j-mitigation-windows/agent/faq/log4j_mitigation/#seeing-if-your-agent-version-is-vulnerable

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
