### PR TITLE
Add manifest v2 option to ddev create examples

### DIFF
--- a/content/en/developers/marketplace/_index.md
+++ b/content/en/developers/marketplace/_index.md
@@ -157,7 +157,7 @@ For standalone software and services--or if your integration is using the Datado
 In the `marketplace` or `integrations-extras` directory you specified above, run: 
 
 ```
-ddev create -t tile "<Offering Name>"
+ddev create -t tile --v2 "<Offering Name>"
 ```
 
 #### Full integration
@@ -165,7 +165,7 @@ ddev create -t tile "<Offering Name>"
 To generate a complete integration scaffolding, from the `marketplace` or `integrations-extras` directory specified above, run: 
 
 ```
-ddev create "<Offering Name>"
+ddev create --v2 "<Offering Name>"
 ```
 
 ### Populate the tile scaffolding

--- a/content/en/developers/marketplace/_index.md
+++ b/content/en/developers/marketplace/_index.md
@@ -157,7 +157,7 @@ For standalone software and services--or if your integration is using the Datado
 In the `marketplace` or `integrations-extras` directory you specified above, run: 
 
 ```
-ddev create -t tile --v2 "<Offering Name>"
+ddev create -t tile -v2 "<Offering Name>"
 ```
 
 #### Full integration
@@ -165,7 +165,7 @@ ddev create -t tile --v2 "<Offering Name>"
 To generate a complete integration scaffolding, from the `marketplace` or `integrations-extras` directory specified above, run: 
 
 ```
-ddev create --v2 "<Offering Name>"
+ddev create -v2 "<Offering Name>"
 ```
 
 ### Populate the tile scaffolding


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The latest ddev release supports the new ManifestV2 formats.  This PR updates the Marketplace docs to use that new CLI option.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
