### PR TITLE
Remove note about Windows Nano Server not being supported

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -147,7 +147,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [OpenSUSE][7] with systemd               | OpenSUSE 15+ in Agent 6.33.0+/7.33.0+                     |
 | [Fedora][8]                              | Fedora 26+                                                |
 | [macOS][9]                               | macOS 10.12+                                              |
-| [Windows Server][10]                     | Windows Server 2008 R2+ and Server Core (not Nano Server) |
+| [Windows Server][10]                     | Windows Server 2008 R2+ (including Server Core)           |
 | [Windows][10]                            | Windows 7+                                                |
 | [Windows Azure Stack HCI OS][10]         | All Versions                                              |
 


### PR DESCRIPTION
### Motivation
It has limited functionality, but we provide a Docker image based on Nano Server.

### Preview
https://docs-staging.datadoghq.com/albertvaka/windows-nano-support/basic_agent_usage

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
