### PR TITLE
feature: add documentation for DD_TRACE_SAMPLE_RATE (python)

### DIFF
--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -181,6 +181,11 @@ Override the port that the default tracer submits DogStatsD metrics to.
 : **Default**: `false`<br>
 Enable [connecting logs and trace injection][8].
 
+
+`DD_TRACE_SAMPLE_RATE`
+: **Default**: `1.0`<br>
+A float, f, 0.0 <= f <= 1.0. where f*100% of traces will be sampled and the remaining traces will be discarded by the trace agent [9].
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -193,3 +198,4 @@ Enable [connecting logs and trace injection][8].
 [6]: /tracing/guide/setting_primary_tags_to_scope/
 [7]: https://ddtrace.readthedocs.io/en/stable/integrations.html#django
 [8]: /tracing/connect_logs_and_traces/python/
+[9]: /tracing/faq/trace_sampling_and_storage/

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -148,6 +148,9 @@ It is recommended to use `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, 
 `DD_VERSION`
 : Set the application’s version, for example: `1.2.3`, `6c44da20`, `2020.02.13`. Available in version 0.38+.
 
+`DD_TRACE_SAMPLE_RATE`
+: Enable [Tracing without Limits][9].
+
 `DD_TAGS`
 : A list of default tags to be added to every span and profile, for example: `layer:api,team:intake`. Available in version 0.38+.
 
@@ -181,9 +184,6 @@ Override the port that the default tracer submits DogStatsD metrics to.
 : **Default**: `false`<br>
 Enable [connecting logs and trace injection][8].
 
-
-`DD_TRACE_SAMPLE_RATE`
-: Enable [Tracing without Limits][9].
 
 ## Further Reading
 

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -183,7 +183,7 @@ Enable [connecting logs and trace injection][8].
 
 
 `DD_TRACE_SAMPLE_RATE`
-Enable [Tracing without Limits][9].
+: Enable [Tracing without Limits][9].
 
 ## Further Reading
 

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -184,7 +184,7 @@ Enable [connecting logs and trace injection][8].
 
 `DD_TRACE_SAMPLE_RATE`
 : **Default**: `1.0`<br>
-A float, f, 0.0 <= f <= 1.0. where f*100% of traces will be sampled and the remaining traces will be discarded by the trace agent [9].
+A float, f, 0.0 <= f <= 1.0. This value represents the proportion of traces which will be retained by the agent [9].
 
 ## Further Reading
 

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -198,4 +198,4 @@ A float, f, 0.0 <= f <= 1.0. This value represents the proportion of traces whic
 [6]: /tracing/guide/setting_primary_tags_to_scope/
 [7]: https://ddtrace.readthedocs.io/en/stable/integrations.html#django
 [8]: /tracing/connect_logs_and_traces/python/
-[9]: /tracing/faq/trace_sampling_and_storage/
+[9]: /tracing/faq/trace_retention_and_ingestion/

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -184,7 +184,7 @@ Enable [connecting logs and trace injection][8].
 
 `DD_TRACE_SAMPLE_RATE`
 : **Default**: `1.0`<br>
-A float, f, 0.0 <= f <= 1.0. This value represents the proportion of traces which will be retained by the agent [9].
+A float, f, 0.0 <= f <= 1.0. This value represents the proportion of traces which are retained by the agent [9].
 
 ## Further Reading
 

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -183,8 +183,7 @@ Enable [connecting logs and trace injection][8].
 
 
 `DD_TRACE_SAMPLE_RATE`
-: **Default**: `1.0`<br>
-A float, f, 0.0 <= f <= 1.0. This value represents the proportion of traces which are retained by the agent [9].
+Enable [Tracing without Limits][9].
 
 ## Further Reading
 

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -197,4 +197,4 @@ Enable [connecting logs and trace injection][8].
 [6]: /tracing/guide/setting_primary_tags_to_scope/
 [7]: https://ddtrace.readthedocs.io/en/stable/integrations.html#django
 [8]: /tracing/connect_logs_and_traces/python/
-[9]: /tracing/faq/trace_retention_and_ingestion/
+[9]: /tracing/trace_retention_and_ingestion/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Adds documentation for `DD_TRACE_SAMPLE_RATE` in tracing/setup_overview

### Motivation

Currently `DD_TRACE_SAMPLE_RATE` is only documented in the dd-trace-py.

### Preview
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/munir/ddtracepy/dd-sampling-rate-documentation/tracing/setup_overview/setup/python/?tab=containers

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
