### PR TITLE
DOCS-2963 - filter the range over doing it per loop

### DIFF
--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -35,10 +35,8 @@
 
 <span class="c1"># Curl command</span>
 <span class="n">curl</span> <span class="o">-X</span> <span class="s1">{{ $endpoint.actionType | upper }}</span> {{ range $region, $url := $endpoint.regions }}{{ if ne $region "local" }}<span class="kn d-none" data-region="{{ $region }}">"{{ $url }}</span>{{ else }}<span class="kn">"{{ $url }}</span>{{ end }}{{ end }}<span class="kn">{{ replace $endpoint.pathKey "{" "${" }}</span>
-{{- range $qi, $q := $parameters.queryStrings -}}
-    {{- if eq .required true -}}
-        <span class="kn">{{ cond (gt $qi 0) "&" "?" }}</span><span class="kn">{{ $q.name }}</span><span class="kn">=</span><span class="kn">${ {{- $q.name -}} }</span>
-    {{- end -}}
+{{- range $qi, $q := where $parameters.queryStrings ".required" true -}}
+      <span class="kn">{{ cond (gt $qi 0) "&" "?" }}</span><span class="kn">{{ $q.name }}</span><span class="kn">=</span><span class="kn">${ {{- $q.name -}} }</span>
 {{- end -}}
 
 {{- /* Render authentication query parameters "?api_key=XXX" */ -}}


### PR DESCRIPTION
### What does this PR do?
This PR fixes the auto generated curl examples `?` and `&` positions

### Motivation
https://datadoghq.atlassian.net/browse/DOCS-2963

### Preview
Check the curl example query string starts with `?` and not `&`
https://docs-staging.datadoghq.com/david.jones/curl-querystring-fix/api/latest/snapshots/#take-graph-snapshots

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
