### PR TITLE
DOCS-2996 - resource limits on gke autopilot

### DIFF
--- a/content/en/agent/kubernetes/distributions.md
+++ b/content/en/agent/kubernetes/distributions.md
@@ -158,13 +158,15 @@ Depending on the operation mode of your cluster, the Datadog Agent needs to be c
 
 ### Standard
 
-Since Agent 7.26, no specific configuration is required for GKE anymore (whether you run `Docker` and/or `containerd`).
+Since Agent 7.26, no specific configuration is required for GKE (whether you run `Docker` or `containerd`).
 
 **Note**: When using COS (Container Optimized OS), the eBPF-based `OOM Kill` and `TCP Queue Length` checks are not supported due to missing Kernel headers.
 
 ### Autopilot
 
-GKE Autopilot comes with hardened security and limited Nodes access. Thus requiring some specific configuration.
+GKE Autopilot requires some configuration, shown below.
+
+Datadog recommends that you specify resource limits for the Agent container. Autopilot sets a relatively low default limit (50m CPU, 100Mi memory) that may quickly lead the Agent container to OOMKill depending on your environment. If applicable, also specify resource limits for the Trace Agent and Process Agent containers.
 
 {{< tabs >}}
 {{% tab "Helm" %}}
@@ -183,16 +185,42 @@ datadog:
   # Avoid deploying kube-state-metrics chart.
   # The new `kubernetes_state_core` doesn't require to deploy the kube-state-metrics anymore.
   kubeStateMetricsEnabled: false
+  
+  containers:
+    agent:
+      # resources for the Agent container
+      resources:
+        requests:
+          cpu: 200m
+          memory: 256Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
+
+    traceAgent:
+      # resources for the Trace Agent container
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+        limits:
+          cpu: 100m
+          memory: 200Mi
+
+    processAgent:
+      # resources for the Process Agent container
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+        limits:
+          cpu: 100m
+          memory: 200Mi
 
 providers:
   gke:
     autopilot: true
 ```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
-
-Not supported yet. Will be available with the Datadog Operator v0.7.0.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
notes that you should set resource limits in gke autopilot if you don't want an oomkill

### Motivation
@kaitlavs 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/cswatt/gke-resources/agent/kubernetes/distributions/?tab=helm#autopilot 

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
