### PR TITLE
(DOCS-2910) update sidenav and index for Github to Github Actions

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2096,7 +2096,7 @@ main:
     parent: setup_pipelines
     identifier: ci_circleci
     weight: 202
-  - name: GitHub
+  - name: GitHub Actions
     url: continuous_integration/setup_pipelines/github/
     parent: setup_pipelines
     identifier: ci_github

--- a/content/en/continuous_integration/setup_pipelines/_index.md
+++ b/content/en/continuous_integration/setup_pipelines/_index.md
@@ -8,7 +8,7 @@ disable_sidebar: true
 {{< whatsnext desc="CI pipelines providers:" >}}
     {{< nextlink href="continuous_integration/setup_pipelines/buildkite" >}}Buildkite{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_pipelines/circleci" >}}CircleCI{{< /nextlink >}}
-    {{< nextlink href="continuous_integration/setup_pipelines/github" >}}GitHub{{< /nextlink >}}
+    {{< nextlink href="continuous_integration/setup_pipelines/github" >}}GitHub Actions{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_pipelines/gitlab" >}}GitLab{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_pipelines/jenkins" >}}Jenkins{{< /nextlink >}}
     {{< nextlink href="continuous_integration/setup_pipelines/custom_commands" >}}Custom Commands{{< /nextlink >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the sidebar nav and the link on the index of setup tracing page in CI Visibility to be "Github Actions" instead of just "Github"

### Motivation
PM/stakeholder request

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jorie/DOCS-2910/continuous_integration/setup_pipelines/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
