### PR TITLE
CI-app - Swift -  Document instrumenting stdout and stderr

### DIFF
--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -209,10 +209,10 @@ For the following configuration settings:
 ### Enabling auto-instrumentation
 
 `DD_ENABLE_STDOUT_INSTRUMENTATION`
-: Captures messages written to `stdout` (for example, `print()` ) and reports them as logs. This may impact your bill. (Boolean)
+: Captures messages written to `stdout` (for example, `print()`) and reports them as logs. This may impact your bill. (Boolean)
 
 `DD_ENABLE_STDERR_INSTRUMENTATION`
-: Captures messages written to `stderr` (for example, `NSLog()`, UITest steps ) and reports them as logs. This may impact your bill. (Boolean)
+: Captures messages written to `stderr` (for example, `NSLog()`, UITest steps) and reports them as logs. This may impact your bill. (Boolean)
 
 ### Disabling auto-instrumentation
 

--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -184,7 +184,7 @@ If you are running tests in non-supported CI providers or with no `.git` folder,
 
 ### Running tests
 
-After installation, run your tests as you normally do, for example using the `xcodebuild test` command. Tests, network requests, and application logs are instrumented automatically. Pass your environment variables when running your tests in the CI, for example:
+After installation, run your tests as you normally do, for example using the `xcodebuild test` command. Tests, network requests, and application crashes are instrumented automatically. Pass your environment variables when running your tests in the CI, for example:
 
 <pre>
 <code>
@@ -205,6 +205,14 @@ For UITests, both the test target and the application running from the UITests m
 For the following configuration settings:
  - `Boolean` variables can use any of: `1`, `0`, `true`, `false`, `YES`, or `NO`
  - `String` list variables accept a list of elements separated by `,` or `;`
+ 
+### Enabling auto-instrumentation
+
+`DD_ENABLE_STDOUT_INSTRUMENTATION`
+: Captures messages written to `stdout` (e.g `print()` ) and reports them as Logs. (Implies charges for Logs product) (Boolean)
+
+`DD_ENABLE_STDERR_INSTRUMENTATION`
+: Captures messages written to `stderr` (e.g `NSLog()`, UITest steps ) and reports them as Logs. (Implies charges for Logs product) (Boolean)
 
 ### Disabling auto-instrumentation
 
@@ -212,12 +220,6 @@ The framework enables auto-instrumentation of all supported libraries, but in so
 
 `DD_DISABLE_NETWORK_INSTRUMENTATION`
 : Disables all network instrumentation (Boolean)
-
-`DD_DISABLE_STDOUT_INSTRUMENTATION`
-: Disables all `stdout` instrumentation (Boolean)
-
-`DD_DISABLE_STDERR_INSTRUMENTATION`
-: Disables all `stderr` instrumentation (Boolean)
 
 `DD_DISABLE_SDKIOS_INTEGRATION`
 : Disables integration with `dd-sdk-ios` logs and traces (Boolean)

--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -209,10 +209,10 @@ For the following configuration settings:
 ### Enabling auto-instrumentation
 
 `DD_ENABLE_STDOUT_INSTRUMENTATION`
-: Captures messages written to `stdout` (e.g `print()` ) and reports them as Logs. (Implies charges for Logs product) (Boolean)
+: Captures messages written to `stdout` (for example, `print()` ) and reports them as logs. This may impact your bill. (Boolean)
 
 `DD_ENABLE_STDERR_INSTRUMENTATION`
-: Captures messages written to `stderr` (e.g `NSLog()`, UITest steps ) and reports them as Logs. (Implies charges for Logs product) (Boolean)
+: Captures messages written to `stderr` (for example, `NSLog()`, UITest steps ) and reports them as logs. This may impact your bill. (Boolean)
 
 ### Disabling auto-instrumentation
 


### PR DESCRIPTION
### What does this PR do?
Update documentation to clarify how to instrument `stdout` and `stderr` now that wont be enabled by default. Also make clear that it can incur charges to Logs product

### Motivation
This changed with last release

### Preview
https://docs-staging.datadoghq.com/nachoBonafonte/new-stdout-instrumentation-logic/continuous_integration/setup_tests/swift

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
