### PR TITLE
[DOCS-3085] Update logs permissions docs for Jan 18 release

### DIFF
--- a/content/en/logs/guide/access-your-log-data-programmatically.md
+++ b/content/en/logs/guide/access-your-log-data-programmatically.md
@@ -28,9 +28,9 @@ The following examples are covered in this guide:
 
 ## Prerequisites
 
-- An API key and an application key from an admin user is required to use the API. These are available in your [Datadog account API key page][2]. Replace `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your Datadog API key and your Datadog application key.
+- Use of the Logs Search API requires an [API key][2] and an [application key][3]. The user who created the application key must have the appropriate permission to access the data. To use the examples below, replace `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your Datadog API key and your Datadog application key, respectively.
 
-- This guide features `curl` examples. Install [curl][3] if you do not have it installed, or reference additional language examples for this API endpoint in the [API documentation][1].
+- This guide features `curl` examples. Install [curl][4] if you do not have it installed, or reference additional language examples for this API endpoint in the [Logs API][1].
 
 **Note:** By default, all users with Admin, Standard, and Read-Only roles have access to all log data. But the search results might be restricted based on the permissions of the user owning the `<DATADOG_APP_KEY>`.
 
@@ -445,7 +445,7 @@ The `from` and `to` parameters can be:
 }
 ```
 
-The timezone can be specified both as an offset (eg "UTC+03:00") or a regional zone (eg "Europe/Paris"). If both offset and timezone are supplied then the offset takes precedence. The offset must be specified in seconds.
+The timezone can be specified both as an offset (for example, "UTC+03:00") or a regional zone (for exampe, "Europe/Paris"). If both offset and timezone are supplied then the offset takes precedence. The offset must be specified in seconds.
 
 ```javascript
 {
@@ -552,8 +552,7 @@ In the response, the next two results, `joe` with 500 `pageviews` and `chris` wi
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /api/v2/logs/
-[2]: /api/v1/authentication/
-[3]: https://curl.haxx.se/download.html
-[4]: /logs/search_syntax/
+[2]: /account_management/api-app-keys/#api-keys
+[3]: /account_management/api-app-keys/#application-keys
+[4]: https://curl.haxx.se/download.html
 [5]: /account_management/rbac/permissions/?tab=ui#log-data-access
-[6]: /logs/explorer/facets/#overview

--- a/content/en/logs/guide/access-your-log-data-programmatically.md
+++ b/content/en/logs/guide/access-your-log-data-programmatically.md
@@ -32,8 +32,6 @@ The following examples are covered in this guide:
 
 - This guide features `curl` examples. Install [curl][4] if you do not have it installed, or reference additional language examples for this API endpoint in the [Logs API][1].
 
-**Note:** If you are in the Datadog EU site, use https://api.datadoghq.eu/api/  as the endpoint.
-
 ## Examples
 
 ### Basic search

--- a/content/en/logs/guide/access-your-log-data-programmatically.md
+++ b/content/en/logs/guide/access-your-log-data-programmatically.md
@@ -445,7 +445,7 @@ The `from` and `to` parameters can be:
 }
 ```
 
-The timezone can be specified both as an offset (for example, "UTC+03:00") or a regional zone (for exampe, "Europe/Paris"). If both offset and timezone are supplied then the offset takes precedence. The offset must be specified in seconds.
+The timezone can be specified both as an offset (for example, "UTC+03:00") or a regional zone (for example, "Europe/Paris"). If both offset and timezone are supplied then the offset takes precedence. The offset must be specified in seconds.
 
 ```javascript
 {

--- a/content/en/logs/guide/access-your-log-data-programmatically.md
+++ b/content/en/logs/guide/access-your-log-data-programmatically.md
@@ -32,7 +32,7 @@ The following examples are covered in this guide:
 
 - This guide features `curl` examples. Install [curl][4] if you do not have it installed, or reference additional language examples for this API endpoint in the [Logs API][1].
 
-**Note:** By default, all users with Admin, Standard, and Read-Only roles have access to all log data. But the search results might be restricted based on the permissions of the user owning the `<DATADOG_APP_KEY>`.
+**Note:** If you are in the Datadog EU site, use https://api.datadoghq.eu/api/  as the endpoint.
 
 ## Examples
 

--- a/content/en/logs/guide/build-custom-reports-using-log-analytics-api.md
+++ b/content/en/logs/guide/build-custom-reports-using-log-analytics-api.md
@@ -28,11 +28,9 @@ The following examples are covered in this guide:
 
 ## Prerequisites
 
-Since this guide describes usage of the API, you will need an API key and an application key from an admin user. These are available in your [Datadog account API key page][2].
+- Use of the Log Analytics API requires an [API key][2] and an [application key][3]. The user who created the application key must have the appropriate permission to access the data. To use the examples below, replace `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your Datadog API key and your Datadog application key, respectively.
 
-Throughout this article, you will need to replace all occurrences of `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your Datadog API key and your Datadog application key, respectively.
-
-This guide also assumes that you have a terminal with `CURL`. 
+- This guide also assumes that you have a terminal with `curl`.
 
 **Note:** If you are in the Datadog EU site, use https://api.datadoghq.eu/api/  as the endpoint.
 
@@ -870,4 +868,5 @@ curl -L -X POST "https://api.datadoghq.com/api/v2/logs/analytics/aggregate" -H "
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://docs.datadoghq.com/api/v2/logs/
-[2]: https://docs.datadoghq.com/api/v1/authentication/
+[2]: /account_management/api-app-keys/#api-keys
+[3]: /account_management/api-app-keys/#application-keys

--- a/content/en/logs/guide/build-custom-reports-using-log-analytics-api.md
+++ b/content/en/logs/guide/build-custom-reports-using-log-analytics-api.md
@@ -32,8 +32,6 @@ The following examples are covered in this guide:
 
 - This guide also assumes that you have a terminal with `curl`.
 
-**Note:** If you are in the Datadog EU site, use https://api.datadoghq.eu/api/  as the endpoint.
-
 ## Examples
 
 ### Getting counts

--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -17,7 +17,7 @@ Once you've created [RBAC roles for logs][1], assign or remove [permissions][2] 
 {{< tabs >}}
 {{% tab "UI" %}}
 
-Assign or remove permission to a role directly by [updating the role in the Datadog application][1].
+Assign or remove permission to a role directly by [updating the role on the Datadog site][1].
 
 {{< img src="account_management/rbac/logs_permissions.png" alt="Logs Permissions" style="width:75%;" >}}
 
@@ -59,7 +59,6 @@ This permission is global and enables both the creation of new indexes, and the 
 
 **Note**: This permission also grants [Logs Read Index Data](#logs_read_index_data) and [Logs Write Exclusion Filters](#logs_write_exclusion_filters) permissions behind the scenes.
 
-
 ### `logs_write_exclusion_filters`
 
 Grants a role the ability to create or modify [exclusion filters][8] within an index.
@@ -72,7 +71,7 @@ This permission can be assigned either globally or restricted to a subset of ind
 {{% tab "UI" %}}
 
 1. Remove the global permission on the role.
-2. Grant this permission to the role in [the Index page of the Datadog app][1] by editing an index and adding a role to the "Grant editing Exclusion Filters of this index to" field (screenshot below).
+2. Grant this permission to the role in [the Index page on the Datadog site][1] by editing an index and adding a role to the "Grant editing Exclusion Filters of this index to" field (screenshot below).
 
 {{< img src="account_management/rbac/logs_write_exclusion_filters.png" alt="Logs Write Exclusion Filters" style="width:75%;" >}}
 
@@ -98,10 +97,9 @@ Grants a role the ability to create and modify [log processing pipelines][9]. Th
 
 **Note**: This permission also grants [Logs Write Processors](#logs_write_processors) (for all processors on all pipelines) permissions behind the scenes.
 
-
 ### `logs_write_processors`
 
-Grants a role the ability to create, edit or delete processors and nested pipelines.
+Grants a role the ability to create, edit, or delete processors and nested pipelines.
 
 This permission can be assigned either globally or restricted to a subset of pipelines.
 
@@ -110,7 +108,7 @@ This permission can be assigned either globally or restricted to a subset of pip
 
 Assign the role(s) in the modal of a specific pipeline.
 
-{{< img src="account_management/rbac/logs_write_processors.png" alt="Logs Write Processors"  style="width:75%;" >}}
+{{< img src="account_management/rbac/logs_write_processors.png" alt="Logs Write Processors" style="width:75%;" >}}
 
 {{% /tab %}}
 {{% tab "API" %}}
@@ -141,7 +139,7 @@ curl -X POST \
 
 ### `logs_write_archives`
 
-Grants the ability to create, edit or delete [Log Archives][12]. This includes:
+Grants the ability to create, edit, or delete [Log Archives][12]. This includes:
 
 - Setting archives filters for what logs should be routed to the archive
 - Setting the name of the archive
@@ -162,14 +160,14 @@ In the following example, assuming all roles but `Guest` have the `logs_read_arc
 * Prod is accessible to all users belonging to `Customer Support`.
 * Security-Audit is not accessible to users who belong to `Customer Support`, unless they also belong to `Audit & Security`.
 
-{{< img src="account_management/rbac/logs_archives_list.png" alt="Create a custom Role"  style="width:90%;">}}
+{{< img src="account_management/rbac/logs_archives_list.png" alt="Create a custom Role" style="width:90%;">}}
 
 {{< tabs >}}
 {{% tab "UI" %}}
 
 Proceed to archive creation, or update at any moment while editing the archive.
 
-{{< img src="account_management/rbac/logs_archive_restriction.png" alt="Create a custom Role"  style="width:90%;">}}
+{{< img src="account_management/rbac/logs_archive_restriction.png" alt="Create a custom Role" style="width:90%;">}}
 
 {{% /tab %}}
 {{% tab "API" %}}
@@ -188,7 +186,7 @@ Grants the ability to write historical views, meaning to trigger a [Log Rehydrat
 
 This permission is global. It enables users to trigger a rehydration for archives on which they have [Logs Read Archive](#logs_read_archives) permission.
 
-{{< img src="account_management/rbac/logs_hv_roles_combination.png" alt="Write Historical View"  style="width:70%;">}}
+{{< img src="account_management/rbac/logs_hv_roles_combination.png" alt="Write Historical View" style="width:70%;">}}
 
 In the example above:
 
@@ -197,25 +195,12 @@ In the example above:
 * `PROD` Role members **cannot** rehydrate from the `Audit Archive`, as they do not have the Read Archive permission.
 
 
-When assigning `team:audit` tags on all logs rehydrated from the `Audit Archive`, make sure that `Audit` role members who are restricted to read `team:audit`logs  can only access rehydrated content. For more details on how to add tags and rehydration, see the [Log Archive Setup section][12].
+When assigning `team:audit` tags on all logs rehydrated from the `Audit Archive`, make sure that `Audit` role members who are restricted to read `team:audit`logs can only access rehydrated content. For more details on how to add tags and rehydration, see the [Log Archive Setup section][12].
 
 For `service:ci-cd` logs that are rehydrated from the `Prod Archive`, note the following:
 
 * If you **do not** use the [Log Read Index Data](#logs_read_index_data) legacy permission, these logs are accessible for `CI-CD` role members.
 * If you **do** use the [Log Read Index Data](#logs_read_index_data) legacy permission, these logs are not accessible for `CI-CD` role members, as the resulting historical view is restricted to `PROD` and `ADMIN` role members.
-
-
-### `logs_public_config_api`
-
-Grants the ability to view, create, or modify log configuration through the Datadog API:
-
-* View and configure [archives][14] through the API
-* View and configure [indexes][15] through the API
-* View and configure [pipelines][16] through the API
-* View and configure [restriction queries][17] through the API
-* View and configure [metrics generated from logs][18] through the API
-
-The Log Public Configuration API permission only grants the permission to operate actions through API. For instance, a user without [Log Write Exclusion Filter Permission](#logs_write_exclusion_filters) cannot update sampling rate through API, even if granted The Log Public Configuration API permission.
 
 ## Log data access
 
@@ -226,9 +211,9 @@ Grant the following permissions to manage read access on subsets of log data:
 
 ### `logs_read_data`
 
-Read access to log data. If granted, other restrictions then apply such as `logs_read_index_data` or with [restriction query][17].
+Read access to log data. If granted, other restrictions then apply such as `logs_read_index_data` or with [restriction query][14].
 
-Roles are additive: if a user belongs to multiple roles, the data they have access to is the union of all the permissions from each of the roles.
+Roles are additive. If a user belongs to multiple roles, the data they have access to is the union of all the permissions from each of the roles.
 
 **Example**:
 
@@ -241,12 +226,11 @@ Roles are additive: if a user belongs to multiple roles, the data they have acce
 {{< tabs >}}
 {{% tab "UI" %}}
 
-To restrict users so they see no more than logs matching a restriction query, use the [Data Access page][1] in the Datadog App to:
+To restrict users so they see no more than logs matching a restriction query, use the [Data Access page][1]:
 
 1. [Create](#create-a-restriction-query) a restriction query.
 2. [Assign](#assign-a-role-to-a-restriction-query) one or multiple roles to that restriction query.
 3. [Check](#check-restriction-queries) what roles and users are assigned to which restriction queries.
-
 
 This view lists:
 
@@ -254,13 +238,11 @@ This view lists:
 * **`Unrestricted Access` section**: all roles that have `log_read_data` permission with no further restrictions,
 * **`No Access` section**: all roles that does not have the `log_read_data` permission.
 
-
 ## Create a restriction query
 
 Create a new restriction query defining its query filter. The new query appears in the list of restrictions with no role attached to it.
 
 {{< img src="account_management/rbac/logs_rq-create.mp4" alt="Create a Restriction Query" video=true style="width:70%;">}}
-
 
 ### Assign a role to a restriction query
 
@@ -274,25 +256,25 @@ Likewise, use the same "Move" interaction to grant `Unrestricted Access` to a Ro
 
 ### Check restriction queries
 
-This page won't display more than 50 restriction queries at once, and more than 50 roles per section. In case you have hundreds if not thousands of roles and restriction queries, use the filters to scope this view down:
+The Data Access page displays a maximum of 50 restriction queries, and 50 roles per section. If you have more roles and restriction queries than the page can display, use the filters to scope this view down:
 
 * with the restriction query filter:
 
-{{< img src="account_management/rbac/logs_rq-filter.png" alt="Filter Restriction Queries"  style="width:70%;">}}
+{{< img src="account_management/rbac/logs_rq-filter.png" alt="Filter Restriction Queries" style="width:70%;">}}
 
 * with the role filter:
 
-{{< img src="account_management/rbac/logs_rq-view_as_role.png" alt="View as Roles"  style="width:70%;">}}
+{{< img src="account_management/rbac/logs_rq-view_as_role.png" alt="View as Roles" style="width:70%;">}}
 
 * with the user filter, which is a convenient way to see what a specific user belonging to multiple roles actually has access to:
 
-{{< img src="account_management/rbac/logs_rq-view_as_user.png" alt="View as Roles"  style="width:70%;">}}
+{{< img src="account_management/rbac/logs_rq-view_as_user.png" alt="View as Roles" style="width:70%;">}}
 
 [1]: https://app.datadoghq.com/logs/pipelines/data-access
 {{% /tab %}}
 {{% tab "API" %}}
 
-Revoke or grant this permission from a role via [the Roles API][1].
+Revoke or grant this permission from a role with [the Roles API][1].
 Use [Restriction Queries][2] to scope the permission to a subset of Log Data.
 
 [1]: /api/#roles
@@ -321,7 +303,7 @@ To scope this permission to a subset of indexes, first remove the `logs_read_ind
 
 Grant this role access to the index in [Configuration page][1].
 
-{{< img src="account_management/rbac/logs_read_index_data.png" alt="Grant read access for indexes to specific roles"  style="width:75%;" >}}
+{{< img src="account_management/rbac/logs_read_index_data.png" alt="Grant read access for indexes to specific roles" style="width:75%;" >}}
 
 
 [1]: https://app.datadoghq.com/logs/indexes
@@ -355,7 +337,7 @@ curl -X POST \
 
 ### `logs_live_tail`
 
-Grants a role the ability to use the [Live Tail][19] feature.
+Grants a role the ability to use the [Live Tail][15] feature.
 
 This permission is global, and grants access to the livetail regardless of [Log Read Index Data](#logs_read_index_data) permission.
 
@@ -379,9 +361,5 @@ This permission is global, and grants access to the livetail regardless of [Log 
 [11]: /logs/explorer/facets/#alias-facets
 [12]: /logs/archives
 [13]: /logs/archives/rehydrating
-[14]: /api/v2/logs-archives/
-[15]: /api/v1/logs-indexes/
-[16]: /api/v1/logs-pipelines/
-[17]: /api/v2/logs-restriction-queries/
-[18]: /api/v2/logs-metrics/
-[19]: /logs/explorer/live_tail/
+[14]: /api/v2/logs-restriction-queries/
+[15]: /logs/explorer/live_tail/

--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -201,9 +201,9 @@ For `service:ci-cd` logs that are rehydrated from the `Prod Archive`, note the f
 * If you **do not** use the [Log Read Index Data](#logs_read_index_data) legacy permission, these logs are accessible for `CI-CD` role members.
 * If you **do** use the [Log Read Index Data](#logs_read_index_data) legacy permission, these logs are not accessible for `CI-CD` role members, as the resulting historical view is restricted to `PROD` and `ADMIN` role members.
 
-### `logs_public_config_api`
+### Removed: `logs_public_config_api`
 
-Datadog has deprecated the `logs_public_config_api` permission. 
+Datadog has removed the `logs_public_config_api` permission. 
 
 Five separate permissions control the ability to view, create, or modify log configuration through the Datadog API:
 * `logs_generate_metrics`

--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -19,7 +19,6 @@ Once you've created [RBAC roles for logs][1], assign or remove [permissions][2] 
 
 Assign or remove permission to a role directly by [updating the role on the Datadog site][1].
 
-{{< img src="account_management/rbac/logs_permissions.png" alt="Logs Permissions" style="width:75%;" >}}
 
 [1]: https://app.datadoghq.com/access/roles
 {{% /tab %}}
@@ -201,6 +200,17 @@ For `service:ci-cd` logs that are rehydrated from the `Prod Archive`, note the f
 
 * If you **do not** use the [Log Read Index Data](#logs_read_index_data) legacy permission, these logs are accessible for `CI-CD` role members.
 * If you **do** use the [Log Read Index Data](#logs_read_index_data) legacy permission, these logs are not accessible for `CI-CD` role members, as the resulting historical view is restricted to `PROD` and `ADMIN` role members.
+
+### `logs_public_config_api`
+
+Datadog has deprecated the `logs_public_config_api` permission. 
+
+Five separate permissions control the ability to view, create, or modify log configuration through the Datadog API:
+* `logs_generate_metrics`
+* `logs_modify_indexes`
+* `logs_write_archives`
+* `logs_write_pipelines`
+* `user_access_manage`
 
 ## Log data access
 

--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -206,11 +206,11 @@ For `service:ci-cd` logs that are rehydrated from the `Prod Archive`, note the f
 Datadog has removed the `logs_public_config_api` permission. 
 
 Five separate permissions control the ability to view, create, or modify log configuration through the Datadog API:
-* `logs_generate_metrics`
-* `logs_modify_indexes`
-* `logs_write_archives`
-* `logs_write_pipelines`
-* `user_access_manage`
+* [`logs_generate_metrics`](#logs_generate_metrics)
+* [`logs_modify_indexes`](#logs_modify_indexes)
+* [`logs_write_archives`](#logs_write_archives)
+* [`logs_write_pipelines`](#logs_write_pipelines)
+* [`user_access_manage`][14]
 
 ## Log data access
 
@@ -221,7 +221,7 @@ Grant the following permissions to manage read access on subsets of log data:
 
 ### `logs_read_data`
 
-Read access to log data. If granted, other restrictions then apply such as `logs_read_index_data` or with [restriction query][14].
+Read access to log data. If granted, other restrictions then apply such as `logs_read_index_data` or with [restriction query][15].
 
 Roles are additive. If a user belongs to multiple roles, the data they have access to is the union of all the permissions from each of the roles.
 
@@ -347,7 +347,7 @@ curl -X POST \
 
 ### `logs_live_tail`
 
-Grants a role the ability to use the [Live Tail][15] feature.
+Grants a role the ability to use the [Live Tail][16] feature.
 
 This permission is global, and grants access to the livetail regardless of [Log Read Index Data](#logs_read_index_data) permission.
 
@@ -371,5 +371,6 @@ This permission is global, and grants access to the livetail regardless of [Log 
 [11]: /logs/explorer/facets/#alias-facets
 [12]: /logs/archives
 [13]: /logs/archives/rehydrating
-[14]: /api/v2/logs-restriction-queries/
-[15]: /logs/explorer/live_tail/
+[14]: /account_management/rbac/permissions/#access-management
+[15]: /api/v2/logs-restriction-queries/
+[16]: /logs/explorer/live_tail/

--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -19,7 +19,7 @@ Once you've created [RBAC roles for logs][1], assign or remove [permissions][2] 
 
 Assign or remove permission to a role directly by [updating the role in the Datadog application][1].
 
-{{< img src="account_management/rbac/logs_permissions.png" alt="Logs Permissions"  style="width:75%;" >}}
+{{< img src="account_management/rbac/logs_permissions.png" alt="Logs Permissions" style="width:75%;" >}}
 
 [1]: https://app.datadoghq.com/access/roles
 {{% /tab %}}
@@ -74,7 +74,7 @@ This permission can be assigned either globally or restricted to a subset of ind
 1. Remove the global permission on the role.
 2. Grant this permission to the role in [the Index page of the Datadog app][1] by editing an index and adding a role to the "Grant editing Exclusion Filters of this index to" field (screenshot below).
 
-{{< img src="account_management/rbac/logs_write_exclusion_filters.png" alt="Logs Write Exclusion Filters"  style="width:75%;" >}}
+{{< img src="account_management/rbac/logs_write_exclusion_filters.png" alt="Logs Write Exclusion Filters" style="width:75%;" >}}
 
 
 [1]: /logs/log_configuration/indexes/


### PR DESCRIPTION
### What does this PR do?
Update the 3 Logs pages that will be made out of date by the January 18 AAA code release. Follows the tracking spreadsheet/update plan here: https://docs.google.com/spreadsheets/d/1qAFjGVoxZusiOP8Qlevj5mCvELGuU4BYYc0OiZWLfAA/edit#gid=1935103315.

### Motivation
Docs need to be brought up to date to be consistent with January 18 AAA code release.

The January 18 changes are:
- removal of the `logs_public_config_api` permission. Instead, logs API permissions are governed by logs_generate_metrics, logs_modify_indexes, logs_write_archives, logs_write_pipelines, and user_access_manage
- There is no longer a permission called 'admin'. Permissions that used to be enabled by 'admin' are delegated to more specific roles and permissions.

### Preview
https://docs-staging.datadoghq.com/uchen/admin-release-1/logs/guide/access-your-log-data-programmatically/
https://docs-staging.datadoghq.com/uchen/admin-release-1/logs/guide/build-custom-reports-using-log-analytics-api/?tab=table
https://docs-staging.datadoghq.com/uchen/admin-release-1/logs/guide/logs-rbac-permissions/?tab=ui

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
