### PR TITLE
Update broken img in CSPM docs

### DIFF
--- a/content/fr/compliance_monitoring/_index.md
+++ b/content/fr/compliance_monitoring/_index.md
@@ -11,7 +11,7 @@ La surveillance de la conformité est actuellement disponible en version bêta p
 
 La surveillance de la conformité Datadog permet de surveiller en continu la sécurité des runtimes et la conformité des conteneurs et des hosts.
 
-{{< img src="compliance_monitoring/compliance-overview.png" alt="Surveillance de la conformité Datadog" >}}
+{{< img src="/security_platform/cspm/landing_page.png" alt="Surveillance de la conformité Datadog" >}}
 
 Utilisez la **surveillance de l'intégrité des fichiers (FIM)** pour détecter les modifications apportées aux fichiers et répertoires clés de vos hosts ou conteneurs en temps réel, ou les checks de **surveillance de la conformité en continu** pour détecter les problèmes de configuration sur vos conteneurs et clusters Kubernetes. Un problème de configuration est défini tel que dans les références de conformité émises par le CIS pour Docker et Kubernetes. Selon vos besoins, vous pouvez activer l'une de ces fonctionnalités ou les deux.
 


### PR DESCRIPTION
### What does this PR do?
Updates a broken image in the CSPM FR docs

### Motivation
It was using the old file path; updated to surface the image

### Preview
https://docs-staging.datadoghq.com/fr/compliance_monitoring/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
