### PR TITLE
Primary Operations in Services - Custom Instrumentation Update

### DIFF
--- a/content/en/tracing/guide/configuring-primary-operation.md
+++ b/content/en/tracing/guide/configuring-primary-operation.md
@@ -59,26 +59,11 @@ To ensure that all traces are being sent to Datadog correctly outside of any ins
 
 {{< img src="tracing/guide/primary_operation/dropdown.mp4" alt="APM save" video=true >}}
 
-## Manual instrumentation
+## Custom Instrumentation
 
-When manually instrumenting your code, statically set the span name to ensure that your resources are grouped with the same primary operation (for example, `web.request`). If the span is being named dynamically, set it as the resource.
+When writing custom spans, statically set the span name to ensure that your resources are grouped with the same primary operation (for example, `web.request`). If the span is being named dynamically, set it as the resource (for example, `/user/profile`).
 
-Modify the primary operation for Python:
-
-```text
-  @tracer.wrap('tornado.notify',
-                service='tornado-notification',
-                resource='MainHandler.do_something')
-    @tornado.gen.coroutine
-    def do_something(self):
-        # do something
-```
-
-This function explicitly sets both the service name and primary operation, being `tornado-notification` and `tornado.notify`, respectively.
-
-Also note that the resource name is set manually, `MainHandler.do_something`.
-
-By default, the resource name would be set to this as it’s the name of the function and the class for which it lives under in Tornado.
+See [Custom Instrumentation][3] for your programming language for detailed information.
 
 ## OpenTracing
 
@@ -157,7 +142,7 @@ For more information, see [Setting up Go and OpenTracing][1].
 
 ```javascript
 const span = tracer.startSpan('http.request');
-span.setTag('resource.name',  ‘/user/profile’)
+span.setTag('resource.name',  '/user/profile')
 span.setTag('span.type', 'web')
 // code being traced
 span.finish();
@@ -241,3 +226,4 @@ For more information, see [Setting up CPP and Custom Instrumentation][1].
 
 [1]: /tracing/guide/metrics_namespace/
 [2]: https://app.datadoghq.com/apm/settings
+[3]: /tracing/setup_overview/custom_instrumentation/

--- a/content/en/tracing/guide/configuring-primary-operation.md
+++ b/content/en/tracing/guide/configuring-primary-operation.md
@@ -59,7 +59,7 @@ To ensure that all traces are being sent to Datadog correctly outside of any ins
 
 {{< img src="tracing/guide/primary_operation/dropdown.mp4" alt="APM save" video=true >}}
 
-## Custom Instrumentation
+## Manual instrumentation
 
 When writing custom spans, statically set the span name to ensure that your resources are grouped with the same primary operation (for example, `web.request`). If the span is being named dynamically, set it as the resource (for example, `/user/profile`).
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR defers to the custom span section of this doc: https://docs.datadoghq.com/tracing/setup_overview/custom_instrumentation/ to explain how to set operation names and resource names.

### Motivation
<!-- What inspired you to submit this pull request?-->

When writing custom spans, it is useful to be able to set up resource names to group under a specific operation name.

The current example only applies to Python and only covers one scenario: `@tracer.wrap`. Rather than add all the possible scenarios to this doc, each custom instrumentation doc now explains how to set resource names and operation names when using the various APIs.

Python, for example, has three different options to [create spans in the doc section](https://docs.datadoghq.com/tracing/setup_overview/custom_instrumentation/python?tab=decorator#creating-spans): Decorator, Context Manager, and Manual. Each option has been updated to show how resource could be set.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/wantsui/link-to-custom-instrumentation-section/tracing/guide/configuring-primary-operation/#apm-services

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
