### PR TITLE
[agent] Fix HTTP Logs Agent destination

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -40,7 +40,7 @@ All Agent traffic is sent over SSL. The destination is dependent on the Datadog 
 
 [Logs][5] & [HIPAA logs][6]
 : TCP: `{{< region-param key="tcp_endpoint" code="true" >}}`<br>
-HTTP: `{{< region-param key="http_endpoint" code="true" >}}`<br>
+HTTP: `{{< region-param key="agent_http_endpoint" code="true" >}}`<br>
 Other: See [logs endpoints][7]
 
 [HIPAA logs legacy][6]


### PR DESCRIPTION
### What does this PR do?
Fixes HTTP Logs Agent destination.

### Motivation
The agent uses the `agent-http-intake`-prefixed one.

### Preview
https://docs-staging.datadoghq.com/olivielpeau/fix-logs-http-endpoint/agent/guide/network/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
