### PR TITLE
Extend list of monitor template variables 

### DIFF
--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -345,15 +345,18 @@ Variable content is escaped by default. To prevent content such as JSON or code 
 
 Use template variables to customize your monitor notifications. The built-in variables are:
 
-| Variable                      | Description                                                                  |
-|-------------------------------|------------------------------------------------------------------------------|
-| `{{value}}`                   | The value that breached the alert for metric based query monitors.           |
-| `{{threshold}}`               | The value of the alert threshold set in the monitor's alert conditions.      |
-| `{{warn_threshold}}`          | The value of the warning threshold set in the monitor's alert conditions.    |
-| `{{ok_threshold}}`            | The value that recovered the monitor.                                        |
-| `{{comparator}}`              | The relational value set in the monitor's alert conditions.                  |
-| `{{last_triggered_at}}`       | The UTC date and time when the monitor last triggered.                       |
-| `{{last_triggered_at_epoch}}` | The UTC date and time when the monitor last triggered in epoch milliseconds. |
+| Variable                       | Description                                                                   |
+|--------------------------------|-------------------------------------------------------------------------------|
+| `{{value}}`                    | The value that breached the alert for metric based query monitors.            |
+| `{{threshold}}`                | The value of the alert threshold set in the monitor's alert conditions.       |
+| `{{warn_threshold}}`           | The value of the warning threshold set in the monitor's alert conditions.     |
+| `{{ok_threshold}}`             | The value that recovered the monitor.                                         |
+| `{{comparator}}`               | The relational value set in the monitor's alert conditions.                   |
+| `{{first_triggered_at}}`       | The UTC date and time when the monitor first triggered.                       |
+| `{{first_triggered_at_epoch}}` | The UTC date and time when the monitor first triggered in epoch milliseconds. |
+| `{{last_triggered_at}}`        | The UTC date and time when the monitor last triggered.                        |
+| `{{last_triggered_at_epoch}}`  | The UTC date and time when the monitor last triggered in epoch milliseconds.  |
+| `{{triggered_duration_sec}}`   | The number of seconds the monitor has been in a triggered state.              |
 
 ### Evaluation
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds `first_triggered_at`, `first_triggered_at_epoch`, and `triggered_duration_sec` and their respective explanations to the list of monitor template variables.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
