### PR TITLE
[CIAPP-3567] Update CI Visibility GitHub Actions docs

### DIFF
--- a/content/en/continuous_integration/setup_tests/agent.md
+++ b/content/en/continuous_integration/setup_tests/agent.md
@@ -180,7 +180,8 @@ To run the Agent in GitHub Actions, use the [Datadog Agent GitHub Action][1] `da
 jobs:
   test:
     steps:
-      - uses: datadog/agent-github-action@v1
+      - name: Start the Datadog Agent locally
+        uses: datadog/agent-github-action@v1
         with:
           api_key: ${{ secrets.DD_API_KEY }}
       - run: make test

--- a/content/en/continuous_integration/setup_tests/agent.md
+++ b/content/en/continuous_integration/setup_tests/agent.md
@@ -173,7 +173,7 @@ Add your [Datadog API key][2] to your [project environment variables][3] with th
 {{% /tab %}}
 {{% tab "GitHub Actions" %}}
 
-To run the Agent in GitHub Actions, use the [datadog/agent-github-action][1].
+To run the Agent in GitHub Actions, use the [Datadog Agent GitHub Action][1] `datadog/agent-github-action`.
 
 {{< site-region region="us" >}}
 {{< code-block lang="yaml" >}}

--- a/content/en/continuous_integration/setup_tests/agent.md
+++ b/content/en/continuous_integration/setup_tests/agent.md
@@ -180,7 +180,7 @@ To run the Agent in GitHub Actions, use the [datadog/agent-github-action][1].
 jobs:
   test:
     steps:
-      - uses: datadog/agent-github-action@v0.1.0
+      - uses: datadog/agent-github-action@v1
         with:
           api_key: ${{ secrets.DD_API_KEY }}
       - run: make test
@@ -194,7 +194,7 @@ Replace `<datadog_site>` with the selected site: {{< region-param key="dd_site" 
 jobs:
   test:
     steps:
-      - uses: datadog/agent-github-action@v0.1.0
+      - uses: datadog/agent-github-action@v1
         with:
           api_key: ${{ secrets.DD_API_KEY }}
           datadog_site: <datadog_site>

--- a/content/en/continuous_integration/setup_tests/agent.md
+++ b/content/en/continuous_integration/setup_tests/agent.md
@@ -195,7 +195,8 @@ Replace `<datadog_site>` with the selected site: {{< region-param key="dd_site" 
 jobs:
   test:
     steps:
-      - uses: datadog/agent-github-action@v1
+      - name: Start the Datadog Agent locally
+        uses: datadog/agent-github-action@v1
         with:
           api_key: ${{ secrets.DD_API_KEY }}
           datadog_site: <datadog_site>

--- a/content/en/continuous_integration/setup_tests/agent.md
+++ b/content/en/continuous_integration/setup_tests/agent.md
@@ -173,50 +173,38 @@ Add your [Datadog API key][2] to your [project environment variables][3] with th
 {{% /tab %}}
 {{% tab "GitHub Actions" %}}
 
-To run the Agent in GitHub Actions, define the Agent container under [services][1].
+To run the Agent in GitHub Actions, use the [datadog/agent-github-action][1].
 
 {{< site-region region="us" >}}
 {{< code-block lang="yaml" >}}
 jobs:
   test:
-    services:
-      datadog-agent:
-        image: gcr.io/datadoghq/agent:latest
-        ports:
-          - 8126:8126
-        env:
-          DD_API_KEY: ${{ secrets.DD_API_KEY }}
-          DD_INSIDE_CI: "true"
-          DD_HOSTNAME: "none"
     steps:
+      - uses: datadog/agent-github-action@v0.1.0
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
       - run: make test
 {{< /code-block >}}
 {{< /site-region >}}
 {{< site-region region="us3,us5,eu" >}}
 
-Replace `<DD_SITE>` with the selected site: {{< region-param key="dd_site" code="true" >}}.
+Replace `<datadog_site>` with the selected site: {{< region-param key="dd_site" code="true" >}}.
 
 {{< code-block lang="yaml" >}}
 jobs:
   test:
-    services:
-      datadog-agent:
-        image: gcr.io/datadoghq/agent:latest
-        ports:
-          - 8126:8126
-        env:
-          DD_API_KEY: ${{ secrets.DD_API_KEY }}
-          DD_INSIDE_CI: "true"
-          DD_HOSTNAME: "none"
-          DD_SITE: "<DD_SITE>"
     steps:
+      - uses: datadog/agent-github-action@v0.1.0
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          datadog_site: <datadog_site>
       - run: make test
 {{< /code-block >}}
 {{< /site-region >}}
 
 Add your [Datadog API key][2] to your [project secrets][3] with the key `DD_API_KEY`.
 
-[1]: https://docs.github.com/en/actions/guides/about-service-containers
+[1]: https://github.com/marketplace/actions/datadog-agent
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 [3]: https://docs.github.com/en/actions/reference/encrypted-secrets
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update the GitHub Action test tracing docs to use the [GitHub action ](https://github.com/marketplace/actions/datadog-agent)t o start the datadog agent.
### Motivation
<!-- What inspired you to submit this pull request?-->
The old instructions could mean that due to ungraceful shutdown not all the test where sent.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/carlos.gonzalez/ci-vis-update-github-actions-instructions/continuous_integration/setup_tests/agent/?tab=githubactions

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
