### PR TITLE
Fix metrics index page alt text

### DIFF
--- a/content/en/metrics/_index.md
+++ b/content/en/metrics/_index.md
@@ -29,7 +29,7 @@ In Datadog, metric data is ingested and stored as data points with a value and t
 [ 17.82,  22:11:01 ]
 ```
 
-A sequence of data points is stored as a time series:
+A sequence of data points is stored as a timeseries:
 
 ```text
 [ 17.82,  22:11:01 ]
@@ -50,11 +50,11 @@ In addition, metrics can help you adjust the scale of your environment to meet t
 
 ### Visualizing metrics in Datadog
 
-You can visualize your metrics and create graphs throughout the Datadog app: in [Metrics Explorer][3], [Dashboards][4], or [Notebooks][5].
+You can visualize your metrics and create graphs throughout Datadog: in [Metrics Explorer][3], [Dashboards][4], or [Notebooks][5].
 
 Here’s an example of a timeseries visualization:
 
-{{< img src="metrics/introduction/timeseries_example.png" alt="Timeseries example" >}}
+{{< img src="metrics/introduction/timeseries_example.png" alt="A timeseries graph displays a latency metric represented by a single blue line with several spikes" >}}
 
 This line graph plots latency (in milliseconds) experienced by users on the y-axis against time on the x-axis.
 
@@ -108,7 +108,7 @@ _Grouping_ defines what constitutes a line on the graph. For example, if you hav
 
 #### Apply functions (optional)
 
-You can modify your graph values with mathematical [functions][17]. This can mean performing arithmetic between an integer and a metric (for example, multiplying a metric by 2). Or performing arithemetic between two metrics (for example, creating a new timeseries for the memory utilization rate like this: `jvm.heap_memory / jvm.heap_memory_max`).
+You can modify your graph values with mathematical [functions][17]. This can mean performing arithmetic between an integer and a metric (for example, multiplying a metric by 2). Or performing arithmetic between two metrics (for example, creating a new timeseries for the memory utilization rate like this: `jvm.heap_memory / jvm.heap_memory_max`).
 
 ### Time and space aggregation
 
@@ -116,7 +116,7 @@ _Time aggregation_ and _space aggregation_ are two important components of any q
 
 #### Time aggregation
 
-Datadog stores a large volume of points, and in most cases it’s not possible to display all of them on a graph. There would be more datapoints than pixels. Datadog uses time aggregation to solve this problem by combining data points into time buckets.  For example, when examining four hours, data points are combined into two-minute buckets. This is called a _rollup_. As the time interval you’ve defined for your query increases, the granularity of your data becomes coarser.
+Datadog stores a large volume of points, and in most cases it’s not possible to display all of them on a graph. There would be more datapoints than pixels. Datadog uses time aggregation to solve this problem by combining data points into time buckets. For example, when examining four hours, data points are combined into two-minute buckets. This is called a _rollup_. As the time interval you’ve defined for your query increases, the granularity of your data becomes coarser.
 
 There are five aggregations you can apply to combine your data in each time bucket: sum, min, max, avg, and count.
 
@@ -154,9 +154,9 @@ The [Metrics Summary page][19] displays a list of your metrics reported to Datad
 
 Click on any metric name to display a details sidepanel with more detailed information. The details sidepanel displays key information for a given metric, including its metadata (type, unit, interval), number of distinct metrics, number of reporting hosts, number of tags submitted, and a table containing all tags submitted on a metric. Seeing which tags are being submitted on a metric helps you understand the number of distinct metrics reporting from it, since this number depends on your tag value combinations.
 
-Note: The number of distinct metrics reported in the details sidepanel on Metrics Summary does not define your bill. See your [usage details][20] for a precise accounting of your usage over the past month.
+**Note:** The number of distinct metrics reported in the details sidepanel on Metrics Summary does not define your bill. See your [usage details][20] for a precise accounting of your usage over the past month.
 
-See the [full Metrics Summary documentation][21] for more details.
+Read the [metrics summary documentation][21] for more details.
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Well, it started out just fixing some alt text but then I ended up proof reading and linting a little 😅 

### Motivation
To be included in a docs4docs example

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jorie/alt-text-examples/metrics/
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
