### PR TITLE
Set missing metrics step to manual in gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -386,6 +386,7 @@ evaluate_missing_metrics:
   environment: "live"
   script:
     - chmod +x ./local/bin/py/missing_metrics.py && ./local/bin/py/missing_metrics.py -k $(get_secret 'dd-demo-api-key') -p $(get_secret 'dd-demo-app-key') -a $(get_secret 'dd_api_key') -b $(get_secret 'dd-app-key')
+  when: manual
   only:
     - master
 


### PR DESCRIPTION
### What does this PR do?
Sets the `evaluate_missing_metrics` step in the Gitlab pipeline to run manually instead of automatically.

### Motivation
https://datadoghq.atlassian.net/browse/DOCS-3048
After Ruth left the company, the missing metrics evaluation step, which she set up, stopped working. It appears to be relying on her API key. After I get back from vacation, I will fix the step so it works again. For now, I am turning it off so the `documentation` master builds turn back to green.

### Preview
none

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
