### PR TITLE
add blog links to NPM pages

### DIFF
--- a/content/en/network_monitoring/performance/_index.md
+++ b/content/en/network_monitoring/performance/_index.md
@@ -22,6 +22,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/npm-best-practices/"
   tag: "Blog"
   text: "Best practices for getting started with Datadog NPM"
+- link: "https://www.datadoghq.com/blog/monitor-consul-with-datadog-npm/"
+  tag: "Blog"
+  text: "Datadog NPM now supports Consul networking"
 ---
 
 ## Overview

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -14,6 +14,9 @@ further_reading:
     - link: '/network_monitoring/devices'
       tag: 'Documentation'
       text: 'Network Device Monitoring'
+    - link: "https://www.datadoghq.com/blog/monitor-consul-with-datadog-npm/"
+      tag: "Blog"
+      text: "Datadog NPM now supports Consul networking"
 ---
 
 Datadog Network Performance Monitoring (NPM) gives you visibility into your network traffic between services, containers, availability zones, and any other tag in Datadog so you can:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
adds links to a new blog post to two NPM pages, the performance index and setup.

### Motivation
whimsy

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/cswatt/consul-links/network_monitoring/performance
https://docs-staging.datadoghq.com/cswatt/consul-links/network_monitoring/performance/setup

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
