### PR TITLE
s/less/fewer in vale warning message

### DIFF
--- a/.github/styles/Datadog/sentencelength.yml
+++ b/.github/styles/Datadog/sentencelength.yml
@@ -1,5 +1,5 @@
 extends: occurrence
-message: "Try to keep your sentence length to 25 words or less."
+message: "Try to keep your sentence length to 25 words or fewer."
 level: warning
 # Here, we're counting the number of words
 # in a sentence.


### PR DESCRIPTION
less vs. fewer:
less is for uncountable quantities (less time, less air)
fewer is for countable quantities (fewer seconds, fewer molecules—fewer words)