### PR TITLE
[ci-visibility] Add Subsection to Wall Time Calculation Troubleshooting

### DIFF
--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -84,15 +84,18 @@ If you cannot see the tests wall time it is likely that the CI provider metadata
 
 ### The tests wall time is not what is expected
 
+#### How wall time is calculated
 The wall time is defined as the time difference between the start time of the first test and the end time of the last test for the given pipeline.
 
 This is done using the following algorithm:
 
 1. Compute a hash based on CI information to group the tests.
-  a. If the tests have `ci.job.url`, this information is used to calculate the hash.
-  b. If the tests don’t have `ci.job.url`, the hash is calculated using `ci.pipeline.id` + `ci.pipeline.name` + `ci.pipeline.number`.
-2. Calculate wall time is associated with every given hash. **Note**: There can be multiple wall times for a certain pipeline, for example, if there are multiple jobs that execute tests.
-3. If there are multiple wall times, the maximum wall time calculated for a given pipeline in a certain commit is used.
+  a. If the tests include `ci.job.url`, use this tag to calculate the hash.
+  b. If the tests don’t include `ci.job.url`, use `ci.pipeline.id` + `ci.pipeline.name` + `ci.pipeline.number` to calculate the hash.
+2. The calculated wall time is associated to a given hash. **Note**: If there are multiple jobs that execute tests, the wall time is the time difference between the start of the first test in the earliest job and the end of the last test in the latest job.
+
+#### Possible issues with wall time calculation
+If you're using a library for testing time-dependent code, like [timecop][7] for Ruby or [FreezeGun][8] for Python, it is possible that test timestamps and calculated wall times are wrong. If this is the case, make sure that modifications to time are rolled back before finishing your tests.
 
 ### Need further help?
 
@@ -105,3 +108,5 @@ Still need help? Contact [Datadog support][1].
 [4]: https://app.datadoghq.com/ci/test-services
 [5]: /tracing/troubleshooting/tracer_debug_logs
 [6]: /continuous_integration/setup_tests/containers/
+[7]: https://github.com/travisjeffery/timecop
+[8]: https://github.com/spulec/freezegun

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -95,7 +95,7 @@ This is done using the following algorithm:
 2. The calculated wall time is associated to a given hash. **Note**: If there are multiple jobs that execute tests, the wall time is the time difference between the start of the first test in the earliest job and the end of the last test in the latest job.
 
 #### Possible issues with wall time calculation
-If you're using a library for testing time-dependent code, like [timecop][7] for Ruby or [FreezeGun][8] for Python, it is possible that test timestamps and calculated wall times are wrong. If this is the case, make sure that modifications to time are rolled back before finishing your tests.
+If you're using a library for testing time-dependent code, like [timecop][7] for Ruby or [FreezeGun][8] for Python, it is possible that test timestamps are wrong, and therefore calculated wall times. If this is the case, make sure that modifications to time are rolled back before finishing your tests.
 
 ### Need further help?
 


### PR DESCRIPTION
### What does this PR do?
Add warning about time mocking libraries and clarify wall time calculation.

### Motivation
Make it easier to understand potential issues with wall time calculation.

### Preview
https://docs-staging.datadoghq.com/juan-fernandez/add-to-walltime-troubleshooting/continuous_integration/troubleshooting/#the-tests-wall-time-is-not-what-is-expected

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
