### PR TITLE
Update to Secrets Management for cleanup, examples, and new provider strategy

### DIFF
--- a/content/en/agent/guide/secrets-management.md
+++ b/content/en/agent/guide/secrets-management.md
@@ -9,7 +9,7 @@ further_reading:
 
 If you wish to avoid storing secrets in plaintext in the Agent’s configuration files, you can use the secrets management package.
 
-The Agent is able to leverage the `secrets` package to call a user-provided executable to handle retrieval and decryption of secrets, which are then loaded in memory by the Agent. This approach allows users to rely on any secrets management backend (such as HashiCorp Vault or AWS Secrets Manager), and select their preferred authentication method to establish initial trust with it.
+The Agent is able to leverage the `secrets` package to call a user-provided executable to handle retrieval and decryption of secrets, which are then loaded in memory by the Agent. This approach allows users to rely on any secrets management backend (such as HashiCorp Vault or AWS Secrets Manager), and select their preferred authentication method to establish initial trust with it. As a convenience containerized deployments of the Agent are pre-packaged with [Helper Scripts](#helper-scripts-for-autodiscovery) to use for this executable.
 
 Starting with version 6.12, the secrets management package is generally available on Linux for metrics, APM, and process monitoring, as well as on Windows for metrics and APM.
 
@@ -87,7 +87,7 @@ Relying on a user-provided executable has multiple benefits:
 
 Set the following variable in `datadog.yaml`:
 
-```text
+```yaml
 secret_backend_command: <EXECUTABLE_PATH>
 ```
 
@@ -126,7 +126,7 @@ The executable respects a simple API: it reads JSON from the standard input and 
 
 If the exit code of the executable is anything other than `0`, the integration configuration currently being decrypted is considered erroneous and is dropped.
 
-**Input**:
+##### API example input
 
 The executable receives a JSON payload from the standard input, containing the list of secrets to fetch:
 
@@ -137,7 +137,7 @@ The executable receives a JSON payload from the standard input, containing the l
 * `version`: is a string containing the format version (currently 1.0).
 * `secrets`: is a list of strings; each string is a handle from a configuration corresponding to a secret to fetch.
 
-**Output**:
+##### API example output
 
 The executable is expected to output to the standard output a JSON payload containing the fetched secrets:
 
@@ -153,7 +153,7 @@ The expected payload is a JSON object, where each key is one of the handles requ
 * `value`: a string; the actual secret value to be used in the check configurations (can be null in the case of error).
 * `error`: a string; the error message, if needed. If error is anything other than null, the integration configuration that uses this handle is considered erroneous and is dropped.
 
-**Example**:
+##### Example executable
 
 The following is a dummy Go program prefixing every secret with `decrypted_`:
 
@@ -216,79 +216,118 @@ instances:
     password: decrypted_db_prod_password
 ```
 
-### Helper scripts for Autodiscovery
+## Helper scripts for Autodiscovery
 
 Many Datadog integrations require credentials to retrieve metrics. To avoid hardcoding these credentials in an [Autodiscovery template][1], you can use secrets management to separate them from the template itself.
 
-Starting with version 7.32.0, the [helper script][2] is available in the Docker image as `/readsecret_multiple_providers.sh`, and you can use it to fetch secrets from files and Kubernetes secrets. The two scripts provided in previous versions (`readsecret.sh` and `readsecret.py`) are supported, but can only read from files.
+Starting with version 7.32.0, the [helper script][2] is available in the Agent's container image as `/readsecret_multiple_providers.sh`, and you can use it to fetch secrets from files and Kubernetes secrets. The two scripts provided in previous versions (`readsecret.sh` and `readsecret.py`) are still supported, but can only read from files.
 
-#### Script for reading from multiple secret providers (`readsecret_multiple_providers.sh`)
+### Script for reading from multiple secret providers
 
-##### Usage
+#### Multiple providers usage
+The script `readsecret_multiple_providers.sh` can be used to read from both files as well as Kubernetes Secrets. These Secrets must follow the format `ENC[provider@some/path]`. For example:
 
-Secrets must follow the format `ENC[provider@some/path]`. For example, for reading from files, a valid secret would be `ENC[file@/some/path]`. For Kubernetes secrets, the format is `ENC[k8s_secret@some_namespace/some_name/a_key]`.
+| Provider               | Format                                           |
+|------------------------|--------------------------------------------------|
+| Read from files        | `ENC[file@/path/to/file]`                        |
+| Kubernetes Secrets     | `ENC[k8s_secret@some_namespace/some_name/a_key]` |
 
-To read from Kubernetes, ensure that the Agent can access your secrets by setting the appropriate Kubernetes roles and bindings.
-
-##### Setup examples
-
-To use the `db_prod_password` secret value exposed in the `/run/secrets/db_prod_password` file, insert `ENC[file@/run/secrets/db_prod_password]` in your template and set the following environment variable:
-
+To utilize this executable set the environment variable:
 ```
 DD_SECRET_BACKEND_COMMAND=/readsecret_multiple_providers.sh
 ```
 
-To read the `db_prod_password` secret value exposed in the `password` key of the Kubernetes `db_credentials` secret present in the `db` namespace, insert `ENC[k8s_secret@db/db_credentials/password]` in your template and set the following environment variable:
+#### Read from file example
+The Agent can read a specified file relative to the path provided. This file can be brought in from [Kubernetes Secrets](#kubernetes-secrets), [Docker Swarm Secrets](#docker-swarm-secrets), or any other custom method.
 
+If the Agent container has the file `/etc/secret-volume/password` whose contents were the plaintext password, this would be referenced with a notation like `ENC[file@/etc/secret-volume/password]`.
+
+##### Kubernetes secrets
+Kubernetes supports [exposing secrets as files][3] inside a pod. For example: if the `Secret: test-secret` has the data `db_prod_password: example`, by mounting the Secret into the Agent container like so:
+```yaml
+  containers:
+    - name: agent
+      #(...)
+      volumeMounts:
+        - name: secret-volume
+          mountPath: /etc/secret-volume
+  #(...)
+  volumes:
+    - name: secret-volume
+      secret:
+        secretName: test-secret
 ```
-DD_SECRET_BACKEND_COMMAND=/readsecret_multiple_providers.sh
+The Agent container will contain the file `/etc/secret-volume/db_prod_password` with the contents of `example`. This would be referenced in the configuration by `ENC[file@/etc/secret-volume/db_prod_password]`.
+
+**Notes:**
+- The Secret must exist in the same namespace as the pod it is being mounted in.
+- Datadog recommends using a dedicated folder instead of `/var/run/secrets`, as the script will be able to access all subfolders, including the sensitive `/var/run/secrets/kubernetes.io/serviceaccount/token` file.
+
+##### Docker Swarm secrets
+[Docker swarm secrets][4] are mounted in the `/run/secrets` folder. So the Docker secret `db_prod_passsword` would be located in `/run/secrets/db_prod_password` of the Agent container. This would be referenced in the configuration by `ENC[file@/run/secrets/db_prod_password]`.
+
+#### Read from Kubernetes Secret example
+This setup allows the Agent to directly read Kubernetes Secrets within its own and *other* namespaces. However, to do so the Agent's `ServiceAccount` must be granted permissions with the appropriate `Roles` and `RoleBindings` to do so.
+
+If the `Secret: database-secret` existed in the `Namespace: database`, and contained the data `password: example` this would be referenced in the configuration by `ENC[k8s_secret@database/database-secret/password]`. This will have the Agent pull this Secret directly from Kubernetes, which can be helpful when referencing a Secret that exists in a different namespace than the Agent is in.
+
+This does require additional permissions that are manually granted to the Agent's Service Account. For example the RBAC policy of:
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: datadog-secret-reader
+  namespace: database
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["database-secret"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: datadog-read-secrets
+  namespace: example
+subjects:
+  - kind: ServiceAccount
+    name: datadog-agent
+    apiGroup: ""
+    namespace: default
+roleRef:
+  kind: Role
+  name: datadog-secret-reader
+  apiGroup: ""
 ```
+This `Role` would give access to the `Secret: database-secret` in the `Namespace: database`. The `RoleBinding` links up this permission to the `ServiceAccount: datadog-agent` in the `Namespace: default`. This will need to be manually added to your cluster with respect to your resources deployed.
 
-#### Scripts for reading from files (`readsecret.py` and `readsecret.sh`)
+### (Legacy) Scripts for reading from files
+In version 7.32 of the Agent the script `readsecret_multiple_providers.sh` was added. This is the recommended script to use, rather than the legacy ones introduced in 6.12,  `/readsecret.py` and `/readsecret.sh`. However, `/readsecret.py` and `/readsecret.sh` are still included and supported in the Agent to read files.
 
-##### Usage
+#### Usage
+These scripts require a folder passed as an argument. Secret handles are interpreted as file names, relative to this folder. The script refuses to access any file out of the root folder specified (including symbolic link targets) to avoid leaking sensitive information.
 
-The script requires a folder passed as an argument. Secret handles are interpreted as file names, relative to this folder. The script refuses to access any file out of the root folder (including symbolic link targets) to avoid leaking sensitive information.
+This script is incompatible with [OpenShift restricted SCC operations][5] and requires that the Agent runs as the `root` user.
 
-This script is incompatible with [OpenShift restricted SCC operations][3] and requires that the Agent runs as the `root` user.
-
-Starting with version 6.10.0, `ENC[]` tokens in config values passed as environment variables are supported. Previous versions only support `ENC[]` tokens found in `datadog.yaml` and in Autodiscovery templates.
-
-##### Setup examples
-
-###### Docker Swarm secrets
-
-[Docker secrets][4] are mounted in the `/run/secrets` folder. Pass the following environment variables to your Agent container:
+##### Docker
+[Docker swarm secrets][4] are mounted in the `/run/secrets` folder. These can be read by passing the following environment variables to your Agent container:
 
 ```
 DD_SECRET_BACKEND_COMMAND=/readsecret.py
 DD_SECRET_BACKEND_ARGUMENTS=/run/secrets
 ```
 
-To use the `db_prod_password` secret value, exposed in the `/run/secrets/db_prod_password` file, just insert `ENC[db_prod_password]` in your template.
+This will have the Datadog Agent read any secret files located in the `/run/secrets` directory. For example the configuration `ENC[password]` would have the Agent search for the `/run/secrets/password` file.
 
-###### Kubernetes secrets
-
-Kubernetes supports [exposing secrets as files][5] inside a pod.
-
-If your secrets are mounted in `/etc/secret-volume`, use the following environment variables:
+##### Kubernetes
+Kubernetes supports [exposing secrets as files][3] inside a pod. If your secrets are mounted in `/etc/secret-volume`, use the following environment variables:
 
 ```
 DD_SECRET_BACKEND_COMMAND=/readsecret.py
 DD_SECRET_BACKEND_ARGUMENTS=/etc/secret-volume
 ```
 
-**Note**: The Datadog Cluster Agent uses a different command than the Datadog Agent:
-
-```
-DD_SECRET_BACKEND_COMMAND=/readsecret.sh
-DD_SECRET_BACKEND_ARGUMENTS=/etc/secret-volume
-```
-The Datadog Cluster Agent also uses a different secret helper command. Instead of `agent secret`, as used in the Node Agent, the Cluster Agent uses `cluster-agent secret-helper`.
-
-Following the linked example, the password field is stored in the `/etc/secret-volume/password` file, and accessible through the `ENC[password]` token.
-
-**Note**: Datadog recommends using a dedicated folder instead of `/var/run/secrets`, as the script will be able to access all subfolders, including the sensitive `/var/run/secrets/kubernetes.io/serviceaccount/token` file.
+This will have the Datadog Agent read any secret files located in the `/etc/secret-volume` directory. For example the configuration `ENC[password]` would have the Agent search for the `/etc/secret-volume/password` file.
 
 ## Troubleshooting
 
@@ -297,6 +336,9 @@ Following the linked example, the password field is stored in the `/etc/secret-v
 The `secret` command in the Agent CLI shows any errors related to your setup. For example, if the rights on the executable are incorrect. It also lists all handles found, and where they are located.
 
 On Linux, the command outputs file mode, owner and group for the executable. On Windows, ACL rights are listed.
+
+{{< tabs >}}
+{{% tab "Linux" %}}
 
 Example on Linux:
 
@@ -318,6 +360,9 @@ Secrets handle decrypted:
 - db_prod_user: from postgres.yaml
 - db_prod_password: from postgres.yaml
 ```
+
+{{% /tab %}}
+{{% tab "Windows" %}}
 
 Example on Windows (from an Administrator Powershell):
 
@@ -349,9 +394,13 @@ Secrets handle decrypted:
 - db_prod_password: from sqlserver.yaml
 ```
 
+{{% /tab %}}
+{{< /tabs >}}
+
+
 ### Seeing configurations after secrets were injected
 
-To quickly see how the check's configurations are resolved, you can use the `configcheck` command :
+To quickly see how the check's configurations are resolved, you can use the `configcheck` command:
 
 ```shell
 sudo -u dd-agent -- datadog-agent configcheck
@@ -381,6 +430,8 @@ password: <decrypted_password2>
 
 To test or debug outside of the Agent, you can mimic how the Agent runs it:
 
+{{< tabs >}}
+{{% tab "Linux" %}}
 #### Linux
 
 ```bash
@@ -389,6 +440,9 @@ sudo su dd-agent - bash -c "echo '{\"version\": \"1.0\", \"secrets\": [\"secret1
 
 The `dd-agent` user is created when you install the Datadog Agent.
 
+
+{{% /tab %}}
+{{% tab "Windows" %}}
 #### Windows
 
 ##### Rights related errors
@@ -422,24 +476,21 @@ To do so, follow those steps:
 
 1. Remove `ddagentuser` from the `Local Policies/User Rights Assignement/Deny Log on locally` list in the `Local Security Policy`.
 2. Set a new password for `ddagentuser` (since the one generated at install time is never saved anywhere). In Powershell, run:
-
-  ```powershell
-  $user = [ADSI]"WinNT://./ddagentuser";
-  $user.SetPassword("a_new_password")
-  ```
-
+    ```powershell
+    $user = [ADSI]"WinNT://./ddagentuser";
+    $user.SetPassword("a_new_password")
+    ```
 3. Update the password to be used by `DatadogAgent` service in the Service Control Manager. In Powershell, run:
-
-  ```powershell
-  sc.exe config DatadogAgent password= "a_new_password"
-  ```
+    ```powershell
+    sc.exe config DatadogAgent password= "a_new_password"
+    ```
 
 You can now login as `ddagentuser` to test your executable. Datadog has a [Powershell script][7] to help you test your
 executable as another user. It switches user contexts and mimics how the Agent runs your executable.
 
 Example on how to use it:
 
-```text
+```powershell
 .\secrets_tester.ps1 -user ddagentuser -password a_new_password -executable C:\path\to\your\executable.exe -payload '{"version": "1.0", "secrets": ["secret_ID_1", "secret_ID_2"]}'
 Creating new Process with C:\path\to\your\executable.exe
 Waiting a second for the process to be up and running
@@ -452,6 +503,10 @@ exit code:
 0
 ```
 
+{{% /tab %}}
+{{< /tabs >}}
+
+
 ### Agent refusing to start
 
 The first thing the Agent does on startup is to load `datadog.yaml` and decrypt any secrets in it. This is done before setting up the logging. This means that on platforms like Windows, errors occurring when loading `datadog.yaml` aren't written in the logs, but on `stderr`. This can occur when the executable given to the Agent for secrets returns an error.
@@ -461,14 +516,31 @@ If you have secrets in `datadog.yaml` and the Agent refuses to start:
 * Try to start the Agent manually to be able to see `stderr`.
 * Remove the secrets from `datadog.yaml` and test with secrets in a check configuration file first.
 
+### Testing Kubernetes Permissions
+When reading Secrets directly from Kubernetes you can double check your permissions with the `kubectl auth` command. The general form of this is:
+
+```
+kubectl auth can-i get secret/<SECRET_NAME> -n <SECRET_NAMESPACE> --as system:serviceaccount:<AGENT_NAMESPACE>:<AGENT_SERVICE_ACCOUNT>
+```
+
+In the previous [Kubernetes Secrets example](#read-from-kubernetes-secret-example) with:
+- `Secret: database-secret` in the `Namespace: database`
+- `ServiceAccount: datadog-agent` in the `Namespace: default`
+
+The command would look like:
+```
+kubectl auth can-i get secret/database-secret -n database --as system:serviceaccount:default:datadog-agent
+```
+
+This should just return a simple yes/no if the permissions are valid for the Agent to view this Secret.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/kubernetes/integrations/
 [2]: https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent/secrets-helper/readsecret_multiple_providers.sh
-[3]: https://github.com/DataDog/datadog-agent/blob/6.4.x/Dockerfiles/agent/OPENSHIFT.md#restricted-scc-operations
+[3]: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-pod-that-has-access-to-the-secret-data-through-a-volume
 [4]: https://docs.docker.com/engine/swarm/secrets/
-[5]: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-pod-that-has-access-to-the-secret-data-through-a-volume
+[5]: https://github.com/DataDog/datadog-agent/blob/6.4.x/Dockerfiles/agent/OPENSHIFT.md#restricted-scc-operations
 [6]: /agent/guide/agent-commands/#restart-the-agent
-[7]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets_scripts/secrets_tester.ps1

--- a/content/en/agent/guide/secrets-management.md
+++ b/content/en/agent/guide/secrets-management.md
@@ -544,3 +544,4 @@ This should just return a simple yes/no if the permissions are valid for the Age
 [4]: https://docs.docker.com/engine/swarm/secrets/
 [5]: https://github.com/DataDog/datadog-agent/blob/6.4.x/Dockerfiles/agent/OPENSHIFT.md#restricted-scc-operations
 [6]: /agent/guide/agent-commands/#restart-the-agent
+[7]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets_scripts/secrets_tester.ps1


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Several changes to this doc included in this PR. 
- With the addition of the `/readsecret_multiple_providers.sh` script reformatting this doc to try and highlight that as recommended the option rather than the legacy ones 
- Provide examples for mounting Kubernetes Secrets as Files
- Provide examples for giving RBAC to read secrets directly
- Separate instructions into Linux/Windows tabs more

### Motivation
<!-- What inspired you to submit this pull request?-->
General cleanup to clarify instruction steps, especially with respect to the newer option.

### Preview
Staging Doc:
https://docs-staging.datadoghq.com/jack.davenport/secrets_management/agent/guide/secrets-management/

Current Doc: 
https://docs.datadoghq.com/agent/guide/secrets-management/?tab=linux

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
