### PR TITLE
Update troubleshooting docs on DBM host limit

### DIFF
--- a/content/en/database_monitoring/troubleshooting.md
+++ b/content/en/database_monitoring/troubleshooting.md
@@ -341,6 +341,11 @@ The `schema` tag (also known as "database") is present on MySQL Query Metrics an
 
 If there is no default database configured for a connection, then none of the queries made by that connection have the `schema` tag on them.
 
+### DBM Host Limit
+
+Depending on how complex the databases being monitored are, too many DBM hosts on one Agent could overload the Agent and cause data collection to be delayed. If the Agent is overloaded, you may see warnings like `Job loop stopping due to check inactivity in the Agent logs`.
+As a rule of thumb, we recommend having a single Datadog Agent monitor at most 10 DBM hosts. If you have more than 10 DBM hosts then we recommend spreading them over multiple Datadog Agents.
+
 ## Need more help?
 
 If you are still experiencing problems, contact [Datadog Support][5] for help.


### PR DESCRIPTION
this update adds a note on the recommended DBM host limit

internal wiki: https://datadoghq.atlassian.net/wiki/spaces/DM/pages/2083291245/Support+FAQ#Is-there-a-limit-to-the-number-of-DBM-hosts-that-an-agent-can-monitor%3F

related escalation: https://datadoghq.atlassian.net/browse/SDBM-46