### PR TITLE
Add note for aiohttp

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/python.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/python.md
@@ -28,7 +28,7 @@ The `ddtrace` library includes support for a number of web frameworks, including
 | Framework                 | Supported Version | Library Documentation                                              |
 | ------------------------- | ----------------- | ------------------------------------------------------------------ |
 | [asgi][3]                 | >= 2.0            | https://ddtrace.readthedocs.io/en/stable/integrations.html#asgi    |
-| [aiohttp][4]              | >= 1.2            | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp |
+| [aiohttp*][4]              | >= 1.2            | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp |
 | [Bottle][5]               | >= 0.11           | https://ddtrace.readthedocs.io/en/stable/integrations.html#bottle  |
 | [CherryPy][6]            | >= 11.2.0         | https://ddtrace.readthedocs.io/en/stable/integrations.html#cherrypy|
 | [Django][7]               | >= 1.8            | https://ddtrace.readthedocs.io/en/stable/integrations.html#django  |
@@ -43,6 +43,8 @@ The `ddtrace` library includes support for a number of web frameworks, including
 | [Sanic][15]               | >= 19.6.0         | https://ddtrace.readthedocs.io/en/stable/integrations.html#sanic   |
 | [Starlette][16]           | >= 0.13.0         | https://ddtrace.readthedocs.io/en/stable/integrations.html#starlette |
 | [Tornado][17]             | >= 4.0            | https://ddtrace.readthedocs.io/en/stable/integrations.html#tornado |
+
+* Note: This integration requires additional configuration for automatic instrumentation to be applied. Please view the library documentation for instructions.
 
 ### Datastore compatibility
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/python.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/python.md
@@ -28,7 +28,7 @@ The `ddtrace` library includes support for a number of web frameworks, including
 | Framework                 | Supported Version | Library Documentation                                              |
 | ------------------------- | ----------------- | ------------------------------------------------------------------ |
 | [asgi][3]                 | >= 2.0            | https://ddtrace.readthedocs.io/en/stable/integrations.html#asgi    |
-| [aiohttp*][4]              | >= 1.2            | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp |
+| [aiohttp][4]              | >= 1.2            | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp <br>The iaohttp integration requires additional configuration for automatic instrumentation to be applied. See the library documentation for instructions.|
 | [Bottle][5]               | >= 0.11           | https://ddtrace.readthedocs.io/en/stable/integrations.html#bottle  |
 | [CherryPy][6]            | >= 11.2.0         | https://ddtrace.readthedocs.io/en/stable/integrations.html#cherrypy|
 | [Django][7]               | >= 1.8            | https://ddtrace.readthedocs.io/en/stable/integrations.html#django  |
@@ -44,7 +44,7 @@ The `ddtrace` library includes support for a number of web frameworks, including
 | [Starlette][16]           | >= 0.13.0         | https://ddtrace.readthedocs.io/en/stable/integrations.html#starlette |
 | [Tornado][17]             | >= 4.0            | https://ddtrace.readthedocs.io/en/stable/integrations.html#tornado |
 
-* Note: This integration requires additional configuration for automatic instrumentation to be applied. Please view the library documentation for instructions.
+
 
 ### Datastore compatibility
 


### PR DESCRIPTION
Since additional configuration is required for the aiohttp integration to work, we want to warn/inform users so they're not confused if they don't see the expected spans for the application out of the box: https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp

### What does this PR do?
Adds a note for customers that additional setup is required for the aiohttp integration to work

### Motivation
Customer confusion about expectations and how to setup aiohttp integration



---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
