### PR TITLE
[ci-visibility] Fix Wrong Redirection in Flaky Tests

### DIFF
--- a/content/en/continuous_integration/explore_tests.md
+++ b/content/en/continuous_integration/explore_tests.md
@@ -2,7 +2,7 @@
 title: Exploring Tests
 kind: documentation
 further_reading:
-    - link: "/continuous_integration/guides/find_flaky_tests/"
+    - link: "/continuous_integration/guides/flaky_test_management/"
       tag: "Guide"
       text: "Finding Flaky Tests"
     - link: "/continuous_integration/troubleshooting/"

--- a/content/en/continuous_integration/guides/flaky_test_management.md
+++ b/content/en/continuous_integration/guides/flaky_test_management.md
@@ -1,7 +1,7 @@
 ---
 title: Flaky Test Management
 kind: guide
-aliases: /continuous_integration/guides/find_flaky_tests/
+aliases: /continuous_integration/guides/flaky_test_management/
 ---
 
 {{< site-region region="gov" >}}

--- a/content/ja/continuous_integration/explore_tests.md
+++ b/content/ja/continuous_integration/explore_tests.md
@@ -2,7 +2,7 @@
 title: テストの確認
 kind: documentation
 further_reading:
-  - link: /continuous_integration/guides/find_flaky_tests/
+  - link: /continuous_integration/guides/flaky_test_management/
     tag: ガイド
     text: 不安定なテストを見つける
   - link: /continuous_integration/troubleshooting/

--- a/content/ja/continuous_integration/guides/flaky_test_management.md
+++ b/content/ja/continuous_integration/guides/flaky_test_management.md
@@ -1,7 +1,7 @@
 ---
 title: 不安定なテストの管理
 kind: ガイド
-aliases: /continuous_integration/guides/find_flaky_tests/
+aliases: /continuous_integration/guides/flaky_test_management/
 ---
 
 _不安定なテスト_は、同じコミットの複数のテスト実行で成功と失敗の両方のステータスを示すテストです。コードをコミットして CI を介して実行し、テストが失敗し、CI を介して再度実行してテストが成功した場合、そのテストは品質コードの証明として信頼できません。


### PR DESCRIPTION
### What does this PR do?
* Fix redirection in flaky tests.

### Motivation
When clicking on "Finding flaky tests" at https://docs.datadoghq.com/continuous_integration/explore_tests/#further-reading we get redirected to the Japanese version of the docs. 

This PR fixes this. 

### Preview
https://docs-staging.datadoghq.com/juan-fernandez/fix-redirect-flaky-tests/continuous_integration/explore_tests/#further-reading


### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
