### PR TITLE
correct some aliases

### DIFF
--- a/content/fr/logs/guide/how-to-set-up-only-logs.md
+++ b/content/fr/logs/guide/how-to-set-up-only-logs.md
@@ -1,7 +1,7 @@
 ---
 title: Utiliser l'Agent Datadog pour la collecte de logs ou de traces uniquement
 aliases:
-  - /logs/faq/how-to-set-up-only-logs
+  - /fr/logs/faq/how-to-set-up-only-logs
 kind: documentation
 ---
 <div class="alert alert-danger">
@@ -115,7 +115,7 @@ spec:
           ## {name: DD_API_KEY, valueFrom:{ secretKeyRef:{ name: datadog-secret, key: api-key }}
           - {name: DD_API_KEY, value: "<CLÉ_API_DATADOG>"}
 
-          ## Définir DD_SITE sur votre site Datadog 
+          ## Définir DD_SITE sur votre site Datadog
           - {name: DD_SITE, value: "<VOTRE_SITE_DD>"}
 
           ## Chemin vers le socket Docker

--- a/content/ja/continuous_integration/guides/flaky_test_management.md
+++ b/content/ja/continuous_integration/guides/flaky_test_management.md
@@ -1,7 +1,7 @@
 ---
 title: 不安定なテストの管理
 kind: ガイド
-aliases: /continuous_integration/guides/find_flaky_tests/
+aliases: /ja/continuous_integration/guides/find_flaky_tests/
 ---
 
 _不安定なテスト_は、同じコミットの複数のテスト実行で成功と失敗の両方のステータスを示すテストです。コードをコミットして CI を介して実行し、テストが失敗し、CI を介して再度実行してテストが成功した場合、そのテストは品質コードの証明として信頼できません。

--- a/content/ja/logs/guide/how-to-set-up-only-logs.md
+++ b/content/ja/logs/guide/how-to-set-up-only-logs.md
@@ -1,7 +1,7 @@
 ---
 title: Datadog Agent をログまたはトレースの収集のみに使用
 aliases:
-  - /logs/faq/how-to-set-up-only-logs
+  - /ja/logs/faq/how-to-set-up-only-logs
 kind: documentation
 ---
 <div class="alert alert-danger">
@@ -117,7 +117,7 @@ spec:
           ## DD_SITE を Datadog サイトに設定します
           - {name: DD_SITE, value: "<YOUR_DD_SITE>"}
 
-          ## Docker ソケットへのパス - {name: DD_CRI_SOCKET_PATH, value: /host/var/run/docker.sock} - {name: DOCKER_HOST, value: unix:///host/var/run/docker.sock} 
+          ## Docker ソケットへのパス - {name: DD_CRI_SOCKET_PATH, value: /host/var/run/docker.sock} - {name: DOCKER_HOST, value: unix:///host/var/run/docker.sock}
 
           ## StatsD の収集を許可するには、DD_DOGSTATSD_NON_LOCAL_TRAFFIC を true に設定します。
           - {name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC, value: "false" }


### PR DESCRIPTION
### What does this PR do?

This PR fixes a couple of aliases in the ja site to avoid users being redirected to the ja site when they shouldn't.

### Motivation

Slack

### Preview

Both these urls should redirect but stay on the `en` version of the site
https://docs-staging.datadoghq.com/david.jones/alias-fix/continuous_integration/guides/find_flaky_tests/
https://docs-staging.datadoghq.com/david.jones/alias-fix/logs/faq/how-to-set-up-only-logs/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
