### PR TITLE
Add documentation team as reviewer for SDK versions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,8 +9,8 @@
 package.json              @DataDog/corpweb @DataDog/documentation
 
 # SDK versions
-.github/workflows/bump_versions.yml   @DataDog/integrations-tools-and-libraries
-/data/sdk_versions.json               @DataDog/integrations-tools-and-libraries
+.github/workflows/bump_versions.yml   @DataDog/integrations-tools-and-libraries @DataDog/documentation
+/data/sdk_versions.json               @DataDog/integrations-tools-and-libraries @DataDog/documentation
 
 # Serverless
 


### PR DESCRIPTION
Makes sure that @DataDog/documentation team is added as reviewer for generated PRs like #12656.