### PR TITLE
Adds Datadog IAM Policy Link

### DIFF
--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -191,7 +191,7 @@ For example:
 
 **Note**: If you are migrating to one of the recommended solutions, you'll need to start instrumenting your custom metrics under **new metric names** when submitting them to Datadog. The same metric name cannot simultaneously exist as both distribution and non-distribution metric types.
 
-This requires the following AWS permissions in your [Datadog IAM policy][0].
+This requires the following AWS permissions in your [Datadog IAM policy][11].
 
 | AWS Permission            | Description                                                 |
 | ------------------------- | ----------------------------------------------------------- |
@@ -226,3 +226,4 @@ Where:
 [8]: /agent/proxy/
 [9]: /serverless/forwarder/
 [10]: /metrics/
+[11]: /integrations/amazon_web_services/?tab=roledelegation#datadog-aws-iam-policy


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds a link to the Datadog IAM Policy which was previously broken.

### Motivation
<!-- What inspired you to submit this pull request?-->

Transifex

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/transifex-anchor-link-fix/serverless/custom_metrics/#deprecated-cloudwatch-logs

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
