### PR TITLE
Update profiling namespacing for ddtrace 1.0

### DIFF
--- a/content/en/tracing/profiler/enabling/ruby.md
+++ b/content/en/tracing/profiler/enabling/ruby.md
@@ -37,7 +37,7 @@ To begin profiling applications:
 2. Add the `ddtrace` and `google-protobuf` gems to your `Gemfile` or `gems.rb` file:
 
     ```ruby
-    gem 'ddtrace', '>= 0.53.0'
+    gem 'ddtrace', '~> 1'
     gem 'google-protobuf', '~> 3.0'
     ```
 

--- a/content/en/tracing/profiler/enabling/ruby.md
+++ b/content/en/tracing/profiler/enabling/ruby.md
@@ -89,7 +89,7 @@ end
     If starting the application via `ddtracerb exec` is not an option (eg. when using the Phusion Passenger web server), you can alternatively start the profiler by adding the following to your application entry point such as `config.ru` for a web application:
 
     ```ruby
-    require 'ddtrace/profiling/preload'
+    require 'datadog/profiling/preload'
     ```
 
 


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This PR updates the profiler `require` path after changes to `ddtrace`'s namespacing scheme in the coming 1.0 release: https://github.com/DataDog/dd-trace-rb/pull/1849

The only namespace change applicable to our documentation is the profiler's directory being moved from `ddtrace/profiling` to `datadog/profiling`.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/marcotc/namespace-profiler/tracing/profiler/enabling/ruby/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
