### PR TITLE
fix typo in DBM MySQL setup page

### DIFF
--- a/content/en/database_monitoring/setup_mysql/selfhosted.md
+++ b/content/en/database_monitoring/setup_mysql/selfhosted.md
@@ -69,7 +69,7 @@ To collect query metrics, samples, and explain plans, enable the [MySQL Performa
 {{< /tabs >}}
 
 
-**Note**: A recommended practice is to allow the agent to enable the `performance-schema-consumer-*` settings dynamically at runtime, as part of granting the Agent access, next. See [Runtime setup consumers](#runtime-setup-consumers).
+**Note**: A recommended practice is to allow the agent to enable the `performance-schema-consumer-*` settings dynamically at runtime, as part of granting the Agent access. See [Runtime setup consumers](#runtime-setup-consumers).
 
 ## Grant the Agent access
 


### PR DESCRIPTION
### What does this PR do?
remove some unneeded and erroneous letters

### Motivation
A translator noticed the unneeded and erroneous letters.

### Preview
https://docs-staging.datadoghq.com/uchen/dbm-setup-typo/database_monitoring/setup_mysql/selfhosted/?tab=mysql56

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
