### PR TITLE
Fix incorrect links

### DIFF
--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -22,15 +22,13 @@ aliases:
 
 ## Prerequisites
 
-The [Datadog Forwarder Lambda function][1] is required to ingest AWS Lambda traces, enhanced metrics, custom metrics, and logs.
-
-If your Go Lambda functions are still using runtime `go1.x`, consider either [migrating][2] to `provided.al2` or using the [Datadog Forwarder][3] instead of the Datadog Lambda Extension.
+If your Go Lambda functions are still using runtime `go1.x`, you must either [migrate][1] to `provided.al2` or use the [Datadog Forwarder][2] instead of the Datadog Lambda Extension.
 
 ## Configuration
 
 ### Install the Datadog Lambda library
 
-Install the [Datadog Lambda library][2] locally by running the following command:
+Install the [Datadog Lambda library][3] locally by running the following command:
 
 ```
 go get github.com/DataDog/datadog-lambda-go
@@ -162,9 +160,9 @@ If your Lambda function is running in a VPC, follow the [Datadog Lambda Extensio
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /serverless/guide/datadog_forwarder_go
-[2]: https://github.com/DataDog/datadog-lambda-go
-[3]: https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-to-al2/
+[1]: https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-to-al2/
+[2]: /serverless/guide/datadog_forwarder_go
+[3]: https://github.com/DataDog/datadog-lambda-go
 [4]: https://app.datadoghq.com/organization-settings/api-keys
 [5]: /serverless/libraries_integrations/extension/#tagging
 [6]: https://app.datadoghq.com/functions


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Fix incorrect links in the serverless go installation doc
- Emphasize that user MUST migrate to `provided.al2` runtime, instead of "consider" (based on customer feedback)

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tian.chu/fix-serverless-go-links/serverless/installation/go

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
