### PR TITLE
Postgres Integration quantize_sql_tables option nested under obfuscator_options

### DIFF
--- a/content/en/database_monitoring/setup_postgres/advanced_configuration.md
+++ b/content/en/database_monitoring/setup_postgres/advanced_configuration.md
@@ -27,20 +27,20 @@ SELECT * FROM daily_aggregates_002
 SELECT * FROM daily_aggregates_003
 ```
 
-In these cases, track these queries as a single normalized query using the `quantize_sql_tables` option, so all metrics for those queries are rolled up into a single query:
+In these cases, track these queries as a single normalized query using the `replace_digits` option, so all metrics for those queries are rolled up into a single query:
 
 ```sql
 SELECT * FROM daily_aggregates_?
 ```
 
-Add the `quantize_sql_tables` option to your database instance configuration in the Datadog Agent:
+Add the `replace_digits` option to your database instance configuration in the Datadog Agent:
 
 ```yaml
 instances:
   - dbm: true
     ...
     obfuscator_options:
-      quantize_sql_tables: true
+      replace_digits: true
 ```
 
 ## Raising the sampling rate

--- a/content/en/database_monitoring/setup_postgres/advanced_configuration.md
+++ b/content/en/database_monitoring/setup_postgres/advanced_configuration.md
@@ -39,7 +39,8 @@ Add the `quantize_sql_tables` option to your database instance configuration in 
 instances:
   - dbm: true
     ...
-    quantize_sql_tables: true
+    obfuscator_options:
+      quantize_sql_tables: true
 ```
 
 ## Raising the sampling rate


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the postgres integration documentation `quantize_sql_tables` option to be nested under `obfuscator_options`. Currently its not nested and the parameter is ignored.

### Motivation
Troubleshooting the integration and support brought up the missing nested option.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.
Replace the branch name and add the complete path: -->

https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

This is an external fork



### Additional Notes

I didn't see quantize_sql_tables at all in the sample yaml to update.

---