### PR TITLE
Document env var DD_SERVICE_MAPPING

### DIFF
--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -99,7 +99,7 @@ Enable web framework and library instrumentation. When false, the application co
 
 `DD_SERVICE_MAPPING`
 : **Default**: `null` <br>
-Dynamically rename services through configuration. Services can be separated by commas or spaces, for example: `mysql:mysql-service-name,postgres:postgres-service-name`, `mysql:mysql-service-name postgres:postgres-service-name`
+Dynamically rename services through configuration. Services can be separated by commas or spaces, for example: `mysql:mysql-service-name,postgres:postgres-service-name`, `mysql:mysql-service-name postgres:postgres-service-name`.
 
 
 Datadog recommends using `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, `service`, and `version` for your services.

--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -99,7 +99,7 @@ Enable web framework and library instrumentation. When false, the application co
 
 `DD_SERVICE_MAPPING`
 : **Default**: `null` <br>
-Dynamically rename services through configuration. Tags can be separated by commas or spaces, for example: `mysql:mysql-service-name,postgres:postgres-service-name`, `mysql:mysql-service-name postgres:postgres-service-name`
+Dynamically rename services through configuration. Services can be separated by commas or spaces, for example: `mysql:mysql-service-name,postgres:postgres-service-name`, `mysql:mysql-service-name postgres:postgres-service-name`
 
 
 Datadog recommends using `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, `service`, and `version` for your services.

--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -99,7 +99,7 @@ Enable web framework and library instrumentation. When false, the application co
 
 `DD_SERVICE_MAPPING`
 : **Default**: `null` <br>
-Dynamically rename services via configuration. Tags can be separated by commas or spaces, for example: `mysql:mysql-service-name,postgres:postgres-service-name`, `mysql:mysql-service-name postgres:postgres-service-name`
+Dynamically rename services through configuration. Tags can be separated by commas or spaces, for example: `mysql:mysql-service-name,postgres:postgres-service-name`, `mysql:mysql-service-name postgres:postgres-service-name`
 
 
 Datadog recommends using `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, `service`, and `version` for your services.

--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -97,6 +97,10 @@ Enable debug logging in the tracer.
 : **Default**: `true` <br>
 Enable web framework and library instrumentation. When false, the application code doesn’t generate any traces.
 
+`DD_SERVICE_MAPPING`
+: **Default**: `null` <br>
+Dynamically rename services via configuration. Tags can be separated by commas or spaces, for example: `mysql:mysql-service-name,postgres:postgres-service-name`, `mysql:mysql-service-name postgres:postgres-service-name`
+
 
 Datadog recommends using `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, `service`, and `version` for your services.
 


### PR DESCRIPTION
### What does this PR do?
Document env var DD_SERVICE_MAPPING

### Motivation
Support for env var DD_SERVICE_MAPPING was added in this PR: https://github.com/DataDog/dd-trace-go/pull/1077

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
