### PR TITLE
Update documentation to reflect new OTLP receiver based configuration

### DIFF
--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -333,10 +333,13 @@ The OTLP ingestion is configured through the `datadog.yaml` file. The following 
 ```yaml
 experimental:
   otlp:
-    grpc_port: 4317
-    http_port: 4318
+    receiver:
+      protocols:
+        grpc:
+        http:
 ```
 
+The `receiver` section follows the [OpenTelemetry Collector OTLP receiver configuration schema][25].
 You can also configure the endpoints by providing the port through the `DD_OTLP_GRPC_PORT` and `DD_OTLP_HTTP_PORT` environment variables. These must be passed to both the core Agent and trace Agent. 
 
 Check [the OpenTelemetry instrumentation documentation][18] to understand how to point your instrumentation to the Agent, and [contact Datadog support][19] to get more information on this feature and provide feedback.
@@ -381,3 +384,4 @@ Datadog recommends you use the OpenTelemetry Collector Datadog exporter or the O
 [22]: /tracing/setup_overview/open_standards/python#opentelemetry
 [23]: /tracing/setup_overview/open_standards/ruby#opentelemetry
 [24]: /tracing/setup_overview/open_standards/nodejs#opentelemetry
+[25]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/config.md


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update "OTLP ingest in Datadog Agent" example configuration to reflect the new OTLP receiver based configuration.

### Motivation
<!-- What inspired you to submit this pull request?-->

This is the configuration we want users to use starting on 7.33.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mx-psi/update-config-otlp/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent

### Additional Notes
<!-- Anything else we should know when reviewing?-->

The configuration was added on 7.33

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
