### PR TITLE
client-tokens-not-revoked

### DIFF
--- a/content/en/account_management/api-app-keys.md
+++ b/content/en/account_management/api-app-keys.md
@@ -38,6 +38,8 @@ Client tokens are unique to your organization. A client token is required by the
 
 For security reasons, API keys cannot be used to send data from a browser, as they would be exposed client-side in the JavaScript code. To collect logs from web browsers, a client token must be used.
 
+**Note:** A client token will not be revoked if the user who created it was deactivated. They will still be available for use in your RUM applications and to collect logs.
+
 ## Add an API key or client token
 
 To add a Datadog API key or client token:


### PR DESCRIPTION
Updating the documentation to emphasize that client tokens will not be revoked if the user who created them was deactivated.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Emphasizes that client tokens will not be revoked upon user deactivation.

### Motivation
<!-- What inspired you to submit this pull request?-->

Customer was unclear in this ticket: https://datadog.zendesk.com/agent/tickets/640512

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

https://docs.datadoghq.com/account_management/api-app-keys/#client-tokens

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
