### PR TITLE
Update serverless_tracing_and_webpack.md

### DIFF
--- a/content/en/serverless/troubleshooting/serverless_tracing_and_webpack.md
+++ b/content/en/serverless/troubleshooting/serverless_tracing_and_webpack.md
@@ -40,6 +40,16 @@ Datadog's tracing libraries (`dd-trace`) are known to be not compatible with [we
             - datadog-lambda-js
     ```
 
+    **Note:** This exclusion may not be enough if you have at least one dependency that itself depends on `datadog-lambda-js` or `dd-trace` (transitive dependencies). In this case, **forceExclude** won't avoid the inclusion of one of these libraries. If this is your case, you can try to remove them manually using something like this:
+
+    ```
+    custom:
+      webpack:
+        packagerOptions:
+          scripts:
+            - rm -rf node_modules/datadog-lambda-js node_modules/dd-trace
+    ```
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
Added an additional note for the case of transitive dependencies with `datadog-lambda-js` or `dd-trace`. See [this link](https://github.com/DataDog/datadog-lambda-js/issues/209) for more information.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
