### PR TITLE
Move sls webpack to guide

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1274,10 +1274,6 @@ main:
     url: serverless/troubleshooting/connect_invoking_resources
     parent: serverless_troubleshooting
     weight: 703
-  - name: Webpack Compatibility
-    url: serverless/troubleshooting/serverless_tracing_and_webpack
-    parent: serverless_troubleshooting
-    weight: 704
   - name: Azure App Service Extension
     url: serverless/azure_app_services
     parent: serverless

--- a/content/en/serverless/guide/_index.md
+++ b/content/en/serverless/guide/_index.md
@@ -13,3 +13,7 @@ kind: guide
     {{< nextlink href="/serverless/guide/forwarder_extension_migration" >}}Migrating from the Datadog Forwarder to the Datadog Lambda Extension{{< /nextlink >}}
     {{< nextlink href="/serverless/guide/extension_private_link" >}}Datadog Lambda Extension AWS PrivateLink Setup{{< /nextlink >}}
 {{< /whatsnext >}}
+
+{{< whatsnext desc="Troubleshooting:" >}}
+    {{< nextlink href="/serverless/troubleshooting/serverless_tracing_and_webpack" >}}Node.js Lambda Tracing and Webpack Compatibility{{< /nextlink >}}
+{{< /whatsnext >}}

--- a/content/en/serverless/guide/datadog_forwarder_node.md
+++ b/content/en/serverless/guide/datadog_forwarder_node.md
@@ -90,7 +90,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 [1]: https://docs.datadoghq.com/serverless/serverless_integrations/plugin
 [2]: https://docs.datadoghq.com/serverless/forwarder/
 [3]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
-[4]: /serverless/troubleshooting/serverless_tracing_and_webpack/
+[4]: /serverless/guide/serverless_tracing_and_webpack/
 [5]: https://webpack.js.org/
 {{% /tab %}}
 {{% tab "AWS SAM" %}}
@@ -304,7 +304,7 @@ Subscribe the Datadog Forwarder Lambda function to each of your function’s log
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
 [2]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
 [3]: https://www.npmjs.com/package/datadog-lambda-js
-[4]: /serverless/troubleshooting/serverless_tracing_and_webpack/
+[4]: /serverless/guide/serverless_tracing_and_webpack/
 [5]: https://webpack.js.org/
 [6]: https://docs.datadoghq.com/serverless/forwarder/
 [7]: https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group

--- a/content/en/serverless/guide/serverless_tracing_and_webpack.md
+++ b/content/en/serverless/guide/serverless_tracing_and_webpack.md
@@ -5,6 +5,8 @@ further_reading:
 - link: '/serverless/installation/nodejs'
   tag: 'Documentation'
   text: 'Instrumenting Node.js Applications'
+aliases:
+    - /serverless/troubleshooting/serverless_tracing_and_webpack
 ---
 
 # Compatibility


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Move the serverless webpack guide from "Troubleshooting" to "Guides". The "Troubleshooting" section is actually about using the Datadog monitoring product to troubleshoot customers' serverless applications, not about troubleshooting the Datadog monitoring set up.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tian.chu/mv-sls-webpack-guide/serverless/troubleshooting/serverless_tracing_and_webpack

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
