### PR TITLE
[DOCS-3064] Add banner for US1-Fed not supported for DBM getting started

### DIFF
--- a/content/en/getting_started/database_monitoring/_index.md
+++ b/content/en/getting_started/database_monitoring/_index.md
@@ -12,6 +12,11 @@ further_reading:
       tag: 'Blog'
       text: 'Database performance monitoring with Datadog'
 ---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Database Monitoring is not available for your selected Datadog site ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 ## Overview
 
 Datadog Database Monitoring helps you to better understand the health and performance of your databases, and quickly determine the root cause of any problems.


### PR DESCRIPTION
### What does this PR do?

Adds banner saying US1-Fed not support on DBM Getting Started. 

### Motivation

[DOCS-3064]

### Preview

https://docs-staging.datadoghq.com/may/add-fed-not-supported/getting_started/database_monitoring/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-3064]: https://datadoghq.atlassian.net/browse/DOCS-3064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ