### PR TITLE
Fixing the build 🥺 

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -129,7 +129,7 @@
         front_matters:
           title: Ansible
           kind: documentation
-          dependencies: ["https://github.com/DataDog/ansible-datadog/blob/main/README.md"]
+          dependencies: ["https://github.com/DataDog/ansible-datadog/blob/master/README.md"]
 
   - repo_name: chef-datadog
     contents:

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -120,7 +120,7 @@
     contents:
 
     - action: pull-and-push-file
-      branch: master
+      branch: main
       globs:
       - README.md
       options:
@@ -129,7 +129,7 @@
         front_matters:
           title: Ansible
           kind: documentation
-          dependencies: ["https://github.com/DataDog/ansible-datadog/blob/master/README.md"]
+          dependencies: ["https://github.com/DataDog/ansible-datadog/blob/main/README.md"]
 
   - repo_name: chef-datadog
     contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -121,7 +121,7 @@
     contents:
 
     - action: pull-and-push-file
-      branch: master
+      branch: main
       globs:
       - README.md
       options:
@@ -130,7 +130,7 @@
         front_matters:
           title: Ansible
           kind: documentation
-          dependencies: ["https://github.com/DataDog/ansible-datadog/blob/master/README.md"]
+          dependencies: ["https://github.com/DataDog/ansible-datadog/blob/main/README.md"]
 
   - repo_name: chef-datadog
     contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -130,7 +130,7 @@
         front_matters:
           title: Ansible
           kind: documentation
-          dependencies: ["https://github.com/DataDog/ansible-datadog/blob/main/README.md"]
+          dependencies: ["https://github.com/DataDog/ansible-datadog/blob/master/README.md"]
 
   - repo_name: chef-datadog
     contents:


### PR DESCRIPTION
so basically `ansible-datadog` was having to have its default branch be called `master` to pull updates from ansible galaxy (see https://github.com/ansible/galaxy/issues/2852) and initially we were just gonna reference `master` but @albertvaka and i have come upon a brilliant scheme by which we can still have the default branch be `main`

it is known as renaming it `master` before doing an update and naming it back afterwards.

anyway, this fixes the docs part of it