### PR TITLE
fix detection rules link

### DIFF
--- a/content/en/security_platform/default_rules/_index.md
+++ b/content/en/security_platform/default_rules/_index.md
@@ -9,10 +9,11 @@ aliases:
 disable_sidebar: true
 ---
 
-Datadog provides out-of-the-box (OOTB) [detection rules][4] to flag attacker techniques and potential misconfigurations so you can immediately take steps to remediate. Datadog continuously develops new default rules, which are automatically imported into your account, your Application Security library, and the Agent, depending on your configuration. For more information, see the Detection Rules documentation.
+Datadog provides out-of-the-box (OOTB) [detection rules][1] to flag attacker techniques and potential misconfigurations so you can immediately take steps to remediate. Datadog continuously develops new default rules, which are automatically imported into your account, your Application Security library, and the Agent, depending on your configuration. For more information, see the Detection Rules documentation.
 
-Click on the buttons below to filter by different parts of the Datadog Security Platform. OOTB rules are available for [Cloud SIEM][1], [Posture Management][2], which is divided into cloud or infrastructure configuration, [Workload Security][3], and Application Security.
+Click on the buttons below to filter by different parts of the Datadog Security Platform. OOTB rules are available for [Cloud SIEM][2], [Posture Management][3], which is divided into cloud or infrastructure configuration, [Workload Security][4], and Application Security.
 
-[1]: /security_platform/cloud_siem/
-[2]: /security_platform/cspm/
-[3]: /security_platform/cloud_workload_security/
+[1]: /security_platform/detection_rules/
+[2]: /security_platform/cloud_siem/
+[3]: /security_platform/cspm/
+[4]: /security_platform/cloud_workload_security/


### PR DESCRIPTION
### What does this PR do?
Fixes the detection rules link in the OOTB docs - it got lobbed off the end of the file

### Motivation
'Tis broken.

### Preview
https://docs-staging.datadoghq.com/sarina/ootb-rules-link/security_platform/default_rules/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
