### PR TITLE
Update python.md

### DIFF
--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -437,6 +437,12 @@ COPY --from=public.ecr.aws/datadog/lambda-extension:<TAG> /opt/extensions/ /opt/
 
 Replace `<TAG>` with either a specific version number (for example, `{{< latest-lambda-layer-version layer="extension" >}}`) or with `latest`. You can see a complete list of possible tags in the [Amazon ECR repository][1].
 
+Beginning with lambda-extension TAG=11, both the linux/amd64 & linux/arm platforms are included in the image's manifest. Make sure to set the proper platform when building your Dockerfile.
+
+```
+docker build --platform "linux/amd64" .
+```
+
 ### Configure the function
 
 1. Set your image's `CMD` value to `datadog_lambda.handler.handler`. You can set this in AWS or directly in your Dockerfile. Note that the value set in AWS overrides the value in the Dockerfile if you set both.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds installation instruction for installing the datadog-lambda-extension in a Container Image an architecture that is compatible with a user's dockerfile.

### Motivation
Avoid other engineers from giving up on upgrading the DataDog extension past Tag 11 because of unfamiliarity with docker architecture hints.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
