### PR TITLE
security rules nav selection

### DIFF
--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -181,7 +181,7 @@ function getPathElement(event = null) {
 
     // if security rules section that has links to hashes, #cat-workload-security etc. try and highlight correct sidenav
     if (path.includes('security_platform/default_rules')) {
-        const ref = (event) ? event.target.href : window.location.hash;
+        const ref = ((event) ? event.target.href : window.location.hash) || window.location.hash;
         if(ref) {
           sideNavPathElement = document.querySelector(
             `.side [href*="${ref}"]`

--- a/src/scripts/datadog-docs.js
+++ b/src/scripts/datadog-docs.js
@@ -130,7 +130,7 @@ function hasParentLi(el) {
     }
 }
 
-function getPathElement() {
+function getPathElement(event = null) {
     const domain = window.location.origin;
     let path = window.location.pathname;
     const activeMenus = document.querySelectorAll('.side .sidenav-nav-main .active, header .sidenav-nav-main .active');
@@ -178,7 +178,20 @@ function getPathElement() {
             'header .nav-top-level > [data-path*="integrations"]'
         );
     }
-    
+
+    // if security rules section that has links to hashes, #cat-workload-security etc. try and highlight correct sidenav
+    if (path.includes('security_platform/default_rules')) {
+        const ref = (event) ? event.target.href : window.location.hash;
+        if(ref) {
+          sideNavPathElement = document.querySelector(
+            `.side [href*="${ref}"]`
+          );
+          mobileNavPathElement = document.querySelector(
+            `header [href*="${ref}"]`
+          );
+        }
+    }
+
     if (sideNavPathElement) {
         sideNavPathElement.classList.add('active');
         hasParentLi(sideNavPathElement);
@@ -206,7 +219,7 @@ function closeNav(){
 
 function updateSidebar(event) {
     closeNav();
-    getPathElement();
+    getPathElement(event);
 
     const isLi = event.target.nodeName === 'LI';
 
@@ -344,6 +357,16 @@ function rulesListClickHandler(event, pathString) {
             loadPage(targetURL);
             window.history.pushState({}, '' /* title */, targetURL);
             updateSidebar(event);
+        }
+    }
+    // if security rules section that has links to hashes, #cat-workload-security etc. try and highlight correct sidenav
+    // by passing the relevant sidenav target to updateSidebar()
+    if (event.target.matches('.controls a')) {
+        const split = event.target.href.split('#')
+        const targetURL = (split.length > 1) ? `#${split[1]}` : event.target.href;
+        const target = document.querySelector(`.side [href*="${targetURL}"]`);
+        if (target) {
+          updateSidebar({target: target});
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR makes the side nav select the correct entry for ootb rules when selecting categories on the page.

### Motivation
#12934 

### Preview

Try clicking categories and observe the sidenav
Switching between cloud siem and workload security should toggle the appropriate side nav entries open.
The other categories will just remain on the sidenav entry you are on

https://docs-staging.datadoghq.com/david.jones/rules-nav-select/security_platform/default_rules/#cat-workload-security

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
