### PR TITLE
[ciapp] Add new point (network issues) to CI Visibility Jenkins troubleshooting section

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -465,6 +465,17 @@ Send pipeline traces.
 ...
 {{< /code-block >}}
 
+### The Datadog Plugin cannot write payloads to the server
+
+If this error message appears in the **Jenkins Log**, make sure that the plugin configuration is correct.
+
+{{< code-block lang="text" >}}
+Error writing to server
+{{< /code-block >}}
+
+1. If you are using `localhost` as hostname, try to change it to the server hostname instead.
+2. If your Jenkins instance is behind a HTTP proxy, go to **Manage Jenkins > Manage Plugins > Advanced tab** and make sure the proxy configuration is correct.
+
 ### The Datadog Plugin section does not appear in the Jenkins configuration
 
 If the Datadog Plugin section does not appear in Jenkins configuration section, make sure that the plugin is enabled. To do so:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR adds a new section in the troubleshooting docs for the Jenkins plugin (CI Visibility product)

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/drodriguezhdez/add_troubleshooting_jenkins_proxy//continuous_integration/setup_pipelines/jenkins

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
