### PR TITLE
Add examples for relative time ranges and for logs

### DIFF
--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -411,6 +411,12 @@ Use the `{{host.name}}` [tag variable](#attribute-and-tag-variables) and an `<IN
 https://app.datadoghq.com/dash/integration/<INTEGRATION_NAME>?tpl_var_scope=host:{{host.name}}
 ```
 
+Use the `{{last_triggered_at_epoch}}` [template variable](#template-variables) as well as a `<DASHBOARD_ID>` and `<DASHBOARD_NAME>` to link to dashboards with relative time ranges from the moment of the alert:
+
+```text
+https://app.datadoghq.com/dashboard/<DASHBOARD_ID>/<DASHBOARD_NAME>?from_ts={{eval "last_triggered_at_epoch-10*60*1000}}&to_ts={{eval "last_triggered_at_epoch+10*60*1000}}&live=false
+```
+
 {{% /tab %}}
 {{% tab "Host map" %}}
 
@@ -447,6 +453,25 @@ The monitors link is customizable with additional parameters. The most common ar
 
 
 [1]: /monitors/create/types/
+
+{{% /tab %}}
+{{% tab "Logs" %}}
+
+Use the `{{last_triggered_at_epoch}}` [template variable](#template-variables) to provide a link to all logs happening in the moment of the alert.
+
+```text
+https://app.datadoghq.com/logs>?from_ts={{eval "last_triggered_at_epoch-10*60*1000}}&to_ts={{eval "last_triggered_at_epoch+10*60*1000}}&live=false
+```
+
+The logs link is customizable with additional parameters. The most common are:
+
+| Parameter | Defined with               | Determines                             |
+|-----------|----------------------------|----------------------------------------|
+| `service` | `service=<SERVICE_NAME>`   | Filter on logs of a specific service.  |
+| `host`    | `host=<HOST_NAME>`         | Filter on logs of a specific host      |
+| `status`  | `status=<STATUS>`          | Status of logs: Error, Warn, Info etc. |
+
+
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds more examples for dynamic URL building in monitors to link to other parts of the product while using tag and template variables.

### Motivation
The lack of examples resulted in a support question.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/daljeet/monitor-dynamic-links-examples/monitors/notify/variables/?tab=dashboards#dynamic-links

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
