### PR TITLE
Update CSPM OOTB page

### DIFF
--- a/content/en/security_platform/cspm/configuration_rules.md
+++ b/content/en/security_platform/cspm/configuration_rules.md
@@ -1,7 +1,6 @@
 ---
-title: Default Configuration Rules
+title: OOTB Rules
 kind: documentation
-disable_toc: true
 ---
 
 {{< site-region region="us3,us5,gov,eu" >}}
@@ -12,27 +11,27 @@ Cloud Security Posture Management is not currently available in this site.
 
 ## Overview
 
-Datadog provides default configuration detection rules to flag potential misconfigurations to help immediately improve your security posture. Configuration detection rules follow the same [conditional logic][1] as all Datadog Security Platform detection rules.
+Datadog provides [out-of-the-box (OOTB) detection rules][1] to flag potential misconfigurations and help improve your security posture. OOTB detection rules follow the same [conditional logic][2] as all Datadog Security Platform detection rules.
 
 {{< img src="security_platform/cspm/configuration_rules/configuration_rule.png" alt="A configuration rule in Datadog" width="65%">}}
 
-Datadog CSPM uses the following rule types to validate the configuration of your cloud infrastructure:
+Datadog Cloud Security Posture Management (CSPM) uses the following rule types to validate the configuration of your cloud infrastructure:
 
-- [Cloud configuration][2]: These detection rules analyze the configuration of resources within your cloud environment. For example, the rule [Cloudfront distribution is encrypted][3] evaluates an AWS Cloudfront distribution’s configuration for encrypted status. Customization of a cloud configuration query directly is not supported at this time, but you can customize how you environment is [scanned][4] for each rule.
+- [Cloud configuration][1]: These detection rules analyze the configuration of resources within your cloud environment. For example, the rule [Cloudfront distribution is encrypted][3] evaluates an AWS Cloudfront distribution’s configuration for encrypted status. Customization of a cloud configuration query directly is not supported at this time, but you can customize how you environment is [scanned][4] for each rule.
 
-- [Infrastructure configuration][5]: These detection rules analyze your containers and Kubernetes clusters in order to find configuration issues, as defined in the popular CIS compliance benchmarks for Docker and Kubernetes. For example, the rule [/etc/default/docker file permissions are set to 644 or more restrictively][6] evaluates Docker file permissions running on a host.
+- [Infrastructure configuration][5]: These detection rules analyze your containers and Kubernetes clusters to find configuration issues, as defined in the popular CIS compliance benchmarks for Docker and Kubernetes. For example, the rule [/etc/default/docker file permissions are set to 644 or more restrictively][6] evaluates Docker file permissions running on a host.
 
-These detection rules work with out-of-the-box integration configurations and map to controls within a [compliance framework or industry benchmark][5]. When new default configuration detection rules are added, they are automatically imported into your account.
+These detection rules work with out-of-the-box integration configurations and map to controls within a [compliance framework or industry benchmark][4]. When new default configuration detection rules are added, they are automatically imported into your account.
 
 {{< whatsnext desc="To get started, choose a type of rule based on your environment:">}}
-  {{< nextlink href="/security_platform/default_rules#cat-cloud-configuration">}}<u>Cloud Configuration</u>: These detection rules analyze the configuration of resources within your cloud environment.{{< /nextlink >}}
-  {{< nextlink href="/security_platform/default_rules#cat-infrastructure-configuration">}}<u>Infrastructure Configuration</u>: These detection rules analyze your containers, and Kubernetes clusters in order to find configuration issues, as defined in the popular CIS compliance benchmarks for Docker and Kubernetes.{{< /nextlink >}}
+  {{< nextlink href="/security_platform/default_rules/#cat-posture-management-cloud">}}<u>Cloud Configuration</u>{{< /nextlink >}}
+  {{< nextlink href="/security_platform/default_rules/#cat-posture-management-infra">}}<u>Infrastructure Configuration</u>{{< /nextlink >}}
 {{< /whatsnext >}}
 
 
-[1]: /security_platform/detection_rules/
-[2]: /security_platform/default_rules#cat-cloud-configuration
+[1]: /security_platform/default_rules/#cat-posture-management-cloud
+[2]: /security_platform/detection_rules/
 [3]: https://docs.datadoghq.com/security_monitoring/default_rules/aws-cloudfront-distributions-encrypted/
 [4]: /security_platform/cspm/frameworks_and_benchmarks
-[5]: /security_platform/default_rules#cat-infrastructure-configuration
+[5]: /security_platform/default_rules/#cat-posture-management-infra
 [6]: https://docs.datadoghq.com/security_monitoring/default_rules/cis-docker-1.2.0-3.22/


### PR DESCRIPTION
### What does this PR do?
- Updates the CSPM OOTB rules page links as there are new hashes now for Cloud/Infra rules on the OOTB rules page

### Motivation
OOTB rules page changes

### Preview
https://docs-staging.datadoghq.com/sarina/ootb-config-rules/security_platform/cspm/configuration_rules.md

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
