### PR TITLE
Add `datadog.trace_agent.profile` description

### DIFF
--- a/content/en/tracing/troubleshooting/agent_apm_metrics.md
+++ b/content/en/tracing/troubleshooting/agent_apm_metrics.md
@@ -52,7 +52,7 @@ Increment by one on every code panic.
 
 `datadog.trace_agent.profile`
 : **Type**: Count<br>
-Increment by one every a reverse proxy of profile endpoints is created.
+Increment by one every time a reverse proxy of profile endpoints is created.
 
 `datadog.trace_agent.ratelimit`
 : **Type**: Gauge<br>

--- a/content/en/tracing/troubleshooting/agent_apm_metrics.md
+++ b/content/en/tracing/troubleshooting/agent_apm_metrics.md
@@ -50,6 +50,10 @@ Increment by one every time an SQL obfuscation happens.
 : **Type**: Gauge<br>
 Increment by one on every code panic.
 
+`datadog.trace_agent.profile`
+: **Type**: Count<br>
+Increment by one every a reverse proxy of profile endpoints is created.
+
 `datadog.trace_agent.ratelimit`
 : **Type**: Gauge<br>
 If lower than `1`, it means payloads are being refused due to high resource usage (cpu or memory).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add `datadog.trace_agent.profile` description.

I referred this comment to describe this metric.
https://github.com/DataDog/datadog-agent/blob/cd8c943f35c92f196b03a6dc618effdfc3f66825/pkg/trace/api/profiles.go#L99-L100

### Motivation

The description is missing.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
