### PR TITLE
[live containers] add pv and pvc to resource compatibility matrix

### DIFF
--- a/content/en/infrastructure/livecontainers/configuration.md
+++ b/content/en/infrastructure/livecontainers/configuration.md
@@ -136,6 +136,9 @@ The following table presents the list of collected resources and the minimal Age
 | CronJobs | 7.27.0 | 1.13.1 | 2.15.5 |
 | DaemonSets | 7.27.0 | 1.14.0 | 2.16.3 |
 | Statefulsets | 7.27.0 | 1.15.0 | 2.20.1 |
+| PersistentVolume | 7.27.0 | 1.18.0 | 2.20.1 |
+| PersistentVolumeClaims | 7.27.0 | 1.18.0 | 2.30.4 |
+
 
 ### Instructions for previous Agent and Cluster Agent versions.
 

--- a/content/en/infrastructure/livecontainers/configuration.md
+++ b/content/en/infrastructure/livecontainers/configuration.md
@@ -136,7 +136,7 @@ The following table presents the list of collected resources and the minimal Age
 | CronJobs | 7.27.0 | 1.13.1 | 2.15.5 |
 | DaemonSets | 7.27.0 | 1.14.0 | 2.16.3 |
 | Statefulsets | 7.27.0 | 1.15.0 | 2.20.1 |
-| PersistentVolume | 7.27.0 | 1.18.0 | 2.20.1 |
+| PersistentVolumes | 7.27.0 | 1.18.0 | 2.20.1 |
 | PersistentVolumeClaims | 7.27.0 | 1.18.0 | 2.30.4 |
 
 ### Instructions for previous Agent and Cluster Agent versions.

--- a/content/en/infrastructure/livecontainers/configuration.md
+++ b/content/en/infrastructure/livecontainers/configuration.md
@@ -136,7 +136,7 @@ The following table presents the list of collected resources and the minimal Age
 | CronJobs | 7.27.0 | 1.13.1 | 2.15.5 |
 | DaemonSets | 7.27.0 | 1.14.0 | 2.16.3 |
 | Statefulsets | 7.27.0 | 1.15.0 | 2.20.1 |
-| PersistentVolumes | 7.27.0 | 1.18.0 | 2.20.1 |
+| PersistentVolumes | 7.27.0 | 1.18.0 | 2.30.4 |
 | PersistentVolumeClaims | 7.27.0 | 1.18.0 | 2.30.4 |
 
 ### Instructions for previous Agent and Cluster Agent versions.

--- a/content/en/infrastructure/livecontainers/configuration.md
+++ b/content/en/infrastructure/livecontainers/configuration.md
@@ -139,7 +139,6 @@ The following table presents the list of collected resources and the minimal Age
 | PersistentVolume | 7.27.0 | 1.18.0 | 2.20.1 |
 | PersistentVolumeClaims | 7.27.0 | 1.18.0 | 2.30.4 |
 
-
 ### Instructions for previous Agent and Cluster Agent versions.
 
 The Kubernetes resources view for Live Containers used to require [Agent version >= 7.21.1][2] and [Cluster Agent version >= 1.9.0][3] before minimal versions were updated. For those older versions, the DaemonSet configuration was slightly different and full instructions are retained here for reference.


### PR DESCRIPTION
helm chart version: builds on: https://github.com/DataDog/helm-charts/pull/523

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
