### PR TITLE
[ci-visibility] [do not merge] CI Visibility Changes for Ruby `1.0.0`

### DIFF
--- a/content/en/continuous_integration/setup_tests/ruby.md
+++ b/content/en/continuous_integration/setup_tests/ruby.md
@@ -57,20 +57,15 @@ To activate your integration, add the following code to your application:
 
 ```ruby
 require 'cucumber'
-require 'datadog/ci'
+require 'ddtrace'
 
-Datadog::CI.configure do |c|
-  # Only activates test instrumentation on CI
-  c.tracer.enabled = (ENV["DD_ENV"] == "ci")
 
-  # Configures the tracer to ensure results delivery
-  c.ci_mode.enabled = true
-
-  # The name of the service or library under test
-  c.service = 'my-ruby-app'
-
-  # Enables the Cucumber instrumentation
-  c.use :cucumber
+if ENV["DD_ENV"] == "ci"
+    Datadog.configure do |c|
+      c.service = 'my-ruby-app'
+      c.ci.enabled = true
+      c.ci.instrument :cucumber
+    end
 end
 ```
 
@@ -89,20 +84,14 @@ To activate your integration, add this to the `spec_helper.rb` file:
 
 ```ruby
 require 'rspec'
-require 'datadog/ci'
+require 'ddtrace'
 
-Datadog::CI.configure do |c|
-  # Only activates test instrumentation on CI
-  c.tracer.enabled = (ENV["DD_ENV"] == "ci")
-
-  # Configures the tracer to ensure results delivery
-  c.ci_mode.enabled = true
-
-  # The name of the service or library under test
-  c.service = 'my-ruby-app'
-
-  # Enables the RSpec instrumentation
-  c.use :rspec
+if ENV["DD_ENV"] == "ci"
+    Datadog.configure do |c|
+      c.service = 'my-ruby-app'
+      c.ci.enabled = true
+      c.ci.instrument :rspec
+    end
 end
 ```
 
@@ -117,7 +106,7 @@ DD_ENV=ci bundle exec rake spec
 
 ## Configuration settings
 
-The following is a list of the most important configuration settings that can be used with the tracer, either in code by using a `Datadog::CI.configure` block, or using environment variables:
+The following is a list of the most important configuration settings that can be used with the tracer, either in code by using a `Datadog.configure` block, or using environment variables:
 
 `service`
 : Name of the service or library under test.<br/>

--- a/content/en/continuous_integration/setup_tests/ruby.md
+++ b/content/en/continuous_integration/setup_tests/ruby.md
@@ -59,7 +59,7 @@ To activate your integration, add the following code to your application:
 require 'cucumber'
 require 'datadog/ci'
 
-Datadog.configure do |c|
+Datadog::CI.configure do |c|
   # Only activates test instrumentation on CI
   c.tracer.enabled = (ENV["DD_ENV"] == "ci")
 
@@ -91,7 +91,7 @@ To activate your integration, add this to the `spec_helper.rb` file:
 require 'rspec'
 require 'datadog/ci'
 
-Datadog.configure do |c|
+Datadog::CI.configure do |c|
   # Only activates test instrumentation on CI
   c.tracer.enabled = (ENV["DD_ENV"] == "ci")
 
@@ -117,7 +117,7 @@ DD_ENV=ci bundle exec rake spec
 
 ## Configuration settings
 
-The following is a list of the most important configuration settings that can be used with the tracer, either in code by using a `Datadog.configure` block, or using environment variables:
+The following is a list of the most important configuration settings that can be used with the tracer, either in code by using a `Datadog::CI.configure` block, or using environment variables:
 
 `service`
 : Name of the service or library under test.<br/>

--- a/content/ja/continuous_integration/setup_tests/ruby.md
+++ b/content/ja/continuous_integration/setup_tests/ruby.md
@@ -49,20 +49,17 @@ Cucumber インテグレーションでは、`cucumber` フレームワークを
 
 ```ruby
 require 'cucumber'
-require 'datadog/ci'
+require 'ddtrace'
 
-Datadog::CI.configure do |c|
-  # CI でのみテストインスツルメンテーションをアクティブ化します
-  c.tracer.enabled = (ENV["DD_ENV"] == "ci")
-
-  # 結果が確実に配信されるようにトレーサーを構成します
-  c.ci_mode.enabled = true
-
-  # テスト中のサービスまたはライブラリの名前
-  c.service = 'my-ruby-app'
-
-  # Cucumber のインスツルメンテーションを有効にします
-  c.use :cucumber
+if ENV["DD_ENV"] == "ci"
+  Datadog.configure do |c|
+    # 結果が確実に配信されるようにトレーサーを構成します
+    c.ci.enabled = true
+    # テスト中のサービスまたはライブラリの名前
+    c.service = 'my-ruby-app'
+    # Cucumber のインスツルメンテーションを有効にします
+    c.ci.instrument :cucumber
+  end
 end
 ```
 
@@ -81,20 +78,17 @@ RSpec インテグレーションでは、`rspec` テストフレームワーク
 
 ```ruby
 require 'rspec'
-require 'datadog/ci'
+require 'ddtrace'
 
-Datadog::CI.configure do |c|
-  # CI でのみテストインスツルメンテーションをアクティブ化します
-  c.tracer.enabled = (ENV["DD_ENV"] == "ci")
-
-  # 結果が確実に配信されるようにトレーサーを構成します
-  c.ci_mode.enabled = true
-
-  # テスト中のサービスまたはライブラリの名前
-  c.service = 'my-ruby-app'
-
-  # RSpec のインスツルメンテーションを有効にします
-  c.use :rspec
+if ENV["DD_ENV"] == "ci"
+  Datadog.configure do |c|
+    # 結果が確実に配信されるようにトレーサーを構成します
+    c.ci.enabled = true
+    # テスト中のサービスまたはライブラリの名前
+    c.service = 'my-ruby-app'
+    # Cucumber のインスツルメンテーションを有効にします
+    c.ci.instrument :rspec
+  end
 end
 ```
 
@@ -109,7 +103,7 @@ DD_ENV=ci bundle exec rake spec
 
 ## コンフィギュレーション設定
 
-以下は、`Datadog::CI.configure` ブロックを使用するか、環境変数を使用するコードで、トレーサーで使用できる最も重要なコンフィギュレーション設定のリストです。
+以下は、`Datadog.configure` ブロックを使用するか、環境変数を使用するコードで、トレーサーで使用できる最も重要なコンフィギュレーション設定のリストです。
 
 `service`
 : テスト中のサービスまたはライブラリの名前。<br/>

--- a/content/ja/continuous_integration/setup_tests/ruby.md
+++ b/content/ja/continuous_integration/setup_tests/ruby.md
@@ -51,7 +51,7 @@ Cucumber インテグレーションでは、`cucumber` フレームワークを
 require 'cucumber'
 require 'datadog/ci'
 
-Datadog.configure do |c|
+Datadog::CI.configure do |c|
   # CI でのみテストインスツルメンテーションをアクティブ化します
   c.tracer.enabled = (ENV["DD_ENV"] == "ci")
 
@@ -83,7 +83,7 @@ RSpec インテグレーションでは、`rspec` テストフレームワーク
 require 'rspec'
 require 'datadog/ci'
 
-Datadog.configure do |c|
+Datadog::CI.configure do |c|
   # CI でのみテストインスツルメンテーションをアクティブ化します
   c.tracer.enabled = (ENV["DD_ENV"] == "ci")
 
@@ -109,7 +109,7 @@ DD_ENV=ci bundle exec rake spec
 
 ## コンフィギュレーション設定
 
-以下は、`Datadog.configure` ブロックを使用するか、環境変数を使用するコードで、トレーサーで使用できる最も重要なコンフィギュレーション設定のリストです。
+以下は、`Datadog::CI.configure` ブロックを使用するか、環境変数を使用するコードで、トレーサーで使用できる最も重要なコンフィギュレーション設定のリストです。
 
 `service`
 : テスト中のサービスまたはライブラリの名前。<br/>


### PR DESCRIPTION
### What does this PR do?
Update the instructions for the ruby tracer when `1.0.0` is stable. 

### Motivation
Keep up to date with ruby tracer version.

### Preview
https://docs-staging.datadoghq.com/juan-fernandez/fix-breaking-changes-ruby/continuous_integration/setup_tests/ruby/?tab=cucumber


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
