### PR TITLE
App Sec mentions across SP docs

### DIFF
--- a/content/en/security_platform/_index.md
+++ b/content/en/security_platform/_index.md
@@ -30,7 +30,7 @@ Cloud Security Posture Management is not currently available in US1-FED.
 
 Bring speed and scale to your production security operations. Datadog’s Security Platform delivers real-time threat detection, and continuous configuration audits across applications, hosts, containers, and cloud infrastructure. Coupled with the greater Datadog observability platform, the Datadog security platform brings unprecedented integration between security and operations aligned to your organizations shared goals.
 
-The Datadog Security Platform includes [Cloud SIEM](#security-monitoring), [Cloud Security Posture Management (CSPM)](#cloud-security-posture-management), and [Cloud Workload Security (CWS)](#cloud-workload-security).
+The Datadog Security Platform includes [Application Security](#application-security), [Cloud SIEM](#security-monitoring), [Cloud Security Posture Management (CSPM)](#cloud-security-posture-management), and [Cloud Workload Security (CWS)](#cloud-workload-security).
 
 {{< vimeo 408512902 >}}
 </br>

--- a/content/en/security_platform/_index.md
+++ b/content/en/security_platform/_index.md
@@ -41,7 +41,7 @@ The Datadog Security Platform includes [Application Security](#application-secur
 Application Security is in public beta. See the <a href="https://app.datadoghq.com/security/appsec?instructions=all">in-app instructions</a> to get started.
 </div>
 
-[Application Security][7] monitors application-level attacks aiming to exploit code-level vulnerabilities, such as Server-Side-Request-Forgery (SSRF), SQL injection, Log4Shell, and Reflected Cross-Site-Scripting (XSS). Application Security leverages Datadog [APM][1], the [Datadog Agent][2], and in-app detection rules to detect threats in your application environment.
+[Application Security][7] monitors application-level attacks aiming to exploit code-level vulnerabilities, such as Server-Side-Request-Forgery (SSRF), SQL injection, Log4Shell, and Reflected Cross-Site-Scripting (XSS). Application Security leverages Datadog [APM][8], the [Datadog Agent][9], and in-app detection rules to detect threats in your application environment.
 
 {{< img src="/security_platform/application_security/app-sec-landing-page.png" alt="A security signal panel in Datadog, which displays attack flows and flame graphs" width="75%">}}
 

--- a/content/en/security_platform/_index.md
+++ b/content/en/security_platform/_index.md
@@ -35,6 +35,16 @@ The Datadog Security Platform includes [Cloud SIEM](#security-monitoring), [Clou
 {{< vimeo 408512902 >}}
 </br>
 
+## Application Security
+
+<div class="alert alert-warning">
+Application Security is in public beta. See the <a href="https://app.datadoghq.com/security/appsec?instructions=all">in-app instructions</a> to get started.
+</div>
+
+[Application Security][7] monitors application-level attacks aiming to exploit code-level vulnerabilities, such as Server-Side-Request-Forgery (SSRF), SQL injection, Log4Shell, and Reflected Cross-Site-Scripting (XSS). Application Security leverages Datadog [APM][1], the [Datadog Agent][2], and in-app detection rules to detect threats in your application environment.
+
+{{< img src="/security_platform/application_security/app-sec-landing-page.png" alt="A security signal panel in Datadog, which displays attack flows and flame graphs" width="75%">}}
+
 ## Cloud SIEM
 
 [Cloud SIEM][1] (Security Information and Event Management) detects real-time threats to your application and infrastructure, like a targeted attack, an IP communicating with your systems which matches a threat intel list, or an insecure configuration. Cloud SIEM is powered by [Datadog Log Management][2]. With these areas combined, you can [automate remediation of threats detected by Datadog Cloud SIEM][3] to speed up your threat-response workflow.
@@ -65,3 +75,4 @@ To get started with the Datadog Security Platform, navigate to the [Setup & Conf
 [4]: /security_platform/cspm/
 [5]: /security_platform/cloud_workload_security/
 [6]: https://app.datadoghq.com/security/configuration
+[7]: /security_platform/application_security/

--- a/content/en/security_platform/_index.md
+++ b/content/en/security_platform/_index.md
@@ -76,3 +76,5 @@ To get started with the Datadog Security Platform, navigate to the [Setup & Conf
 [5]: /security_platform/cloud_workload_security/
 [6]: https://app.datadoghq.com/security/configuration
 [7]: /security_platform/application_security/
+[8]: /tracing/
+[9]: /agent/

--- a/content/en/security_platform/default_rules/_index.md
+++ b/content/en/security_platform/default_rules/_index.md
@@ -11,9 +11,10 @@ disable_sidebar: true
 
 Datadog provides out-of-the-box (OOTB) [detection rules][1] to flag attacker techniques and potential misconfigurations so you can immediately take steps to remediate. Datadog continuously develops new default rules, which are automatically imported into your account, your Application Security library, and the Agent, depending on your configuration. For more information, see the Detection Rules documentation.
 
-Click on the buttons below to filter by different parts of the Datadog Security Platform. OOTB rules are available for [Cloud SIEM][2], [Posture Management][3], which is divided into cloud or infrastructure configuration, [Workload Security][4], and Application Security.
+Click on the buttons below to filter by different parts of the Datadog Security Platform. OOTB rules are available for [Cloud SIEM][2], [Posture Management][3], which is divided into cloud or infrastructure configuration, [Workload Security][4], and [Application Security][5].
 
 [1]: /security_platform/detection_rules/
 [2]: /security_platform/cloud_siem/
 [3]: /security_platform/cspm/
 [4]: /security_platform/cloud_workload_security/
+[5]: /security_platform/application_security/


### PR DESCRIPTION
### What does this PR do?
- Adds App Sec to the Security Platform landing page
- Updates the OOTB rules page with a link to App Sec docs

### Motivation
Jira

### Preview
https://docs-staging.datadoghq.com/sarina/app-sec-mentions/security_platform/
https://docs-staging.datadoghq.com/sarina/app-sec-mentions/default_rules/


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
