### PR TITLE
[DOCS-3112] Create custom alias to forward anchor to new page

### DIFF
--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>{{ .Permalink | absURL }}</title>
+        <link rel="canonical" href="{{ .Permalink | absURL }}" />
+        <meta name="robots" content="noindex">
+        <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+        <script>
+            if( window.location.hash ) {
+                const redirect_url = '{{ .Permalink | absURL }}'
+                window.location = `${ redirect_url }${ window.location.hash }`
+            }
+        </script>
+        <meta http-equiv="refresh" content="10; url={{ .Permalink | absURL }}" />
+    </head>
+</html>

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -6,10 +6,8 @@
         <meta name="robots" content="noindex">
         <meta http-equiv="content-type" content="text/html; charset=utf-8" />
         <script>
-            if( window.location.hash ) {
-                const redirect_url = '{{ .Permalink | absURL }}'
-                window.location = `${ redirect_url }${ window.location.hash }`
-            }
+            const redirect_url = '{{ .Permalink | absURL }}'
+            window.location = `${ redirect_url }${ window.location.search }${ window.location.hash }`
         </script>
         <meta http-equiv="refresh" content="10; url={{ .Permalink | absURL }}" />
     </head>


### PR DESCRIPTION
### What does this PR do?

Experimental PR to override the default Hugo redirect template
- If there is an anchor in the request URL, the template will forward to the destination page with the anchor value intact 
- There might be a better way to accomplish this, but testing out some inital links to see if the approach will work for existing urls that have changed 

### Motivation
https://datadoghq.atlassian.net/browse/DOCS-3112

### Preview
The following URLs should redirect with the anchor value included:

https://docs-staging.datadoghq.com/nsollecito/anchor-in-alias/logs/processing/parsing/?tab=matcher#parsing-dates
https://docs-staging.datadoghq.com/nsollecito/anchor-in-alias/logs/processing/processors/?tab=ui#geoip-parser
https://docs-staging.datadoghq.com/nsollecito/anchor-in-alias/logs/processing/processors/?tab=ui#lookup-processor


### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
