### PR TITLE
Fix a small mistake on Japanese document

### DIFF
--- a/content/ja/logs/log_configuration/parsing.md
+++ b/content/ja/logs/log_configuration/parsing.md
@@ -123,7 +123,7 @@ MyParsingRule %{word:user} connected on %{date("MM/dd/yyyy"):connect_date}
 `mac`
 : MAC アドレスに一致します。
 
-`mac`
+`ipv4`
 : IPV4 に一致します。
 
 `ipv6`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

To correct a mistake in Japanese document.

### Motivation
<!-- What inspired you to submit this pull request?-->

I found just one mistake on the document.
It differs from English Document.
https://github.com/DataDog/documentation/blob/master/content/en/logs/log_configuration/parsing.md

```markdown
`mac`
: Matches a MAC address.

`ipv4`
: Matches an IPV4.

`ipv6`
: Matches an IPV6.

`ip`
: Matches an IP (v4 or v6).
```

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
