### PR TITLE
Fix Google Analytics gtag

### DIFF
--- a/src/scripts/helpers/helpers.js
+++ b/src/scripts/helpers/helpers.js
@@ -37,7 +37,7 @@ function reloadWistiaVidScripts(vidId) {
 
 function gtag(...args) {
     const dataLayer = window.dataLayer || [];
-    dataLayer.push(args);
+    dataLayer.push(arguments);
 }
 
 const getCookieByName = (name) => {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
fixes the gtag function by replacing ...args with arguments

### Motivation
it's a common bug, I found this repo by searching for it.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->
see
https://github.com/v8/v8.dev/blob/d6805e0423c7301d019a5fba3c19bc1c8c304cda/src/_js/main.mjs#L45-L61

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
