### PR TITLE
Add versioning info for AAS .net extension

### DIFF
--- a/content/en/serverless/azure_app_services.md
+++ b/content/en/serverless/azure_app_services.md
@@ -70,14 +70,16 @@ The Datadog extension for Azure App Service provides additional monitoring capab
 
 **Note**: Datadog automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, APM). To ensure maximum visibility, run only one APM solution within your application environment.
 
-**Note**: Starting with version 2.3.0, the .Net extension doesn't rely on usual semantic versioning. Indeed, the extension will use the following scheme: `x.y.zAA` where `x.y.z` is the .Net Tracer version and `AA` is dedicated to the extension only. Also note that any leading 0 in `zAA` is trimmed by nuget packing so the version becomes `x.y.A`. Here are a few examples:
+Starting with v2.3.0, the .NET extension no longer relies on semantic versioning. The extension uses the following scheme: `x.y.zAA` where `x.y.z` is the .Net Tracer version and `AA` is dedicated only to the extension. Any leading zeroes in `zAA` is trimmed by NuGet packaging so the version becomes `x.y.A`. 
 
-- Extension `2.3.0` uses the tracer `2.3.0`
-- Extension `2.3.1` uses the tracer `2.3.0`
-- Extension `2.3.2` uses the tracer `2.3.0`
-- Extension `2.3.100` uses the tracer `2.3.1`
-- Extension `2.3.101` uses the tracer `2.3.1`
-- Extension `2.3.200` uses the tracer `2.3.2`
+For example:
+
+- Extension `2.3.0` uses the Tracer v`2.3.0`
+- Extension `2.3.1` uses the Tracer v`2.3.0`
+- Extension `2.3.2` uses the Tracer v`2.3.0`
+- Extension `2.3.100` uses the Tracer v`2.3.1`
+- Extension `2.3.101` uses the Tracer v`2.3.1`
+- Extension `2.3.200` uses the Tracer v`2.3.2`
 
 ### Installation
 

--- a/content/en/serverless/azure_app_services.md
+++ b/content/en/serverless/azure_app_services.md
@@ -70,6 +70,15 @@ The Datadog extension for Azure App Service provides additional monitoring capab
 
 **Note**: Datadog automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, APM). To ensure maximum visibility, run only one APM solution within your application environment.
 
+**Note**: Starting with version 2.3.0, the .Net extension doesn't rely on usual semantic versioning. Indeed, the extension will use the following scheme: `x.y.zAA` where `x.y.z` is the .Net Tracer version and `AA` is dedicated to the extension only. Also note that any leading 0 in `zAA` is trimmed by nuget packing so the version becomes `x.y.A`. Here are a few examples:
+
+- Extension `2.3.0` uses the tracer `2.3.0`
+- Extension `2.3.1` uses the tracer `2.3.0`
+- Extension `2.3.2` uses the tracer `2.3.0`
+- Extension `2.3.100` uses the tracer `2.3.1`
+- Extension `2.3.101` uses the tracer `2.3.1`
+- Extension `2.3.200` uses the tracer `2.3.2`
+
 ### Installation
 
 1. Configure the [Azure integration][1] to monitor your web app or function. Verify it is configured correctly by ensuring that you see the corresponding `azure.app_service.count` or `azure.functions.count` metric in Datadog. **Note**: This step is critical for metric/trace correlation, functional trace panel views, and improves the overall experience of using Datadog with Azure App Services.


### PR DESCRIPTION
### What does this PR do?
Documents how the .Net AAS extension is versioned

### Motivation
Make it clearer for customers and support teams what version of the tracer is running in AAS.

### Preview
https://docs-staging.datadoghq.com/pierre/aas-versioning/serverless/azure_app_services/?tab=net#requirements

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
