### PR TITLE
Clarify that Intelligent Retention Filter does not contribute to billing on usage_metrics.md

### DIFF
--- a/content/en/tracing/trace_retention/usage_metrics.md
+++ b/content/en/tracing/trace_retention/usage_metrics.md
@@ -43,7 +43,7 @@ The default [Trace Analytics Dashboard][5] has several groups of widgets to see 
 
 {{< img src="tracing/trace_indexing_and_ingestion/RetentionFilters.png" style="width:100%;" alt="Span Indexing" >}}
 
-Each retention filter set on your services, results in an _increase_ to the number of Indexed Spans for your Datadog account.
+Each retention filter set on your services results in an _increase_ to the number of Indexed Spans for your Datadog account.
 
 Because Indexed Spans can impact your bill, the 'Spans Indexed' column appears alongside each filter you set, showing the number of spans indexed based on the timeframe selected for that filter.
 

--- a/content/en/tracing/trace_retention/usage_metrics.md
+++ b/content/en/tracing/trace_retention/usage_metrics.md
@@ -43,11 +43,11 @@ The default [Trace Analytics Dashboard][5] has several groups of widgets to see 
 
 {{< img src="tracing/trace_indexing_and_ingestion/RetentionFilters.png" style="width:100%;" alt="Span Indexing" >}}
 
-Each retention filter set on your services, including the default [Datadog Intelligent Retention Filter][6], results in an _increase_ to the number of Indexed Spans for your Datadog account.
+Each retention filter set on your services, results in an _increase_ to the number of Indexed Spans for your Datadog account.
 
 Because Indexed Spans can impact your bill, the 'Spans Indexed' column appears alongside each filter you set, showing the number of spans indexed based on the timeframe selected for that filter.
 
-**Note:** The Datadog Intelligent Retention Filter on its own does not cause any billing implications outside of the included Indexed Spans with your APM Host pricing.
+**Note:** The [Datadog Intelligent Retention Filter][6] does not cause any billing implications.
 
 **Note**: Admin rights are required to create, modify, or disable retention filters.
 

--- a/content/en/tracing/trace_retention/usage_metrics.md
+++ b/content/en/tracing/trace_retention/usage_metrics.md
@@ -47,7 +47,7 @@ Each retention filter set on your services results in an _increase_ to the numbe
 
 Because Indexed Spans can impact your bill, the 'Spans Indexed' column appears alongside each filter you set, showing the number of spans indexed based on the timeframe selected for that filter.
 
-**Note:** The [Datadog Intelligent Retention Filter][6] does not cause any billing implications.
+**Note:** The [Datadog Intelligent Retention Filter][6] does not have any billing implications.
 
 **Note**: Admin rights are required to create, modify, or disable retention filters.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Clarify that  Datadog Intelligent Retention Filter does not contribute to billing.

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer / Datadog Sales Engineer feedback. APM PM agreed that this does need rephrasing for clarity.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/mecsantos/indexed-spans-wording-update/tracing/trace_retention/usage_metrics/#indexed-spans

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Aside from docs team, can we also have APM product check this?

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
