### PR TITLE
Fix CWS doc link text and tag

### DIFF
--- a/content/en/security_platform/cloud_workload_security/workload_security_rules.md
+++ b/content/en/security_platform/cloud_workload_security/workload_security_rules.md
@@ -3,8 +3,8 @@ title: Cloud Workload Security Rules
 kind: documentation
 further_reading:
 - link: "/security_platform/cloud_workload_security/getting_started"
-  tag: "Blog"
-  text: "Get Started with Cloud Runtime Security"
+  tag: "Documentation"
+  text: "Get Started with Cloud Workload Security"
 - link: "/security_platform/cloud_workload_security/agent_expressions"
   tag: "Documentation"
   text: "Agent Expressions"


### PR DESCRIPTION
### What does this PR do?

Change “Get Started with Runtime Security” to “Get Started with Cloud Workload Security". Also change tag to documentation.

### Motivation

Justin Massey asked for the text to be changed.

### Preview

https://docs-staging.datadoghq.com/may/fix_cws_link_text/security_platform/cloud_workload_security/workload_security_rules/?tab=host#configure-the-policy-in-your-environment

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
