### PR TITLE
Stanleyposo/update uts ecs language

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -236,7 +236,7 @@ As explained in the full configuration, these labels can be set in a Dockerfile 
 {{% tab "ECS" %}}
 ##### Full configuration
 
-Set the `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` environment variables and corresponding Docker labels in your container's runtime environment to your get the full range of unified service tagging. For instance, you can set all of this configuration in one place through your ECS task definition:
+Set the `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` environment variables and corresponding Docker labels in your container's runtime environment of each service's container to your get the full range of unified service tagging. For instance, you can set all of this configuration in one place through your ECS task definition:
 
 ```
 "environment": [

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -236,7 +236,7 @@ As explained in the full configuration, these labels can be set in a Dockerfile 
 {{% tab "ECS" %}}
 ##### Full configuration
 
-Set the `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` environment variables and corresponding Docker labels in your container's runtime environment of each service's container to your get the full range of unified service tagging. For instance, you can set all of this configuration in one place through your ECS task definition:
+Set the `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` environment variables and corresponding Docker labels in the runtime environment of each service's container to get the full range of unified service tagging. For instance, you can set all of this configuration in one place through your ECS task definition:
 
 ```
 "environment": [


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This would add some detail in our Unified Service Tagging guidelines specific to properly applying the Service Tag to an environments applications that are being traced in an ECS environment.

### Motivation
<!-- What inspired you to submit this pull request?-->
We had a customer (United Airlines / ) share their frustration with how our documents are.  We assessed each of his points and found that this was one of the ambigious sections which could be improved further.  This specifically points to where the DD service tag should be and it should be set in the service containers (or application container).

ticket reference:
https://datadog.zendesk.com/agent/tickets/647170


### Preview
https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=ecs#configuration-1

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/getting_started/tagging/unified_service_tagging.md

*used github directly

### Additional Notes
I used this method when editing this document and created a separate branch.
https://datadoghq.atlassian.net/wiki/spaces/TS/pages/328404476/Short+Guide+to+Updating+Docs#Even-Easier-Method 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
