### PR TITLE
Document availability of the Continuous Profiler in US5

### DIFF
--- a/content/en/tracing/profiler/_index.md
+++ b/content/en/tracing/profiler/_index.md
@@ -43,12 +43,6 @@ Continuous profiler runs in production across all services by leveraging technol
 
 ## Getting started
 
-{{< site-region region="us5" >}}
-<div class="alert alert-warning">
-  The Continuous Profiler is not available for the Datadog {{< region-param key="dd_site_name" >}}  site.
-</div>
-{{< /site-region >}}
-
 Profiling your service to visualize all your stack traces in one place takes just minutes.
 
 ### Instrument your application

--- a/content/en/tracing/profiler/enabling/_index.md
+++ b/content/en/tracing/profiler/enabling/_index.md
@@ -13,12 +13,6 @@ further_reading:
       text: 'Fix problems you encounter while using the profiler'
 ---
 
-{{< site-region region="us5" >}}
-<div class="alert alert-warning">
-  The Continuous Profiler is not available for the Datadog {{< region-param key="dd_site_name" >}} site.
-</div>
-{{< /site-region >}}
-
 The profiler is shipped within Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, you can skip installing the library and go directly to enabling the profiler.
 
 Select your language below to learn how to enable a profiler for your application:

--- a/content/en/tracing/profiler/enabling/dotnet.md
+++ b/content/en/tracing/profiler/enabling/dotnet.md
@@ -16,12 +16,6 @@ further_reading:
       text: 'Fix problems you encounter while using the profiler'
 ---
 
-{{< site-region region="us5" >}}
-<div class="alert alert-warning">
-  The Continuous Profiler is not available for the Datadog {{< region-param key="dd_site_name" >}} site.
-</div>
-{{< /site-region >}}
-
 <div class="alert alert-warning">
 Datadog .NET Profiler is currently in public beta. Datadog recommends evaluating the profiler in a non-sensitive environment before deploying in production.
 </div>

--- a/content/en/tracing/profiler/enabling/go.md
+++ b/content/en/tracing/profiler/enabling/go.md
@@ -16,12 +16,6 @@ further_reading:
       text: 'Fix problems you encounter while using the profiler'
 ---
 
-{{< site-region region="us5" >}}
-<div class="alert alert-warning">
-  The Continuous Profiler is not available for the Datadog {{< region-param key="dd_site_name" >}} site.
-</div>
-{{< /site-region >}}
-
 The profiler is shipped within Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, you can skip installing the library and go directly to enabling the profiler.
 
 ## Requirements

--- a/content/en/tracing/profiler/enabling/java.md
+++ b/content/en/tracing/profiler/enabling/java.md
@@ -16,12 +16,6 @@ further_reading:
       text: 'Fix problems you encounter while using the profiler'
 ---
 
-{{< site-region region="us5" >}}
-<div class="alert alert-warning">
-  The Continuous Profiler is not available for the Datadog {{< region-param key="dd_site_name" >}} site.
-</div>
-{{< /site-region >}}
-
 The profiler is shipped within Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, you can skip installing the library and go directly to enabling the profiler.
 
 ## Requirements

--- a/content/en/tracing/profiler/enabling/linux.md
+++ b/content/en/tracing/profiler/enabling/linux.md
@@ -13,12 +13,6 @@ further_reading:
       text: 'Fix problems you encounter while using the profiler'
 ---
 
-{{< site-region region="us5" >}}
-<div class="alert alert-warning">
-  The Continuous Profiler is not available for the Datadog {{< region-param key="dd_site_name" >}} site.
-</div>
-{{< /site-region >}}
-
 <div class="alert alert-warning">
 The Datadog Profiler for Linux is in public beta. Datadog recommends evaluating the profiler in a non-sensitive environment before deploying in production.
 </div>

--- a/content/en/tracing/profiler/enabling/nodejs.md
+++ b/content/en/tracing/profiler/enabling/nodejs.md
@@ -16,12 +16,6 @@ further_reading:
       text: 'Fix problems you encounter while using the profiler'
 ---
 
-{{< site-region region="us5" >}}
-<div class="alert alert-warning">
-  The Continuous Profiler is not available for the Datadog {{< region-param key="dd_site_name" >}} site.
-</div>
-{{< /site-region >}}
-
 <div class="alert alert-warning">
 Datadog Node.js Profiler is currently in public beta. Datadog recommends evaluating the profiler in a non-sensitive environment before deploying in production.
 </div>

--- a/content/en/tracing/profiler/enabling/php.md
+++ b/content/en/tracing/profiler/enabling/php.md
@@ -16,12 +16,6 @@ further_reading:
       text: 'Fix problems you encounter while using the profiler'
 ---
 
-{{< site-region region="us5" >}}
-<div class="alert alert-warning">
-  The Continuous Profiler is not available for the Datadog {{< region-param key="dd_site_name" >}} site.
-</div>
-{{< /site-region >}}
-
 <div class="alert alert-warning">
 The Datadog PHP Profiler is in public beta. Datadog recommends evaluating the profiler in a non-sensitive environment before deploying in production.
 </div>

--- a/content/en/tracing/profiler/enabling/python.md
+++ b/content/en/tracing/profiler/enabling/python.md
@@ -16,12 +16,6 @@ further_reading:
       text: 'Fix problems you encounter while using the profiler'
 ---
 
-{{< site-region region="us5" >}}
-<div class="alert alert-warning">
-  The Continuous Profiler is not available for the Datadog {{< region-param key="dd_site_name" >}} site.
-</div>
-{{< /site-region >}}
-
 The profiler is shipped within Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, you can skip installing the library and go directly to enabling the profiler.
 
 ## Requirements

--- a/content/en/tracing/profiler/enabling/ruby.md
+++ b/content/en/tracing/profiler/enabling/ruby.md
@@ -19,12 +19,6 @@ further_reading:
       text: 'Analyze Ruby code performance with Datadog Continuous Profiler'
 ---
 
-{{< site-region region="us5" >}}
-<div class="alert alert-warning">
-  The Continuous Profiler is not available for the Datadog {{< region-param key="dd_site_name" >}} site.
-</div>
-{{< /site-region >}}
-
 The profiler is shipped within Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, you can skip installing the library and go directly to enabling the profiler.
 
 ## Requirements

--- a/content/fr/tracing/profiler/enabling/_index.md
+++ b/content/fr/tracing/profiler/enabling/_index.md
@@ -12,11 +12,6 @@ further_reading:
     tag: Documentation
     text: Résoudre les problèmes rencontrés en utilisant le profileur
 ---
-{{< site-region region="us5" >}}
-<div class="alert alert-warning">
-  Le profileur en continu n'est pas disponible pour le site Datadog {{< region-param key="dd_site_name" >}}.
-</div>
-{{< /site-region >}}
 
 Le profileur est fourni dans les bibliothèques de tracing Datadog. Si vous utilisez déjà [l'APM pour recueillir des traces][1] pour votre application, vous pouvez ignorer l'installation de la bibliothèque et passer directement à l'activation du profileur.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Removes the warning indicating that the Continuous Profiler is not available in US5.

### Motivation

All the work required to set the profiler up in US5 has been completed, see our internal ticket PROF-3997 for reference.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/py/PROF-4868-profiler-us5/tracing/profiler/

### Additional Notes

N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
