### PR TITLE
Document trigger latency in log-based monitor

### DIFF
--- a/content/en/monitors/create/types/log.md
+++ b/content/en/monitors/create/types/log.md
@@ -19,6 +19,8 @@ further_reading:
 
 Once [log management is enabled][1] for your organization, you can create a logs monitor to alert you when a specified type of log exceeds a user-defined threshold over a given period of time.
 
+<div class="alert alert-info"><strong>Note</strong>: Log monitors are subject to an inherent latency of a few minutes between log ingestion and the log monitor triggering. To reduce the trigger latency, you may consider [generating metrics from logs][7] together with a [metric monitor][8].</div>
+
 ## Monitor creation
 
 To create a [logs monitor][2] in Datadog, use the main navigation: *Monitors --> New Monitor --> Logs*.
@@ -106,3 +108,5 @@ Include a sample of 10 logs in the alert notification:
 [4]: /logs/explorer/facets/
 [5]: /monitors/create/configuration/#advanced-alert-conditions
 [6]: /monitors/notify/
+[7]: /logs/log_configuration/logs_to_metrics/
+[8]: /monitors/create/types/metric/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Ref Datadog support ticket 657964.

This change documents the latency between a log event being ingested, and a log-based monitor being able to evaluate/trigger on the ingested event. In my experience, the latency is a bit above 180 seconds. Datadog support confirms the latency in the referenced support ticket, and recommends using the combination of log-derived metric and a metric-based monitor instead.

### Motivation
I'm unable to find any mention of latency between log indexing and log-based monitor triggering. With Datadog support confirming the latency issue, it would make sense that it is documented. Then users can quickly determine whether a log-based metric would suit their use case, or whether to immediately go for a log-derived metric + metric monitor instead.

It would of course be better if this inherent latency was fixed, rather than documenting it. Maybe this PR can help push a fix forward.

### Additional Notes
I put the info box prominently at the top, which is maybe a bit too much. At least it would save users time if their monitor is timing sensitive.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
