### PR TITLE
Bowen/update node startup debug docs

### DIFF
--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -88,6 +88,7 @@ const tracer = require('dd-trace').init({
   debug: true
 })
 ```
+**Note:** For version 2.X debug mode can only be configured by the environment variable `DD_TRACE_DEBUG`
 
 **Application Logs**
 

--- a/content/en/tracing/troubleshooting/tracer_startup_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_startup_logs.md
@@ -165,6 +165,8 @@ The Go Tracer prints one of two possible diagnostic lines, one for when the Agen
 {{< /programming-lang >}}
 {{< programming-lang lang="nodejs" >}}
 
+**Note:** Startup logs are disabled by default in version 2.X+. They can enabled using the environment variable `DD_TRACE_STARTUP_LOGS=true`.
+
 **Configuration:**
 
 ```text


### PR DESCRIPTION
### What does this PR do?
Updates the APM troubleshooting debug and startup log guides for the NodeJS tracer

### Motivation
Breaking changes to the node tracer in the release of the 2.X version  - https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md 

### Preview

Debug logs: https://docs-staging.datadoghq.com/bowen/update_node_startup_debug_docs/tracing/troubleshooting/tracer_debug_logs

Startup logs: https://docs-staging.datadoghq.com/bowen/update_node_startup_debug_docs/tracing/troubleshooting/tracer_startup_logs

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
