### PR TITLE
Feature Application Security test value in Java, Node.Js, PHP getting started

### DIFF
--- a/content/en/security_platform/application_security/getting_started/java.md
+++ b/content/en/security_platform/application_security/getting_started/java.md
@@ -97,7 +97,7 @@ java -javaagent:dd-java-agent.jar \
 
 {{< /tabs >}}
 
-{{% appsec-getstarted-2 %}}
+{{% appsec-getstarted-2-canary %}}
 
 {{< img src="/security_platform/application_security/application-security-signal.png" alt="Security Signal details page showing tags, metrics, suggested next steps, and attacker IP addresses associated with a threat." style="width:100%;" >}}
 

--- a/content/en/security_platform/application_security/getting_started/nodejs.md
+++ b/content/en/security_platform/application_security/getting_started/nodejs.md
@@ -131,7 +131,7 @@ DD_APPSEC_ENABLED=true node app.js
 {{% /tab %}}
 {{< /tabs >}}
 
-{{% appsec-getstarted-2 %}}
+{{% appsec-getstarted-2-canary %}}
 
 {{< img src="/security_platform/application_security/application-security-signal.png" alt="Security Signal details page showing tags, metrics, suggested next steps, and attacker IP addresses associated with a threat." style="width:100%;" >}}
 

--- a/content/en/security_platform/application_security/getting_started/php.md
+++ b/content/en/security_platform/application_security/getting_started/php.md
@@ -82,7 +82,7 @@ Update your ECS task definition JSON file, by adding this in the environment sec
 
 {{< /tabs >}}
 
-{{% appsec-getstarted-2 %}}
+{{% appsec-getstarted-2-canary %}}
 
 {{< img src="/security_platform/application_security/application-security-signal.png" alt="Security Signal details page showing tags, metrics, suggested next steps, and attacker IP addresses associated with a threat." style="width:100%;" >}}
 

--- a/layouts/shortcodes/appsec-getstarted-2-canary.md
+++ b/layouts/shortcodes/appsec-getstarted-2-canary.md
@@ -1,0 +1,13 @@
+   The library collects security data from your application and sends it to the Agent, which sends it to Datadog, where [out-of-the-box detection rules][202] flag attacker techniques and potential misconfigurations so you can take steps to remediate. 
+   
+1.  **To see Application Security threat detection in action, send known attack patterns to your application**. For example, trigger the [Security Scanner Detected][203] rule by running a file that contains the following curl script:
+    <div>
+    <pre><code>for ((i=1;i<=200;i++)); <br>do<br># Target existing service’s routes<br>curl https://your-application-url/existing-route -A dd-test-scanner-log;<br># Target non existing service’s routes<br>curl https://your-application-url/non-existing-route -A dd-test-scanner-log;<br>done</code></pre></div>
+
+    A few minutes after you enable your application and exercise it, **threat information appears in the [Application Trace and Signals Explorer][201] in Datadog**.
+
+    Note: The "dd-test-scanner-log" value is supported in the most recent releases and in the application security event configuration file version >= 1.2.5.
+
+[201]: https://app.datadoghq.com/security/appsec
+[202]: /security_platform/default_rules/#cat-application-security
+[203]: /security_platform/default_rules/security-scan-detected/

--- a/layouts/shortcodes/appsec-getstarted-2-canary.md
+++ b/layouts/shortcodes/appsec-getstarted-2-canary.md
@@ -4,9 +4,9 @@
     <div>
     <pre><code>for ((i=1;i<=200;i++)); <br>do<br># Target existing service’s routes<br>curl https://your-application-url/existing-route -A dd-test-scanner-log;<br># Target non existing service’s routes<br>curl https://your-application-url/non-existing-route -A dd-test-scanner-log;<br>done</code></pre></div>
 
-    A few minutes after you enable your application and exercise it, **threat information appears in the [Application Trace and Signals Explorer][201] in Datadog**.
+    **Note**: The `dd-test-scanner-log` value is supported in the most recent releases and in the application security event configuration file version >= 1.2.5.
 
-    Note: The "dd-test-scanner-log" value is supported in the most recent releases and in the application security event configuration file version >= 1.2.5.
+    A few minutes after you enable your application and exercise it, **threat information appears in the [Application Trace and Signals Explorer][201] in Datadog**.
 
 [201]: https://app.datadoghq.com/security/appsec
 [202]: /security_platform/default_rules/#cat-application-security


### PR DESCRIPTION
… started

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR features the Application Security "dd-test-scanner-log" test value in the Getting Started, instead of the Arachni user-agent

### Motivation
This value simplifies the test of Application Security as the Arachni user-agent might be blocked by network WAF

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
