### PR TITLE
[profiling] Set the right profile intake URL

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -299,7 +299,7 @@ backend datadog-profiles
     balance roundrobin
     mode tcp
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 profile.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 intake.profile.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
     # server mothership profile.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify none
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes the intake URL for Haproxy configuration page.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
https://docs-staging.datadoghq.com/fd/fix-intake-url-haproxy

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
