### PR TITLE
Update getting_started.md

### DIFF
--- a/content/en/security_platform/cloud_workload_security/getting_started.md
+++ b/content/en/security_platform/cloud_workload_security/getting_started.md
@@ -60,6 +60,60 @@ There are two types of monitoring that the Datadog Agent uses for Cloud Workload
 [2]: https://docs.datadoghq.com/integrations/kubernetes_audit_logs/
 {{% /tab %}}
 
+{{% tab "Kubernetes (DaemonSet)" %}}
+1. If you installed the Datadog Agent as a DaemonSet with a manual [manifest](https://docs.datadoghq.com/agent/kubernetes/?tab=daemonset), then you can add the following lines to activate CWS module :
+
+```
+    containers:
+        - image: 'datadog/agent:latest-jmx'
+          ...
+          securityContext:
+              capabilities:
+                add:
+                  - SYS_ADMIN
+                  - SYS_RESOURCE
+                  - SYS_PTRACE
+                  - NET_ADMIN
+                  - IPC_LOCK
+          env:
+              - name: DD_SYSTEM_PROBE_ENABLED
+                value: "true"
+              - name: DD_RUNTIME_SECURITY_CONFIG_ENABLED
+                value: "true"
+              - name: HOST_ROOT
+                value: "/host/root"
+          volumeMounts:
+              - name: passwd
+                mountPath: /etc/passwd
+                readOnly: true
+              - name: group
+                mountPath: /etc/group
+                readOnly: true
+              - name: root
+                mountPath: /host/root
+                readOnly: true
+              - name: os-release
+                mountPath: /host/etc/os-release
+    ...            
+    volumes:
+                - name: passwd
+                  hostPath:
+                      path: /etc/passwd
+                - name: group
+                  hostPath:
+                      path: /etc/group
+                - name: root
+                  hostPath:
+                      path: /
+                - name: os-release
+                  hostPath:
+                      path: /etc/os-release            
+```
+
+2. Apply the modified file and make sure Datadog Agent pods are restarting correctly.
+3. **Optional, if Cloud SIEM is checked** Follow [these instructions][2] to collect audit logs for Kubernetes.
+
+{{% /tab %}}
 {{% tab "Docker" %}}
 
 The following command can be used to start the Runtime Security Agent and `system-probe` in a Docker environment:

--- a/content/en/security_platform/cloud_workload_security/getting_started.md
+++ b/content/en/security_platform/cloud_workload_security/getting_started.md
@@ -82,6 +82,8 @@ There are two types of monitoring that the Datadog Agent uses for Cloud Workload
                 value: "true"
               - name: HOST_ROOT
                 value: "/host/root"
+              - name: HOST_ETC
+                value: "/host/root/etc"
           volumeMounts:
               - name: passwd
                 mountPath: /etc/passwd


### PR DESCRIPTION
**Adding instructions for enabling CWS module when Datadog Agent has been installed manually as a Daemonset**

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
