### PR TITLE
Serverless package too large

### DIFF
--- a/content/en/serverless/guide/_index.md
+++ b/content/en/serverless/guide/_index.md
@@ -16,5 +16,5 @@ kind: guide
 
 {{< whatsnext desc="Troubleshooting:" >}}
     {{< nextlink href="/serverless/guide/serverless_tracing_and_webpack" >}}Node.js Lambda Tracing and Webpack Compatibility{{< /nextlink >}}
-    {{< nextlink href="/serverless/guide/serverless_package_too_large" >}}Serverless Package Too Large{{< /nextlink >}}
+    {{< nextlink href="/serverless/guide/serverless_package_too_large" >}}Troubleshooting Serverless Package Too Large Errors{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/serverless/guide/_index.md
+++ b/content/en/serverless/guide/_index.md
@@ -15,5 +15,6 @@ kind: guide
 {{< /whatsnext >}}
 
 {{< whatsnext desc="Troubleshooting:" >}}
-    {{< nextlink href="/serverless/troubleshooting/serverless_tracing_and_webpack" >}}Node.js Lambda Tracing and Webpack Compatibility{{< /nextlink >}}
+    {{< nextlink href="/serverless/guide/serverless_tracing_and_webpack" >}}Node.js Lambda Tracing and Webpack Compatibility{{< /nextlink >}}
+    {{< nextlink href="/serverless/guide/serverless_package_too_large" >}}Serverless Package Too Large{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/serverless/guide/serverless_package_too_large.md
+++ b/content/en/serverless/guide/serverless_package_too_large.md
@@ -1,0 +1,66 @@
+---
+title: Serverless Package Too Large
+kind: documentation
+further_reading:
+- link: '/serverless/installation/nodejs'
+  tag: 'Documentation'
+  text: 'Instrumenting Node.js Applications'
+---
+
+This guide helps you troubleshoot the error "Code uncompressed size is greater than max allowed size of 272629760" when instrumenting your Node.js serverless application using the Datadog serverless plugin. Although there have been very few reports of the error when instrumenting applications written in other languages or deployed using other tools, the ideas described below may still apply.
+
+Essentially this error indicates that your function's _uncompressed_ code size exceeds the 250 MB limit. Both your [function package][1] (the .zip artifact containing your function code and dependencies) and the [Lambda layers][2] configured on your function count towards this limit. Therefore you want to examine both of them to narrow down the root cause. 
+
+## Layers
+
+Typically Datadog adds two Lambda layers for instrumentation -- a language-specific library that instruments the function code and the Extension that aggregates, buffers and forwards the observability data to the Datadog backend.
+
+You can inspect the content and size of the Datadog Lambda layers using AWS CLI command [aws lambda get-layer-version][3]. For example, running the following commands gives you links to download the Lambda layers for _Datadog-Node14-x version 67_ and _Datadog-Extension version 19_ and inspect the uncompressed size (~30 MB combined). The uncompressed size varies by layers and versions, and you should replace the layer name and version number with the ones used by your applications.
+
+```
+aws lambda get-layer-version \
+  --layer-name arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node14-x \
+  --version-number 67
+
+aws lambda get-layer-version \
+  --layer-name arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension \
+  --version-number 19
+```
+
+Besides Datadog Lambda layers, you should also inspect other Lambda layers added (or to be added) to your functions. If you are using the [Serverless Framework][4], you can find the the CloudFormation template from the hidden `.serverless` folder after running the `deploy` or `package` command, and the list of Lambda layers from the `Layers` section.
+
+## Package
+
+The function deployment package may often contain large files or code that you don't actually need. If you are using the Serverless Framework, you can find the generated deployment package (.zip file) from the hidden `.serverless` folder after running the `deploy` or `package` command.
+
+If the size of the deployment package and layers don't add up to the limit, you should contact AWS Support for investigation. If the total size does exceed the limit, you should inspect the deployment package and exclude large files that you don't actually need in runtime using the [package][5] option.
+
+## Dependencies
+
+The Datadog Lambda layer packages the instrumentation libraries and makes them available to use in the Lambda execution environment, therefore you do _NOT_ need to define `datadog-lambda-js` and `dd-trace` as `dependencies` in your `package.json`. If you do need the Datadog libraries for local build or tests, define them as `devDependencies` so that they get excluded from the deployment package. Similarly, `serverless-plugin-datadog` is only needed for dev, and should be defined under `devDependencies`.
+
+Besides Datadog dependencies, you should also inspect other dependencies (the `node_modules` folder) that are included into your deployment package and only leave the ones that you need in `dependencies`.
+
+## Webpack
+
+Using a bundler like [Webpack][6] can dramatically reduce your deployment package size by only including the code that are used. See [Node.js Lambda Tracing and Webpack Compatibility][7] for required webpack configurations.
+
+## Get help
+
+If you need the Datadog support team to help investigate, please include the following information in your ticket.
+
+1. the function's configured Lambda layers (name and version, or ARNs)
+2. the function's deployment package (or a screenshot showing the content and size of the uncompressed package) to be uploaded to AWS
+3. the project configuration files (don't forget to redact hardcoded secrets) - serverless.yaml, package.json, package-lock.json, yarn.lock, tsconfig.json and webpack.config.json.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-package.html#gettingstarted-package-zip
+[2]: https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-package.html#gettingstarted-package-layers
+[3]: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/get-layer-version.html
+[4]: https://www.serverless.com/
+[5]: https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml/#package
+[6]: https://webpack.js.org
+[7]: /serverless/guide/serverless_tracing_and_webpack/

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -117,10 +117,13 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
     ```
     Find your Datadog API key on the [API Management page][3]. For additional settings, see the [plugin documentation][1].
 
+If you encounter the "Code uncompressed size is greater than max allowed size of 272629760" error after adding `serverless-plugin-datadog`, see this [troubleshooting guide][4]. 
+
 
 [1]: https://docs.datadoghq.com/serverless/serverless_integrations/plugin
 [2]: /serverless/libraries_integrations/extension
 [3]: https://app.datadoghq.com/organization-settings/api-keys
+[4]: /serverless/guide/serverless_package_too_large
 {{% /tab %}}
 {{% tab "AWS SAM" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add a troubleshooting guide for a common issue when setting up Datadog serverless monitoring. For example, issue like https://github.com/DataDog/serverless-plugin-datadog/issues/212 is particularly difficult to troubleshoot on the Datadog side. However, it's much easier to be troubleshooted on the customer side with full access to the project encountering the issue.   

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tian.chu/sls-pkg-too-large/serverless/guide/serverless_package_too_large/
https://docs-staging.datadoghq.com/tian.chu/sls-pkg-too-large/serverless/installation/nodejs/?tab=serverlessframework#configuration

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
