### PR TITLE
Add env var for auto_multi_line_detection

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -458,7 +458,7 @@ logs_config:
   auto_multi_line_detection: true
 ```
 
-For containerized deployments this can be enabled with the environment variable `DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION=true`.
+For containerized deployments, you can enable `auto_multi_line_detection` with the `DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION=true` environment variable.
 
 It can also be enabled or disabled (overriding the global config) per log configuration:
 

--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -458,6 +458,8 @@ logs_config:
   auto_multi_line_detection: true
 ```
 
+For containerized deployments this can be enabled with the environment variable `DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION=true`.
+
 It can also be enabled or disabled (overriding the global config) per log configuration:
 
 {{< tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Provide the instructions to enable `auto_multi_line_detection` for containerized environments through environment variables rather than the `datadog.yaml` as this is the easier/preferred way.

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer case

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jack.davenport/multi_line/agent/logs/advanced_log_collection/?tab=configurationfile#automatic-multi-line-aggregation

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
