### PR TITLE
Warn serverless forwarder users

### DIFF
--- a/content/en/serverless/guide/_index.md
+++ b/content/en/serverless/guide/_index.md
@@ -6,6 +6,8 @@ kind: guide
 {{< whatsnext desc="Using the Datadog Forwarder:" >}}
     {{< nextlink href="/serverless/guide/datadog_forwarder_node" >}}Installing Serverless with the Datadog Forwarder - Node.js{{< /nextlink >}}
     {{< nextlink href="/serverless/guide/datadog_forwarder_python" >}}Installing Serverless with the Datadog Forwarder - Python{{< /nextlink >}}
+    {{< nextlink href="/serverless/guide/datadog_forwarder_java" >}}Installing Serverless with the Datadog Forwarder - Java{{< /nextlink >}}
+    {{< nextlink href="/serverless/guide/datadog_forwarder_go" >}}Installing Serverless with the Datadog Forwarder - Go{{< /nextlink >}}
 {{< /whatsnext >}}
 
 {{< whatsnext desc="Using the Datadog Lambda Extension:" >}}

--- a/content/en/serverless/guide/datadog_forwarder_go.md
+++ b/content/en/serverless/guide/datadog_forwarder_go.md
@@ -4,22 +4,24 @@ kind: guide
 ---
 ## Overview
 
-If you are a new user of Datadog Serverless, Datadog recommends using the [out-of-the-box Lambda functionality][1]. However, if you were set up on Datadog Serverless using the Datadog Forwarder before Lambda offered out-of-the-box functionality, use this guide to maintain your instance.
+<div class="alert alert-warning">
+If you are a new user of Datadog Serverless, follow the <a href="/serverless/installation/go">instructions to instrument your Lambda functions using the Datadog Lambda Extension</a> instead. If you have setup Datadog Serverless with the Datadog Forwarder before Lambda offered out-of-the-box functionality, use this guide to maintain your instance.
+</div>
 
 ## Required setup
 
 If not already configured:
 
-- Install the [AWS integration][2]. This allows Datadog to ingest Lambda metrics from AWS. 
-- Install the [Datadog Forwarder Lambda function][3], which is required to ingest AWS Lambda traces, enhanced metrics, custom metrics, and logs. 
+- Install the [AWS integration][1]. This allows Datadog to ingest Lambda metrics from AWS. 
+- Install the [Datadog Forwarder Lambda function][2], which is required to ingest AWS Lambda traces, enhanced metrics, custom metrics, and logs. 
 
-After you have installed the [AWS integration][2] and the [Datadog Forwarder][3], follow these steps to instrument your application to send metrics, logs, and traces to Datadog.
+After you have installed the [AWS integration][1] and the [Datadog Forwarder][2], follow these steps to instrument your application to send metrics, logs, and traces to Datadog.
 
 ## Configuration
 
 ### Install
 
-Install the [Datadog Lambda library][4] locally by running the following command:
+Install the [Datadog Lambda library][3] locally by running the following command:
 
 ```
 go get github.com/DataDog/datadog-lambda-go
@@ -80,16 +82,16 @@ Follow these steps to instrument the function:
 
 Subscribe the Datadog Forwarder Lambda function to each of your function’s log groups, in order to send metrics, traces, and logs to Datadog.
 
-1. [Install the Datadog Forwarder if you haven't][3].
-2. [Subscribe the Datadog Forwarder to your function's log groups][5].
+1. [Install the Datadog Forwarder if you haven't][2].
+2. [Subscribe the Datadog Forwarder to your function's log groups][4].
 
 ### Tag
 
-Although it's optional, Datadog recommends tagging your serverless applications with the `env`, `service`, and `version` tags for [unified service tagging][6].
+Although it's optional, Datadog recommends tagging your serverless applications with the `env`, `service`, and `version` tags for [unified service tagging][5].
 
 ## Explore
 
-After configuring your function following the steps above, view your metrics, logs, and traces on the [Serverless homepage][7].
+After configuring your function following the steps above, view your metrics, logs, and traces on the [Serverless homepage][6].
 
 ## Monitor custom business logic
 
@@ -134,17 +136,16 @@ func myHandler(ctx context.Context, event MyEvent) (string, error) {
 }
 ```
 
-Learn more about [custom metric submission][8].
+Learn more about [custom metric submission][7].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /serverless/installation
-[2]: /integrations/amazon_web_services/
-[3]: /serverless/forwarder/
-[4]: https://github.com/DataDog/datadog-lambda-go
-[5]: /logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
-[6]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
-[7]: https://app.datadoghq.com/functions
-[8]: /serverless/custom_metrics?tab=go
+[1]: /integrations/amazon_web_services/
+[2]: /serverless/forwarder/
+[3]: https://github.com/DataDog/datadog-lambda-go
+[4]: /logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
+[5]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
+[6]: https://app.datadoghq.com/functions
+[7]: /serverless/custom_metrics?tab=go

--- a/content/en/serverless/guide/datadog_forwarder_java.md
+++ b/content/en/serverless/guide/datadog_forwarder_java.md
@@ -2,11 +2,16 @@
 title: Using the Datadog Forwarder - Java
 kind: guide
 ---
+## Overview
+
+<div class="alert alert-warning">
+If you are a new user of Datadog Serverless, follow the <a href="/serverless/installation/java">instructions to instrument your Lambda functions using the Datadog Lambda Extension</a> instead. If you have setup Datadog Serverless with the Datadog Forwarder before Lambda offered out-of-the-box functionality, use this guide to maintain your instance.
+</div>
 
 {{< img src="serverless/java-lambda-tracing.png" alt="Monitor Java Lambda Functions with Datadog" style="width:100%;">}}
 
 <div class="alert alert-danger">
-Some older versions of <code>datadog-lambda-java</code> import <code>log4j <=2.14.0</code> as a transitive dependency. <a href="#upgrading">Upgrade instructions</a> are below. 
+Some older versions of <code>datadog-lambda-java</code> import <code>log4j <=2.14.0</code> as a transitive dependency. <a href="#upgrading">Upgrade instructions</a> are below.
 </div>
 
 ## Prerequisites

--- a/content/en/serverless/guide/datadog_forwarder_node.md
+++ b/content/en/serverless/guide/datadog_forwarder_node.md
@@ -3,11 +3,15 @@ title: Using the Datadog Forwarder - Node
 kind: guide
 ---
 
-If you are a new user of Datadog Serverless, Datadog recommends using the [out-of-the-box Lambda functionality][1]. However, if you got set up on Datadog Serverless using the Datadog Forwarder before Lambda offered out-of-the-box functionality, use this guide to maintain your instance.
+## Overview
+
+<div class="alert alert-warning">
+If you are a new user of Datadog Serverless, follow the <a href="/serverless/installation/nodejs">instructions to instrument your Lambda functions using the Datadog Lambda Extension</a> instead. If you have setup Datadog Serverless with the Datadog Forwarder before Lambda offered out-of-the-box functionality, use this guide to maintain your instance.
+</div>
 
 ## Prerequisites
 
-The [Datadog Forwarder Lambda function][2] is required to ingest AWS Lambda traces, enhanced metrics, custom metrics, and logs.
+The [Datadog Forwarder Lambda function][1] is required to ingest AWS Lambda traces, enhanced metrics, custom metrics, and logs.
 
 ## Configuration
 
@@ -313,11 +317,11 @@ Subscribe the Datadog Forwarder Lambda function to each of your function’s log
 
 ### Tag
 
-Although it's optional, Datadog recommends tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][3].
+Although it's optional, Datadog recommends tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][2].
 
 ## Explore
 
-After configuring your function following the steps above, view your metrics, logs, and traces on the [Serverless homepage][4].
+After configuring your function following the steps above, view your metrics, logs, and traces on the [Serverless homepage][3].
 
 ## Monitor custom business logic
 
@@ -370,16 +374,15 @@ exports.handler = async (event) => {
 };
 ```
 
-For more information on custom metric submission, see [Serverless Custom Metrics][5]. For additional details on custom instrumentation, see the Datadog APM documentation for [custom instrumentation][6].
+For more information on custom metric submission, see [Serverless Custom Metrics][4]. For additional details on custom instrumentation, see the Datadog APM documentation for [custom instrumentation][5].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: /serverless/installation
-[2]: /serverless/forwarder
-[3]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
-[4]: https://app.datadoghq.com/functions
-[5]: /serverless/custom_metrics?tab=nodejs
-[6]: /tracing/custom_instrumentation/nodejs/
+[1]: /serverless/forwarder
+[2]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
+[3]: https://app.datadoghq.com/functions
+[4]: /serverless/custom_metrics?tab=nodejs
+[5]: /tracing/custom_instrumentation/nodejs/

--- a/content/en/serverless/guide/datadog_forwarder_python.md
+++ b/content/en/serverless/guide/datadog_forwarder_python.md
@@ -2,12 +2,15 @@
 title: Using the Datadog Forwarder - Python
 kind: guide
 ---
+## Overview
 
-If you are a new user of Datadog Serverless, Datadog recommends using the [out-of-the-box Lambda functionality][1]. However, if you got set up on Datadog Serverless using the Datadog Forwarder before Lambda offered out-of-the-box functionality, use this guide to maintain your instance.
+<div class="alert alert-warning">
+If you are a new user of Datadog Serverless, follow the <a href="/serverless/installation/python">instructions to instrument your Lambda functions using the Datadog Lambda Extension</a> instead. If you have setup Datadog Serverless with the Datadog Forwarder before Lambda offered out-of-the-box functionality, use this guide to maintain your instance.
+</div>
 
 ## Prerequisites
 
-The [Datadog Forwarder Lambda function][2] is required to ingest AWS Lambda traces, enhanced metrics, custom metrics, and logs.
+The [Datadog Forwarder Lambda function][1] is required to ingest AWS Lambda traces, enhanced metrics, custom metrics, and logs.
 
 ## Configuration
 
@@ -381,11 +384,11 @@ Subscribe the Datadog Forwarder Lambda function to each of your function’s log
 
 ### Tag
 
-Although it's optional, Datadog recommends tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][3].
+Although it's optional, Datadog recommends tagging you serverless applications with the `env`, `service`, and `version` tags following the [unified service tagging documentation][2].
 
 ## Explore
 
-After configuring your function following the steps above, view your metrics, logs, and traces on the [Serverless homepage][4].
+After configuring your function following the steps above, view your metrics, logs, and traces on the [Serverless homepage][3].
 
 ## Monitor custom business logic
 
@@ -426,15 +429,15 @@ def get_message():
     return 'Hello from serverless!'
 ```
 
-For more information on custom metric submission, see [here][5]. For additional details on custom instrumentation, see the Datadog APM documentation for [custom instrumentation][5].
+For more information on custom metric submission, see [here][4]. For additional details on custom instrumentation, see the Datadog APM documentation for [custom instrumentation][5].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: /serverless/installation
-[2]: /serverless/forwarder
-[3]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
-[4]: https://app.datadoghq.com/functions
+[1]: /serverless/forwarder
+[2]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
+[3]: https://app.datadoghq.com/functions
+[4]: /serverless/custom_metrics?tab=python
 [5]: /tracing/custom_instrumentation/python/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Make the warning message (what's originally in the first paragraph) more prominent. Apparently some new users have missed it and ended up following this guide to set up instrumentation using the Forwarder (instead of the recommended Extension). 

### Motivation
Customer feedback. Google sometimes still lead users to the old docs depending on the searched keywords.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tian.chu/sls-warn-forwarder-users/serverless/guide/datadog_forwarder_python
https://docs-staging.datadoghq.com/tian.chu/sls-warn-forwarder-users/serverless/guide/datadog_forwarder_node
https://docs-staging.datadoghq.com/tian.chu/sls-warn-forwarder-users/serverless/guide/datadog_forwarder_java
https://docs-staging.datadoghq.com/tian.chu/sls-warn-forwarder-users/serverless/guide/datadog_forwarder_go

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
