### PR TITLE
Workload security rule sourcing

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -611,8 +611,8 @@
         - "runtime/**/*.yml"
         - "runtime/**/*.md"
         # new
-        - "workload-security/signal-rules/*.yaml"
-        - "workload-security/signal-rules/*.md"
+        - "workload-security/backend-rules/*.yaml"
+        - "workload-security/backend-rules/*.md"
         - "security-monitoring/*.json"
         - "security-monitoring/*.md"
         - "posture-management/**/*.json"

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -612,8 +612,8 @@
         - "runtime/**/*.yml"
         - "runtime/**/*.md"
         # new
-        - "workload-security/signal-rules/*.yaml"
-        - "workload-security/signal-rules/*.md"
+        - "workload-security/backend-rules/*.yaml"
+        - "workload-security/backend-rules/*.md"
         - "security-monitoring/*.json"
         - "security-monitoring/*.md"
         - "posture-management/**/*.json"


### PR DESCRIPTION
### What does this PR do?

The directory name changed where we are sourcing workload security rules.
This PR updates this so we are pulling them in again.

### Motivation

https://github.com/DataDog/documentation/pull/13042#issuecomment-1033880715

### Preview

https://docs-staging.datadoghq.com/david.jones/wrkload-security/security_platform/default_rules/#all

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
