### PR TITLE
[RUM][REPLAY] ServiceWorker FAQ note for other browsers

### DIFF
--- a/content/en/real_user_monitoring/faq/session_replay_service_worker.md
+++ b/content/en/real_user_monitoring/faq/session_replay_service_worker.md
@@ -17,7 +17,7 @@ If you have blocked third-party cookies in your browser settings, or if your bro
 
 Datadog recommends that you make an exception to your third-party cookie blocking to allow Session Replay's service worker to function properly.
 
-Steps for Chrome are as follows. They are very similar for Firefox and other browsers.
+If you use Google Chrome, follow the instructions below. This exception workflow also applies to Firefox and other desktop browsers, including Brave and Edge.
 
 1. In your web browser, click the **Lock** icon to the left of the page URL.
 2. Click **Cookies**. A popup modal appears.

--- a/content/en/real_user_monitoring/faq/session_replay_service_worker.md
+++ b/content/en/real_user_monitoring/faq/session_replay_service_worker.md
@@ -17,6 +17,8 @@ If you have blocked third-party cookies in your browser settings, or if your bro
 
 Datadog recommends that you make an exception to your third-party cookie blocking to allow Session Replay's service worker to function properly.
 
+Steps for Chrome are as follows. They are very similar for Firefox and other browsers.
+
 1. In your web browser, click the **Lock** icon to the left of the page URL.
 2. Click **Cookies**. A popup modal appears.
 


### PR DESCRIPTION
### What does this PR do?
Adds a brief note clarifying that the listed steps are for Chrome, and that Firefox and other browsers follow very similar steps.
Follow up for #12771

### Motivation
This FAQ article is linked from Session Replay whenever third-party cookie blocking is detected. As we support other browsers, making a note seems reasonable. It's not reasonable to add screenshots and steps for every browser, however.

### Preview
https://docs-staging.datadoghq.com/alfonso.corretti/Session-Replay-Service-Worker-note-for-firefox/real_user_monitoring/faq/session_replay_service_worker/

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
