### PR TITLE
Add Supported languages section for .NET profiler

### DIFF
--- a/content/en/tracing/profiler/enabling/dotnet.md
+++ b/content/en/tracing/profiler/enabling/dotnet.md
@@ -39,7 +39,7 @@ Datadog .NET Profiler is currently in public beta. Datadog recommends evaluating
 
 **Supported languages:**
 
-Any language targeting the .NET runtime, such as C#, F#, Visual Basic and others.
+Any language that targets the .NET runtime, such as C#, F#, and Visual Basic.
 
 ## Installation
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR adds a *Supported languages* section for the .NET profiler

### Motivation
<!-- What inspired you to submit this pull request?-->
In case customers have doubt about if their .NET-based language is supported the .NET profiler. This helps in clearing things off.

### Preview
https://docs-staging.datadoghq.com/gleocadie/add-information-about-supported-dotnet-languages/tracing/profiler/enabling/dotnet/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
