### PR TITLE
EBS config: use the Linux Agent install_script.sh

### DIFF
--- a/static/config/99datadog-amazon-linux-2.config
+++ b/static/config/99datadog-amazon-linux-2.config
@@ -1,76 +1,28 @@
-# .ebextensions/99datadog-amazon-linux-2.config
+# .ebextensions/99datadog.config
 option_settings:
-    - namespace:  aws:elasticbeanstalk:application:environment
-      option_name:  DD_API_KEY
-      value:  "<YOUR_DD_API_KEY>"
-    - namespace:  aws:elasticbeanstalk:application:environment
-      option_name:  DD_AGENT_VERSION
-      value:  "" # For example, "7.21.1". Leave empty to install the latest version. Only Agent 7 is supported.
+    - namespace: aws:elasticbeanstalk:application:environment
+      option_name: DD_AGENT_VERSION_MAJOR_VERSION
+      value: "7"
+    - namespace: aws:elasticbeanstalk:application:environment
+      option_name: DD_AGENT_MINOR_VERSION
+      value: "" # Eg: 34 to install 7.34.x, leave empty to install the latest 7.x
+
 files:
-    "/configure_datadog_yaml.sh":
-        mode: "000700"
-        owner: root
-        group: root
-        content: |
-            #!/bin/bash
-            sed 's/api_key:.*/api_key: '$DD_API_KEY'/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
-            # Use the following command if you're in the EU. Replace datadoghq.eu with another region if in a different region.
-            # sed -i 's/datadoghq.com/datadoghq.eu/' /etc/datadog-agent/datadog.yaml
+  "/etc/datadog-agent/datadog.yaml": 
+    mode: "000640"
+    owner: root # will be changed to dd-agent after the installation
+    group: root
+    content: |
+      # Add here the Agent configuration
+      api_key: "<YOUR API KEY HERE>"
+      site: datadoghq.com
 
-    "/datadog/datadog.repo":
-        mode: "000644"
-        owner: root
-        group: root
-        content: |
-            [datadog]
-            name = Datadog, Inc.
-            baseurl = https://yum.datadoghq.com/stable/7/x86_64/
-            enabled=1
-            gpgcheck=1
-            repo_gpgcheck=1
-            gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
-                   https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
-                   https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-
-    "/start_datadog.sh":
-        mode: "000700"
-        owner: root
-        group: root
-        content: |
-            #!/bin/bash
-            STATUS=$(sudo systemctl status datadog-agent)
-            if [[ "$STATUS" == *"active (running)"* ]]
-              then
-                echo "Agent already running"
-              else
-                echo "Agent starting..."
-                sudo systemctl start datadog-agent
-            fi
-
-    "/stop_datadog.sh":
-        mode: "000700"
-        owner: root
-        group: root
-        content: |
-            #!/bin/bash
-            STATUS=$(sudo systemctl status datadog-agent)
-            if [[ "$STATUS" == *"active (running)"* ]]
-              then
-                echo "Agent stopping..."
-                sudo systemctl stop datadog-agent
-              else
-                echo "Agent already stopped"
-            fi
-
+  "/datadog_install_script.sh": 
+    mode: "000700"
+    owner: root
+    group: root
+    source: https://s3.amazonaws.com/dd-agent/scripts/install_script.sh
 
 container_commands:
-    02stop_datadog:
-        command: "/stop_datadog.sh"
-    04install_datadog:
-        test: '[ -f /datadog/datadog.repo ]'
-        command: 'cp /datadog/datadog.repo /etc/yum.repos.d/datadog.repo; yum -y makecache; yum -y install datadog-agent${DD_AGENT_VERSION:+-$DD_AGENT_VERSION-1}'
     05setup_datadog:
-        test: '[ -x /configure_datadog_yaml.sh ]'
-        command: "/configure_datadog_yaml.sh"
-    06start_datadog:
-        command: "/start_datadog.sh"
+        command: "DD_API_KEY=unused /datadog_install_script.sh; sed -i 's/ install_script/ ebs_install_script/' /etc/datadog-agent/install_info"

--- a/static/config/99datadog.config
+++ b/static/config/99datadog.config
@@ -1,99 +1,28 @@
 # .ebextensions/99datadog.config
 option_settings:
-    - namespace:  aws:elasticbeanstalk:application:environment
-      option_name:  DD_API_KEY
-      value:  "<YOUR_DD_API_KEY>"
-    - namespace:  aws:elasticbeanstalk:application:environment
-      option_name:  DD_AGENT_VERSION
-      value:  "" # For example, "7.21.1". Leave empty to install the latest version. Only Agent 7 is supported.
+    - namespace: aws:elasticbeanstalk:application:environment
+      option_name: DD_AGENT_VERSION_MAJOR_VERSION
+      value: "7"
+    - namespace: aws:elasticbeanstalk:application:environment
+      option_name: DD_AGENT_MINOR_VERSION
+      value: "" # Eg: 34 to install 7.34.x, leave empty to install the latest 7.x
+
 files:
-    "/configure_datadog_yaml.sh":
-        mode: "000700"
-        owner: root
-        group: root
-        content: |
-            #!/bin/bash
+  "/etc/datadog-agent/datadog.yaml": 
+    mode: "000640"
+    owner: root # will be changed to dd-agent after the installation
+    group: root
+    content: |
+      # Add here the Agent configuration
+      api_key: "<YOUR API KEY HERE>"
+      site: datadoghq.com
 
-            DD_KEY="$(/opt/elasticbeanstalk/bin/get-config environment -k DD_API_KEY)"
-
-            sed 's/api_key:.*/api_key: '$DD_KEY'/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
-            # Use the following command if you're in the EU. Replace datadoghq.eu with another region if in a different region.
-            # sed -i 's/datadoghq.com/datadoghq.eu/' /etc/datadog-agent/datadog.yaml
-
-    "/datadog/datadog.repo":
-        mode: "000644"
-        owner: root
-        group: root
-        content: |
-            [datadog]
-            name = Datadog, Inc.
-            baseurl = https://yum.datadoghq.com/stable/7/x86_64/
-            enabled=1
-            gpgcheck=1
-            repo_gpgcheck=1
-            gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
-                   https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
-                   https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-
-    "/datadog/hooks/99start_datadog.sh":
-        mode: "000755"
-        owner: root
-        group: root
-        content: |
-            #!/bin/bash
-            STATUS=`sudo initctl status datadog-agent`
-            if [[ "$STATUS" == *"datadog-agent start/running"* ]]
-            then
-              echo "Agent already running"
-            else
-              echo "Agent starting..."
-              sudo initctl start datadog-agent
-            fi
-
-    "/datadog/hooks/99stop_datadog.sh":
-        mode: "000755"
-        owner: root
-        group: root
-        content: |
-            #!/bin/bash
-            STATUS=`sudo initctl status datadog-agent`
-            if [[ "$STATUS" == *"datadog-agent stop/waiting"* ]]
-            then
-              echo "Agent already stopped"
-            else
-              echo "Agent stopping..."
-              sudo initctl stop datadog-agent
-            fi
-
+  "/datadog_install_script.sh": 
+    mode: "000700"
+    owner: root
+    group: root
+    source: https://s3.amazonaws.com/dd-agent/scripts/install_script.sh
 
 container_commands:
-    02mkdir_appdeploy_post:
-        test: '[ ! -d /opt/elasticbeanstalk/hooks/appdeploy/post ]'
-        command: "mkdir /opt/elasticbeanstalk/hooks/appdeploy/post"
-    02mkdir_configdeploy_post:
-        test: '[ ! -d /opt/elasticbeanstalk/hooks/configdeploy/post ]'
-        command: "mkdir /opt/elasticbeanstalk/hooks/configdeploy/post"
-    10appdeploy_pre_stop:
-        test: '[ -f /datadog/hooks/99stop_datadog.sh ]'
-        command: "cp /datadog/hooks/99stop_datadog.sh /opt/elasticbeanstalk/hooks/appdeploy/pre/"
-    11appdeploy_post_start:
-        test: '[ -f /datadog/hooks/99start_datadog.sh ]'
-        command: "cp /datadog/hooks/99start_datadog.sh /opt/elasticbeanstalk/hooks/appdeploy/post/"
-    20preinit_stop:
-        test: '[ -f /datadog/hooks/99stop_datadog.sh ]'
-        command: "cp /datadog/hooks/99stop_datadog.sh /opt/elasticbeanstalk/hooks/preinit"
-    21postinit_start:
-        test: '[ -f /datadog/hooks/99start_datadog.sh ]'
-        command: "cp /datadog/hooks/99start_datadog.sh /opt/elasticbeanstalk/hooks/postinit"
-    30configdeploy_pre_stop:
-        test: '[ -f /datadog/hooks/99stop_datadog.sh ]'
-        command: "cp /datadog/hooks/99stop_datadog.sh /opt/elasticbeanstalk/hooks/configdeploy/pre/"
-    31configdeploy_post_start:
-        test: '[ -f /datadog/hooks/99start_datadog.sh ]'
-        command: "cp /datadog/hooks/99start_datadog.sh /opt/elasticbeanstalk/hooks/configdeploy/post/"
-    90install_datadog:
-        test: '[ -f /datadog/datadog.repo ]'
-        command: 'cp /datadog/datadog.repo /etc/yum.repos.d/datadog.repo; yum -y makecache; DD_AGENT_VERSION="$(/opt/elasticbeanstalk/bin/get-config environment -k DD_AGENT_VERSION)"; yum -y install datadog-agent${DD_AGENT_VERSION:+-$DD_AGENT_VERSION-1}'
-    91setup_datadog:
-        test: '[ -x /configure_datadog_yaml.sh ]'
-        command: "/configure_datadog_yaml.sh"
+    05setup_datadog:
+        command: "DD_API_KEY=unused /datadog_install_script.sh; sed -i 's/ install_script/ ebs_install_script/' /etc/datadog-agent/install_info"


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Simplifies the logic in the sample Elastic Beanstalk config by leveraging
the regular Linux install_script.sh. This also adds support for ARM hosts.

### Motivation
De-duplicate the install logic.

### Additional Notes
Even though the contents of both files are the same now, I'm keeping both
to not break existing links.

The documentation page that links to these files lives in a different repo. I'll open a separate PR there to update instructions.