### PR TITLE
DOCS-3133 Update Browser RUM and Logs intake URLs in documentation

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -53,7 +53,7 @@ Other: See [logs endpoints][7]
 : `orchestrator.`{{< region-param key="dd_site" code="true" >}}
 
 [Real User Monitoring (RUM)][9]
-: `rum.`{{< region-param key="browser_sdk_endpoint_domain" code="true" >}}
+: `rum.`{{< region-param key="browser_sdk_endpoint_domain" code="true" >}}<br>
 `session-replay.`{{< region-param key="browser_sdk_endpoint_domain" code="true" >}}
 
 [Profiling][10]

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -53,7 +53,8 @@ Other: See [logs endpoints][7]
 : `orchestrator.`{{< region-param key="dd_site" code="true" >}}
 
 [Real User Monitoring (RUM)][9]
-: `rum-http-intake.logs.`{{< region-param key="dd_site" code="true" >}}
+: `rum.`{{< region-param key="browser_sdk_endpoint_domain" code="true" >}}
+`session-replay.`{{< region-param key="browser_sdk_endpoint_domain" code="true" >}}
 
 [Profiling][10]
 : `intake.profile.`{{< region-param key="dd_site" code="true" >}}

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -159,7 +159,7 @@ Used for Agent services communicating with each other locally within the host on
 
 [1]: /agent/faq/network-time-protocol-ntp-offset-issues/
 [2]: /integrations/ntp/#overview
-[3]: /logs/log_collection/#datadog-logs-endpoints
+[3]: /logs/log_collection/#logging-endpoints
 [4]: /agent/basic_agent_usage/kubernetes/
 [5]: /integrations/go_expvar/
 [6]: /agent/basic_agent_usage/#gui
@@ -220,7 +220,7 @@ To avoid running out of storage space, the Agent stores the metrics on disk only
 [4]: /infrastructure/process/
 [5]: /logs/
 [6]: /security/logs/#hipaa-enabled-customers
-[7]: /logs/log_collection/#datadog-logs-endpoints
+[7]: /logs/log_collection/#logging-endpoints
 [8]: /infrastructure/livecontainers/#kubernetes-resources-1
 [9]: /real_user_monitoring/
 [10]: /tracing/profiler/

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -121,16 +121,17 @@ Use the [site][13] selector dropdown on the right side of the page to see suppor
 
 {{< site-region region="us" >}}
 
-| Site | Type        | Endpoint                                | Port         | Description                                                                                                                                                                 |
-|------|-------------|-----------------------------------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| US   | HTTPS       | `http-intake.logs.datadoghq.com`        | 443          | Used by custom forwarder to send logs in JSON or plain text format over HTTPS. See the [Logs HTTP API documentation][1].                                                    |
-| US   | HTTPS       | `agent-http-intake.logs.datadoghq.com`  | 443          | Used by the Agent to send logs in JSON format over HTTPS. See the [Host Agent Log collection documentation][2].                                                             |
-| US   | HTTPS       | `lambda-http-intake.logs.datadoghq.com` | 443          | Used by Lambda functions to send logs in raw, Syslog, or JSON format over HTTPS.                                                                                            |
-| US   | TCP         | `agent-intake.logs.datadoghq.com`       | 10514        | Used by the Agent to send logs in JSON format over HTTPS. See the [Host Agent Log collection documentation][2].                                                             |
-| US   | TCP and TLS | `agent-intake.logs.datadoghq.com`       | 10516 or 443 | Used by the Agent to send logs in JSON format over HTTPS. See the [Host Agent Log collection documentation][2].                                                             |
-| US   | TCP and TLS | `intake.logs.datadoghq.com`             | 443          | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.                                                                 |
-| US   | TCP and TLS | `functions-intake.logs.datadoghq.com`   | 443          | Used by Azure functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection. **Note**: This endpoint may be useful with other cloud providers. |
-| US   | TCP and TLS | `lambda-intake.logs.datadoghq.com`      | 443          | Used by Lambda functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.                                                                  |
+| Site | Type        | Endpoint                                                                  | Port         | Description                                                                                                                                                                 |
+|------|-------------|---------------------------------------------------------------------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| US   | HTTPS       | `http-intake.logs.datadoghq.com`                                          | 443          | Used by custom forwarder to send logs in JSON or plain text format over HTTPS. See the [Logs HTTP API documentation][1].                                                    |
+| US   | HTTPS       | `agent-http-intake.logs.datadoghq.com`                                    | 443          | Used by the Agent to send logs in JSON format over HTTPS. See the [Host Agent Log collection documentation][2].                                                             |
+| US   | HTTPS       | `lambda-http-intake.logs.datadoghq.com`                                   | 443          | Used by Lambda functions to send logs in raw, Syslog, or JSON format over HTTPS.                                                                                            |
+| US   | HTTPS       | `logs.`{{< region-param key="browser_sdk_endpoint_domain" code="true" >}} | 443          | Used by the Browser SDK to send logs in JSON format over HTTPS.                                                                                                             |
+| US   | TCP         | `agent-intake.logs.datadoghq.com`                                         | 10514        | Used by the Agent to send logs in JSON format over HTTPS. See the [Host Agent Log collection documentation][2].                                                             |
+| US   | TCP and TLS | `agent-intake.logs.datadoghq.com`                                         | 10516 or 443 | Used by the Agent to send logs in JSON format over HTTPS. See the [Host Agent Log collection documentation][2].                                                             |
+| US   | TCP and TLS | `intake.logs.datadoghq.com`                                               | 443          | Used by custom forwarders to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.                                                                 |
+| US   | TCP and TLS | `functions-intake.logs.datadoghq.com`                                     | 443          | Used by Azure functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection. **Note**: This endpoint may be useful with other cloud providers. |
+| US   | TCP and TLS | `lambda-intake.logs.datadoghq.com`                                        | 443          | Used by Lambda functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.                                                                  |
 
 [1]: /api/latest/logs/#send-logs
 [2]: /agent/logs/#send-logs-over-https
@@ -138,14 +139,15 @@ Use the [site][13] selector dropdown on the right side of the page to see suppor
 
 {{< site-region region="eu" >}}
 
-| Site | Type        | Endpoint                               | Port | Description                                                                                                                                                                 |
-|------|-------------|----------------------------------------|------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| EU   | HTTPS       | `http-intake.logs.datadoghq.eu`        | 443  | Used by custom forwarder to send logs in JSON or plain text format over HTTPS. See the [Logs HTTP API documentation.][1]                                                    |
-| EU   | HTTPS       | `agent-http-intake.logs.datadoghq.eu`  | 443  | Used by the Agent to send logs in JSON format over HTTPS. See the [Host Agent Log collection documentation][2].                                                             |
-| EU   | HTTPS       | `lambda-http-intake.logs.datadoghq.eu` | 443  | Used by Lambda functions to send logs in raw, Syslog, or JSON format over HTTPS.                                                                                            |
-| EU   | TCP and TLS | `agent-intake.logs.datadoghq.eu`       | 443  | Used by the Agent to send logs in protobuf format over an SSL-encrypted TCP connection.                                                                                     |
-| EU   | TCP and TLS | `functions-intake.logs.datadoghq.eu`   | 443  | Used by Azure functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection. **Note**: This endpoint may be useful with other cloud providers. |
-| EU   | TCP and TLS | `lambda-intake.logs.datadoghq.eu`      | 443  | Used by Lambda functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.                                                                  |
+| Site | Type        | Endpoint                                                                  | Port | Description                                                                                                                                                                 |
+|------|-------------|---------------------------------------------------------------------------|------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| EU   | HTTPS       | `http-intake.logs.datadoghq.eu`                                           | 443  | Used by custom forwarder to send logs in JSON or plain text format over HTTPS. See the [Logs HTTP API documentation.][1]                                                    |
+| EU   | HTTPS       | `agent-http-intake.logs.datadoghq.eu`                                     | 443  | Used by the Agent to send logs in JSON format over HTTPS. See the [Host Agent Log collection documentation][2].                                                             |
+| EU   | HTTPS       | `lambda-http-intake.logs.datadoghq.eu`                                    | 443  | Used by Lambda functions to send logs in raw, Syslog, or JSON format over HTTPS.                                                                                            |
+| EU   | HTTPS       | `logs.`{{< region-param key="browser_sdk_endpoint_domain" code="true" >}} | 443  | Used by the Browser SDK to send logs in JSON format over HTTPS.                                                                                                             |
+| EU   | TCP and TLS | `agent-intake.logs.datadoghq.eu`                                          | 443  | Used by the Agent to send logs in protobuf format over an SSL-encrypted TCP connection.                                                                                     |
+| EU   | TCP and TLS | `functions-intake.logs.datadoghq.eu`                                      | 443  | Used by Azure functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection. **Note**: This endpoint may be useful with other cloud providers. |
+| EU   | TCP and TLS | `lambda-intake.logs.datadoghq.eu`                                         | 443  | Used by Lambda functions to send logs in raw, Syslog, or JSON format over an SSL-encrypted TCP connection.                                                                  |
 
 [1]: /api/latest/logs/#send-logs
 [2]: /agent/logs/#send-logs-over-https
@@ -153,11 +155,12 @@ Use the [site][13] selector dropdown on the right side of the page to see suppor
 
 {{< site-region region="us3" >}}
 
-| Site | Type  | Endpoint                                    | Port | Description                                                                                                              |
-|------|-------|---------------------------------------------|------|--------------------------------------------------------------------------------------------------------------------------|
-| US3  | HTTPS | `http-intake.logs.us3.datadoghq.com`        | 443  | Used by custom forwarder to send logs in JSON or plain text format over HTTPS. See the [Logs HTTP API documentation][1]. |
-| US3  | HTTPS | `lambda-http-intake.logs.us3.datadoghq.com` | 443  | Used by Lambda functions to send logs in raw, Syslog, or JSON format over HTTPS.                                         |
-| US3  | HTTPS | `agent-http-intake.logs.us3.datadoghq.com`  | 443  | Used by the Agent to send logs in JSON format over HTTPS. See the [Host Agent Log collection documentation][2].          |
+| Site | Type  | Endpoint                                                                  | Port | Description                                                                                                              |
+|------|-------|---------------------------------------------                              |------|--------------------------------------------------------------------------------------------------------------------------|
+| US3  | HTTPS | `http-intake.logs.us3.datadoghq.com`                                      | 443  | Used by custom forwarder to send logs in JSON or plain text format over HTTPS. See the [Logs HTTP API documentation][1]. |
+| US3  | HTTPS | `lambda-http-intake.logs.us3.datadoghq.com`                               | 443  | Used by Lambda functions to send logs in raw, Syslog, or JSON format over HTTPS.                                         |
+| US3  | HTTPS | `agent-http-intake.logs.us3.datadoghq.com`                                | 443  | Used by the Agent to send logs in JSON format over HTTPS. See the [Host Agent Log collection documentation][2].          |
+| US3  | HTTPS | `logs.`{{< region-param key="browser_sdk_endpoint_domain" code="true" >}} | 443  | Used by the Browser SDK to send logs in JSON format over HTTPS.                                                          |
 
 [1]: /api/latest/logs/#send-logs
 [2]: /agent/logs/#send-logs-over-https
@@ -166,11 +169,12 @@ Use the [site][13] selector dropdown on the right side of the page to see suppor
 
 {{< site-region region="us5" >}}
 
-| Site | Type  | Endpoint                                    | Port | Description                                                                                                              |
-|------|-------|---------------------------------------------|------|--------------------------------------------------------------------------------------------------------------------------|
-| US5  | HTTPS | `http-intake.logs.us5.datadoghq.com`        | 443  | Used by custom forwarder to send logs in JSON or plain text format over HTTPS. See the [Logs HTTP API documentation][1]. |
-| US5  | HTTPS | `lambda-http-intake.logs.us5.datadoghq.com` | 443  | Used by Lambda functions to send logs in raw, Syslog, or JSON format over HTTPS.                                         |
-| US5  | HTTPS | `agent-http-intake.logs.us5.datadoghq.com`  | 443  | Used by the Agent to send logs in JSON format over HTTPS. See the [Host Agent Log collection documentation][2].          |
+| Site | Type  | Endpoint                                                                  | Port | Description                                                                                                              |
+|------|-------|---------------------------------------------------------------------------|------|--------------------------------------------------------------------------------------------------------------------------|
+| US5  | HTTPS | `http-intake.logs.us5.datadoghq.com`                                      | 443  | Used by custom forwarder to send logs in JSON or plain text format over HTTPS. See the [Logs HTTP API documentation][1]. |
+| US5  | HTTPS | `lambda-http-intake.logs.us5.datadoghq.com`                               | 443  | Used by Lambda functions to send logs in raw, Syslog, or JSON format over HTTPS.                                         |
+| US5  | HTTPS | `agent-http-intake.logs.us5.datadoghq.com`                                | 443  | Used by the Agent to send logs in JSON format over HTTPS. See the [Host Agent Log collection documentation][2].          |
+| US5  | HTTPS | `logs.`{{< region-param key="browser_sdk_endpoint_domain" code="true" >}} | 443  | Used by the Browser SDK to send logs in JSON format over HTTPS.                                                          |
 
 [1]: /api/latest/logs/#send-logs
 [2]: /agent/logs/#send-logs-over-https
@@ -179,11 +183,12 @@ Use the [site][13] selector dropdown on the right side of the page to see suppor
 
 {{< site-region region="gov" >}}
 
-| Site    | Type  | Endpoint                                         | Port | Description                                                                                                              |
-|---------|-------|--------------------------------------------------|------|--------------------------------------------------------------------------------------------------------------------------|
-| US1-FED | HTTPS | `http-intake.logs.ddog-gov.datadoghq.com`        | 443  | Used by custom forwarder to send logs in JSON or plain text format over HTTPS. See the [Logs HTTP API documentation][1]. |
-| US1-FED | HTTPS | `lambda-http-intake.logs.ddog-gov.datadoghq.com` | 443  | Used by Lambda functions to send logs in raw, Syslog, or JSON format over HTTPS.                                         |
-| US1-FED | HTTPS | `agent-http-intake.logs.ddog-gov.datadoghq.com`  | 443  | Used by the Agent to send logs in JSON format over HTTPS. See the [Host Agent Log collection documentation][2].          |
+| Site    | Type  | Endpoint                                                                  | Port | Description                                                                                                              |
+|---------|-------|---------------------------------------------------------------------------|------|--------------------------------------------------------------------------------------------------------------------------|
+| US1-FED | HTTPS | `http-intake.logs.ddog-gov.datadoghq.com`                                 | 443  | Used by custom forwarder to send logs in JSON or plain text format over HTTPS. See the [Logs HTTP API documentation][1]. |
+| US1-FED | HTTPS | `lambda-http-intake.logs.ddog-gov.datadoghq.com`                          | 443  | Used by Lambda functions to send logs in raw, Syslog, or JSON format over HTTPS.                                         |
+| US1-FED | HTTPS | `agent-http-intake.logs.ddog-gov.datadoghq.com`                           | 443  | Used by the Agent to send logs in JSON format over HTTPS. See the [Host Agent Log collection documentation][2].          |
+| US1-FED | HTTPS | `logs.`{{< region-param key="browser_sdk_endpoint_domain" code="true" >}} | 443  | Used by the Browser SDK to send logs in JSON format over HTTPS.                                                          |
 
 [1]: /api/latest/logs/#send-logs
 [2]: /agent/logs/#send-logs-over-https

--- a/content/en/real_user_monitoring/faq/content_security_policy.md
+++ b/content/en/real_user_monitoring/faq/content_security_policy.md
@@ -13,48 +13,9 @@ If you are using [Content Security Policy (CSP)][1] on your websites, add the fo
 
 Depending on the `site` option used to initialize [Real User Monitoring][2] or [browser logs collection][3], add the appropriate `connect-src` entry:
 
-{{< site-region region="us" >}}
-
 ```txt
-connect-src https://*.browser-intake-datadoghq.com
+connect-src https://*.{{< region-param key="browser_sdk_endpoint_domain" >}}
 ```
-
-{{< /site-region >}}
-
-
-{{< site-region region="eu" >}}
-
-```txt
-connect-src https://*.browser-intake-datadoghq.eu
-```
-
-{{< /site-region >}}
-
-
-{{< site-region region="us3" >}}
-
-```txt
-connect-src https://*.browser-intake-us3-datadoghq.com
-```
-
-{{< /site-region >}}
-
-{{< site-region region="us5" >}}
-
-```txt
-connect-src https://*.browser-intake-us5-datadoghq.com
-```
-
-{{< /site-region >}}
-
-
-{{< site-region region="gov" >}}
-
-```txt
-connect-src https://*.browser-intake-ddog-gov.com
-```
-
-{{< /site-region >}}
 
 ## Session Replay worker
 

--- a/regions.config.js
+++ b/regions.config.js
@@ -136,5 +136,12 @@ export default {
       us5: 'The US5 functions endpoint port is not supported.',
       eu: 'The EU functions endpoint port is not supported.',
       gov: 'The GOV functions endpoint port is not supported.'
+    },
+    browser_sdk_endpoint_domain: {
+      us: 'browser-intake-datadoghq.com',
+      us3: 'browser-intake-us3-datadoghq.com',
+      us5: 'browser-intake-us5-datadoghq.com',
+      eu: 'browser-intake-datadoghq.eu',
+      gov: 'browser-intake-ddog-gov.com'
     }
 };


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update and fix the Browser RUM and Browser Logs intake URLs in the documentation.

### Motivation
<!-- What inspired you to submit this pull request?-->

* The RUM intake URL was incorrect and the Session Replay intake URL was missing in [agent/guide/network](https://docs.datadoghq.com/agent/guide/network/?tab=agentv6v7#overview)
* The Browser Logs intake URL was missing in [logs/log_collection](https://docs.datadoghq.com/logs/log_collection/?tab=host#logging-endpoints)


### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->

https://docs-staging.datadoghq.com/benoit/fix-rum-intake-url-in-agent-guide/agent/guide/network
https://docs-staging.datadoghq.com/benoit/fix-rum-intake-url-in-agent-guide/logs/log_collection#logging-endpoints

Make sure intake endpoint is still displayed correctly in
https://docs-staging.datadoghq.com/benoit/fix-rum-intake-url-in-agent-guide/real_user_monitoring/faq/content_security_policy

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
