### PR TITLE
Fix .NET image for serverless

### DIFF
--- a/layouts/partials/serverless/getting-started-languages.html
+++ b/layouts/partials/serverless/getting-started-languages.html
@@ -29,7 +29,7 @@
             </a>
             <a class="card" href="/serverless/installation/dotnet/">
                 <div class="card-body text-center py-2 px-1">
-                    {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet-framework.png" "class" "img-fluid" "alt" ".NET" "width" "400") }}
+                    {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet-core.png" "class" "img-fluid" "alt" ".NET" "width" "400") }}
                 </div>
             </a>
         </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
What AWS supports OOB for Lambda is .NET Core not .NET Framework. Updating the image.

### Motivation
People were confused.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tian.chu/fix-sls-dotnet-image/serverless

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
