### PR TITLE
Update documentation / content / en / monitors / notify / _index.md

### DIFF
--- a/content/en/monitors/notify/_index.md
+++ b/content/en/monitors/notify/_index.md
@@ -106,7 +106,7 @@ Disk space is low @ops-team@company.com
 
 #### Email
 
-* Notify a Datadog user by email with `@<DD_USER_EMAIL_ADDRESS>`. **Note**: An email address associated with a pending Datadog user invitation is considered inactive and does not receive notifications.
+* Notify a Datadog user by email with `@<DD_USER_EMAIL_ADDRESS>`. **Note**: An email address associated with a pending Datadog user invitation is considered inactive and does not receive notifications. An email address associted with a disabled Datadog user also will not recieve notifications.
 * Notify any non-Datadog user by email with `@<EMAIL>`.
 
 #### Integrations


### PR DESCRIPTION
Add additional information to clarify that email addresses for Disabled Datadog users will not receive notifications.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds additional information about who can and cannot receive alert notifications. Email addresses associated with a Disabled Datadog user will not receive notifications.


### Motivation
<!-- What inspired you to submit this pull request?-->
Ticket: https://datadog.zendesk.com/agent/tickets/662493

We have information saying that both Datadog and non-Datadog users can be notified via email for monitor alerts. We mention that if a Datadog user is 'Pending' from an invite, they won't receive alerts.  We should also include information regarding 'Disabled' users as the customer would see this as a non-Datadog user, and assume they should get email alerts.
This PR is meant to clarify a gray area.

### Preview
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/monitors/notify/#notify-your-team
<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
