### PR TITLE
backticks should be regularticks

### DIFF
--- a/content/en/tracing/setup_overview/setup/nodejs.md
+++ b/content/en/tracing/setup_overview/setup/nodejs.md
@@ -88,7 +88,7 @@ via environment variables, you can also use `dd-trace/init`, which loads and
 initializes in one step.
 
 ```typescript
-import `dd-trace/init`;
+import 'dd-trace/init';
 ```
 
 ### Adding the tracer via command line arguments


### PR DESCRIPTION
The code sample provided here does not work because of the backticks.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Replace backticks with single quotes.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/hmil-patch-1/tracing/setup_overview/setup/nodejs/?tab=containers

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
