### PR TITLE
[WEB-2106] Adds query parameter to tab href

### DIFF
--- a/layouts/partials/code-lang-tabs.html
+++ b/layouts/partials/code-lang-tabs.html
@@ -25,7 +25,7 @@
 
     {{ range $finalCodeLangs }}
         <li class="nav-item" style="margin-bottom: 6px;">
-            <a class="nav-link mr-1 js-code-example-link" data-code-lang-trigger="{{ . }}" href="#">{{ index $.context.Site.Params.code_language_ids . }}</a>
+            <a class="nav-link mr-1 js-code-example-link" data-code-lang-trigger="{{ . }}" href="?code-lang={{ . }}#">{{ index $.context.Site.Params.code_language_ids . }}</a>
         </li>
 
         {{ $count = add $count 1 }}


### PR DESCRIPTION
### What does this PR do?
Add a query string to code lang tabs

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2106

### Preview
- https://docs-staging.datadoghq.com/brian.deutsch/prog-lang-qs/security_platform/application_security/setup_and_configure/
- https://docs-staging.datadoghq.com/brian.deutsch/prog-lang-qs/api/latest/dashboard-lists/

Nothing about the code lang tab functionality should have changed aside from the query param.   If a user hovers over the tab and copies the URL, it should include the query param.

### Additional Notes
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
