### PR TITLE
Bump datadog-lambda-python layer to version 52 and datadog-lambda-js layer to version 69

### DIFF
--- a/layouts/shortcodes/latest-lambda-layer-version.html
+++ b/layouts/shortcodes/latest-lambda-layer-version.html
@@ -11,7 +11,7 @@
 
 <!-- Node Layer -->
 {{- if eq (.Get "layer") "node" -}}
-    67
+    69
 {{- end -}}
 
 <!-- Ruby Layer -->

--- a/layouts/shortcodes/latest-lambda-layer-version.html
+++ b/layouts/shortcodes/latest-lambda-layer-version.html
@@ -6,7 +6,7 @@
 
 <!-- Python Layer -->
 {{- if eq (.Get "layer") "python" -}}
-    51
+    52
 {{- end -}}
 
 <!-- Node Layer -->


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
We released new features for both python and javascript, this PR bumps the layer versions in our documentation

### Motivation
I wrote new features :) 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
