### PR TITLE
use corp ja links when on ja pages

### DIFF
--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -13,6 +13,8 @@
     {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.footer }}
 {{ end }}
 {{ $datafile := ($.Scratch.Get "data") }}
+<!-- only ja pages on corp -->
+{{ $langPrefix := cond (eq $dot.Page.Lang "ja") "ja/" "" }}
 
 <footer class="pt-3 position-relative">
     <div class="container">
@@ -69,7 +71,7 @@
                                     {{ if eq $.Site.Params.full_translation true }}
                                         {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absLangURL) ) }}
                                     {{ else }}
-                                        {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s" .URL) }}
+                                        {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s%s" $langPrefix (strings.TrimPrefix "/" .URL)) }}
                                         {{ partial "footer_link" (dict "footer_link" . "base_url" $url ) }}
                                     {{ end }}
                                 </li>
@@ -83,7 +85,7 @@
                                     {{ if eq $.Site.Params.full_translation true }}
                                         {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absLangURL) ) }}
                                     {{ else }}
-                                        {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s" .URL) }}
+                                        {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s%s" $langPrefix (strings.TrimPrefix "/" .URL)) }}
                                         {{ partial "footer_link" (dict "footer_link" . "base_url" $url ) }}
                                     {{ end }}
                                 </li>
@@ -101,7 +103,7 @@
                                 {{ if eq $.Site.Params.full_translation true }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absLangURL) ) }}
                                 {{ else }}
-                                    {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s" .URL) }}
+                                    {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s%s" $langPrefix (strings.TrimPrefix "/" .URL)) }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" $url ) }}
                                 {{ end }}
                             </li>
@@ -116,7 +118,7 @@
                                 {{ if eq $.Site.Params.full_translation true }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absLangURL) ) }}
                                 {{ else }}
-                                    {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s" .URL) }}
+                                    {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s%s" $langPrefix (strings.TrimPrefix "/" .URL)) }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" $url ) }}
                                 {{ end }}
                             </li>
@@ -130,7 +132,7 @@
                                 {{ if eq $.Site.Params.full_translation true }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absLangURL) ) }}
                                 {{ else }}
-                                    {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s" .URL) }}
+                                    {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s%s" $langPrefix (strings.TrimPrefix "/" .URL)) }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" $url ) }}
                                 {{ end }}
                             </li>
@@ -150,7 +152,7 @@
                                 {{ if eq $.Site.Params.full_translation true }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" ( .URL | absLangURL) ) }}
                                 {{ else }}
-                                    {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s" .URL) }}
+                                    {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s%s" $langPrefix (strings.TrimPrefix "/" .URL)) }}
                                     {{ partial "footer_link" (dict "footer_link" . "base_url" $url ) }}
                                 {{ end }}
                             </li>
@@ -162,7 +164,7 @@
                         <ul class="footer-menu mt-1">
                             {{ range .Site.Menus.footer_blog }}
                             <li>
-                                {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s" (strings.TrimPrefix "/" .URL)) }}
+                                {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s%s" $langPrefix (strings.TrimPrefix "/" .URL)) }}
                                 {{ partial "footer_link" (dict "footer_link" . "base_url" $url ) }}
                             </li>
                             {{ end }}
@@ -228,7 +230,7 @@
                             <ul class="footer-menu d-flex align-items-center">
                                 {{ range $index, $v := .Site.Menus.footer_sub }}
                                     <li class="d-flex align-items-center">
-                                        {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s" .URL) }}
+                                        {{ $url := cond (hasPrefix .URL "http") (.URL | absURL) (printf "https://www.datadoghq.com/%s%s" $langPrefix (strings.TrimPrefix "/" .URL)) }}
                                         {{ if eq $.Site.Params.full_translation true }}
                                             <a href="{{ $url }}">{{- $v.Name -}}</a>{{ if ne $index ( sub (len $.Site.Menus.footer_sub) 1 ) }}<span style="font-size: 16px; transform: translateY(-1px);">&nbsp;|&nbsp;</span>{{end}}
                                         {{ else }}

--- a/layouts/partials/menulink.html
+++ b/layouts/partials/menulink.html
@@ -1,3 +1,5 @@
 {{- $dot := (index $ 3) -}}
-{{- $url := cond (hasPrefix (index $ 1) "http") (index $ 1) (printf "https://www.datadoghq.com/%s" (index $ 1)) -}}
+{{/*<!-- only ja pages on corp -->*/}}
+{{- $langPrefix := cond (eq $dot.Page.Lang "ja") "ja/" "" -}}
+{{- $url := cond (hasPrefix (index $ 1) "http") ((index $ 1) | absURL) (printf "https://www.datadoghq.com/%s%s" $langPrefix (strings.TrimPrefix "/" (index $ 1))) -}}
 {{- $url -}}


### PR DESCRIPTION
### What does this PR do?

links in header and footer to corpsite from `/ja/` should link to ja corpsite
links in header and footer on en or fr should link to en corpsite

### Motivation

Followup fixes after another pr

### Preview

https://docs-staging.datadoghq.com/david.jones/ja-link-fixes/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
