### PR TITLE
Change reference to Watchdog stories to Watchdog alerts

### DIFF
--- a/content/en/dashboards/correlations/_index.md
+++ b/content/en/dashboards/correlations/_index.md
@@ -24,7 +24,7 @@ Metric Correlations can help you find potential root causes for an observed issu
 
 ## Search
 
-You can start your metric correlations exploration from any of your dashboards, notebooks, APM, Watchdog stories, or monitor status pages.
+You can start your metric correlations exploration from any of your dashboards, notebooks, APM, Watchdog alerts, or monitor status pages.
 
 * Left click on any graph and select **Find correlated metrics**.
 * From a full-screen graph, click the **Correlations** tab.


### PR DESCRIPTION
### What does this PR do?
Update the reference to Watchdog on the Metrics Correlations page. Watchdog stories are no more, long live Watchdog alerts!

### Motivation
Requested by Watchdog product manager Sacha Guyon.

### Preview
https://docs-staging.datadoghq.com/uchen/watchdog-correlations/dashboards/correlations/#search

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
