### PR TITLE
Add blog link to serverless doc

### DIFF
--- a/content/en/serverless/distributed_tracing/_index.md
+++ b/content/en/serverless/distributed_tracing/_index.md
@@ -18,6 +18,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/datadog-serverless-view/"
   tag: "Blog"
   text: "Monitor your serverless stack in the Serverless view"
+- link: "https://www.datadoghq.com/blog/monitor-aws-fully-managed-services-datadog-serverless-monitoring/"
+  tag: "Blog"
+  text: "Datadog Serverless Monitoring for AWS fully managed services"
 ---
 
 {{< img src="tracing/serverless_functions/ServerlessDistributedTrace.png" alt="Trace Serverless Functions"  style="width:100%;">}}


### PR DESCRIPTION
### What does this PR do?

Adds blog link to serverless doc

### Motivation

New blog

### Preview

https://docs-staging.datadoghq.com/may/add-serverles-blog-link/serverless/distributed_tracing/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
