### PR TITLE
[DOCS-3142] Add datadog to helm example

### DIFF
--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -211,7 +211,8 @@ To enable Network Performance Monitoring for Windows hosts:
 To enable Network Performance Monitoring with Kubernetes using Helm, add:
 
   ```yaml
-  networkMonitoring:
+  datadog:
+    networkMonitoring:
       enabled: true
   ```
 to your values.yaml. **Helm chart v2.4.39+ is required**. For more information, see the [Datadog Helm Chart documentation][1].


### PR DESCRIPTION
### What does this PR do?

Adds `datadog:` to helm values.yaml example.

### Motivation

DOCS-3142

### Preview

https://docs-staging.datadoghq.com/may/add-datadog-helm/network_monitoring/performance/setup/?tab=kubernetes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
