### PR TITLE
DOCS-3135 Upload Javascript source maps Edits

### DIFF
--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -87,12 +87,12 @@ The best way to upload source maps is to add an extra step in your CI pipeline a
 1. Add `@datadog/datadog-ci` to your `package.json` file (make sure you're using the latest version).
 2. [Create a dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
 3. Run the following command:
-  ```bash
-  datadog-ci sourcemaps upload /path/to/dist \
-    --service=my-service \
-    --release-version=v35.2395005 \
-    --minified-path-prefix=https://hostname.com/static/js
-  ```
+   ```bash
+   datadog-ci sourcemaps upload /path/to/dist \
+     --service=my-service \
+     --release-version=v35.2395005 \
+     --minified-path-prefix=https://hostname.com/static/js
+   ```
 
 
 [1]: https://app.datadoghq.com/organization-settings/api-keys
@@ -103,12 +103,12 @@ The best way to upload source maps is to add an extra step in your CI pipeline a
 2. [Create a dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
 3. Configure the CLI to upload files to the EU region by exporting two environment variables: `export DATADOG_SITE="datadoghq.eu"` and `export DATADOG_API_HOST="api.datadoghq.eu"`.
 4. Run the following command:
-  ```bash
-  datadog-ci sourcemaps upload /path/to/dist \
-    --service=my-service \
-    --release-version=v35.2395005 \
-    --minified-path-prefix=https://hostname.com/static/js
-  ```
+   ```bash
+   datadog-ci sourcemaps upload /path/to/dist \
+     --service=my-service \
+     --release-version=v35.2395005 \
+     --minified-path-prefix=https://hostname.com/static/js
+   ```
 
 
 [1]: https://app.datadoghq.com/organization-settings/api-keys

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -12,17 +12,22 @@ further_reading:
 
 ## Overview
 
-If your front-end Javascript source code is minified, you need to upload your source maps to Datadog so that your different stack traces can be deobfuscated. For a given error, you then get access to the file path, the line number, as well as a code snippet for each frame of the related stack trace.
+If your front-end Javascript source code is minified, upload your source maps to Datadog to de-obfuscate your different stack traces. For any given error, you can access the file path, line number, and code snippet for each frame of the related stack trace.
 
-<div class="alert alert-info"><strong>Note</strong>: Only errors collected by <a href="/real_user_monitoring/">Real User Monitoring (RUM)</a> can be unminified and processed by <a href="/real_user_monitoring/error_tracking/">Error Tracking</a>.</div>
+<div class="alert alert-info">Only errors collected by <a href="/real_user_monitoring/">Real User Monitoring (RUM)</a> can be unminified and processed by <a href="/real_user_monitoring/error_tracking/">Error Tracking</a>.</div>
 
 ## Instrument your code
-You must configure your Javascript bundler so that, when minifying your source code, it generates source maps which directly include the related source code in the `sourcesContent` attribute. In addition, ensure that the size of each source map augmented with the size of the related minified file does not exceed __our limit of 50MB__. Check below for some configurations for popular Javascript bundlers.
+
+Configure your Javascript bundler such that when minifying your source code, it generates source maps that directly include the related source code in the `sourcesContent` attribute. Also, ensure that the size of each source map augmented with the size of the related minified file does not exceed the limit of **50MB**. 
+
+See the following configurations for popular Javascript bundlers.
 
 {{< tabs >}}
 {{% tab "WebpackJS" %}}
 
-You can generate source maps by using the built-in webpack plugin named [SourceMapDevToolPlugin][1]. Check below how to configure it in your `webpack.config.js` file:
+You can generate source maps by using the built-in webpack plugin named [SourceMapDevToolPlugin][1]. 
+
+See the example configuration in your `webpack.config.js` file:
 
 ```javascript
 // ...
@@ -46,18 +51,20 @@ module.exports = {
 };
 ```
 
-**Note**: If you are using TypeScript, make sure to set `compilerOptions.sourceMap` to `true` when configuring your `tsconfig.json` file.
+**Note**: If you are using TypeScript, set `compilerOptions.sourceMap` to `true` in your `tsconfig.json` file.
 
 [1]: https://webpack.js.org/plugins/source-map-dev-tool-plugin/
 {{% /tab %}}
 {{% tab "ParcelJS" %}}
 
-Parcel generates source maps by default when you run the build command: `parcel build <entry file>`
+Parcel generates source maps by default when you run the build command: `parcel build <entry file>`.
 
 {{% /tab %}}
 {{< /tabs >}}
 
-After building your application, bundlers generate a directory, most of the time named `dist`, with minified Javascript files colocated with their corresponding source maps. Check an example below:
+After building your application, bundlers generate a directory (typically named `dist`) with minified Javascript files co-located with their corresponding source maps. 
+
+See the following example:
 
 ```bash
 ./dist
@@ -68,61 +75,67 @@ After building your application, bundlers generate a directory, most of the time
         javascript.464388.js.map
 ```
 
-<div class="alert alert-info">If, for example, the sum of the file size of <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds <i>the 50MB limit</i>, reduce it by configuring your bundler to split the source code into multiple smaller chunks (<a href="https://webpack.js.org/guides/code-splitting/">See how to do this with WebpackJS</a>).</div>
+<div class="alert alert-warning">If the sum of the file size for <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds the <b>the 50MB</b> limit, reduce it by configuring your bundler to split the source code into multiple smaller chunks. For more information, see <a href="https://webpack.js.org/guides/code-splitting/">Code Splitting with WebpackJS</a>).</div>
 
 ## Upload your source maps
 
-The best way to upload source maps is to add an extra-step in your CI pipeline and to run the dedicated command from the [Datadog CLI][1]. It scans the `dist` directory and its subdirectories to automatically upload the source maps with their related minified files. The flow is the following:
+The best way to upload source maps is to add an extra step in your CI pipeline and run the dedicated command from the [Datadog CLI][1]. It scans the `dist` directory and subdirectories to automatically upload source maps with relevant minified files. 
 
 {{< tabs >}}
 {{% tab "US" %}}
 
-1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
-2. [Create a new and dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
+1. Add `@datadog/datadog-ci` to your `package.json` file (make sure you're using the latest version).
+2. [Create a dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
 3. Run the following command:
-```bash
-datadog-ci sourcemaps upload /path/to/dist \
-	--service=my-service \
-	--release-version=v35.2395005 \
-	--minified-path-prefix=https://hostname.com/static/js
-```
+  ```bash
+  datadog-ci sourcemaps upload /path/to/dist \
+    --service=my-service \
+    --release-version=v35.2395005 \
+    --minified-path-prefix=https://hostname.com/static/js
+  ```
 
 
 [1]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
 {{% tab "EU" %}}
 
-1. Add `@datadog/datadog-ci` to your `package.json` file (make sure to use the latest version).
-2. [Create a new and dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
-3. Configure the CLI to upload files to the EU region by exporting two additonal environment variables: `export DATADOG_SITE="datadoghq.eu"` and `export DATADOG_API_HOST="api.datadoghq.eu"`.
+1. Add `@datadog/datadog-ci` to your `package.json` file (make sure you're using the latest version).
+2. [Create a dedicated Datadog API key][1] and export it as an environment variable named `DATADOG_API_KEY`.
+3. Configure the CLI to upload files to the EU region by exporting two environment variables: `export DATADOG_SITE="datadoghq.eu"` and `export DATADOG_API_HOST="api.datadoghq.eu"`.
 4. Run the following command:
-```bash
-datadog-ci sourcemaps upload /path/to/dist \
-	--service=my-service \
-	--release-version=v35.2395005 \
-	--minified-path-prefix=https://hostname.com/static/js
-```
+  ```bash
+  datadog-ci sourcemaps upload /path/to/dist \
+    --service=my-service \
+    --release-version=v35.2395005 \
+    --minified-path-prefix=https://hostname.com/static/js
+  ```
 
 
 [1]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: The CLI has been optimized to upload as many source maps as you need in a short amount of time (typically a few seconds) to minimize the overhead on your CI's performance.
+To minimize overhead on your CI's performance, the CLI is optimized to upload as many source maps as you need in a short amount of time (typically a few seconds).
 
-By running this command against the example `dist` directory (see previous section), Datadog expects your server or your CDN to deliver the javascript files at `https://hostname.com/static/js/javascript.364758.min.js` and `https://hostname.com/static/js/subdirectory/javascript.464388.min.js`. When an error occurs in a session of one of your users, the RUM SDK instantaneously collects it. Whenever the given error originated in a file that were downloaded from one of those urls and is also tagged with `version:v35.2395005` and `service:my-service`, the related source map is used to deobfuscate the stack trace (in this case, the `javascript.464388.js.map` file).
+By running the command against the example `dist` directory, Datadog expects your server or CDN to deliver the Javascript files at `https://hostname.com/static/js/javascript.364758.min.js` and `https://hostname.com/static/js/subdirectory/javascript.464388.min.js`. 
 
-**Note**: Only source maps with the `.js.map` extension work to correctly unminify stack traces in the error tracking UI. Source maps with other extensions, such as `.mjs.map`, are accepted but do not unminify stack traces.
+The RUM SDK instantly collects errors that occur in user sessions. When a given error originates in a file that was downloaded from one of these URLs and is tagged with `version:v35.2395005` and `service:my-service`, the related source map is used to de-obfuscate the stack trace (in this example, the `javascript.464388.js.map` file).
 
-<div class="alert alert-info">A given JavaScript source file can be served from different subdomains depending on the environment (for example, staging or production). You can upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full url (specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>).</div>
+**Note**: Only source maps with the `.js.map` extension work to correctly unminify stack traces in Error Tracking. Source maps with other extensions such as `.mjs.map` are accepted but do not unminify stack traces.
+
+<div class="alert alert-info">Any JavaScript source file can be served from different subdomains depending on the environment (such as staging or production). You can upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full URL. For example, specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>).</div>
+
+If you have successfully uploaded source maps but they do not appear in the RUM dashboard, see [RUM Browser Troubleshooting][2].
 
 ## Troubleshoot errors with ease
 
-A minified stack trace is not helpful as you don't have access to the file path and the line number. It's hard to know where something is happening in your code base. In addition, the code snippet is still minified (one long line of transformed code) which makes the troubleshooting process even harder. See below an example of an minified stack trace:
+Without access to the file path and the line number, a minified stack trace is not helpful in troubleshooting your code base. Also, the code snippet is minified (which means there is one long line of transformed code), making the troubleshooting process more difficult. 
 
-{{< img src="real_user_monitoring/error_tracking/minified_stacktrace.png" alt="Error Tracking Minified Stack Trace"  >}}
+The following example displays a minified stack trace:
 
-On the contrary, an unminified stack trace gives you all the context you need for a fast and seamless troubleshooting:
+{{< img src="real_user_monitoring/error_tracking/minified_stacktrace.png" alt="Error Tracking Minified Stack Trace" >}}
+
+On the other hand, an unminified stack trace provides you with all the context you need for quick, seamless troubleshooting:
 
 {{< img src="real_user_monitoring/error_tracking/unminified_stacktrace.mp4" alt="Error Tracking Unminified Stack Trace" video=true >}}
 
@@ -131,3 +144,4 @@ On the contrary, an unminified stack trace gives you all the context you need fo
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps
+[2]: /real_user_monitoring/browser/troubleshooting/

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -123,7 +123,7 @@ The RUM SDK instantly collects errors that occur in user sessions. When a given 
 
 **Note**: Only source maps with the `.js.map` extension work to correctly unminify stack traces in Error Tracking. Source maps with other extensions such as `.mjs.map` are accepted but do not unminify stack traces.
 
-<div class="alert alert-info">Any JavaScript source file can be served from different subdomains depending on the environment (such as staging or production). You can upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full URL. For example, specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>).</div>
+<div class="alert alert-info">If you are serving the same JavaScript source files from different subdomains, upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full URL. For example, specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>).</div>
 
 If you have successfully uploaded source maps but they do not appear in the RUM dashboard, see [RUM Browser Troubleshooting][2].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Links this guide to the Troubleshooting page for Browser RUM + copy nits.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-3135 (Hotjar)

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/real-user-monitoring-source-maps-guide-update/real_user_monitoring/guide/upload-javascript-source-maps

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
