### PR TITLE
updating_interpolation_use_case

### DIFF
--- a/content/en/dashboards/functions/interpolation.md
+++ b/content/en/dashboards/functions/interpolation.md
@@ -36,7 +36,7 @@ The `default_zero()` function is intended to address the following use cases (th
 - Aligning gauges as 0 when performing arithmetic on sparse metrics (note: `COUNT` or `RATE` type metrics queried `as_count()` or `as_rate()` are _always_ aligned as 0, so using `default_zero()` does not change how they are aligned; it only affects `GAUGE` type metrics).
 - Resolving monitors from a no-data condition. This works for both simple and multi-alerts, but the value 0 must not cause the monitor to trigger. For example, this would not work for a monitor with the query `avg(last_10m):avg:system.cpu.idle{*} < 10` because this monitor triggers (instead of resolving) when it evaluates to 0. Avoid using this function for error rate monitors with `as_count()` queries. See the [as_count() in Monitor Evaluations guide][2] for more details.
 - Filling in empty intervals in sparse (but nonempty) series for visual reasons or to affect the min/max/average of a timeseries in a monitor evaluation.
-- Showing the value 0 on the query value widget when there is no data.
+- Showing the value 0 on the timeseries widget when there is no data.
 
 ### Example
 


### PR DESCRIPTION
### What does this PR do?

Updates the default_zero use case for replacing no data QVW queries with 0. As of this recently pushed PR. the default zero function can no longer replace no data with 0 for query value widgets:

https://github.com/DataDog/dogweb/pull/71928

### Motivation
- customer requests

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
