### PR TITLE
DOCS-3098 - moving some faqs into guides

### DIFF
--- a/content/en/agent/faq/_index.md
+++ b/content/en/agent/faq/_index.md
@@ -25,7 +25,7 @@ aliases:
     {{< nextlink href="agent/faq/rpm-gpg-key-rotation-agent-6" >}}RPM GPG Key Rotation{{< /nextlink >}}
     {{< nextlink href="agent/faq/agent-v6-changes" >}}Datadog Agent v6 Changes{{< /nextlink >}}
     {{< nextlink href="agent/faq/ec2-use-win-prefix-detection" >}}Windows EC2 hostnames starting with EC2AMAZ-{{< /nextlink >}}
-    {{< nextlink href="agent/faq/auto_conf" >}}Auto-configuration for Autodiscovery.{{< /nextlink >}}
+    {{< nextlink href="agent/guide/auto_conf" >}}Auto-configuration for Autodiscovery{{< /nextlink >}}
     {{< nextlink href="agent/guide/template_variables" >}}Template variables used for Autodiscovery{{< /nextlink >}}
-    {{< nextlink href="agent/faq/commonly-used-log-processing-rules" >}}Commonly Used Log Processing Rules{{< /nextlink >}}
+    {{< nextlink href="logs/guide/commonly-used-log-processing-rules" >}}Commonly Used Log Processing Rules{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/agent/guide/_index.md
+++ b/content/en/agent/guide/_index.md
@@ -35,6 +35,7 @@ private: true
     {{< nextlink href="/agent/guide/podman-support-with-docker-integration" >}}Using the Docker integration with Podman container runtime{{< /nextlink >}}
     {{< nextlink href="/agent/guide/changing_container_registry" >}}Changing Your Container Registry{{< /nextlink >}}
     {{< nextlink href="/agent/guide/template_variables" >}}Autodiscovery Template Variables{{< /nextlink >}}
+    {{< nextlink href="/agent/guide/auto_conf" >}}Autodiscovery Auto-Configuration{{< /nextlink >}}
 {{< /whatsnext >}}
 
 {{< whatsnext desc="Agent v5 guides:" >}}

--- a/content/en/agent/guide/auto_conf.md
+++ b/content/en/agent/guide/auto_conf.md
@@ -3,6 +3,7 @@ title: Autodiscovery Auto-Configuration
 kind: faq
 aliases:
  - /agent/autodiscovery/auto_conf
+ - /agent/faq/auto_conf
 further_reading:
 - link: "/agent/kubernetes/integrations/"
   tag: "Documentation"

--- a/content/en/logs/guide/_index.md
+++ b/content/en/logs/guide/_index.md
@@ -30,6 +30,7 @@ private: true
 {{< whatsnext desc="Log Processing" >}}
     {{< nextlink href="logs/guide/log-parsing-best-practice" >}}Log Parsing Best Practices{{< /nextlink >}}
     {{< nextlink href="/logs/guide/enrichment-tables/" >}}Add Custom Metadata to Logs with Enrichment Tables{{< /nextlink >}}
+    {{< nextlink href="/logs/guide/commonly-used-log-processing-rules" >}}Commonly Used Log Processing Rules{{< /nextlink >}}
 {{< /whatsnext >}}
 
 <br>

--- a/content/en/logs/guide/commonly-used-log-processing-rules.md
+++ b/content/en/logs/guide/commonly-used-log-processing-rules.md
@@ -17,6 +17,8 @@ further_reading:
 - link: "logs/logging_without_limits"
   tag: "Documentation"
   text: "Logging without Limits*"
+aliases:
+  - /agent/faq/commonly-used-log-processing-rules
 ---
 
 Find on this page examples of commonly used log processing rules.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
moves autodiscovery autoconf faq to an agent guide
moves commonly used log processing rules to a log guide

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/cswatt/autodisco-guides/agent/faq
https://docs-staging.datadoghq.com/cswatt/autodisco-guides/agent/guide
https://docs-staging.datadoghq.com/cswatt/autodisco-guides/logs/guide
https://docs-staging.datadoghq.com/cswatt/autodisco-guides/agent/guide/auto_conf
https://docs-staging.datadoghq.com/cswatt/autodisco-guides/logs/guide/commonly-used-log-processing-rules/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
