### PR TITLE
AppSec:Ruby:Update installation instructions for ddtrace 1.0

### DIFF
--- a/content/en/security_platform/application_security/getting_started/ruby.md
+++ b/content/en/security_platform/application_security/getting_started/ruby.md
@@ -31,7 +31,7 @@ further_reading:
    {{< tabs >}}
 
 {{% tab "Rails" %}}
-   The APM tracer is required to operate AppSec. If you want to enable the APM tracer via auto-instrument, update your Gemfile:
+   Note: The APM tracer is required to operate AppSec. If you want to enable the APM tracer via auto-instrument, update your Gemfile:
 
    ```
    gem 'ddtrace', '~> 1.0.0.beta1', require: 'ddtrace/auto_instrument'
@@ -56,9 +56,9 @@ further_reading:
 {{% /tab %}}
 
 {{% tab "Sinatra" %}}
-   The APM tracer is required to operate AppSec.
+   Note: The APM tracer is required to operate AppSec.
 
-   And add to your app's startup:
+   Add to your app's startup:
 
    ```
    require 'ddtrace'
@@ -104,6 +104,8 @@ further_reading:
    {{< tabs >}}
 {{% tab "Docker CLI" %}}
 
+Note: The APM tracer is required to operate AppSec.
+
 Update your configuration container for APM by adding the following argument in your `docker run` command:
 
 ```
@@ -113,6 +115,8 @@ docker run [...] -e DD_APPSEC_ENABLED=true [...]
 {{% /tab %}}
 {{% tab "Dockerfile" %}}
 
+Note: The APM tracer is required to operate AppSec.
+
 Add the following environment variable value to your container Dockerfile:
 
 ```
@@ -121,6 +125,8 @@ ENV DD_APPSEC_ENABLED=true
 
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
+
+Note: The APM tracer is required to operate AppSec.
 
 Update your configuration yaml file container for APM and add the AppSec env variable:
 
@@ -139,6 +145,8 @@ spec:
 {{% /tab %}}
 {{% tab "AWS ECS" %}}
 
+Note: The APM tracer is required to operate AppSec.
+
 Update your ECS task definition JSON file, by adding this in the  environment section:
 
 ```
@@ -153,6 +161,8 @@ Update your ECS task definition JSON file, by adding this in the  environment se
 
 {{% /tab %}}
 {{% tab "AWS Fargate" %}}
+
+Note: The APM tracer is required to operate AppSec.
 
 Initialize Application Security in your code or set `DD_APPSEC_ENABLED` environment variable to true in your service invocation:
 ```

--- a/content/en/security_platform/application_security/getting_started/ruby.md
+++ b/content/en/security_platform/application_security/getting_started/ruby.md
@@ -25,19 +25,19 @@ further_reading:
 
    For information about which language and framework versions are supported by the library, see [Compatibility][1].
 
-   See our [upgrade guide to 1.0][2] if you were using a 0.x version of `ddtrace`.
+   For more information about upgrading from a `dd-trace` 0.x version, see [the Ruby tracer upgrade guide][2].
 
 2. **Enable Application Security**, either in your code:
    {{< tabs >}}
 
 {{% tab "Rails" %}}
-   Note: The APM tracer is required to operate AppSec. If you want to enable the APM tracer via auto-instrument, update your Gemfile:
+   Either enable the tracer through auto-instrumentation by updating your Gemfile:
 
    ```
    gem 'ddtrace', '~> 1.0.0.beta1', require: 'ddtrace/auto_instrument'
    ```
 
-   Add an initializer:
+   Or enable the tracer by adding an initializer in your application code:
 
    ```
    # config/initializers/datadog.rb
@@ -46,7 +46,7 @@ further_reading:
 
    Datadog.configure do |c|
      # enable the APM tracer
-     # not needed if `gem 'ddtrace', require: 'ddtrace/auto_instrument'` is used
+     # not needed if `gem 'ddtrace', require: 'ddtrace/auto_instrument' is used
      c.tracing.instrument :rails
 
      c.appsec.enabled = true
@@ -56,9 +56,7 @@ further_reading:
 {{% /tab %}}
 
 {{% tab "Sinatra" %}}
-   Note: The APM tracer is required to operate AppSec.
-
-   Add to your app's startup:
+   Enable the tracer by adding the following to your application's startup:
 
    ```
    require 'ddtrace'
@@ -66,7 +64,6 @@ further_reading:
 
    Datadog.configure do |c|
      # enable the APM tracer
-     # not needed if `require 'ddtrace/auto_instrument'` is used
      c.tracing.instrument :sinatra
 
      # enable appsec for Sinatra
@@ -77,7 +74,7 @@ further_reading:
 {{% /tab %}}
 
 {{% tab "Rack" %}}
-   The APM tracer is required to operate AppSec. Add this to your `config.ru`:
+   Enable the tracer by adding the following to your `config.ru` file:
 
    ```
    require 'ddtrace'
@@ -104,8 +101,6 @@ further_reading:
    {{< tabs >}}
 {{% tab "Docker CLI" %}}
 
-Note: The APM tracer is required to operate AppSec.
-
 Update your configuration container for APM by adding the following argument in your `docker run` command:
 
 ```
@@ -115,8 +110,6 @@ docker run [...] -e DD_APPSEC_ENABLED=true [...]
 {{% /tab %}}
 {{% tab "Dockerfile" %}}
 
-Note: The APM tracer is required to operate AppSec.
-
 Add the following environment variable value to your container Dockerfile:
 
 ```
@@ -125,8 +118,6 @@ ENV DD_APPSEC_ENABLED=true
 
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
-
-Note: The APM tracer is required to operate AppSec.
 
 Update your configuration yaml file container for APM and add the AppSec env variable:
 
@@ -145,8 +136,6 @@ spec:
 {{% /tab %}}
 {{% tab "AWS ECS" %}}
 
-Note: The APM tracer is required to operate AppSec.
-
 Update your ECS task definition JSON file, by adding this in the  environment section:
 
 ```
@@ -161,8 +150,6 @@ Update your ECS task definition JSON file, by adding this in the  environment se
 
 {{% /tab %}}
 {{% tab "AWS Fargate" %}}
-
-Note: The APM tracer is required to operate AppSec.
 
 Initialize Application Security in your code or set `DD_APPSEC_ENABLED` environment variable to true in your service invocation:
 ```

--- a/content/en/security_platform/application_security/getting_started/ruby.md
+++ b/content/en/security_platform/application_security/getting_started/ruby.md
@@ -19,7 +19,7 @@ further_reading:
 
 1. **Update your gem file to include the Datadog library**:
    ```
-   gem 'ddtrace', '1.0.0.beta1'
+   gem 'ddtrace', '~> 1.0.0.beta1'
    ```
    For information about which language and framework versions are supported by the library, see [Compatibility][1].
 

--- a/content/en/security_platform/application_security/getting_started/ruby.md
+++ b/content/en/security_platform/application_security/getting_started/ruby.md
@@ -19,19 +19,18 @@ further_reading:
 
 1. **Update your gem file to include the Datadog library**:
    ```
-   gem install ddtrace
+   gem 'ddtrace', '1.0.0.beta1'
    ```
    For information about which language and framework versions are supported by the library, see [Compatibility][1].
 
 2. **Enable Application Security**, either in your code:
    ```
    require 'datadog/security'
-   Datadog::Security.configure do |c|
-     c.use :rails
-   end
-   # not needed if require 'ddtrace/auto_instrument' is used
    Datadog.configure do |c|
-     c.use :rails
+     c.appsec.instrument :rails
+
+     # not needed if `gem 'ddtrace', require: 'ddtrace/auto_instrument'` is used
+     c.tracing.instrument :rails
    end
    ```
    Or one of the following methods, depending on where your application runs:
@@ -39,10 +38,10 @@ further_reading:
    {{< tabs >}}
 {{% tab "Docker CLI" %}}
 
-Update your configuration container for APM by adding the following argument in your `docker run` command: 
+Update your configuration container for APM by adding the following argument in your `docker run` command:
 
 ```
-docker run [...] -e DD_APPSEC_ENABLED=true [...] 
+docker run [...] -e DD_APPSEC_ENABLED=true [...]
 ```
 
 {{% /tab %}}

--- a/content/en/security_platform/application_security/getting_started/ruby.md
+++ b/content/en/security_platform/application_security/getting_started/ruby.md
@@ -18,21 +18,87 @@ further_reading:
 ## Get started
 
 1. **Update your Gemfile to include the Datadog library**:
+
    ```
    gem 'ddtrace', '~> 1.0.0.beta1'
    ```
+
    For information about which language and framework versions are supported by the library, see [Compatibility][1].
 
-2. **Enable Application Security**, either in your code:
-   ```
-   require 'datadog/security'
-   Datadog.configure do |c|
-     c.appsec.instrument :rails
+   See our [upgrade guide to 1.0][2] if you were using a 0.x version of `ddtrace`.
 
+2. **Enable Application Security**, either in your code:
+   {{< tabs >}}
+
+{{% tab "Rails" %}}
+   The APM tracer is required to operate AppSec. If you want to enable the APM tracer via auto-instrument, update your Gemfile:
+
+   ```
+   gem 'ddtrace', '~> 1.0.0.beta1', require: 'ddtrace/auto_instrument'
+   ```
+
+   Add an initializer:
+
+   ```
+   # config/initializers/datadog.rb
+
+   require 'datadog/appsec'
+
+   Datadog.configure do |c|
+     # enable the APM tracer
      # not needed if `gem 'ddtrace', require: 'ddtrace/auto_instrument'` is used
      c.tracing.instrument :rails
+
+     c.appsec.enabled = true
+     c.appsec.instrument :rails
    end
    ```
+{{% /tab %}}
+
+{{% tab "Sinatra" %}}
+   The APM tracer is required to operate AppSec.
+
+   And add to your app's startup:
+
+   ```
+   require 'ddtrace'
+   require 'datadog/appsec'
+
+   Datadog.configure do |c|
+     # enable the APM tracer
+     # not needed if `require 'ddtrace/auto_instrument'` is used
+     c.tracing.instrument :sinatra
+
+     # enable appsec for Sinatra
+     c.appsec.enabled = true
+     c.appsec.instrument :sinatra
+   end
+   ```
+{{% /tab %}}
+
+{{% tab "Rack" %}}
+   The APM tracer is required to operate AppSec. Add this to your `config.ru`:
+
+   ```
+   require 'ddtrace'
+   require 'datadog/appsec'
+
+   Datadog.configure do |c|
+     # enable the APM tracer
+     c.tracing.instrument :rack
+
+     # enable appsec for Rack
+     c.appsec.enabled = true
+     c.appsec.instrument :rack
+   end
+
+   use Datadog::Tracing::Contrib::Rack::TraceMiddleware
+   use Datadog::AppSec::Contrib::Rack::RequestMiddleware
+   ```
+{{% /tab %}}
+
+{{< /tabs >}}
+
    Or one of the following methods, depending on where your application runs:
 
    {{< tabs >}}
@@ -106,3 +172,4 @@ env DD_APPSEC_ENABLED=true rails server
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /security_platform/application_security/setup_and_configure/?code-lang=ruby#compatibility
+[2]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#from-0x-to-10

--- a/content/en/security_platform/application_security/getting_started/ruby.md
+++ b/content/en/security_platform/application_security/getting_started/ruby.md
@@ -17,7 +17,7 @@ further_reading:
 
 ## Get started
 
-1. **Update your gem file to include the Datadog library**:
+1. **Update your Gemfile to include the Datadog library**:
    ```
    gem 'ddtrace', '~> 1.0.0.beta1'
    ```

--- a/content/en/security_platform/application_security/getting_started/ruby.md
+++ b/content/en/security_platform/application_security/getting_started/ruby.md
@@ -160,7 +160,7 @@ env DD_APPSEC_ENABLED=true rails server
 
 {{< /tabs >}}
 
-{{% appsec-getstarted-2 %}}
+{{% appsec-getstarted-2-canary %}}
 
 {{< img src="/security_platform/application_security/application-security-signal.png" alt="Security Signal details page showing tags, metrics, suggested next steps, and attacker IP addresses associated with a threat." style="width:100%;" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates AppSec onboarding for Ruby clients for the upcoming [`ddtrace` 1.0](https://github.com/DataDog/dd-trace-rb/milestone/79) release.

This will be the first release with official AppSec support.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/marcotc/ruby-appsec-namespacing-1.0/security_platform/application_security/getting_started/ruby

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
