### PR TITLE
Add exclusion filters and uninstall to App Sec docs

### DIFF
--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -202,6 +202,8 @@ To create an exclusion filter, do one of the following:
 - Click on a signal in [Application Security Signals][2] and click the **Create Exclusion Filter** button in the top left corner. This method automatically generates a filter query for the targeted service.
 - Navigate to [Exclusion Filters Configuration][3] and manually configure a new exclusion filter based on your own filter query.
 
+**Note**: Requests (traces) matching an exclusion filter are not billed.
+
 ## Disable
 
 To disable Application Security, remove the `DD_APPSEC_ENABLED=true` environment variable from your application configuration. Once removed, restart your service.

--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -192,7 +192,8 @@ The Datadog Agent and some tracing libraries have options available to address t
 
 ## Exclusion filters
 
-There may be a time when an Application Security signal is a false positive. For example, a targeted service is repeatedly generating the same signal, but the signal has been reviewed and is not a threat.
+There may be a time when an Application Security signal is a false positive. For example, Application Security repeatedly detects
+the same suspicious request and a signal is generated, but the signal has been reviewed and is not a threat.
 
 You can set an exclusion filter, which ignore events from a rule, to eliminate these noisy signal patterns and focus on legitimate suspicious requests.
 

--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -192,7 +192,7 @@ The Datadog Agent and some tracing libraries have options available to address t
 
 ## Exclusion filters
 
-There may be a time when an Application Security signal is a false positive. For example, Application Security repeatedly detects
+There may be a time when an Application Security signal, or a suspicious request, is a false positive. For example, Application Security repeatedly detects
 the same suspicious request and a signal is generated, but the signal has been reviewed and is not a threat.
 
 You can set an exclusion filter, which ignore events from a rule, to eliminate these noisy signal patterns and focus on legitimate suspicious requests.

--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -204,7 +204,7 @@ To create an exclusion filter, do one of the following:
 
 **Note**: Requests (traces) matching an exclusion filter are not billed.
 
-## Disable
+## Disable Application Security
 
 To disable Application Security, remove the `DD_APPSEC_ENABLED=true` environment variable from your application configuration. Once removed, restart your service.
 

--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -203,7 +203,7 @@ To create an exclusion filter, do one of the following:
 
 ## Uninstall
 
-To uninstall Application Security, remove the `DD_APPSEC_ENABLED=true` environment variable from your application configuration. If you need additional help, contact [Datadog support].
+To uninstall Application Security, remove the `DD_APPSEC_ENABLED=true` environment variable from your application configuration. If you need additional help, contact [Datadog support][4].
 
 ## Further Reading
 
@@ -212,3 +212,4 @@ To uninstall Application Security, remove the `DD_APPSEC_ENABLED=true` environme
 [1]: /tracing/setup_overview/configure_data_security/
 [2]: https://app.datadoghq.com/security/appsec/signals
 [3]: https://app.datadoghq.com/security/appsec/exclusions
+[4]: /help/

--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -204,7 +204,9 @@ To create an exclusion filter, do one of the following:
 
 ## Disable
 
-To uninstall Application Security, remove the `DD_APPSEC_ENABLED=true` environment variable from your application configuration. If you need additional help, contact [Datadog support][4].
+To disable Application Security, remove the `DD_APPSEC_ENABLED=true` environment variable from your application configuration. Once removed, restart your service.
+
+If you need additional help, contact [Datadog support][4].
 
 ## Further Reading
 

--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -202,7 +202,7 @@ To create an exclusion filter, do one of the following:
 - Click on a signal in [Application Security Signals][2] and click the **Create Exclusion Filter** button in the top left corner. This method automatically generates a filter query for the targeted service.
 - Navigate to [Exclusion Filters Configuration][3] and manually configure a new exclusion filter based on your own filter query.
 
-## Uninstall
+## Disable
 
 To uninstall Application Security, remove the `DD_APPSEC_ENABLED=true` environment variable from your application configuration. If you need additional help, contact [Datadog support][4].
 

--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -31,11 +31,11 @@ The Datadog library supports Java JRE 1.8 and higher of both Oracle JDK and Open
 - macOS (Darwin) x86, x86-64
 - Windows (msvc) x86, x86-64
 
-Datadog does not officially support any early-access versions of Java. 
+Datadog does not officially support any early-access versions of Java.
 
 ### Supported frameworks
 
-| Framework Web Server    | Minimum Framework Version   | 
+| Framework Web Server    | Minimum Framework Version   |
 | ----------------------- | --------------------------- |
 | Servlet Compatible      | 2.3+, 3.0+                  |
 | Spring                  | 3.1                         |
@@ -67,7 +67,7 @@ These are supported on the following architectures:
 
 The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual Basic).
 
-| Framework Web Server    | Minimum Framework Version   | 
+| Framework Web Server    | Minimum Framework Version   |
 | ----------------------- | --------------------------- |
 | ASP.NET                 | 4.6                         |
 | ASP.NET Core            | 2.1                         |
@@ -98,11 +98,11 @@ Integrate the Go tracer with the following list of web frameworks using one of t
 ### Enabling CGO
 
 Compiling your code with Application Security enabled involves [CGO][8] and therefore requires:
-	
+
 - The `gcc` compiler for the target `GOOS` and `GOARCH`.
 - The C library headers.
 - The CGO bindings enabled. This is controlled by the `CGO_ENABLED` environment variable which is enabled by default when compiling natively.
-	
+
 To install the above requirements:
 
 | Operating system     | Console command |
@@ -111,7 +111,7 @@ To install the above requirements:
 | Alpine               | `$ apk add gcc musl-dev`        |
 | RHEL, CentOS, Fedora | `$ yum install gcc glibc-devel` |
 | macOS                | `$ xcode-select --install`      |
-	
+
 **Note**: The Go toolchain disables CGO when cross-compiling and needs to be explicitly enabled.
 
 [1]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib
@@ -139,7 +139,7 @@ These are supported on the following architectures:
 
 ### Supported frameworks
 
-| Framework Web Server    | Minimum Framework Version   | 
+| Framework Web Server    | Minimum Framework Version   |
 | ----------------------- | --------------------------- |
 | Rack                    | 1.1                         |
 | Rails                   | 3.2 (also depends on Ruby version) |
@@ -176,7 +176,7 @@ These are supported on the following architectures:
 
 ### Supported frameworks
 
-| Framework Web Server    | Minimum Framework Version   | 
+| Framework Web Server    | Minimum Framework Version   |
 | ----------------------- | --------------------------- |
 | Express                 | 4.0                         |
 
@@ -190,9 +190,25 @@ The data that you’re collecting with Datadog can contain sensitive information
 
 The Datadog Agent and some tracing libraries have options available to address these situations and modify or discard spans. See [APM Data Security][1] for details that also apply to Application Security.
 
+## Exclusion filters
+
+There may be a time when an Application Security signal is a false positive. For example, a targeted service is repeatedly generating the same signal, but the signal has been reviewed and is not a threat.
+
+You can set an exclusion filter, which ignore events from a rule, to eliminate these noisy signal patterns and focus on legitimate suspicious requests.
+
+To create an exclusion filter, do one of the following:
+
+- Click on a signal in [Application Security Signals][2] and click the **Create Exclusion Filter** button in the top left corner. This method automatically generates a filter query for the targeted service.
+- Navigate to [Exclusion Filters Configuration][3] and manually configure a new exclusion filter based on your own filter query.
+
+## Uninstall
+
+To uninstall Application Security, remove the `DD_APPSEC_ENABLED=true` environment variable from your application configuration. If you need additional help, contact [Datadog support].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing/setup_overview/configure_data_security/
+[2]: https://app.datadoghq.com/security/appsec/signals
+[3]: https://app.datadoghq.com/security/appsec/exclusions


### PR DESCRIPTION
### What does this PR do?
Adds a section for exclusion filters and uninstallation to the App Sec setup + config section

### Motivation
Q1 OKR

### Preview
https://docs-staging.datadoghq.com/sarina/appsec-setup-edits/security_platform/application_security/setup_and_configure/#exclusion-filters

### Additional Notes
It looks like the formatter formatted some white space for us, magic ✨ 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
