### PR TITLE
[doc] fix broken header link to

### DIFF
--- a/content/en/logs/guide/control-sensitive-logs-data.md
+++ b/content/en/logs/guide/control-sensitive-logs-data.md
@@ -33,7 +33,7 @@ If you have already indexed logs that contain sensitive data, then follow these 
 
 1. [Determine the scope of the data being sent](#determine-the-scope-of-the-data-being-sent)
 2. [Fix the source of the data upstream](#fix-the-source-of-the-data-upstream)
-3. [Handle data already sent to Datadog](#handle-data-already-sent-to-datadog)
+3. [Handle data already sent to Datadog](#handle-data-already-sent-to-and-indexed-in-datadog)
 
 ## Determine the scope of the data being sent
 


### PR DESCRIPTION
fix link to #handle-data-already-sent

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
