### PR TITLE
Update error_budget.md

### DIFF
--- a/content/en/monitors/service_level_objectives/error_budget.md
+++ b/content/en/monitors/service_level_objectives/error_budget.md
@@ -38,7 +38,8 @@ error_budget("slo_id").over("time_window") > 75
 
 In addition, SLO error budget alerts can also be created using the [datadog_monitor resource in Terraform][6]. Below is an example `.tf` for configuring an error budget alert for a metric-based SLO using the same example query as above.
 
-For provider version v2.7+ :
+**For provider versions v2.7.0 or earlier and v2.13.0 or later**
+
 **Note:** SLO error budget alerts are only supported in Terraform provider v2.7.0 or earlier and in provider v2.13.0 or later. Versions between v2.7.0 and v2.13.0 are not supported.
 
 ```
@@ -58,7 +59,7 @@ resource "datadog_monitor" "metric-based-slo" {
 }
 ```
 
-For provider version v3+
+**For provider version v3+**
 
 ```
 resource "datadog_monitor" "metric-based-slo" {

--- a/content/en/monitors/service_level_objectives/error_budget.md
+++ b/content/en/monitors/service_level_objectives/error_budget.md
@@ -38,6 +38,7 @@ error_budget("slo_id").over("time_window") > 75
 
 In addition, SLO error budget alerts can also be created using the [datadog_monitor resource in Terraform][6]. Below is an example `.tf` for configuring an error budget alert for a metric-based SLO using the same example query as above.
 
+For provider version v2.7+ :
 **Note:** SLO error budget alerts are only supported in Terraform provider v2.7.0 or earlier and in provider v2.13.0 or later. Versions between v2.7.0 and v2.13.0 are not supported.
 
 ```
@@ -51,6 +52,25 @@ resource "datadog_monitor" "metric-based-slo" {
 
     message = "Example monitor message"
     monitor_thresholds = {
+      critical = 75
+    }
+    tags = ["foo:bar", "baz"]
+}
+```
+
+For provider version v3+
+
+```
+resource "datadog_monitor" "metric-based-slo" {
+    name = "SLO Error Budget Alert Example"
+    type  = "slo alert"
+    
+    query = <<EOT
+    error_budget("slo_id").over("time_window") > 75 
+    EOT
+
+    message = "Example monitor message"
+    monitor_thresholds {
       critical = 75
     }
     tags = ["foo:bar", "baz"]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add new terraform way to create an error budget alert ( the monitor_threshold is now a block rather than an argument as documented for version 2.7+ )

### Motivation
<!-- What inspired you to submit this pull request?-->
I faced an issue when I tried to apply this documentation

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
