### PR TITLE
Refactor docs to account for managed service monitoring and tracing

### DIFF
--- a/content/en/serverless/distributed_tracing/_index.md
+++ b/content/en/serverless/distributed_tracing/_index.md
@@ -52,11 +52,16 @@ The Datadog Lambda Library and tracing libraries for Python and Node.js support:
 - Installation without any code changes using Serverless Framework, AWS SAM and AWS CDK integrations.
 - Tracing HTTP requests invoking downstream Lambda functions or containers.
 - Tracing consecutive Lambda invocations made via the AWS SDK.
-- Tracing asynchronous Lambda invocations through AWS SQS.
+- Tracing asynchronous Lambda invocations through AWS Managed Services
+  - API Gateway
+  - SQS
+  - SNS
+  - SNS and SQS direct integration
+  - Kinesis
+  - EventBridge
 - Tracing dozens of additional out-of-the-box [Python][4] and [Node.js][5] libraries.
-- Tracing non-HTTP requests made through SNS, Kinesis, EventBridge, MQTT and more (requires additional instrumention outlined [here][6]).
 
-For Python and Node.js serverless applications, Datadog recommends you [install Datadog's tracing libraries][7]. If your application requires AWS X-Ray active tracing in AWS managed services such as API Gateway or Step Functions, Datadog recommends you augment AWS X-Ray traces with Datadog APM by configuring _both_ AWS X-Ray and Datadog APM tracing libraries as described in [Serverless Trace Merging][8].
+For Python and Node.js serverless applications, Datadog recommends you [install Datadog's tracing libraries][7]. If your application requires AWS X-Ray active tracing in AWS managed services such as AppSync or Step Functions, Datadog recommends you augment AWS X-Ray traces with Datadog APM by configuring _both_ AWS X-Ray and Datadog APM tracing libraries as described in [Serverless Trace Merging][8].
 
 If you are already tracing your serverless functions with X-Ray and want to continue using X-Ray, you can [install the AWS X-Ray integration][3].
 

--- a/content/en/serverless/distributed_tracing/serverless_trace_merging.md
+++ b/content/en/serverless/distributed_tracing/serverless_trace_merging.md
@@ -11,10 +11,10 @@ further_reading:
 
 ## Use cases
 
-Serverless trace merging is required to see a single, connected trace when you configure both Datadog's tracing libraries (`dd-trace`) and AWS X-Ray tracing libraries in your application. If you aren't sure which tracing library to use, read about [choosing your tracing library][1].
+Datadog recommends using only the Datadog APM trace library (`dd-trace`), but in some situations users can combine Datadog tracing and AWS X-Ray using trace merging. If you aren't sure which tracing library to use, read about [choosing your tracing library][1].
 
 There are two primary reasons for instrumenting both `dd-trace` and AWS X-Ray tracing libraries:
-- In an AWS serverless environment, you are already tracing your Lambda functions with `dd-trace`, you require AWS X-Ray active tracing for AWS managed services such as API Gateway or Step Functions, and you want to visualize the `dd-trace` and AWS X-Ray spans in one single trace.
+- In an AWS serverless environment, you are already tracing your Lambda functions with `dd-trace`, you require AWS X-Ray active tracing for AWS managed services such as AppSync and Step Functions, and you want to visualize the `dd-trace` and AWS X-Ray spans in one single trace.
 - In a hybrid environment with both Lambda functions and hosts, `dd-trace` instruments your hosts, AWS X-Ray instruments your Lambda functions, and you want to visualize connected traces for transactions across Lambda functions and hosts.
 
 **Note:** This may result in higher usage bills. X-Ray spans continue to be available in your merged traces after 2-5 minutes. In many cases, Datadog recommends only using a single tracing library. Learn more about [choosing your tracing library][1].
@@ -28,7 +28,7 @@ You can find setup instructions for each of the above use cases below:
 
 AWS X-Ray provides both a backend AWS service (AWS X-Ray active tracing) and a set of client libraries. [Enabling the backend AWS service alone in the Lambda console][2] gives you `Initialization` and `Invocation` spans for your AWS Lambda functions. You can also enable AWS X-Ray active tracing from the API Gateway and Step Function consoles.
 
-Both the AWS X-Ray SDK and Datadog APM client libraries (`dd-trace`) add medatada and spans for downstream calls by accessing the function directly. Assuming you are using `dd-trace` to trace at the handler level, your setup should be similar to the following:
+Both the AWS X-Ray SDK and Datadog APM client libraries (`dd-trace`) add metadata and spans for downstream calls by accessing the function directly. Assuming you are using `dd-trace` to trace at the handler level, your setup should be similar to the following:
 
 1. You have enabled [AWS X-Ray active tracing][2] on your Lambda functions from the AWS Lambda console and our [AWS X-Ray integration within Datadog][3].
 2. You have instrumented your Lambda functions with Datadog APM (`dd-trace`) by following the [installation instructions for your Lambda runtime][4].

--- a/content/en/serverless/distributed_tracing/serverless_trace_propagation.md
+++ b/content/en/serverless/distributed_tracing/serverless_trace_propagation.md
@@ -22,7 +22,7 @@ Additional instrumentation is sometimes required to see a single, connected trac
 - Triggering Lambda functions via Step Functions
 - Invoking Lambda functions via non-HTTP protocols such as MQTT
 
-Tracing many AWS Managed services (listed [here][4]) are supported out-of-the-box and do not require following the steps outlined on this page.
+Tracing many AWS Managed services (listed [here][4]) is supported out-of-the-box and does not require following the steps outlined on this page.
 
 To successfully connect trace context between resources sending traces, you need to:
 - Include Datadog trace context in outgoing events. The outgoing event can originate from a host or Lambda function with `dd-trace` installed.
@@ -95,7 +95,7 @@ To extract the above trace context from the consumer Lambda function, you need t
 
 ### Sample extractors
 
-The following code samples outline sample extractors you might use for propagating trace context across a 3rd party system, or an API which does not support standard HTTP headers.
+The following code samples outline sample extractors you might use for propagating trace context across a third party system, or an API which does not support standard HTTP headers.
 
 {{< tabs >}}
 {{% tab "Python" %}}

--- a/content/en/serverless/distributed_tracing/serverless_trace_propagation.md
+++ b/content/en/serverless/distributed_tracing/serverless_trace_propagation.md
@@ -19,10 +19,10 @@ further_reading:
 ## Required setup
 
 Additional instrumentation is sometimes required to see a single, connected trace in Node and Python serverless applications asynchronously triggering Lambda functions. If you are just getting started with monitoring serverless applications in Datadog, [follow our main installation steps][1] and [read this page on choosing your tracing library][2]. Once you are sending traces from your Lambda functions to Datadog using the [Datadog Lambda Library][3], you may want to follow these steps to connect traces between two Lambda functions in cases such as:
-- Asynchronously triggering Lambda functions via SNS, Kinesis or EventBridge
+- Triggering Lambda functions via Step Functions
 - Invoking Lambda functions via non-HTTP protocols such as MQTT
 
-Many tracing integrations (listed [here][4]) are supported out-of-the-box and do not require following the steps outlined on this page.
+Tracing many AWS Managed services (listed [here][4]) are supported out-of-the-box and do not require following the steps outlined on this page.
 
 To successfully connect trace context between resources sending traces, you need to:
 - Include Datadog trace context in outgoing events. The outgoing event can originate from a host or Lambda function with `dd-trace` installed.
@@ -30,7 +30,7 @@ To successfully connect trace context between resources sending traces, you need
 
 ## Passing trace context
 
-The following code samples outline how to pass trace context in outgoing events to some technologies in Node and Python:
+The following code samples outline how to pass trace context in outgoing payloads to services which do not support HTTP headers, or managed services not supported [natively][4] by Datadog in Node and Python:
 
 {{< tabs >}}
 {{% tab "Python" %}}
@@ -44,37 +44,15 @@ import os
 
 from datadog_lambda.tracing import get_dd_trace_context  # Datadog tracing helper function
 
-sns_client = boto3.client('sns')
-kinesis_client = boto3.client('kinesis')
-eventbridge_client = boto3.client('eventbridge')
-
 def handler(event, context):
-    sns_client.publish(
-        TopicArn = 'PLACEHOLDER' # Your SNS topic ARN.
-        Message = 'Asynchronously invoking a Lambda function with SNS.',
-        MessageAttributes = {
-            '_datadog': {
-                'DataType': 'String',
-                'StringValue': json.dumps(get_dd_trace_context()) # Includes trace context in outgoing message to SNS topic.
-            },
-        },
-    )
-
-    kinesis_client.put_record(
-      Data= json.dumps(get_dd_trace_context()),
-      PartitionKey='test',
-      StreamName='PLACEHOLDER', # Your Kinesis stream ARN.
-    )
-
-    eventbridge_client.put_events(
-      Entries=[
+    my_custom_client.sendRequest(
         {
-            'Source': 'tracing-tests-python',
-            'DetailType': 'transaction',
-            'Detail': json.dumps(get_dd_trace_context()),
-            'EventBusName': 'PLACEHOLDER', # Your Event Bus name.
-        }
-      ]
+          'myCustom': 'data',
+          '_datadog': {
+              'DataType': 'String',
+              'StringValue': json.dumps(get_dd_trace_context()) # Includes trace context in outgoing payload.
+          },
+        },
     )
 ```
 
@@ -84,45 +62,13 @@ def handler(event, context):
 In Node, you can use the `getTraceHeaders` helper function to pass tracing context to outgoing events in a Lambda function:
 
 ```js
-const AWS = require('aws-sdk');
 const { getTraceHeaders } = require("datadog-lambda-js"); // Datadog tracing helper function
-
-const sns = new AWS.SNS();
-const kinesis = new AWS.Kinesis();
-const eventBridge = new AWS.EventBridge();
 
 module.exports.handler = async event => {
   const _datadog = getTraceHeaders(); // Captures current Datadog trace context.
 
-  var snsParams = {
-    Message: JSON.stringify({ data: 'sns' }),
-    MessageAttributes: {
-      '_datadog': {
-        DataType: 'String',
-        StringValue: JSON.stringify(_datadog)  // Includes trace context in outgoing message to SNS topic.
-      },
-    },
-    TopicArn: process.env.SNS_ARN
-  };
-
-  const kinesisParams = {
-    Data: JSON.stringify({ data: 'kinesis', _datadog }),
-    PartitionKey: 'test',
-    StreamName: 'PLACEHOLDER', // Your Kinesis stream ARN.
-  };
-
-  var eventBridgeParams = {
-    Entries: [{
-      EventBusName: 'tracing-tests',
-      Source: 'tracing-tests-node',
-      DetailType: 'transaction',
-      Detail: JSON.stringify({ data: 'eventBridge', _datadog }), // Includes trace context in outgoing message to event bus.
-    }]
-  };
-  
-  await sns.publish(snsParams).promise();
-  await kinesis.putRecord(kinesisParams).promise();
-  await eventBridge.putEvents(eventBridgeParams).promise()
+  var payload = JSON.stringify({ data: 'sns', _datadog });
+  await myCustomClient.sendRequest(payload)
 ```
 
 {{% /tab %}}
@@ -145,107 +91,33 @@ exports.handler = async event => {
 
 ## Extracting trace context
 
-To extract the above trace context from the consumer Lambda function, you need to define an extractor function that runs captures trace context before the execution of your Lambda function handler. To do this, configure the `DD_TRACE_EXTRACTOR` environment variable to point to the location of your extractor function (format is `<FILE NAME>.<FUNCTION NAME>`, for example, `extractors.sns` if the `sns` extract method is in the `extractors.js` file). Datadog recommends you place your extractor methods all in one file, as extractors can be re-used across multiple Lambda functions. These extractors are completely customizable to fit any use case, and some sample extractors for common use cases are included in the next section.
+To extract the above trace context from the consumer Lambda function, you need to define an extractor function that runs captures trace context before the execution of your Lambda function handler. To do this, configure the `DD_TRACE_EXTRACTOR` environment variable to point to the location of your extractor function (format is `<FILE NAME>.<FUNCTION NAME>`, for example, `extractors.json` if the `json` extract method is in the `extractors.js` file). Datadog recommends you place your extractor methods all in one file, as extractors can be re-used across multiple Lambda functions. These extractors are completely customizable to fit any use case.
 
 ### Sample extractors
 
-The following code samples outline sample extractors you might use for propagating trace context across managed resources such as SNS, Kinesis or EventBridge.
+The following code samples outline sample extractors you might use for propagating trace context across a 3rd party system, or an API which does not support standard HTTP headers.
 
 {{< tabs >}}
-{{% tab "SNS" %}}
-
-Python:
-
+{{% tab "Python" %}}
 ```py
-def extractor(event, context):
-    trace_headers = json.loads(event["Records"][0]["Sns"]["MessageAttributes"]["_datadog"]["Value"])
-    trace_id = trace_headers["x-datadog-trace-id"]
-    parent_id = trace_headers["x-datadog-parent-id"]
-    sampling_priority = trace_headers["x-datadog-sampling-priority"]
-    return trace_id, parent_id, sampling_priority
-```
-
-Node.js:
-
-```js
-exports.sns = (event, context) => {
-    const traceData = JSON.parse(event.Records[0].Sns.MessageAttributes._datadog.Value);
-    const traceID = traceData["x-datadog-trace-id"];
-    const parentID = traceData["x-datadog-parent-id"];
-    const sampledHeader = traceData["x-datadog-sampling-priority"];
-    const sampleMode = parseInt(sampledHeader, 10);
-    const result = {
-      parentID,
-      sampleMode,
-      source: 'event',
-      traceID,
-    };
-    console.log(JSON.stringify(result));
-    return result
-  }
-```
-
-{{% /tab %}}
-{{% tab "Kinesis" %}}
-
-Python:
-
-```py
-def extractor(event, context):
-    trace_headers = json.loads(event["Records"][0]["kinesis"]["data"])
-    trace_data = trace_headers["_datadog"]
-    trace_id = trace_data["x-datadog-trace-id"]
-    parent_id = trace_data["x-datadog-parent-id"]
-    sampling_priority = trace_data["x-datadog-sampling-priority"]
-    return trace_id, parent_id, sampling_priority
-```
-
-Node.js:
-
-```js
-exports.kinesis = (event, context) => {
-  const JSONData = Buffer.from(event.Records[0].kinesis.data, 'base64').toString('utf-8')
-  const parsedData = JSON.parse(JSONData);
-  const traceData = parsedData._datadog;
-
-  const traceID = traceData["x-datadog-trace-id"];
-  const parentID = traceData["x-datadog-parent-id"];
-  const sampledHeader = traceData["x-datadog-sampling-priority"];
-  const sampleMode = parseInt(sampledHeader, 10);
-
-  return {
-    parentID,
-    sampleMode,
-    source: 'event',
-    traceID,
-  };
-};
-```
-
-{{% /tab %}}
-{{% tab "EventBridge" %}}
-
-Python:
-
-```py
-def extractor(event, context):
-    trace_headers = json.loads(event["detail"]["_datadog"]);
+def extractor(payload):
+    trace_headers = json.loads(payload["_datadog"]);
     trace_id = trace_headers["x-datadog-trace-id"];
     parent_id = trace_headers["x-datadog-parent-id"];
     sampling_priority = trace_headers["x-datadog-sampling-priority"];
     return trace_id, parent_id, sampling_priority
 ```
-
-Node.js:
+{{% /tab %}}
+{{% tab "Node.js" %}}
 
 ```js
-exports.eventBridge = (event, context) => {
-    const traceData = event.detail._datadog
+exports.json = (payload) => {
+    const traceData = payload._datadog
     const traceID = traceData["x-datadog-trace-id"];
     const parentID = traceData["x-datadog-parent-id"];
     const sampledHeader = traceData["x-datadog-sampling-priority"];
     const sampleMode = parseInt(sampledHeader, 10);
-  
+
     return {
       parentID,
       sampleMode,


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
We recently released Tracing and Monitoring for AWS Managed Services (https://www.datadoghq.com/blog/monitor-aws-fully-managed-services-datadog-serverless-monitoring/).

These docs reflect the previous state, where trace context was propagated manually. Now this is automatic for Python and Node!

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/aj.stuyvenberg/bump-datadog-lambda-python-version-52/serverless/distributed_tracing/serverless_trace_propagation/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
