### PR TITLE
Clarify that profiling is not supported on serverless.

### DIFF
--- a/content/en/tracing/profiler/enabling/dotnet.md
+++ b/content/en/tracing/profiler/enabling/dotnet.md
@@ -29,6 +29,8 @@ Datadog .NET Profiler is currently in public beta. Datadog recommends evaluating
 - Windows 10
 - Windows Server starting from version 2012
 
+Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
+
 **Supported .NET runtimes:**
 
 64-bit applications running on:
@@ -40,8 +42,6 @@ Datadog .NET Profiler is currently in public beta. Datadog recommends evaluating
 **Supported languages:**
 
 Any language that targets the .NET runtime, such as C#, F#, and Visual Basic.
-
-Profiling is not supported on serverless platforms.
 
 ## Installation
 

--- a/content/en/tracing/profiler/enabling/dotnet.md
+++ b/content/en/tracing/profiler/enabling/dotnet.md
@@ -41,6 +41,8 @@ Datadog .NET Profiler is currently in public beta. Datadog recommends evaluating
 
 Any language that targets the .NET runtime, such as C#, F#, and Visual Basic.
 
+Profiling is not supported on serverless platforms.
+
 ## Installation
 
 <div class="alert alert-warning">
@@ -59,7 +61,7 @@ Any language that targets the .NET runtime, such as C#, F#, and Visual Basic.
 1. Set needed environment variables to configure and enable Profiler. To enable the Profiler for IIS applications, it is required to set the `DD_PROFILING_ENABLED`, `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` environment variables in the Registry under <code>HKLM\System\CurrentControlSet\Services\WAS</code> and <code>HKLM\System\CurrentControlSet\Services\W3SVC</code> nodes.
 
    **With the Registry Editor:**
-   
+
    In the Registry Editor, modify the multi-string value called `Environment` in the `HKLM\System\CurrentControlSet\Services\WAS` and `HKLM\System\CurrentControlSet\Services\W3SVC` nodes and set the value data as follows:
 
    For .NET Core and .NET 5+:
@@ -70,9 +72,9 @@ Any language that targets the .NET runtime, such as C#, F#, and Visual Basic.
    DD_ENV=production
    DD_VERSION=1.2.3
    ```
-   
+
    {{< img src="tracing/setup/dotnet/RegistryEditorCoreIIS.png" alt="Using the Registry Editor to create environment variables for a .NET Core application in IIS" style="width:90%" >}}
-   
+
    For .NET Framework:
    ```text
    COR_ENABLE_PROFILING=1

--- a/content/en/tracing/profiler/enabling/go.md
+++ b/content/en/tracing/profiler/enabling/go.md
@@ -20,7 +20,9 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 ## Requirements
 
-The Datadog Profiler requires Go 1.12+. 
+The Datadog Profiler requires Go 1.12+.
+
+Profiling is not supported on serverless platforms.
 
 ## Installation
 

--- a/content/en/tracing/profiler/enabling/go.md
+++ b/content/en/tracing/profiler/enabling/go.md
@@ -22,7 +22,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 The Datadog Profiler requires Go 1.12+.
 
-Profiling is not supported on serverless platforms.
+Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
 
 ## Installation
 

--- a/content/en/tracing/profiler/enabling/java.md
+++ b/content/en/tracing/profiler/enabling/java.md
@@ -24,6 +24,8 @@ The Datadog Profiler requires [JDK Flight Recorder][2]. The Datadog Profiler lib
 
 All JVM-based languages, such as Java, Scala, Groovy, Kotlin, and Clojure are supported.
 
+Profiling is not supported on serverless platforms.
+
 ## Installation
 
 To begin profiling applications:
@@ -42,7 +44,7 @@ To begin profiling applications:
    {{< tabs >}}
 {{% tab "Command arguments" %}}
 
-Invoke your service: 
+Invoke your service:
 ```diff
 java \
     -javaagent:dd-java-agent.jar \

--- a/content/en/tracing/profiler/enabling/java.md
+++ b/content/en/tracing/profiler/enabling/java.md
@@ -24,7 +24,7 @@ The Datadog Profiler requires [JDK Flight Recorder][2]. The Datadog Profiler lib
 
 All JVM-based languages, such as Java, Scala, Groovy, Kotlin, and Clojure are supported.
 
-Profiling is not supported on serverless platforms.
+Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
 
 ## Installation
 

--- a/content/en/tracing/profiler/enabling/linux.md
+++ b/content/en/tracing/profiler/enabling/linux.md
@@ -21,7 +21,9 @@ The Datadog Profiler for Linux lets you collect profile data for applications ru
 
 ## Requirements
 
-The Datadog Profiler requires Linux kernel v4.17+ on an `amd64` compatible processor. It does not support macOS, BSD, Windows, or other operating systems besides Linux v4.17 or later. 
+The Datadog Profiler requires Linux kernel v4.17+ on an `amd64` compatible processor. It does not support macOS, BSD, Windows, or other operating systems besides Linux v4.17 or later.
+
+Profiling is not supported on serverless platforms.
 
 ## Installation
 

--- a/content/en/tracing/profiler/enabling/linux.md
+++ b/content/en/tracing/profiler/enabling/linux.md
@@ -23,7 +23,7 @@ The Datadog Profiler for Linux lets you collect profile data for applications ru
 
 The Datadog Profiler requires Linux kernel v4.17+ on an `amd64` compatible processor. It does not support macOS, BSD, Windows, or other operating systems besides Linux v4.17 or later.
 
-Profiling is not supported on serverless platforms.
+Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
 
 ## Installation
 

--- a/content/en/tracing/profiler/enabling/nodejs.md
+++ b/content/en/tracing/profiler/enabling/nodejs.md
@@ -26,6 +26,8 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 The Datadog Profiler requires at least Node.js 12, but Node.js 16 or higher is recommended. **If you use a version of Node.js earlier than 16, some applications see tail latency spikes every minute when starting the next profile.**
 
+Profiling is not supported on serverless platforms.
+
 ## Installation
 
 To begin profiling applications:

--- a/content/en/tracing/profiler/enabling/nodejs.md
+++ b/content/en/tracing/profiler/enabling/nodejs.md
@@ -26,7 +26,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 The Datadog Profiler requires at least Node.js 12, but Node.js 16 or higher is recommended. **If you use a version of Node.js earlier than 16, some applications see tail latency spikes every minute when starting the next profile.**
 
-Profiling is not supported on serverless platforms.
+Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
 
 ## Installation
 

--- a/content/en/tracing/profiler/enabling/php.md
+++ b/content/en/tracing/profiler/enabling/php.md
@@ -47,7 +47,7 @@ Version 3.13 or newer of Alpine Linux is required because the profiler is built 
 {{% /tab %}}
 {{< /tabs >}}
 
-Profiling is not supported on serverless platforms.
+Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
 
 ## Installation
 

--- a/content/en/tracing/profiler/enabling/php.md
+++ b/content/en/tracing/profiler/enabling/php.md
@@ -24,7 +24,7 @@ The Datadog PHP Profiler is in public beta. Datadog recommends evaluating the pr
 
 The Datadog Profiler requires at least PHP 7.1, on 64-bit Linux.
 
-The following are **not** supported: 
+The following are **not** supported:
 - PHP 8.1
 - ZTS builds of PHP
 - PHP debug builds
@@ -46,6 +46,8 @@ Version 3.13 or newer of Alpine Linux is required because the profiler is built 
 
 {{% /tab %}}
 {{< /tabs >}}
+
+Profiling is not supported on serverless platforms.
 
 ## Installation
 

--- a/content/en/tracing/profiler/enabling/python.md
+++ b/content/en/tracing/profiler/enabling/python.md
@@ -33,6 +33,8 @@ The following profiling features are available depending on your Python version:
 | Lock profiling       | Python >= 2.7                      |
 | Memory profiling     | Python >= 3.5                      |
 
+Profiling is not supported on serverless platforms.
+
 ## Installation
 
 Install `ddtrace`, which provides both tracing and profiling functionalities:

--- a/content/en/tracing/profiler/enabling/python.md
+++ b/content/en/tracing/profiler/enabling/python.md
@@ -33,7 +33,7 @@ The following profiling features are available depending on your Python version:
 | Lock profiling       | Python >= 2.7                      |
 | Memory profiling     | Python >= 3.5                      |
 
-Profiling is not supported on serverless platforms.
+Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
 
 ## Installation
 

--- a/content/en/tracing/profiler/enabling/ruby.md
+++ b/content/en/tracing/profiler/enabling/ruby.md
@@ -23,7 +23,9 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 ## Requirements
 
-The Datadog Profiler requires MRI Ruby 2.1+. **Wall time profiling is available for users on every platform (including macOS and Windows), but CPU time profiles are currently only available on Linux platforms**. 
+The Datadog Profiler requires MRI Ruby 2.1+. **Wall time profiling is available for users on every platform (including macOS and Windows), but CPU time profiles are currently only available on Linux platforms**.
+
+Profiling is not supported on serverless platforms.
 
 ## Installation
 

--- a/content/en/tracing/profiler/enabling/ruby.md
+++ b/content/en/tracing/profiler/enabling/ruby.md
@@ -25,7 +25,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 The Datadog Profiler requires MRI Ruby 2.1+. **Wall time profiling is available for users on every platform (including macOS and Windows), but CPU time profiles are currently only available on Linux platforms**.
 
-Profiling is not supported on serverless platforms.
+Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
 
 ## Installation
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds text clarifying that the profiling product does not support serverless.

### Motivation
<!-- What inspired you to submit this pull request?-->

Customers not finding out that profiling doesn't support serverless without a lot of hassle.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/henrik.dafgard/profiling-serverless/tracing/profiler/enabling/go
https://docs-staging.datadoghq.com/henrik.dafgard/profiling-serverless/tracing/profiler/enabling/java
https://docs-staging.datadoghq.com/henrik.dafgard/profiling-serverless/tracing/profiler/enabling/python
https://docs-staging.datadoghq.com/henrik.dafgard/profiling-serverless/tracing/profiler/enabling/ruby
https://docs-staging.datadoghq.com/henrik.dafgard/profiling-serverless/tracing/profiler/enabling/nodejs
https://docs-staging.datadoghq.com/henrik.dafgard/profiling-serverless/tracing/profiler/enabling/dotnet
https://docs-staging.datadoghq.com/henrik.dafgard/profiling-serverless/tracing/profiler/enabling/php
https://docs-staging.datadoghq.com/henrik.dafgard/profiling-serverless/tracing/profiler/enabling/linux

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
