### PR TITLE
Update public docs to reflect log permission flattening.

### DIFF
--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -94,8 +94,6 @@ Grants a role the ability to create and modify [log processing pipelines][9]. Th
 - Granting another role the [Logs Write Processors](#logs_write_processors) permission, scoped for that pipeline
 - Managing [standard attributes][10] or [aliasing facets][11]
 
-**Note**: This permission also grants [Logs Write Processors](#logs_write_processors) (for all processors on all pipelines) permissions behind the scenes.
-
 ### `logs_write_processors`
 
 Grants a role the ability to create, edit, or delete processors and nested pipelines.


### PR DESCRIPTION
This line is no longer accurate after “log permission flattening”.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Removes outdated note from Logs RBAC Permissions.

```
Note: This permission also grants [Logs Write Processors](https://docs.datadoghq.com/logs/guide/logs-rbac-permissions/?tab=ui#logs_write_processors) (for all processors on all pipelines) permissions behind the scenes.
```
### Motivation
https://datadoghq.atlassian.net/browse/ACCESS-650

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alexaliaskovski/access-650/logs/guide/logs-rbac-permissions

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
