### PR TITLE
[ACCESS-650] Update public docs to reflect log permission flattening.

### DIFF
--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -56,8 +56,6 @@ Grants a role the ability to create and modify [log indexes][5]. This includes:
 
 This permission is global and enables both the creation of new indexes, and the edition of existing ones.
 
-**Note**: This permission also grants [Logs Read Index Data](#logs_read_index_data) and [Logs Write Exclusion Filters](#logs_write_exclusion_filters) permissions behind the scenes.
-
 ### `logs_write_exclusion_filters`
 
 Grants a role the ability to create or modify [exclusion filters][8] within an index.

--- a/content/en/logs/guide/logs-rbac-permissions.md
+++ b/content/en/logs/guide/logs-rbac-permissions.md
@@ -94,8 +94,6 @@ Grants a role the ability to create and modify [log processing pipelines][9]. Th
 - Granting another role the [Logs Write Processors](#logs_write_processors) permission, scoped for that pipeline
 - Managing [standard attributes][10] or [aliasing facets][11]
 
-**Note**: This permission also grants [Logs Write Processors](#logs_write_processors) (for all processors on all pipelines) permissions behind the scenes.
-
 ### `logs_write_processors`
 
 Grants a role the ability to create, edit, or delete processors and nested pipelines.


### PR DESCRIPTION
This line is no longer accurate after “log permission flattening”.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Removes outdated note from Logs RBAC Permissions.

```
Note: This permission also grants [Logs Write Processors](https://docs.datadoghq.com/logs/guide/logs-rbac-permissions/?tab=ui#logs_write_processors) (for all processors on all pipelines) permissions behind the scenes.
```

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/browse/ACCESS-650

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alexa.liaskovski/access-650/logs/guide/logs-rbac-permissions

<img width="1875" alt="Screen Shot 2022-02-17 at 2 22 20 PM" src="https://user-images.githubusercontent.com/33159092/154555258-c84c298e-ccd0-4fd9-a98b-3beb6bd6f149.png">


### Additional Notes
<!-- Anything else we should know when reviewing?-->

cc @DataDog/team-aaa-access 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
