### PR TITLE
[ciapp] Add section to propagate git info in Jenkins

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -272,7 +272,7 @@ pipeline {
 
 The Jenkins plugin uses environment variables to determine the Git information. However, these environment variables may not be available if you are not using a `Jenkinsfile` in your repository and you're configuring the pipeline directly in Jenkins using explicitly the `checkout` step.
 
-If this happens, propagate the Git information to the environment variables in your build. You can use the `.each {k,v -> env.setProperty(k, v)}` function after executing the `checkout` step or `git` step. For example:
+If this happens, propagate the Git information to the environment variables in your build. You can use the `.each {k,v -> env.setProperty(k, v)}` function after executing the `checkout` or `git` steps. For example:
 
 {{< tabs >}}
 {{% tab "Using Declarative Pipelines" %}}
@@ -415,10 +415,6 @@ pipeline {
   }
 }
 {{< /code-block >}}
-
-### Propagate Git information in scripted pipelines.
-
-
 
 ## Customization
 

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -270,9 +270,9 @@ pipeline {
 
 ## Propagate Git information in pipelines without a Jenkinsfile from SCM.
 
-The Jenkins plugin uses environment variables to determine the Git information. However, these environment variables may not be available if you are not using a `Jenkinsfile` in your repository and you're configuring the pipeline directly in Jenkins using explicitly the `checkout` step.
+The Jenkins plugin uses environment variables to determine the Git information. However, these environment variables may not be available if you are not using a `Jenkinsfile` in your repository, and you're configuring the pipeline directly in Jenkins using the `checkout` step.
 
-If this happens, propagate the Git information to the environment variables in your build. You can use the `.each {k,v -> env.setProperty(k, v)}` function after executing the `checkout` or `git` steps. For example:
+In this case, you can propagate the Git information to the environment variables in your build. Use the `.each {k,v -> env.setProperty(k, v)}` function after executing the `checkout` or `git` steps. For example:
 
 {{< tabs >}}
 {{% tab "Using Declarative Pipelines" %}}

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -268,6 +268,72 @@ pipeline {
 }
 {{< /code-block >}}
 
+## Propagate Git information in pipelines without a Jenkinsfile from SCM.
+
+The Jenkins plugin uses environment variables to determine the Git information. However, these environment variables may not be available if you are not using a `Jenkinsfile` in your repository and you're configuring the pipeline directly in Jenkins using explicitly the `checkout` step.
+
+If this happens, propagate the Git information to the environment variables in your build. You can use the `.each {k,v -> env.setProperty(k, v)}` function after executing the `checkout` step or `git` step. For example:
+
+{{< tabs >}}
+{{% tab "Using Declarative Pipelines" %}}
+If you're using a declarative pipeline to configure your pipeline, propagate Git information using a `script` block as follows:
+
+Using the `checkout` step:
+{{< code-block lang="groovy" >}}
+pipeline {
+  stages {
+    stage('Checkout') {
+        script {
+          checkout(...).each {k,v -> env.setProperty(k,v)}
+        }
+    }
+    ...
+  }
+}
+{{< /code-block >}}
+
+Using the `git` step:
+{{< code-block lang="groovy" >}}
+pipeline {
+  stages {
+    stage('Checkout') {
+      script {
+        git(...).each {k,v -> env.setProperty(k,v)}
+      }
+    }
+    ...
+  }
+}
+{{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "Using Scripted Pipelines" %}}
+If you're using a scripted pipeline to configure your pipeline, you can propagate the git information to environment variables directly.
+
+Using the `checkout` step:
+{{< code-block lang="groovy" >}}
+node {
+  stage('Checkout') {
+    checkout(...).each {k,v -> env.setProperty(k,v)}
+  }
+  ...
+}
+{{< /code-block >}}
+
+Using the `git` step:
+{{< code-block lang="groovy" >}}
+node {
+  stage('Checkout') {
+    git(...).each {k,v -> env.setProperty(k,v)}
+  }
+  ...
+}
+{{< /code-block >}}
+
+{{% /tab %}}
+{{< /tabs >}}
+
+
 ## Set Git information manually
 
 The Jenkins plugin uses environment variables to determine the Git information. However, these environment variables are not always set
@@ -349,6 +415,10 @@ pipeline {
   }
 }
 {{< /code-block >}}
+
+### Propagate Git information in scripted pipelines.
+
+
 
 ## Customization
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds a new section in the Jenkins docs for CIViz explaining how to propagate Git information to the Datadog Plugin if the customer is not using a Jenkinsfile.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/drodriguezhdez/gitinfo_jenkins/continuous_integration/setup_pipelines/jenkins/?tab=usingui

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
