### PR TITLE
Enclose `pwd` in Agent installation log files

### DIFF
--- a/content/en/agent/guide/agent-log-files.md
+++ b/content/en/agent/guide/agent-log-files.md
@@ -71,7 +71,7 @@ The Datadog Agent does a logs rollover every 10MB. When a rollover occurs, one b
 
 | Platform                             | Location and file name        |
 |--------------------------------------|-------------------------------|
-| Linux                                | `$pwd/ddagent-install.log`    |
+| Linux                                | `$(pwd)/ddagent-install.log`    |
 | macOS                                | `/tmp/dd_agent.log`           |
 | Windows                              | `%TEMP%\MSI*.LOG`             |
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Update `$pwd` to `$(pwd)`.

### Motivation

`$pwd` is considered as an environment variable.

```bash
vagrant@vagrant:~$ cat $pwd/ddagent-install.log
cat: /ddagent-install.log: No such file or directory
```

`$pwd` should be `$(pwd)`.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
