### PR TITLE
[CIAPP] Document dd_metrics for buildkite pipelines

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/buildkite.md
+++ b/content/en/continuous_integration/setup_pipelines/buildkite.md
@@ -56,7 +56,7 @@ The resulting pipeline looks as follows:
 
 To create numerical tags that can be use for measures the metadata command can be used. Any metadata
 with a key starting with `dd_metrics.` and a numerical value will be set as a metric tag.
-This can be used for example to set the binary size on the pipeline:
+This can be used for example to measure the binary size in a pipeline:
 
 ```yaml
 steps:

--- a/content/en/continuous_integration/setup_pipelines/buildkite.md
+++ b/content/en/continuous_integration/setup_pipelines/buildkite.md
@@ -30,7 +30,8 @@ The steps to activate the Datadog integration for [Buildkite][1] are:
 ### Setting custom tags
 
 Custom tags can be added to Buildkite traces by using the `buildkite-agent meta-data set` command.
-Any metadata tags with a key starting with `dd_tags.` are added to the job and pipeline spans.
+Any metadata tags with a key starting with `dd_tags.` are added to the job and pipeline spans. This
+tags can be used to create string facets to search and organize the pipelines.
 
 The YAML below illustrates a simple pipeline where tags for the team name and the Go version have
 been set.
@@ -52,6 +53,24 @@ The following tags are shown in the root span as well as the relevant job span i
 The resulting pipeline looks as follows:
 
 {{< img src="ci/buildkite-custom-tags.png" alt="Buildkite pipeline trace with custom tags" style="width:100%;">}}
+
+To create numerical tags that can be use for measures the metadata command can be used. Any metadata
+with a key starting with `dd_metrics.` and a numerical value will be set as a metric tag.
+This can be used for example to set the binary size on the pipeline:
+
+```yaml
+steps:
+  - commands:
+    - go build -o dst/binary .
+    - ls -l dst/binary | awk '{print \$5}' | tr -d '\n' | buildkite-agent meta-data set "dd_metrics.binary_size"
+    label: Go build
+```
+
+The resulting pipeline will have the tags shown below in the pipeline span:
+
+- `binary_size: 502` (output depends on the file size)
+
+This value can be used to plot the change in the binary size over time for example.
 
 ## Visualize pipeline data in Datadog
 

--- a/content/en/continuous_integration/setup_pipelines/buildkite.md
+++ b/content/en/continuous_integration/setup_pipelines/buildkite.md
@@ -30,7 +30,7 @@ The steps to activate the Datadog integration for [Buildkite][1] are:
 ### Setting custom tags
 
 Custom tags can be added to Buildkite traces by using the `buildkite-agent meta-data set` command.
-Any metadata tags with a key starting with `dd_tags.` are added to the job and pipeline spans. This
+Any metadata tags with a key starting with `dd_tags.` are added to the job and pipeline spans. These
 tags can be used to create string facets to search and organize the pipelines.
 
 The YAML below illustrates a simple pipeline where tags for the team name and the Go version have
@@ -54,9 +54,9 @@ The resulting pipeline looks as follows:
 
 {{< img src="ci/buildkite-custom-tags.png" alt="Buildkite pipeline trace with custom tags" style="width:100%;">}}
 
-To create numerical tags that can be use for measures the metadata command can be used. Any metadata
-with a key starting with `dd_metrics.` and a numerical value will be set as a metric tag.
-This can be used for example to measure the binary size in a pipeline:
+Any metadata with a key starting with `dd-metrics.` and containing a numerical value will be set as
+a metric tag that can be used to create numerical measures. You can use the `buildkite-agent meta-data set`
+command to create such tags. This can be used for example to measure the binary size in a pipeline:
 
 ```yaml
 steps:
@@ -70,7 +70,7 @@ The resulting pipeline will have the tags shown below in the pipeline span:
 
 - `binary_size: 502` (output depends on the file size)
 
-This value can be used to plot the change in the binary size over time for example.
+In this example, you can use the value of `binary_size` to plot the change in the binary size over time.
 
 ## Visualize pipeline data in Datadog
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->


### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Documents the usage of `dd_metrics` metadata tags in buildkite.

### Motivation
<!-- What inspired you to submit this pull request?-->
This together with the `dd_tags` allows setting string metadata tags and float metrics tag to cover uses of measures and facets.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/carlos.gonzalez/add-dd-metrics-to-buildkite-pipeline/continuous_integration/setup_pipelines/buildkite/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
