### PR TITLE
Add proxy settings doc for network devices metadata

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -262,6 +262,14 @@ frontend database_monitoring_samples_frontend
     option tcplog
     default_backend datadog-database-monitoring-samples
 
+# This declares the endpoint where your Agents connects for
+# sending Network Devices Monitoring metadata (e.g the value of "network_devices.metadata.dd_url")
+frontend network_devices_metadata_frontend
+    bind *:3841
+    mode http
+    option tcplog
+    default_backend datadog-network-devices-metadata
+
 # This is the Datadog server. In effect any TCP request coming
 # to the forwarder frontends defined above are proxied to
 # Datadog's public endpoints.
@@ -335,6 +343,14 @@ backend datadog-database-monitoring-samples
     # Uncomment the following configuration for older HAProxy versions
     # server datadog agent-http-intake.logs.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify none
 
+backend datadog-network-devices-metadata
+    balance roundrobin
+    mode http
+    # The following configuration is for HAProxy 1.8 and newer
+    server-template mothership 5 ndm-intake.{{< region-param key="dd_site" >}}:443  check port 443 ssl verify none check resolvers my-dns init-addr none resolve-prefer ipv4
+    # Uncomment the following configuration for older HAProxy versions
+    # server mothership ndm-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify none
+
 ```
 
 **Note**: Download the certificate with one of the following commands:
@@ -383,6 +399,11 @@ database_monitoring:
         logs_no_ssl: true
     samples:
         logs_dd_url: haproxy.example.com:3840
+        logs_no_ssl: true
+
+network_devices:
+    metadata:
+        logs_dd_url: haproxy.example.com:3839
         logs_no_ssl: true
 ```
 
@@ -515,6 +536,11 @@ stream {
         proxy_ssl on;
         proxy_pass dbquery-intake.{{< region-param key="dd_site" >}}:443;
     }
+    server {
+        listen 3841; #listen for network devices metadata
+        proxy_ssl on;
+        proxy_pass ndm-intake.{{< region-param key="dd_site" >}}:443;
+    }
 }
 ```
 
@@ -535,6 +561,10 @@ database_monitoring:
         dd_url: "<PROXY_SERVER_DOMAIN>:3839"
     samples:
         dd_url: "<PROXY_SERVER_DOMAIN>:3840"
+
+network_devices:
+    metadata:
+        dd_url: "<PROXY_SERVER_DOMAIN>:3841"
 ```
 
 When sending logs over TCP, see <a href="/agent/logs/proxy">TCP Proxy for Logs</a>.

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -403,7 +403,7 @@ database_monitoring:
 
 network_devices:
     metadata:
-        logs_dd_url: haproxy.example.com:3839
+        logs_dd_url: haproxy.example.com:3841
         logs_no_ssl: true
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add proxy settings doc for network devices metadata

### Motivation
<!-- What inspired you to submit this pull request?-->

Missing doc for network devices metadata

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alex/ndm_proxy/agent/proxy/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
