### PR TITLE
[CWS] add troubleshooting section about security-agent flare

### DIFF
--- a/content/en/agent/troubleshooting/send_a_flare.md
+++ b/content/en/agent/troubleshooting/send_a_flare.md
@@ -69,7 +69,13 @@ kubectl exec -it <AGENT_POD_NAME> -c process-agent -- agent flare <CASE_ID> --lo
 ```bash
 kubectl exec -it <AGENT_POD_NAME> -c trace-agent -- agent flare <CASE_ID> --local
 ```
-  
+
+### Security Agent
+
+```bash
+kubectl exec -it <AGENT_POD_NAME> -c security-agent -- security-agent flare <CASE_ID>
+```
+
 ### System probe
 
 The system-probe container cannot send a flare so get container logs instead:

--- a/content/en/security_platform/cloud_workload_security/troubleshooting.md
+++ b/content/en/security_platform/cloud_workload_security/troubleshooting.md
@@ -22,7 +22,7 @@ If you don’t have a case ID, just enter your email address used to login in Da
 
 ## Agent Self tests
 
-In order to ensure that the communication between the `security-agent` and the `system-probe` is working as expected and the Cloud Workload Security probe is able to detect system events, you can manually trigger self tests by running the following command:
+In order to ensure that the communication between the `security-agent` and the `system-probe` is working as expected and that Cloud Workload Security is able to detect system events, you can manually trigger self tests by running the following command:
 
 | Platform     | Command                                                                             |
 | --------     | -------                                                                             |

--- a/content/en/security_platform/cloud_workload_security/troubleshooting.md
+++ b/content/en/security_platform/cloud_workload_security/troubleshooting.md
@@ -6,7 +6,7 @@ description: "Troubleshooting for Cloud Workload Security."
 
 ## Security Agent Flare
 
-Similar to the agent flare (TODO add link), you can send necessary troubleshooting information to the Datadog support team with one flare command.
+Similar to the [Agent flare][1], you can send necessary troubleshooting information to the Datadog support team with one flare command.
 
 If needed, the flare can be reviewed prior to sending since the flare prompts a confirmation before uploading it.
 
@@ -40,3 +40,5 @@ Runtime self test: OK
 You can now see events coming from the `runtime-security-agent` in the Log Explorer.
 
 {{< img src="security_platform/cws/self_test_logs.png" alt="Self test events in the Log Explorer" style="width:90%;">}}
+
+[1]: /agent/troubleshooting/send_a_flare/?tab=agentv6v7

--- a/content/en/security_platform/cloud_workload_security/troubleshooting.md
+++ b/content/en/security_platform/cloud_workload_security/troubleshooting.md
@@ -8,7 +8,7 @@ description: "Troubleshooting for Cloud Workload Security."
 
 Similar to the [Agent flare][1], you can send necessary troubleshooting information to the Datadog support team with one flare command.
 
-If needed, the flare can be reviewed prior to sending since the flare prompts a confirmation before uploading it.
+The flare asks for confirmation before upload, so you may review the content before the Security Agent sends it.
 
 In the commands below, replace `<CASE_ID>` with your Datadog support case ID if you have one, then enter the email address associated with it.
 

--- a/content/en/security_platform/cloud_workload_security/troubleshooting.md
+++ b/content/en/security_platform/cloud_workload_security/troubleshooting.md
@@ -4,11 +4,25 @@ kind: documentation
 description: "Troubleshooting for Cloud Workload Security."
 ---
 
+## Security Agent Flare
+
+Similar to the agent flare (TODO add link), you can send necessary troubleshooting information to the Datadog support team with one flare command.
+
+If needed, the flare can be reviewed prior to sending since the flare prompts a confirmation before uploading it.
+
+In the commands below, replace <CASE_ID> with your Datadog support case ID if you have one, then enter the email address associated with it.
+
+If you don’t have a case ID, just enter your email address used to login in Datadog to create a new support case.
+
+| Platform     | Command                                                                             |
+| --------     | -------                                                                             |
+| Docker       | `docker exec -it datadog-agent security-agent flare <CASE_ID>`                      |
+| Kubernetes   | `kubectl exec -it <POD_NAME> -c security-agent -- security-agent flare <CASE_ID>`   |
+| Host         | `sudo /opt/datadog-agent/embedded/bin/security-agent flare <CASE_ID>`               |
+
 ## Agent Self tests
 
 In order to ensure that the communication between the `security-agent` and the `system-probe` is working as expected and the Cloud Workload Security probe is able to detect system events, you can manually trigger self tests by running the following command:
-
-
 
 | Platform     | Command                                                                             |
 | --------     | -------                                                                             |

--- a/content/en/security_platform/cloud_workload_security/troubleshooting.md
+++ b/content/en/security_platform/cloud_workload_security/troubleshooting.md
@@ -4,7 +4,7 @@ kind: documentation
 description: "Troubleshooting for Cloud Workload Security."
 ---
 
-## Security Agent Flare
+## Security Agent flare
 
 Similar to the [Agent flare][1], you can send necessary troubleshooting information to the Datadog support team with one flare command.
 

--- a/content/en/security_platform/cloud_workload_security/troubleshooting.md
+++ b/content/en/security_platform/cloud_workload_security/troubleshooting.md
@@ -10,7 +10,7 @@ Similar to the [Agent flare][1], you can send necessary troubleshooting informat
 
 If needed, the flare can be reviewed prior to sending since the flare prompts a confirmation before uploading it.
 
-In the commands below, replace <CASE_ID> with your Datadog support case ID if you have one, then enter the email address associated with it.
+In the commands below, replace `<CASE_ID>` with your Datadog support case ID if you have one, then enter the email address associated with it.
 
 If you don’t have a case ID, just enter your email address used to login in Datadog to create a new support case.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/paulcacheux/cws-secagent-flare
https://docs-staging.datadoghq.com/paulcacheux/cws-secagent-flare/agent/troubleshooting/send_a_flare/?tab=agentv6v7
https://docs-staging.datadoghq.com/paulcacheux/cws-secagent-flare/security_platform/cloud_workload_security/troubleshooting

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
