### PR TITLE
Update documentation to use only API Key for reporting, dont mention …

### DIFF
--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -102,8 +102,8 @@ Set all these variables in your test target:
 **Recommended**: `$(DD_TEST_RUNNER)`<br/>
 **Example**: `true`
 
-`DATADOG_CLIENT_TOKEN`
-: Use the [Datadog Client Token][1] to report test results. Alternatively, use an API key.<br/>
+`DD_API_KEY`
+: Use the [Datadog API Key][1] to report test results.<br/>
 **Default**: `(empty)`<br/>
 **Example**: `pub0zxxxyyyxxxyyxxxzzxxyyxxxyyy`
 
@@ -682,6 +682,6 @@ Always call `session.end()` at the end so that all the test info is flushed to D
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/organization-settings/client-tokens
+[1]: https://app.datadoghq.com/organization-settings/api-keys
 [2]: /getting_started/site/
 [3]: https://opentelemetry.io/


### PR DESCRIPTION
### What does this PR do?

Update documentation to use only API Key for reporting

### Motivation

We were currently using Client tokens for reporting, but it will stop working in the future. Update the docs as soon as possible to avoid conflicts in the future

### Preview

https://docs-staging.datadoghq.com/nachoBonafonte/update-api-key-info/continuous_integration/setup_tests/swift

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
