### PR TITLE
Perform OR logic in API tests assertions Edit

### DIFF
--- a/content/en/synthetics/guide/or-logic-api-tests-assertions.md
+++ b/content/en/synthetics/guide/or-logic-api-tests-assertions.md
@@ -8,14 +8,16 @@ further_reading:
     - link: '/synthetics/multistep'
       tag: 'Documentation'
       text: 'Create a Multistep API Test'
-    - link: "/getting_started/synthetics/api_test"
-      tag: "Documentation"
-      text: "Get started with HTTP tests"
+    - link: '/getting_started/synthetics/api_test'
+      tag: 'Documentation'
+      text: 'Get started with HTTP tests'
 ---
 
-You can perform `OR` logic on your [API test][1] assertions to define several different expected values for the same assertion type. For example, you may want your [HTTP test][2] `status code` assertion to succeed in case your server responds with a `200` **or** with a `302`.
+## Overview
 
-To do this, you can use the [`matches regex` comparator][3] and define a regex like `(200|302)`. With such an assertion, your test result is successful if the status code returned by the server is 200 **or** 302.
+You can perform `OR` logic on your [API test][1] assertions to define several different expected values for the same assertion type. For example, you may want your [HTTP test][2] `status code` assertion to succeed in case your server responds with a `200` or with a `302`.
+
+To do this, you can use the [`matches regex` comparator][3] and define a regex like `(200|302)`. With such an assertion, your test result is successful if the status code returned by the server is 200 or 302.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Small doc edit with Jules.

### Motivation
<!-- What inspired you to submit this pull request?-->

Introduction to Docs!

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/synthetics-guide-nit/synthetics/guide/or-logic-api-tests-assertions/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
