### PR TITLE
DOCS-3140 instruct users about child of SAML strict parent org

### DIFF
--- a/content/en/account_management/multi_organization.md
+++ b/content/en/account_management/multi_organization.md
@@ -64,7 +64,7 @@ To configure SAML for multi-organizations:
 
 ### SAML strict parent organizations
 
-Under some circumstances, you may be unable to access a newly created child organization. When an organization requires users to log in using SAML, the user accounts usually lack passwords. Since child organizations do not inherit SAML settings from their parents, logging into the child organization requires a password that does not exist.
+Under some circumstances, you may be unable to access a newly created child organization. When an organization requires users to log in using SAML, its user accounts may lack passwords. Since child organizations do not inherit SAML settings from their parents, logging into the child organization requires a password that does not exist.
 
 To ensure that you can log into a child organization created from a SAML strict parent organization, take the following steps in the parent organization:
 1. Click **Organization Settings** from the account menu in the bottom of the left side navigation, or select **Organization Settings** from the header dropdown at the top of the Personal Settings page.
@@ -74,7 +74,7 @@ To ensure that you can log into a child organization created from a SAML strict 
 5. Under **Select user's login methods**, place a checkmark in the **Password** checkbox.
 6. Ensure your account has a password. If you need help setting a password, contact [Datadog support][2].
 
-Following the steps above ensure that you can log into the parent account using an email and password combination. After creating your child organization, you can also log into it using your email and password.
+Following the steps above ensures that you can log into the parent account using an email and password combination. After creating your child organization, you can also log into it using your email and password.
 
 If you already created the child organization and are locked out, following the procedure allows you to log in.
 

--- a/content/en/account_management/multi_organization.md
+++ b/content/en/account_management/multi_organization.md
@@ -62,6 +62,22 @@ To configure SAML for multi-organizations:
 2. Invite SAML users.
 3. Login as a SAML user and set SAML.
 
+### SAML strict parent organizations
+
+Under some circumstances, you may be unable to access a newly created child organization. When an organization requires users to log in using SAML, the user accounts usually lack passwords. Since child organizations do not inherit SAML settings from their parents, logging into the child organization requires a password that does not exist.
+
+To ensure that you can log into a child organization created from a SAML strict parent organization, take the following steps in the parent organization:
+1. Click **Organization Settings** from the account menu in the bottom of the left side navigation, or select **Organization Settings** from the header dropdown at the top of the Personal Settings page.
+2. In the left page menu, select **Users**.
+3. Select your user profile.
+4. Set the **Override Default Login Methods** toggle to the on position.
+5. Under **Select user's login methods**, place a checkmark in the **Password** checkbox.
+6. Ensure your account has a password. If you need help setting a password, contact [Datadog support][2].
+
+Following the steps above ensure that you can log into the parent account using an email and password combination. After creating your child organization, you can also log into it using your email and password.
+
+If you already created the child organization and are locked out, following the procedure allows you to log in.
+
 ## Multi-org usage
 
 The parent-organization can view the total and billable usage of all their organizations (child and parent organizations) by hovering over their username on the bottom left corner and navigating to **Plan & Usage** > **Usage**.


### PR DESCRIPTION
### What does this PR do?
Creates a section in the Multi Organization doc that tells users what steps to take so they can properly access a child organization created from a parent organization that is SAML strict.

### Motivation
Éanna, a Solutions Engineer, reported [DOCS-3140](https://datadoghq.atlassian.net/browse/DOCS-3140). When creating a child org from a SAML strict parent org, users have to configure a user that bypasses SAML and can log in with a username and password. Child orgs do not inherit SAML settings from their parents, so the default behavior leaves no way to log in to the newly created child org.

### Preview
https://docs-staging.datadoghq.com/uchen/saml-child/account_management/multi_organization/#saml-strict-parent-organizations

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
