### PR TITLE
four standard metrics not three

### DIFF
--- a/content/en/tracing/trace_retention/usage_metrics.md
+++ b/content/en/tracing/trace_retention/usage_metrics.md
@@ -26,7 +26,7 @@ This document details the available metrics and default dashboard for monitoring
 
 Datadog provides an out-of-the-box [Usage Dashboard][5] for monitoring your APM usage, as well as your ingested and indexed span volumes.
 
-Each metric on this dashboard is powered by one of the below three Datadog standard metrics available in your account.
+Each metric on this dashboard is powered by one of the below four Datadog standard metrics available in your account.
 
  - `datadog.estimated_usage.apm.ingested_bytes`
  - `datadog.estimated_usage.apm.ingested_spans`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Correct what seems to be a missing edit where the text refers to "three" metrics but lists four.

### Motivation
I was reading the docs and this seemed like a simple mistake

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ajgajg1134-four-metrics/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
