### PR TITLE
fix typo in config parameter name

### DIFF
--- a/content/en/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration.md
+++ b/content/en/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration.md
@@ -13,7 +13,7 @@ Datadog recommends gathering instance tags through the EC2 Instance Metadata Ser
 This mechanism is available in the Datadog Agent v7.35.0.
 
 1. Ensure that the EC2 instance is configured to allow access to tags in the instance metadata. See the [AWS documentation][1].
-2. In the `datadog.yaml` file, set `collect_ec2_tags: true` and `ec2_collect_tags_use_imds: true`.
+2. In the `datadog.yaml` file, set `collect_ec2_tags: true` and `collect_ec2_tags_use_imds: true`.
 3. [Restart the Agent][2].
 
 [1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#allow-access-to-tags-in-IMDS


### PR DESCRIPTION
### What does this PR do?

Fixes typo

### Motivation

Found in QA.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
