### PR TITLE
Add notebooks blog link

### DIFF
--- a/content/en/notebooks/_index.md
+++ b/content/en/notebooks/_index.md
@@ -4,6 +4,9 @@ kind: documentation
 aliases:
   - /graphing/notebooks/
 further_reading:
+- link: "https://www.datadoghq.com/blog/incident-management-templates-notebooks-list/"
+  tag: "Blog"
+  text: "Create and navigate a documentation library"
 - link: "https://www.datadoghq.com/blog/collaborative-notebooks-datadog/"
   tag: "Blog"
   text: "Tell data-driven stories with Collaborative Notebooks"


### PR DESCRIPTION

### What does this PR do?
Adds link to Notebooks docs to Blog post

### Motivation
on-call tasks

### Preview

https://docs-staging.datadoghq.com/kari/add-notebooks-blog-link/notebooks/
