### PR TITLE
Fix margin-bottom on product category titles

### DIFF
--- a/assets/styles/components/_header.scss
+++ b/assets/styles/components/_header.scss
@@ -5,6 +5,14 @@ $ddpurple: #632ca6;
     margin-top: 30px !important;
   }
 }
+// NOTE: exception style for Docs due to reboot styles
+.main-nav {
+  .product-menu p {
+    @include media-breakpoint-up(lg) {
+      margin-bottom: 0;
+    }
+  }
+}
 
 body > header {
   box-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.07);
@@ -187,7 +195,6 @@ body > header {
             margin-right: 12px;
           }
         }
-
 
         &.product-menu li {
           font-size: 18px;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- removes `margin-bottom` from the product dropdown menu's category titles – a result of reboot styles on Docs

### Motivation
- recent changes to product dropdown menu

### Preview

https://docs-staging.datadoghq.com/carlos/product-menu-spacing-fix/

- [ ] review product dropdown menu spacing and compare to both current live Docs and Corpsite
- [ ] product dropdown category titles should not have margin-bottom e.g. `Logs` `Digital Experience`
- [ ] check spacing for consistency on FR and JA menus as well

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
