### PR TITLE
[CIAPP] explicitly exclude http mode for jenkins

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -44,7 +44,7 @@ Install and enable the [Datadog Jenkins plugin][3] v3.3.0 or newer:
 
 1. In your Jenkins instance web interface, go to **Manage Jenkins > Configure System**.
 2. Go to the `Datadog Plugin` section, scrolling down the configuration screen.
-3. Select the `Datadog Agent` mode. Data collection using Datadog API URL and API key is **not supported**.
+3. Select the `Datadog Agent` mode. CI Visibility is **not supported** using Datadog API URL and API key.
 4. Configure the `Agent` host.
 5. Configure the `Traces Collection` port (default `8126`).
 6. Click on `Enable CI Visibility` checkbox to activate it.
@@ -172,7 +172,7 @@ Second, enable job log collection on the Datadog Plugin:
 
 1. In the web interface of your Jenkins instance, go to **Manage Jenkins > Configure System**.
 2. Go to the `Datadog Plugin` section, scrolling down the configuration screen.
-3. Select the `Datadog Agent` mode. Data collection using Datadog API URL and API key is **not supported**.
+3. Select the `Datadog Agent` mode.
 4. Configure the `Agent` host, if not previously configured.
 5. Configure the `Log Collection` port, as configured in the previous step.
 6. Click on `Enable Log Collection` checkbox to activate it.

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -44,7 +44,7 @@ Install and enable the [Datadog Jenkins plugin][3] v3.3.0 or newer:
 
 1. In your Jenkins instance web interface, go to **Manage Jenkins > Configure System**.
 2. Go to the `Datadog Plugin` section, scrolling down the configuration screen.
-3. Select the `Datadog Agent` mode.
+3. Select the `Datadog Agent` mode. Data collection using Datadog API URL and API key is **not supported**.
 4. Configure the `Agent` host.
 5. Configure the `Traces Collection` port (default `8126`).
 6. Click on `Enable CI Visibility` checkbox to activate it.
@@ -172,7 +172,7 @@ Second, enable job log collection on the Datadog Plugin:
 
 1. In the web interface of your Jenkins instance, go to **Manage Jenkins > Configure System**.
 2. Go to the `Datadog Plugin` section, scrolling down the configuration screen.
-3. Select the `Datadog Agent` mode.
+3. Select the `Datadog Agent` mode. Data collection using Datadog API URL and API key is **not supported**.
 4. Configure the `Agent` host, if not previously configured.
 5. Configure the `Log Collection` port, as configured in the previous step.
 6. Click on `Enable Log Collection` checkbox to activate it.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This PR adds a clarification about the fact the HTTP mode is not supported for CI App for the Jenkins plugin.

### Motivation

We had some customers wondering if they could use the HTTP mode, so we clarify it here.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alexc/CIAPP-jenkins-http/continuous_integration/setup_pipelines/jenkins/?tab=usingui

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
