### PR TITLE
Fixed integrations documentation link

### DIFF
--- a/content/en/agent/troubleshooting/agent_check_status.md
+++ b/content/en/agent/troubleshooting/agent_check_status.md
@@ -43,7 +43,7 @@ sudo -u dd-agent datadog-agent check <CHECK_NAME> --check-rate
 sudo -u dd-agent dd-agent check <CHECK_NAME>
 ```
 
-Replace `<CHECK_NAME>` with any Agent check. For example: `activemq`, `ceph`, or `elastic`. Review an [integration's documentation][1] to confirm the Agent check name.
+Replace `<CHECK_NAME>` with any Agent check. For example: `activemq`, `ceph`, or `elastic`. Review an [integration's documentation][4] to confirm the Agent check name.
 
 If you want to include rate metrics, add `--check-rate` to your command, for instance for Agent v6.x run:
 
@@ -145,3 +145,4 @@ sudo journalctl -u dd-agent.service
 [1]: /help/
 [2]: /agent/troubleshooting/send_a_flare/
 [3]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands
+[4]: /integrations/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Added a new symlink:  [4] integrations
Previous link ` integration’s documentation` directed to /help/

Corrected: the integrations tab misdirection
https://a.cl.ly/GGuED7W9 

Now directs to /integrations/
-> https://docs.datadoghq.com/integrations/ 

### Motivation
Correct broken link paths

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
