### PR TITLE
Provide instructions on Agent minor version upgrades

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -802,7 +802,7 @@ main:
     url: agent/versions/upgrade_to_agent_v6/
     parent: agent_versions
     weight: 1002
-  - name: Upgrade Between Datadog Agent Minor Versions
+  - name: Upgrade Between Agent Minor Versions
     url: agent/versions/upgrade_between_agent_minor_versions
     parent: agent_versions
     weight: 1003

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -802,6 +802,10 @@ main:
     url: agent/versions/upgrade_to_agent_v6/
     parent: agent_versions
     weight: 1002
+  - name: Upgrade Between Datadog Agent Minor Versions
+    url: agent/versions/upgrade_between_agent_minor_versions
+    parent: agent_versions
+    weight: 1003
   - name: Troubleshooting
     url: agent/troubleshooting/
     parent: agent

--- a/content/en/agent/versions/_index.md
+++ b/content/en/agent/versions/_index.md
@@ -10,7 +10,7 @@ further_reading:
       text: 'Upgrade to Agent v6'
     - link: 'agent/versions/upgrade_between_agent_minor_versions'
       tag: 'Documentation'
-      text: 'Upgrade Between Datadog Agent Minor Versions'
+      text: 'Upgrade Between Agent Minor Versions'
     - link: 'agent/faq/agent_v6_changes'
       tag: 'FAQ'
       text: 'Agent v6 Changes'

--- a/content/en/agent/versions/_index.md
+++ b/content/en/agent/versions/_index.md
@@ -8,6 +8,9 @@ further_reading:
     - link: 'agent/versions/upgrade_to_agent_v6'
       tag: 'Documentation'
       text: 'Upgrade to Agent v6'
+    - link: 'agent/versions/upgrade_between_agent_minor_versions'
+      tag: 'Documentation'
+      text: 'Upgrade Between Datadog Agent Minor Versions'
     - link: 'agent/faq/agent_v6_changes'
       tag: 'FAQ'
       text: 'Agent v6 Changes'
@@ -18,7 +21,7 @@ Datadog recommends you update Datadog Agent with every minor and patch release, 
 <p>
 Upgrading to a major Datadog Agent version and keeping it updated is the only supported way to get the latest Agent functionality and fixes. The Agent has frequent update releases, though, and managing updates at enterprise scale can be challenging. That doesn't mean you should wait for major releases before updating. The right update cadence for your organization will depend on your infrastructure and your configuration management practices, but aim for monthly.</p>
 <p>
-To update the Datadog Agent core between two minor versions on a given host, run [the corresponding install command for your platform][1].</p>
+To update the Datadog Agent core between two minor versions on a given host, run <a href="/agent/versions/upgrade_between_agent_minor_versions">the corresponding install command for your platform</a>.</p>
 <p>
 Datadog Agent release numbering follows <a href="https://semver.org/">SemVer</a> rules.</p>
 </div>

--- a/content/en/agent/versions/_index.md
+++ b/content/en/agent/versions/_index.md
@@ -26,8 +26,6 @@ To update the Datadog Agent core between two minor versions on a given host, run
 Datadog Agent release numbering follows <a href="https://semver.org/">SemVer</a> rules.</p>
 </div>
 
-[1]: /agent/versions/upgrade_between_agent_minor_versions
-
 ## Changes between major Agent versions
 
 {{< tabs >}}

--- a/content/en/agent/versions/_index.md
+++ b/content/en/agent/versions/_index.md
@@ -18,10 +18,12 @@ Datadog recommends you update Datadog Agent with every minor and patch release, 
 <p>
 Upgrading to a major Datadog Agent version and keeping it updated is the only supported way to get the latest Agent functionality and fixes. The Agent has frequent update releases, though, and managing updates at enterprise scale can be challenging. That doesn't mean you should wait for major releases before updating. The right update cadence for your organization will depend on your infrastructure and your configuration management practices, but aim for monthly.</p>
 <p>
-To update the Datadog Agent core between two minor versions on a given host, run <a href="https://app.datadoghq.com/account/settings#agent">the corresponding install command for your platform</a>.</p>
+To update the Datadog Agent core between two minor versions on a given host, run [the corresponding install command for your platform][1].</p>
 <p>
 Datadog Agent release numbering follows <a href="https://semver.org/">SemVer</a> rules.</p>
 </div>
+
+[1]: /agent/versions/upgrade_between_agent_minor_versions
 
 ## Changes between major Agent versions
 

--- a/content/en/agent/versions/upgrade_between_agent_minor_versions.md
+++ b/content/en/agent/versions/upgrade_between_agent_minor_versions.md
@@ -11,7 +11,7 @@ aliases:
 {{< tabs >}}
 {{% tab "Linux" %}}
 
-The recommended way to upgrade between minor versions of Agent 6 and 7 is using the `install_script.sh` script. Following commands work on all supported Linux distributions.
+The recommended way to upgrade between minor versions of Agent 6 and 7 is to use the `install_script.sh` script. The following commands work on all supported Linux distributions.
 
 Upgrading to a given Agent 6 minor version:
 
@@ -34,11 +34,11 @@ Upgrading to the latest Agent 7 minor version:
 
 Download and install the desired installation package.
 
-URL for a given minor version of Agent 6:
+URL to download a specific Agent 6 minor version:
 
 : `https://ddagent-windows-stable.s3.amazonaws.com/ddagent-cli-6.<minor_version>.<bugfix_version>.msi`
 
-URL for a given minor version of Agent 7:
+URL to download a specific Agent 7 minor version
 
 : `https://ddagent-windows-stable.s3.amazonaws.com/ddagent-cli-7.<minor_version>.<bugfix_version>.msi`
 
@@ -47,11 +47,11 @@ URL for a given minor version of Agent 7:
 
 **Note**: There is currently no way to upgrade to a specific minor version.
 
-Upgrading to the latest Agent 6 minor version:
+Command to upgrade to the latest Agent 6 minor version:
 
 : `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_mac_os.sh)"`
 
-Upgrading to the latest Agent 7 minor version:
+Command to upgrade to the latest Agent 7 minor version:
 
 : `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_mac_os.sh)"`
 

--- a/content/en/agent/versions/upgrade_between_agent_minor_versions.md
+++ b/content/en/agent/versions/upgrade_between_agent_minor_versions.md
@@ -32,7 +32,7 @@ Upgrading to the latest Agent 7 minor version:
 {{% /tab %}}
 {{% tab "Windows" %}}
 
-Download and install the desired installation package.
+Download and install the specific version's installation package.
 
 URL to download a specific Agent 6 minor version:
 

--- a/content/en/agent/versions/upgrade_between_agent_minor_versions.md
+++ b/content/en/agent/versions/upgrade_between_agent_minor_versions.md
@@ -15,19 +15,19 @@ The recommended way to upgrade between minor versions of Agent 6 and 7 is using 
 
 Upgrading to a given Agent 6 minor version:
 
-: `DD_AGENT_MAJOR_VERSION=6 DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"`
+: `DD_AGENT_MAJOR_VERSION=6 DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script.sh)"`
 
 Upgrading to the latest Agent 6 minor version:
 
-: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"`
+: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script.sh)"`
 
 Upgrading to a given Agent 7 minor version:
 
-: `DD_AGENT_MAJOR_VERSION=7 DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"`
+: `DD_AGENT_MAJOR_VERSION=7 DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script.sh)"`
 
 Upgrading to the latest Agent 7 minor version:
 
-: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"`
+: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -36,11 +36,11 @@ Download and install the desired installation package.
 
 URL for a given minor version of Agent 6:
 
-: `https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-6.<minor_version>.<bugfix_version>.msi`
+: `https://ddagent-windows-stable.s3.amazonaws.com/ddagent-cli-6.<minor_version>.<bugfix_version>.msi`
 
 URL for a given minor version of Agent 7:
 
-: `https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-7.<minor_version>.<bugfix_version>.msi`
+: `https://ddagent-windows-stable.s3.amazonaws.com/ddagent-cli-7.<minor_version>.<bugfix_version>.msi`
 
 {{% /tab %}}
 {{% tab "MacOS" %}}
@@ -49,11 +49,11 @@ URL for a given minor version of Agent 7:
 
 Upgrading to the latest Agent 6 minor version:
 
-: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"`
+: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_mac_os.sh)"`
 
 Upgrading to the latest Agent 7 minor version:
 
-: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"`
+: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_mac_os.sh)"`
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/versions/upgrade_between_agent_minor_versions.md
+++ b/content/en/agent/versions/upgrade_between_agent_minor_versions.md
@@ -1,0 +1,59 @@
+---
+title: Upgrade Between Datadog Agent Minor Versions
+kind: documentation
+aliases:
+  - /agent/faq/upgrade-between-agent-minor-versions
+  - /agent/guide/upgrade-between-agent-minor-versions
+---
+
+## Upgrade Between Minor Versions of Agent 6 and 7
+
+{{< tabs >}}
+{{% tab "Linux" %}}
+
+The recommended way to upgrade between minor versions of Agent 6 and 7 is using the `install_script.sh` script. Following commands work on all supported Linux distributions.
+
+Upgrading to a given Agent 6 minor version:
+
+: `DD_AGENT_MAJOR_VERSION=6 DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"`
+
+Upgrading to the latest Agent 6 minor version:
+
+: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"`
+
+Upgrading to a given Agent 7 minor version:
+
+: `DD_AGENT_MAJOR_VERSION=7 DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"`
+
+Upgrading to the latest Agent 7 minor version:
+
+: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"`
+
+{{% /tab %}}
+{{% tab "Windows" %}}
+
+Download and install the desired installation package.
+
+URL for a given minor version of Agent 6:
+
+: `https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-6.<minor_version>.<bugfix_version>.msi`
+
+URL for a given minor version of Agent 7:
+
+: `https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-7.<minor_version>.<bugfix_version>.msi`
+
+{{% /tab %}}
+{{% tab "MacOS" %}}
+
+**Note**: There is currently no way to upgrade to a specific minor version.
+
+Upgrading to the latest Agent 6 minor version:
+
+: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"`
+
+Upgrading to the latest Agent 7 minor version:
+
+: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"`
+
+{{% /tab %}}
+{{< /tabs >}}

--- a/content/en/agent/versions/upgrade_between_agent_minor_versions.md
+++ b/content/en/agent/versions/upgrade_between_agent_minor_versions.md
@@ -6,7 +6,7 @@ aliases:
   - /agent/guide/upgrade-between-agent-minor-versions
 ---
 
-## Upgrade Between Minor Versions of Agent 6 and 7
+## Upgrade between minor versions of Agent 6 and 7
 
 {{< tabs >}}
 {{% tab "Linux" %}}
@@ -45,7 +45,7 @@ URL to download a specific Agent 7 minor version
 {{% /tab %}}
 {{% tab "MacOS" %}}
 
-**Note**: There is currently no way to upgrade to a specific minor version.
+**Note**: It is not possible to upgrade to a specific minor version.
 
 Command to upgrade to the latest Agent 6 minor version:
 


### PR DESCRIPTION
### What does this PR do?

Provides instructions for Agent minor version upgrades.

This will need https://github.com/DataDog/datadog-agent/pull/11079 merged and released first before merging.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview

https://docs-staging.datadoghq.com/slavek.kabrda/agent-minor-upgrades/agent/versions/upgrade_between_agent_minor_versions/?tab=linux
https://docs-staging.datadoghq.com/slavek.kabrda/agent-minor-upgrades/agent/versions?tab=agentv7vsv6

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
