### PR TITLE
Update custom_time_frames.md to include week as unit

### DIFF
--- a/content/en/dashboards/guide/custom_time_frames.md
+++ b/content/en/dashboards/guide/custom_time_frames.md
@@ -43,19 +43,20 @@ Both fixed and relative custom time frames are supported:
 
 ### Relative dates
 
-| Format       | Examples                                                        | Notes                                                     |
-|--------------|-----------------------------------------------------------------|-----------------------------------------------------------|
-| `N{unit}`    | 3m<br>3 min<br>3h<br>3 hours<br>3d<br>3 days<br>3mo<br>3 months | Displays the past N units, for example: the past 3 months |
-| `today`      |                                                                 | Displays the current calendar day until present           |
-| `yesterday`  |                                                                 | Displays the full previous calendar day                   |
-| `this month` |                                                                 | Displays the current calendar month until present         |
-| `last month` |                                                                 | Displays the full previous calendar month                 |
-| `this year`  |                                                                 | Displays the current calendar year until present          |
-| `last year`  |                                                                 | Displays the full previous calendar year                  |
+| Format       | Examples                                                                         | Notes                                                     |
+|--------------|----------------------------------------------------------------------------------|-----------------------------------------------------------|
+| `N{unit}`    | 3m<br>3 min<br>3h<br>3 hours<br>3d<br>3 days<br>3w<br>3 weeks<br>3mo<br>3 months | Displays the past N units, for example: the past 3 months |
+| `today`      |                                                                                  | Displays the current calendar day until present           |
+| `yesterday`  |                                                                                  | Displays the full previous calendar day                   |
+| `this month` |                                                                                  | Displays the current calendar month until present         |
+| `last month` |                                                                                  | Displays the full previous calendar month                 |
+| `this year`  |                                                                                  | Displays the current calendar year until present          |
+| `last year`  |                                                                                  | Displays the full previous calendar year                  |
 
 * The following strings are accepted for any `{unit}` in a relative date:
   * Minutes: `m`, `min`, `mins`, `minute`, `minutes`
   * Hours: `h`, `hr`, `hrs`, `hour`, `hours`
   * Days: `d`, `day`, `days`
+  * Weeks: `w`, `week`, `weeks`
   * Months: `mo`, `mos`, `mon`, `mons`, `month`, `months`
 * `today`, `yesterday`, `this month`, `this year`, and `last year` are calculated when entered. They won’t continue to update as time passes.


### PR DESCRIPTION
Weeks are also available as unit in a relative date.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Weeks (w, week, weeks) are supported unit of relative time.

### Motivation
<!-- What inspired you to submit this pull request?-->
Completeness of our documentation. Also, week is a unit that usually show ups on documentation and images.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
