### PR TITLE
update language on rate limits to be generic and refer to X-Ratelimit-Name for increase requests

### DIFF
--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -14,13 +14,9 @@ Rate limits can be increased from the defaults by [contacting the Datadog suppor
 Regarding the API rate limit policy:
 
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
-- The rate limit for metric **retrieval** is `100` per hour per organization.
 - The rate limit for event submission is `500,000` events per hour per organization.
 - The rate limit for event aggregation is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
-- The rate limit for the [Query a Timeseries API][4] call is `1600` per hour per organization. This can be extended on demand.
-- The rate limit for the [Log Query API][5] call is `300` per hour per organization. This can be extended on demand.
-- The rate limit for the [Graph a Snapshot API][6] call is `60` per hour per organization. This can be extended on demand.
-- The [Log Configuration APIs][7] can be read `84` times per minute per organization for a total of `5040` calls per hour, and can be updated `2` times per minute per organization for a total of `120` calls per hour. This can be extended on demand.
+- The rate limits for endpoints vary and are included in the headers detailed below. These can be extended on demand.
 
 <div class="alert alert-warning">
 The list above is not comprehensive of all rate limits on Datadog API's. If you are experiencing rate limiting, reach out to <a href="https://www.datadoghq.com/support/">support</a> for more information about the API's you're using and their limits.</div>
@@ -31,11 +27,8 @@ The list above is not comprehensive of all rate limits on Datadog API's. If you 
 | `X-RateLimit-Period`    | length of time in seconds for resets (calendar aligned). |
 | `X-RateLimit-Remaining` | number of allowed requests left in the current time period.  |
 | `X-RateLimit-Reset`     | time in seconds until next reset.                        |
+| `X-RateLimit-Name`      | name of the rate limit for increase requests             |
 
 [1]: /help/
 [2]: /api/v1/metrics/
 [3]: /metrics/custom_metrics/
-[4]: /api/v1/metrics/#query-timeseries-points
-[5]: /api/v1/logs/#get-a-list-of-logs
-[6]: /api/v1/snapshots/
-[7]: /api/v1/logs-indexes/

--- a/content/en/api/v1/rate-limits/_index.md
+++ b/content/en/api/v1/rate-limits/_index.md
@@ -14,13 +14,9 @@ Rate limits can be increased from the defaults by [contacting the Datadog suppor
 Regarding the API rate limit policy:
 
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
-- The rate limit for metric **retrieval** is `100` per hour per organization.
 - The rate limit for event submission is `500,000` events per hour per organization.
 - The rate limit for event aggregation is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
-- The rate limit for the [Query a Timeseries API][4] call is `1600` per hour per organization. This can be extended on demand.
-- The rate limit for the [Log Query API][5] call is `300` per hour per organization. This can be extended on demand.
-- The rate limit for the [Graph a Snapshot API][6] call is `60` per hour per organization. This can be extended on demand.
-- The rate limit for the [Log Configuration API][7] is `6000` per minute per organization. This can be extended on demand.
+- The rate limits for endpoints vary and are included in the headers detailed below. These can be extended on demand.
 
 | Rate Limit Headers      | Description                                              |
 | ----------------------- | -------------------------------------------------------- |
@@ -28,11 +24,8 @@ Regarding the API rate limit policy:
 | `X-RateLimit-Period`    | length of time in seconds for resets (calendar aligned). |
 | `X-RateLimit-Remaining` | number of allowed requests left in the current time period.  |
 | `X-RateLimit-Reset`     | time in seconds until next reset.                        |
+| `X-RateLimit-Name`      | name of the rate limit for increase requests             |
 
 [1]: /help/
 [2]: /api/v1/metrics/
 [3]: /metrics/custom_metrics/
-[4]: /api/v1/metrics/#query-timeseries-points
-[5]: /api/v1/logs/#get-a-list-of-logs
-[6]: /api/v1/snapshots/
-[7]: /api/v1/logs-indexes/

--- a/content/en/api/v2/rate-limits/_index.md
+++ b/content/en/api/v2/rate-limits/_index.md
@@ -14,13 +14,9 @@ Rate limits can be increased from the defaults by [contacting the Datadog suppor
 Regarding the API rate limit policy:
 
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
-- The rate limit for metric **retrieval** is `100` per hour per organization.
 - The rate limit for event submission is `500,000` events per hour per organization.
 - The rate limit for event aggregation is `1000` per aggregate per day per organization. An aggregate is a group of similar events.
-- The rate limit for the [Query a Timeseries API][4] call is `1600` per hour per organization. This can be extended on demand.
-- The rate limit for the [Log Query API][5] call is `300` per hour per organization. This can be extended on demand.
-- The rate limit for the [Graph a Snapshot API][6] call is `60` per hour per organization. This can be extended on demand.
-- The rate limit for the [Log Configuration API][7] is `6000` per minute per organization. This can be extended on demand.
+- The rate limits for endpoints vary and are included in the headers detailed below. These can be extended on demand.
 
 | Rate Limit Headers      | Description                                              |
 | ----------------------- | -------------------------------------------------------- |
@@ -28,11 +24,8 @@ Regarding the API rate limit policy:
 | `X-RateLimit-Period`    | length of time in seconds for resets (calendar aligned). |
 | `X-RateLimit-Remaining` | number of allowed requests left in the current time period.  |
 | `X-RateLimit-Reset`     | time in seconds until next reset.                        |
+| `X-RateLimit-Name`      | name of the rate limit for increase requests             |
 
 [1]: /help/
 [2]: /api/v1/metrics/
 [3]: /metrics/custom_metrics/
-[4]: /api/v1/metrics/#query-timeseries-points
-[5]: /api/v1/logs/#get-a-list-of-logs
-[6]: /api/v1/snapshots/
-[7]: /api/v1/logs-indexes/


### PR DESCRIPTION
### What does this PR do?
Update language on rate limits to be generic and refer to X-Ratelimit-Name for increase requests.

These are being reflected to have shorter time-to-recovery windows and different datacenters had different values. This language is more generic and provides details on where to find information for additional requests beyond default rate limits.

### Motivation
Difficult to keep this documentation in line for every datacenter as it's not tied to the source of truth and was missing the large majority of endpoints. This provides a more general response to `api(.*)?.datadoghq.(com|eu)` && govcloud while maintaining intake + event aggregation specifics

### Preview
https://docs-staging.datadoghq.com/rate-limits-fix/api/latest/rate-limits

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
