### PR TITLE
[APM/PHP] Update requirements page to include support for PHP 8.1

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/php.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/php.md
@@ -20,6 +20,7 @@ PHP APM supports the following PHP versions:
 
 | Version    | Support type                          |
 |:-----------|:--------------------------------------|
+| 8.1.x      | Fully Supported (tracer `0.66.0+`)    |
 | 8.0.x      | Fully Supported (tracer `0.52.0+`)    |
 | 7.4.x      | Fully Supported                       |
 | 7.3.x      | Fully Supported                       |


### PR DESCRIPTION
### What does this PR do?
Requirements page was not up to date with PHP 8.1


[Preview](https://docs-staging.datadoghq.com/apm/php/8.1/tracing/setup_overview/compatibility_requirements/php/)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
