### PR TITLE
Clarify docker docs for "Host agent with custom logging"

### DIFF
--- a/content/en/agent/docker/log.md
+++ b/content/en/agent/docker/log.md
@@ -159,6 +159,8 @@ The commands related to log collection are:
 
 3. [Restart the Agent][4] to see all of your container logs in Datadog.
 
+**Note**: In order for the agent to collect logs produced by a container with a custom log configuration, the logs must be written to a volume accessible from the host. We recommend container logs be written to stdout and stderr so that they can be collected automatically. 
+
 [1]: /agent/basic_agent_usage/
 [2]: /agent/logs/#custom-log-collection
 [3]: /agent/guide/agent-configuration-files/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Clarify that if you are trying to collect logs from a container with a custom logging configuration that the logs must be accessible from the host. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
