### PR TITLE
C++: mention DD_APM_RECEIVER_SOCKET earlier in the setup doc

### DIFF
--- a/content/en/tracing/setup_overview/setup/cpp.md
+++ b/content/en/tracing/setup_overview/setup/cpp.md
@@ -175,7 +175,7 @@ g++ -std=c++11 -o tracer_example tracer_example.cpp -lopentracing
 
 Install and configure the Datadog Agent to receive traces from your instrumented application.
 
-By default the Datadog Agent is enabled in your `datadog.yaml` file under `apm_config` with `enabled: true` and listens for trace traffic at `localhost:8126`. The Agent may be configured to listen on a unix domain socket instead by setting the environment variable `DD_APM_RECEIVER_SOCKET` to the desired socket file path.
+By default APM is enabled in the `datadog.yaml` file under `apm_config`, which is set to `enabled: true`. The Datadog Agent listens for trace traffic at `localhost:8126`. The Agent may be configured to listen on a Unix domain socket instead by setting the environment variable `DD_APM_RECEIVER_SOCKET` to the desired socket file path.
 
 For containerized environments, follow the links below to enable trace collection within the Datadog Agent.
 

--- a/content/en/tracing/setup_overview/setup/cpp.md
+++ b/content/en/tracing/setup_overview/setup/cpp.md
@@ -173,7 +173,11 @@ g++ -std=c++11 -o tracer_example tracer_example.cpp -lopentracing
 
 ## Configure the Datadog Agent for APM
 
-Install and configure the Datadog Agent to receive traces from your now instrumented application. By default the Datadog Agent is enabled in your `datadog.yaml` file under `apm_config` with `enabled: true` and listens for trace traffic at `localhost:8126`. For containerized environments, follow the links below to enable trace collection within the Datadog Agent.
+Install and configure the Datadog Agent to receive traces from your now instrumented application.
+
+By default the Datadog Agent is enabled in your `datadog.yaml` file under `apm_config` with `enabled: true` and listens for trace traffic at `localhost:8126`.  The Agent may be configured to listen on a unix domain socket instead by setting the environment variable `DD_APM_RECEIVER_SOCKET` to the desired socket file path.
+
+For containerized environments, follow the links below to enable trace collection within the Datadog Agent.
 
 {{< tabs >}}
 {{% tab "Containers" %}}

--- a/content/en/tracing/setup_overview/setup/cpp.md
+++ b/content/en/tracing/setup_overview/setup/cpp.md
@@ -173,9 +173,9 @@ g++ -std=c++11 -o tracer_example tracer_example.cpp -lopentracing
 
 ## Configure the Datadog Agent for APM
 
-Install and configure the Datadog Agent to receive traces from your now instrumented application.
+Install and configure the Datadog Agent to receive traces from your instrumented application.
 
-By default the Datadog Agent is enabled in your `datadog.yaml` file under `apm_config` with `enabled: true` and listens for trace traffic at `localhost:8126`.  The Agent may be configured to listen on a unix domain socket instead by setting the environment variable `DD_APM_RECEIVER_SOCKET` to the desired socket file path.
+By default the Datadog Agent is enabled in your `datadog.yaml` file under `apm_config` with `enabled: true` and listens for trace traffic at `localhost:8126`. The Agent may be configured to listen on a unix domain socket instead by setting the environment variable `DD_APM_RECEIVER_SOCKET` to the desired socket file path.
 
 For containerized environments, follow the links below to enable trace collection within the Datadog Agent.
 


### PR DESCRIPTION
### What does this PR do?
Add a sentence to the C++ tracing setup guide about the Datadog Agent's "listen on a unix domain socket" feature.

### Motivation
There's an initiative to get all tracing teams (programming languages) on the same page with respect to the use of unix domain sockets.  Part of this is consistent customer documentation.

### Preview
https://docs-staging.datadoghq.com/david.goffredo/c++-unix-domain-sockets/tracing/setup_overview/setup/cpp

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
