### PR TITLE
add missing link to trace retention docs

### DIFF
--- a/content/en/tracing/trace_retention/_index.md
+++ b/content/en/tracing/trace_retention/_index.md
@@ -103,3 +103,4 @@ For example, you can create filters to keep all traces for:
 [4]: /tracing/visualization/#service-entry-span
 [5]: /tracing/trace_explorer/?tab=timeseriesview#indexed-spans-search-with-15-day-retention
 [6]: /tracing/trace_explorer/#historical-search-mode
+[7]: /tracing/trace_ingestion


### PR DESCRIPTION
I saw that a link wasn't being rendered in these docs, because the corresponding footnote-style link wasn't in the markdown, so I added what I think the link intended to refer to.

Preview: https://docs-staging.datadoghq.com/dgoffredo-patch-1/tracing/trace_retention/
