### PR TITLE
DOCS 2971 - adding cluster agent windows info

### DIFF
--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -236,6 +236,32 @@ Datadog Cluster Agent
 
 Kubernetes events are beginning to flow into your Datadog account, and relevant metrics collected by your Agents are tagged with their corresponding cluster level metadata.
 
+### Windows containers
+
+The Datadog Cluster Agent can only deployed on Linux nodes.
+
+To monitor Windows containers, use two Helm charts in a mixed cluster. The first Helm chart deploys the Datadog Cluster Agent (with `targetSystem: linux`). The second Helm chart (with `targetSystem: windows`) targets only Windows nodes and connects to the existing Cluster Agent deployed as aprt of the first Helm chart.
+
+Use the following `values.yaml` file to configure communication between Agents deployed on Windows nodes and the Cluster Agent.
+
+```yaml
+targetSystem: windows
+existingClusterAgent:
+  join: true
+  serviceName: "<EXISTING_DCA_SECRET_NAME>" # from the first Datadog Helm chart
+  tokenSecretName: "<EXISTING_DCA_SERVICE_NAME>" # from the first Datadog Helm chart
+
+# Disable datadogMetrics deployment since it should have been already deployed with the first chart.
+datadog-crds:
+  crds:
+    datadogMetrics: false
+# Disable kube-state-metrics deployment
+datadog:
+  kubeStateMetricsEnabled: false
+```
+
+For more information, see [Troubleshooting Windows Container Issues][2].
+
 #### Monitoring AWS managed services
 
 To monitor an AWS managed service like MSK, ElastiCache, or RDS, set `clusterChecksRunner` to create a pod with an IAM role assigned through the serviceAccountAnnotation in the Helm chart. Then, set the integration configurations under `clusterAgent.confd`.
@@ -265,3 +291,4 @@ clusterAgent:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6v7#agent-information
+[2]: https://docs.datadoghq.com/agent/troubleshooting/windows_containers/#mixed-clusters-linux--windows

--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -238,9 +238,9 @@ Kubernetes events are beginning to flow into your Datadog account, and relevant 
 
 ### Windows containers
 
-The Datadog Cluster Agent can only deployed on Linux nodes.
+The Datadog Cluster Agent can only be deployed on Linux nodes.
 
-To monitor Windows containers, use two Helm charts in a mixed cluster. The first Helm chart deploys the Datadog Cluster Agent (with `targetSystem: linux`). The second Helm chart (with `targetSystem: windows`) targets only Windows nodes and connects to the existing Cluster Agent deployed as aprt of the first Helm chart.
+To monitor Windows containers, use two installations of the Helm chart in a mixed cluster. The first Helm chart deploys the Datadog Cluster Agent and the Agent DaemonSet for Linux nodes (with `targetSystem: linux`). The second Helm chart (with `targetSystem: windows`) deploys the Agent only on Windows nodes and connects to the existing Cluster Agent deployed as part of the first Helm chart.
 
 Use the following `values.yaml` file to configure communication between Agents deployed on Windows nodes and the Cluster Agent.
 

--- a/content/en/agent/troubleshooting/windows_containers.md
+++ b/content/en/agent/troubleshooting/windows_containers.md
@@ -63,7 +63,7 @@ kube-state-metrics:
 
 #### Mixed clusters with the Datadog Cluster Agent
 
-With Cluster Agent v1.18+, this configuration is supported by the Datadog Cluster Agent.
+With Cluster Agent v1.18+, a configuration with mixed clusters is supported by the Datadog Cluster Agent.
 
 Use the following `values.yaml` file to configure communication between Agents deployed on Windows nodes and the Cluster Agent.
 

--- a/content/en/agent/troubleshooting/windows_containers.md
+++ b/content/en/agent/troubleshooting/windows_containers.md
@@ -63,7 +63,7 @@ kube-state-metrics:
 
 #### Mixed clusters with the Datadog Cluster Agent
 
-With Cluster Agent v2.98+, this configuration is supported by the Datadog Cluster Agent.
+With Cluster Agent v1.18+, this configuration is supported by the Datadog Cluster Agent.
 
 Use the following `values.yaml` file to configure communication between Agents deployed on Windows nodes and the Cluster Agent.
 

--- a/content/en/agent/troubleshooting/windows_containers.md
+++ b/content/en/agent/troubleshooting/windows_containers.md
@@ -39,7 +39,7 @@ Live processes do not appear in containers (except for the Datadog Agent).
 
 ### Mixed clusters (Linux + Windows)
 
-The recommended way of deploying the Datadog Agent on a mixed cluster is to perform two installations of our Helm chart with a different `targetSystem`.
+The recommended way of deploying the Datadog Agent on a mixed cluster is to perform two installations of the Helm chart with different `targetSystem`s. 
 
 The Datadog Agent uses a `nodeSelector` to automatically select Linux or Windows nodes based on `targetSystem`.
 
@@ -60,6 +60,46 @@ kube-state-metrics:
 * Deploy Kube State Metrics yourself separately by setting `datadog.kubeStateMetricsEnabled` to `false`.
 
 **Note**: When using two Datadog installations (one with `targetSystem: linux`, one with `targetSystem: windows`), make sure the second one has `datadog.kubeStateMetricsEnabled` set to `false` to avoid deploying two instances of Kube State Metrics.
+
+#### Mixed clusters with the Datadog Cluster Agent
+
+With Cluster Agent v2.98+, this configuration is supported by the Datadog Cluster Agent.
+
+Use the following `values.yaml` file to configure communication between Agents deployed on Windows nodes and the Cluster Agent.
+
+```yaml
+targetSystem: windows
+existingClusterAgent:
+  join: true
+  serviceName: "<EXISTING_DCA_SECRET_NAME>" # from the first Datadog Helm chart
+  tokenSecretName: "<EXISTING_DCA_SERVICE_NAME>" # from the first Datadog Helm chart
+
+# Disable datadogMetrics deployment since it should have been already deployed with the first chart.
+datadog-crds:
+  crds:
+    datadogMetrics: false
+# Disable kube-state-metrics deployment
+datadog:
+  kubeStateMetricsEnabled: false
+```
+
+#### Limited configuration options for Windows deployments
+
+Some configuration options are not available on Windows. The following is a list of **unsupported** options:
+
+| Parameter                      | Reason |
+| --- | ----------- |
+| `datadog.dogstatsd.useHostPID` |  Host PID not supported on Windows containers |
+| `datadog.dogstatsd.useSocketVolume` | Unix sockets not supported on Windows |
+| `datadog.dogstatsd.socketPath` |  Unix sockets not supported on Windows |
+| `datadog.processAgent.processCollection` |  Unable to access host/other containers processes |
+| `datadog.systemProbe.seccomp` | System probe is not available for Windows |
+| `datadog.systemProbe.seccompRoot` | System probe is not available for Windows |
+| `datadog.systemProbe.debugPort` | System probe is not available for Windows |
+| `datadog.systemProbe.enableConntrack` | System probe is not available for Windows |
+| `datadog.systemProbe.bpfDebug` |  System probe is not available for Windows |
+| `datadog.systemProbe.apparmor` |  System probe is not available for Windows |
+| `agents.useHostNetwork` | Host network not supported by Windows Containers |
 
 ### HostPort for APM or DogStatsD
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

adds info about how you can monitor windows containers with the cluster agent

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/cswatt/windows-cluster/agent/troubleshooting/windows_containers/#mixed-clusters-linux--windows
https://docs-staging.datadoghq.com/cswatt/windows-cluster/agent/cluster_agent/setup/?tab=helm#windows-containers

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
