### PR TITLE
DOCS-3178 Simplify Javadoc links for DogStatsD clients

### DIFF
--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -489,7 +489,7 @@ For all available options, see [Datadog's GoDoc][1].
 {{< /programming-lang >}}
 {{< programming-lang lang="java" >}}
 
-As of v2.10.0 the recommended way to instantiate the client is via the NonBlockingStatsDClientBuilder. You
+As of v2.10.0 the recommended way to instantiate the client is with the NonBlockingStatsDClientBuilder. You
 can use the following builder methods to define the client parameters.
 
 | Builder Method                               | Type           | Default   | Description                                                                         |
@@ -501,23 +501,19 @@ can use the following builder methods to define the client parameters.
 | `blocking(boolean val)`                      | Boolean        | false     | The type of client to instantiate: blocking vs non-blocking.                        |
 | `socketBufferSize(int val)`                  | Integer        | -1        | The size of the underlying socket buffer.                                           |
 | `enableTelemetry(boolean val)`               | Boolean        | false     | Client telemetry reporting.                                                         |
-| `entityID(String val)`                       | String         | null      | Entitity ID for origin detection.                                                   |
+| `entityID(String val)`                       | String         | null      | Entity ID for origin detection.                                                   |
 | `errorHandler(StatsDClientErrorHandler val)` | Integer        | null      | Error handler in case of an internal client error.                                  |
-| `maxPacketSizeBytes(int val)`                | Integer        | 8192/1432 | The maxumum packet size; 8192 over UDS, 1432 for UDP.                               |
+| `maxPacketSizeBytes(int val)`                | Integer        | 8192/1432 | The maximum packet size; 8192 over UDS, 1432 for UDP.                               |
 | `processorWorkers(int val)`                  | Integer        | 1         | The number of processor worker threads assembling buffers for submission.           |
 | `senderWorkers(int val)`                     | Integer        | 1         | The number of sender worker threads submitting buffers to the socket.               |
 | `poolSize(int val)`                          | Integer        | 512       | Network packet buffer pool size.                                                    |
 | `queueSize(int val)`                         | Integer        | 4096      | Maximum number of unprocessed messages in the queue.                                |
 | `timeout(int val)`                           | Integer        | 100       | the timeout in milliseconds for blocking operations. Applies to unix sockets only.  |
 
-For more information, see the [NonBlockingStatsDClient Class][1] and [NonBlockingStatsDClientBuilder Class][2] documentation.
-
-If you are on an older client release, please see the deprecated constructor documentation [here][3].
+For more information, search the Java DogStatsD [package][1] for the NonBlockingStatsDClient Class and NonBlockingStatsDClientBuilder Class. Make sure you view the version that matches your client release.
 
 
-[1]: https://jar-download.com/javaDoc/com.datadoghq/java-dogstatsd-client/2.13.0/com/timgroup/statsd/NonBlockingStatsDClient.html
-[2]: https://jar-download.com/javaDoc/com.datadoghq/java-dogstatsd-client/2.13.0/com/timgroup/statsd/NonBlockingStatsDClientBuilder.html
-[3]: https://javadoc.io/static/com.datadoghq/java-dogstatsd-client/2.9.0/com/timgroup/statsd/NonBlockingStatsDClient.html
+[1]: https://javadoc.io/doc/com.datadoghq/java-dogstatsd-client/latest/index.html
 {{< /programming-lang >}}
 {{< programming-lang lang="PHP" >}}
 


### PR DESCRIPTION
### What does this PR do?
Fix typos and broken links on DogStatsD page

### Motivation
[DOCS-3178](https://datadoghq.atlassian.net/browse/DOCS-3178) A translator noticed some broken links on this page.

### Preview
https://docs-staging.datadoghq.com/uchen/dogstatsd-links/developers/dogstatsd/?tab=hostagent

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
