### PR TITLE
Change custom time set minimum 5min from 1min

### DIFF
--- a/content/en/monitors/create/types/log.md
+++ b/content/en/monitors/create/types/log.md
@@ -48,7 +48,7 @@ As you define the search query, the graph above the search fields updates.
 ### Set alert conditions
 
 * Trigger when the metric is `above`, `above or equal to`, `below`, or `below or equal to`
-* the threshold during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between `1 minute` and `2 days`.
+* the threshold during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between `5 minute` and `2 days`.
 * Alert threshold `<NUMBER>`
 * Warning threshold `<NUMBER>`
 


### PR DESCRIPTION
The minimum logs monitor evaluation time is 5min (recommended). Though in the UI customer can set custom time below 5min (all the way down to 1min). Time evaluation less than 5min cause the monitor to through `BADPARAM` error and the monitor goes to infinite `NO DATA` state. There are multiple escalations from the customer related to this issue and our engineering is aware of it. They are working on a fix which is a bit complicated and may take time. Which is why in the meantime we are going to update the logs monitor doc so that at least we can go back to the customer and say please use 5min or more as per the doc.

Issue 1: https://datadoghq.atlassian.net/browse/LOGSS-5430
Issue 2: https://datadoghq.atlassian.net/browse/LOGSS-5551

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
