### PR TITLE
ross-macwilliam/update_configure_time_aggregation

### DIFF
--- a/content/en/metrics/_index.md
+++ b/content/en/metrics/_index.md
@@ -96,7 +96,7 @@ After selecting a metric, you can filter your query based on tag(s). For instanc
 
 #### Configure time aggregation
 
-Next, choose the granularity of your data using time rollup. In this example, you've defined that there is one data point for every six minutes (360 seconds). You can also choose how you want to aggregate the data in each time bucket. By default, _avg_ is applied, but other available options are _sum_, _min_, _max_, and _count_. If you wanted to apply max, you would use `.rollup(max, 60)`.
+Next, choose the granularity of your data using time rollup. In this example, you've defined that there is one data point for every hour (3600 seconds). You can also choose how you want to aggregate the data in each time bucket. By default, _avg_ is applied, but other available options are _sum_, _min_, _max_, and _count_. If you wanted to apply max, you would use `.rollup(max, 60)`.
 
 #### Configure space aggregation
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Changing the Configure Time Aggregation to match the image of the metric query. It has 3600 seconds in the image, has 360 seconds in the Configure Time Aggregation
 
https://docs.datadoghq.com/metrics/#configure-time-aggregation

### Motivation
<!-- What inspired you to submit this pull request?-->
Small typo in the docs

### Preview
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/metrics/

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
