### PR TITLE
Remove note about version

### DIFF
--- a/layouts/shortcodes/appsec-getstarted-2-canary.md
+++ b/layouts/shortcodes/appsec-getstarted-2-canary.md
@@ -4,7 +4,7 @@
     <div>
     <pre><code>for ((i=1;i<=200;i++)); <br>do<br># Target existing service’s routes<br>curl https://your-application-url/existing-route -A dd-test-scanner-log;<br># Target non existing service’s routes<br>curl https://your-application-url/non-existing-route -A dd-test-scanner-log;<br>done</code></pre></div>
 
-    **Note**: The `dd-test-scanner-log` value is supported in the most recent releases and in the application security event configuration file version >= 1.2.5.
+    **Note**: The `dd-test-scanner-log` value is supported in the most recent releases.
 
     A few minutes after you enable your application and exercise it, **threat information appears in the [Application Trace and Signals Explorer][201] in Datadog**.
 


### PR DESCRIPTION
### What does this PR do?

Remove the part about the version because customers don't have access to that information.

### Motivation

Eng requested it.

### Preview

https://docs-staging.datadoghq.com/may/remove-version-note/security_platform/application_security/getting_started/java/

https://docs-staging.datadoghq.com/may/remove-version-note/security_platform/application_security/getting_started/dotnet/

https://docs-staging.datadoghq.com/may/remove-version-note/security_platform/application_security/getting_started/ruby/

https://docs-staging.datadoghq.com/may/remove-version-note/security_platform/application_security/getting_started/php/

https://docs-staging.datadoghq.com/may/remove-version-note/security_platform/application_security/getting_started/nodejs/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
