### PR TITLE
[DOCS-3040] Add AppSec troubleshooting links

### DIFF
--- a/content/en/security_platform/application_security/getting_started/_index.md
+++ b/content/en/security_platform/application_security/getting_started/_index.md
@@ -12,6 +12,9 @@ further_reading:
 - link: "/security_platform/default_rules/#cat-application-security"
   tag: "Documentation"
   text: "OOTB Application Security Rules"
+- link: "/security_platform/application_security/troubleshooting"
+  tag: "Documentation"
+  text: "Troubleshooting Application Security Monitoring"
 ---
 
 <div class="alert alert-warning">

--- a/content/en/security_platform/application_security/getting_started/dotnet.md
+++ b/content/en/security_platform/application_security/getting_started/dotnet.md
@@ -11,6 +11,9 @@ further_reading:
     - link: "/security_platform/default_rules/#cat-application-security"
       tag: "Documentation"
       text: "OOTB Application Security Rules"
+    - link: "/security_platform/application_security/troubleshooting"
+      tag: "Documentation"
+      text: "Troubleshooting Application Security Monitoring"
 ---
 
 {{% appsec-getstarted %}}

--- a/content/en/security_platform/application_security/getting_started/go.md
+++ b/content/en/security_platform/application_security/getting_started/go.md
@@ -11,6 +11,9 @@ further_reading:
     - link: "/security_platform/default_rules/#cat-application-security"
       tag: "Documentation"
       text: "OOTB Application Security Rules"
+    - link: "/security_platform/application_security/troubleshooting"
+      tag: "Documentation"
+      text: "Troubleshooting Application Security Monitoring"
 ---
 
 {{% appsec-getstarted %}}

--- a/content/en/security_platform/application_security/getting_started/java.md
+++ b/content/en/security_platform/application_security/getting_started/java.md
@@ -11,6 +11,10 @@ further_reading:
 - link: "/security_platform/default_rules/#cat-application-security"
   tag: "Documentation"
   text: "OOTB Application Security Rules"
+- link: "/security_platform/application_security/troubleshooting"
+  tag: "Documentation"
+  text: "Troubleshooting Application Security Monitoring"
+
 ---
 
 {{% appsec-getstarted %}}

--- a/content/en/security_platform/application_security/getting_started/nodejs.md
+++ b/content/en/security_platform/application_security/getting_started/nodejs.md
@@ -11,6 +11,9 @@ further_reading:
     - link: "/security_platform/default_rules/#cat-application-security"
       tag: "Documentation"
       text: "OOTB Application Security Rules"
+    - link: "/security_platform/application_security/troubleshooting"
+      tag: "Documentation"
+      text: "Troubleshooting Application Security Monitoring"
 ---
 
 {{% appsec-getstarted %}}

--- a/content/en/security_platform/application_security/getting_started/php.md
+++ b/content/en/security_platform/application_security/getting_started/php.md
@@ -14,6 +14,9 @@ further_reading:
     - link: "/security_platform/default_rules/#cat-application-security"
       tag: "Documentation"
       text: "OOTB Application Security Rules"
+    - link: "/security_platform/application_security/troubleshooting"
+      tag: "Documentation"
+      text: "Troubleshooting Application Security Monitoring"
 ---
 
 {{% appsec-getstarted %}}

--- a/content/en/security_platform/application_security/getting_started/ruby.md
+++ b/content/en/security_platform/application_security/getting_started/ruby.md
@@ -11,6 +11,9 @@ further_reading:
     - link: "/security_platform/default_rules/#cat-application-security"
       tag: "Documentation"
       text: "OOTB Application Security Rules"
+    - link: "/security_platform/application_security/troubleshooting"
+      tag: "Documentation"
+      text: "Troubleshooting Application Security Monitoring"
 ---
 
 {{% appsec-getstarted %}}

--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -11,6 +11,9 @@ further_reading:
 - link: "/security_platform/default_rules/#cat-application-security"
   tag: "Documentation"
   text: "Out-of-the-Box Application Security Rules"
+- link: "/security_platform/application_security/troubleshooting"
+  tag: "Documentation"
+  text: "Troubleshooting Application Security Monitoring"
 ---
 
 <div class="alert alert-warning">


### PR DESCRIPTION
### What does this PR do?

Adds the AppSec troubleshooting link to the further reading sections of the Getting Started and Setup / Config pages.

### Motivation

DOCS-3040

### Preview

https://docs-staging.datadoghq.com/may/add-troubleshooting-link/security_platform/application_security/getting_started/

https://docs-staging.datadoghq.com/may/remove-version-note/security_platform/application_security/getting_started/java/

https://docs-staging.datadoghq.com/may/remove-version-note/security_platform/application_security/getting_started/dotnet/

https://docs-staging.datadoghq.com/may/remove-version-note/security_platform/application_security/getting_started/ruby/

https://docs-staging.datadoghq.com/may/remove-version-note/security_platform/application_security/getting_started/php/

https://docs-staging.datadoghq.com/may/remove-version-note/security_platform/application_security/getting_started/nodejs/

https://docs-staging.datadoghq.com/may/add-troubleshooting-link/security_platform/application_security/setup_and_configure/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
