### PR TITLE
[DOCS-3199] Update APM dashboard link

### DIFF
--- a/content/en/tracing/trace_retention/usage_metrics.md
+++ b/content/en/tracing/trace_retention/usage_metrics.md
@@ -59,5 +59,5 @@ Because Indexed Spans can impact your bill, the 'Spans Indexed' column appears a
 [2]: /tracing/trace_ingestion/ingestion_controls
 [3]: https://www.datadoghq.com/pricing/?product=apm#apm
 [4]: /account_management/billing/apm_distributed_tracing/
-[5]: https://app.datadoghq.com/dashboard/lists?q=APM+Traces+-+Estimated+Usage
+[5]: https://app.datadoghq.com/dash/integration/30337/apm-traces---estimated-usage
 [6]: /tracing/trace_retention/#datadog-intelligent-retention-filter


### PR DESCRIPTION
### What does this PR do?

Change APM dashboard link to go to the actual dashboard.

### Motivation

DOCS-3199

### Preview

https://docs-staging.datadoghq.com/may/update-apm-dashboard-link/tracing/trace_retention/usage_metrics

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
