### PR TITLE
zachg fixing command from status to info

### DIFF
--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -153,7 +153,7 @@ For other environments, please refer to the [Integrations][5] documentation for 
 {{% /tab %}}
 {{< /tabs >}}
 
-Once you've finished setup and are running the tracer with your application, you can run `ddtrace-run --status` to check that configurations are working as expected. Note that the output from this command does not reflect configuration changes made during runtime in code.
+Once you've finished setup and are running the tracer with your application, you can run `ddtrace-run --info` to check that configurations are working as expected. Note that the output from this command does not reflect configuration changes made during runtime in code.
 
 For more advanced usage, configuration, and fine-grain control, see Datadog's [API documentation][3].
 


### PR DESCRIPTION


### What does this PR do?
Fix the flag to get information once you've setup tracing.

### Motivation
The flag was incorrect and status does not exist, it should be info



### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
