### PR TITLE
chore(tracing/python): add documentation for DD_TRACE_RATE_LIMIT

### DIFF
--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -185,6 +185,9 @@ It is recommended to use `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, 
 `DD_TRACE_SAMPLE_RATE`
 : Enable [Tracing without Limits][8].
 
+`DD_TRACE_RATE_LIMIT`
+: Maximum number of spans to sample per-second, per-Python process. Defaults to `100` when `DD_TRACE_SAMPLE_RATE` is set. Otherwise, delegates rate limiting to the Datadog Agent.
+
 `DD_TAGS`
 : A list of default tags to be added to every span and profile, for example: `layer:api,team:intake`. Available in version 0.38+.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Document an existing `DD_TRACE_RATE_LIMIT` environment variable/configuration for the Python tracing client.

### Motivation
This is currently only documented on the tracing client's own API docs, but we want it to be present/available here as well.

### Preview
<!-- Impacted pages preview links-->

https://docs-staging.datadoghq.com/brettlangdon/rate.limit.doc/tracing/setup_overview/setup/python#configuration

<img width="799" alt="image" src="https://user-images.githubusercontent.com/1320353/156765421-504ed50d-6297-4b57-b0b0-d15d88108a1f.png">


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
