### PR TITLE
Adjust global padding-top for tablet viewports

### DIFF
--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -43,7 +43,7 @@ iframe {
     //padding-top: 159px;
 
     @include media-breakpoint-between(md, lg) {
-        padding-top: 100px;
+        padding-top: 130px;
     }
 }
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- fixes a nav overlap issue with the main content container on tablet-sized (< 1200 > 991px) viewports
![image](https://user-images.githubusercontent.com/62921667/156809298-db6fb73b-42f2-481d-ace1-884947aa33eb.png)


### Motivation
https://datadoghq.atlassian.net/browse/WEB-2192

### Preview

https://docs-staging.datadoghq.com/carlos/global-padding-top-tablet/
- [ ] navigate through pages on Docs at a viewport size of < 1200 and > 991px and confirm there is no overlap of the nav and the main content container as seen in the screenshot above.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
