### PR TITLE
[ci-visibility] Instructions for `datadog-ci` standalone binary

### DIFF
--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -32,13 +32,16 @@ npm install -g @datadog/datadog-ci
 
 ### Standalone binary (beta)
 
-If installing node in your environment is an issue, it's possible to use the standalone binary version of the library:
+If installing nodejs in the CI is an issue, a standalone binary is provided with releases. Only _linux-x64_, _darwin-x64_ (macOS) and _win-x64_ (Windows) are supported at the time. To install for linux:
 
 {{< code-block lang="bash" >}}
-curl https://raw.githubusercontent.com/DataDog/datadog-ci/master/quick-install.sh | bash
+curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci-linux" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
 {{< /code-block >}}
 
-<div class="alert alert-warning"><strong>Note</strong>: the standalone binary is in beta and its stability is not guaranteed.</div>
+For other operating systems, change the URL to the corresponding OS: https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci-win.exe or https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci-macos.
+
+
+<div class="alert alert-warning"><strong>Note</strong>: the standalone binaries are in beta and their stability is not guaranteed.</div>
 
 
 ## Uploading test reports

--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -32,7 +32,7 @@ npm install -g @datadog/datadog-ci
 
 ### Standalone binary (beta)
 
-If installing nodejs in the CI is an issue, standalone binaries are provided with [releases][3]. Only _linux-x64_, _darwin-x64_ (MacOS) and _win-x64_ (Windows) are supported at the time. To install:
+If installing NodeJS in the CI is an issue, standalone binaries are provided with [Datadog CI releases][3]. Only _linux-x64_, _darwin-x64_ (MacOS) and _win-x64_ (Windows) are supported. To install, run the following from your CLI:
 
 {{< tabs >}}
 {{% tab "Linux" %}}
@@ -75,7 +75,7 @@ Start-Process -FilePath "./datadog-ci.exe" -ArgumentList version
 
 {{< /tabs >}}
 
-<div class="alert alert-warning"><strong>Note</strong>: the standalone binaries are in <strong>beta</strong> and their stability is not guaranteed.</div>
+<div class="alert alert-warning"><strong>Note</strong>: The standalone binaries are in <strong>beta</strong> and their stability is not guaranteed.</div>
 
 
 ## Uploading test reports

--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -32,16 +32,50 @@ npm install -g @datadog/datadog-ci
 
 ### Standalone binary (beta)
 
-If installing nodejs in the CI is an issue, a standalone binary is provided with releases. Only _linux-x64_, _darwin-x64_ (macOS) and _win-x64_ (Windows) are supported at the time. To install for linux:
+If installing nodejs in the CI is an issue, standalone binaries are provided with [releases][3]. Only _linux-x64_, _darwin-x64_ (MacOS) and _win-x64_ (Windows) are supported at the time. To install:
 
+{{< tabs >}}
+{{% tab "Linux" %}}
 {{< code-block lang="bash" >}}
-curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci-linux" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
+curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
 {{< /code-block >}}
 
-For other operating systems, change the URL to the corresponding OS: https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci-win.exe or https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci-macos.
+Then run any command via `datadog-ci`:
+{{< code-block lang="bash" >}}
+datadog-ci version
+{{< /code-block >}}
+
+{{% /tab %}}
+
+{{% tab "MacOS" %}}
+{{< code-block lang="bash" >}}
+curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_darwin-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
+{{< /code-block >}}
+
+Then run any command via `datadog-ci`:
+{{< code-block lang="bash" >}}
+datadog-ci version
+{{< /code-block >}}
+
+{{% /tab %}}
 
 
-<div class="alert alert-warning"><strong>Note</strong>: the standalone binaries are in beta and their stability is not guaranteed.</div>
+
+{{% tab "Windows" %}}
+{{< code-block lang="powershell" >}}
+Invoke-WebRequest -Uri "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_win-x64.exe" -OutFile "datadog-ci.exe"
+{{< /code-block >}}
+
+Then run any command via `Start-Process -FilePath "datadog-ci.exe"`:
+{{< code-block lang="powershell" >}}
+Start-Process -FilePath "./datadog-ci.exe" -ArgumentList version
+{{< /code-block >}}
+
+{{% /tab %}}
+
+{{< /tabs >}}
+
+<div class="alert alert-warning"><strong>Note</strong>: the standalone binaries are in <strong>beta</strong> and their stability is not guaranteed.</div>
 
 
 ## Uploading test reports
@@ -52,7 +86,7 @@ To upload your JUnit XML test reports to Datadog, run the following command, spe
 datadog-ci junit upload --service <service_name> <path> [<path> ...]
 {{< /code-block >}}
 
-Specify a valid [Datadog API key][3] in the `DATADOG_API_KEY` environment variable, and the environment where tests were run (for example, `local` when uploading results from a developer workstation, or `ci` when uploading them from a CI provider) in the `DD_ENV` environment variable. For example:
+Specify a valid [Datadog API key][4] in the `DATADOG_API_KEY` environment variable, and the environment where tests were run (for example, `local` when uploading results from a developer workstation, or `ci` when uploading them from a CI provider) in the `DD_ENV` environment variable. For example:
 
 <pre>
 <code>
@@ -97,19 +131,19 @@ Positional arguments
 The following environment variables are supported:
 
 `DATADOG_API_KEY` (Required)
-: [Datadog API key][3] used to authenticate the requests.<br/>
+: [Datadog API key][4] used to authenticate the requests.<br/>
 **Default**: (none)
 
 Additionally, configure the Datadog site to use the selected one ({{< region-param key="dd_site_name" >}}):
 
 `DATADOG_SITE` (Required)
-: The [Datadog site][4] to upload results to.<br/>
+: The [Datadog site][5] to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
 **Selected site**: {{< region-param key="dd_site" code="true" >}}
 
 ## Collecting repository and commit metadata
 
-Datadog uses Git information for visualizing your test results and grouping them by repository and commit. Git metadata is collected by the Datadog CI CLI from CI provider environment variables and the local `.git` folder in the project path, if available. To read this directory, the [`git`][5] binary is required.
+Datadog uses Git information for visualizing your test results and grouping them by repository and commit. Git metadata is collected by the Datadog CI CLI from CI provider environment variables and the local `.git` folder in the project path, if available. To read this directory, the [`git`][6] binary is required.
 
 If you are running tests in non-supported CI providers or with no `.git` folder, you can set the Git information manually using environment variables. These environment variables take precedence over any auto-detected information. Set the following environment variables to provide Git information:
 
@@ -251,6 +285,7 @@ To be processed, the `name` attribute in the `<property>` element must have the 
 
 [1]: https://junit.org/junit5/
 [2]: https://www.npmjs.com/package/@datadog/datadog-ci
-[3]: https://app.datadoghq.com/organization-settings/api-keys
-[4]: /getting_started/site/
-[5]: https://git-scm.com/downloads
+[3]: https://github.com/DataDog/datadog-ci/releases
+[4]: https://app.datadoghq.com/organization-settings/api-keys
+[5]: /getting_started/site/
+[6]: https://git-scm.com/downloads

--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -30,6 +30,17 @@ Install the [`datadog-ci`][2] CLI globally using `npm`:
 npm install -g @datadog/datadog-ci
 {{< /code-block >}}
 
+### Standalone binary (beta)
+
+If installing node in your environment is an issue, it's possible to use the standalone binary version of the library:
+
+{{< code-block lang="bash" >}}
+curl https://raw.githubusercontent.com/DataDog/datadog-ci/master/quick-install.sh | bash
+{{< /code-block >}}
+
+<div class="alert alert-warning"><strong>Note</strong>: the standalone binary is in beta and its stability is not guaranteed.</div>
+
+
 ## Uploading test reports
 
 To upload your JUnit XML test reports to Datadog, run the following command, specifying the name of the service or library that was tested using the `--service` parameter, and one or more file paths to either the XML report files directly or directories containing them:

--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -40,7 +40,7 @@ If installing nodejs in the CI is an issue, standalone binaries are provided wit
 curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
 {{< /code-block >}}
 
-Then run any command via `datadog-ci`:
+Then run any command with `datadog-ci`:
 {{< code-block lang="bash" >}}
 datadog-ci version
 {{< /code-block >}}
@@ -52,7 +52,7 @@ datadog-ci version
 curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_darwin-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
 {{< /code-block >}}
 
-Then run any command via `datadog-ci`:
+Then run any command with `datadog-ci`:
 {{< code-block lang="bash" >}}
 datadog-ci version
 {{< /code-block >}}
@@ -66,7 +66,7 @@ datadog-ci version
 Invoke-WebRequest -Uri "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_win-x64.exe" -OutFile "datadog-ci.exe"
 {{< /code-block >}}
 
-Then run any command via `Start-Process -FilePath "datadog-ci.exe"`:
+Then run any command with `Start-Process -FilePath "datadog-ci.exe"`:
 {{< code-block lang="powershell" >}}
 Start-Process -FilePath "./datadog-ci.exe" -ArgumentList version
 {{< /code-block >}}

--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -32,7 +32,9 @@ npm install -g @datadog/datadog-ci
 
 ### Standalone binary (beta)
 
-If installing NodeJS in the CI is an issue, standalone binaries are provided with [Datadog CI releases][3]. Only _linux-x64_, _darwin-x64_ (MacOS) and _win-x64_ (Windows) are supported. To install, run the following from your CLI:
+<div class="alert alert-warning"><strong>Note</strong>: The standalone binaries are in <strong>beta</strong> and their stability is not guaranteed.</div>
+
+If installing NodeJS in the CI is an issue, standalone binaries are provided with [Datadog CI releases][3]. Only _linux-x64_, _darwin-x64_ (MacOS) and _win-x64_ (Windows) are supported. To install, run the following from your terminal:
 
 {{< tabs >}}
 {{% tab "Linux" %}}
@@ -75,7 +77,6 @@ Start-Process -FilePath "./datadog-ci.exe" -ArgumentList version
 
 {{< /tabs >}}
 
-<div class="alert alert-warning"><strong>Note</strong>: The standalone binaries are in <strong>beta</strong> and their stability is not guaranteed.</div>
 
 
 ## Uploading test reports


### PR DESCRIPTION
### What does this PR do?
Include instructions for the usage of `datadog-ci`'s standalone binary.

### Motivation
Make it simpler to use `datadog-ci`, without needing to install `node` in your environment. 

### Preview
https://docs-staging.datadoghq.com/juan-fernandez/standalone-binary-datadog-ci/continuous_integration/setup_tests/junit_upload/#standalone-binary-beta

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
