### PR TITLE
[WEB-2196] Adding rapdev_services md to ignored files config

### DIFF
--- a/translate.yaml
+++ b/translate.yaml
@@ -30,6 +30,7 @@ ignores:
   - "content/en/**/faq/!(agent_v6_changes|certificate_verify_failed-error).md"
   - "content/en/security_platform/default_rules/*.md"
   - "content/en/security_monitoring/default_rules/*.md"
+  - "content/en/integrations/rapdev_services.md"
   - "**/*.fr.md"
   - "**/*.fr.yaml"
   - "**/*.fr.json"


### PR DESCRIPTION
### What does this PR do?
Ignore `rapdev_services` in the translation config so the file will not be sent to Transifex.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2196

### Preview
n/a

### Additional Notes
The resource was deleted directly in Transifex, and there is a marketplace PR to hide the tile from the Docs site.  https://github.com/DataDog/marketplace/pull/352.   When this work is ready to go public we will have to remove the redirect from CloudOps as well.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
