### PR TITLE
Manually Adding the Browser Test Chrome Extension to Internal Applications Stores Guide Edits

### DIFF
--- a/content/en/synthetics/guide/manually-adding-chrome-extension.md
+++ b/content/en/synthetics/guide/manually-adding-chrome-extension.md
@@ -35,4 +35,4 @@ If you are unable to download applications directly from the Chrome Web Store be
 [2]: https://app.datadoghq.com/synthetics/browser/create
 [3]: /synthetics/browser_tests/#configuration
 [4]: /synthetics/browser_tests/#record-test
-[5]: https://www.crx4chrome.com/crx/190075/
+[5]: https://github.com/DataDog/synthetics-browser-extension

--- a/content/en/synthetics/guide/manually-adding-chrome-extension.md
+++ b/content/en/synthetics/guide/manually-adding-chrome-extension.md
@@ -5,27 +5,34 @@ further_reading:
     - link: 'https://www.datadoghq.com/blog/browser-tests/'
       tag: 'Blog'
       text: 'User experience monitoring with Datadog Browser Tests'
-    - link: 'synthetics/browser_tests'
+    - link: '/synthetics/browser_tests'
       tag: 'Documentation'
-      text: 'Configure a Browser Test'
+      text: 'Create a browser Test'
 ---
 
-If you are unable to download applications directly from the Chrome Web Store for security reasons, you can still record Synthetic browser tests by leveraging Datadog's smart extension detection system (available starting from extension version 3.1.6).
+## Overview
 
-1. Download the [Datadog test recorder extension][1] CRX file.
-2. Upload this CRX file to your internal application store and repackage it. The icon of your new extension should appear in your Chrome browser, next to your other Chrome extensions.
-  {{< img src="synthetics/guide/manually_adding_chrome_extension/icon.png" alt="the icon that appears in your browser">}}
-3. Start creating your [browser test][2]: [define your test configuration][3] (test name, tags, locations, frequency, etc.), then click `Save Details & Record Test`. You are on the recorder page: you should see a message asking you to download the [Datadog test recorder extension][1] to get started with your recording.
-4. Click the icon that just appeared at the top right hand corner of your browser. The [Datadog test recorder extension][1] automatically detects the extension that was uploaded to your internal application store and you’re now able to [start recording your browser test’ steps][4].
-  {{< img src="synthetics/guide/manually_adding_chrome_extension/record_test.png" alt="record your browser tests">}}
+If you are unable to download applications directly from the Chrome Web Store because of security reasons, leverage Datadog's extension detection system, available for the Datadog Synthetics Chrome Extension v3.1.6+, to record Synthetic browser tests.
 
-**Note:** Manually update your internal extension when Datadog releases test recorder extension updates.
+1. Download the Datadog test recorder extension's [latest CRX file][5].
+2. Upload this CRX file to your internal application store and repackage it. Your new extension's icon appears in the Chrome browser next to your extensions.
+  
+   {{< img src="synthetics/guide/manually_adding_chrome_extension/icon.png" alt="the icon that appears in your browser" style="width:100%;" >}}
+
+3. Create your [browser test][2] by [defining your test configuration][3] (such as the test name, tags, locations, and frequency) and clicking **Save Details & Record Test**. To get started with your recording, first download the [Datadog test recorder extension][1].
+4. Click the recorder extension icon on the top right hand corner of your browser. The Datadog test recorder extension automatically detects the extension uploaded in your internal application store.
+5. Start [recording your browser test's steps][4] and click **Save Recording** when you're done. 
+  
+   {{< img src="synthetics/guide/manually_adding_chrome_extension/record_test.png" alt="record your browser tests" style="width:100%;" >}}
+
+**Note:** Datadog releases test recorder extension updates on the [Chrome Web Store][1]. You can manually update your internal extension to record browser tests.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://chrome.google.com/webstore/detail/datadog-test-recorder/kkbncfpddhdmkfmalecgnphegacgejoa?hl=en
-[2]: /synthetics/browser_tests
+[2]: https://app.datadoghq.com/synthetics/browser/create
 [3]: /synthetics/browser_tests/#configuration
 [4]: /synthetics/browser_tests/#record-test
+[5]: https://www.crx4chrome.com/crx/190075/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Copy edits + adds new links to the CRX file and in-app workflow.

### Motivation
<!-- What inspired you to submit this pull request?-->

Slack with Alex

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/synthetics-manual-chrome-extension-guide-update/synthetics/guide/manually-adding-chrome-extension/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
