### PR TITLE
DOCS-2567 Preview Staging Branch

### DIFF
--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -551,14 +551,14 @@
               text: "Explore your services, resources, and traces"
 
     - action: pull-and-push-folder
-      branch: master
+      branch: alai97/crash-reportin-error-tracking-doc-edits
       globs:
         - docs/rum_collection/*
       options:
         dest_dir: '/real_user_monitoring/ios/'
         path_to_remove: 'docs/rum_collection/'
         front_matters:
-          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
+          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/alai97/crash-reportin-error-tracking-doc-edits/docs/rum_collection/" ]
 
     - action: pull-and-push-folder
       branch: master


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Previews updates to iOS Crash Reporting and Error Tracking doc page in PR [#776](https://github.com/DataDog/dd-sdk-ios/pull/776).

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-2567

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/crash-reporting-error-tracking-doc-edits/real_user_monitoring/ios/crash_reporting/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Delete this PR when you are ready to merge.
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
