### PR TITLE
agent: update agent overhead section from version 6.7.0 to 7.34.0

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -256,13 +256,13 @@ Enabling JMX Checks forces the Agent to use more memory depending on the number 
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
 
-* Agent Test version: 6.7.0
-* CPU: ~ 0.12% of the CPU used on average
-* Memory: ~ 60MB of RAM used (RSS memory)
-* Network bandwidth: ~ 86 B/s ▼ | 260 B/s ▲
+* Agent Test version: 7.34.0
+* CPU: ~ 0.08% of the CPU used on average
+* Memory: ~ 130MB of RAM used (RSS memory)
+* Network bandwidth: ~ 140 B/s ▼ | 800 B/s ▲
 * Disk:
-  * Linux 350MB to 400MB depending on the distribution
-  * Windows: 260MB
+  * Linux 850MB to 1.2GB depending on the distribution
+  * Windows: 870MB
 
 {{% /tab %}}
 {{% tab "Agent v5" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR update the Agent Overhead values. Previous values were on the version 6.7.0 of the Agent.
New values are from the most recent version : 7.34.0.

### Motivation
<!-- What inspired you to submit this pull request?-->

6.7.0 is a really old version of the agent. Several changes that impact the overhead have been added since and so values were out of date.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nicolas.guerguadj/update-agent-overhead/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

All values were computed using EC2 instances on AWS. (4 VCPU/ 8GB RAM)

* CPU and Memory were computed using Datadog with process-agent enabled.
       x86  ~ 135MB RSS
       ARM ~ 120MB RSS 
* Bandwidth was computed using tools such as `nethogs`.
       Note: most of the time agent does not send nor receive data. Values here are thoses the agent send and receive at a regular interval.
* Disk usage was computed using tools such as `df` before and after the installation from a brand new instance. Those values might be lower if dependencies are already installed. 
       ~860MB on Amazon Linux 2
       ~1.2GB on Ubuntu 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
