### PR TITLE
[DOCS-3184] Update docker flare command

### DIFF
--- a/content/en/agent/troubleshooting/send_a_flare.md
+++ b/content/en/agent/troubleshooting/send_a_flare.md
@@ -28,7 +28,7 @@ If you don't have a case ID, just enter your email address used to login in Data
 | Platform   | Command                                                 |
 |------------|---------------------------------------------------------|
 | AIX        | `datadog-agent flare <CASE_ID>`                         |
-| Docker     | `docker exec -it datadog-agent agent flare <CASE_ID>`   |
+| Docker     | `docker exec -it dd-agent agent flare <CASE_ID>`        |
 | macOS      | `datadog-agent flare <CASE_ID>` or via the [web GUI][1] |
 | CentOS     | `sudo datadog-agent flare <CASE_ID>`                    |
 | Debian     | `sudo datadog-agent flare <CASE_ID>`                    |


### PR DESCRIPTION
### What does this PR do?

Update the docker flare command because the Datadog agent container is named `dd-agent` and not `datadog-agent`.

### Motivation

DOCS-3184

### Preview

https://docs-staging.datadoghq.com/may/update-docker-flare-command/agent/troubleshooting/send_a_flare/?tab=agentv6v7#pagetitle

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
