### PR TITLE
[DOCS-3211] Update trace remapper link

### DIFF
--- a/content/en/logs/log_configuration/pipelines.md
+++ b/content/en/logs/log_configuration/pipelines.md
@@ -146,7 +146,7 @@ Specify alternate attributes to use as the source of a log's trace ID by setting
 
 
 [1]: /tracing/connect_logs_and_traces/
-[2]: /logs/log_configuration/#trace-remapper
+[2]: /logs/log_configuration/processors/#trace-remapper
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
### What does this PR do?

Update the link to the trace remapper which is now in the logs processors' page.

### Motivation

DOCS-3211

### Preview

https://docs-staging.datadoghq.com/may/update-trace-remapper-link/logs/log_configuration/pipelines/?tab=traceid#trace-id-attribute

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
