### PR TITLE
[APM/PHP] Add spans limit property

### DIFF
--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -366,7 +366,7 @@ A JSON encoded string to configure the sampling rate. Examples: Set the sample r
 `DD_TRACE_SPANS_LIMIT`
 : **INI**: `datadog.trace.spans_limit`
 **Default**: `null`<br>
-The maximum number of spans that are generated within one trace. If this amount of span is reached, then no more spans are generated. If this limit is increased, then the amount of memory that is occupied by a pending trace will increase and might reach the PHP maximum amount of allowed memory. The maximum amount of allowed memory can be increased by the PHP INI system setting `memory_limit`.
+The maximum number of spans that are generated within one trace. If the maximum number of spans is reached, then spans are no longer generated. If the limit is increased, then the amount of memory that is used by a pending trace will increase and might reach the PHP maximum amount of allowed memory. The maximum amount of allowed memory can be increased with the PHP INI system setting `memory_limit`.
 
 `DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED`
 : **INI**: `datadog.trace.url_as_resource_names_enabled`<br>

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -365,7 +365,7 @@ A JSON encoded string to configure the sampling rate. Examples: Set the sample r
 
 `DD_TRACE_SPANS_LIMIT`
 : **INI**: `datadog.trace.spans_limit`
-**Default**: `null`<br>
+**Default**: `1000`<br>
 The maximum number of spans that are generated within one trace. If the maximum number of spans is reached, then spans are no longer generated. If the limit is increased, then the amount of memory that is used by a pending trace will increase and might reach the PHP maximum amount of allowed memory. The maximum amount of allowed memory can be increased with the PHP INI system setting `memory_limit`.
 
 `DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED`

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -363,6 +363,11 @@ The sampling rate for the traces (defaults to: between `0.0` and `1.0`). For ver
 **Default**: `null`<br>
 A JSON encoded string to configure the sampling rate. Examples: Set the sample rate to 20%: `'[{"sample_rate": 0.2}]'`. Set the sample rate to 10% for services starting with 'a' and span name 'b' and set the sample rate to 20% for all other services: `'[{"service": "a.*", "name": "b", "sample_rate": 0.1}, {"sample_rate": 0.2}]'` (see [Integration names](#integration-names)). Note that the JSON object **must** be included in single quotes (`'`) to avoid problems with escaping of the double quote (`"`) character.|
 
+`DD_TRACE_SPANS_LIMIT`
+: **INI**: `datadog.trace.spans_limit`
+**Default**: `null`<br>
+The maximum number of spans that are generated within one trace. If this amount of span is reached, then no more spans are generated. If this limit is increased, then the amount of memory that is occupied by a pending trace will increase and might reach the PHP maximum amount of allowed memory. The maximum amount of allowed memory can be increased by the PHP INI system setting `memory_limit`.
+
 `DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED`
 : **INI**: `datadog.trace.url_as_resource_names_enabled`<br>
 **Default**: `true`<br>


### PR DESCRIPTION
### What does this PR do?
Add `DD_TRACE_SPANS_LIMIT` property description to our docs.

### Preview

https://docs-staging.datadoghq.com/apm/php/span-limit/tracing/setup_overview/setup/php/?tab=containers#configuration

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
