### PR TITLE
[CIAPP] Show a disclaimer about 1k flaky tests limit in the flaky tests management page.

### DIFF
--- a/content/en/continuous_integration/guides/flaky_test_management.md
+++ b/content/en/continuous_integration/guides/flaky_test_management.md
@@ -26,6 +26,8 @@ The app helps you prioritize flaky tests by providing the following information 
 
 Once you identify a flaky test you want to fix, click on the test to see links to view the most recent failed test run or the first flaky test run.
 
+<div class="alert alert-info"><strong>Note</strong>: The table is limited to the 1000 flaky tests that exhibited more flakiness in the selected time window.</div>
+
 ## Remediation
 
 If a flaky test has not failed in the past 30 days, it is automatically removed from the table. You can also manually remove a flaky test by clicking on the trash icon that appears when you hover over the test row. It is added again if it re-exhibits flaky behavior.

--- a/content/en/continuous_integration/guides/flaky_test_management.md
+++ b/content/en/continuous_integration/guides/flaky_test_management.md
@@ -26,7 +26,7 @@ The app helps you prioritize flaky tests by providing the following information 
 
 Once you identify a flaky test you want to fix, click on the test to see links to view the most recent failed test run or the first flaky test run.
 
-<div class="alert alert-info"><strong>Note</strong>: The table is limited to the 1000 flaky tests that exhibited flakiness in more commits for the selected time window.</div>
+<div class="alert alert-info"><strong>Note</strong>: The table is limited to the 1000 flaky tests with the highest number of commits flaked for the selected time frame.</div>
 
 ## Remediation
 

--- a/content/en/continuous_integration/guides/flaky_test_management.md
+++ b/content/en/continuous_integration/guides/flaky_test_management.md
@@ -26,7 +26,7 @@ The app helps you prioritize flaky tests by providing the following information 
 
 Once you identify a flaky test you want to fix, click on the test to see links to view the most recent failed test run or the first flaky test run.
 
-<div class="alert alert-info"><strong>Note</strong>: The table is limited to the 1000 flaky tests that exhibited more flakiness in the selected time window.</div>
+<div class="alert alert-info"><strong>Note</strong>: The table is limited to the 1000 flaky tests that exhibited flakiness in more commits for the selected time window.</div>
 
 ## Remediation
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR adds a disclaimer in the flaky tests management section informing that there is a limit in the flaky tests we're showing in that table of 1000 flaky tests.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/drodriguezhdez/add_disclaimer_max_1k_flaky_tests/continuous_integration/guides/flaky_test_management

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
