### PR TITLE
tracing(python): update aiohttp support

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/python.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/python.md
@@ -28,7 +28,8 @@ The `ddtrace` library includes support for a number of web frameworks, including
 | Framework                 | Supported Version | Automatic | Library Documentation                                              |
 | ------------------------- | ----------------- | --------- |------------------------------------------------------------------ |
 | [asgi][3]                 | >= 2.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#asgi    |
-| [aiohttp][4]              | >= 1.2            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp |
+| [aiohttp][4] (client)     | >= 2.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp |
+| [aiohttp][4] (server)     | >= 2.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp |
 | [Bottle][5]               | >= 0.11           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#bottle  |
 | [CherryPy][6]            | >= 11.2.0         | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#cherrypy|
 | [Django][7]               | >= 1.8            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#django  |


### PR DESCRIPTION

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update documented aiohttp support

### Motivation
<!-- What inspired you to submit this pull request?-->

The aiohttp integration has been updated https://github.com/DataDog/dd-trace-py/pull/3362

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

PR on hold until the upstream PR is merged and released.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
