### PR TITLE
Update documentation for collecting Boolean string mBeans 

### DIFF
--- a/content/en/integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect.md
+++ b/content/en/integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect.md
@@ -66,18 +66,19 @@ instances:
       service: master
     conf:
       - include:
+          domain: Hadoop
           bean: "Hadoop:service=HBase,name=Master,sub=Server"
           [...]
             tag.isActiveMaster:
               alias: jmx.hadoop.hbase.master.server.tag.isActiveMaster
-              metric_type: gauge
-              values:
-                true: 1
-                false: 0
+              attribute:
+                tag.isActiveMaster:
+                  metric_type: gauge
+
               # Note: If using Agent 6, boolean keys must be in quotes values: {"true": 1, "false": 0, default: 0}
 ```
 
-Jmxfetch then knows it's a string and uses this rule to transform that into a numeric metric.
+Jmxfetch then knows it's a string and uses this rule to transform that into a numeric metric. Only string values are supported as keys with this custom mapping.
 
 Reach out to [Datadog Support team][7] if you are still having issues.
 

--- a/content/en/integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect.md
+++ b/content/en/integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect.md
@@ -77,7 +77,10 @@ instances:
 
 ```
 
-Jmxfetch then knows it's a string and uses this rule to transform that into a numeric metric. Only string values are supported as keys with this custom mapping.
+
+**Note:** Boolean metrics are automatically mapped to integers.
+
+Jmxfetch can identify this string and uses this rule to transform it into a numeric metric. Only string values are supported as keys with this custom mapping.
 
 Reach out to [Datadog Support team][7] if you are still having issues.
 

--- a/content/en/integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect.md
+++ b/content/en/integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect.md
@@ -75,7 +75,6 @@ instances:
                 tag.isActiveMaster:
                   metric_type: gauge
 
-              # Note: If using Agent 6, boolean keys must be in quotes values: {"true": 1, "false": 0, default: 0}
 ```
 
 Jmxfetch then knows it's a string and uses this rule to transform that into a numeric metric. Only string values are supported as keys with this custom mapping.


### PR DESCRIPTION
### What does this PR do?
Updates the documentation for collecting Boolean string-type mBeans. 
### Motivation
Customer request 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/laura.hampton/update-syntax-for-bool-mbeans/integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
