### PR TITLE
Tiny fix to linux profiler troubleshooting

### DIFF
--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -316,7 +316,7 @@ This error usually means that the profiler is unable to connect to the Datadog A
 
 Your profiles may be empty ("No CPU time reported") or contain few frames. Sometimes this is caused when applications have poor symbolization information. This may also be expected--the profiler activates only when the instrumented application is scheduled on the CPU, and applications may be predominately off-CPU for many reasons, such as low user load or high application wait time.
 
-The root of your profile is the frame annotated with the application name in parentheses. If this frame shows a significant amount of CPU time, but no frames, your application may have poor profiling fidelity. Consider the following:
+The root of your profile is the frame annotated with the application name in parentheses. If this frame shows a significant amount of CPU time, but no child frames, your application may have poor profiling fidelity. Consider the following:
 - Stripped binaries do not have symbols available. Try using a non-stripped binary or a non-minified container image.
 - Certain applications and libraries benefit from their debug packages being installed. This is true for services installed through your repo's package manager or similar.
 


### PR DESCRIPTION

### What does this PR do?
Adds a word to clarify the sentence describing low-fidelity profiles

### Motivation
question from translator

### Preview
https://docs-staging.datadoghq.com/kari/linux-prof-fix/tracing/profiler/profiler_troubleshooting/#profiles-are-empty-or-sparse

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
