### PR TITLE
(DOCS-3245) Update agent-log-files.md

### DIFF
--- a/content/en/agent/guide/agent-log-files.md
+++ b/content/en/agent/guide/agent-log-files.md
@@ -25,7 +25,7 @@ The Datadog Agent does a logs rollover every 10MB. When a rollover occurs, one b
 | Platform                              | Command                       |
 |---------------------------------------|-------------------------------|
 | Linux                                 | `/var/log/datadog/`           |
-| macOS, Agent v7.28+ and v6.28+        | `/opt/datadog-agent/log`      |
+| macOS, Agent v7.28+ and v6.28+        | `/opt/datadog-agent/logs`      |
 | macOS, Agent older than 6.28.0/7.28.0 | `/var/log/datadog`            |
 | Windows Server 2008, Vista and newer  | `C:\ProgramData\Datadog\logs` |
 | Windows Server 2003, XP or older      | *unsupported Platform*        |


### PR DESCRIPTION
on my mac, the files are in /opt/datadog-agent/logs not /opt/datadog-agent/log (plural v singular)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
