### PR TITLE
Remove tracing without limits occurrences

### DIFF
--- a/content/en/account_management/billing/_index.md
+++ b/content/en/account_management/billing/_index.md
@@ -23,7 +23,6 @@ It is recommended that containers are monitored with a single containerized Agen
 
 Datadog bills based on the sum of AWS Lambda invocations across the month for your accounts. Pro and Enterprise plans include 150,000 Indexed Spans and 5 custom metrics per million invocations. Billing for serverless APM depends on the total number of [Indexed Spans][4] exceeding the bundled quantity submitted to the Datadog APM service at the end of the month. There are no billable [APM Hosts][4] when using serverless.
 
-**Note** Indexed Spans were formerly known as Analyzed Spans and renamed with the launch of Tracing Without Limits on October 20th, 2020.
 
 For more information, see the [Serverless billing page][5] and the [Datadog Pricing page][6].
 

--- a/content/en/account_management/billing/apm_tracing_profiler.md
+++ b/content/en/account_management/billing/apm_tracing_profiler.md
@@ -9,7 +9,7 @@ aliases:
 
 [APM & Continuous Profiler][1] powers you to find service bottlenecks, analyze distributed traces and code performance across your microservices architecture.
 
-There are two options available for pricing, depending on whether APM and Profiling are bundled. Additionally, using the [Tracing Without Limits][2] feature with APM allows you to filter and group your application data with spans indexed by [tagged-based custom retention filters][3].
+There are two options available for pricing, depending on whether APM and Profiling are bundled. Control the stream of ingested data with the [ingestion controls][2] parameters and which spans to retain for a longer time period by indexing it with [tagged-based retention filters][3].
 
 | Billing Parameter  | Price                                      | Ingested and Indexed Spans                                                                 | Billing                                                                                                                                                                                                                                                                                                                          |
 |--------------------|--------------------------------------------|-------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -140,7 +140,7 @@ Kubernetes creates pause containers to acquire the respective pod’s IP address
 
 **6. How is the host billing related to your services?**
 
-APM is billed on the basis of [hosts][4] deployed with agents sending traces and not services. Tracing without Limits is billed on the basis of Indexed and Ingested span count. To estimate how many ingested and indexed spans each of your services is sending, see the [Usage Metrics][13] documentation.
+APM is billed on the basis of [hosts][4] deployed with agents sending traces and not services.  Additionally, over the monthly allocation by host, APM is billed on the basis of Ingested span volume and Indexed span count. To estimate how many ingested and indexed spans each of your services is sending, see the [ingestion][2] and [retention][13] documentation.
 
 **7. What happens to your existing App Analytics filters?**
 
@@ -148,7 +148,7 @@ As of October 20, 2020, all existing App Analytics filters are automatically tra
 
 **8. How do you estimate your ingested or indexed span volume?**
 
-Datadog provides the metrics `datadog.estimated_usage.apm.ingested_bytes` and `datadog.estimated_usage.apm.ingested_spans` for monitoring ingested and indexed span volume. More information is available in the [Usage Metrics][13] documentation.
+Datadog provides the metrics `datadog.estimated_usage.apm.ingested_bytes` and `datadog.estimated_usage.apm.ingested_spans` for monitoring ingested and indexed span volume. More information is available in the [Usage Metrics][14] documentation.
 
 **9. Is the Continuous Profiler available as a standalone product?**
 
@@ -164,7 +164,7 @@ Yes. Let Datadog know if you are interested in buying the Continuous Profiler wi
 
 
 [1]: /tracing/
-[2]: /tracing/trace_explorer/
+[2]: /tracing/trace_ingestion/ingestion_controls
 [3]: /tracing/trace_retention/#retention-filters
 [4]: /account_management/billing/pricing/#infrastructure-monitoring
 [5]: /account_management/billing/pricing/#apm
@@ -175,4 +175,5 @@ Yes. Let Datadog know if you are interested in buying the Continuous Profiler wi
 [10]: https://docs.datadoghq.com/account_management/billing/serverless/#serverless-functions
 [11]: /account_management/billing/
 [12]: /tracing/setup_overview/setup/java/?tab=containers#configure-the-datadog-agent-for-apm
-[13]: /tracing/trace_retention/usage_metrics
+[13]: /tracing//trace_retention/
+[14]: /tracing/trace_retention/usage_metrics

--- a/content/en/account_management/billing/pricing.md
+++ b/content/en/account_management/billing/pricing.md
@@ -30,14 +30,12 @@ Datadog has many pricing plans to fit your needs. For more information, see the 
 
 You can put controls in place for both Indexed and Ingested span volumes. For more information, read the [Trace Ingestion][4] and [Retention][5] documentation.
 
-**Note:** Indexed Spans were formerly known as Analyzed Spans and renamed with the launch of Tracing Without Limits on October 20th, 2020.
-
 ## Database Monitoring
 
-* Datadog records the number of unique database hosts you are monitoring with Datadog Database Monitoring each hour. 
+* Datadog records the number of unique database hosts you are monitoring with Datadog Database Monitoring each hour.
   * On a high watermark plan (HWMP), these hourly measurements are ordered from highest to lowest at the end of the month, and Datadog charges based on the eighth highest measurement.
   * On a hybrid monthly/hourly plan (MHP), Datadog charges your minimum monthly commitment, and for any host hours above that commitment, Datadog charges an hourly rate.
-* A **normalized query**, often called a query digest, represents an aggregate of queries with similar structure, differing only by the query parameters. Datadog charges based on the total number of configured normalized queries being tracked at any given time. 
+* A **normalized query**, often called a query digest, represents an aggregate of queries with similar structure, differing only by the query parameters. Datadog charges based on the total number of configured normalized queries being tracked at any given time.
 
 ## Log management
 

--- a/content/en/account_management/billing/serverless.md
+++ b/content/en/account_management/billing/serverless.md
@@ -9,8 +9,6 @@ Purchase Serverless function invocations on [Datadog Pro and Enterprise plans][1
 
 **Note:** If you are using a previous billing model for Datadog's Serverless Monitoring and would like to move to invocation-based billing, contact your [Customer Success Manager][3].
 
-**Note:** Indexed Spans were formerly known as Analyzed Spans and renamed with the launch of Tracing Without Limits on October 20th, 2020.
-
 ## Serverless invocations
 
 Datadog charges by calculating the sum of the your AWS Lambda function invocations at the end of the month.

--- a/content/en/account_management/billing/usage_attribution.md
+++ b/content/en/account_management/billing/usage_attribution.md
@@ -30,8 +30,6 @@ Administrators can access the Usage Attribution tab from the Plan & Usage sectio
 - Network Flows
 - Real User Monitoring
 
-**Note: Indexed Spans were formerly known as Analyzed Spans and renamed with the launch of Tracing Without Limits on October 20th, 2020.**
-
 ### Getting started
 
 To start receiving daily data, an administrator needs to create a new report with the user interface.

--- a/content/en/account_management/billing/usage_monitor_apm.md
+++ b/content/en/account_management/billing/usage_monitor_apm.md
@@ -6,8 +6,6 @@ kind: documentation
 Datadog has many pricing plans to fit your needs. For more information, see the [Pricing page][1].
 Read APM documentation on [APM Billing][2] to understand how billing works for APM and Distributed Tracing.
 
-**Note:** Indexed Spans were formerly known as Analyzed Spans and renamed with the launch of Tracing Without Limits on October 20th, 2020.
-
 ## Usage page
 
 If you are an admin of your account, you can view your account usage using the [Usage Page][3] which gets updated every 72 hours.

--- a/content/en/account_management/faq/usage_control_apm.md
+++ b/content/en/account_management/faq/usage_control_apm.md
@@ -4,7 +4,7 @@ kind: documentation
 ---
 
 <div class="alert alert-danger">
-On October 20, 2020, App Analytics was replaced by Tracing without Limits. This is a deprecated page with configuration information relevant to legacy App Analytics, useful for troubleshooting or modifying some old setups. Use Tracing without Limits™ to have full control over your <a href="https://docs.datadoghq.com/tracing/trace_retention_and_ingestion">data ingestion and trace retention</a> with no sampling.
+On October 20, 2020, App Analytics was replaced by Tracing without Limits. This is a deprecated page with configuration information relevant to legacy App Analytics, useful for troubleshooting or modifying some old setups. Use the new configuration options to have full control over your <a href="https://docs.datadoghq.com/tracing/trace_retention_and_ingestion">data ingestion and trace retention</a>.
 <br>
 Migrate to <a href="https://docs.datadoghq.com/tracing/trace_retention_and_ingestion"> Trace Retention and Ingestion </a> to use the new functionality.
 </div>

--- a/content/en/account_management/multi_organization.md
+++ b/content/en/account_management/multi_organization.md
@@ -54,7 +54,7 @@ For example, the URL `https://app.datadoghq.com/event/event?id=1` is associated 
 
 ## Set up SAML
 
-SAML setup is _not_ inherited by child-organizations from the parent-organization. SAML must be configured for each child-organization individually. 
+SAML setup is _not_ inherited by child-organizations from the parent-organization. SAML must be configured for each child-organization individually.
 
 To configure SAML for multi-organizations:
 
@@ -121,7 +121,7 @@ On the **Individual Organizations** usage tab, you can view the usage of your ch
 
 The default view is the "Billable" view, which shows usage that contributes to your final bill. This view removes child organizations that are not billable such as trial organizations, and other adjustments that provide a more accurate summary of what drives your bill. Switch to the "All" view to see the unadjusted, raw usage of your parent-organization and all child-organizations. Both views can be downloaded as a CSV file.
 
-To view the [Usage Details][9] of a child-organization, you can click on the child-organization's name. 
+To view the [Usage Details][9] of a child-organization, you can click on the child-organization's name.
 
 ## Usage attribution
 
@@ -143,9 +143,7 @@ Note: the following usage types are not supported in this tool:
 
 * Indexed Log Events
 * Ingested Logs
-* Indexed Spans
-
-**Note:** Indexed Spans were formerly known as Analyzed Spans and renamed with the launch of Tracing Without Limits on October 20th, 2020.
+* Indexed Spans (retained with retention filters)
 
 Usage Attribution is an advanced feature included in the Enterprise plan. For all other plans, contact your account representative or <a href="mailto:success@datadoghq.com">success@datadoghq.com</a>.
 

--- a/content/en/tracing/_index.md
+++ b/content/en/tracing/_index.md
@@ -37,7 +37,7 @@ aliases:
 
 Datadog APM & Continuous Profiler gives deep visibility into your applications with **out-of-the-box performance dashboards** for web services, queues, and databases to monitor requests, errors, and latency. Distributed traces **seamlessly correlate** to browser sessions, logs, profiles, synthetic checks, network, processes, and infrastructure metrics across hosts, containers, proxies, and serverless functions. Navigate directly from investigating a slow trace to **identifying the specific line of code** causing performance bottlenecks with code hotspots.
 
-#### Tracing Without Limits: journey of a trace
+#### Journey of a trace
 
 {{< img src="tracing/live_search_and_analytics/tracing_without_limits_lifecycle-0.png" style="width:100%; background:none; border:none; box-shadow:none;" alt="Trace Journey" >}}
 

--- a/content/en/tracing/faq/app_analytics_agent_configuration.md
+++ b/content/en/tracing/faq/app_analytics_agent_configuration.md
@@ -8,7 +8,7 @@ aliases:
 ---
 
 <div class="alert alert-danger">
-On October 20, 2020, App Analytics was replaced by Tracing without Limits. This is a deprecated page with configuration information relevant to legacy App Analytics, useful for troubleshooting or modifying some old setups. Now, instead, use Tracing without Limits™ to have full control over your <a href="https://docs.datadoghq.com/tracing/trace_retention_and_ingestion">data ingestion and trace retention</a> with no sampling.
+On October 20, 2020, App Analytics was replaced by Tracing without Limits. This is a deprecated page with configuration information relevant to legacy App Analytics, useful for troubleshooting or modifying some old setups. Instead, use new configuration options to have full control over your <a href="https://docs.datadoghq.com/tracing/trace_retention_and_ingestion">data ingestion and trace retention</a> with no sampling.
 <br>
 Migrate to <a href="https://docs.datadoghq.com/tracing/trace_retention_and_ingestion"> Trace Retention and Ingestion </a> to use the new functionality.
 </div>

--- a/content/en/tracing/faq/trace_sampling_and_storage.md
+++ b/content/en/tracing/faq/trace_sampling_and_storage.md
@@ -26,7 +26,7 @@ further_reading:
 ---
 
 <div class="alert alert-danger">
-On October 20, 2020, App Analytics was replaced by Tracing without Limits. This is a deprecated page with configuration information relevant to legacy App Analytics, useful for troubleshooting or modifying some old setups. Now, instead, use Tracing without Limits™ to have full control over your <a href="https://docs.datadoghq.com/tracing/trace_retention_and_ingestion">data ingestion and trace retention</a> with no sampling.
+On October 20, 2020, App Analytics was replaced by Tracing without Limits. This is a deprecated page with configuration information relevant to legacy App Analytics, useful for troubleshooting or modifying some old setups. Now, use new configuration options to have full control over your <a href="https://docs.datadoghq.com/tracing/trace_retention_and_ingestion">data ingestion and trace retention</a> with no sampling.
 <br>
 Migrate to <a href="https://docs.datadoghq.com/tracing/trace_retention_and_ingestion"> Trace Retention and Ingestion </a> to use the new functionality.
 </div>

--- a/content/en/tracing/generate_metrics/_index.md
+++ b/content/en/tracing/generate_metrics/_index.md
@@ -15,9 +15,7 @@ further_reading:
 
 ## Generate span-based metrics
 
-With Tracing without Limits™, you can generate metrics from 100% of ingested spans, regardless of whether they are indexed by a [retention filter][1].
-
-You can pair these metrics with retention filters and Analytics monitors, or use them on their own.
+Generate metrics from 100% of ingested spans, regardless of whether they are indexed by a [retention filter][1].
 
 Use custom metrics for specific fixed queries and comparisons, while creating retention filters to allow arbitrary querying and investigation of the retained trace and its flame graph.
 

--- a/content/en/tracing/guide/ingestion_control_page.md
+++ b/content/en/tracing/guide/ingestion_control_page.md
@@ -1,7 +1,7 @@
 ---
 title: Ingestion Control Page v2
 kind: documentation
-description: "Learn how to control Ingestion and Indexing rates with Tracing without Limits."
+description: "Learn how to control Ingestion and Indexing rates with APM."
 ---
 
 <div class="alert alert-warning">

--- a/content/en/tracing/legacy_app_analytics/_index.md
+++ b/content/en/tracing/legacy_app_analytics/_index.md
@@ -8,7 +8,7 @@ aliases:
 ---
 
 <div class="alert alert-danger">
-On October 20, 2020, App Analytics was replaced by Tracing without Limits.  This is a deprecated page with configuration information relevant to legacy App Analytics, useful for troubleshooting or modifying some old setups. Now, instead, use Tracing without Limits™ to have full control over your <a href="https://docs.datadoghq.com/tracing/trace_retention_and_ingestion">data ingestion and trace retention</a> with no sampling.
+On October 20, 2020, App Analytics was replaced by Tracing without Limits.  This is a deprecated page with configuration information relevant to legacy App Analytics, useful for troubleshooting or modifying some old setups. Instead, use new configuration options to have full control over your <a href="https://docs.datadoghq.com/tracing/trace_retention_and_ingestion">data ingestion and trace retention</a> with no sampling.
 <br>
 Migrate to <a href="https://docs.datadoghq.com/tracing/trace_retention_and_ingestion"> Trace Retention and Ingestion </a> to use the new functionality.
 </div>

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -42,7 +42,7 @@ further_reading:
 
 ### Supported .NET Core runtimes
 
-The .NET Tracer supports instrumentation on .NET Core 2.1, 3.1, .NET 5, and .NET 6. 
+The .NET Tracer supports instrumentation on .NET Core 2.1, 3.1, .NET 5, and .NET 6.
 
 For a full list of supported libraries and processor architectures, see [Compatibility Requirements][1].
 
@@ -84,7 +84,7 @@ To install the .NET Tracer machine-wide:
 1. Download the latest [.NET Tracer package][1] that supports your operating system and architecture.
 
 2. Run one of the following commands to install the package and create the .NET tracer log directory `/var/log/datadog/dotnet` with the appropriate permissions:
-   
+
    Debian or Ubuntu
    : `sudo dpkg -i ./datadog-dotnet-apm_<TRACER_VERSION>_amd64.deb && /opt/datadog/createLogPath.sh`
 
@@ -118,7 +118,7 @@ To install the .NET Tracer per-application:
 
 ### Enable the tracer for your service
 
-To enable the .NET Tracer for your service, set the required environment variables and restart the application. 
+To enable the .NET Tracer for your service, set the required environment variables and restart the application.
 
 For information about the different methods for setting environment variables, see [Configuring process environment variables](#configuring-process-environment-variables).
 
@@ -191,7 +191,7 @@ For information about the different methods for setting environment variables, s
    Windows x86      | `<APP_DIRECTORY>\datadog\win-x86\Datadog.Trace.ClrProfiler.Native.dll`
 
 2. For Docker images running on Linux, configure the image to run the `createLogPath.sh` script:
-  
+
    ```
    RUN /<APP_DIRECTORY>/datadog/createLogPath.sh
    ```
@@ -225,7 +225,7 @@ For containerized, serverless, and cloud environments:
 
 3. After instrumenting your application, the tracing client sends traces to `localhost:8126` by default. If this is not the correct host and port, change it by setting the `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` environment variables. For more information on how to set these variables, see [Configuration](#configuration).
 
-{{< site-region region="us3,us5,eu,gov" >}} 
+{{< site-region region="us3,us5,eu,gov" >}}
 
 4. To ensure the Agent sends data to the right Datadog location, set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" code="true" >}}.
 
@@ -381,7 +381,7 @@ Enables or disables automatic injection of correlation identifiers into applicat
 
 `DD_TRACE_SAMPLE_RATE`
 : **TracerSettings property**: `GlobalSamplingRate` <br>
-Enables [Tracing without Limits][5].
+Enables ingestion rate control.
 
 `DD_MAX_TRACES_PER_SECOND`
 : **TracerSettings property**: `MaxTracesSubmittedPerSecond` <br>
@@ -448,11 +448,11 @@ The following table lists configuration variables that are available **only** wh
 
 `DD_DISABLED_INTEGRATIONS`
 : **TracerSettings property**: `DisabledIntegrationNames` <br>
-Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][6] section.
+Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][5] section.
 
 `DD_TRACE_<INTEGRATION_NAME>_ENABLED`
 : **TracerSettings property**: `Integrations[<INTEGRATION_NAME>].Enabled` <br>
-Enables or disables a specific integration. Valid values are: `true` or `false`. Integration names are listed in the [Integrations][6] section.<br>
+Enables or disables a specific integration. Valid values are: `true` or `false`. Integration names are listed in the [Integrations][5] section.<br>
 **Default**: `true`
 
 #### Experimental features
@@ -466,7 +466,7 @@ The following configuration variables are for features that are available for us
 #### Deprecated settings
 
 `DD_TRACE_LOG_PATH`
-: Sets the path for the automatic instrumentation log file and determines the directory of all other .NET Tracer log files. Ignored if `DD_TRACE_LOG_DIRECTORY` is set. 
+: Sets the path for the automatic instrumentation log file and determines the directory of all other .NET Tracer log files. Ignored if `DD_TRACE_LOG_DIRECTORY` is set.
 
 `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED`
 : Enables improved resource names for web spans when set to `true`. Uses route template information where available, adds an additional span for ASP.NET Core integrations, and enables additional tags. Added in version 1.26.0. Enabled by default in 2.0.0<br>
@@ -517,7 +517,7 @@ To use custom instrumentation in your .NET application:
 
 {{< /tabs >}}
 
-For more information on adding spans and tags for custom instrumentation, see the [.NET Custom Instrumentation documentation][7].
+For more information on adding spans and tags for custom instrumentation, see the [.NET Custom Instrumentation documentation][6].
 
 ## Configuring process environment variables
 
@@ -627,7 +627,7 @@ When using `systemctl` to run .NET applications as a service, you can add the re
 
 When using `systemctl` to run .NET applications as a service, you can also set environment variables to be loaded for all services run by `systemctl`.
 
-1. Set the required environment variables by running [`systemctl set-environment`][8]:
+1. Set the required environment variables by running [`systemctl set-environment`][7]:
 
     ```bash
     systemctl set-environment CORECLR_ENABLE_PROFILING=1
@@ -648,7 +648,6 @@ When using `systemctl` to run .NET applications as a service, you can also set e
 [2]: /agent/
 [3]: https://app.datadoghq.com/apm/traces
 [4]: /getting_started/tagging/unified_service_tagging/
-[5]: /tracing/trace_ingestion/
-[6]: /tracing/setup_overview/compatibility_requirements/dotnet-core#integrations
-[7]: /tracing/setup_overview/custom_instrumentation/dotnet/
-[8]: https://www.freedesktop.org/software/systemd/man/systemctl.html#set-environment%20VARIABLE=VALUE%E2%80%A6
+[5]: /tracing/setup_overview/compatibility_requirements/dotnet-core#integrations
+[6]: /tracing/setup_overview/custom_instrumentation/dotnet/
+[7]: https://www.freedesktop.org/software/systemd/man/systemctl.html#set-environment%20VARIABLE=VALUE%E2%80%A6

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -100,7 +100,7 @@ To install the .NET Tracer per-application:
 
 ### Enable the tracer for your service
 
-To enable the .NET Tracer for your service, set the required environment variables and restart the application. 
+To enable the .NET Tracer for your service, set the required environment variables and restart the application.
 
 For information about the different methods for setting environment variables, see [Configuring process environment variables](#configuring-process-environment-variables).
 
@@ -163,7 +163,7 @@ For information about the different methods for setting environment variables, s
 
 ### Configure the Datadog Agent for APM
 
-[Install and configure the Datadog Agent][2] to receive traces from your instrumented application. By default, the Datadog Agent is enabled in your `datadog.yaml` file under `apm_config` with `enabled: true` and listens for trace traffic at `localhost:8126`. 
+[Install and configure the Datadog Agent][2] to receive traces from your instrumented application. By default, the Datadog Agent is enabled in your `datadog.yaml` file under `apm_config` with `enabled: true` and listens for trace traffic at `localhost:8126`.
 
 For containerized, serverless, and cloud environments:
 
@@ -180,7 +180,7 @@ For containerized, serverless, and cloud environments:
 
 3. After instrumenting your application, the tracing client sends traces to `localhost:8126` by default. If this is not the correct host and port, change it by setting the `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` environment variables. For more information on how to set these variables, see [Configuration](#configuration).
 
-{{< site-region region="us3,us5,eu,gov" >}} 
+{{< site-region region="us3,us5,eu,gov" >}}
 
 4. To ensure the Agent sends data to the right Datadog location, set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" code="true" >}}.
 
@@ -349,7 +349,7 @@ Enables or disables automatic injection of correlation identifiers into applicat
 
 `DD_TRACE_SAMPLE_RATE`
 : **TracerSettings property**: `GlobalSamplingRate` <br>
-Enables [Tracing without Limits][5].
+Enables ingestion rate control.
 
 `DD_MAX_TRACES_PER_SECOND`
 : **TracerSettings property**: `MaxTracesSubmittedPerSecond` <br>
@@ -416,11 +416,11 @@ The following table lists configuration variables that are available **only** wh
 
 `DD_DISABLED_INTEGRATIONS`
 : **TracerSettings property**: `DisabledIntegrationNames` <br>
-Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][6] section.
+Sets a list of integrations to disable. All other integrations remain enabled. If not set, all integrations are enabled. Supports multiple values separated with semicolons. Valid values are the integration names listed in the [Integrations][5] section.
 
 `DD_TRACE_<INTEGRATION_NAME>_ENABLED`
 : **TracerSettings property**: `Integrations[<INTEGRATION_NAME>].Enabled` <br>
-Enables or disables a specific integration. Valid values are: `true` or `false`. Integration names are listed in the [Integrations][6] section.<br>
+Enables or disables a specific integration. Valid values are: `true` or `false`. Integration names are listed in the [Integrations][5] section.<br>
 **Default**: `true`
 
 #### Experimental features
@@ -434,7 +434,7 @@ The following configuration variables are for features that are available for us
 #### Deprecated settings
 
 `DD_TRACE_LOG_PATH`
-: Sets the path for the automatic instrumentation log file and determines the directory of all other .NET Tracer log files. Ignored if `DD_TRACE_LOG_DIRECTORY` is set. 
+: Sets the path for the automatic instrumentation log file and determines the directory of all other .NET Tracer log files. Ignored if `DD_TRACE_LOG_DIRECTORY` is set.
 
 `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED`
 : Enables improved resource names for web spans when set to `true`. Uses route template information where available, adds an additional span for ASP.NET Core integrations, and enables additional tags. Added in version 1.26.0. Enabled by default in 2.0.0<br>
@@ -471,7 +471,7 @@ To use custom instrumentation in your .NET application:
 
 {{< /tabs >}}
 
-For more information on adding spans and tags for custom instrumentation, see the [.NET Custom Instrumentation documentation][7].
+For more information on adding spans and tags for custom instrumentation, see the [.NET Custom Instrumentation documentation][6].
 
 ## Configuring process environment variables
 
@@ -528,6 +528,5 @@ dotnet.exe example.dll
 [2]: /agent/
 [3]: https://app.datadoghq.com/apm/traces
 [4]: /getting_started/tagging/unified_service_tagging/
-[5]: /tracing/trace_ingestion/
-[6]: /tracing/setup_overview/compatibility_requirements/dotnet-framework/#integrations
-[7]: /tracing/setup_overview/custom_instrumentation/dotnet/
+[5]: /tracing/setup_overview/compatibility_requirements/dotnet-framework/#integrations
+[6]: /tracing/setup_overview/custom_instrumentation/dotnet/

--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -61,7 +61,7 @@ Datadog has a series of pluggable packages which provide out-of-the-box support 
 
 Datadog recommends using `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, `service`, and `version` for your services.
 
-Read the [Unified Service Tagging][10] documentation for recommendations on how to configure these environment variables. These variables are available for versions 1.24.0+ of the Go tracer.
+Read the [Unified Service Tagging][8] documentation for recommendations on how to configure these environment variables. These variables are available for versions 1.24.0+ of the Go tracer.
 
 You may also elect to provide `env`, `service`, and `version` through the tracer's API:
 
@@ -86,7 +86,7 @@ func main() {
 ```
 
 The Go tracer supports additional environment variables and functions for configuration.
-See all available options in the [configuration documentation][8].
+See all available options in the [configuration documentation][9].
 
 `DD_VERSION`
 : Set the application’s version, for example: `1.2.3`, `6c44da20`, `2020.02.13`
@@ -106,7 +106,7 @@ Override the default trace Agent host address for trace submission.
 Override the default trace Agent port for DogStatsD metric submission.
 
 `DD_TRACE_SAMPLE_RATE`
-: Enable [Tracing without Limits][9].
+: Enable ingestion rate control.
 
 `DD_TAGS`
 : **Default**: [] <br>
@@ -208,11 +208,11 @@ For other environments, please refer to the [Integrations][5] documentation for 
 
 ## Configure APM environment name
 
-The [APM environment name][11] may be configured [in the agent][12] or using the [WithEnv][8] start option of the tracer.
+The [APM environment name][10] may be configured [in the agent][11] or using the [WithEnv][9] start option of the tracer.
 
 ### B3 headers extraction and injection
 
-The Datadog APM tracer supports [B3 headers extraction][13] and injection for distributed tracing.
+The Datadog APM tracer supports [B3 headers extraction][12] and injection for distributed tracing.
 
 Distributed headers injection and extraction is controlled by
 configuring injection/extraction styles. Two styles are
@@ -243,9 +243,8 @@ extracted value is used.
 [5]: https://github.com/DataDog/dd-trace-go/tree/v1/MIGRATING.md
 [6]: /tracing/profiler/enabling/?code-lang=go
 [7]: https://app.datadoghq.com/apm/docs
-[8]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#StartOption
-[9]: /tracing/trace_ingestion/
-[10]: /getting_started/tagging/unified_service_tagging
-[11]: /tracing/advanced/setting_primary_tags_to_scope/#environment
-[12]: /getting_started/tracing/#environment-name
-[13]: https://github.com/openzipkin/b3-propagation
+[8]: /getting_started/tagging/unified_service_tagging
+[9]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#StartOption
+[10]: /tracing/advanced/setting_primary_tags_to_scope/#environment
+[11]: /getting_started/tracing/#environment-name
+[12]: https://github.com/openzipkin/b3-propagation

--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -47,7 +47,7 @@ Otherwise, to begin tracing your applications:
    ```
    To access a specific version of the tracer, visit Datadog's [Maven repository][4].
 
-2. To run your app from an IDE, Maven or Gradle application script, or `java -jar` command, with continuous profiler, deployment tracking, logs injection (if you are sending logs to Datadog), and Tracing without Limits, add the `-javaagent` JVM argument and the following configuration options, as applicable:
+2. To run your app from an IDE, Maven or Gradle application script, or `java -jar` command, with continuous profiler, deployment tracking, logs injection (if you are sending logs to Datadog), and trace volume control, add the `-javaagent` JVM argument and the following configuration options, as applicable:
 
     ```text
     java -javaagent:/path/to/dd-java-agent.jar -Ddd.profiling.enabled=true -XX:FlightRecorderOptions=stackdepth=256 -Ddd.logs.injection=true -Ddd.trace.sample.rate=1 -Ddd.service=my-app -Ddd.env=staging -jar path/to/your/app.jar -Ddd.version=1.0
@@ -62,7 +62,7 @@ Otherwise, to begin tracing your applications:
 | `DD_VERSION` | `dd.version` |  Your application version (for example, `2.5`, `202003181415`, `1.3-alpha`, etc.) |
 | `DD_PROFILING_ENABLED`      | `dd.profiling.enabled`          | Enable the [Continous Profiler][6] |
 | `DD_LOGS_INJECTION`   | `dd.logs.injection`     | Enable automatic MDC key injection for Datadog trace and span IDs. See [Advanced Usage][7] for details. |
-| `DD_TRACE_SAMPLE_RATE` | `dd.trace.sample.rate` |   Enable [Tracing without Limits][8]     |
+| `DD_TRACE_SAMPLE_RATE` | `dd.trace.sample.rate` |   Enable trace volume control     |
 
 Additional [configuration options](#configuration) are described below.
 
@@ -105,7 +105,7 @@ Install and configure the Datadog Agent to receive traces from your instrumented
 
    Similarly, the trace client attempts to send stats to the `/var/run/datadog/dsd.socket` Unix domain socket. If the socket does not exist then stats are sent to `http://localhost:8125`.
 
-{{< site-region region="us3,us5,eu,gov" >}} 
+{{< site-region region="us3,us5,eu,gov" >}}
 
 4. Set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
 
@@ -188,7 +188,7 @@ set "JAVA_OPTS=%JAVA_OPTS% -javaagent:X:/path/to/dd-java-agent.jar"
 - In domain mode:
 
   Add the following line in the file `domain.xml`, under the tag server-groups.server-group.jvm.jvm-options:
- 
+
 ```text
 <option value="-javaagent:/path/to/dd-java-agent.jar"/>
 ```
@@ -240,13 +240,13 @@ For additional details and options, see the [WebSphere docs][1].
    java -javaagent:/path/to/dd-java-agent.jar -jar my_app.jar
    ```
 
-     For more information, see the [Oracle documentation][9].
+     For more information, see the [Oracle documentation][8].
 
 - Never add `dd-java-agent` to your classpath. It can cause unexpected behavior.
 
 ## Automatic instrumentation
 
-Automatic instrumentation for Java uses the `java-agent` instrumentation capabilities [provided by the JVM][10]. When a `java-agent` is registered, it has the ability to modify class files at load time.
+Automatic instrumentation for Java uses the `java-agent` instrumentation capabilities [provided by the JVM][9]. When a `java-agent` is registered, it has the ability to modify class files at load time.
 
 Instrumentation may come from auto-instrumentation, the OpenTracing api, or a mixture of both. Instrumentation generally captures the following info:
 
@@ -309,7 +309,7 @@ Default value sends traces to the Agent. Configuring with `LoggingWriter` instea
 `dd.agent.host`
 : **Environment Variable**: `DD_AGENT_HOST`<br>
 **Default**: `localhost`<br>
-Hostname for where to send traces to. If using a containerized environment, configure this to be the host IP. See [Tracing Docker Applications][11] for more details.
+Hostname for where to send traces to. If using a containerized environment, configure this to be the host IP. See [Tracing Docker Applications][10] for more details.
 
 `dd.trace.agent.port`
 : **Environment Variable**: `DD_TRACE_AGENT_PORT`<br>
@@ -354,7 +354,7 @@ Available since version 0.96.0.
 
 `dd.trace.annotations`
 : **Environment Variable**: `DD_TRACE_ANNOTATIONS`<br>
-**Default**: ([listed here][12])<br>
+**Default**: ([listed here][11])<br>
 **Example**: `com.some.Trace;io.other.Trace`<br>
 A list of method annotations to treat as `@Trace`.
 
@@ -493,14 +493,14 @@ When `true`, user principal is collected. Available for versions 0.61+.
 
 - If the same key type is set for both, the system property configuration takes priority.
 - System properties can be used as JVM parameters.
-- By default, JMX metrics from your application are sent to the Datadog Agent thanks to DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][13].
+- By default, JMX metrics from your application are sent to the Datadog Agent thanks to DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][12].
 
-  - If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to `true`][14], and that port `8125` is open on the Agent container.
-  - In Kubernetes, [bind the DogStatsD port to a host port][15]; in ECS, [set the appropriate flags in your task definition][16].
+  - If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to `true`][13], and that port `8125` is open on the Agent container.
+  - In Kubernetes, [bind the DogStatsD port to a host port][14]; in ECS, [set the appropriate flags in your task definition][15].
 
 ### Integrations
 
-See how to disable integrations in the [integrations][17] compatibility section.
+See how to disable integrations in the [integrations][16] compatibility section.
 
 ### Examples
 
@@ -620,11 +620,11 @@ Would produce the following result:
 
 {{< img src="tracing/setup/java/jmxfetch_example.png" alt="JMX fetch example"  >}}
 
-See the [Java integration documentation][18] to learn more about Java metrics collection with JMX fetch.
+See the [Java integration documentation][17] to learn more about Java metrics collection with JMX fetch.
 
 ### B3 headers extraction and injection
 
-Datadog APM tracer supports [B3 headers extraction][19] and injection for distributed tracing.
+Datadog APM tracer supports [B3 headers extraction][18] and injection for distributed tracing.
 
 Distributed headers injection and extraction is controlled by configuring injection/extraction styles. Currently two styles are supported:
 
@@ -704,15 +704,14 @@ Java APM has minimal impact on the overhead of an application:
 [5]: /account_management/billing/apm_tracing_profiler/
 [6]: /tracing/profiler/
 [7]: /tracing/connect_logs_and_traces/java/
-[8]: /tracing/trace_ingestion/
-[9]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
-[10]: https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html
-[11]: /tracing/setup/docker/
-[12]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java#L37
-[13]: /developers/dogstatsd/#setup
-[14]: /agent/docker/#dogstatsd-custom-metrics
-[15]: /developers/dogstatsd/
-[16]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task
-[17]: /tracing/compatibility_requirements/java#disabling-integrations
-[18]: /integrations/java/?tab=host#metric-collection
-[19]: https://github.com/openzipkin/b3-propagation
+[8]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
+[9]: https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html
+[10]: /tracing/setup/docker/
+[11]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAnnotationsInstrumentation.java#L37
+[12]: /developers/dogstatsd/#setup
+[13]: /agent/docker/#dogstatsd-custom-metrics
+[14]: /developers/dogstatsd/
+[15]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task
+[16]: /tracing/compatibility_requirements/java#disabling-integrations
+[17]: /integrations/java/?tab=host#metric-collection
+[18]: https://github.com/openzipkin/b3-propagation

--- a/content/en/tracing/setup_overview/setup/python.md
+++ b/content/en/tracing/setup_overview/setup/python.md
@@ -123,7 +123,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
      dogstatsd_url="unix:///var/run/datadog/dsd.socket",
    )
    ```
-{{< site-region region="us3,us5,eu,gov" >}} 
+{{< site-region region="us3,us5,eu,gov" >}}
 
 4. Set `DD_SITE` in the Datadog Agent to {{< region-param key="dd_site" code="true" >}} to ensure the Agent sends data to the right Datadog location.
 
@@ -183,7 +183,7 @@ It is recommended to use `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, 
 : Set the application’s version, for example: `1.2.3`, `6c44da20`, `2020.02.13`. Available in version 0.38+.
 
 `DD_TRACE_SAMPLE_RATE`
-: Enable [Tracing without Limits][8].
+: Enable trace volume control
 
 `DD_TRACE_RATE_LIMIT`
 : Maximum number of spans to sample per-second, per-Python process. Defaults to `100` when `DD_TRACE_SAMPLE_RATE` is set. Otherwise, delegates rate limiting to the Datadog Agent.
@@ -219,7 +219,7 @@ Override the port that the default tracer submits DogStatsD metrics to.
 
 `DD_LOGS_INJECTION`
 : **Default**: `false`<br>
-Enable [connecting logs and trace injection][9].
+Enable [connecting logs and trace injection][8].
 
 
 ## Further Reading
@@ -233,5 +233,4 @@ Enable [connecting logs and trace injection][9].
 [5]: /getting_started/tagging/unified_service_tagging
 [6]: /tracing/guide/setting_primary_tags_to_scope/
 [7]: https://ddtrace.readthedocs.io/en/stable/integrations.html#django
-[8]: /tracing/trace_ingestion/
-[9]: /tracing/connect_logs_and_traces/python/
+[8]: /tracing/connect_logs_and_traces/python/

--- a/content/en/tracing/trace_explorer/_index.md
+++ b/content/en/tracing/trace_explorer/_index.md
@@ -30,7 +30,7 @@ The Trace Explorer shows an **Search - Only Indexed Data** indicator whenever yo
 
 Live Search is the default view on the Traces page. Switch from Live Search to Indexed Data Search by using the time selector in the top right-hand corner.
 
-### Tracing Without Limits (recommended)
+### Trace volume control
 
 You can customize settings for both [ingestion][6] and [retention][7] to send and keep exactly what data is most relevant to you.
 

--- a/content/en/tracing/trace_ingestion/_index.md
+++ b/content/en/tracing/trace_ingestion/_index.md
@@ -16,7 +16,7 @@ further_reading:
 
 {{< img src="tracing/live_search_and_analytics/tracing_without_limits_lifecycle-2.png" style="width:100%; background:none; border:none; box-shadow:none;" alt="Trace Journey: Ingestion" >}}
 
-With Tracing without Limits™, the ingestion of traces to Datadog is fully customizable.
+With APM, the ingestion of traces to Datadog is fully customizable.
 
 ## Ingestion mechanisms
 

--- a/content/en/tracing/trace_ingestion/ingestion_controls.md
+++ b/content/en/tracing/trace_ingestion/ingestion_controls.md
@@ -103,7 +103,7 @@ The breakdown is composed of the following parts:
 
 ### Traces dropped before ingestion
 
-100% trace ingestion cannot be achieved if you have not set the environment variable configuration `DD_TRACE_SAMPLE_RATE=1.0` for Tracing without Limits, and:
+100% trace ingestion cannot be achieved if you have not set the environment variable configuration `DD_TRACE_SAMPLE_RATE=1.0` for trace volume control, and:
 - your applications generate above 50 traces per second;
 - your applications send intermittent traffic loads; or
 - your applications traces are large in size or otherwise have complicated trace payloads.

--- a/content/en/tracing/trace_ingestion/mechanisms.md
+++ b/content/en/tracing/trace_ingestion/mechanisms.md
@@ -100,7 +100,7 @@ span.SetTag(ext.ManualDrop, true)
 `ingestion_reason: analytic`
 
 <div class="alert alert-warning">
-On October 20, 2020, App Analytics was replaced by Tracing without Limits. This is a deprecated mechanism with configuration information relevant to legacy App Analytics. Now, instead, use Tracing without Limits™ <a href="#head-based-default-mechanism">head-based sampling</a> to have full control over your data ingestion.
+On October 20, 2020, App Analytics was replaced by Tracing without Limits. This is a deprecated mechanism with configuration information relevant to legacy App Analytics. Instead, use new configuration options <a href="#head-based-default-mechanism">head-based sampling</a> to have full control over your data ingestion.
 </div>
 
 If you need to sample a specific span, but don't need the full trace to be available, tracers allow a sampling rate to be configured for a single span. This span will be ingested at no less than the configured rate, even when the enclosing trace is dropped.

--- a/content/en/tracing/trace_retention/_index.md
+++ b/content/en/tracing/trace_retention/_index.md
@@ -16,9 +16,9 @@ further_reading:
 
 {{< img src="tracing/live_search_and_analytics/tracing_without_limits_lifecycle-3.png" style="width:100%; background:none; border:none; box-shadow:none;" alt="Trace Journey: Indexing" >}}
 
-With Tracing without Limits™, both the [ingestion of traces to Datadog][7] as well as the retention of those traces for 15 days are fully customizable.
+With APM, both the [ingestion of traces to Datadog][1] as well as the retention of those traces for 15 days are fully customizable.
 
-To track or monitor your usage of Tracing without Limits™, see the [Usage Metrics][1] documentation.
+To track or monitor your volume of ingested and indexed data, see the [Usage Metrics][2] documentation.
 
 ## Retention filters
 
@@ -30,7 +30,7 @@ You can also create any number of additional [tag-based retention filters](#crea
 
 {{< img src="tracing/trace_indexing_and_ingestion/RetentionFilters.png" style="width:100%;" alt="Retention Filters" >}}
 
-In Datadog, on the [Retention Filters tab][2], you can see the following information:
+In Datadog, on the [Retention Filters tab][3], you can see the following information:
 
 Filter Name
 : The name of each filter used to index spans. By default, the only filter is [Datadog Intelligent Retention](#datadog-intelligent-retention-filter).
@@ -52,13 +52,13 @@ Enabled toggle
 
 In addition to the `Spans Indexed` column for each retention filter, there is also the `datadog.estimated_usage.apm.indexed_spans` metric, which you can use to track spans that are indexed by retention filters.
 
-For more information, read the [Usage Metrics][1] documentation, or see the [dashboard][3] available in your account.
+For more information, read the [Usage Metrics][2] documentation, or see the [dashboard][4] available in your account.
 
 <div class="alert alert-info"><strong>Note</strong>: Retention filters do not affect what traces are collected by the Agent and sent to Datadog ("ingested"). The only way to change how much tracing data is ingested is through <a href="/tracing/trace_ingestion/mechanisms">ingestion controls</a>.</div>
 
 ### Datadog intelligent retention filter
 
-Intelligent retention is always active for your services, and it keeps a proportion of traces to help you monitor the health of your applications. All [service entry spans][4] are indexed for the traces kept by the intelligent retention filter.
+Intelligent retention is always active for your services, and it keeps a proportion of traces to help you monitor the health of your applications. All [service entry spans][5] are indexed for the traces kept by the intelligent retention filter.
 
 For 30 days, intelligent retention retains:
 
@@ -67,7 +67,7 @@ For 30 days, intelligent retention retains:
  - All resources with any traffic that have associated traces in the past for any time window selection.
  - True maximum duration trace for each time window.
 
-**Note**: Because intelligent retention chooses spans intentionally and not randomly, spans that are retained only by the intelligent filter are **not** included in the [Trace explorer timeseries view][5]. Aggregated views (timeseries, toplist, table) are available only for spans retained by [custom retention filters](#create-your-own-retention-filter).
+**Note**: Because intelligent retention chooses spans intentionally and not randomly, spans that are retained only by the intelligent filter are **not** included in the [Trace explorer timeseries view][6]. Aggregated views (timeseries, toplist, table) are available only for spans retained by [custom retention filters](#create-your-own-retention-filter).
 
 If there are specific tags, facets, or groups of traces that you want to investigate _in detail_, meaning you want to retain more than what Intelligent Retention retains, then [create your own retention filter](#create-your-own-retention-filter). For example, you might want to keep more than a representative selection of errors from your production environment. To ensure _all_ production errors are retained and available for search and analytics for 15 days, create a 100 percent retention filter scoped to `env:prod` and `status:error`. As discussed below, this may have an impact on your bill.
 
@@ -75,15 +75,15 @@ If there are specific tags, facets, or groups of traces that you want to investi
 
 {{< img src="tracing/trace_indexing_and_ingestion/IndexFilter2.mp4" style="width:100%;" alt="Span Indexing" video=true >}}
 
-To customize what spans are indexed and retained for 15 days, you can create, modify, and disable additional filters based on tags, and set a percentage of spans matching each filter to be retained. Any span that is retained has its corresponding trace saved as well, and when it is viewed, the complete trace is available. In order to be searched by tag in [Explorer][6], however, the span that directly contains the searched-upon tag must have been indexed by a retention filter.
+To customize what spans are indexed and retained for 15 days, you can create, modify, and disable additional filters based on tags, and set a percentage of spans matching each filter to be retained. Any span that is retained has its corresponding trace saved as well, and when it is viewed, the complete trace is available. In order to be searched by tag in [Explorer][7], however, the span that directly contains the searched-upon tag must have been indexed by a retention filter.
 
 1. Name your filter.
 2. Set the tags you would like to index spans that match **all** of.
-3. Select whether this filter retains any span that matches the criteria, or only [service entry spans][4].
+3. Select whether this filter retains any span that matches the criteria, or only [service entry spans][5].
 4. Set a percentage of spans matching these tags to be indexed.
 5. Save your new filter.
 
-Selecting "Top-Level Spans for Services Only" means the retention filter retains only the selected proportion of [service entry spans][4] of the service and indexes them. Use this if you want to only index service entry spans with matching tags. If "All Spans" is selected, the retention filter retains the selected proportion of all spans of the distributed trace, irrespective of their hierarchy, and indexes them. This may have an impact on your bill, and the visual indicator within the app while setting a retention filter informs you how many matching spans have been detected over the time period.
+Selecting "Top-Level Spans for Services Only" means the retention filter retains only the selected proportion of [service entry spans][5] of the service and indexes them. Use this if you want to only index service entry spans with matching tags. If "All Spans" is selected, the retention filter retains the selected proportion of all spans of the distributed trace, irrespective of their hierarchy, and indexes them. This may have an impact on your bill, and the visual indicator within the app while setting a retention filter informs you how many matching spans have been detected over the time period.
 
 Filters are retained in a serial order. If you have an upstream filter that retains spans with the `resource:POST /hello_world` tag, those spans do not show up in the **Edit** window of a downstream filter that searches for spans with the same tag because they have been retained by the upstream filter.
 
@@ -97,10 +97,10 @@ For example, you can create filters to keep all traces for:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/trace_retention/usage_metrics
-[2]: https://app.datadoghq.com/apm/traces/retention-filters
-[3]: https://app.datadoghq.com/dash/integration/30337/app-analytics-usage
-[4]: /tracing/visualization/#service-entry-span
-[5]: /tracing/trace_explorer/?tab=timeseriesview#indexed-spans-search-with-15-day-retention
-[6]: /tracing/trace_explorer/#historical-search-mode
-[7]: /tracing/trace_ingestion
+[1]: /tracing/trace_ingestion
+[2]: /tracing/trace_retention/usage_metrics
+[3]: https://app.datadoghq.com/apm/traces/retention-filters
+[4]: https://app.datadoghq.com/dash/integration/30337/app-analytics-usage
+[5]: /tracing/visualization/#service-entry-span
+[6]: /tracing/trace_explorer/?tab=timeseriesview#indexed-spans-search-with-15-day-retention
+[7]: /tracing/trace_explorer/#historical-search-mode

--- a/content/en/tracing/trace_retention/usage_metrics.md
+++ b/content/en/tracing/trace_retention/usage_metrics.md
@@ -3,7 +3,7 @@ title: Usage Metrics
 kind: documentation
 aliases:
     - /tracing/trace_retention_and_ingestion/usage_metrics/
-description: "Learn how to monitor your Tracing without Limits usage."
+description: "Learn how to monitor your APM usage."
 further_reading:
 - link: "/tracing/trace_ingestion/mechanisms"
   tag: "Documentation"
@@ -22,7 +22,7 @@ This document details the available metrics and default dashboard for monitoring
 
 ## Trace analytics usage dashboard
 
-{{< img src="tracing/trace_indexing_and_ingestion/usage_metrics/AnalyticsDashboardOverview_2.png" style="width:100%;" alt="Tracing without Limits Usage Dashboard" >}}
+{{< img src="tracing/trace_indexing_and_ingestion/usage_metrics/AnalyticsDashboardOverview_2.png" style="width:100%;" alt="Trace Usage Dashboard" >}}
 
 Datadog provides an out-of-the-box [Usage Dashboard][5] for monitoring your APM usage, as well as your ingested and indexed span volumes.
 

--- a/content/en/tracing/visualization/_index.md
+++ b/content/en/tracing/visualization/_index.md
@@ -43,9 +43,6 @@ The APM UI provides many tools to troubleshoot application performance and corre
 | [Sublayer Metric](#sublayer-metric) | A sublayer metric is the execution duration of a given type / service within a trace.
 | [Execution Time](#execution-time) | Total time that a span is considered 'active' (not waiting for a child span to complete).
 
-
-**Note:** Indexed Spans were formerly known as Analyzed Spans and renamed with the launch of Tracing Without Limits on October 20th, 2020.
-
 ## Services
 
 After [instrumenting your application][3], the [Services List][4] is your main landing page for APM data.
@@ -149,8 +146,6 @@ Trace metrics are useful for monitoring. APM monitors can be set up on the [New 
 [Explore and perform analytics][14] on 100% of ingested traces for 15 minutes and all [indexed spans](#indexed-span) for 15 days.
 
 ## Indexed span
-
-**Note:** Indexed Spans were formerly known as Analyzed Spans and renamed with the launch of Tracing Without Limits on October 20th, 2020.
 
 Indexed Spans represent spans indexed by a [retention filter](#retention-filters) stored in Datadog for 15 days that can be used to search, query, and monitor in [Trace Search and Analytics][14] by the [tags](#span-tags) included on the span.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Remove all Tracing Without Limits occurrences from the public documentation

### Motivation
<!-- What inspired you to submit this pull request?-->
As we are rolling out the billing of ingestion overconsumption (0.10$/GB) in Q2, stopping using Tracing Without Limits in the public documentation is needed: we do not recommend to set 100% of ingestion rate at the tracing library level anymore.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/antoine.dussault/remove_twl

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
