### PR TITLE
[APM .NET] Document DD_TRACE_RATE_LIMIT

### DIFF
--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -383,9 +383,10 @@ Enables or disables automatic injection of correlation identifiers into applicat
 : **TracerSettings property**: `GlobalSamplingRate` <br>
 Enables [Tracing without Limits][5].
 
-`DD_MAX_TRACES_PER_SECOND`
+`DD_TRACE_RATE_LIMIT`
 : **TracerSettings property**: `MaxTracesSubmittedPerSecond` <br>
-The number of traces allowed to be submitted per second.
+The number of traces allowed to be submitted per second (deprecates `DD_MAX_TRACES_PER_SECOND`). <br>
+**Default**: `100` when `DD_TRACE_SAMPLE_RATE` is set. Otherwise, delegates rate limiting to the Datadog Agent. <br>
 
 `DD_TRACE_GLOBAL_TAGS`
 : **TracerSettings property**: `GlobalTags`<br>

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -351,9 +351,10 @@ Enables or disables automatic injection of correlation identifiers into applicat
 : **TracerSettings property**: `GlobalSamplingRate` <br>
 Enables [Tracing without Limits][5].
 
-`DD_MAX_TRACES_PER_SECOND`
+`DD_TRACE_RATE_LIMIT`
 : **TracerSettings property**: `MaxTracesSubmittedPerSecond` <br>
-The number of traces allowed to be submitted per second.
+The number of traces allowed to be submitted per second (deprecates `DD_MAX_TRACES_PER_SECOND`). <br>
+**Default**: `100` when `DD_TRACE_SAMPLE_RATE` is set. Otherwise, delegates rate limiting to the Datadog Agent. <br>
 
 `DD_TRACE_GLOBAL_TAGS`
 : **TracerSettings property**: `GlobalTags`<br>


### PR DESCRIPTION
### What does this PR do?
Documents DD_TRACE_RATE_LIMIT to match other tracers (https://github.com/DataDog/documentation/pull/13286)

### Motivation
Consistency

### Preview
![image](https://user-images.githubusercontent.com/22597395/157921021-0f0acc8a-8142-4ee3-909b-cf8bf008dee9.png)

https://docs-staging.datadoghq.com/pierre/net-fix-trace-limit-param/tracing/setup_overview/setup/dotnet-framework/?tab=windows

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
