### PR TITLE
[ci-app] Remove two examples from Swift variables

### DIFF
--- a/content/en/continuous_integration/setup_tests/swift.md
+++ b/content/en/continuous_integration/setup_tests/swift.md
@@ -99,13 +99,11 @@ Set all these variables in your test target:
 `DD_TEST_RUNNER`
 : Enables or disables the instrumentation of tests. Set this value to `$(DD_TEST_RUNNER)` so you can enable and disable test instrumentation with a environment variable defined outside of the test process (for example, in the CI build).<br/>
 **Default**: `false`<br/>
-**Recommended**: `$(DD_TEST_RUNNER)`<br/>
-**Example**: `true`
+**Recommended**: `$(DD_TEST_RUNNER)`
 
 `DD_API_KEY`
-: Use the [Datadog API Key][1] to report test results.<br/>
-**Default**: `(empty)`<br/>
-**Example**: `pub0zxxxyyyxxxyyxxxzzxxyyxxxyyy`
+: The [Datadog API key][1] used to upload the test results.<br/>
+**Default**: `(empty)`
 
 `DD_SERVICE`
 : Name of the service or library under test.<br/>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Removes examples for `DD_TEST_RUNNER` and `DD_API_KEY` env vars in Swift instructions in CI Visibility docs

### Motivation
<!-- What inspired you to submit this pull request?-->

The example for the API key is for a client token, not an API key.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fermayo/ciapp-remove-confusing-examples/continuous_integration/setup_tests/swift/?tab=swiftpackagemanager#configuring-datadog

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
