### PR TITLE
APM ingestion control: fix env variables

### DIFF
--- a/content/en/tracing/trace_ingestion/mechanisms.md
+++ b/content/en/tracing/trace_ingestion/mechanisms.md
@@ -34,7 +34,7 @@ For instance, if service `A` has more traffic than service `B`, the Agent might 
 Set Agent's target traces-per-second in its main configuration file (`datadog.yaml`) or as an environment variable :
 ```
 @param max_traces_per_second - integer - optional - default: 10
-@env DD_APM_CONFIG_MAX_TRACES_PER_SECOND - integer - optional - default: 10
+@env DD_APM_MAX_TPS - integer - optional - default: 10
 ```
 
 ### In tracing libraries: user-defined rules
@@ -145,7 +145,7 @@ In the Agent, an additional rate limiter is set to 200 spans per second. If the 
 Set the rate in the Agent main configuration file (`datadog.yaml`) or as an environment variable:
 ```
 @param max_events_per_second - integer - optional 200
-@env DD_APM_CONFIG_MAX_EVENTS_PER_SECOND - integer - optional 200
+@env DD_APM_MAX_EPS - integer - optional 200
 ```
 
 ## Error and rare traces


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix 2 wrong env variables. The same fix will be shipped on agent 7.36 config template https://github.com/DataDog/datadog-agent/pull/11271/files

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
