### PR TITLE
Use WithService instead of WithServiceName in the example

### DIFF
--- a/content/en/tracing/setup_overview/custom_instrumentation/go.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/go.md
@@ -52,7 +52,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-    tracer.Start(tracer.WithServiceName("<SERVICE_NAME>"))
+    tracer.Start(tracer.WithService("<SERVICE_NAME>"))
     defer tracer.Stop()
     http.HandleFunc("/posts", handler)
     log.Fatal(http.ListenAndServe(":8080", nil))


### PR DESCRIPTION
WithServiceName has been deprecated and no longer works.
See: https://github.com/DataDog/dd-trace-go/blob/2414cdc7dad50aefc51bd94cee9a84c1f698b370/ddtrace/tracer/option.go#L520-L523

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Keep the example up to date with the latest specifications.

### Motivation
<!-- What inspired you to submit this pull request?-->
I happened to notice it.
The documentation here has already been updated.
https://docs.datadoghq.com/tracing/setup_overview/setup/go/?tab=containers

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
