### PR TITLE
Update synthetics pages for custom roles GA

### DIFF
--- a/content/en/synthetics/api_tests/dns_tests.md
+++ b/content/en/synthetics/api_tests/dns_tests.md
@@ -159,7 +159,7 @@ These reasons include the following:
 
 By default, only users with the [Datadog Admin and Datadog Standard roles][10] can create, edit, and delete Synthetic DNS tests. To get create, edit, and delete access to Synthetic DNS tests, upgrade your user to one of those two [default roles][10].
 
-If you have access to the [custom role feature][11], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
+If you are using the [custom role feature][11], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
 
 ### Restrict access
 

--- a/content/en/synthetics/api_tests/dns_tests.md
+++ b/content/en/synthetics/api_tests/dns_tests.md
@@ -163,8 +163,7 @@ If you are using the [custom role feature][11], add your user to any custom role
 
 ### Restrict access
 
-<div class="alert alert-warning">
-Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their accounts.</div>
+Access restriction is available for customers using [custom roles][12] on their accounts.
 
 You can restrict access to a DNS test based on the roles in your organization. When creating a DNS test, choose which roles (in addition to your user) can read and write your test. 
 
@@ -185,3 +184,4 @@ You can restrict access to a DNS test based on the roles in your organization. W
 [9]: /synthetics/settings/#global-variables
 [10]: /account_management/rbac/
 [11]: /account_management/rbac#custom-roles
+[12]: /account_management/rbac/#create-a-custom-role

--- a/content/en/synthetics/api_tests/dns_tests.md
+++ b/content/en/synthetics/api_tests/dns_tests.md
@@ -164,7 +164,7 @@ If you are using the [custom role feature][11], add your user to any custom role
 ### Restrict access
 
 <div class="alert alert-warning">
-Access restriction is available for customers with <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> enabled on their accounts.</div>
+Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their accounts.</div>
 
 You can restrict access to a DNS test based on the roles in your organization. When creating a DNS test, choose which roles (in addition to your user) can read and write your test. 
 

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -243,8 +243,7 @@ If you are using the [custom role feature][14], add your user to any custom role
 
 ### Restrict access
 
-<div class="alert alert-warning">
-Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their accounts.</div>
+Access restriction is available for customers using [custom roles][15] on their accounts.
 
 You can restrict access to an HTTP test based on the roles in your organization. When creating an HTTP test, choose which roles (in addition to your user) can read and write your test. 
 
@@ -268,3 +267,4 @@ You can restrict access to an HTTP test based on the roles in your organization.
 [12]: /synthetics/api_tests/errors/#ssl-errors
 [13]: /account_management/rbac/
 [14]: /account_management/rbac#custom-roles
+[15]: /account_management/rbac/#create-a-custom-role

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -244,7 +244,7 @@ If you are using the [custom role feature][14], add your user to any custom role
 ### Restrict access
 
 <div class="alert alert-warning">
-Access restriction is available for customers with <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> enabled on their accounts.</div>
+Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their accounts.</div>
 
 You can restrict access to an HTTP test based on the roles in your organization. When creating an HTTP test, choose which roles (in addition to your user) can read and write your test. 
 

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -239,7 +239,7 @@ These reasons include the following:
 
 By default, only users with the [Datadog Admin and Datadog Standard roles][13] can create, edit, and delete Synthetic HTTP tests. To get create, edit, and delete access to Synthetic HTTP tests, upgrade your user to one of those two [default roles][13].
 
-If you have access to the [custom role feature][14], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
+If you are using the [custom role feature][14], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
 
 ### Restrict access
 

--- a/content/en/synthetics/api_tests/icmp_tests.md
+++ b/content/en/synthetics/api_tests/icmp_tests.md
@@ -149,7 +149,7 @@ If you are using the [custom role feature][10], add your user to any custom role
 ### Restrict access
 
 <div class="alert alert-warning">
-Access restriction is available for customers with <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> enabled on their accounts.</div>
+Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their accounts.</div>
 
 You can restrict access to an ICMP test based on the roles in your organization. When creating an ICMP test, choose which roles (in addition to your user) can read and write your test. 
 

--- a/content/en/synthetics/api_tests/icmp_tests.md
+++ b/content/en/synthetics/api_tests/icmp_tests.md
@@ -144,7 +144,7 @@ These reasons include the following:
 
 By default, only users with the [Datadog Admin and Datadog Standard roles][9] can create, edit, and delete Synthetic ICMP tests. To get create, edit, and delete access to Synthetic ICMP tests, upgrade your user to one of those two [default roles][9].
 
-If you have access to the [custom role feature][10], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
+If you are using the [custom role feature][10], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
 
 ### Restrict access
 

--- a/content/en/synthetics/api_tests/icmp_tests.md
+++ b/content/en/synthetics/api_tests/icmp_tests.md
@@ -148,8 +148,7 @@ If you are using the [custom role feature][10], add your user to any custom role
 
 ### Restrict access
 
-<div class="alert alert-warning">
-Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their accounts.</div>
+Access restriction is available for customers using [custom roles][11] on their accounts.
 
 You can restrict access to an ICMP test based on the roles in your organization. When creating an ICMP test, choose which roles (in addition to your user) can read and write your test. 
 
@@ -169,3 +168,4 @@ You can restrict access to an ICMP test based on the roles in your organization.
 [8]: /synthetics/settings/#global-variables
 [9]: /account_management/rbac/
 [10]: /account_management/rbac#custom-roles
+[11]: /account_management/rbac/#create-a-custom-role

--- a/content/en/synthetics/api_tests/ssl_tests.md
+++ b/content/en/synthetics/api_tests/ssl_tests.md
@@ -171,7 +171,7 @@ These reasons include the following:
 
 By default, only users with the [Datadog Admin and Datadog Standard roles][11] can create, edit, and delete Synthetic SSL tests. To get create, edit, and delete access to Synthetic SSL tests, upgrade your user to one of those two [default roles][11].
 
-If you have access to the [custom role feature][12], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
+If you are using the [custom role feature][12], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
 
 ### Restrict access
 

--- a/content/en/synthetics/api_tests/ssl_tests.md
+++ b/content/en/synthetics/api_tests/ssl_tests.md
@@ -175,8 +175,7 @@ If you are using the [custom role feature][12], add your user to any custom role
 
 ### Restrict access
 
-<div class="alert alert-warning">
-Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their account.</div>
+Access restriction is available for customers using [custom roles][13] on their account.
 
 You can restrict access to an SSL test based on the roles in your organization. When creating an SSL test, choose which roles (in addition to your user) can read and write your test. 
 
@@ -198,3 +197,4 @@ You can restrict access to an SSL test based on the roles in your organization. 
 [10]: /synthetics/api_tests/errors/#ssl-errors
 [11]: /account_management/rbac/
 [12]: /account_management/rbac#custom-roles
+[13]: /account_management/rbac/#create-a-custom-role

--- a/content/en/synthetics/api_tests/ssl_tests.md
+++ b/content/en/synthetics/api_tests/ssl_tests.md
@@ -175,7 +175,7 @@ If you are using the [custom role feature][12], add your user to any custom role
 
 ### Restrict access
 
-Access restriction is available for customers using [custom roles][13] on their account.
+Access restriction is available for customers using [custom roles][13] on their accounts.
 
 You can restrict access to an SSL test based on the roles in your organization. When creating an SSL test, choose which roles (in addition to your user) can read and write your test. 
 

--- a/content/en/synthetics/api_tests/ssl_tests.md
+++ b/content/en/synthetics/api_tests/ssl_tests.md
@@ -176,7 +176,7 @@ If you are using the [custom role feature][12], add your user to any custom role
 ### Restrict access
 
 <div class="alert alert-warning">
-Access restriction is available for customers with <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> enabled on their account.</div>
+Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their account.</div>
 
 You can restrict access to an SSL test based on the roles in your organization. When creating an SSL test, choose which roles (in addition to your user) can read and write your test. 
 

--- a/content/en/synthetics/api_tests/tcp_tests.md
+++ b/content/en/synthetics/api_tests/tcp_tests.md
@@ -157,8 +157,7 @@ If you are using the [custom role feature][10], add your user to any custom role
 
 ### Restrict access
 
-<div class="alert alert-warning">
-Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their accounts.</div>
+Access restriction is available for customers using [custom roles][11] on their accounts.
 
 You can restrict access to a TCP test based on the roles in your organization. When creating a TCP test, choose which roles (in addition to your user) can read and write your test. 
 
@@ -178,3 +177,4 @@ You can restrict access to a TCP test based on the roles in your organization. W
 [8]: /synthetics/settings/#global-variables
 [9]: /account_management/rbac/
 [10]: /account_management/rbac#custom-roles
+[11]: /account_management/rbac/#create-a-custom-role

--- a/content/en/synthetics/api_tests/tcp_tests.md
+++ b/content/en/synthetics/api_tests/tcp_tests.md
@@ -153,7 +153,7 @@ These reasons include the following:
 
 By default, only users with the [Datadog Admin and Datadog Standard roles][9] can create, edit, and delete Synthetic TCP tests. To get create, edit, and delete access to Synthetic TCP tests, upgrade your user to one of those two [default roles][9].
 
-If you have access to the [custom role feature][10], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
+If you are using the [custom role feature][10], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
 
 ### Restrict access
 

--- a/content/en/synthetics/api_tests/tcp_tests.md
+++ b/content/en/synthetics/api_tests/tcp_tests.md
@@ -158,7 +158,7 @@ If you are using the [custom role feature][10], add your user to any custom role
 ### Restrict access
 
 <div class="alert alert-warning">
-Access restriction is available for customers with <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> enabled on their accounts.</div>
+Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their accounts.</div>
 
 You can restrict access to a TCP test based on the roles in your organization. When creating a TCP test, choose which roles (in addition to your user) can read and write your test. 
 

--- a/content/en/synthetics/api_tests/udp_tests.md
+++ b/content/en/synthetics/api_tests/udp_tests.md
@@ -160,8 +160,7 @@ If you are using the [custom role feature][10], add your user to any custom role
 
 ### Restrict access
 
-<div class="alert alert-warning">
-Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their accounts.</div>
+Access restriction is available for customers using [custom roles][11] on their accounts.
 
 You can restrict access to a UDP test based on the roles in your organization. When creating a UDP test, choose which roles (in addition to your user) can read and write your test. 
 
@@ -181,3 +180,4 @@ You can restrict access to a UDP test based on the roles in your organization. W
 [8]: /synthetics/settings/#global-variables
 [9]: /account_management/rbac/
 [10]: /account_management/rbac#custom-roles
+[11]: /account_management/rbac/#create-a-custom-role

--- a/content/en/synthetics/api_tests/udp_tests.md
+++ b/content/en/synthetics/api_tests/udp_tests.md
@@ -161,7 +161,7 @@ If you are using the [custom role feature][10], add your user to any custom role
 ### Restrict access
 
 <div class="alert alert-warning">
-Access restriction is available for customers with <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> enabled on their accounts.</div>
+Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their accounts.</div>
 
 You can restrict access to a UDP test based on the roles in your organization. When creating a UDP test, choose which roles (in addition to your user) can read and write your test. 
 

--- a/content/en/synthetics/api_tests/udp_tests.md
+++ b/content/en/synthetics/api_tests/udp_tests.md
@@ -156,7 +156,7 @@ These reasons include the following:
 
 By default, only users with the Datadog Admin and Datadog Standard roles can create, edit, and delete Synthetic UDP tests. To get create, edit, and delete access to Synthetic UDP tests, upgrade your user to one of those two [default roles][9].
 
-If you have access to the [custom role feature][10], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
+If you are using the [custom role feature][10], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
 
 ### Restrict access
 

--- a/content/en/synthetics/api_tests/websocket_tests.md
+++ b/content/en/synthetics/api_tests/websocket_tests.md
@@ -179,8 +179,7 @@ If you are using the [custom role feature][11], add your user to any custom role
 
 ### Restrict access
 
-<div class="alert alert-warning">
-Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their accounts.</div>
+Access restriction is available for customers using [custom roles][12] on their accounts.</div>
 
 You can restrict access to a WebSocket test based on the roles in your organization. When creating a WebSocket test, choose which roles (in addition to your user) can read and write your test. 
 
@@ -201,3 +200,4 @@ You can restrict access to a WebSocket test based on the roles in your organizat
 [9]: /synthetics/api_tests/errors/#ssl-errors
 [10]: /account_management/rbac/
 [11]: /account_management/rbac#custom-roles
+[12]: /account_management/rbac/#create-a-custom-role

--- a/content/en/synthetics/api_tests/websocket_tests.md
+++ b/content/en/synthetics/api_tests/websocket_tests.md
@@ -179,7 +179,7 @@ If you are using the [custom role feature][11], add your user to any custom role
 
 ### Restrict access
 
-Access restriction is available for customers using [custom roles][12] on their accounts.</div>
+Access restriction is available for customers using [custom roles][12] on their accounts.
 
 You can restrict access to a WebSocket test based on the roles in your organization. When creating a WebSocket test, choose which roles (in addition to your user) can read and write your test. 
 

--- a/content/en/synthetics/api_tests/websocket_tests.md
+++ b/content/en/synthetics/api_tests/websocket_tests.md
@@ -180,7 +180,7 @@ If you are using the [custom role feature][11], add your user to any custom role
 ### Restrict access
 
 <div class="alert alert-warning">
-Access restriction is available for customers with <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> enabled on their accounts.</div>
+Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their accounts.</div>
 
 You can restrict access to a WebSocket test based on the roles in your organization. When creating a WebSocket test, choose which roles (in addition to your user) can read and write your test. 
 

--- a/content/en/synthetics/api_tests/websocket_tests.md
+++ b/content/en/synthetics/api_tests/websocket_tests.md
@@ -175,7 +175,7 @@ These reasons include the following:
 
 By default, only users with the [Datadog Admin and Datadog Standard roles][10] can create, edit, and delete Synthetic WebSocket tests. To get create, edit, and delete access to Synthetic WebSocket tests, upgrade your user to one of those two [default roles][10].
 
-If you have access to the [custom role feature][11], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
+If you are using the [custom role feature][11], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
 
 ### Restrict access
 

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -157,7 +157,7 @@ Tests can be only recorded from [Google Chrome][10]. To record your test, downlo
 
 By default, only users with the [Datadog Admin and Datadog Standard roles][14] can create, edit, and delete Synthetic browser tests. To get create, edit, and delete access to Synthetic browser tests, upgrade your user to one of those two [default roles][14].
 
-If you have access to the [custom role feature][15], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
+If you are using the [custom role feature][15], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions.
 
 ### Restrict access
 

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -162,7 +162,7 @@ If you are using the [custom role feature][15], add your user to any custom role
 ### Restrict access
 
 <div class="alert alert-warning">
-Access restriction is available for customers with <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> enabled on their accounts.</div>
+Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their accounts.</div>
 
 You can restrict access to a browser test based on the roles in your organization. When creating a browser test, choose which roles (in addition to your user) can read and write your test. 
 

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -161,7 +161,7 @@ If you are using the [custom role feature][15], add your user to any custom role
 
 ### Restrict access
 
-Access restriction is available for customers using [custom roles][16] on their accounts.</div>
+Access restriction is available for customers using [custom roles][16] on their accounts.
 
 You can restrict access to a browser test based on the roles in your organization. When creating a browser test, choose which roles (in addition to your user) can read and write your test. 
 

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -161,8 +161,7 @@ If you are using the [custom role feature][15], add your user to any custom role
 
 ### Restrict access
 
-<div class="alert alert-warning">
-Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their accounts.</div>
+Access restriction is available for customers using [custom roles][16] on their accounts.</div>
 
 You can restrict access to a browser test based on the roles in your organization. When creating a browser test, choose which roles (in addition to your user) can read and write your test. 
 
@@ -187,3 +186,4 @@ You can restrict access to a browser test based on the roles in your organizatio
 [13]: /synthetics/browser_tests/actions/#assertion
 [14]: /account_management/rbac/
 [15]: /account_management/rbac#custom-roles
+[16]: /account_management/rbac/#create-a-custom-role

--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -279,7 +279,7 @@ A test is considered `FAILED` if a step does not satisfy one or several assertio
 
 By default, only users with the [Datadog Admin and Datadog Standard roles][16] can create, edit, and delete Synthetic multistep API tests. To get create, edit, and delete access to Synthetic multistep API tests, upgrade your user to one of those two [default roles][16].
 
-If you have access to the [custom role feature][17], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions for Synthetic Monitoring.
+If you are using the [custom role feature][17], add your user to any custom role that includes `synthetics_read` and `synthetics_write` permissions for Synthetic Monitoring.
 
 ## Restrict access
 

--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -283,7 +283,7 @@ If you are using the [custom role feature][17], add your user to any custom role
 
 ## Restrict access
 
-Access restriction is available for customers using [custom roles][18] on their account.
+Access restriction is available for customers using [custom roles][18] on their accounts.
 
 You can restrict access to a multistep API test based on the roles in your organization. When creating a multistep API test, choose which roles (in addition to your user) can read and write your test. 
 

--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -284,7 +284,7 @@ If you are using the [custom role feature][17], add your user to any custom role
 ## Restrict access
 
 <div class="alert alert-warning">
-Access restriction is available for customers with <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> enabled on their account.</div>
+Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their account.</div>
 
 You can restrict access to a multistep API test based on the roles in your organization. When creating a multistep API test, choose which roles (in addition to your user) can read and write your test. 
 

--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -283,8 +283,7 @@ If you are using the [custom role feature][17], add your user to any custom role
 
 ## Restrict access
 
-<div class="alert alert-warning">
-Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their account.</div>
+Access restriction is available for customers using [custom roles][18] on their account.
 
 You can restrict access to a multistep API test based on the roles in your organization. When creating a multistep API test, choose which roles (in addition to your user) can read and write your test. 
 
@@ -311,3 +310,4 @@ You can restrict access to a multistep API test based on the roles in your organ
 [15]: /synthetics/api_tests/errors/#ssl-errors
 [16]: /account_management/rbac/
 [17]: /account_management/rbac#custom-roles
+[18]: /account_management/rbac/#create-a-custom-role

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -571,7 +571,7 @@ By default, only users with the Datadog Admin Role can create private locations,
 
 Users with the [Datadog Admin and Datadog Standard roles][20] can view private locations, search for private locations, and assign Synthetic tests to private locations. Grant access to the [**Private Locations** page][22] by upgrading your user to one of these two [default roles][19]. 
 
-If you have access to the [custom role feature][21], add your user to a custom role that includes `synthetics_private_location_read` and `synthetics_private_location_write` permissions. 
+If you are using the [custom role feature][21], add your user to a custom role that includes `synthetics_private_location_read` and `synthetics_private_location_write` permissions. 
 
 ## Further Reading
 

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -101,7 +101,7 @@ If you are using the [custom role feature][12], add your user to any custom role
 #### Restrict access
 
 <div class="alert alert-warning">
-Access restriction is available for customers with <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> enabled on their account.</div>
+Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their account.</div>
 
 You can restrict access to a global variable based on the roles in your organization. When creating a global variable, choose which roles (in addition to your user) can read and write your global variable in **Permissions settings**. 
 

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -100,8 +100,7 @@ If you are using the [custom role feature][12], add your user to any custom role
 
 #### Restrict access
 
-<div class="alert alert-warning">
-Access restriction is available for customers using <a href="https://docs.datadoghq.com/account_management/rbac/?tab=datadogapplication#create-a-custom-role">custom roles</a> on their account.</div>
+Access restriction is available for customers using [custom roles][13] on their account.
 
 You can restrict access to a global variable based on the roles in your organization. When creating a global variable, choose which roles (in addition to your user) can read and write your global variable in **Permissions settings**. 
 
@@ -137,7 +136,7 @@ To enable tag enforcement, click **Enforce tags for usage attributions on all te
 
 {{< img src="synthetics/settings/tag_enforcement.png" alt="Enforce tags for usage attributions on all tests" style="width:100%;">}}
 
-For more information, see [Usage Attribution][13].
+For more information, see [Usage Attribution][14].
 
 ### Permissions
 
@@ -161,4 +160,5 @@ If you are using the [custom role feature][12], add your user to any custom role
 [10]: /synthetics/browser_tests/actions#using-variables
 [11]: /account_management/rbac/?tab=datadogapplication#datadog-default-roles
 [12]: /account_management/rbac/?tab=datadogapplication#custom-role
-[13]: /account_management/billing/usage_attribution
+[13]: /account_management/rbac/#create-a-custom-role
+[14]: /account_management/billing/usage_attribution

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -143,7 +143,7 @@ For more information, see [Usage Attribution][13].
 
 By default, only users with the [Datadog Admin and Datadog Standard roles][11] can access the Synthetic Monitoring **Default Settings** page. To get access to the **Default Settings** page, upgrade your user to one of those two [default roles][11]. 
 
-If you have access to the [custom role feature][12], add your user to any custom role that includes `synthetics_default_settings_read` and `synthetics_default_settings_write` permissions. 
+If you are using the [custom role feature][12], add your user to any custom role that includes `synthetics_default_settings_read` and `synthetics_default_settings_write` permissions. 
 
 ## Further Reading
 

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -100,7 +100,7 @@ If you are using the [custom role feature][12], add your user to any custom role
 
 #### Restrict access
 
-Access restriction is available for customers using [custom roles][13] on their account.
+Access restriction is available for customers using [custom roles][13] on their accounts.
 
 You can restrict access to a global variable based on the roles in your organization. When creating a global variable, choose which roles (in addition to your user) can read and write your global variable in **Permissions settings**. 
 

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -96,7 +96,7 @@ Once created, global variables can be used in all Synthetic tests by typing `{{`
 
 By default, only users with the [Datadog Admin and Datadog Standard roles][11] can access the Synthetic Monitoring **Global Variables** page. You can get access to the **Global Variables** page by having your user upgraded to one of those two [default roles][11]. 
 
-If you have access to the [custom role feature][12], add your user to any custom role that includes `synthetics_global_variable_read` and `synthetics_global_variable_write` permissions. 
+If you are using the [custom role feature][12], add your user to any custom role that includes `synthetics_global_variable_read` and `synthetics_global_variable_write` permissions. 
 
 #### Restrict access
 


### PR DESCRIPTION
### What does this PR do?
Updates the wording of the Permissions section of Synthetics pages to reflect the GA (Generally Available) status of Custom Roles.

### Motivation
Custom Roles will be GA in the next 1-2 weeks.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/uchen/admin-synthetics

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
