### PR TITLE
DOCS-3191 - fixing link in cluster agent command section

### DIFF
--- a/content/en/agent/cluster_agent/commands.md
+++ b/content/en/agent/cluster_agent/commands.md
@@ -52,13 +52,13 @@ The following environment variables are supported:
 : Enables cluster level metadata mapping. Defaults to `true`.
 
 `DD_COLLECT_KUBERNETES_EVENTS`                
-: Configures the Agent to collect Kubernetes events. Defaults to `false`. See the [Event collection documentation][2] for more details.
+: Configures the Agent to collect Kubernetes events. Defaults to `false`. See the [Cluster Agent Event Collection documentation][2] for more details.
 
 `DD_LEADER_ELECTION`                          
 : Activates leader election. Set `DD_COLLECT_KUBERNETES_EVENTS` to `true` to activate this feature. Defaults to `false`.
 
 `DD_LEADER_LEASE_DURATION`                    
-: Used only if leader election is activated. See the details [in the leader election section][3]. Value in seconds, 60 by default.
+: Used only if leader election is activated. See the details about leader election [in the Cluster Agent Event Collection documentation][2]. Value in seconds, 60 by default.
 
 `DD_CLUSTER_AGENT_AUTH_TOKEN`                 
 : 32 characters long token that needs to be shared between the node Agent and the Datadog Cluster Agent.


### PR DESCRIPTION
the old link was pointing to the wrong place
also made the link language a bit clearer

https://docs-staging.datadoghq.com/cswatt/cluster-agent-linkfix/agent/cluster_agent/commands

