### PR TITLE
Update network.md

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -65,6 +65,9 @@ API test results for worker v>0.1.6 `intake.synthetics.`{{< region-param key="dd
 Browser test results for worker v>0.2.0 `intake-v2.synthetics.`{{< region-param key="dd_site" code="true" >}}<br>
 API test results for worker v<0.1.5 `api.`{{< region-param key="dd_site" code="true" >}}
 
+[Network Device Monitoring][13]
+: `ndm-intake.`{{< region-param key="dd_site" code="true" >}}
+
 All other Agent data
 : `<VERSION>-app.agent.`{{< region-param key="dd_site" code="true" >}}<br>
 For example, Agent v7.31.0 reports to `7-31-0-app.agent.`{{< region-param key="dd_site" code="true" >}}. Therefore you must add `*.agent.`{{< region-param key="dd_site" code="true" >}} to your inclusion list in your firewall(s).<br>
@@ -226,3 +229,4 @@ To avoid running out of storage space, the Agent stores the metrics on disk only
 [10]: /tracing/profiler/
 [11]: /synthetics/private_locations
 [12]: /agent/proxy/
+[13]: /network_monitoring/devices


### PR DESCRIPTION
Bill Cain, E.T. working together to add this item because it is a requirement for customers that use proxy servers and if this endpoint is not known, the agents forwarding NDM related metadata will never be able to get this data back into their Datadog account through the proxy.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
