### PR TITLE
Fix EBS sample config

### DIFF
--- a/static/config/99datadog-amazon-linux-2.config
+++ b/static/config/99datadog-amazon-linux-2.config
@@ -26,3 +26,5 @@ files:
 container_commands:
     05setup_datadog:
         command: "DD_API_KEY=unused /datadog_install_script.sh; sed -i 's/ install_script/ ebs_install_script/' /etc/datadog-agent/install_info"
+    06chown_datadog_config:
+        command: "chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml"


### PR DESCRIPTION
### What does this PR do?
Adds a line to change the owner of `datadog.yaml` since the `install_script.sh` only does this the first time, when creating the file.

### Motivation
Customer report issue. Bug introduced in #13071

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
