### PR TITLE
Update python.md

### DIFF
--- a/content/en/tracing/setup_overview/open_standards/_index.md
+++ b/content/en/tracing/setup_overview/open_standards/_index.md
@@ -350,11 +350,7 @@ To connect OpenTelemetry traces and logs so that your application logs monitorin
 
 ## Other alternatives
 
-Datadog recommends you use the OpenTelemetry Collector Datadog exporter or the OTLP Ingest in the Datadog Agent in conjunction with OpenTelemetry tracing clients. However, if that doesn't work for you:
-
-  - Each of the supported languages also has support for [sending OpenTracing data to Datadog][22].
-
-  - [Python][23], [Ruby][24], and [NodeJS][25] also have language-specific OpenTelemetry Datadog span exporters, which export traces directly from OpenTelemetry tracing clients to a Datadog Agent.
+Datadog recommends you use the OpenTelemetry Collector Datadog exporter or the OTLP Ingest in the Datadog Agent in conjunction with OpenTelemetry tracing clients. However, if that doesn't work for you, each of the supported languages also has support for [sending OpenTracing data to Datadog][22].
 
 ## Further Reading
 
@@ -382,6 +378,3 @@ Datadog recommends you use the OpenTelemetry Collector Datadog exporter or the O
 [20]: https://docs.datadoghq.com/help/
 [21]: /tracing/connect_logs_and_traces/opentelemetry
 [22]: /tracing/setup_overview/open_standards/java
-[23]: /tracing/setup_overview/open_standards/python#opentelemetry
-[24]: /tracing/setup_overview/open_standards/ruby#opentelemetry
-[25]: /tracing/setup_overview/open_standards/nodejs#opentelemetry

--- a/content/en/tracing/setup_overview/open_standards/nodejs.md
+++ b/content/en/tracing/setup_overview/open_standards/nodejs.md
@@ -30,11 +30,11 @@ See [opentracing.io][1] for OpenTracing NodeJS usage.
 
 ## OpenTelemetry
 
-OpenTelemetry support is available by using the `opentelemetry-exporter-datadog` package to export traces from OpenTelemetry to Datadog.
-
 <div class="alert alert-warning">
-This feature is currently in beta. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> if it doesn't work as you expect.
+This exporter is deprecated. To export your OTLP traces from OpenTelemetry SDK directly to Datadog Agent, see <a href="/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent">OTLP Ingest in the Agent</a>. <a href="/help/">Reach out to support</a> for questions.
 </div>
+
+OpenTelemetry support is available by using the `opentelemetry-exporter-datadog` package to export traces from OpenTelemetry to Datadog.
 
 ### Installation
 

--- a/content/en/tracing/setup_overview/open_standards/python.md
+++ b/content/en/tracing/setup_overview/open_standards/python.md
@@ -46,7 +46,7 @@ The tracer can now be used like in any other OpenTracing application. See [opent
 ## OpenTelemetry
 
 <div class="alert alert-warning">
-This exporter has been deprecated. To export your OTLP traces from OpenTelemetry SDK directly to Datadog Agent, see <a href="https://docs.datadoghq.com/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent">OTLP Ingest in the Agent</a>. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> for questions.
+This exporter is deprecated. To export your OTLP traces from OpenTelemetry SDK directly to Datadog Agent, see <a href="/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent">OTLP Ingest in the Agent</a>. <a href="/help/">Reach out to support</a> for questions.
 </div>
 
 OpenTelemetry support is available by using the `opentelemetry-exporter-datadog` package to export traces from OpenTelemetry to Datadog.

--- a/content/en/tracing/setup_overview/open_standards/python.md
+++ b/content/en/tracing/setup_overview/open_standards/python.md
@@ -45,11 +45,11 @@ The tracer can now be used like in any other OpenTracing application. See [opent
 
 ## OpenTelemetry
 
-OpenTelemetry support is available by using the `opentelemetry-exporter-datadog` package to export traces from OpenTelemetry to Datadog.
-
 <div class="alert alert-warning">
-This feature is currently in beta. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> if it doesn't work as you expect.
+This exporter has been deprecated. To export your OTLP traces from OpenTelemetry SDK directly to Datadog Agent, please refer to <a href="https://docs.datadoghq.com/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent">OTLP Ingest in the Agent</a>. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> for questions.
 </div>
+
+OpenTelemetry support is available by using the `opentelemetry-exporter-datadog` package to export traces from OpenTelemetry to Datadog.
 
 ### Installation
 

--- a/content/en/tracing/setup_overview/open_standards/python.md
+++ b/content/en/tracing/setup_overview/open_standards/python.md
@@ -46,7 +46,7 @@ The tracer can now be used like in any other OpenTracing application. See [opent
 ## OpenTelemetry
 
 <div class="alert alert-warning">
-This exporter has been deprecated. To export your OTLP traces from OpenTelemetry SDK directly to Datadog Agent, please refer to <a href="https://docs.datadoghq.com/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent">OTLP Ingest in the Agent</a>. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> for questions.
+This exporter has been deprecated. To export your OTLP traces from OpenTelemetry SDK directly to Datadog Agent, see <a href="https://docs.datadoghq.com/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent">OTLP Ingest in the Agent</a>. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> for questions.
 </div>
 
 OpenTelemetry support is available by using the `opentelemetry-exporter-datadog` package to export traces from OpenTelemetry to Datadog.

--- a/content/en/tracing/setup_overview/open_standards/ruby.md
+++ b/content/en/tracing/setup_overview/open_standards/ruby.md
@@ -38,11 +38,11 @@ However, additional instrumentation provided by Datadog can be activated alongsi
 
 ## OpenTelemetry
 
-OpenTelemetry support is available by using the `opentelemetry-exporters-datadog` gem to export traces from OpenTelemetry to Datadog.
-
 <div class="alert alert-warning">
-This feature is currently in beta. <a href="https://docs.datadoghq.com/help/">Reach out to support</a> if it doesn't work as you expect.
+This exporter is deprecated. To export your OTLP traces from OpenTelemetry SDK directly to Datadog Agent, see <a href="/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent">OTLP Ingest in the Agent</a>. <a href="/help/">Reach out to support</a> for questions.
 </div>
+
+OpenTelemetry support is available by using the `opentelemetry-exporters-datadog` gem to export traces from OpenTelemetry to Datadog.
 
 ### Installation
 


### PR DESCRIPTION
Changed the warning message to indicate that the python span exporter is being deprecated

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- Changed the warning message to indicate that OpenTelemetry python span exporter is being deprecated-->

### Motivation
<!-- OpenTelemetry Python span exporter has been superseded by OTLP Ingest in the Agent-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/pj-datadog-patch-1/tracing/setup_overview/open_standards/python/#opentelemetry

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
