### PR TITLE
Update information about supported Debian versions

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -136,8 +136,8 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | Platform                                 | Supported versions                                        |
 |------------------------------------------|-----------------------------------------------------------|
 | [Amazon Linux][1]                        | Amazon Linux 2                                            |
-| [Debian][2] with systemd                 | Debian 7 (wheezy)+                                        |
-| [Debian][2] with SysVinit                | Debian 7 (wheezy)+ in Agent 6.6.0+                        |
+| [Debian][2] with systemd                 | Debian 7 (wheezy)+ in Agent < 6.36.0/7.36.0, Debian 8 (jessie)+ in Agent 6.36.0+/7.36.0+ |
+| [Debian][2] with SysVinit                | Debian 7 (wheezy)+ in Agent 6.6.0 - 6.36.0/7.36.0, Debian 8 (jessie)+ in Agent 6.36.0+/7.36.0+ |
 | [Ubuntu][3]                              | Ubuntu 14.04+                                             |
 | [RedHat/CentOS/AlmaLinux/Rocky][4]       | RedHat/CentOS 6+, AlmaLinux/Rocky 8+ in Agent 6.33.0+/7.33.0+ |
 | [Docker][5]                              | Version 1.12+                                             |

--- a/content/en/agent/basic_agent_usage/deb.md
+++ b/content/en/agent/basic_agent_usage/deb.md
@@ -24,7 +24,7 @@ This page outlines the basic features of the Datadog Agent for Debian. If you ha
 
 Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
 
-**Note**: Debian 7 (wheezy) and above is supported. SysVinit is supported in Agent v6.6.0+.
+**Note**: Debian 7 (wheezy) and above is supported in Agent < 6.36.0/7.36.0. Debian 8 (jessie) is supported in Agent >= 6.36.0/7.36.0. SysVinit is supported in Agent v6.6.0+.
 
 ## Commands
 

--- a/content/en/agent/basic_agent_usage/deb.md
+++ b/content/en/agent/basic_agent_usage/deb.md
@@ -24,7 +24,7 @@ This page outlines the basic features of the Datadog Agent for Debian. If you ha
 
 Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
 
-**Note**: Debian 7 (wheezy) and above is supported in Agent < 6.36.0/7.36.0. Debian 8 (jessie) is supported in Agent >= 6.36.0/7.36.0. SysVinit is supported in Agent v6.6.0+.
+**Note**: Debian 7 (wheezy) and above is supported in Agent < 6.36.0/7.36.0. Debian 8 (jessie) and above is supported in Agent >= 6.36.0/7.36.0. SysVinit is supported in Agent v6.6.0+.
 
 ## Commands
 


### PR DESCRIPTION
### What does this PR do?

Because https://github.com/DataDog/datadog-agent/pull/11311 was merged, Agent 6.36.0/7.36.0 will drop Debian 7 support. This PR updates docs accordingly (it basically does for Debian exactly what https://github.com/DataDog/documentation/pull/12112 did for SUSE).

To be merged when 6.36.0/7.36.0 get released.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview

https://docs-staging.datadoghq.com/slavek.kabrda/debian-support-update/agent/basic_agent_usage/?tab=agentv6v7
https://docs-staging.datadoghq.com/slavek.kabrda/debian-support-update/agent/basic_agent_usage/deb/?tab=agentv6v7

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
