### PR TITLE
Change ja/fr Java profiling pages to use correct tracer link

### DIFF
--- a/content/fr/tracing/profiler/getting_started.md
+++ b/content/fr/tracing/profiler/getting_started.md
@@ -31,7 +31,7 @@ Le profileur Datadog nécessite [JDK Flight Recorder][1]. La bibliothèque du pr
 2. Téléchargez `dd-java-agent.jar`, qui contient les fichiers de classe de l'Agent Java :
 
     ```shell
-    wget -O dd-java-agent.jar 'https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.datadoghq&a=dd-java-agent&v=LATEST'
+    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
     ```
 
      **Remarque** : le profileur est disponible dans la bibliothèque `dd-java-agent.jar` dans la version 0.55 et les versions ultérieures.

--- a/content/ja/tracing/profiler/getting_started.md
+++ b/content/ja/tracing/profiler/getting_started.md
@@ -31,7 +31,7 @@ Datadog Profiler には [JDK Flight Recorder][1] が必要です。Datadog Profi
 2. Java Agent クラスファイルを含む `dd-java-agent.jar` をダウンロードします。
 
     ```shell
-    wget -O dd-java-agent.jar 'https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.datadoghq&a=dd-java-agent&v=LATEST'
+    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
     ```
 
    **注**: Profiler は、0.55 以降のバージョンの `dd-java-agent.jar` ライブラリで利用できます。

--- a/content/ja/tracing/profiling/getting_started.md
+++ b/content/ja/tracing/profiling/getting_started.md
@@ -21,7 +21,7 @@ Datadog Profiler には [JDK Flight Recorder][1] が必要です。Datadog Profi
 2. Java Agent クラスファイルを含む `dd-java-agent.jar` をダウンロードします。
 
     ```shell
-    wget -O dd-java-agent.jar 'https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.datadoghq&a=dd-java-agent&v=LATEST'
+    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
     ```
 
    **注**: プロファイリングは、0.55 以降のバージョンの `dd-java-agent.jar` ライブラリで利用できます。


### PR DESCRIPTION
### What does this PR do?

Changes the ja/fr profiling getting started pages to use the correct java tracer download link

### Motivation

The old link in these pages have been changed for all other pages, and today the old link stopped working.

### Preview
https://docs-staging.datadoghq.com/ban/use-official-java-tracer-link-in-jp-fr-docs/fr/tracing/profiler/getting_started
https://docs-staging.datadoghq.com/ban/use-official-java-tracer-link-in-jp-fr-docs/ja/tracing/profiler/getting_started
https://docs-staging.datadoghq.com/ban/use-official-java-tracer-link-in-jp-fr-docs/ja/tracing/profiling/getting_started

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
