### PR TITLE
Add watchdog insights for logs to navbar

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2397,6 +2397,10 @@ main:
     url: logs/explorer/export/
     parent: log_explorer
     weight: 508
+  - name: Watchdog Insights for Logs
+    url: logs/explorer/watchdog_insights/
+    parent: log_explorer
+    weight: 509
   - name: Saved Views
     url: logs/explorer/saved_views/
     parent: log_explorer


### PR DESCRIPTION
### What does this PR do?

Adds Watchdog Insights for logs to the navbar for GA release

### Motivation

PM requested

### Preview

https://docs-staging.datadoghq.com/may/add-insights-navbar/logs/explorer/watchdog_insights/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
