### PR TITLE
add `stream-logs` command to Agent pages

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -238,6 +238,7 @@ With Agent v6+, the command line interface is based on subcommands. To run a sub
 | `start`           | [Start the Agent][3].                                                       |
 | `start-service`   | Start the Agent within the service control manager.                         |
 | `status`          | [Print the current Agent status][4].                                        |
+| `stream-logs`     | Stream the logs being processed by a running agent.                         |
 | `stop`            | [Stop the Agent][5].                                                        |
 | `stopservice`     | Stop the Agent within the service control manager.                          |
 | `version`         | Print version info.                                                         |

--- a/content/en/agent/guide/agent-commands.md
+++ b/content/en/agent/guide/agent-commands.md
@@ -271,6 +271,7 @@ Some options have flags and options detailed under `--help`. For example, use he
 | `remove-service`  | Remove the Agent from the service control manager. Windows only.            |
 | `restart-service` | Restart the Agent within the service control manager. Windows only.         |
 | `start-service`   | Start the Agent within the service control manager. Windows only.           |
+| `stream-logs`     | Stream the logs being processed by a running agent.                         |
 | `stopservice`     | Stop the Agent within the service control manager. Windows only.            |
 | `version`         | Print version info.                                                         |
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add `stream-logs` command to CLI of basic agent usage.

### Motivation

It doesn't mention `stream-logs` command, even we can use it.

https://github.com/DataDog/datadog-agent/pull/7163 added this feature.

```
vagrant@vagrant:~$ sudo datadog-agent stream-logs -h
Stream the logs being processed by a running agent

Usage:
  datadog-agent stream-logs [flags]

Flags:
  -h, --help            help for stream-logs
      --name string     Filter by name
      --source string   Filter by source
      --type string     Filter by type

Global Flags:
  -c, --cfgpath string           path to directory containing datadog.yaml
  -n, --no-color                 disable color output
      --sysprobecfgpath string   path to directory containing system-probe.yaml
```

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
