### PR TITLE
[CIAPP] Use "Alpha" for ci pipeline monitors

### DIFF
--- a/content/en/monitors/create/types/ci_pipelines.md
+++ b/content/en/monitors/create/types/ci_pipelines.md
@@ -19,7 +19,7 @@ further_reading:
 <div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-<div class="alert alert-info">CI Pipeline monitors are in beta.
+<div class="alert alert-info">CI Pipeline monitors are in alpha.
 </div>
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR changes the status for CI Pipeline monitors from "Beta" to "Alpha"

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/drodriguezhdez/use_alpha_label_for_cipipelines/monitors/create/types/ci_pipelines

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
