### PR TITLE
Notes about ILogger calling serilogger and traceid notes

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -32,6 +32,8 @@ The .NET Tracer supports the following logging libraries:
 
 ## Getting started
 
+Before you begin, 
+
 To inject correlation identifiers into your log messages, follow the instructions for your logging library.
 
 {{< tabs >}}
@@ -224,6 +226,8 @@ Examples:
 
 **Note**: The Serilog library requires message property names to be valid C# identifiers. The required property names are: `dd_env`, `dd_service`, `dd_version`, `dd_trace_id`, and `dd_span_id`.
 
+**Note**: If you are using Serilog through ILogger, see the [ILogger section](?tab=microsoftextensionslogging#configure-log-collection) to configure these properties via `BeginScope()`.
+
 ```csharp
 using Datadog.Trace;
 using Serilog.Context;
@@ -289,6 +293,8 @@ using (MappedDiagnosticsLogicalContext.SetScoped("dd.span_id", CorrelationIdenti
 {{% /tab %}}
 {{% tab "Microsoft.Extensions.Logging" %}}
 
+*Note:* If you are using Serilog as an ILogger provider, it is preferrably to use this `ILogger.BeginScope()` method as opposed to the Serilog static properties. Passing an `ILogger.BeginScope()` an `IDictionary<string,object>`. See [this blog by the author of Serilog][13].
+
 ```csharp
 using Datadog.Trace;
 using Microsoft.Extensions.Logging;
@@ -314,7 +320,7 @@ using(_logger.BeginScope(new Dictionary<string, object>
 
 ## Configure log collection
 
-Ensure that log collection is configured in the Datadog Agent and that the [Logs Agent configuration][12] for the specified files to tail is set to `source: csharp` so log pipelines can parse the log files. For more information, see [C# Log Collection][7].
+Ensure that log collection is configured in the Datadog Agent and that the [Logs Agent configuration][12] for the specified files to tail is set to `source: csharp` so log pipelines can parse the log files. For more information, see [C# Log Collection][7]. If you do configure the `source` to a value other than `csharp`, add a [trace remapper](/logs/log_configuration/processors/?tab=ui#trace-remapper) to that source so the trace id gets marked. Otherwise correlation will not occur.
 
 <div class="alert alert-warning"><strong>Note:</strong> Automatic log collection only works for logs formatted as JSON. Alternatively, use custom parsing rules.</div>
 
@@ -334,3 +340,4 @@ Ensure that log collection is configured in the Datadog Agent and that the [Logs
 [10]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel/?tab=custom
 [11]: https://www.nuget.org/packages/Datadog.Trace/
 [12]: /logs/log_collection/csharp/#configure-your-datadog-agent
+[13]: https://nblumhardt.com/2016/11/ilogger-beginscope/

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -293,7 +293,7 @@ using (MappedDiagnosticsLogicalContext.SetScoped("dd.span_id", CorrelationIdenti
 {{% /tab %}}
 {{% tab "Microsoft.Extensions.Logging" %}}
 
-*Note:* If you are using Serilog as an ILogger provider, it is preferrably to use this `ILogger.BeginScope()` method as opposed to the Serilog static properties. Passing an `ILogger.BeginScope()` an `IDictionary<string,object>`. See [this blog by the author of Serilog][13].
+*Note:* If you are using Serilog as an ILogger provider, it is preferrably to use this `ILogger.BeginScope()` method as opposed to the Serilog static properties. Passing an `ILogger.BeginScope()` an `IDictionary<string,object>` as the same effect as `LogContext.PushProperty()`. See [this blog by the author of Serilog][13].
 
 ```csharp
 using Datadog.Trace;

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -32,8 +32,6 @@ The .NET Tracer supports the following logging libraries:
 
 ## Getting started
 
-Before you begin, 
-
 To inject correlation identifiers into your log messages, follow the instructions for your logging library.
 
 {{< tabs >}}
@@ -211,6 +209,8 @@ If you prefer to manually correlate your traces with your logs, you can add corr
 
 **Note:** If you are not using a [Datadog Log Integration][7] to parse your logs, custom log parsing rules must parse `dd.trace_id` and `dd.span_id` as strings. For information, see the [FAQ on this topic][10].
 
+**Note**: If you are using Serilog, Nlog or log4net *through* ILogger, see the Microsoft.Extensions.Logging section to configure these properties via `BeginScope()`.
+
 After completing the [getting started steps](#getting-started), finish your manual log enrichment setup:
 
 1. Reference the [`Datadog.Trace` NuGet package][11] in your project.
@@ -225,8 +225,6 @@ Examples:
 {{% tab "Serilog" %}}
 
 **Note**: The Serilog library requires message property names to be valid C# identifiers. The required property names are: `dd_env`, `dd_service`, `dd_version`, `dd_trace_id`, and `dd_span_id`.
-
-**Note**: If you are using Serilog through ILogger, see the [ILogger section](?tab=microsoftextensionslogging#configure-log-collection) to configure these properties via `BeginScope()`.
 
 ```csharp
 using Datadog.Trace;

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -315,9 +315,9 @@ using(_logger.BeginScope(new Dictionary<string, object>
 {{< /tabs >}}
 
 You can read more about using BeginScope to create structured log messages using the following log providers:
-- [Serilog][13],
-- [NLog][14],
-- [log4net][15]
+- Serilog: [The semantics of ILogger.BeginScope()][13]
+- NLog: [NLog properties with Microsoft Extension Logging][14]
+- log4net: [Using BeginScope][15]
 
 ## Configure log collection
 

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -318,7 +318,7 @@ using(_logger.BeginScope(new Dictionary<string, object>
 
 ## Configure log collection
 
-Ensure that log collection is configured in the Datadog Agent and that the [Logs Agent configuration][12] for the specified files to tail is set to `source: csharp` so log pipelines can parse the log files. For more information, see [C# Log Collection][7]. If the `source` is set to a value other than `csharp`, you may need to add a [trace remapper](/logs/log_configuration/processors/?tab=ui#trace-remapper) to the appropriate log processing pipeline for correlation to work properly.
+Ensure that log collection is configured in the Datadog Agent and that the [Logs Agent configuration][12] for the specified files to tail is set to `source: csharp` so log pipelines can parse the log files. For more information, see [C# Log Collection][7]. If the `source` is set to a value other than `csharp`, you may need to add a [trace remapper](/logs/log_configuration/processors/?tab=ui#trace-remapper) to the appropriate log processing pipeline for the correlation to work correctly.
 
 <div class="alert alert-warning"><strong>Note:</strong> Automatic log collection only works for logs formatted as JSON. Alternatively, use custom parsing rules.</div>
 

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -291,8 +291,6 @@ using (MappedDiagnosticsLogicalContext.SetScoped("dd.span_id", CorrelationIdenti
 {{% /tab %}}
 {{% tab "Microsoft.Extensions.Logging" %}}
 
-*Note:* If you are using Serilog as an ILogger provider, it is preferrably to use this `ILogger.BeginScope()` method as opposed to the Serilog static properties. Passing an `ILogger.BeginScope()` an `IDictionary<string,object>` as the same effect as `LogContext.PushProperty()`. See [this blog by the author of Serilog][13].
-
 ```csharp
 using Datadog.Trace;
 using Microsoft.Extensions.Logging;
@@ -315,6 +313,11 @@ using(_logger.BeginScope(new Dictionary<string, object>
 
 {{% /tab %}}
 {{< /tabs >}}
+
+You can read more about using BeginScope to create structured log messages using the following log providers:
+- [Serilog][13],
+- [NLog][14],
+- [log4net][15]
 
 ## Configure log collection
 
@@ -339,3 +342,5 @@ Ensure that log collection is configured in the Datadog Agent and that the [Logs
 [11]: https://www.nuget.org/packages/Datadog.Trace/
 [12]: /logs/log_collection/csharp/#configure-your-datadog-agent
 [13]: https://nblumhardt.com/2016/11/ilogger-beginscope/
+[14]: https://github.com/NLog/NLog.Extensions.Logging/wiki/NLog-properties-with-Microsoft-Extension-Logging
+[15]: https://github.com/huorswords/Microsoft.Extensions.Logging.Log4Net.AspNetCore#using-beginscope

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -209,7 +209,7 @@ If you prefer to manually correlate your traces with your logs, you can add corr
 
 **Note:** If you are not using a [Datadog Log Integration][7] to parse your logs, custom log parsing rules must parse `dd.trace_id` and `dd.span_id` as strings. For information, see the [FAQ on this topic][10].
 
-**Note**: If you are using Serilog, Nlog or log4net *through* ILogger, see the Microsoft.Extensions.Logging section to configure these properties via `BeginScope()`.
+**Note**: If you are using Serilog, Nlog or log4net through ILogger, see the Microsoft.Extensions.Logging section to configure these properties using `BeginScope()`.
 
 After completing the [getting started steps](#getting-started), finish your manual log enrichment setup:
 

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -314,14 +314,14 @@ using(_logger.BeginScope(new Dictionary<string, object>
 {{% /tab %}}
 {{< /tabs >}}
 
-You can read more about using BeginScope to create structured log messages using the following log providers:
+You can read more about using BeginScope to create structured log messages for the following log providers:
 - Serilog: [The semantics of ILogger.BeginScope()][13]
 - NLog: [NLog properties with Microsoft Extension Logging][14]
 - log4net: [Using BeginScope][15]
 
 ## Configure log collection
 
-Ensure that log collection is configured in the Datadog Agent and that the [Logs Agent configuration][12] for the specified files to tail is set to `source: csharp` so log pipelines can parse the log files. For more information, see [C# Log Collection][7]. If the `source` is set to a value other than `csharp`, you may need to add a [trace remapper](/logs/log_configuration/processors/?tab=ui#trace-remapper) to the appropriate log processing pipeline for the correlation to work correctly.
+Ensure that log collection is configured in the Datadog Agent and that the [Logs Agent configuration][12] for the specified files to tail is set to `source: csharp` so log pipelines can parse the log files. For more information, see [C# Log Collection][7]. If the `source` is set to a value other than `csharp`, you may need to add a [trace remapper][8] to the appropriate log processing pipeline for the correlation to work correctly.
 
 <div class="alert alert-warning"><strong>Note:</strong> Automatic log collection only works for logs formatted as JSON. Alternatively, use custom parsing rules.</div>
 

--- a/content/en/tracing/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/connect_logs_and_traces/dotnet.md
@@ -320,7 +320,7 @@ using(_logger.BeginScope(new Dictionary<string, object>
 
 ## Configure log collection
 
-Ensure that log collection is configured in the Datadog Agent and that the [Logs Agent configuration][12] for the specified files to tail is set to `source: csharp` so log pipelines can parse the log files. For more information, see [C# Log Collection][7]. If you do configure the `source` to a value other than `csharp`, add a [trace remapper](/logs/log_configuration/processors/?tab=ui#trace-remapper) to that source so the trace id gets marked. Otherwise correlation will not occur.
+Ensure that log collection is configured in the Datadog Agent and that the [Logs Agent configuration][12] for the specified files to tail is set to `source: csharp` so log pipelines can parse the log files. For more information, see [C# Log Collection][7]. If the `source` is set to a value other than `csharp`, you may need to add a [trace remapper](/logs/log_configuration/processors/?tab=ui#trace-remapper) to the appropriate log processing pipeline for correlation to work properly.
 
 <div class="alert alert-warning"><strong>Note:</strong> Automatic log collection only works for logs formatted as JSON. Alternatively, use custom parsing rules.</div>
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Some notes about using Serilog through ILogger and how source relates to traceid.

### Motivation

Struggling with integration APM traces and logs in my day job and having the answer be unintuitive made me want to add some notes.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
