### PR TITLE
Specify permissions for using Login Methods

### DIFF
--- a/content/en/account_management/login_methods.md
+++ b/content/en/account_management/login_methods.md
@@ -3,7 +3,11 @@ title: Configuring Login Methods
 kind: documentation
 ---
 
-Login Methods are how users are able to authenticate themselves and log into your Datadog organization. If you have  privileged access permission, as with the Datadog Admin Role, you can use Login Methods to enable and disable the default login methods for users in your organization. 
+Login Methods determine how users may authenticate themselves and log into your Datadog organization. Using Login Methods to enable or disable the default login methods requires one of the following privileged access permissions:
+
+- Datadog Admin Role
+- Org Management (`org_management`) permission
+- Edit Login Methods (`edit_login_methods`) permission
 
 When a login method is enabled by default, any user who is not explicitly denied access ([by a user login method override][1]) can use that login method to access Datadog, provided their username (their email address) matches the user that is invited to the organization.
 

--- a/content/en/account_management/users/_index.md
+++ b/content/en/account_management/users/_index.md
@@ -56,7 +56,7 @@ To discover all of the roles available and how to create custom ones, see the [R
 
 ## Edit a user's login methods
 
-Only users with the User Access Management permission, such as users with the Datadog Admin Role, can change another user's login methods.
+Only users with the Org Management permission, such as users with the Datadog Admin Role, can change another user's login methods.
 
 Default login methods for an organization can be set through the Login Methods page. There you can allow or disallow all users in your organization to use a Datadog username and password, to sign in with Google, or to sign in with SAML. In User Management you can override on a per-user basis to allow a specific user to use one method or multiple methods. This is helpful in circumstances where you want all users to use SAML but need to enable a set of users to log in with username and password in an emergency.
 


### PR DESCRIPTION
### What does this PR do?
Update description of Login Methods to include the exact permissions users need to modify login methods.

### Motivation
Datadog Admin permission is being deprecated, and the Custom Roles feature is going GA. This PR is part of a larger effort to update all docs to be consistent with Custom Role project.

### Preview
https://docs-staging.datadoghq.com/uchen/login-methods/account_management/login_methods/
https://docs-staging.datadoghq.com/uchen/login-methods/account_management/users/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
