### PR TITLE
Remove principal parameter in IAM policy

### DIFF
--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -132,9 +132,6 @@ Add the following two permission statements to your IAM policies attached to the
       "Sid": "DatadogUploadAndRehydrateLogArchives",
       "Effect": "Allow",
       "Action": ["s3:PutObject", "s3:GetObject"],
-       "Principal": {
-          "AWS": "arn:aws:iam::MY_AWS_ACCOUNTID:role/<MY_ROLE_NAME>"
-       },
       "Resource": [
         "arn:aws:s3:::<MY_BUCKET_NAME_1_/_MY_OPTIONAL_BUCKET_PATH_1>/*",
         "arn:aws:s3:::<MY_BUCKET_NAME_2_/_MY_OPTIONAL_BUCKET_PATH_2>/*"
@@ -144,9 +141,6 @@ Add the following two permission statements to your IAM policies attached to the
       "Sid": "DatadogRehydrateLogArchivesListBucket",
       "Effect": "Allow",
       "Action": "s3:ListBucket",
-      "Principal": {
-          "AWS": "arn:aws:iam::MY_AWS_ACCOUNTID:role/<MY_ROLE_NAME>"
-       },
       "Resource": [
         "arn:aws:s3:::<MY_BUCKET_NAME_1>",
         "arn:aws:s3:::<MY_BUCKET_NAME_2>"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Remove principal parameter in IAM policy. 

### Motivation
<!-- What inspired you to submit this pull request?-->
IAM policies do not support the principal parameter. The [previous text](https://github.com/DataDog/documentation/blob/6fe5e0637797836bb0d2b56293d1e7dcb98854ed/content/en/logs/log_configuration/archives.md?plain=1#L119) implies you should add the permission statements to the IAM policies attached to the role, which is not possible.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
