### PR TITLE
[serverless] Include tiered compilation settings in JAVA_TOOL_OPTIONS

### DIFF
--- a/content/en/serverless/guide/datadog_forwarder_java.md
+++ b/content/en/serverless/guide/datadog_forwarder_java.md
@@ -63,7 +63,7 @@ dependencies {
 2. Configure the following environment variables on your function:
 
     ```yaml
-    JAVA_TOOL_OPTIONS: -javaagent:"/opt/java/lib/dd-java-agent.jar"
+    JAVA_TOOL_OPTIONS: -javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1
     DD_LOGS_INJECTION: true
     DD_JMXFETCH_ENABLED: false
     DD_TRACE_ENABLED: true

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -152,7 +152,7 @@ Configure the following environment variables on your function:
 
 ```yaml
 DD_API_KEY: <DATADOG_API_KEY> # Replace <DATADOG_API_KEY> with your Datadog API key
-JAVA_TOOL_OPTIONS: -javaagent:"/opt/java/lib/dd-java-agent.jar"
+JAVA_TOOL_OPTIONS: -javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1
 DD_LOGS_INJECTION: true
 DD_JMXFETCH_ENABLED: false
 DD_TRACE_ENABLED: true


### PR DESCRIPTION
### What does this PR do?
Update the instructions for adding dd-trace-java to a Lambda function to include setting up tiered compilation. This will improve cold start performance of the functions.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
