### PR TITLE
Add disclaimer for F&F monitors in the monitor template variables section.

### DIFF
--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -281,7 +281,7 @@ If your facet has periods, use brackets around the facet, for example:
 
 _Available for [Log monitors][2], [Trace Analytics monitors][3] (APM), [RUM monitors][4] and [CI Pipeline monitors][5]_
 
-<div class="alert alert-info"><strong>Note</strong>: This feature is only available for monitors that do not use Formulas & Functions in its query for the moment. It will be available for those monitors in the near future.</div>
+<div class="alert alert-info"><strong>Note</strong>: This feature is only available for monitors that do not use Formulas & Functions in their queries.</div>
 
 To include **any** attribute or tag from a log, a trace span, a RUM event, or a CI Pipeline event matching the monitor query, use the following variables:
 

--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -281,6 +281,8 @@ If your facet has periods, use brackets around the facet, for example:
 
 _Available for [Log monitors][2], [Trace Analytics monitors][3] (APM), [RUM monitors][4] and [CI Pipeline monitors][5]_
 
+<div class="alert alert-info"><strong>Note</strong>:This feature is only available for monitors that do not use Formulas & Functions in its query for the moment. It will be available for those monitors in the near future.</div>
+
 To include **any** attribute or tag from a log, a trace span, a RUM event, or a CI Pipeline event matching the monitor query, use the following variables:
 
 | Monitor type    | Variable syntax                                         |

--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -281,7 +281,7 @@ If your facet has periods, use brackets around the facet, for example:
 
 _Available for [Log monitors][2], [Trace Analytics monitors][3] (APM), [RUM monitors][4] and [CI Pipeline monitors][5]_
 
-<div class="alert alert-info"><strong>Note</strong>:This feature is only available for monitors that do not use Formulas & Functions in its query for the moment. It will be available for those monitors in the near future.</div>
+<div class="alert alert-info"><strong>Note</strong>: This feature is only available for monitors that do not use Formulas & Functions in its query for the moment. It will be available for those monitors in the near future.</div>
 
 To include **any** attribute or tag from a log, a trace span, a RUM event, or a CI Pipeline event matching the monitor query, use the following variables:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR adds a disclaimer for Formulas&Functions monitors in the `Matching attribute/tag variables` section of the monitor variables.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/drodriguezhdez/template_variables_fnf_monitors/monitors/notify/variables/?tab=is_alert#matching-attributetag-variables

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
