### PR TITLE
(DOCS-2708) Add CI Visibility to pricing page

### DIFF
--- a/content/en/account_management/billing/pricing.md
+++ b/content/en/account_management/billing/pricing.md
@@ -80,8 +80,8 @@ You can put controls in place for both Indexed and Ingested span volumes. For mo
 ## CI Visibility
 
 * Datadog tracks the number of unique committers who send test and pipeline data to the CI Visibility service.
-* A **committer** means an active git committer; identified by their git author email address. A committer is counted towards billing if they commit at least 3 times in a given month.
-  * In the event that a pipeline is not associated to a git repository, or git metadata is unavailable, the username of the person triggering the pipeline execution is used as the billable committer.
+* A **committer** means an active git committer, identified by their git author email address. A committer is counted towards billing if they commit at least three times in a given month.
+  * In the event that a pipeline is not associated with a git repository, or git metadata is unavailable, the username of the person triggering the pipeline execution is used as the billable committer.
 * For Pipeline Visibility, every pipeline, pipeline stage, and pipeline job counts as a **pipeline span**. For Testing Visibility, every individual test run counts as a **test span**.
 
 ## Troubleshooting

--- a/content/en/account_management/billing/pricing.md
+++ b/content/en/account_management/billing/pricing.md
@@ -77,6 +77,12 @@ You can put controls in place for both Indexed and Ingested span volumes. For mo
 * Datadog tracks the number of monthly active users who participate in incident management and response.
  * An **active user** is only counted if they contribute comments or signals (graphs, links, etc.) to an incident. Anyone who only opens or closes an incident or anyone who only views the incident are not counted. Additionally, these are not named seats, so you do not need to determine which specific users have access.
 
+## CI Visibility
+
+* Datadog tracks the number of unique committers who send test and pipeline data to the CI Visibility service.
+* A **committer** means an active git committer; identified by their git author email address. A committer is counted towards billing if they commit at least 3 times in a given month.
+  * In the event that a pipeline is not associated to a git repository, or git metadata is unavailable, the username of the person triggering the pipeline execution is used as the billable committer.
+* For Pipeline Visibility, every pipeline, pipeline stage, and pipeline job counts as a **pipeline span**. For Testing Visibility, every individual test run counts as a **test span**.
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Adds CI Visibility to the billing/pricing page.

### Motivation


### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jorie/DOCS-2708/account_management/billing/pricing/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
