### PR TITLE
Add Heroku Postgres DB monitoring guide

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1870,6 +1870,11 @@ main:
     parent: dbm
     identifier: dbm_troubleshooting
     weight: 6
+  - name: Guides
+    url: database_monitoring/guide/
+    parent: dbm
+    identifier: dbm_guides
+    weight: 7
   - name: Log Management
     url: logs/
     pre: log

--- a/content/en/database_monitoring/guide/_index.md
+++ b/content/en/database_monitoring/guide/_index.md
@@ -1,0 +1,9 @@
+---
+title: Database Monitoring Guides
+kind: guide
+private: true
+---
+
+{{< whatsnext desc="General guides:" >}}
+    {{< nextlink href="database_monitoring/guide/heroku-postgres" >}}Setting up Heroku Postgres for Database Monitoring{{< /nextlink >}}
+{{< /whatsnext >}}

--- a/content/en/database_monitoring/guide/heroku-postgres.md
+++ b/content/en/database_monitoring/guide/heroku-postgres.md
@@ -1,0 +1,117 @@
+---
+title: Setting up Heroku Postgres for Database Monitoring
+kind: guide
+private: true
+further_reading:
+- link: "/agent/basic_agent_usage/heroku/"
+  tag: "Documentation"
+  text: "Datadog Heroku Buildpack"
+---
+
+This guide assumes that you have configured the [Datadog Heroku buildpack][1] in your application dynos.
+
+[Datadog Database Monitoring][2] allows you to view query metrics and explain plans from all of your databases in a single place. This guide will cover how to set it up for [Heroku Postgres managed database][3].
+
+*Note*: Only databases in the [Standard and Premium plans][4] publish metrics used by the integration. Not all the features of Database Monitoring are available when used with a Postgres instance in the Hobby plan.
+
+First, create a `datadog` user in your database:
+
+```shell
+# Ensure that you are in the root directory of the application
+heroku pg:credentials:create --name datadog
+
+# Attach the new credential to the application
+heroku addons:attach <database-name> --credential datadog
+```
+
+Attaching the new credential to the application will create a new environment variable in your application with the connection URL. Note that environment variable, as we use it later.
+
+Login to your Postgres database using the default credentials and give the `datadog` credential the right permissions:
+
+```shell
+heroku pg:psql
+```
+
+Once in the psql terminal, create the following schema:
+
+```
+CREATE SCHEMA datadog;
+GRANT USAGE ON SCHEMA datadog TO datadog;
+GRANT USAGE ON SCHEMA public TO datadog;
+GRANT pg_monitor TO datadog;
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+```
+
+Create the following function in the database:
+
+```
+CREATE OR REPLACE FUNCTION datadog.explain_statement (
+   l_query text,
+   out explain JSON
+)
+RETURNS SETOF JSON AS
+$$
+BEGIN
+   RETURN QUERY EXECUTE 'EXPLAIN (FORMAT JSON) ' || l_query;
+END;
+$$
+LANGUAGE 'plpgsql'
+RETURNS NULL ON NULL INPUT
+SECURITY DEFINER;
+```
+
+Finally, we configure the Datadog agent to enable the Postgres check using the new credentials: 
+
+```shell
+# Ensure that you are in the root directory of your application
+# Create the folder for the integrations configuration in your application code
+mkdir -p datadog/conf.d/
+```
+
+Create a configuration file called `postgres.yaml` with the following contents (do not replace with your credentials, as this is done as part of the prerun script):
+
+```yaml
+init_config:
+
+instances:
+  - dbm: true
+    host: <YOUR HOSTNAME>
+    port: <YOUR PORT>
+    username: <YOUR USERNAME>
+    password: <YOUR PASSWORD>
+    dbname: <YOUR DBNAME>
+    ssl: True
+```
+
+Using the environment variable that was created when the `datadog` credential was attached to the application (in the example below we assume this is `HEROKU_POSTGRESQL_PINK_URL`, add the following to the [prerun script][5] to replace those values before starting the Datadog Agent:
+
+```shell
+#!/usr/bin/env bash
+
+# Update the Postgres configuration from above using the Heroku application environment variable
+if [ -n "$HEROKU_POSTGRESQL_PINK_URL" ]; then
+  POSTGREGEX='^postgres://([^:]+):([^@]+)@([^:]+):([^/]+)/(.*)$'
+  if [[ $HEROKU_POSTGRESQL_PINK_URL =~ $POSTGREGEX ]]; then
+    sed -i "s/<YOUR HOSTNAME>/${BASH_REMATCH[3]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
+    sed -i "s/<YOUR USERNAME>/${BASH_REMATCH[1]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
+    sed -i "s/<YOUR PASSWORD>/${BASH_REMATCH[2]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
+    sed -i "s/<YOUR PORT>/${BASH_REMATCH[4]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
+    sed -i "s/<YOUR DBNAME>/${BASH_REMATCH[5]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
+  fi
+fi
+```
+
+Deploy to Heroku:
+
+```shell
+# Deploy to Heroku 
+git add .
+git commit -m "Enable postgres integration"
+git push heroku main
+```
+
+[1]: /agent/basic_agent_usage/heroku/
+[2]: https://www.datadoghq.com/product/database-monitoring/
+[3]: https://devcenter.heroku.com/articles/heroku-postgresql
+[4]: https://devcenter.heroku.com/articles/heroku-postgres-plans
+[5]: /agent/basic_agent_usage/heroku/#prerun-script

--- a/content/en/database_monitoring/guide/heroku-postgres.md
+++ b/content/en/database_monitoring/guide/heroku-postgres.md
@@ -10,7 +10,7 @@ further_reading:
 
 This guide assumes that you have configured the [Datadog Heroku buildpack][1] in your application dynos.
 
-[Datadog Database Monitoring][2] allows you to view query metrics and explain plans from all of your databases in a single place. This guide will cover how to set it up for [Heroku Postgres managed database][3].
+[Datadog Database Monitoring][2] allows you to view query metrics and explain plans from all of your databases in a single place. This guide covers how to set up Database Monitoring for a [Heroku Postgres managed database][3].
 
 *Note*: Only databases in the [Standard and Premium plans][4] publish metrics used by the integration. Not all the features of Database Monitoring are available when used with a Postgres instance in the Hobby plan.
 
@@ -24,7 +24,7 @@ heroku pg:credentials:create --name datadog
 heroku addons:attach <database-name> --credential datadog
 ```
 
-Attaching the new credential to the application will create a new environment variable in your application with the connection URL. Note that environment variable, as we use it later.
+Attaching the new credential to the application creates a new environment variable in your application with the connection URL. Note that environment variable, as you will use it later.
 
 Login to your Postgres database using the default credentials and give the `datadog` credential the right permissions:
 
@@ -83,7 +83,7 @@ instances:
     ssl: True
 ```
 
-Using the environment variable that was created when the `datadog` credential was attached to the application (in the example below we assume this is `HEROKU_POSTGRESQL_PINK_URL`, add the following to the [prerun script][5] to replace those values before starting the Datadog Agent:
+Using the environment variable that was created when the `datadog` credential was attached to the application (in the example below, this is assumed to be `HEROKU_POSTGRESQL_PINK_URL`) add the following to the [prerun script][5] to replace those values before starting the Datadog Agent:
 
 ```shell
 #!/usr/bin/env bash


### PR DESCRIPTION
Signed-off-by: Ara Pulido <ara.pulido@datadoghq.com>


### What does this PR do?
It creates a new DB Monitoring guide section, and adds a Heroku Postgres set up guide.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ara.pulido/heroku_db_guide/database_monitoring/guide/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
