### PR TITLE
Fix links to ECS create a task information

### DIFF
--- a/content/en/tracing/runtime_metrics/dotnet.md
+++ b/content/en/tracing/runtime_metrics/dotnet.md
@@ -68,5 +68,5 @@ net localgroup "Performance Monitor Users" "IIS APPPOOL\DefaultAppPool" /add
 [2]: /developers/dogstatsd/#setup
 [3]: /agent/docker/#dogstatsd-custom-metrics
 [4]: /developers/dogstatsd/?tab=kubernetes#agent
-[5]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task
+[5]: /agent/amazon_ecs/#create-an-ecs-task
 [6]: https://app.datadoghq.com/dash/integration/30412/net-runtime-metrics

--- a/content/en/tracing/runtime_metrics/go.md
+++ b/content/en/tracing/runtime_metrics/go.md
@@ -50,5 +50,5 @@ Along with displaying these metrics in your APM Service Page, Datadog provides a
 [2]: /developers/dogstatsd/#setup
 [3]: /agent/docker/#dogstatsd-custom-metrics
 [4]: /developers/dogstatsd/?tab=kubernetes#agent
-[5]: /integrations/amazon_ecs/#create-an-ecs-task
+[5]: /agent/amazon_ecs/#create-an-ecs-task
 [6]: https://app.datadoghq.com/dash/integration/30587/go-runtime-metrics

--- a/content/en/tracing/runtime_metrics/java.md
+++ b/content/en/tracing/runtime_metrics/java.md
@@ -56,7 +56,7 @@ Additional JMX metrics can be added using configuration files that are passed on
 [2]: /developers/dogstatsd/#setup
 [3]: /agent/docker/#dogstatsd-custom-metrics
 [4]: /developers/dogstatsd/?tab=kubernetes#agent
-[5]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task
+[5]: /agent/amazon_ecs/#create-an-ecs-task
 [6]: https://github.com/DataDog/dd-trace-java/releases/tag/v0.24.0
 [7]: https://app.datadoghq.com/dash/integration/256/jvm-runtime-metrics
 [8]: https://github.com/DataDog/integrations-core/search?q=jmx_metrics&unscoped_q=jmx_metrics

--- a/content/en/tracing/runtime_metrics/nodejs.md
+++ b/content/en/tracing/runtime_metrics/nodejs.md
@@ -47,5 +47,5 @@ Along with displaying these metrics in your APM Service Page, Datadog provides a
 [2]: /metrics/dogstatsd_metrics_submission/#setup
 [3]: /agent/docker/#dogstatsd-custom-metrics
 [4]: /developers/dogstatsd/?tab=kubernetes#agent
-[5]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task
+[5]: /agent/amazon_ecs/#create-an-ecs-task
 [6]: https://app.datadoghq.com/dash/integration/30269/node-runtime-metrics

--- a/content/en/tracing/runtime_metrics/python.md
+++ b/content/en/tracing/runtime_metrics/python.md
@@ -57,5 +57,5 @@ Along with displaying these metrics in your APM Service Page, Datadog provides a
 [3]: /metrics/dogstatsd_metrics_submission/#setup
 [4]: /agent/docker/#dogstatsd-custom-metrics
 [5]: /developers/dogstatsd/?tab=kubernetes#agent
-[6]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task
+[6]: /agent/amazon_ecs/#create-an-ecs-task
 [7]: https://app.datadoghq.com/dash/integration/30267/python-runtime-metrics

--- a/content/en/tracing/runtime_metrics/ruby.md
+++ b/content/en/tracing/runtime_metrics/ruby.md
@@ -67,5 +67,5 @@ Along with displaying these metrics in your APM Service Page, Datadog provides a
 [3]: https://app.datadoghq.com/apm/service
 [4]: /agent/docker/#dogstatsd-custom-metrics
 [5]: /developers/dogstatsd/?tab=kubernetes#agent
-[6]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task
+[6]: /agent/amazon_ecs/#create-an-ecs-task
 [7]: https://app.datadoghq.com/dash/integration/30268/ruby-runtime-metrics

--- a/content/en/tracing/setup_overview/setup/java.md
+++ b/content/en/tracing/setup_overview/setup/java.md
@@ -711,7 +711,7 @@ Java APM has minimal impact on the overhead of an application:
 [12]: /developers/dogstatsd/#setup
 [13]: /agent/docker/#dogstatsd-custom-metrics
 [14]: /developers/dogstatsd/
-[15]: /integrations/amazon_ecs/?tab=python#create-an-ecs-task
+[15]: /agent/amazon_ecs/#create-an-ecs-task
 [16]: /tracing/compatibility_requirements/java#disabling-integrations
 [17]: /integrations/java/?tab=host#metric-collection
 [18]: https://github.com/openzipkin/b3-propagation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes incorrect link

### Motivation
DOCS-3294

### Preview

https://docs-staging.datadoghq.com/kari/docs-3294/tracing/runtime_metrics/dotnet
https://docs-staging.datadoghq.com/kari/docs-3294/tracing/runtime_metrics/go
https://docs-staging.datadoghq.com/kari/docs-3294/tracing/runtime_metrics/java
https://docs-staging.datadoghq.com/kari/docs-3294/tracing/runtime_metrics/nodejs
https://docs-staging.datadoghq.com/kari/docs-3294/tracing/runtime_metrics/python
https://docs-staging.datadoghq.com/kari/docs-3294/tracing/runtime_metrics/ruby
https://docs-staging.datadoghq.com/kari/docs-3294/tracing/setup_overview/setup/java

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
