### PR TITLE
DOCS-3296 Adds the Synthetics CircleCI Orb README into Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ content/en/real_user_monitoring/reactnative.md
 
 # Synthetics
 content/en/synthetics/cicd_integrations/github_actions.md
-content/en/synthetics/cicd_integrations/circleci_orbs.md
+content/en/synthetics/cicd_integrations/circleci_orb.md
 
 # serverless
 content/en/serverless/libraries_integrations/forwarder.md

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ content/en/real_user_monitoring/reactnative.md
 
 # Synthetics
 content/en/synthetics/cicd_integrations/github_actions.md
+content/en/synthetics/cicd_integrations/circleci_orbs.md
 
 # serverless
 content/en/serverless/libraries_integrations/forwarder.md

--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ clean-auto-doc: ##Remove all doc automatically created
 	rm -f content/en/serverless/libraries_integrations/macro.md ;fi
 	@if [ content/en/serverless/libraries_integrations/cli.md ]; then \
 	rm -f content/en/serverless/libraries_integrations/cli.md ;fi
-	@if [ content/en/synthetics/cicd_integrations/circleci_orbs.md ]; then \
-	rm -f content/en/synthetics/cicd_integrations/circleci_orbs.md ;fi
+	@if [ content/en/synthetics/cicd_integrations/circleci_orb.md ]; then \
+	rm -f content/en/synthetics/cicd_integrations/circleci_orb.md ;fi
 	@if [ content/en/synthetics/cicd_integrations/github_actions.md ]; then \
 	rm -f content/en/synthetics/cicd_integrations/github_actions.md ;fi
 	@if [ content/en/real_user_monitoring/android/_index.md ]; then \

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,8 @@ clean-auto-doc: ##Remove all doc automatically created
 	rm -f content/en/serverless/libraries_integrations/macro.md ;fi
 	@if [ content/en/serverless/libraries_integrations/cli.md ]; then \
 	rm -f content/en/serverless/libraries_integrations/cli.md ;fi
+	@if [ content/en/synthetics/cicd_integrations/circleci_orbs.md ]; then \
+	rm -f content/en/synthetics/cicd_integrations/circleci_orbs.md ;fi
 	@if [ content/en/synthetics/cicd_integrations/github_actions.md ]; then \
 	rm -f content/en/synthetics/cicd_integrations/github_actions.md ;fi
 	@if [ content/en/real_user_monitoring/android/_index.md ]; then \

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2309,10 +2309,10 @@ main:
     parent: synthetics_cicd_integrations
     identifier: synthetics_cicd_integrations_configuration
     weight: 501
-  - name: CircleCI Orbs
-    url: /synthetics/cicd_integrations/circleci_orbs
+  - name: CircleCI Orb
+    url: /synthetics/cicd_integrations/circleci_orb
     parent: synthetics_cicd_integrations
-    identifier: synthetics_cicd_integrations_circleci_orbs
+    identifier: synthetics_cicd_integrations_circleci_orb
     weight: 502
   - name: GitHub Actions
     url: /synthetics/cicd_integrations/github_actions

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2309,16 +2309,21 @@ main:
     parent: synthetics_cicd_integrations
     identifier: synthetics_cicd_integrations_configuration
     weight: 501
+  - name: CircleCI Orbs
+    url: /synthetics/cicd_integrations/circleci_orbs
+    parent: synthetics_cicd_integrations
+    identifier: synthetics_cicd_integrations_circleci_orbs
+    weight: 502
   - name: GitHub Actions
     url: /synthetics/cicd_integrations/github_actions
     parent: synthetics_cicd_integrations
     identifier: synthetics_cicd_integrations_github_actions
-    weight: 502
+    weight: 503
   - name: Jenkins
     url: /synthetics/cicd_integrations/jenkins
     parent: synthetics_cicd_integrations
     identifier: synthetics_cicd_integrations_jenkins
-    weight: 503
+    weight: 504
   - name: CI Results Explorer
     url: /synthetics/ci_results_explorer
     parent: synthetics

--- a/content/en/synthetics/cicd_integrations/_index.md
+++ b/content/en/synthetics/cicd_integrations/_index.md
@@ -40,7 +40,7 @@ To get started, see [Integrations](#integrations) and [use the API](#use-the-api
 ## Integrations
 
 {{< whatsnext desc="With Synthetics and CI/CD, you can run Synthetic tests in the CI platform provider of your choice:" >}}
-    {{< nextlink href="synthetics/cicd_integrations/circleci_orbs" >}}CircleCI Orb{{< /nextlink >}}
+    {{< nextlink href="synthetics/cicd_integrations/circleci_orb" >}}CircleCI Orb{{< /nextlink >}}
     {{< nextlink href="synthetics/cicd_integrations/github_actions" >}}GitHub Actions{{< /nextlink >}}
     {{< nextlink href="synthetics/cicd_integrations/jenkins" >}}Jenkins{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/synthetics/cicd_integrations/_index.md
+++ b/content/en/synthetics/cicd_integrations/_index.md
@@ -40,7 +40,7 @@ To get started, see [Integrations](#integrations) and [use the API](#use-the-api
 ## Integrations
 
 {{< whatsnext desc="With Synthetics and CI/CD, you can run Synthetic tests in the CI platform provider of your choice:" >}}
-    {{< nextlink href="synthetics/cicd_integrations/circleci_orbs" >}}CircleCI Orbs{{< /nextlink >}}
+    {{< nextlink href="synthetics/cicd_integrations/circleci_orbs" >}}CircleCI Orb{{< /nextlink >}}
     {{< nextlink href="synthetics/cicd_integrations/github_actions" >}}GitHub Actions{{< /nextlink >}}
     {{< nextlink href="synthetics/cicd_integrations/jenkins" >}}Jenkins{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/synthetics/cicd_integrations/_index.md
+++ b/content/en/synthetics/cicd_integrations/_index.md
@@ -40,6 +40,7 @@ To get started, see [Integrations](#integrations) and [use the API](#use-the-api
 ## Integrations
 
 {{< whatsnext desc="With Synthetics and CI/CD, you can run Synthetic tests in the CI platform provider of your choice:" >}}
+    {{< nextlink href="synthetics/cicd_integrations/circleci_orbs" >}}CircleCI Orbs{{< /nextlink >}}
     {{< nextlink href="synthetics/cicd_integrations/github_actions" >}}GitHub Actions{{< /nextlink >}}
     {{< nextlink href="synthetics/cicd_integrations/jenkins" >}}Jenkins{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -286,6 +286,20 @@
           dependencies: ["https://github.com/DataDog/synthetics-ci-github-action/blob/main/README.md"]
           title: Synthetics and CI GitHub Actions
           kind: documentation
+  
+  - repo_name: synthetics-ci-orb
+    contents:
+    - action: pull-and-push-file
+      branch: main
+      globs:
+      - 'README.md'
+      options:
+        dest_path: '/synthetics/cicd_integrations/'
+        file_name: 'circleci_orb.md'
+        front_matters:
+          dependencies: ["https://github.com/DataDog/synthetics-ci-orb/blob/main/README.md"]
+          title: Synthetics CI CircleCI Orb
+          kind: documentation
 
   - repo_name: dd-sdk-android
     contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -296,10 +296,10 @@
       - 'README.md'
       options:
         dest_path: '/synthetics/cicd_integrations/'
-        file_name: 'circleci_orbs.md'
+        file_name: 'circleci_orb.md'
         front_matters:
           dependencies: ["https://github.com/DataDog/synthetics-ci-orb/blob/main/README.md"]
-          title: Synthetics CI CircleCI Orbs
+          title: Synthetics CI CircleCI Orb
           kind: documentation
 
   - repo_name: dd-sdk-android

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -288,6 +288,20 @@
           title: Synthetics CI GitHub Actions
           kind: documentation
 
+  - repo_name: synthetics-ci-orb
+    contents:
+    - action: pull-and-push-file
+      branch: main
+      globs:
+      - 'README.md'
+      options:
+        dest_path: '/synthetics/cicd_integrations/'
+        file_name: 'circleci_orbs.md'
+        front_matters:
+          dependencies: ["https://github.com/DataDog/synthetics-ci-orb/blob/main/README.md"]
+          title: Synthetics CI CircleCI Orbs
+          kind: documentation
+
   - repo_name: dd-sdk-android
     contents:
     - action: pull-and-push-file


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds single sourcing logic for CircleCI Orb documentation. 

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-3296

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/single-sourcing-ci-orb-docs/synthetics/cicd_integrations/circleci_orb/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Remember to add single sourcing logic to the `pull_config.yaml` file before merging! 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
