### PR TITLE
File log configs supported only with Docker socket

### DIFF
--- a/content/en/agent/kubernetes/log.md
+++ b/content/en/agent/kubernetes/log.md
@@ -270,6 +270,8 @@ These integration templates are meant for basic cases. If you need a custom Data
 1. Create a `conf.d/<INTEGRATION_NAME>.d/conf.yaml` file on your host and add your custom auto-configuration.
 2. Mount your host `conf.d/` folder to the containerized Agent's `conf.d` folder.
 
+**Note**: This is only supported when collecting logs through the Docker Socket, and not when using the Kubernetes log file method. To use the Docker Socket for log collection in a Kubernetes environment, ensure Docker is the runtime and `DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE` has been set to `false`.
+
 **Example auto-configuration file**:
 
 ```text
@@ -289,6 +291,8 @@ See the [Autodiscovery Container Identifiers][1] documentation for information o
 {{% tab "ConfigMap" %}}
 
 On Kubernetes, you can use [ConfigMaps][1]. Reference the template below and the [Kubernetes Custom Integrations][2] documentation.
+
+**Note**: This is only supported when collecting logs through the Docker Socket, and not when using the Kubernetes log file method. To use the Docker Socket for log collection in a Kubernetes environment, ensure Docker is the runtime and `DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE` has been set to `false`.
 
 ```text
 kind: ConfigMap
@@ -369,6 +373,9 @@ With the key-value store enabled as a template source, the Agent looks for templ
 {{% tab "Helm" %}}
 
 You can customize logs collection per integration within `confd`. This method mounts the desired configuration onto the Agent container.
+
+**Note**: This is only supported when collecting logs through the Docker Socket, and not when using the Kubernetes log file method. To use the Docker Socket for log collection in a Kubernetes environment, ensure Docker is the runtime and `DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE` has been set to `false`.
+
   ```yaml
   confd:
     <INTEGRATION_NAME>.yaml: |-


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Applying log configurations via the file method (file, configMap, helm) is only supported when the Docker socket is being used to collect logs. This does not work when the Kubernetes log launcher is used.

### Motivation
Customer believed this should work based on the documentation, so adding a note to clarify this behavior.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/kaitlavs-kubernetes-log/agent/kubernetes/log

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
