### PR TITLE
Clarify GKE Private Cluster firewall steps

### DIFF
--- a/content/en/agent/cluster_agent/admission_controller.md
+++ b/content/en/agent/cluster_agent/admission_controller.md
@@ -151,7 +151,7 @@ Possible options:
 - The admission controller doesn't inject the environment variables `DD_VERSION`, `DD_ENV`, and `DD_SERVICE` if they already exist.
 - To disable the admission controller injection feature, use the Cluster Agent configuration: `DD_ADMISSION_CONTROLLER_INJECT_CONFIG_ENABLED=false`
 - By using the Datadog admission controller, users can skip configuring the application pods using downward API ([step 2 in Kubernetes Trace Collection setup][3]).
-- If you are using a private cluster and your configuration is not getting injected into your pods, open a firewall rule for the control plane to talk to the Datadog webhook. In this case, ensure that the firewall rules open port 443 as described in [Adding firewall rules in GCP][4].
+- In a GKE Private Cluster, you will need to [add a Firewall Rule for the control plane][4]. As the webhook handling this will receive the incoming request over port `443` and direct it to a service implemented on port `8000`. By default in the Network for the cluster there should be a Firewall Rule named like `gke-<CLUSTER_NAME>-master` where the "Source filters" matches the "Control plane address range" of the cluster. Edit this Firewall Rule to allow ingress to the tcp port `8000`.
 
 
 ## Further Reading


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Clarify the steps necessary to setup the Firewall Rule in a GKE Private Cluster to get the Admission Controller working. This is relative to the default Firewall Rules created when the cluster created. As by default port 443 is allowed but not port 8000 (which the Admission Controller uses).

### Motivation
<!-- What inspired you to submit this pull request?-->
Support cases

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
