### PR TITLE
Add note about infra support esp Fargate

### DIFF
--- a/content/en/security_platform/application_security/_index.md
+++ b/content/en/security_platform/application_security/_index.md
@@ -22,7 +22,7 @@ Application Security is in public beta. See the <a href="https://app.datadoghq.c
 
 {{< img src="/security_platform/application_security/app-sec-landing-page.png" alt="A security signal panel in Datadog, which displays attack flows and flame graphs" width="75%">}}
 
-Datadog Application Security monitors application-level attacks aiming to exploit code-level vulnerabilities, such as Server-Side-Request-Forgery (SSRF), SQL injection, Log4Shell, and Reflected Cross-Site-Scripting (XSS).
+Datadog Application Security monitors application-level attacks aiming to exploit code-level vulnerabilities, such as Server-Side-Request-Forgery (SSRF), SQL injection, Log4Shell, and Reflected Cross-Site-Scripting (XSS). You can monitor application security for apps running in Docker, Kubernetes, AWS ECS, and (for supported languages) AWS Fargate.
 
 Application Security leverages Datadog [tracing libraries][1], the [Datadog Agent][2], and in-app detection rules to detect threats in your application environment and trigger signals whenever an attack targets your production system, or a vulnerability is triggered from the code.
 

--- a/content/en/security_platform/application_security/getting_started/_index.md
+++ b/content/en/security_platform/application_security/getting_started/_index.md
@@ -24,7 +24,7 @@ further_reading:
 Application Security is in public beta. See the <a href="https://app.datadoghq.com/security/appsec?instructions=all">in-app instructions</a> to get started.
 </div>
 
-Set up your application to [detect threats][1] targeting your production systems, using the Datadog library for your application language. 
+Set up your application to [detect threats][1] targeting your production systems, using the Datadog library for your application language. You can monitor application security for apps running in Docker, Kubernetes, AWS ECS, and (for supported languages) AWS Fargate.
 
 {{% appsec-getstarted %}}
 

--- a/content/en/security_platform/application_security/getting_started/dotnet.md
+++ b/content/en/security_platform/application_security/getting_started/dotnet.md
@@ -16,6 +16,8 @@ further_reading:
       text: "Troubleshooting Application Security Monitoring"
 ---
 
+You can monitor application security for .NET apps running in Docker, Kubernetes, AWS ECS, and AWS Fargate. 
+
 {{% appsec-getstarted %}}
 
 ## Get started

--- a/content/en/security_platform/application_security/getting_started/go.md
+++ b/content/en/security_platform/application_security/getting_started/go.md
@@ -16,6 +16,8 @@ further_reading:
       text: "Troubleshooting Application Security Monitoring"
 ---
 
+You can monitor application security for Go apps running in Docker, Kubernetes, and AWS ECS. 
+
 {{% appsec-getstarted %}}
 - One of the [supported APM tracing integrations][1].
 - [CGO][2] is enabled in your build environment, along with the C library headers and the C toolchain for your compilation target. For detailed instructions, see [Enabling CGO][3]

--- a/content/en/security_platform/application_security/getting_started/java.md
+++ b/content/en/security_platform/application_security/getting_started/java.md
@@ -17,6 +17,8 @@ further_reading:
 
 ---
 
+You can monitor application security for Java apps running in Docker, Kubernetes, AWS ECS, and AWS Fargate. 
+
 {{% appsec-getstarted %}}
 
 ## Get started

--- a/content/en/security_platform/application_security/getting_started/nodejs.md
+++ b/content/en/security_platform/application_security/getting_started/nodejs.md
@@ -16,6 +16,8 @@ further_reading:
       text: "Troubleshooting Application Security Monitoring"
 ---
 
+You can monitor application security for NodeJS apps running in Docker, Kubernetes, AWS ECS, and AWS Fargate. 
+
 {{% appsec-getstarted %}}
 
 ## Get started

--- a/content/en/security_platform/application_security/getting_started/php.md
+++ b/content/en/security_platform/application_security/getting_started/php.md
@@ -19,6 +19,8 @@ further_reading:
       text: "Troubleshooting Application Security Monitoring"
 ---
 
+You can monitor application security for PHP apps running in Docker, Kubernetes, and AWS ECS. 
+
 {{% appsec-getstarted %}}
 
 ## Get started

--- a/content/en/security_platform/application_security/getting_started/ruby.md
+++ b/content/en/security_platform/application_security/getting_started/ruby.md
@@ -16,6 +16,8 @@ further_reading:
       text: "Troubleshooting Application Security Monitoring"
 ---
 
+You can monitor application security for Ruby apps running in Docker, Kubernetes, AWS ECS, and AWS Fargate. 
+
 {{% appsec-getstarted %}}
 
 ## Get started

--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -39,12 +39,15 @@ The Datadog library supports Java JRE 1.8 and higher of both Oracle JDK and Open
 
 Datadog does not officially support any early-access versions of Java.
 
+You can monitor application security for Java apps running in Docker, Kubernetes, AWS ECS, and AWS Fargate.
+
 ### Supported frameworks
 
 | Framework Web Server    | Minimum Framework Version   |
 | ----------------------- | --------------------------- |
 | Servlet Compatible      | 2.3+, 3.0+                  |
 | Spring                  | 3.1                         |
+
 **Note**: Many application servers are Servlet compatible and are supported by Application Security, such as WebSphere, WebLogic, and JBoss. Also, frameworks like Spring Boot are supported by virtue of using a supported embedded application server (such as Tomcat, Jetty, or Netty).
 
 
@@ -69,6 +72,8 @@ These are supported on the following architectures:
 - macOS (Darwin) x86, x86-64
 - Windows (msvc) x86, x86-64
 
+You can monitor application security for .NET apps running in Docker, Kubernetes, AWS ECS, and AWS Fargate.
+
 ### Supported frameworks
 
 The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual Basic).
@@ -89,6 +94,9 @@ The Datadog Go tracing library supports Go version 1.14 and greater, on the foll
 - Linux (GNU) x86-64
 - Alpine Linux (musl) x86-64
 - macOS (Darwin) x86-64
+
+You can monitor application security for Go apps running in Docker, Kubernetes, and AWS ECS. 
+
 
 ### Supported frameworks
 
@@ -143,6 +151,8 @@ These are supported on the following architectures:
 - Alpine Linux (musl) x86-64, aarch64
 - macOS (Darwin) x86-64, arm64
 
+You can monitor application security for Ruby apps running in Docker, Kubernetes, AWS ECS, and AWS Fargate. 
+
 ### Supported frameworks
 
 | Framework Web Server    | Minimum Framework Version   |
@@ -159,6 +169,8 @@ The Datadog PHP library supports PHP version 7.0 and above on the following arch
 
 - Linux (GNU) x86-64
 - Alpine Linux (musl) x86-64
+
+You can monitor application security for PHP apps running in Docker, Kubernetes, and AWS ECS. 
 
 It supports the use of all PHP frameworks, and also the use no framework.
 
@@ -179,6 +191,8 @@ These are supported on the following architectures:
 - Alpine Linux (musl) x86-64
 - macOS (Darwin) x86-64
 - Windows (msvc) x86, x86-64
+
+You can monitor application security for NodeJS apps running in Docker, Kubernetes, AWS ECS, and AWS Fargate. 
 
 ### Supported frameworks
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Ensures people see that Fargate (and other cloud/container infra) is supported by AppSec

### Motivation
DOCS-3289

### Preview

https://docs-staging.datadoghq.com/kari/docs-3289/security_platform/application_security/
https://docs-staging.datadoghq.com/kari/docs-3289/security_platform/application_security/getting_started/
https://docs-staging.datadoghq.com/kari/docs-3289/security_platform/application_security/setup_and_configure/




### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
