### PR TITLE
APM > .NET > Update DD_TRACE_METHODS configuration documentation

### DIFF
--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -445,8 +445,8 @@ Enables or disables all automatic instrumentation. Setting the environment varia
 Added in version 1.23.0.
 
 `DD_TRACE_METHODS`
-: List of classes and methods to trace. Accepts a semicolon (`;`) separated list where each entry has the format `TypeName[MethodNames]`, where `MethodNames` is a comma (`,`) separated list of method names. For generic types, replace the angled brackets and the type parameters' names with a backtick (`` ` ``) followed by the number of generic type parameters. For example, `Dictionary<TKey, TValue>` must be written as `` Dictionary`2 ``. For generic methods, you only need to specify the method name. <br>
-**Example**: ```Namespace1.Class1[Method1,GenericMethodOfT,];Namespace1.GenericTypeWithOneTypeVariable`1[ExecuteAsync]```<br>
+: List of methods to trace. Accepts a semicolon (`;`) separated list where each entry has the format `TypeName[MethodNames]`, where `MethodNames` is a comma (`,`) separated list of method names. For generic types, replace the angled brackets and the type parameters' names with a backtick (`` ` ``) followed by the number of generic type parameters. For example, `Dictionary<TKey, TValue>` must be written as `` Dictionary`2 ``. For generic methods, you only need to specify the method name. <br>
+**Example**: ```Namespace1.Class1[Method1,GenericMethod];Namespace1.GenericTypeWithOneTypeVariable`1[ExecuteAsync]```<br>
 Added in version 2.5.1
 
 #### Automatic instrumentation integration configuration

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -413,8 +413,8 @@ Enables or disables all automatic instrumentation. Setting the environment varia
 Added in version 1.23.0.
 
 `DD_TRACE_METHODS`
-: List of classes and methods to trace. Accepts a semicolon (`;`) separated list where each entry has the format `TypeName[MethodNames]`, where `MethodNames` is a comma (`,`) separated list of method names. For generic types, replace the angled brackets and the type parameters' names with a backtick (`` ` ``) followed by the number of generic type parameters. For example, `Dictionary<TKey, TValue>` must be written as `` Dictionary`2 ``. For generic methods, you only need to specify the method name. <br>
-**Example**: ```Namespace1.Class1[Method1,GenericMethodOfT,];Namespace1.GenericTypeWithOneTypeVariable`1[ExecuteAsync]```<br>
+: List of methods to trace. Accepts a semicolon (`;`) separated list where each entry has the format `TypeName[MethodNames]`, where `MethodNames` is a comma (`,`) separated list of method names. For generic types, replace the angled brackets and the type parameters' names with a backtick (`` ` ``) followed by the number of generic type parameters. For example, `Dictionary<TKey, TValue>` must be written as `` Dictionary`2 ``. For generic methods, you only need to specify the method name. <br>
+**Example**: ```Namespace1.Class1[Method1,GenericMethod];Namespace1.GenericTypeWithOneTypeVariable`1[ExecuteAsync]```<br>
 Added in version 2.5.1
 
 #### Automatic instrumentation integration configuration


### PR DESCRIPTION
### What does this PR do?
Updates the `DD_TRACE_METHODS` documentation with feedback from the engineering team

### Motivation
The engineering team had further feedback on the documentation recently added in #13516 

### Preview
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-trace-methods-update/tracing/setup_overview/setup/dotnet-framework?tab=windows#automatic-instrumentation-optional-configuration
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-trace-methods-update/tracing/setup_overview/setup/dotnet-core?tab=windows#automatic-instrumentation-optional-configuration

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
