### PR TITLE
[WEB-2256] remove alias

### DIFF
--- a/content/ja/continuous_integration/guides/rum_integration.md
+++ b/content/ja/continuous_integration/guides/rum_integration.md
@@ -1,7 +1,7 @@
 ---
 title: RUM によるブラウザテストのインスツルメント
 kind: ガイド
-aliases: /continuous_integration/guides/rum_integration/
+aliases: /ja/continuous_integration/guides/rum_integration/
 ---
 {{< site-region region="gov" >}}
 <div class="alert alert-warning">選択したサイト ({{< region-param key="dd_site_name" >}}) では現在 CI Visibility は利用できません。</div>

--- a/content/ja/continuous_integration/guides/rum_integration.md
+++ b/content/ja/continuous_integration/guides/rum_integration.md
@@ -1,7 +1,6 @@
 ---
 title: RUM によるブラウザテストのインスツルメント
 kind: ガイド
-aliases: /ja/continuous_integration/guides/rum_integration/
 ---
 {{< site-region region="gov" >}}
 <div class="alert alert-warning">選択したサイト ({{< region-param key="dd_site_name" >}}) では現在 CI Visibility は利用できません。</div>


### PR DESCRIPTION
### What does this PR do?
Removes alias URL so the en page won't redirect to ja page.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2256

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/fix-alias/continuous_integration/guides/rum_integration/ does not redirect to the ja version.

live bug here: https://docs.datadoghq.com/continuous_integration/guides/rum_integration/

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
