### PR TITLE
switch back to the old tms on previews

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -170,17 +170,21 @@ link_checks_preview:
   interruptible: true
 
 missing_tms_preview:
-  <<: *base_template
+  image:
+    name: 486234852809.dkr.ecr.us-east-1.amazonaws.com/vale:v4036929-ee9929a-2.9.1
+    entrypoint: [ "" ]
+  tags: ["runner:main"]
   stage: post-deploy
-  environment: "preview"
-  allow_failure: true
   cache: {}
+  environment: "preview"
   variables:
     GIT_STRATEGY: none
   dependencies:
     - build_preview
   script:
-    - check_missing_tms
+    # remove dirs we don't need to scan
+    - rm -rf ./public/api/v1/ ./public/api/v2/
+    - GOMAXPROCS=$(nproc --all) vale --glob='*.{html}' ./public
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
   interruptible: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -182,9 +182,7 @@ missing_tms_preview:
   dependencies:
     - build_preview
   script:
-    # remove dirs we don't need to scan
-    - rm -rf ./public/fr ./public/ja ./public/api/v1/ ./public/api/v2/
-    - GOMAXPROCS=$(nproc --all) vale --glob='*.{html}' ./public
+    - check_missing_tms
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
   interruptible: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -170,21 +170,17 @@ link_checks_preview:
   interruptible: true
 
 missing_tms_preview:
-  image:
-    name: 486234852809.dkr.ecr.us-east-1.amazonaws.com/vale:v4036929-ee9929a-2.9.1
-    entrypoint: [ "" ]
-  tags: ["runner:main"]
+  <<: *base_template
   stage: post-deploy
-  cache: {}
   environment: "preview"
+  allow_failure: true
+  cache: {}
   variables:
     GIT_STRATEGY: none
   dependencies:
     - build_preview
   script:
-    # remove dirs we don't need to scan
-    - rm -rf ./public/api/v1/ ./public/api/v2/
-    - GOMAXPROCS=$(nproc --all) vale --glob='*.{html}' ./public
+    - check_missing_tms
   only:
     - /.+?\/[a-zA-Z0-9_-]+/
   interruptible: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -170,13 +170,11 @@ link_checks_preview:
   interruptible: true
 
 missing_tms_preview:
-  image:
-    name: 486234852809.dkr.ecr.us-east-1.amazonaws.com/vale:v4036929-ee9929a-2.9.1
-    entrypoint: [ "" ]
-  tags: ["runner:main"]
+  <<: *base_template
   stage: post-deploy
-  cache: {}
   environment: "preview"
+  allow_failure: true
+  cache: {}
   variables:
     GIT_STRATEGY: none
   dependencies:

--- a/.vale.ini
+++ b/.vale.ini
@@ -20,6 +20,7 @@ Datadog.inclusive = NO
 Datadog.links = NO
 Datadog.oxfordcomma = NO
 Datadog.pronouns = NO
+Datadog.sentencelength = NO
 Datadog.spaces = NO
 Datadog.tense = NO
 Datadog.words = NO


### PR DESCRIPTION
### What does this PR do?

Trademark checker on prod vs preview differs, while the new one is faster the old one is more reliable.
Turning the old one back on for previews until we can plan a better solution for speed + reliability.

### Motivation

Recent pr that passed its preview trademark check but once merged failed the live deploy check.

### Preview

Doesn't impact the site built only the post deploy checking job
https://docs-staging.datadoghq.com/david.jones/old-tms/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
