### PR TITLE
Explain how to disable GitHub Actions CI Viz integration

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/github.md
+++ b/content/en/continuous_integration/setup_pipelines/github.md
@@ -45,7 +45,7 @@ The [Pipelines][4] and [Pipeline Executions][5] pages populate with data after t
 
 ## Disabling GitHub Actions tracing
 
-To disable the CI Visibility GitHub Actions integration make sure the GitHub app is no longer subscribed to the
+To disable the CI Visibility GitHub Actions integration, make sure the GitHub app is no longer subscribed to the
 workflow job and workflow run events. To remove the events:
 
 1. Go to the [GitHub Apps][6] page.

--- a/content/en/continuous_integration/setup_pipelines/github.md
+++ b/content/en/continuous_integration/setup_pipelines/github.md
@@ -50,7 +50,7 @@ workflow job and workflow run events. To remove the events:
 
 1. Go to the [GitHub Apps][6] page.
 2. Click **Edit > Permission & events** on the relevant Datadog GitHub App (if you have multiple apps, you will have to repeat the process for each).
-3. Scroll down to the **Subscribe Events** and make sure that **Workflow job** and **Workflow run** are not selected.
+3. Scroll to the **Subscribe to events** section, and make sure that **Workflow job** and **Workflow run** are not selected.
 
 
 ## Further reading

--- a/content/en/continuous_integration/setup_pipelines/github.md
+++ b/content/en/continuous_integration/setup_pipelines/github.md
@@ -43,6 +43,16 @@ The [Pipelines][4] and [Pipeline Executions][5] pages populate with data after t
 
 **Note**: The Pipelines page shows data for only the default branch of each repository.
 
+## Disabling GitHub Actions tracing
+
+To disable the CI Visibility GitHub Actions integration make sure the GitHub app is no longer subscribed to the
+workflow job and workflow run events. To remove the events:
+
+1. Go to the [GitHub Apps][6] page.
+2. Click **Edit > Permission & events** on the relevant Datadog GitHub App (if you have multiple apps, you will have to repeat the process for each).
+3. Scroll down to the **Subscribe Events** and make sure that **Workflow job** and **Workflow run** are not selected.
+
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -52,3 +62,4 @@ The [Pipelines][4] and [Pipeline Executions][5] pages populate with data after t
 [3]: https://app.datadoghq.com/account/settings#integrations/github-apps
 [4]: https://app.datadoghq.com/ci/pipelines
 [5]: https://app.datadoghq.com/ci/pipeline-executions
+[6]: https://github.com/settings/apps


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add instructions on how to disable the GitHub Actions CI Visibility integration

### Motivation
<!-- What inspired you to submit this pull request?-->
The process is not obvious so customers have been having doubts on how to do this.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/carlos.gonzalez/add-gha-disable-instructions/continuous_integration/setup_pipelines/github/#disabling-github-actions-tracing

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
