### PR TITLE
content/en/tracing/setup_overview/setup: add documentation for DD_TRACE_RATE_LIMIT

### DIFF
--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -108,6 +108,9 @@ Override the default trace Agent port for DogStatsD metric submission.
 `DD_TRACE_SAMPLE_RATE`
 : Enable ingestion rate control.
 
+`DD_TRACE_RATE_LIMIT`
+: Maximum number of spans to sample per-second, per-Go process. Defaults to 100 when DD_TRACE_SAMPLE_RATE is set. Otherwise, delegates rate limiting to the Datadog Agent.
+
 `DD_TAGS`
 : **Default**: [] <br>
 A list of default tags to be added to every span and profile. Tags can be separated by commas or spaces, for example: `layer:api,team:intake` or `layer:api team:intake`


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This adds documentation to the corp doc site for the `DD_TRACE_RATE_LIMIT` variable.

### Motivation
Part of scheduled OKR work.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/knusbaum/rate-limit/tracing/setup_overview/setup/go


### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
