### PR TITLE
fixing table of contents thing

### DIFF
--- a/content/en/security_platform/explorer.md
+++ b/content/en/security_platform/explorer.md
@@ -20,7 +20,6 @@ From the [Security Signals Explorer][1], correlate and triage security signals. 
 
 In this view, you can:
 
-- [Overview](#overview)
 - [Explore your Security Signals](#explore-your-security-signals)
 - [Inspect a Security Signal](#inspect-a-security-signal)
   - [Threat intelligence](#threat-intelligence)


### PR DESCRIPTION
"overview" got included in the content listing even though it's redundant. a bit difficult to explain here, but the error and fix are pretty clear if you look at the changed file.

https://docs-staging.datadoghq.com/cswatt/small-list-fix/security_platform/explorer/
