### PR TITLE
adding disambiguation for transifex

### DIFF
--- a/content/en/logs/guide/commonly-used-log-processing-rules.md
+++ b/content/en/logs/guide/commonly-used-log-processing-rules.md
@@ -53,9 +53,9 @@ When the string "my_key=" is found, all characters following the string until th
   pattern: (?:my_key=[^.])
 ```
 
-## Social Security numbers
+## Social Security numbers (US)
 
-Redact Social Security numbers.
+Redact United States Social Security numbers.
 
 ```yaml
   - type: mask_sequences


### PR DESCRIPTION
transifex editor noted that the french version of this page specifically says "numéros de sécurité social américains," since the french NIRPP is also common referred to as un numéro de sécurité social. 

we should also disambiguate in english.

https://docs-staging.datadoghq.com/cswatt/us-transifex/logs/guide/commonly-used-log-processing-rules/#social-security-numbers


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
