### PR TITLE
Update Docs preview to use Algolia sandbox

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ cache: &cache
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:nsollecito_algolia-sandbox
   tags:
     - "runner:main"
   except:
@@ -198,7 +198,7 @@ index_algolia_preview:
   timeout: 1h 30m
   script:
     - |-
-        echo APPLICATION_ID=$(get_secret 'ci.documentation.algolia_docsearch_application_id') > .env
+        echo APPLICATION_ID=$(get_secret 'ci.documentation.algolia_preview_application_id') > .env
         echo API_KEY=$(get_secret 'ci.documentation.algolia_preview_api_key') >> .env
         export DISPLAY=:99
         Xvfb :99 -ac &
@@ -218,7 +218,7 @@ replica_algolia_preview:
     policy: pull
   environment: "preview"
   script:
-    - ALGOLIA_APP_ID=$(get_secret 'algolia_docsearch_application_id') ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_preview_api_key') yarn run algolia:config
+    - ALGOLIA_APP_ID=$(get_secret 'algolia_preview_application_id') ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_preview_api_key') yarn run algolia:config
   dependencies:
     - build_preview
   when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -199,7 +199,7 @@ index_algolia_preview:
   script:
     - |-
         echo APPLICATION_ID=$(get_secret 'ci.documentation.algolia_docsearch_application_id') > .env
-        echo API_KEY=$(get_secret 'ci.documentation.algolia_docsearch_api_key') >> .env
+        echo API_KEY=$(get_secret 'ci.documentation.algolia_preview_api_key') >> .env
         export DISPLAY=:99
         Xvfb :99 -ac &
         echo "n" | docsearch run ./local/etc/algolia/docs_datadoghq_preview.json
@@ -218,7 +218,7 @@ replica_algolia_preview:
     policy: pull
   environment: "preview"
   script:
-    - ALGOLIA_APP_ID=$(get_secret 'algolia_docsearch_application_id') ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_docsearch_api_key') yarn run algolia:config
+    - ALGOLIA_APP_ID=$(get_secret 'algolia_docsearch_application_id') ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_preview_api_key') yarn run algolia:config
   dependencies:
     - build_preview
   when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ cache: &cache
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:nsollecito_algolia-sandbox
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:nsollecito_docs-algolia
   tags:
     - "runner:main"
   except:

--- a/src/scripts/config/config-docs.js
+++ b/src/scripts/config/config-docs.js
@@ -19,8 +19,8 @@ module.exports = {
         algoliaConfig: {
             index: 'docsearch_docs_preview',
             api_index: 'docsearch_docs_preview_api',
-            appId: 'EOIG7V0A2O',
-            apiKey: 'c7ec32b3838892b10610af30d06a4e42'
+            appId: 'K8XL4ROVCR',
+            apiKey: 'c00312a19630387f86998847cca3b65c'
         },
         imgUrl: 'https://datadog-docs-staging.imgix.net/',
         gaTag: 'UA-21102638-9'
@@ -31,8 +31,8 @@ module.exports = {
         algoliaConfig: {
             index: 'docsearch_docs_preview',
             api_index: 'docsearch_docs_preview_api',
-            appId: 'EOIG7V0A2O',
-            apiKey: 'c7ec32b3838892b10610af30d06a4e42'
+            appId: 'K8XL4ROVCR',
+            apiKey: 'c00312a19630387f86998847cca3b65c'
         },
         imgUrl: 'http://localhost:1313/',
         gaTag: 'UA-21102638-9'

--- a/yarn.lock
+++ b/yarn.lock
@@ -11202,3 +11202,4 @@ zepto@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/zepto/-/zepto-1.2.0.tgz#e127bd9e66fd846be5eab48c1394882f7c0e4f98"
   integrity sha1-4Se9nmb9hGvl6rSME5SIL3wOT5g=
+


### PR DESCRIPTION
### What does this PR do?
Updates local and preview environments to use Algolia sandbox

### Motivation
Separates staging workloads from Production indexes

### Preview
Test search functions: 
https://docs-staging.datadoghq.com/nsollecito/algolia-sandbox/

### Additional Notes
Once corp-ci PR has been reviewed and merged, gitlab file needs to be updated to point back to main branch image for builds

Sometime after this is merged, we will want to cleanup old indexes in Algolia prod application 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
