### PR TITLE
Document the way for customers to quickly verify the filtering rules

### DIFF
--- a/content/en/account_management/billing/serverless.md
+++ b/content/en/account_management/billing/serverless.md
@@ -21,7 +21,7 @@ You can track the number of billable Serverless invocations in your account by c
 
 To control the functions whose invocations Datadog is monitoring, filter out particular functions by sorting by tag with the [UI](#ui) or by using the [API](#api). 
 
-**Note**: It takes some time for the excluded functions to disappear from the [Datadog serverless page][8] and [Datadog usage page][4]. Verify the filtering rules by checking the `[aws.lambda.invocations][9]` metric for the filtered functions. When Datadog stops monitoring a function, the value of `aws.lambda.invocations` falls to 0.
+**Note**: It takes some time for the excluded functions to disappear from the [Datadog serverless page][8] and [Datadog usage page][4]. Verify the filtering rules by checking the [`aws.lambda.invocations`][9] metric for the filtered functions. When Datadog stops monitoring a function, the value of `aws.lambda.invocations` falls to 0.
 
 ### UI
 

--- a/content/en/account_management/billing/serverless.md
+++ b/content/en/account_management/billing/serverless.md
@@ -19,7 +19,9 @@ For Serverless pricing information, see the [Datadog pricing page][1].
 
 You can track the number of billable Serverless invocations in your account by checking the [Datadog Usage Page][4]. You can see both the Month-To-Date summary, as well as usage over time.
 
-To control the functions whose invocations Datadog is monitoring, filter out particular functions by sorting by tag with the [UI](#ui) or by using the [API](#api). You may note that it takes some time for the excluded functions to disappear from the [Datadog serverless page][8] and [Datadog usage page][4], but you can verify the filtering rules by checking if the [aws.lambda.invocations][9] metric is still being ingested.
+To control the functions whose invocations Datadog is monitoring, filter out particular functions by sorting by tag with the [UI](#ui) or by using the [API](#api). 
+
+**Note**: It takes some time for the excluded functions to disappear from the [Datadog serverless page][8] and [Datadog usage page][4]. Verify the filtering rules by checking the `[aws.lambda.invocations][9]` metric for the filtered functions. When Datadog stops monitoring a function, the value of `aws.lambda.invocations` falls to 0.
 
 ### UI
 

--- a/content/en/account_management/billing/serverless.md
+++ b/content/en/account_management/billing/serverless.md
@@ -19,7 +19,7 @@ For Serverless pricing information, see the [Datadog pricing page][1].
 
 You can track the number of billable Serverless invocations in your account by checking the [Datadog Usage Page][4]. You can see both the Month-To-Date summary, as well as usage over time.
 
-To control the functions whose invocations Datadog is monitoring, filter out particular functions by sorting by tag with the [UI](#ui) or by using the [API](#api).
+To control the functions whose invocations Datadog is monitoring, filter out particular functions by sorting by tag with the [UI](#ui) or by using the [API](#api). You may note that it takes some time for the excluded functions to disappear from the [Datadog serverless page][8] and [Datadog usage page][4], but you can verify the filtering rules by checking if the [aws.lambda.invocations][9] metric is still being ingested.
 
 ### UI
 
@@ -48,3 +48,5 @@ For billing questions, contact your [Customer Success][3] Manager.
 [5]: https://app.datadoghq.com/account/settings#integrations/amazon-web-services
 [6]: /api/latest/aws-integration/#set-an-aws-tag-filter
 [7]: /help/
+[8]: https://app.datadoghq.com/functions
+[9]: https://app.datadoghq.com/metric/explorer?exp_metric=aws.lambda.invocations&exp_group=functionname&exp_agg=sum


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Document the way for customers to quickly verify the filtering rules.

### Motivation
It takes time for serverless and usage page to reflect the filtering. Customers often need to wait a long time to troubleshoot the filtering rules and make adjustments. Using the aws lambda invocations metric provides a shorter feedback loop.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tian.chu/verify-sls-filtering-rules/account_management/billing/serverless/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
