### PR TITLE
Update profiler_troubleshooting.md

### DIFF
--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -61,6 +61,7 @@ jdk.ObjectAllocationOutsideTLAB#enabled=true
 
 ## Enabling the heap profiler
 <div class="alert alert-info">The Java heap profiler feature is in beta.</div>
+<div class="aler alert-info">This feature requires at least Java 11.0.12, 15.0.4, 16.0.2, 17.0.3 or 18 and newer</div>
 To enable the heap profiler, start your application with the `-Ddd.profiling.heap.enabled=true` JVM setting or the `DD_PROFILING_HEAP_ENABLED=true` environment variable.
 
 Alternatively, you can enable the following events in your `jfp` [override template file](#creating-and-using-a-jfr-template-override-file):


### PR DESCRIPTION
### What does this PR do?
Adds a disambiguating statement about the JDK version since when the heap profiling feature is supported.

### Motivation
The current documentation is not specific about the JDK version requirements and unless the customer is vigorously checking the application logs it may be really confusing that even after enabling the feature as instructed in our docs the feature is still not working.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jb_heap_profiling_java/[content/en/tracing/profiler/profiler_troubleshooting.md

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
