### PR TITLE
Update the endpoint ingestion URL

### DIFF
--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -238,10 +238,11 @@ If you've configured the profiler and don't see profiles in the profile search p
       ["response.Error"]="...",
       ```
 
-   6. Check the following field to ensure that the right url is used:
+   6. Check the following field to ensure that the right URL is used. If you use default configuration settings:
       ```
       ["_profilesIngestionEndpoint_url"]="http://127.0.0.1:8126/profiling/v1/input",
       ```
+      If your configuration specifies a different trace Agent URL using `DD_TRACE_AGENT_URL` or `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` environment variables, then this field must match those values. 
 
 Otherwise, turn on [debug mode][1] and [open a support ticket][2] with the debug files and the following information:
 - Operating system type and version (for example, Windows Server 2019).

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -242,7 +242,10 @@ If you've configured the profiler and don't see profiles in the profile search p
       ```
       ["_profilesIngestionEndpoint_url"]="http://127.0.0.1:8126/profiling/v1/input",
       ```
-      If your configuration specifies a different trace Agent URL using `DD_TRACE_AGENT_URL` or `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` environment variables, then this field must match those values. 
+      If your configuration specifies a different trace Agent URL using `DD_TRACE_AGENT_URL` or `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` environment variables, then this field must match those values. For example:
+      ```
+      ["_profilesIngestionEndpoint_url"]="http://<DD_AGENT_HOST>:<DD_TRACE_AGENT_PORT>/profiling/v1/input",
+      ```
 
 Otherwise, turn on [debug mode][1] and [open a support ticket][2] with the debug files and the following information:
 - Operating system type and version (for example, Windows Server 2019).

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -240,7 +240,7 @@ If you've configured the profiler and don't see profiles in the profile search p
 
    6. Check the following field to ensure that the right url is used:
       ```
-      ["_profilesIngestionEndpoint_url"]="https://intake.profile.datadoghq.com/v1/input",
+      ["_profilesIngestionEndpoint_url"]="http://127.0.0.1:8126/profiling/v1/input",
       ```
 
 Otherwise, turn on [debug mode][1] and [open a support ticket][2] with the debug files and the following information:


### PR DESCRIPTION
The previous URL ["_profilesIngestionEndpoint_url"]="https://intake.profile.datadoghq.com/v1/input", was for sending profiles directly to the backend however this is not supported so the correct URL would be ["_profilesIngestionEndpoint_url"]="http://127.0.0.1:8126/profiling/v1/input" where the profiles would be sent to the Agent.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This will update the Ingestion URL to be the Agent URL as opposed to the backend URL that was previously there.

### Motivation
<!-- What inspired you to submit this pull request?-->
[Slack thread](https://dd.slack.com/archives/C019FJ8Q2QJ/p1647613653607099?thread_ts=1647550452.010119&cid=C019FJ8Q2QJ) where there was confusion about what the expected URL should be, and that it should be the Agent URL instead

https://a.cl.ly/jkuvL7dj [Slack link](https://dd.slack.com/archives/C019FJ8Q2QJ/p1647592772261219?thread_ts=1647550452.010119&cid=C019FJ8Q2QJ)

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
