### PR TITLE
disable Session Replay document correction

### DIFF
--- a/content/en/real_user_monitoring/session_replay/_index.md
+++ b/content/en/real_user_monitoring/session_replay/_index.md
@@ -135,7 +135,8 @@ Session Replay follows the same 30 days retention policy as normal RUM sessions.
 
 - Remove startSessionReplayRecording() to stop session recordings.
 - Set `replaySampleRate` to `0` to stop collecting the RUM Session Replay plan which includes resources and long tasks.
-- Upgrade your Browser RUM SDK to version >= 3.6 for these configuration options to apply.
+
+In order to apply these configurations, upgrade the Browser RUM SDK to a version >= 3.6.
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/session_replay/_index.md
+++ b/content/en/real_user_monitoring/session_replay/_index.md
@@ -135,6 +135,7 @@ Session Replay follows the same 30 days retention policy as normal RUM sessions.
 
 - Remove startSessionReplayRecording() to stop session recordings.
 - Set `replaySampleRate` to `0` to stop collecting the RUM Session Replay plan which includes resources and long tasks.
+- Upgrade your Browser RUM SDK to version >= 3.6 for these configuration options to apply.
 
 ## Further Reading
 


### PR DESCRIPTION
A lot of customers and SEs miss this important point, causing frustration.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a third step to disabling Session Replay section of the document.

### Motivation
A customer is terribly unhappy because they were instructed to make the configuration change according to what's in the doc now, but due to an old SDK these configuration changes did not prevent them from being charged the higher replay rate. I see multiple tickets dealing with this problem.

### Preview

https://docs-staging.datadoghq.com/KateYoak-patch-1/real_user_monitoring/session_replay/#how-do-you-disable-session-replay (I get a 404, sorry if I did something wrong.)


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ x] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
