### PR TITLE
convert alias fm to array

### DIFF
--- a/content/en/continuous_integration/guides/flaky_test_management.md
+++ b/content/en/continuous_integration/guides/flaky_test_management.md
@@ -1,7 +1,8 @@
 ---
 title: Flaky Test Management
 kind: guide
-aliases: /continuous_integration/guides/find_flaky_tests/
+aliases: 
+    - /continuous_integration/guides/find_flaky_tests/
 ---
 
 {{< site-region region="gov" >}}

--- a/content/en/continuous_integration/guides/rum_integration.md
+++ b/content/en/continuous_integration/guides/rum_integration.md
@@ -1,8 +1,6 @@
 ---
 title: Instrumenting your browser tests with RUM
 kind: guide
-aliases: 
-    - continuous_integration/guides/rum_integration/
 ---
 
 {{< site-region region="gov" >}}

--- a/content/en/continuous_integration/guides/rum_integration.md
+++ b/content/en/continuous_integration/guides/rum_integration.md
@@ -1,7 +1,8 @@
 ---
 title: Instrumenting your browser tests with RUM
 kind: guide
-aliases: /continuous_integration/guides/rum_integration/
+aliases: 
+    - continuous_integration/guides/rum_integration/
 ---
 
 {{< site-region region="gov" >}}

--- a/content/ja/continuous_integration/guides/flaky_test_management.md
+++ b/content/ja/continuous_integration/guides/flaky_test_management.md
@@ -1,7 +1,8 @@
 ---
 title: 不安定なテストの管理
 kind: ガイド
-aliases: /ja/continuous_integration/guides/find_flaky_tests/
+aliases: 
+    - ja/continuous_integration/guides/find_flaky_tests/
 ---
 
 _不安定なテスト_は、同じコミットの複数のテスト実行で成功と失敗の両方のステータスを示すテストです。コードをコミットして CI を介して実行し、テストが失敗し、CI を介して再度実行してテストが成功した場合、そのテストは品質コードの証明として信頼できません。

--- a/content/ja/continuous_integration/guides/flaky_test_management.md
+++ b/content/ja/continuous_integration/guides/flaky_test_management.md
@@ -2,7 +2,7 @@
 title: 不安定なテストの管理
 kind: ガイド
 aliases: 
-    - ja/continuous_integration/guides/find_flaky_tests/
+    - /ja/continuous_integration/guides/find_flaky_tests/
 ---
 
 _不安定なテスト_は、同じコミットの複数のテスト実行で成功と失敗の両方のステータスを示すテストです。コードをコミットして CI を介して実行し、テストが失敗し、CI を介して再度実行してテストが成功した場合、そのテストは品質コードの証明として信頼できません。


### PR DESCRIPTION
### What does this PR do?
converting some `aliases` frontmatter objects to be array instead of str.

### Motivation
issue that was found when translating one of these files.    

these aren't broken now as Hugo seems to accept a string also, but for uniformity i'm changing these to be arrays.

### Preview
pages redirect normally based on the alias

- https://docs-staging.datadoghq.com/brian.deutsch/alias-array/continuous_integration/guides/find_flaky_tests/
- https://docs-staging.datadoghq.com/brian.deutsch/alias-array/ja/continuous_integration/guides/find_flaky_tests/

removed alias from this page as it was referencing itself, nothing should have changed here

- https://docs-staging.datadoghq.com/brian.deutsch/alias-array/continuous_integration/guides/rum_integration/

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
