### PR TITLE
profiler: remove incorrect line about Hotspots being off by default

### DIFF
--- a/content/en/tracing/profiler/connect_traces_and_profiles.md
+++ b/content/en/tracing/profiler/connect_traces_and_profiles.md
@@ -65,7 +65,7 @@ Requires tracing library version 0.49.0 or greater.
 {{< /programming-lang >}}
 {{< programming-lang lang="go" >}}
 
-Code Hotspots identification for Go is disabled by default. To enable it, [turn on profiling for your service][1] and ensure that:
+To enable Code Hotspots identification for Go, [turn on profiling for your service][1] and ensure that:
 
 - You are using [dd-trace-go][2] version 1.35.0 or later.
 - [`DD_PROFILING_CODE_HOTSPOTS_COLLECTION_ENABLED=true`][3] is set in your environment, or the [`tracer.WithProfilerCodeHotspots(true)`][3] option is passed to [`tracer.Start()`][4]. This option is enabled by default in [dd-trace-go][2] versions 1.37.0+.


### PR DESCRIPTION
The feature is no longer off by default so we can remove that sentence.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
