### PR TITLE
Fix a silly copy-paste mistake

### DIFF
--- a/content/en/account_management/rbac/_index.md
+++ b/content/en/account_management/rbac/_index.md
@@ -119,7 +119,7 @@ To clone an existing role:
 
 1. Go to your [Datadog Roles page][1].
 2. Hover over the role you would like to clone. A series of buttons appears to the right.
-3. Select the clone button on the role you would like to delete.
+3. Select the clone button on the role you would like to clone.
 4. Optionally modify the name or permissions of the role.
 5. Click the **Save** button at the bottom.
 


### PR DESCRIPTION


### What does this PR do?
Replaces the erroneous word "delete" with the correct word, "clone".

### Motivation
noticed a mistake

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/uchen/delete-to-clone/account_management/rbac/?tab=datadogapplication

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
