### PR TITLE
(DOCS-3290) make default enforced interval more clear

### DIFF
--- a/content/en/dashboards/functions/rollup.md
+++ b/content/en/dashboards/functions/rollup.md
@@ -17,7 +17,7 @@ The function takes two parameters, `<AGGREGATOR>` and optionally `<INTERVAL>`: `
 
 | Parameter  | Description                                                                                                     |
 |------------|-----------------------------------------------------------------------------------------------------------------|
-| `<AGGREGATOR>` | Can be `sum`, `min`, `max`, `count`, or `avg` and defines how data points are aggregated within a given time interval. |
+| `<AGGREGATOR>` | Can be `avg`, `sum`, `min`, `max`, or `count`, and defines how data points are aggregated within a given time interval. [Enforced default](#Rollup-interval-enforced-vs-custom): `avg`. |
 | `<INTERVAL>`   | Time (in seconds) of the interval between two data points displayed. Optional.                                            |
 
 You can use them individually or together, for instance `.rollup(sum,120)`. The following bar graph displays a week's worth of CPU usage for a host **without** using the `.rollup()` function:
@@ -57,7 +57,7 @@ A custom `.rollup()` function can be used to enforce the type of time aggregatio
 
   {{< img src="dashboards/functions/rollup/as_count.png" alt="as_count" style="width:50%;">}}
 
-For more details about how to use `.as_count()` and `.as_rate()` see the [blog post][3] or learn more about the effects of those functions with the documentation on [in-application modifiers][4].
+For more details about how to use `.as_count()` and `.as_rate()` see the [Visualize StatsD metrics][3] blog post, or learn more about the effects of those functions with the documentation on [in-application modifiers][4].
 
 ## Rollups in monitors
 

--- a/content/en/dashboards/functions/rollup.md
+++ b/content/en/dashboards/functions/rollup.md
@@ -17,7 +17,7 @@ The function takes two parameters, `<AGGREGATOR>` and optionally `<INTERVAL>`: `
 
 | Parameter  | Description                                                                                                     |
 |------------|-----------------------------------------------------------------------------------------------------------------|
-| `<AGGREGATOR>` | Can be `avg`, `sum`, `min`, `max`, or `count`, and defines how data points are aggregated within a given time interval. [Enforced default](#Rollup-interval-enforced-vs-custom): `avg`. |
+| `<AGGREGATOR>` | Can be `avg`, `sum`, `min`, `max`, or `count`, and defines how data points are aggregated within a given time interval. [Enforced default](#rollup-interval-enforced-vs-custom): `avg`. |
 | `<INTERVAL>`   | Time (in seconds) of the interval between two data points displayed. Optional.                                            |
 
 You can use them individually or together, for instance `.rollup(sum,120)`. The following bar graph displays a week's worth of CPU usage for a host **without** using the `.rollup()` function:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
A customer wanted us to make it clear in this table/earlier in the page that avg is the default enforced interval. 

Also updated some link text to be more specific for the blog post.

### Motivation
Customer request

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jorie/DOCS-3290/dashboards/functions/rollup/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
