### PR TITLE
DOCS-3312 tagging getting started - key:value clarity

### DIFF
--- a/content/en/getting_started/tagging/_index.md
+++ b/content/en/getting_started/tagging/_index.md
@@ -61,7 +61,7 @@ Below are Datadog's tagging requirements:
 
 2. Tags can be **up to 200 characters** long and support Unicode (which includes most character sets, including languages such as Japanese).
 3. Tags are converted to lowercase. Therefore, `CamelCase` tags are not recommended. Authentication (crawler) based integrations convert camel case tags to underscores, for example `TestTag` --> `test_tag`. **Note**: `host` and `device` tags are excluded from this conversion.
-4. A tag can be in the format `value` or `<KEY>:<VALUE>`. For optimal functionality, **Datadog recommends constructing tags in the `<KEY>:<VALUE>` format.** Commonly used tag keys are `env`, `instance`, and `name`. The key always precedes the first colon of the global tag definition, for example:
+4. A tag can be in the format `value` or `<KEY>:<VALUE>`. Commonly used tag keys are `env`, `instance`, and `name`. The key always precedes the first colon of the global tag definition, for example:
 
     | Tag                | Key           | Value          |
     | ------------------ | ------------- | -------------- |


### PR DESCRIPTION
Removing an unnecessary statement because it was causing confusion according to hotjar.


https://docs-staging.datadoghq.com/cswatt/key-value-tags/getting_started/tagging

