### PR TITLE
[CIAPP] Add a disclaimer about UDS support in the Jenkins plugin for CI Visibility

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -28,7 +28,7 @@ Install the [Datadog Agent][1] on the Jenkins controller instance.
 
 If the Jenkins controller and the Datadog Agent have been deployed to a Kubernetes cluster, Datadog recommends using the [Admission Controller][2], which automatically sets the `DD_AGENT_HOST` environment variable in the Jenkins controller pod to communicate with the local Datadog Agent.
 
-<div class="alert alert-info">Note: Unix domain sockets are not supported for sending CI Visibility traces yet.</div>
+<div class="alert alert-info"><strong>Note</strong>: Unix domain sockets are not yet supported for sending CI Visibility traces.</div>
 
 ## Install the Datadog Jenkins plugin
 

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -28,6 +28,8 @@ Install the [Datadog Agent][1] on the Jenkins controller instance.
 
 If the Jenkins controller and the Datadog Agent have been deployed to a Kubernetes cluster, Datadog recommends using the [Admission Controller][2], which automatically sets the `DD_AGENT_HOST` environment variable in the Jenkins controller pod to communicate with the local Datadog Agent.
 
+<div class="alert alert-info">Note: Unix domain sockets are not supported for sending CI Visibility traces yet.</div>
+
 ## Install the Datadog Jenkins plugin
 
 Install and enable the [Datadog Jenkins plugin][3] v3.3.0 or newer:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds a disclaimer about UDS support in the Jenkins plugin for CI Visibility

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/drodriguezhdez/jenkins_uds_limitation/continuous_integration/setup_pipelines/jenkins/?tab=usingui

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
