### PR TITLE
CI Visibility - dotnet agentless beta documentation

### DIFF
--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -29,7 +29,7 @@ Supported test frameworks:
 
 [Install the Datadog Agent to collect tests data][1].
 
-<strong>Note:</strong> Agentless mode is currently on beta, if you want to test this feature follow the [instructions][5].
+<strong>Note:</strong> Agentless mode is currently in beta, if you want to test this feature follow the [instructions][5].
 
 ## Installing the .NET tracer
 

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -159,7 +159,7 @@ Alternatively, you can provide the [Datadog API key][6] using the following envi
 : Enables or disables the agentless mode.<br/>
 **Default**: `false`
 
-`DD_API_KEY`
+`DD_API_KEY` (Required)
 : The [Datadog API key][6] used to upload the test results.<br/>
 **Default**: `(empty)`
 

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -29,7 +29,9 @@ Supported test frameworks:
 
 [Install the Datadog Agent to collect tests data][1].
 
-<strong>Note:</strong> Agentless mode is currently in beta, if you want to test this feature follow the [instructions][5].
+<div class="alert alert-warning">
+Agentless mode is in beta. To test this feature, follow the <a href="/#agentless-beta">instructions</a> on this page.
+</div>
 
 ## Installing the .NET tracer
 
@@ -145,17 +147,17 @@ For more information about how to add spans and tags for custom instrumentation,
 
 ## Agentless (Beta)
 
-To instrument your test suite without requiring an agent, you need to configure the following environment variables:
+To instrument your test suite without requiring an Agent, configure the following environment variables:
 
 `DD_CIVISIBILITY_AGENTLESS_ENABLED` (Required)
-: Enables or disables the agentless mode.<br/>
+: Enables or disables Agentless mode.<br/>
 **Default**: `false`
 
 `DD_API_KEY` (Required)
 : The [Datadog API key][6] used to upload the test results.<br/>
 **Default**: `(empty)`
 
-Then, prefix your test command with `dd-trace ci run`, providing the name of the service or library under test as the `--dd-service` parameter, and the environment where tests are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) as the `--dd-env` parameter. For example:
+Then, prefix your test command with `dd-trace ci run`. Use the `--dd-service` parameter to provide the name of the service or library. Use the `--dd-env` parameter to provide the environment where tests are being run (`local` when running tests on a developer workstation, `ci` when running them on a CI provider, etc.) For example:
 
 {{< code-block lang="bash" >}}
 dd-trace ci run --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
@@ -167,9 +169,9 @@ Alternatively, you can provide the [Datadog API key][6] using the `--api-key` pa
 dd-trace ci run --api-key <API KEY> --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
 {{< /code-block >}}
 
-When the `--api-key` is set, the agentless mode is automatically enabled.
+When the `--api-key` is set, Agentless mode is automatically enabled.
 
-Additionally, configure the Datadog site to use the selected one ({{< region-param key="dd_site_name" >}}):
+Additionally, configure which [Datadog site][7] to which you want to send data. Your Datadog site is {{< region-param key="dd_site_name" >}}.
 
 `DD_SITE` (Required)
 : The [Datadog site][7] to upload results to.<br/>

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -147,7 +147,13 @@ For more information about how to add spans and tags for custom instrumentation,
 
 ## Agentless (Beta)
 
-...
+To instrument your test suite without requiring an agent, prefix your test command with `dd-trace ci run`, providing the Datadog API key][6] as the `--api-key`, the name of the service or library under test as the `--dd-service` parameter, and the environment where tests are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) as the `--dd-env` parameter. For example:
+
+{{< code-block lang="bash" >}}
+dd-trace ci run --api-key <API KEY> --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
+{{< /code-block >}}
+
+When the `--api-key` is set, the agentless mode is automatically enabled.
 
 ## Further reading
 
@@ -159,3 +165,4 @@ For more information about how to add spans and tags for custom instrumentation,
 [3]: https://www.nuget.org/packages/Datadog.Trace
 [4]: /tracing/setup_overview/custom_instrumentation/dotnet/
 [5]: /continuous_integration/setup_tests/dotnet/#agentless-beta
+[6]: https://app.datadoghq.com/organization-settings/api-keys

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -29,9 +29,7 @@ Supported test frameworks:
 
 [Install the Datadog Agent to collect tests data][1].
 
-<div class="alert alert-info">
-  <strong>Note:</strong> Agentless mode is currently on beta, if you want to test this feature follow the [instructions][5].
-</div>
+<strong>Note:</strong> Agentless mode is currently on beta, if you want to test this feature follow the [instructions][5].
 
 ## Installing the .NET tracer
 
@@ -147,13 +145,20 @@ For more information about how to add spans and tags for custom instrumentation,
 
 ## Agentless (Beta)
 
-To instrument your test suite without requiring an agent, prefix your test command with `dd-trace ci run`, providing the Datadog API key][6] as the `--api-key`, the name of the service or library under test as the `--dd-service` parameter, and the environment where tests are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) as the `--dd-env` parameter. For example:
+To instrument your test suite without requiring an agent, prefix your test command with `dd-trace ci run`, providing the [Datadog API key][6] as the `--api-key`, the name of the service or library under test as the `--dd-service` parameter, and the environment where tests are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) as the `--dd-env` parameter. For example:
 
 {{< code-block lang="bash" >}}
 dd-trace ci run --api-key <API KEY> --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
 {{< /code-block >}}
 
 When the `--api-key` is set, the agentless mode is automatically enabled.
+
+Additionally, configure the Datadog site to use the selected one ({{< region-param key="dd_site_name" >}}):
+
+`DD_SITE` (Required)
+: The [Datadog site][2] to upload results to.<br/>
+**Default**: `datadoghq.com`<br/>
+**Selected site**: {{< region-param key="dd_site" code="true" >}}
 
 ## Further reading
 

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -153,10 +153,20 @@ dd-trace ci run --api-key <API KEY> --dd-service=my-dotnet-app --dd-env=ci -- do
 
 When the `--api-key` is set, the agentless mode is automatically enabled.
 
+Alternatively, you can provide the [Datadog API key][6] using the following environment variables:
+
+`DD_CIVISIBILITY_AGENTLESS_ENABLED` (Required)
+: Enables or disables the agentless mode.<br/>
+**Default**: `false`
+
+`DD_API_KEY`
+: The [Datadog API key][6] used to upload the test results.<br/>
+**Default**: `(empty)`
+
 Additionally, configure the Datadog site to use the selected one ({{< region-param key="dd_site_name" >}}):
 
 `DD_SITE` (Required)
-: The [Datadog site][2] to upload results to.<br/>
+: The [Datadog site][7] to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
 **Selected site**: {{< region-param key="dd_site" code="true" >}}
 
@@ -171,3 +181,4 @@ Additionally, configure the Datadog site to use the selected one ({{< region-par
 [4]: /tracing/setup_overview/custom_instrumentation/dotnet/
 [5]: /continuous_integration/setup_tests/dotnet/#agentless-beta
 [6]: https://app.datadoghq.com/organization-settings/api-keys
+[7]: /getting_started/site/

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -30,7 +30,7 @@ Supported test frameworks:
 [Install the Datadog Agent to collect tests data][1].
 
 <div class="alert alert-warning">
-Agentless mode is in beta. To test this feature, follow the <a href="/#agentless-beta">instructions</a> on this page.
+Agentless mode is in beta. To test this feature, follow the <a href="/continuous_integration/setup_tests/dotnet#agentless-beta">instructions</a> on this page.
 </div>
 
 ## Installing the .NET tracer
@@ -171,7 +171,7 @@ dd-trace ci run --api-key <API KEY> --dd-service=my-dotnet-app --dd-env=ci -- do
 
 When the `--api-key` is set, Agentless mode is automatically enabled.
 
-Additionally, configure which [Datadog site][7] to which you want to send data. Your Datadog site is {{< region-param key="dd_site_name" >}}.
+Additionally, configure which [Datadog site][7] to which you want to send data. Your Datadog site is: {{< region-param key="dd_site" >}}.
 
 `DD_SITE` (Required)
 : The [Datadog site][7] to upload results to.<br/>

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -147,6 +147,8 @@ For more information about how to add spans and tags for custom instrumentation,
 
 ## Agentless (Beta)
 
+...
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -156,4 +158,4 @@ For more information about how to add spans and tags for custom instrumentation,
 [2]: /tracing/setup_overview/setup/dotnet-core/?tab=windows#configuration
 [3]: https://www.nuget.org/packages/Datadog.Trace
 [4]: /tracing/setup_overview/custom_instrumentation/dotnet/
-[5]: #agentless-beta
+[5]: /continuous_integration/setup_tests/dotnet/#agentless-beta

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -145,15 +145,7 @@ For more information about how to add spans and tags for custom instrumentation,
 
 ## Agentless (Beta)
 
-To instrument your test suite without requiring an agent, prefix your test command with `dd-trace ci run`, providing the [Datadog API key][6] as the `--api-key`, the name of the service or library under test as the `--dd-service` parameter, and the environment where tests are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) as the `--dd-env` parameter. For example:
-
-{{< code-block lang="bash" >}}
-dd-trace ci run --api-key <API KEY> --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
-{{< /code-block >}}
-
-When the `--api-key` is set, the agentless mode is automatically enabled.
-
-Alternatively, you can provide the [Datadog API key][6] using the following environment variables:
+To instrument your test suite without requiring an agent, you need to configure the following environment variables:
 
 `DD_CIVISIBILITY_AGENTLESS_ENABLED` (Required)
 : Enables or disables the agentless mode.<br/>
@@ -162,6 +154,20 @@ Alternatively, you can provide the [Datadog API key][6] using the following envi
 `DD_API_KEY` (Required)
 : The [Datadog API key][6] used to upload the test results.<br/>
 **Default**: `(empty)`
+
+Then, prefix your test command with `dd-trace ci run`, providing the name of the service or library under test as the `--dd-service` parameter, and the environment where tests are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) as the `--dd-env` parameter. For example:
+
+{{< code-block lang="bash" >}}
+dd-trace ci run --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
+{{< /code-block >}}
+
+Alternatively, you can provide the [Datadog API key][6] using the `--api-key` parameter, for example:
+
+{{< code-block lang="bash" >}}
+dd-trace ci run --api-key <API KEY> --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
+{{< /code-block >}}
+
+When the `--api-key` is set, the agentless mode is automatically enabled.
 
 Additionally, configure the Datadog site to use the selected one ({{< region-param key="dd_site_name" >}}):
 

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -29,6 +29,10 @@ Supported test frameworks:
 
 [Install the Datadog Agent to collect tests data][1].
 
+<div class="alert alert-info">
+  <strong>Note:</strong> Agentless mode is currently on beta, if you want to test this feature follow the [instructions][5].
+</div>
+
 ## Installing the .NET tracer
 
 To install or update the `dd-trace` command globally on the machine, run:
@@ -130,7 +134,7 @@ If you are running tests in non-supported CI providers or with no `.git` folder,
 
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> Your custom instrumentation setup depends on the `dd-trace` version. To use the custom instrumentation, you must keep the package versions for `dd-trace` and `Datadog.Trace` NuGet packages in sync.
+  <strong>Note:</strong> Your custom instrumentation setup depends on the <code>dd-trace</code> version. To use the custom instrumentation, you must keep the package versions for <code>dd-trace</code> and <code>Datadog.Trace</code> NuGet packages in sync.
 </div>
 
 To use the custom instrumentation in your .NET application:
@@ -141,6 +145,8 @@ To use the custom instrumentation in your .NET application:
 
 For more information about how to add spans and tags for custom instrumentation, see the [.NET Custom Instrumentation documentation][4].
 
+## Agentless (Beta)
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -150,3 +156,4 @@ For more information about how to add spans and tags for custom instrumentation,
 [2]: /tracing/setup_overview/setup/dotnet-core/?tab=windows#configuration
 [3]: https://www.nuget.org/packages/Datadog.Trace
 [4]: /tracing/setup_overview/custom_instrumentation/dotnet/
+[5]: #agentless-beta


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a new section for configuring Agentless mode for .NET in CI Visibility mode.

### Motivation
<!-- What inspired you to submit this pull request?-->
There's a new feature to allow users to send test results without installing the Datadog agent, this PR adds the instructions to enable this feature in .NET

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/tony/ciapp-dotnet-agentless/continuous_integration/setup_tests/dotnet/#prerequisites
https://docs-staging.datadoghq.com/tony/ciapp-dotnet-agentless/continuous_integration/setup_tests/dotnet/#agentless-beta

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
