### PR TITLE
Update APM .NET runtime policy

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -97,7 +97,7 @@ The .NET Tracer works on .NET Core 2.0, 2.1, 2.2, and 3.0, but these versions re
 
 ## Runtime support policy for .NET Core APM
 
-Datadog APM for .NET Core is built upon dependencies defined in specific versions of the host operating system, .NET Core runtime, certain .NET Core libraries, and the Datadog Agent/API. When a version of those dependencies are no longer supported by its maintainers, Datadog APM for .NET Core limits its support on that version of the library as well.
+Datadog APM for .NET Core depends on the host operating system, .NET Core runtime, certain .NET Core libraries, and the Datadog Agent/API. These third party software systems support specific versions of .NET Core. When the external software no longer supports a version of .NET Core, Datadog APM for .NET Core also limits its support for that version.
 
 ### Levels of support
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -27,15 +27,12 @@ Datadog APM for .NET Core is built upon dependencies defined in specific version
 
 ### Levels of support
 
-delner marked this conversation as resolved.
-
 | **Level**                                              | **Support provided**                                                                                                                                                          |
 |--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact our customer support team for special requests.][2]                                                             |
 | <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features, bug & security fixes provided on a best-effort basis.                                    |
 | <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                                                    |
 | <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                                                              |
-| <span id="support-legacy">Legacy</span>                |  Legacy implementation. May have limited function, but no maintenance provided. [Contact our customer support team for special requests.][2] |
 | <span id="support-eol">End-of-life (EOL)</span>        |  No support.                                                                                                                                                                  |
 
 ### Package versioning
@@ -43,9 +40,9 @@ delner marked this conversation as resolved.
 Datadog APM for .NET Core practices [semantic versioning][3].
 As this relates to downgrading runtime support, it implies:
 
-  - **Major version updates** (e.g. `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[Legacy](#support-legacy)/[EOL](#support-eol).
-  - **Minor version updates** (e.g. `1.0.0` to `1.1.0`) will not change support for any runtime.
-  - **Patch version updates** (e.g. `1.0.0` to `1.0.1`) will not change support for any runtime.
+  - **Major version updates** (for example `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[Legacy](#support-legacy)/[EOL](#support-eol).
+  - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower our level of support for one runtime but may add support for one.
+  - **Patch version updates** (for example `1.0.0` to `1.0.1`) will not change support for any runtime.
 
 ## Supported .NET Core runtimes
 
@@ -54,7 +51,7 @@ The .NET Tracer supports automatic instrumentation on the following .NET Core ve
 | Version              | Microsoft End of Life | Support level        | Package version      |
 | -------------------- | --------------------- | -------------------- | -------------------- |
 | .NET 6               |                       | [GA](#support-ga)    | latest (>= 2.0.0)    |
-| .NET 5               |                       | [GA](#support-ga)    | latest (>= 1.27.0)   |
+| .NET 5               |                       | [GA](#support-ga)    | latest (>= 2.0.0)    |
 | .NET Core 3.1        | 12/03/2022            | [GA](#support-ga)    | latest               |
 | .NET Core 2.1        | 08/21/2021            | [GA](#support-ga)    | latest               |
 
@@ -66,10 +63,10 @@ The .NET Tracer supports automatic instrumentation on the following architecture
 
 | Processor architectures                   | Support level         | Package version                        |
 | ------------------------------------------|-----------------------|----------------------------------------|
-| Windows x86 (`win-x86`)                   | [GA](#support-ga)     | Latest                                 |
-| Windows x64 (`win-x64`)                   | [GA](#support-ga)     | Latest                                 |
-| Linux x64 (`linux-x64`)                   | [GA](#support-ga)     | Latest                                 |
-| Alpine Linux x64 (`linux-musl-x64`)       | [GA](#support-ga)     | Latest                                 |
+| Windows x86 (`win-x86`)                   | [GA](#support-ga)     | latest                                 |
+| Windows x64 (`win-x64`)                   | [GA](#support-ga)     | latest                                 |
+| Linux x64 (`linux-x64`)                   | [GA](#support-ga)     | latest                                 |
+| Alpine Linux x64 (`linux-musl-x64`)       | [GA](#support-ga)     | latest                                 |
 | Linux ARM64 (`linux-arm64`)               | [GA](#support-ga)     | .NET 5+ only, added in version 1.27.0  |
 
 ## Integrations

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -103,7 +103,7 @@ Datadog APM for .NET Core depends on the host operating system, .NET Core runtim
 
 | **Level**                                              | **Support provided**                                                                                                                                                          |
 |--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact our customer support team for special requests.][10]                                                             |
+| <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact customer support for special requests.][10]                                                             |
 | <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features, bug & security fixes provided on a best-effort basis.                                    |
 | <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                                                    |
 | <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                                                              |

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -33,7 +33,7 @@ The .NET Tracer supports automatic instrumentation on the following .NET Core ve
 | .NET Core 2.2        | 12/23/2019            | [EOL](#support-eol)  | Not recommeded       |
 | .NET Core 2.0        | 10/01/2018            | [EOL](#support-eol)  | Not recommeded       |
 
- Additional information can be found within [Microsoft's .NET Core Lifecycle Policy][3], [End of life APM .NET Core versions](#end-of-life-net-core-versions) and in [Runtime support policy for .NET Core APM][13].
+ Additional information can be found within [Microsoft's .NET Core Lifecycle Policy][3], [End of life APM .NET Core versions](#end-of-life-net-core-versions), and in [Runtime support policy for .NET Core APM](#runtime-support-policy-for-net-core-apm).
 
 ## Supported processor architectures
 
@@ -115,7 +115,7 @@ Datadog APM for .NET Core practices [semantic versioning][11].
 Version updates imply the following changes to runtime support:
 
   - **Major version updates** (for example `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[EOL](#support-eol).
-  - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower our level of support for one runtime but may add support for one.
+  - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower the level of support for one runtime but may add support for one.
   - **Patch version updates** (for example `1.0.0` to `1.0.1`) will not change support for any runtime.
 
 ## Further reading
@@ -129,7 +129,7 @@ Version updates imply the following changes to runtime support:
 [5]: /help/
 [6]: https://github.com/DataDog/dd-trace-dotnet/issues/302#issuecomment-603269367
 [7]: https://github.com/dotnet/runtime/issues/23938
-[8]: https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv6v7
-[9]: https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv5
+[8]: /agent/basic_agent_usage/?tab=agentv6v7
+[9]: /agent/basic_agent_usage/?tab=agentv5
 [10]: https://www.datadoghq.com/support/
 [11]: https://semver.org/

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -114,11 +114,11 @@ The .NET Tracer works on .NET Core 2.0, 2.1, 2.2, and 3.0, but these versions re
 
 ## Supported Datadog Agent versions
 
-| **Datadog Agent version**                                                | **Package version** |
-|--------------------------------------------------------------------------|---------------------|
-| [7.x][10] | Latest              |
-| [6.x][10] | Latest              |
-| [5.x][11]   | Latest              |
+| **Datadog Agent version**   | **Package version** |
+|-----------------------------|---------------------|
+| [7.x][10]                   | Latest              |
+| [6.x][10]                   | Latest              |
+| [5.x][11]                   | Latest              |
 
 ## Further reading
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -17,36 +17,11 @@ further_reading:
 ---
 
 
-- The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual Basic).
-
-- The .NET Tracer library for Datadog is open source. For more information, see the [.NET Tracer repository][1].
-
-## Runtime support policy for .NET Core APM
-
-Datadog APM for .NET Core is built upon dependencies defined in specific versions of the host operating system, .NET Core runtime, certain .NET Core libraries, and the Datadog Agent/API. When these versions are no longer supported by their maintainers, Datadog APM for .NET Core limits its support for these as well.
-
-### Levels of support
-
-| **Level**                                              | **Support provided**                                                                                                                                                          |
-|--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact our customer support team for special requests.][2]                                                             |
-| <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features, bug & security fixes provided on a best-effort basis.                                    |
-| <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                                                    |
-| <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                                                              |
-| <span id="support-eol">End-of-life (EOL)</span>        |  No support.                                                                                                                                                                  |
-
-### Package versioning
-
-Datadog APM for .NET Core practices [semantic versioning][3].
-As this relates to downgrading runtime support, it implies:
-
-  - **Major version updates** (for example `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[Legacy](#support-legacy)/[EOL](#support-eol).
-  - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower our level of support for one runtime but may add support for one.
-  - **Patch version updates** (for example `1.0.0` to `1.0.1`) will not change support for any runtime.
+The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual Basic). It is open source. For more information, see the [.NET Tracer repository][1].
 
 ## Supported .NET Core runtimes
 
-The .NET Tracer supports automatic instrumentation on the following .NET Core versions. It also supports [.NET Framework][4].
+The .NET Tracer supports automatic instrumentation on the following .NET Core versions. It also supports [.NET Framework][2].
 
 | Version              | Microsoft End of Life | Support level        | Package version      |
 | -------------------- | --------------------- | -------------------- | -------------------- |
@@ -54,8 +29,11 @@ The .NET Tracer supports automatic instrumentation on the following .NET Core ve
 | .NET 5               |                       | [GA](#support-ga)    | latest (>= 2.0.0)    |
 | .NET Core 3.1        | 12/03/2022            | [GA](#support-ga)    | latest               |
 | .NET Core 2.1        | 08/21/2021            | [GA](#support-ga)    | latest               |
+| .NET Core 3.0        | 03/03/2020            | [EOL](#support-eol)  | Not recommeded       |
+| .NET Core 2.2        | 12/23/2019            | [EOL](#support-eol)  | Not recommeded       |
+| .NET Core 2.0        | 10/01/2018            | [EOL](#support-eol)  | Not recommeded       |
 
- Additional information on .NET Core support policy can be found within [Microsoft's .NET Core Lifecycle Policy][5]. 
+ Additional information can be found within [Microsoft's .NET Core Lifecycle Policy][3], [End of life APM .NET Core versions](#end-of-life-net-core-versions) and in our [Runtime support policy for .NET Core APM][13].
 
 ## Supported processor architectures
 
@@ -71,7 +49,7 @@ The .NET Tracer supports automatic instrumentation on the following architecture
 
 ## Integrations
 
-The [latest version of the .NET Tracer][6] can automatically instrument the following libraries:
+The [latest version of the .NET Tracer][4] can automatically instrument the following libraries:
 
 | Framework or library            | NuGet package                                                                             | Integration Name     |
 | ------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
@@ -98,37 +76,60 @@ The [latest version of the .NET Tracer][6] can automatically instrument the foll
 | WCF (server)                    | built-in                                                                                  | `Wcf`                |
 | WebClient / WebRequest          | `System.Net.Requests` 4.0+                                                                | `WebRequest`         |
 
-Don’t see your desired frameworks? Datadog is continually adding additional support. [Check with the Datadog team][7] for help.
+Don’t see your desired frameworks? Datadog is continually adding additional support. [Check with the Datadog team][5] for help.
 
-## Out of support .NET Core versions
+## End of life .NET Core versions
 
-The .NET Tracer works on .NET Core 2.0, 2.1, 2.2, and 3.0, but these versions reached their end of life and are no longer supported by Microsoft. See [Microsoft's support policy][5] for more details. Datadog recommends using the latest patch version of .NET Core 3.1, .NET 5, or .NET 6. Older versions of .NET Core may encounter the following runtime issues when enabling automatic instrumentation:
+The .NET Tracer works on .NET Core 2.0, 2.1, 2.2, and 3.0, but these versions reached their end of life and are no longer supported by Microsoft. See [Microsoft's support policy][3] for more details. Datadog recommends using the latest patch version of .NET Core 3.1, .NET 5, or .NET 6. Older versions of .NET Core may encounter the following runtime issues when enabling automatic instrumentation:
 
 | Issue                                         | Affected .NET Core Versions               | Solution                                                               | More information                        |
 |-----------------------------------------------|-------------------------------------------|------------------------------------------------------------------------|-----------------------------------------|
-| JIT Compiler bug on Linux/x64                 | 2.0.x,</br>2.1.0-2.1.11,</br>2.2.0-2.2.5  | Upgrade .NET Core to the latest patch version, or follow steps in the linked issue | [DataDog/dd-trace-dotnet/issues/302][8] |
-| Resource lookup bug with a non `en-US` locale | 2.0.0                                     | Upgrade .NET Core to 2.0.3 or above                                    | [dotnet/runtime/issues/23938][9]        |
+| JIT Compiler bug on Linux/x64                 | 2.0.x,</br>2.1.0-2.1.11,</br>2.2.0-2.2.5  | Upgrade .NET Core to the latest patch version, or follow steps in the linked issue | [DataDog/dd-trace-dotnet/issues/302][6] |
+| Resource lookup bug with a non `en-US` locale | 2.0.0                                     | Upgrade .NET Core to 2.0.3 or above                                    | [dotnet/runtime/issues/23938][7]        |
 
 ## Supported Datadog Agent versions
 
 | **Datadog Agent version**   | **Package version** |
 |-----------------------------|---------------------|
-| [7.x][10]                   | Latest              |
-| [6.x][10]                   | Latest              |
-| [5.x][11]                   | Latest              |
+| [7.x][8]                   | Latest              |
+| [6.x][8]                   | Latest              |
+| [5.x][9]                   | Latest              |
+
+## Runtime support policy for .NET Core APM
+
+Datadog APM for .NET Core is built upon dependencies defined in specific versions of the host operating system, .NET Core runtime, certain .NET Core libraries, and the Datadog Agent/API. When these versions are no longer supported by their maintainers, Datadog APM for .NET Core limits its support for these as well.
+
+### Levels of support
+
+| **Level**                                              | **Support provided**                                                                                                                                                          |
+|--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact our customer support team for special requests.][10]                                                             |
+| <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features, bug & security fixes provided on a best-effort basis.                                    |
+| <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                                                    |
+| <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                                                              |
+| <span id="support-eol">End-of-life (EOL)</span>        |  No support.                                                                                                                                                                  |
+
+### Package versioning
+
+Datadog APM for .NET Core practices [semantic versioning][11].
+As this relates to changing runtime support, it implies:
+
+  - **Major version updates** (for example `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[EOL](#support-eol).
+  - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower our level of support for one runtime but may add support for one.
+  - **Patch version updates** (for example `1.0.0` to `1.0.1`) will not change support for any runtime.
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/dd-trace-dotnet
-[2]: https://www.datadoghq.com/support/
-[3]: https://semver.org/
-[4]: /tracing/compatibility_requirements/dotnet-framework/
-[5]: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-[6]: https://github.com/DataDog/dd-trace-dotnet/releases/latest
-[7]: /help/
-[8]: https://github.com/DataDog/dd-trace-dotnet/issues/302#issuecomment-603269367
-[9]: https://github.com/dotnet/runtime/issues/23938
-[10]: https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv6v7
-[11]: https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv5
+[2]: /tracing/compatibility_requirements/dotnet-framework/
+[3]: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
+[4]: https://github.com/DataDog/dd-trace-dotnet/releases/latest
+[5]: /help/
+[6]: https://github.com/DataDog/dd-trace-dotnet/issues/302#issuecomment-603269367
+[7]: https://github.com/dotnet/runtime/issues/23938
+[8]: https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv6v7
+[9]: https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv5
+[10]: https://www.datadoghq.com/support/
+[11]: https://semver.org/

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -21,33 +21,60 @@ further_reading:
 
 - The .NET Tracer library for Datadog is open source. For more information, see the [.NET Tracer repository][1].
 
+## Runtime support policy for .NET Core APM
+
+Datadog APM for .NET Core is built upon dependencies defined in specific versions of the host operating system, .NET Core runtime, certain .NET Core libraries, and the Datadog Agent/API. When these versions are no longer supported by their maintainers, Datadog APM for .NET Core limits its support for these as well.
+
+### Levels of support
+
+delner marked this conversation as resolved.
+
+| **Level**                                              | **Support provided**                                                                                                                                                          |
+|--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact our customer support team for special requests.][2]                                                             |
+| <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features, bug & security fixes provided on a best-effort basis.                                    |
+| <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                                                    |
+| <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                                                              |
+| <span id="support-legacy">Legacy</span>                |  Legacy implementation. May have limited function, but no maintenance provided. [Contact our customer support team for special requests.][2] |
+| <span id="support-eol">End-of-life (EOL)</span>        |  No support.                                                                                                                                                                  |
+
+### Package versioning
+
+Datadog APM for .NET Core practices [semantic versioning][3].
+As this relates to downgrading runtime support, it implies:
+
+  - **Major version updates** (e.g. `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[Legacy](#support-legacy)/[EOL](#support-eol).
+  - **Minor version updates** (e.g. `1.0.0` to `1.1.0`) will not change support for any runtime.
+  - **Patch version updates** (e.g. `1.0.0` to `1.0.1`) will not change support for any runtime.
+
 ## Supported .NET Core runtimes
-The .NET Tracer supports automatic instrumentation on the following .NET Core versions. It also supports [.NET Framework][2].
 
-| Version              | Microsoft End of Life | APM Supported in 1.x | APM Supported in 2.x |
+The .NET Tracer supports automatic instrumentation on the following .NET Core versions. It also supports [.NET Framework][4].
+
+| Version              | Microsoft End of Life | Support level        | Package version      |
 | -------------------- | --------------------- | -------------------- | -------------------- |
-| .NET 6               |                       | No                   | Yes                  |
-| .NET 5               |                       | Yes                  | Yes                  |
-| .NET Core 3.1        | 12/03/2022            | Yes                  | Yes                  |
-| .NET Core 2.1        | 08/21/2021            | Yes                  | Yes                  |
+| .NET 6               |                       | [GA](#support-ga)    | latest (>= 2.0.0)    |
+| .NET 5               |                       | [GA](#support-ga)    | latest (>= 1.27.0)   |
+| .NET Core 3.1        | 12/03/2022            | [GA](#support-ga)    | latest               |
+| .NET Core 2.1        | 08/21/2021            | [GA](#support-ga)    | latest               |
 
- Additional information on .NET Core support policy can be found within [Microsoft's .NET Core Lifecycle Policy][3]. 
+ Additional information on .NET Core support policy can be found within [Microsoft's .NET Core Lifecycle Policy][5]. 
 
 ## Supported processor architectures
+
 The .NET Tracer supports automatic instrumentation on the following architectures:
 
-| Processor architectures                                                 |
-| ------------------------------------------------------------------------|
-| Windows x86 (`win-x86`)                                                 |
-| Windows x64 (`win-x64`)                                                 |
-| Linux x64 (`linux-x64`)                                                 |
-| Alpine Linux x64 (`linux-musl-x64`)                                     |
-| Linux ARM64 (`linux-arm64`)<br><br>.NET 5+ only, added in version 1.27.0|
-
+| Processor architectures                   | Support level         | Package version                        |
+| ------------------------------------------|-----------------------|----------------------------------------|
+| Windows x86 (`win-x86`)                   | [GA](#support-ga)     | Latest                                 |
+| Windows x64 (`win-x64`)                   | [GA](#support-ga)     | Latest                                 |
+| Linux x64 (`linux-x64`)                   | [GA](#support-ga)     | Latest                                 |
+| Alpine Linux x64 (`linux-musl-x64`)       | [GA](#support-ga)     | Latest                                 |
+| Linux ARM64 (`linux-arm64`)               | [GA](#support-ga)     | .NET 5+ only, added in version 1.27.0  |
 
 ## Integrations
 
-The [latest version of the .NET Tracer][4] can automatically instrument the following libraries:
+The [latest version of the .NET Tracer][6] can automatically instrument the following libraries:
 
 | Framework or library            | NuGet package                                                                             | Integration Name     |
 | ------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
@@ -74,25 +101,37 @@ The [latest version of the .NET Tracer][4] can automatically instrument the foll
 | WCF (server)                    | built-in                                                                                  | `Wcf`                |
 | WebClient / WebRequest          | `System.Net.Requests` 4.0+                                                                | `WebRequest`         |
 
-Don’t see your desired frameworks? Datadog is continually adding additional support. [Check with the Datadog team][5] for help.
+Don’t see your desired frameworks? Datadog is continually adding additional support. [Check with the Datadog team][7] for help.
 
 ## Out of support .NET Core versions
 
-The .NET Tracer works on .NET Core 2.0, 2.1, 2.2, and 3.0, but these versions reached their end of life and are no longer supported by Microsoft. See [Microsoft's support policy][3] for more details. Datadog recommends using the latest patch version of .NET Core 3.1, .NET 5, or .NET 6. Older versions of .NET Core may encounter the following runtime issues when enabling automatic instrumentation:
+The .NET Tracer works on .NET Core 2.0, 2.1, 2.2, and 3.0, but these versions reached their end of life and are no longer supported by Microsoft. See [Microsoft's support policy][5] for more details. Datadog recommends using the latest patch version of .NET Core 3.1, .NET 5, or .NET 6. Older versions of .NET Core may encounter the following runtime issues when enabling automatic instrumentation:
 
 | Issue                                         | Affected .NET Core Versions               | Solution                                                               | More information                        |
 |-----------------------------------------------|-------------------------------------------|------------------------------------------------------------------------|-----------------------------------------|
-| JIT Compiler bug on Linux/x64                 | 2.0.x,</br>2.1.0-2.1.11,</br>2.2.0-2.2.5  | Upgrade .NET Core to the latest patch version, or follow steps in the linked issue | [DataDog/dd-trace-dotnet/issues/302][6] |
-| Resource lookup bug with a non `en-US` locale | 2.0.0                                     | Upgrade .NET Core to 2.0.3 or above                                    | [dotnet/runtime/issues/23938][7]        |
+| JIT Compiler bug on Linux/x64                 | 2.0.x,</br>2.1.0-2.1.11,</br>2.2.0-2.2.5  | Upgrade .NET Core to the latest patch version, or follow steps in the linked issue | [DataDog/dd-trace-dotnet/issues/302][8] |
+| Resource lookup bug with a non `en-US` locale | 2.0.0                                     | Upgrade .NET Core to 2.0.3 or above                                    | [dotnet/runtime/issues/23938][9]        |
+
+## Supported Datadog Agent versions
+
+| **Datadog Agent version**                                                | **Package version** |
+|--------------------------------------------------------------------------|---------------------|
+| [7.x][10] | Latest              |
+| [6.x][10] | Latest              |
+| [5.x][11]   | Latest              |
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/dd-trace-dotnet
-[2]: /tracing/compatibility_requirements/dotnet-framework/
-[3]: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
-[4]: https://github.com/DataDog/dd-trace-dotnet/releases/latest
-[5]: /help/
-[6]: https://github.com/DataDog/dd-trace-dotnet/issues/302#issuecomment-603269367
-[7]: https://github.com/dotnet/runtime/issues/23938
+[2]: https://www.datadoghq.com/support/
+[3]: https://semver.org/
+[4]: /tracing/compatibility_requirements/dotnet-framework/
+[5]: https://dotnet.microsoft.com/platform/support/policy/dotnet-core
+[6]: https://github.com/DataDog/dd-trace-dotnet/releases/latest
+[7]: /help/
+[8]: https://github.com/DataDog/dd-trace-dotnet/issues/302#issuecomment-603269367
+[9]: https://github.com/dotnet/runtime/issues/23938
+[10]: https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv6v7
+[11]: https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv5

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -33,7 +33,7 @@ The .NET Tracer supports automatic instrumentation on the following .NET Core ve
 | .NET Core 2.2        | 12/23/2019            | [EOL](#support-eol)  | Not recommeded       |
 | .NET Core 2.0        | 10/01/2018            | [EOL](#support-eol)  | Not recommeded       |
 
- Additional information can be found within [Microsoft's .NET Core Lifecycle Policy][3], [End of life APM .NET Core versions](#end-of-life-net-core-versions) and in our [Runtime support policy for .NET Core APM][13].
+ Additional information can be found within [Microsoft's .NET Core Lifecycle Policy][3], [End of life APM .NET Core versions](#end-of-life-net-core-versions) and in [Runtime support policy for .NET Core APM][13].
 
 ## Supported processor architectures
 
@@ -112,7 +112,7 @@ Datadog APM for .NET Core is built upon dependencies defined in specific version
 ### Package versioning
 
 Datadog APM for .NET Core practices [semantic versioning][11].
-As this relates to changing runtime support, it implies:
+Version updates imply the following changes to runtime support:
 
   - **Major version updates** (for example `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[EOL](#support-eol).
   - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower our level of support for one runtime but may add support for one.

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-core.md
@@ -91,13 +91,13 @@ The .NET Tracer works on .NET Core 2.0, 2.1, 2.2, and 3.0, but these versions re
 
 | **Datadog Agent version**   | **Package version** |
 |-----------------------------|---------------------|
-| [7.x][8]                   | Latest              |
-| [6.x][8]                   | Latest              |
-| [5.x][9]                   | Latest              |
+| [7.x][8]                    | Latest              |
+| [6.x][8]                    | Latest              |
+| [5.x][9]                    | Latest              |
 
 ## Runtime support policy for .NET Core APM
 
-Datadog APM for .NET Core is built upon dependencies defined in specific versions of the host operating system, .NET Core runtime, certain .NET Core libraries, and the Datadog Agent/API. When these versions are no longer supported by their maintainers, Datadog APM for .NET Core limits its support for these as well.
+Datadog APM for .NET Core is built upon dependencies defined in specific versions of the host operating system, .NET Core runtime, certain .NET Core libraries, and the Datadog Agent/API. When a version of those dependencies are no longer supported by its maintainers, Datadog APM for .NET Core limits its support on that version of the library as well.
 
 ### Levels of support
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -108,6 +108,14 @@ The [latest version of the .NET Tracer][6] can automatically instrument the foll
 
 Don’t see your desired libraries? Datadog is continually adding additional support. [Check with the Datadog team][7] for help.
 
+## Supported Datadog Agent versions
+
+| **Datadog Agent version**   | **Package version** |
+|-----------------------------|---------------------|
+| [7.x][10]                   | Latest              |
+| [6.x][10]                   | Latest              |
+| [5.x][11]                   | Latest              |
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -27,15 +27,12 @@ Datadog APM for .NET Framework is built upon dependencies defined in specific ve
 
 ### Levels of support
 
-delner marked this conversation as resolved.
-
 | **Level**                                              | **Support provided**                                                                                                                                                          |
 |--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact our customer support team for special requests.][2]                                                             |
 | <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features, bug & security fixes provided on a best-effort basis.                                    |
 | <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                                                    |
 | <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                                                              |
-| <span id="support-legacy">Legacy</span>                |  Legacy implementation. May have limited function, but no maintenance provided. [Contact our customer support team for special requests.][2] |
 | <span id="support-eol">End-of-life (EOL)</span>        |  No support.                                                                                                                                                                  |
 
 ### Package versioning
@@ -43,9 +40,9 @@ delner marked this conversation as resolved.
 Datadog APM for .NET Framework practices [semantic versioning][3].
 As this relates to downgrading runtime support, it implies:
 
-  - **Major version updates** (e.g. `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[Legacy](#support-legacy)/[EOL](#support-eol).
-  - **Minor version updates** (e.g. `1.0.0` to `1.1.0`) will not change support for any runtime.
-  - **Patch version updates** (e.g. `1.0.0` to `1.0.1`) will not change support for any runtime.
+  - **Major version updates** (for example `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[Legacy](#support-legacy)/[EOL](#support-eol).
+  - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower our level of support for one runtime but may add support for one.
+  - **Patch version updates** (for example `1.0.0` to `1.0.1`) will not change support for any runtime.
 
 ## Supported .NET Framework runtimes
 
@@ -72,8 +69,8 @@ The .NET Tracer supports automatic instrumentation on the following architecture
  
 | Processor architectures                                                 | Support level         | Package version                        |
 | ------------------------------------------------------------------------|-----------------------|----------------------------------------|
-| Windows x86 (`win-x86`)                                                 | [GA](#support-ga)     | Latest                                 |
-| Windows x64 (`win-x64`)                                                 | [GA](#support-ga)     | Latest                                 |
+| Windows x86 (`win-x86`)                                                 | [GA](#support-ga)     | latest                                 |
+| Windows x64 (`win-x64`)                                                 | [GA](#support-ga)     | latest                                 |
 
 ## Integrations
 
@@ -112,9 +109,9 @@ Don’t see your desired libraries? Datadog is continually adding additional sup
 
 | **Datadog Agent version**   | **Package version** |
 |-----------------------------|---------------------|
-| [7.x][10]                   | Latest              |
-| [6.x][10]                   | Latest              |
-| [5.x][11]                   | Latest              |
+| [7.x][10]                   | latest              |
+| [6.x][10]                   | latest              |
+| [5.x][11]                   | latest              |
 
 ## Further reading
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -89,7 +89,7 @@ Don’t see your desired libraries? Datadog is continually adding additional sup
 
 ## Runtime support policy for .NET Framework APM
 
-Datadog APM for .NET Framework is built upon dependencies defined in specific versions of the host operating system, .NET Framework runtime, certain .NET Framework libraries, and the Datadog Agent/API. When a version of those dependencies are no longer supported by its maintainers, Datadog APM for .NET Framework limits its support on that version of the library as well.
+Datadog APM for .NET Framework depends on the host operating system, .NET Framework runtime, certain .NET Framework libraries, and the Datadog Agent/API. These third party software systems support specific versions of .NET Framework. When the external software no longer supports a version of .NET Framework, Datadog APM for .NET Framework also limits its support for that version.
 
 ### Levels of support
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -104,7 +104,7 @@ Datadog APM for .NET Framework is built upon dependencies defined in specific ve
 ### Package versioning
 
 Datadog APM for .NET Framework practices [semantic versioning][7].
-As this relates to changing runtime support, it implies:
+Version updates imply the following changes to runtime support:
 
   - **Major version updates** (for example `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[EOL](#support-eol).
   - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower our level of support for one runtime but may add support for one.

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -17,51 +17,25 @@ further_reading:
 ---
 
 
-- The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual Basic).
-
-- The .NET Tracer library for Datadog is open source. For more information, see the [.NET Tracer repository][1].
-
-## Runtime support policy for .NET Framework APM
-
-Datadog APM for .NET Framework is built upon dependencies defined in specific versions of the host operating system, .NET Framework runtime, certain .NET Framework libraries, and the Datadog Agent/API. When these versions are no longer supported by their maintainers, Datadog APM for .NET Framework limits its support for these as well.
-
-### Levels of support
-
-| **Level**                                              | **Support provided**                                                                                                                                                          |
-|--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact our customer support team for special requests.][2]                                                             |
-| <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features, bug & security fixes provided on a best-effort basis.                                    |
-| <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                                                    |
-| <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                                                              |
-| <span id="support-eol">End-of-life (EOL)</span>        |  No support.                                                                                                                                                                  |
-
-### Package versioning
-
-Datadog APM for .NET Framework practices [semantic versioning][3].
-As this relates to downgrading runtime support, it implies:
-
-  - **Major version updates** (for example `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[Legacy](#support-legacy)/[EOL](#support-eol).
-  - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower our level of support for one runtime but may add support for one.
-  - **Patch version updates** (for example `1.0.0` to `1.0.1`) will not change support for any runtime.
+The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual Basic). It is open source. For more information, see the [.NET Tracer repository][1].
 
 ## Supported .NET Framework runtimes
 
-The .NET Tracer supports automatic instrumentation on the following .NET Framework versions. It also supports [.NET Core][4].
+The .NET Tracer supports automatic instrumentation on the following .NET Framework versions. It also supports [.NET Core][2].
 
-| .NET Framework Version  | Microsoft End of Life | Support level                          | Package version      |
-| ----------------------- | --------------------- | -------------------------------------- | -------------------- |
-| 4.8                     |                       | [GA](#support-ga)                      | latest               |
-| 4.7.2                   |                       | [GA](#support-ga)                      | latest               |
-| 4.7                     |                       | [GA](#support-ga)                      | latest               |
-| 4.6.2                   |                       | [GA](#support-ga)                      | latest               |
-| 4.6.1                   | 04/26/2022            | [GA](#support-ga)                      | latest               |
-| 4.6                     | 04/26/2022            | [Maintenance](#support-Maintenance)    | < 2.0.0              |
-| 4.5.2                   | 04/26/2022            | [Maintenance](#support-Maintenance)    | < 2.0.0              |
-| 4.5.1                   | 01/12/2016            | [Maintenance](#support-Maintenance)    | < 2.0.0              |
-| 4.5                     | 01/12/2016            | [Maintenance](#support-Maintenance)    | < 2.0.0              |
+| .NET Framework Version  | Microsoft End of Life | Support level                       | Package version | Datadog End of Life |
+| ----------------------- | --------------------- | ----------------------------------- | --------------- | ------------------- |
+| 4.8                     |                       | [GA](#support-ga)                   | latest          |                     |
+| 4.7.2                   |                       | [GA](#support-ga)                   | latest          |                     |
+| 4.7                     |                       | [GA](#support-ga)                   | latest          |                     |
+| 4.6.2                   |                       | [GA](#support-ga)                   | latest          |                     |
+| 4.6.1                   | 04/26/2022            | [GA](#support-ga)                   | latest          |                     |
+| 4.6                     | 04/26/2022            | [Maintenance](#support-Maintenance) | < 2.0.0         | 04/26/2022          |
+| 4.5.2                   | 04/26/2022            | [Maintenance](#support-Maintenance) | < 2.0.0         | 04/26/2022          |
+| 4.5.1                   | 01/12/2016            | [Maintenance](#support-Maintenance) | < 2.0.0         | 04/26/2022          |
+| 4.5                     | 01/12/2016            | [Maintenance](#support-Maintenance) | < 2.0.0         | 04/26/2022          |
 
-End of life for versions < 2.0.0 is scheduled for April 26th, 2022.
-Additional information on .NET Framework support policy can be found within [Microsoft's .NET Framework Lifecycle Policy][5]. 
+Additional information can be found within [Microsoft's .NET Core Lifecycle Policy][3] and in our [Runtime support policy for .NET Framework APM](#runtime-support-policy-for-net-framework-apm).
 
 ## Supported processor architectures
 
@@ -74,7 +48,7 @@ The .NET Tracer supports automatic instrumentation on the following architecture
 
 ## Integrations
 
-The [latest version of the .NET Tracer][6] can automatically instrument the following libraries:
+The [latest version of the .NET Tracer][4] can automatically instrument the following libraries:
 
 | Framework or library            | NuGet package                                                                             | Integration Name     |
 | ------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
@@ -103,7 +77,7 @@ The [latest version of the .NET Tracer][6] can automatically instrument the foll
 | WCF (server)                    | built-in                                                                                  | `Wcf`                |
 | WebClient / WebRequest          | built-in                                                                                  | `WebRequest`         |
 
-Don’t see your desired libraries? Datadog is continually adding additional support. [Check with the Datadog team][7] for help.
+Don’t see your desired libraries? Datadog is continually adding additional support. [Check with the Datadog team][5] for help.
 
 ## Supported Datadog Agent versions
 
@@ -113,14 +87,37 @@ Don’t see your desired libraries? Datadog is continually adding additional sup
 | [6.x][10]                   | latest              |
 | [5.x][11]                   | latest              |
 
+## Runtime support policy for .NET Framework APM
+
+Datadog APM for .NET Framework is built upon dependencies defined in specific versions of the host operating system, .NET Framework runtime, certain .NET Framework libraries, and the Datadog Agent/API. When these versions are no longer supported by their maintainers, Datadog APM for .NET Framework limits its support for these as well.
+
+### Levels of support
+
+| **Level**                                              | **Support provided**                                                                                                                                                          |
+|--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact our customer support team for special requests.][6]                                                             |
+| <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features, bug & security fixes provided on a best-effort basis.                                    |
+| <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                                                    |
+| <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                                                              |
+| <span id="support-eol">End-of-life (EOL)</span>        |  No support.                                                                                                                                                                  |
+
+### Package versioning
+
+Datadog APM for .NET Framework practices [semantic versioning][7].
+As this relates to changing runtime support, it implies:
+
+  - **Major version updates** (for example `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[EOL](#support-eol).
+  - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower our level of support for one runtime but may add support for one.
+  - **Patch version updates** (for example `1.0.0` to `1.0.1`) will not change support for any runtime.
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/dd-trace-dotnet
-[2]: https://www.datadoghq.com/support/
-[3]: https://semver.org/
-[4]: /tracing/compatibility_requirements/dotnet-core/
-[5]: https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework
-[6]: https://github.com/DataDog/dd-trace-dotnet/releases/latest
-[7]: /help/
+[2]: /tracing/compatibility_requirements/dotnet-core/
+[3]: https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework
+[4]: https://github.com/DataDog/dd-trace-dotnet/releases/latest
+[5]: /help/
+[6]: https://www.datadoghq.com/support/
+[7]: https://semver.org/

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -89,7 +89,7 @@ Don’t see your desired libraries? Datadog is continually adding additional sup
 
 ## Runtime support policy for .NET Framework APM
 
-Datadog APM for .NET Framework is built upon dependencies defined in specific versions of the host operating system, .NET Framework runtime, certain .NET Framework libraries, and the Datadog Agent/API. When these versions are no longer supported by their maintainers, Datadog APM for .NET Framework limits its support for these as well.
+Datadog APM for .NET Framework is built upon dependencies defined in specific versions of the host operating system, .NET Framework runtime, certain .NET Framework libraries, and the Datadog Agent/API. When a version of those dependencies are no longer supported by its maintainers, Datadog APM for .NET Framework limits its support on that version of the library as well.
 
 ### Levels of support
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -21,34 +21,63 @@ further_reading:
 
 - The .NET Tracer library for Datadog is open source. For more information, see the [.NET Tracer repository][1].
 
+## Runtime support policy for .NET Framework APM
+
+Datadog APM for .NET Framework is built upon dependencies defined in specific versions of the host operating system, .NET Framework runtime, certain .NET Framework libraries, and the Datadog Agent/API. When these versions are no longer supported by their maintainers, Datadog APM for .NET Framework limits its support for these as well.
+
+### Levels of support
+
+delner marked this conversation as resolved.
+
+| **Level**                                              | **Support provided**                                                                                                                                                          |
+|--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact our customer support team for special requests.][2]                                                             |
+| <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features, bug & security fixes provided on a best-effort basis.                                    |
+| <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                                                    |
+| <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                                                              |
+| <span id="support-legacy">Legacy</span>                |  Legacy implementation. May have limited function, but no maintenance provided. [Contact our customer support team for special requests.][2] |
+| <span id="support-eol">End-of-life (EOL)</span>        |  No support.                                                                                                                                                                  |
+
+### Package versioning
+
+Datadog APM for .NET Framework practices [semantic versioning][3].
+As this relates to downgrading runtime support, it implies:
+
+  - **Major version updates** (e.g. `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[Legacy](#support-legacy)/[EOL](#support-eol).
+  - **Minor version updates** (e.g. `1.0.0` to `1.1.0`) will not change support for any runtime.
+  - **Patch version updates** (e.g. `1.0.0` to `1.0.1`) will not change support for any runtime.
+
 ## Supported .NET Framework runtimes
-The .NET Tracer supports automatic instrumentation on the following .NET Framework versions. It also supports [.NET Core][2].
 
-| .NET Framework Version  | Microsoft End of Life | APM Supported in 1.x | APM Supported in 2.x |
-| ----------------------- | --------------------- | -------------------- | -------------------- |
-| 4.8                     |                       | Yes                  | Yes                  |
-| 4.7.2                   |                       | Yes                  | Yes                  |
-| 4.7                     |                       | Yes                  | Yes                  |
-| 4.6.2                   |                       | Yes                  | Yes                  |
-| 4.6.1                   | 04/26/2022            | Yes                  | Yes                  |
-| 4.6                     | 04/26/2022            | Yes                  | No                   |
-| 4.5.2                   | 04/26/2022            | Yes                  | No                   |
-| 4.5.1                   | 01/12/2016            | Yes                  | No                   |
-| 4.5                     | 01/12/2016            | Yes                  | No                   |
+The .NET Tracer supports automatic instrumentation on the following .NET Framework versions. It also supports [.NET Core][4].
 
- Additional information on .NET Framework support policy can be found within [Microsoft's .NET Framework Lifecycle Policy][3]. 
+| .NET Framework Version  | Microsoft End of Life | Support level                          | Package version      |
+| ----------------------- | --------------------- | -------------------------------------- | -------------------- |
+| 4.8                     |                       | [GA](#support-ga)                      | latest               |
+| 4.7.2                   |                       | [GA](#support-ga)                      | latest               |
+| 4.7                     |                       | [GA](#support-ga)                      | latest               |
+| 4.6.2                   |                       | [GA](#support-ga)                      | latest               |
+| 4.6.1                   | 04/26/2022            | [GA](#support-ga)                      | latest               |
+| 4.6                     | 04/26/2022            | [Maintenance](#support-Maintenance)    | < 2.0.0              |
+| 4.5.2                   | 04/26/2022            | [Maintenance](#support-Maintenance)    | < 2.0.0              |
+| 4.5.1                   | 01/12/2016            | [Maintenance](#support-Maintenance)    | < 2.0.0              |
+| 4.5                     | 01/12/2016            | [Maintenance](#support-Maintenance)    | < 2.0.0              |
+
+End of life for versions < 2.0.0 is scheduled for April 26th, 2022.
+Additional information on .NET Framework support policy can be found within [Microsoft's .NET Framework Lifecycle Policy][5]. 
 
 ## Supported processor architectures
-The .NET Tracer supports automatic instrumentation on the following architectures:
 
-| Processor architectures                                                 |
-| ------------------------------------------------------------------------|
-| Windows x86 (`win-x86`)                                                 |
-| Windows x64 (`win-x64`)                                                 |
+The .NET Tracer supports automatic instrumentation on the following architectures:
+ 
+| Processor architectures                                                 | Support level         | Package version                        |
+| ------------------------------------------------------------------------|-----------------------|----------------------------------------|
+| Windows x86 (`win-x86`)                                                 | [GA](#support-ga)     | Latest                                 |
+| Windows x64 (`win-x64`)                                                 | [GA](#support-ga)     | Latest                                 |
 
 ## Integrations
 
-The [latest version of the .NET Tracer][4] can automatically instrument the following libraries:
+The [latest version of the .NET Tracer][6] can automatically instrument the following libraries:
 
 | Framework or library            | NuGet package                                                                             | Integration Name     |
 | ------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
@@ -77,14 +106,16 @@ The [latest version of the .NET Tracer][4] can automatically instrument the foll
 | WCF (server)                    | built-in                                                                                  | `Wcf`                |
 | WebClient / WebRequest          | built-in                                                                                  | `WebRequest`         |
 
-Don’t see your desired libraries? Datadog is continually adding additional support. [Check with the Datadog team][5] for help.
+Don’t see your desired libraries? Datadog is continually adding additional support. [Check with the Datadog team][7] for help.
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/dd-trace-dotnet
-[2]: /tracing/compatibility_requirements/dotnet-core/
-[3]: https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework
-[4]: https://github.com/DataDog/dd-trace-dotnet/releases/latest
-[5]: /help/
+[2]: https://www.datadoghq.com/support/
+[3]: https://semver.org/
+[4]: /tracing/compatibility_requirements/dotnet-core/
+[5]: https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework
+[6]: https://github.com/DataDog/dd-trace-dotnet/releases/latest
+[7]: /help/

--- a/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/dotnet-framework.md
@@ -35,7 +35,7 @@ The .NET Tracer supports automatic instrumentation on the following .NET Framewo
 | 4.5.1                   | 01/12/2016            | [Maintenance](#support-Maintenance) | < 2.0.0         | 04/26/2022          |
 | 4.5                     | 01/12/2016            | [Maintenance](#support-Maintenance) | < 2.0.0         | 04/26/2022          |
 
-Additional information can be found within [Microsoft's .NET Core Lifecycle Policy][3] and in our [Runtime support policy for .NET Framework APM](#runtime-support-policy-for-net-framework-apm).
+Additional information can be found within [Microsoft's .NET Core Lifecycle Policy][3] and in [Runtime support policy for .NET Framework APM](#runtime-support-policy-for-net-framework-apm).
 
 ## Supported processor architectures
 
@@ -95,7 +95,7 @@ Datadog APM for .NET Framework depends on the host operating system, .NET Framew
 
 | **Level**                                              | **Support provided**                                                                                                                                                          |
 |--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact our customer support team for special requests.][6]                                                             |
+| <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact customer support for special requests.][6]                                                             |
 | <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features, bug & security fixes provided on a best-effort basis.                                    |
 | <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                                                    |
 | <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                                                              |
@@ -107,7 +107,7 @@ Datadog APM for .NET Framework practices [semantic versioning][7].
 Version updates imply the following changes to runtime support:
 
   - **Major version updates** (for example `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[EOL](#support-eol).
-  - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower our level of support for one runtime but may add support for one.
+  - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower the level of support for one runtime but may add support for one.
   - **Patch version updates** (for example `1.0.0` to `1.0.1`) will not change support for any runtime.
 
 ## Further reading


### PR DESCRIPTION
### What does this PR do?
Updates .NET Runtime policy in accordance to https://github.com/DataDog/architecture/pull/992

### Motivation
Make it straightforward for customers to know what versions we do support.

### Preview
https://docs-staging.datadoghq.com/pierre/net-runtime-policy/tracing/setup_overview/compatibility_requirements/dotnet-core

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
