### PR TITLE
Bryce/add note about tag values in notifications

### DIFF
--- a/content/en/monitors/create/types/log.md
+++ b/content/en/monitors/create/types/log.md
@@ -74,7 +74,7 @@ For detailed instructions on the advanced alert options (evaluation delay, new g
 ### Notifications
 
 For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][6] page.  
-**Note:** If you populate your notifications with tag values, and no logs are present when the monitor renotifies or resolves, these values are empty in the notification.
+**Note:** If you populate your notifications with tag values, these values will be empty if the monitor renotifies or resolves with no logs present.
 
 #### Log samples and breaching values toplist
 

--- a/content/en/monitors/create/types/log.md
+++ b/content/en/monitors/create/types/log.md
@@ -73,7 +73,8 @@ For detailed instructions on the advanced alert options (evaluation delay, new g
 
 ### Notifications
 
-For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][6] page.
+For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][6] page.  
+**Note:** If you populate your notifications with tag values, and no logs are present when the monitor renotifies or resolves, these values are empty in the notification.
 
 #### Log samples and breaching values toplist
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add a note about tag values in notifications being empty when logs are absent.

### Motivation
DOCS-3255

### Preview
https://docs-staging.datadoghq.com/bryce/add-note-about-tag-values-in-notifications/monitors/create/types/log/#notifications

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
