### PR TITLE
DOCS-1188 Run Synthetic Tests from Private Locations Edit

### DIFF
--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -252,6 +252,8 @@ To deploy the private locations worker in a secure manner, set up and mount a Ku
     kubectl apply -f private-location-worker-deployment.yaml
     ```
 
+For OpenShift, you need to run the private location with the `anyuid` SCC in order for your browser test to run.
+
 [1]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 
 {{% /tab %}}

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -252,7 +252,7 @@ To deploy the private locations worker in a secure manner, set up and mount a Ku
     kubectl apply -f private-location-worker-deployment.yaml
     ```
 
-For OpenShift, you need to run the private location with the `anyuid` SCC in order for your browser test to run.
+For OpenShift, run the private location with the `anyuid` SCC. This is required for your browser test to run.
 
 [1]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds instructions for OpenShift users to run private locations with anyuid SCC.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-1188

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/private-locations-kubernetes-openshift-specification/synthetics/private_locations/?tab=kubernetesdeployment#install-your-private-location

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
