### PR TITLE
APM > .NET > Restore DD_TRACE_METHODS documentation

### DIFF
--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -450,6 +450,11 @@ This can be useful if you are using parameter names to differentiate between for
 **Default**: `false`
 Added in version 2.5.1.
 
+`DD_TRACE_METHODS`
+: List of methods to trace. Accepts a semicolon (`;`) separated list where each entry has the format `TypeName[MethodNames]`, where `MethodNames` is a comma (`,`) separated list of method names. For generic types, replace the angled brackets and the type parameters' names with a backtick (`` ` ``) followed by the number of generic type parameters. For example, `Dictionary<TKey, TValue>` must be written as `` Dictionary`2 ``. For generic methods, you only need to specify the method name. <br>
+**Example**: ```Namespace1.Class1[Method1,GenericMethod];Namespace1.GenericTypeWithOneTypeVariable`1[ExecuteAsync]```<br>
+Added in version 2.6.0
+
 #### Automatic instrumentation integration configuration
 
 The following table lists configuration variables that are available **only** when using automatic instrumentation and can be set for each integration.

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -416,7 +416,12 @@ Added in version 1.23.0.
 : Expands all route parameters in the application for ASP.NET/ASP.NET Core (except ID parameters)<br>
 This can be useful if you are using parameter names to differentiate between form values, or a slug, such as in GraphQL.
 **Default**: `false`
-Added in version 2.5.1
+Added in version 2.5.2
+
+`DD_TRACE_METHODS`
+: List of methods to trace. Accepts a semicolon (`;`) separated list where each entry has the format `TypeName[MethodNames]`, where `MethodNames` is a comma (`,`) separated list of method names. For generic types, replace the angled brackets and the type parameters' names with a backtick (`` ` ``) followed by the number of generic type parameters. For example, `Dictionary<TKey, TValue>` must be written as `` Dictionary`2 ``. For generic methods, you only need to specify the method name. <br>
+**Example**: ```Namespace1.Class1[Method1,GenericMethod];Namespace1.GenericTypeWithOneTypeVariable`1[ExecuteAsync]```<br>
+Added in version 2.6.0
 
 #### Automatic instrumentation integration configuration
 


### PR DESCRIPTION
### What does this PR do?
Restore the `DD_TRACE_METHODS` configuration documentation for the .NET Tracer 2.6.0 release now that it is stable.

### Motivation
The .NET Tracer just made a 2.6.0 release that improves usage of the `DD_TRACE_METHODS` configuration.

### Preview
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-trace-methods-restore/tracing/setup_overview/setup/dotnet-framework?tab=windows#automatic-instrumentation-optional-configuration
https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-trace-methods-restore/tracing/setup_overview/setup/dotnet-core?tab=windows#automatic-instrumentation-optional-configuration

### Additional Notes
The wording has previously been approved by Docs and Engineering (before being retracted due to feature bugs) so I hope this can be merged right away, now that the feature is ready for public consumption.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
