### PR TITLE
temporary increase algolia timeout

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -295,7 +295,7 @@ index_algolia:
     <<: *cache
     policy: pull
   environment: "live"
-  timeout: 1h 30m
+  timeout: 1h 55m
   script:
     - |-
       echo APPLICATION_ID=$(get_secret 'ci.documentation.algolia_docsearch_application_id') > .env


### PR DESCRIPTION
### What does this PR do?

Increase the timeout on algolia job

### Motivation

This is a temporary solution for indexing

### Preview

https://docs-staging.datadoghq.com/david.jones/increase-timeout/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
