### PR TITLE
Add weighted modifier to modifiers doc

### DIFF
--- a/content/en/metrics/type_modifiers.md
+++ b/content/en/metrics/type_modifiers.md
@@ -76,7 +76,7 @@ Depending on the metric type you applied them to, the behavior differs:
 {{< /tabs >}}
 
 ### The `weighted()` modifier
-High tag churn is seen for tags like `pod name` or `container_name` especially when creating queries for cost management, capacity planning or autoscaling for containerized applications. To ensure mathematical accuracy of queries on gauges regardless of tag churn, there exists a `.weighted()` in-application modifier that guarantees metrics' values are properly weighted based on the lifespan of these frequently churning tags. 
+Tags like `pod name` or `container_name` cause high tag churn, especially when creating queries for cost management, capacity planning or autoscaling for containerized applications. To ensure mathematical accuracy of queries on gauges regardless of tag churn, there exists a `.weighted()` in-application modifier. The `.weighted()` modifier ensures that Datadog properly weights metric values based on the lifespan of these frequently churning tags. 
 
 The `.weighted()` modifier is automatically appended to queries on gauges only if both of the following conditions are met:
 - The gauge metric is submitted regularly, such that there is no interpolation over gaps

--- a/content/en/metrics/type_modifiers.md
+++ b/content/en/metrics/type_modifiers.md
@@ -75,9 +75,17 @@ Depending on the metric type you applied them to, the behavior differs:
 {{% /tab %}}
 {{< /tabs >}}
 
+### The `weighted()` modifier
+High tag churn is seen for tags like `pod name` or `container_name` especially when creating queries for cost management, capacity planning or autoscaling for containerized applications. To ensure mathematical accuracy of queries on gauges regardless of tag churn, there exists a `.weighted()` in-application modifier that guarantees metrics' values are properly weighted based on the lifespan of these frequently churning tags. 
+
+The `.weighted()` modifier is automatically appended to queries on gauges only if both of the following conditions are met:
+- The gauge metric is submitted regularly, such that there is no interpolation over gaps
+- The submission interval is correctly defined and set. 
+Submission intervals are a part of a metric's metadata that can be set at intake by either the Datadog Agent or our integrations; however, they can be modified on the [Metrics Summary page][4].
+
 ## Modify a metric's type within Datadog
 
-While it is not normally required, it is possible to change a metric's type in the [metric summary page][4]:
+While it is not normally required, it is possible to change a metric's type in the [Metrics Summary page][4]:
 
 {{< img src="metrics/type_modifiers/metric_type.png" alt="Metric Type" style="width:70%;">}}
 

--- a/content/en/metrics/type_modifiers.md
+++ b/content/en/metrics/type_modifiers.md
@@ -81,7 +81,8 @@ Tags like `pod name` or `container_name` cause high tag churn, especially when c
 The `.weighted()` modifier is automatically appended to queries on gauges only if both of the following conditions are met:
 - The gauge metric is submitted regularly, such that there is no interpolation over gaps
 - The submission interval is correctly defined and set. 
-Submission intervals are a part of a metric's metadata that can be set at intake by either the Datadog Agent or our integrations; however, they can be modified on the [Metrics Summary page][4].
+
+Either the Datadog Agent or an integration sets the submission interval for a metric at time of intake. Modify submission intervals on the [Metrics Summary page][4].
 
 ## Modify a metric's type within Datadog
 

--- a/content/en/metrics/type_modifiers.md
+++ b/content/en/metrics/type_modifiers.md
@@ -79,7 +79,7 @@ Depending on the metric type you applied them to, the behavior differs:
 Tags like `pod name` or `container_name` cause high tag churn, especially when creating queries for cost management, capacity planning or autoscaling for containerized applications. To ensure mathematical accuracy of queries on gauges regardless of tag churn, there exists a `.weighted()` in-application modifier. The `.weighted()` modifier ensures that Datadog properly weights metric values based on the lifespan of these frequently churning tags. 
 
 The `.weighted()` modifier is automatically appended to queries on gauges only if both of the following conditions are met:
-- The gauge metric is submitted regularly, such that there is no interpolation over gaps
+- The gauge metric is submitted regularly, such that there is no interpolation over gaps.
 - The submission interval is correctly defined and set. 
 
 Either the Datadog Agent or an integration sets the submission interval for a metric at time of intake. Modify submission intervals on the [Metrics Summary page][4].


### PR DESCRIPTION
We've introduced weighted to remove potential double counting that can be seen for  gauge metrics

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
We're releasing docs on the new .weighted modifier() that properly accounts for short-lived tags when summing gauges

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
