### PR TITLE
[DOCS-3319] Replace performance_schema with performance_schema_max_sql_text_length

### DIFF
--- a/content/en/database_monitoring/setup_mysql/selfhosted.md
+++ b/content/en/database_monitoring/setup_mysql/selfhosted.md
@@ -47,7 +47,7 @@ To collect query metrics, samples, and explain plans, enable the [MySQL Performa
 {{% tab "MySQL 5.6" %}}
 | Parameter | Value | Description |
 | --- | --- | --- |
-| `performance_schema` | `ON` | Required. Enables the Performance Schema. |
+| `performance_schema_max_sql_text_length` | `ON` | Required. Enables the Performance Schema. |
 | `max_digest_length` | `4096` | Required for collection of larger queries. If left at the default value then queries longer than `1024` characters will not be collected. |
 | <code style="word-break:break-all;">`performance_schema_max_digest_length`</code> | `4096` | Must match `max_digest_length`. |
 | `performance-schema-consumer-events-statements-current` | `ON` | Required. Enables monitoring of currently running queries. |
@@ -59,7 +59,7 @@ To collect query metrics, samples, and explain plans, enable the [MySQL Performa
 {{% tab "MySQL ≥ 5.7" %}}
 | Parameter | Value | Description |
 | --- | --- | --- |
-| `performance_schema` | `ON` | Required. Enables the Performance Schema. |
+| `performance_schema_max_sql_text_length` | `ON` | Required. Enables the Performance Schema. |
 | `max_digest_length` | `4096` | Required for collection of larger queries. If left at the default value then queries longer than `1024` characters will not be collected. |
 | <code style="word-break:break-all;">`performance_schema_max_digest_length`</code> | `4096` | Must match `max_digest_length`. |
 | <code style="word-break:break-all;">`performance_schema_max_sql_text_length`</code> | `4096` | Must match `max_digest_length`. |
@@ -89,7 +89,7 @@ CREATE USER datadog@'%' IDENTIFIED WITH mysql_native_password by '<UNIQUEPASSWOR
 ALTER USER datadog@'%' WITH MAX_USER_CONNECTIONS 5;
 GRANT REPLICATION CLIENT ON *.* TO datadog@'%';
 GRANT PROCESS ON *.* TO datadog@'%';
-GRANT SELECT ON performance_schema.* TO datadog@'%';
+GRANT SELECT ON performance_schema_max_sql_text_length.* TO datadog@'%';
 ```
 
 {{% /tab %}}
@@ -101,7 +101,7 @@ Create the `datadog` user and grant basic permissions:
 CREATE USER datadog@'%' IDENTIFIED BY '<UNIQUEPASSWORD>';
 GRANT REPLICATION CLIENT ON *.* TO datadog@'%' WITH MAX_USER_CONNECTIONS 5;
 GRANT PROCESS ON *.* TO datadog@'%';
-GRANT SELECT ON performance_schema.* TO datadog@'%';
+GRANT SELECT ON performance_schema_max_sql_text_length.* TO datadog@'%';
 ```
 
 {{% /tab %}}
@@ -147,14 +147,14 @@ GRANT EXECUTE ON PROCEDURE <YOUR_SCHEMA>.explain_statement TO datadog@'%';
 ```
 
 ### Runtime setup consumers
-Datadog recommends that you create the following procedure to give the Agent the ability to enable `performance_schema.events_statements_*` consumers at runtime.
+Datadog recommends that you create the following procedure to give the Agent the ability to enable `performance_schema_max_sql_text_length.events_statements_*` consumers at runtime.
 
 ```SQL
 DELIMITER $$
 CREATE PROCEDURE datadog.enable_events_statements_consumers()
     SQL SECURITY DEFINER
 BEGIN
-    UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%';
+    UPDATE performance_schema_max_sql_text_length.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%';
 END $$
 DELIMITER ;
 GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers TO datadog@'%';


### PR DESCRIPTION
### What does this PR do?

Replace `performance_schema` with `performance_schema_max_sql_text_length`.

### Motivation

DOCS-3319

### Preview

https://docs-staging.datadoghq.com/may/dbm-replace-performance-schema/database_monitoring/setup_mysql/selfhosted/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
