### PR TITLE
Remove incorrectly listed "OOTB" facets

### DIFF
--- a/content/en/logs/explorer/facets.md
+++ b/content/en/logs/explorer/facets.md
@@ -185,7 +185,7 @@ You may wish to keep the non-standard _aliased_ version of the facet if you are 
 
 ### Out-of-the-box facets
 
-Most common facets such as `Host`, `Service`, `URL Path`, or `Duration` come out-of-the-box to start troubleshooting right away once your logs are flowing into log indexes.
+Most common facets such as `Host` and `Service` come out-of-the-box, so you can start troubleshooting right away once your logs are flowing into log indexes.
 
 Facets on [Reserved Attributes][25] and most [Standard Attributes][26] are available by default.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Removes two facets incorrectly listed as OOTB facets. 

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/usman.khan/ootb_facets/logs/explorer/facets/#out-of-the-box-facets

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
