### PR TITLE
Profiler .NET - Add an explicit comment on "configuring environment variables at machine level

### DIFF
--- a/content/en/tracing/profiler/enabling/dotnet.md
+++ b/content/en/tracing/profiler/enabling/dotnet.md
@@ -55,6 +55,10 @@ Any language that targets the .NET runtime, such as C#, F#, and Visual Basic.
 
    Run the installer with administrator privileges.
 
+<div class="alert alert-warning">
+  <strong>Note:</strong> Below, you will have to set environment variables to enable the profiler. We <strong>do not recommend</strong> setting those environment variables at machine level. If you do that, every .NET application running on the machine will be profiled and this will incur a significant overhead on the CPU and memory of your machine.
+</div>
+
 {{< tabs >}}
 
 {{% tab "Internet Information Services (IIS)" %}}

--- a/content/en/tracing/profiler/enabling/dotnet.md
+++ b/content/en/tracing/profiler/enabling/dotnet.md
@@ -56,7 +56,7 @@ Any language that targets the .NET runtime, such as C#, F#, and Visual Basic.
    Run the installer with administrator privileges.
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> Below, you will have to set environment variables to enable the profiler. We <strong>do not recommend</strong> setting those environment variables at machine level. If you do that, every .NET application running on the machine will be profiled and this will incur a significant overhead on the CPU and memory of your machine.
+  <strong>Note:</strong> The following steps include setting environment variables to enable the profiler. Datadog <strong>do not recommend</strong> setting those environment variables at machine-level. If set at machine-level, every .NET application running on the machine is profiled and this incurs a significant overhead on the CPU and memory of your machine.
 </div>
 
 {{< tabs >}}

--- a/content/en/tracing/profiler/enabling/dotnet.md
+++ b/content/en/tracing/profiler/enabling/dotnet.md
@@ -56,7 +56,7 @@ Any language that targets the .NET runtime, such as C#, F#, and Visual Basic.
    Run the installer with administrator privileges.
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> The following steps include setting environment variables to enable the profiler. Datadog <strong>do not recommend</strong> setting those environment variables at machine-level. If set at machine-level, every .NET application running on the machine is profiled and this incurs a significant overhead on the CPU and memory of your machine.
+  <strong>Note:</strong> The following steps include setting environment variables to enable the profiler. Datadog <strong>does not recommend</strong> setting those environment variables at machine-level. If set at machine-level, every .NET application running on the machine is profiled and this incurs a significant overhead on the CPU and memory of your machine.
 </div>
 
 {{< tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->


### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add a `warning note` to inform customers to avoid setting environment variables at machine-level.

### Motivation
<!-- What inspired you to submit this pull request?-->
We had customers lately that reported a huge overhead (CPU and memory) incurred by the profiler. After investigating, we discovered that they set the required environment variables at machine-level. This is not recommended and should be avoid.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/gleocadie/add-warning-for-dotnet-profiler-for-global-configuration/tracing/profiler/enabling/dotnet/?tab=internetinformationservicesiis

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
