### PR TITLE
Fixed link to Python StatsD documentation about metric type Set

### DIFF
--- a/content/en/metrics/types.md
+++ b/content/en/metrics/types.md
@@ -338,7 +338,7 @@ Below is a summary of all available metric submission sources and methods. This 
 [1]: /metrics/type_modifiers/
 [2]: /dashboards/functions/
 [3]: /metrics/summary/
-[4]: https://statsd.readthedocs.io/en/v3.2.1/types.html#sets
+[4]: https://statsd.readthedocs.io/en/v3.2.2/types.html#sets
 [5]: /metrics/agent_metrics_submission/
 [6]: /metrics/dogstatsd_metrics_submission/
 [7]: /api/v1/metrics/#submit-metrics

--- a/content/fr/developers/metrics/types.md
+++ b/content/fr/developers/metrics/types.md
@@ -311,7 +311,7 @@ Vous trouverez ci-dessous une synthèse de l'ensemble des sources et des méthod
 [1]: /fr/metrics/type_modifiers/
 [2]: /fr/dashboards/functions/
 [3]: /fr/metrics/summary/
-[4]: https://statsd.readthedocs.io/en/v3.2.1/types.html#sets
+[4]: https://statsd.readthedocs.io/en/v3.2.2/types.html#sets
 [5]: /fr/metrics/agent_metrics_submission/
 [6]: /fr/metrics/dogstatsd_metrics_submission/
 [7]: /fr/api/v1/metrics/#submit-metrics

--- a/content/ja/developers/metrics/types.md
+++ b/content/ja/developers/metrics/types.md
@@ -335,7 +335,7 @@ GAUGE、HISTOGRAM などのメトリクスタイプと同様に、DISTRIBUTION �
 [1]: /ja/metrics/type_modifiers/
 [2]: /ja/dashboards/functions/
 [3]: /ja/metrics/summary/
-[4]: https://statsd.readthedocs.io/en/v3.2.1/types.html#sets
+[4]: https://statsd.readthedocs.io/en/v3.2.2/types.html#sets
 [5]: /ja/metrics/agent_metrics_submission/
 [6]: /ja/metrics/dogstatsd_metrics_submission/
 [7]: /ja/api/v1/metrics/#submit-metrics

--- a/content/ja/metrics/types.md
+++ b/content/ja/metrics/types.md
@@ -336,7 +336,7 @@ GAUGE、HISTOGRAM などのメトリクスタイプと同様に、DISTRIBUTION �
 [1]: /ja/developers/metrics/type_modifiers/
 [2]: /ja/dashboards/functions/
 [3]: /ja/metrics/summary/
-[4]: https://statsd.readthedocs.io/en/v3.2.1/types.html#sets
+[4]: https://statsd.readthedocs.io/en/v3.2.2/types.html#sets
 [5]: /ja/developers/metrics/agent_metrics_submission/
 [6]: /ja/developers/metrics/dogstatsd_metrics_submission/
 [7]: /ja/api/v1/metrics/#submit-metrics


### PR DESCRIPTION
### What does this PR do?

This PR fixes a link in to the Python StatsD documentation. The documentation currently links to https://statsd.readthedocs.io/en/v3.2.1/types.html#sets, which is a page that does not exist anymore. The new page is https://statsd.readthedocs.io/en/v3.2.2/types.html#sets.

### Motivation

To remove the 404 when following links from the documentation.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
