### PR TITLE
[CIAPP] Add instructions to enable logs collection for gitlab

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -142,14 +142,16 @@ After the integration is successfully configured, the [Pipelines][4] and [Pipeli
 
 ## Enable job log collection (beta)
 
-Supported GitLab versions to collect job logs:
+The following GitLab versions support collecting job logs:
 * GitLab.com (SaaS)
 * GitLab >= 14.8 (self-hosted) only if using [object storage to store job logs][6]
 
-To enable collection of job logs the [feature flag][7] `datadog_integration_logs_collection` must be enabled in your GitLab self-hosted or GitLab.com account.
-After enabling the feature flag, a new option appears in the settings of the Datadog integration: `Enable logs collection`. Enable this option and save the changes.
+To enable collection of job logs:
 
-Job logs will be collected in the [Logs][8] product and automatically correlated with the GitLab pipeline within CI Visibility.
+1. Enable the `datadog_integration_logs_collection` [feature flag][7] in your GitLab self-hosted or GitLab.com account. This reveals the `Enable logs collection` option in the Datadog integration.
+2. Enable the `Enable logs collection` option and save the changes.
+
+Job logs are collected in the [Logs][8] product and automatically correlated with the GitLab pipeline within CI Visibility.
 
 <div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility</div>
 

--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -142,14 +142,14 @@ After the integration is successfully configured, the [Pipelines][4] and [Pipeli
 
 ## Enable job log collection (beta)
 
-Supported GitLab versions for job logs:
+Supported GitLab versions for job logs, only when using [object storage for job logs][6]:
 * GitLab.com (SaaS)
 * GitLab >= 14.8 (self-hosted)
 
-To enable collection of job logs the [feature flag][6] `datadog_integration_logs_collection` must be enabled in your GitLab self-hosted or GitLab.com account.
+To enable collection of job logs the [feature flag][7] `datadog_integration_logs_collection` must be enabled in your GitLab self-hosted or GitLab.com account.
 After enabling it a new option appears in the settings of the integration: `Enable logs collection`. Check this option and save the settings.
 
-Job logs are now available in [Logs][7] and connected to the GitLab pipelines within CI Visibility.
+Job logs are now available in [Logs][8] and connected to the GitLab pipelines within CI Visibility.
 
 <div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. </br>
 Retention filters might be needed to ensure the job logs are not sampled out.</div>
@@ -163,6 +163,6 @@ Retention filters might be needed to ensure the job logs are not sampled out.</d
 [3]: https://docs.gitlab.com/ee/user/project/integrations/webhooks.html
 [4]: https://app.datadoghq.com/ci/pipelines
 [5]: https://app.datadoghq.com/ci/pipeline-executions
-[6]: https://docs.gitlab.com/ee/administration/feature_flags.html
-[7]: /logs/
-
+[6]: https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage
+[7]: https://docs.gitlab.com/ee/administration/feature_flags.html
+[8]: /logs/

--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -139,6 +139,21 @@ After the integration is successfully configured, the [Pipelines][4] and [Pipeli
 
 **Note**: The Pipelines page shows data for only the default branch of each repository.
 
+
+## Enable job log collection (beta)
+
+Supported GitLab versions for job logs:
+* GitLab.com (SaaS)
+* GitLab >= 14.8 (self-hosted)
+
+To enable collection of job logs the [feature flag][6] `datadog_integration_logs_collection` must be enabled in your GitLab self-hosted or GitLab.com account.
+After enabling it a new option appears in the settings of the integration: `Enable logs collection`. Check this option and save the settings.
+
+Job logs are now available in [Logs][7] and connected to the GitLab pipelines within CI Visibility.
+
+<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. </br>
+Retention filters might be needed to ensure the job logs are not sampled out.</div>
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -148,3 +163,6 @@ After the integration is successfully configured, the [Pipelines][4] and [Pipeli
 [3]: https://docs.gitlab.com/ee/user/project/integrations/webhooks.html
 [4]: https://app.datadoghq.com/ci/pipelines
 [5]: https://app.datadoghq.com/ci/pipeline-executions
+[6]: https://docs.gitlab.com/ee/administration/feature_flags.html
+[7]: /logs/
+

--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -142,17 +142,16 @@ After the integration is successfully configured, the [Pipelines][4] and [Pipeli
 
 ## Enable job log collection (beta)
 
-Supported GitLab versions for job logs, only when using [object storage for job logs][6]:
+Supported GitLab versions to collect job logs:
 * GitLab.com (SaaS)
-* GitLab >= 14.8 (self-hosted)
+* GitLab >= 14.8 (self-hosted) only if using [object storage to store job logs][6]
 
 To enable collection of job logs the [feature flag][7] `datadog_integration_logs_collection` must be enabled in your GitLab self-hosted or GitLab.com account.
-After enabling it a new option appears in the settings of the integration: `Enable logs collection`. Check this option and save the settings.
+After enabling the feature flag, a new option appears in the settings of the Datadog integration: `Enable logs collection`. Enable this option and save the changes.
 
-Job logs are now available in [Logs][8] and connected to the GitLab pipelines within CI Visibility.
+Job logs will be collected in the [Logs][8] product and automatically correlated with the GitLab pipeline within CI Visibility.
 
-<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. </br>
-Retention filters might be needed to ensure the job logs are not sampled out.</div>
+<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility</div>
 
 ## Further reading
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Document how to enable collection of job logs in GitLab through the integration with CI Visibility.

This was added in https://gitlab.com/gitlab-org/gitlab/-/merge_requests/74725 GitLab milestone 14.8.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/adrian.lopezcalvo%2Fci-visibility-gitlab-logs




### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
