### PR TITLE
Point CI image to default branch to include new helper function

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ cache: &cache
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:nsollecito_docs-algolia
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/corp-ci:master
   tags:
     - "runner:main"
   except:


### PR DESCRIPTION
### What does this PR do?
In preparation for more translation updates, this change updates the Gitlab config so that it points to the `master` branch of `corp-ci`, where a new helper function has been added.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-1247

### Preview
No frontend is impacted.

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
