### PR TITLE
Update dogstatsd_metrics_submission.md code examples

### DIFF
--- a/content/en/metrics/dogstatsd_metrics_submission.md
+++ b/content/en/metrics/dogstatsd_metrics_submission.md
@@ -380,7 +380,7 @@ Emit a `SET` metric-stored as a `GAUGE` metric-to Datadog.
 
 Run the following code to submit a DogStatsD `SET` metric to Datadog. Remember to `flush`/`close` the client when it is no longer needed.
 
-{{< programming-lang-wrapper langs="python,ruby,go,.NET,PHP" >}}
+{{< programming-lang-wrapper langs="python,ruby,go,java,.NET,PHP" >}}
 
 {{< programming-lang lang="python" >}}
 ```python


### PR DESCRIPTION
java missing from CODE EXAMPLES - "Emit a SET metric-stored as a GAUGE metric-to Datadog."

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Added Java to programming lang wrapper - set metric-stored as a gauge
### Motivation
<!-- What inspired you to submit this pull request?-->
Missing from documentation options
### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
