### PR TITLE
Update PHP AppSec documentation

### DIFF
--- a/content/en/security_platform/application_security/getting_started/php.md
+++ b/content/en/security_platform/application_security/getting_started/php.md
@@ -27,8 +27,8 @@ You can monitor application security for PHP apps running in Docker, Kubernetes,
 
 1. **Install the latest Datadog PHP library** by downloading and running the installer:
    ```
-   wget https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php
-   php dd-library-php-setup.php --php-bin all --tracer-version latest --appsec-version latest
+   wget https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php -O datadog-setup.php
+   php datadog-setup.php --php-bin all --enable-appsec
    ```
    For information about which language and framework versions are supported by the library, see [Compatibility][1].
 

--- a/content/en/security_platform/application_security/troubleshooting.md
+++ b/content/en/security_platform/application_security/troubleshooting.md
@@ -279,25 +279,25 @@ The log files are available in the following directories:
 
 For PHP, to start troubleshooting issues with the Datadog Application Security extension, enable debug logs in the Application Security extension’s `.ini` file.
 
-The extension's `ini` file is usually found in `/etc/php/<version>/xxx/conf.d/98-ddappsec.ini`, but the location may differ depending on your installation. Look at the beginning of the `phpinfo()` output to identify the directory that is scanned for `.ini` files, if any. In the `.ini` file, set the following configuration options with the following: 
+The extension's `ini` file is usually found in `/etc/php/<version>/xxx/conf.d/98-ddtrace.ini`, but the location may differ depending on your installation. Look at the beginning of the `phpinfo()` output to identify the directory that is scanned for `.ini` files, if any. In the `.ini` file, set the following configuration options with the following: 
 
 ```php
-ddappsec.log_level=‘debug’
-ddappsec.helper_extra_args=‘--log_level=debug’
-ddappsec.helper_log_file=‘/tmp/helper.log’
+datadog.appsec.log_level=‘debug’
+datadog.appsec.helper_extra_args=‘--log_level=debug’
+datadog.appsec.helper_log_file=‘/tmp/helper.log’
 ```
 
 The extension outputs logs to the default `php_error` log file. If there are no logs in the file, add the following to the `.ini` file:
 
 ```php
-ddappsec.log_file=’tmp/extension.log’
+datadog.appsec.log_file=’tmp/extension.log’
 ```
 
 ### Installation fails to find PHP
 If the installation script is unable to find the correct PHP version, you can set the `--php-bin` to the PHP binary location, for example:
 
 ```
-$ php dd-library-php-setup.php --php-bin /usr/bin/php7.4 --tracer-version=latest --appsec-version=latest
+$ php datadog-setup.php --php-bin /usr/bin/php7.4 --enable-appsec
 ```
 ### Connection to helper failed
 If the Application Security extension is unable to communicate with the helper process, the following warning occurs:
@@ -325,8 +325,7 @@ If the lock file or socket file has invalid permissions, you can either delete t
 If the user doesn’t have write access to the tmp directory, you can change the location of the lock file and socket file by modifying the following settings in the extension’s `.ini` file:
 
 ```
-ddappsec.helper_socket_path = /<directory with compatible permissions>/ddappsec.sock
-ddappsec.helper_lock_path = /<directory with compatible permissions>/ddappsec.lock
+datadog.appsec.helper_runtime_path = /<directory with compatible permissions>/
 ```
 
 {{< /programming-lang >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR updates the PHP appsec troubleshooting and installation instructions, which are currently out of date.

### Motivation
<!-- What inspired you to submit this pull request?-->
Keep the instructions up to date.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/anilm3/php-docs-update/security_platform/application_security/getting_started/php/?tab=dockercli
https://docs-staging.datadoghq.com/anilm3/php-docs-update/security_platform/application_security/troubleshooting
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
