### PR TITLE
Fix typo in the Specify log file encodings link

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -26,7 +26,7 @@ Customize your log collection configuration:
 * [Aggregate multi-line logs](#multi-line-aggregation)
 * [Copy commonly used examples](#commonly-used-log-processing-rules)
 * [Use wildcards to monitor directories](#tail-directories-by-using-wildcards)
-* [Specify log file encodings](#logfile-encodings)
+* [Specify log file encodings](#log-file-encodings)
 * [Define global processing rules](#global-processing-rules)
 
 **Note**: If you set up multiple processing rules, they are applied sequentially and each rule is applied on the result of the previous one.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The link for "Specify log file encodings" was not working as expected at the top of the Advanced Log collection page. It was not working as there was a typo. It was previously defined as logfile-encodings. It has now been changed to log-file-encodings.

### Motivation
The link was not working as expected. Navigation to the log encodings section  was difficult.

### Preview
https://docs-staging.datadoghq.com/stephen-kinsella-patch-1-2/DataDog/documentation/content/en/agent/logs/advanced_log_collection.md/

### Additional Notes
n/a

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
