### PR TITLE
[DOCS-3408] Clarify where DD_RUM.addAction comes from

### DIFF
--- a/content/en/real_user_monitoring/guide/send-rum-custom-actions.md
+++ b/content/en/real_user_monitoring/guide/send-rum-custom-actions.md
@@ -4,16 +4,24 @@ kind: guide
 further_reading:
 - link: '/real_user_monitoring/explorer'
   tag: 'Documentation'
-  text: 'Visualize your RUM data in the Explorer'
+  text: 'Visualize your RUM data in the RUM Explorer'
 aliases:
   - /real_user_monitoring/guide/send-custom-user-actions/
 ---
 ## Overview
 
-Real User Monitoring [automatically collects actions][1] on your web application. You may also want to collect additional events and timings such as form completions and business transactions. With custom RUM actions, monitor any interesting event with all the relevant context attached. As an example throughout this guide, user checkouts information from an e-commerce website is collected.
+Real User Monitoring [automatically collects actions][1] on your web application. You can collect additional events and timings such as form completions and business transactions. 
+
+Custom RUM actions allow you to monitor interesting events with all the relevant context attached. For example, collecting a user's checkout information on an e-commerce website.
 
 ## Instrument your code
-To create a new RUM action, use the `addAction` API. Give your action a name and then attach context attributes in the form of a JavaScript object. In the following example, a `checkout` action is created with details about the user cart when the user clicks on the checkout button.
+
+Create a RUM action using the `addAction` API. Give your action a name and attach context attributes in the form of a JavaScript object. 
+
+The following example creates a `checkout` action with details about the user cart when the user clicks on the checkout button.
+
+{{< tabs >}}
+{{% tab "NPM" %}}
 
 ```javascript
 import { datadogRum } from '@datadog/browser-rum';
@@ -21,30 +29,65 @@ import { datadogRum } from '@datadog/browser-rum';
 function onCheckoutButtonClick(cart) {
     datadogRum.addAction('checkout', {
         'value': cart.value, // for example, 42.12
-        'items': cart.items, // efor example, ['tomato', 'strawberries']
+        'items': cart.items, // for example, ['tomato', 'strawberries']
     })
 }
 ```
 
-All RUM context is automatically attached (such as current page view information, geoIP data, or browser information) along with extra attributes provided with the [Global Context API][2].
+{{% /tab %}}
+{{% tab "CDN async" %}}
+```javascript
+DD_RUM.onReady(function() {
+    DD_RUM.addAction('<NAME>', '<JSON_OBJECT>');
+})
 
-## Create facets and measures on your new attributes
-After you have deployed the code that creates your custom actions, actions appear in the [RUM Explorer][3], in the **Actions** tab.
+function onCheckoutButtonClick(cart) {
+    DD_RUM.addAction('checkout', {
+        'value': cart.value, // for example, 42.12
+        'items': cart.items, // for example, ['tomato', 'strawberries']
+    })
+}
+```
+{{% /tab %}}
+{{% tab "CDN sync" %}}
 
-To filter on your new custom Actions, use the `Action Target Name` attribute as follow: `@action.target.name:<ACTION_NAME>`. The example uses the following filter: `@action.target.name:checkout`
+```javascript
+window.DD_RUM && DD_RUM.addAction('<NAME>', '<JSON_OBJECT>');
 
-Once you click on the action, all metadata is available in the side panel. You can find your action attributes in the Custom Attributes sections. The next step is to create facets or measures for these attributes by clicking on them. For example, create a facet for the cart items and a measure for the cart value.
+function onCheckoutButtonClick(cart) {
+    DD_RUM.addAction('checkout', {
+        'value': cart.value, // for example, 42.12
+        'items': cart.items, // for example, ['tomato', 'strawberries']
+    })
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+All RUM context such as current page view information, geoIP data, and browser information, is automatically attached along with extra attributes provided with the [Global Context API][2].
+
+## Create facets and measures on attributes
+
+After deploying the code that creates your custom actions, they appear in the **Actions** tab of the [RUM Explorer][3].
+
+To filter on your custom actions, use the `Action Target Name` attribute: `@action.target.name:<ACTION_NAME>`. 
+
+The example below uses the following filter: `@action.target.name:checkout`.
 
 {{< img src="real_user_monitoring/guide/send-custom-user-actions/facet-from-user-action.mp4" alt="Create a facet for custom RUM actions" video=true style="width:100%;">}}
 
-**Note**: Use facets for distinctive values (IDs) and measures for quantitative values (timings, latency, etc.).
+After clicking on an action, a side panel with metadata appears. You can find your action attributes in the **Custom Attributes** section and create facets or measures for these attributes by clicking on them. 
 
-## Use your attributes in the explorer, dashboards, and monitors
-Now that facets and measures have been created, you can use your action attributes in RUM queries. This means you can build dashboards widgets, monitors and advanced queries in [RUM Explorer/Analytics][3].
+Use facets for distinctive values (IDs) and measures for quantitative values such as timings and latency. For example, create a facet for the cart items and a measure for the cart value.
 
-As an example, the following screenshot shows the average cart value per country for the last day. Using the dropdown menu on the top right corner, you can export this query as a dashboard widget or as a monitor.
+## Use attributes in the RUM Explorer
 
-{{< img src="real_user_monitoring/guide/send-custom-user-actions/custom-action-analytics.png" alt="Use RUM actions in Analytics" style="width:100%;">}}
+You can use action attributes along with facets and measures in the [RUM Explorer][3] to build dashboard widgets, monitors, and advanced queries.
+
+The following example displays the average cart value per country in the last two days. Click the **Export** button to export the search query into a dashboard widget or monitor.
+
+{{< img src="real_user_monitoring/guide/send-custom-user-actions/custom-action-analytics.png" alt="Use RUM actions in the RUM Explorer" style="width:100%;">}}
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/guide/send-rum-custom-actions.md
+++ b/content/en/real_user_monitoring/guide/send-rum-custom-actions.md
@@ -36,26 +36,30 @@ function onCheckoutButtonClick(cart) {
 
 {{% /tab %}}
 {{% tab "CDN async" %}}
-```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.addAction('<NAME>', '<JSON_OBJECT>');
-})
 
+Ensure that you wrap the API call with the `onReady` callback:
+
+```javascript
 function onCheckoutButtonClick(cart) {
-    DD_RUM.addAction('checkout', {
-        'value': cart.value, // for example, 42.12
-        'items': cart.items, // for example, ['tomato', 'strawberries']
-    })
+    DD_RUM.onReady(function() {
+        DD_RUM.addAction('checkout', {
+            'value': cart.value, // for example, 42.12
+            'items': cart.items, // for example, ['tomato', 'strawberries']
+        })
+    })    
 }
 ```
+
 {{% /tab %}}
 {{% tab "CDN sync" %}}
+
+Ensure that you check for `DD_RUM` before the API call:
 
 ```javascript
 window.DD_RUM && DD_RUM.addAction('<NAME>', '<JSON_OBJECT>');
 
 function onCheckoutButtonClick(cart) {
-    DD_RUM.addAction('checkout', {
+    window.DD_RUM && DD_RUM.addAction('checkout', {
         'value': cart.value, // for example, 42.12
         'items': cart.items, // for example, ['tomato', 'strawberries']
     })

--- a/content/en/real_user_monitoring/guide/send-rum-custom-actions.md
+++ b/content/en/real_user_monitoring/guide/send-rum-custom-actions.md
@@ -16,8 +16,10 @@ Real User Monitoring [automatically collects actions][1] on your web application
 To create a new RUM action, use the `addAction` API. Give your action a name and then attach context attributes in the form of a JavaScript object. In the following example, a `checkout` action is created with details about the user cart when the user clicks on the checkout button.
 
 ```javascript
+import { datadogRum } from '@datadog/browser-rum';
+
 function onCheckoutButtonClick(cart) {
-    DD_RUM.addAction('checkout', {
+    datadogRum.addAction('checkout', {
         'value': cart.value, // for example, 42.12
         'items': cart.items, // efor example, ['tomato', 'strawberries']
     })


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR shows an explicit import in a code snippet that was previously missing.

### Motivation
From an initial read through of the docs it wasn't clear what `DD_RUM` was or where it came from.  Poking around in the TS types it seems this was actually `datadogRum` from '@datadog/browser-rum'
<!-- What inspired you to submit this pull request?-->

### Preview
I'm on a team using DD so I don't believe I have access to this.
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->

### Additional Notes
N/A
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
