### PR TITLE
DOCS-2890 Synthetics API, Multistep, and Browser Tests Edit

### DIFF
--- a/content/en/synthetics/api_tests/dns_tests.md
+++ b/content/en/synthetics/api_tests/dns_tests.md
@@ -57,6 +57,10 @@ You can create up to 20 assertions per API test by clicking **New Assertion** or
 
 {{< img src="synthetics/api_tests/assertions.png" alt="Define assertions for your DNS test" style="width:90%;" >}}
 
+If a test does not contain an assertion on the response body, the body payload drops and returns an associated response time for the request within the timeout limit set by the Synthetics Worker.
+
+If a test contains an assertion on the response body and the timeout limit is reached, an `Assertions on the body/response cannot be run beyond this limit` error appears.
+
 ### Select locations
 
 Select the **Locations** to run your DNS test from: DNS tests can run from [managed][1] and [private locations][2] depending on whether you are willing to monitor a public or a private domain.

--- a/content/en/synthetics/api_tests/grpc_tests.md
+++ b/content/en/synthetics/api_tests/grpc_tests.md
@@ -61,6 +61,10 @@ You can create up to 20 assertions per API test by clicking **New Assertion** or
 
 {{< img src="synthetics/api_tests/assertions_grpc.png" alt="Define assertions for your gRPC test" style="width:90%;" >}}
 
+If a test does not contain an assertion on the response body, the body payload drops and returns an associated response time for the request within the timeout limit set by the Synthetics Worker.
+
+If a test contains an assertion on the response body and the timeout limit is reached, an `Assertions on the body/response cannot be run beyond this limit` error appears.
+
 ### Select locations
 
 Select the **Locations** to run your gRPC health check test from. gRPC health check tests can run from both [managed][2] and [private locations][3] depending on your preference for running the health check test from outside or inside your network.

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -128,6 +128,10 @@ You can create up to 20 assertions per API test by clicking **New Assertion** or
 
 {{< img src="synthetics/api_tests/assertions.png" alt="Define assertions for your HTTP test" style="width:90%;" >}}
 
+If a test does not contain an assertion on the response body, the body payload drops and returns an associated response time for the request within the timeout limit set by the Synthetics Worker.
+
+If a test contains an assertion on the response body and the timeout limit is reached, an `Assertions on the body/response cannot be run beyond this limit` error appears.
+
 ### Select locations
 
 Select the **Locations** to run your HTTP test from. HTTP tests can run from both [managed][1] and [private locations][2] depending on your preference for running the test from outside or inside your network.

--- a/content/en/synthetics/api_tests/icmp_tests.md
+++ b/content/en/synthetics/api_tests/icmp_tests.md
@@ -54,6 +54,10 @@ You can create up to 20 assertions per API test by selecting **New Assertion** o
 
 {{< img src="synthetics/api_tests/icmp_assertion.png" alt="Define assertions for your ICMP test" style="width:90%;" >}}
 
+If a test does not contain an assertion on the response body, the body payload drops and returns an associated response time for the request within the timeout limit set by the Synthetics Worker.
+
+If a test contains an assertion on the response body and the timeout limit is reached, an `Assertions on the body/response cannot be run beyond this limit` error appears.
+
 ### Select locations
 
 Select the **Locations** to run your ICMP test from. ICMP tests can run from both [managed][1] and [private locations][2] depending on whether you want to trigger the ICMP pings from outside or inside your network.

--- a/content/en/synthetics/api_tests/ssl_tests.md
+++ b/content/en/synthetics/api_tests/ssl_tests.md
@@ -66,6 +66,10 @@ You can create up to 20 assertions per API test by clicking **New Assertion** or
 
 {{< img src="synthetics/api_tests/assertions.png" alt="Define assertions for your SSL test" style="width:90%;" >}}
 
+If a test does not contain an assertion on the response body, the body payload drops and returns an associated response time for the request within the timeout limit set by the Synthetics Worker.
+
+If a test contains an assertion on the response body and the timeout limit is reached, an `Assertions on the body/response cannot be run beyond this limit` error appears.
+
 ### Select locations
 
 Select the **Locations** to run your SSL test from. SSL tests can run from both [managed][1] and [private locations][2] depending on whether you want to monitor certificates from outside or inside your network.

--- a/content/en/synthetics/api_tests/tcp_tests.md
+++ b/content/en/synthetics/api_tests/tcp_tests.md
@@ -51,6 +51,10 @@ You can create up to 20 assertions per API test by clicking **New Assertion** or
 
 {{< img src="synthetics/api_tests/assertions.png" alt="Define assertions for your TCP test" style="width:90%;" >}}
 
+If a test does not contain an assertion on the response body, the body payload drops and returns an associated response time for the request within the timeout limit set by the Synthetics Worker.
+
+If a test contains an assertion on the response body and the timeout limit is reached, an `Assertions on the body/response cannot be run beyond this limit` error appears.
+
 ### Select locations
 
 Select the **Locations** to run your TCP test from: TCP tests can run from both [managed][1] and [private locations][2] depending on whether you want to launch the connection from outside or inside your network.

--- a/content/en/synthetics/api_tests/udp_tests.md
+++ b/content/en/synthetics/api_tests/udp_tests.md
@@ -52,6 +52,10 @@ Select the response preview directly or click **New Assertion** to create an ass
 
 {{< img src="synthetics/api_tests/udp_assertions.png" alt="Define assertions for your UDP test" style="width:90%;" >}}
 
+If a test does not contain an assertion on the response body, the body payload drops and returns an associated response time for the request within the timeout limit set by the Synthetics Worker.
+
+If a test contains an assertion on the response body and the timeout limit is reached, an `Assertions on the body/response cannot be run beyond this limit` error appears.
+
 ### Select locations
 
 Select the **Locations** to run your UDP test from. UDP tests can run from both [managed][1] and [private locations][2] depending on your preference for running the test from outside or inside your network.

--- a/content/en/synthetics/api_tests/websocket_tests.md
+++ b/content/en/synthetics/api_tests/websocket_tests.md
@@ -70,6 +70,10 @@ Select the response preview directly or click **New Assertion** to create an ass
 
 {{< img src="synthetics/api_tests/websocket_assertions.png" alt="Define assertions for your WebSocket test" style="width:90%;" >}}
 
+If a test does not contain an assertion on the response body, the body payload drops and returns an associated response time for the request within the timeout limit set by the Synthetics Worker.
+
+If a test contains an assertion on the response body and the timeout limit is reached, an `Assertions on the body/response cannot be run beyond this limit` error appears.
+
 ### Select locations
 
 Select the **Locations** to run your WebSocket test from. WebSocket tests can run from both [managed][1] and [private locations][2] depending on your preference for running the test from outside or inside your network.

--- a/content/en/synthetics/browser_tests/actions.md
+++ b/content/en/synthetics/browser_tests/actions.md
@@ -136,6 +136,10 @@ Perform verifications on files downloaded in previous steps. You can check that 
 
 **Note**: You can find out more on how to test downloads on [this dedicated guide][6].
 
+If a test does not contain an assertion on the response body, the body payload drops and returns an associated response time for the request within the timeout limit set by the Synthetics Worker.
+
+If a test contains an assertion on the response body and the timeout limit is reached, an `Assertions on the body/response cannot be run beyond this limit` error appears.
+
 ### Navigation
 
 {{< img src="synthetics/browser_tests/navigation_step.png" alt="Browser Test Navigation Step" style="width:60%;">}}

--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -137,6 +137,10 @@ You can create up to 20 assertions per step by clicking **New Assertion** or by 
 
 {{< img src="synthetics/api_tests/assertions2.png" alt="Define assertions for your Multistep API test" style="width:90%;" >}}
 
+If a test does not contain an assertion on the response body, the body payload drops and returns an associated response time for the request within the timeout limit set by the Synthetics Worker.
+
+If a test contains an assertion on the response body and the timeout limit is reached, an `Assertions on the body/response cannot be run beyond this limit` error appears.
+
 #### Add execution parameters
 
 Click **Continue with test if this step fails** to allow your test to move on with subsequent steps after step failure. 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds information describing test behavior when there is/is not a response body assertion.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-2890

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/alai97/synthetics-general-tests-assertions-response-size-note/synthetics/browser_tests/actions/#assertion/

https://docs-staging.datadoghq.com/alai97/synthetics-general-tests-assertions-response-size-note/synthetics/multistep/?tab=requestoptions#add-assertions/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
