### PR TITLE
Update to make the app registration more obvious

### DIFF
--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -57,7 +57,7 @@ If not already configured, set up the [AWS integration][1] for the AWS account t
 
 Set up the [Azure integration][1] within the subscription that holds your new storage account, if you haven't already. This involves [creating an app registration that Datadog can use][2] to integrate with.
 
-**NOTE:** Archiving logs to Azure Blob Storage still requires an App Registration. See instructions [here][3] and set the "site" on the right-hand side of the page to "US." App Registration(s) created for archiving purposes only need the "Storage Blob Data Contributor" role. Note that if your storage bucket is in a subscription being monitored via a Datadog Resource, you will see a warning about the App Registration being redundant. You can ignore this warning.
+**NOTE:** Archiving logs to Azure Blob Storage requires an App Registration. See instructions [on the Azure integration page][3], and set the "site" on the right-hand side of the documentation page to "US." App Registration(s) created for archiving purposes only need the "Storage Blob Data Contributor" role. If your storage bucket is in a subscription being monitored through a Datadog Resource, a warning is displayed about the App Registration being redundant. You can ignore this warning.
 
 [1]: https://app.datadoghq.com/account/settings#integrations/azure
 [2]: /integrations/azure/?tab=azurecliv20#integrating-through-the-azure-portal

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -57,8 +57,11 @@ If not already configured, set up the [AWS integration][1] for the AWS account t
 
 Set up the [Azure integration][1] within the subscription that holds your new storage account, if you haven't already. This involves [creating an app registration that Datadog can use][2] to integrate with.
 
+**NOTE:** Archiving logs to Azure Blob Storage still requires an App Registration. See instructions [here][3] and set the "site" on the right-hand side of the page to "US." App Registration(s) created for archiving purposes only need the "Storage Blob Data Contributor" role. Note that if your storage bucket is in a subscription being monitored via a Datadog Resource, you will see a warning about the App Registration being redundant. You can ignore this warning.
+
 [1]: https://app.datadoghq.com/account/settings#integrations/azure
 [2]: /integrations/azure/?tab=azurecliv20#integrating-through-the-azure-portal
+[3]: /integrations/azure/?tab=azurecliv20
 {{% /tab %}}
 
 {{% tab "Google Cloud Storage" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Makes the fact that an App Registration is still required for an Azure Blob Archive (EVEN IN US3) more obvious.

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer complained about setting this up - it was not obvious for them and required a support ticket.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
