### PR TITLE
[kubernetes_state_core] Remove duplicate entries

### DIFF
--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -296,12 +296,6 @@ datadog:
 `kubernetes_state.container.status_report.count.terminated`
 : Describes the reason the container is in a terminated state. Tags:`kube_namespace` `pod_name` `kube_container_name` `reason` (`env` `service` `version` from standard labels).
 
-`kubernetes_state.container.status_report.count.waiting`
-: Describes the reason the container is in a waiting state. Tags:`kube_namespace` `pod_name` `kube_container_name` `reason` (`env` `service` `version` from standard labels).
-
-`kubernetes_state.container.status_report.count.terminated`
-: Describes the reason the container is in a terminated state. Tags:`kube_namespace` `pod_name` `kube_container_name` `reason` (`env` `service` `version` from standard labels).
-
 `kubernetes_state.pod.ready`
 : Describes whether the pod is ready to serve requests. Tags:`kube_namespace` `pod_name` `condition` (`env` `service` `version` from standard labels).
 

--- a/content/fr/integrations/kubernetes_state_core.md
+++ b/content/fr/integrations/kubernetes_state_core.md
@@ -233,12 +233,6 @@ datadog:
 `kubernetes_state.container.status_report.count.terminated`
 : Décrit la raison pour laquelle le conteneur est actuellement à l'état terminé. Tags : `kube_namespace` `pod_name` `kube_container_name` `reason` (`env` `service` `version` à partir des étiquettes standard).
 
-`kubernetes_state.container.status_report.count.waiting`
-: Décrit la raison pour laquelle le conteneur est actuellement en attente. Tags : `kube_namespace` `pod_name` `kube_container_name` `reason` (`env` `service` `version` à partir des étiquettes standard).
-
-`kubernetes_state.container.status_report.count.terminated`
-: Décrit la raison pour laquelle le conteneur est actuellement à l'état terminé. Tags : `kube_namespace` `pod_name` `kube_container_name` `reason` (`env` `service` `version` à partir des étiquettes standard).
-
 `kubernetes_state.pod.ready`
 : Indique si le pod est prêt à servir les requêtes. Tags : `kube_namespace` `pod_name` `condition` (`env` `service` `version` à partir des étiquettes standard).
 

--- a/content/ja/integrations/kubernetes_state_core.md
+++ b/content/ja/integrations/kubernetes_state_core.md
@@ -239,12 +239,6 @@ datadog:
 `kubernetes_state.container.status_report.count.terminated`
 : コンテナが現在終了状態にある理由を説明します。タグ: `kube_namespace` `pod_name` `kube_container_name` `reason` (標準ラベルの `env` `service` `version`)。
 
-`kubernetes_state.container.status_report.count.waiting`
-: コンテナが現在待機状態にある理由を説明します。タグ: `kube_namespace` `pod_name` `kube_container_name` `reason` (標準ラベルの `env` `service` `version`)。
-
-`kubernetes_state.container.status_report.count.terminated`
-: コンテナが現在終了状態にある理由を説明します。タグ: `kube_namespace` `pod_name` `kube_container_name` `reason` (標準ラベルの `env` `service` `version`)。
-
 `kubernetes_state.pod.ready`
 : ポッドがリクエストを処理する準備ができているかどうかを説明します。 タグ: `kube_namespace` `pod_name` `condition` (標準ラベルの `env` `service` `version`)。
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
In `content/<lang>/integrations/kubernetes_state_core.md`, remove duplicate entries for :

- `kubernetes_state.container.status_report.count.waiting`
- `kubernetes_state.container.status_report.count.terminated`

### Motivation
Will I read this documentation page, I see the duplicate entries and propose this PR to remove them.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fix-duplicate/en/integrations/kubernetes_state_core
https://docs-staging.datadoghq.com/fix-duplicate/fr/integrations/kubernetes_state_core
https://docs-staging.datadoghq.com/fix-duplicate/ja/integrations/kubernetes_state_core

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
