### PR TITLE
[APM][.NET] Add B3 documentation

### DIFF
--- a/content/en/tracing/setup_overview/custom_instrumentation/dotnet.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/dotnet.md
@@ -119,9 +119,30 @@ using (var parentScope =
     }
 }
 ```
+
+### Headers extraction and injection
+
+Datadog APM tracer supports [B3][5] and [W3C][6] headers extraction and injection for distributed tracing.
+
+Distributed headers injection and extraction is controlled by configuring injection/extraction styles. Currently two styles are supported:
+
+- Datadog: `Datadog`
+- B3: `B3`
+- W3C: `TraceParent`
+- B3 Single Header: `B3SingleHeader` or `B3 single header`
+
+Injection and extraction styles can be configured using:
+
+- Environment Variable: `DD_PROPAGATION_STYLE_INJECT=Datadog, B3, W3C`
+- Environment Variable: `DD_PROPAGATION_STYLE_EXTRACT=Datadog, B3, W3C`
+
+The values of these environment variables are comma separated lists of header styles that are enabled for injection or extraction. By default only `Datadog` injection style is enabled.
+
+If multiple extraction styles are enabled extraction attempt is done on the order those styles are configured and first successful extracted value is used.
+
 ## Resource filtering
 
-Traces can be excluded based on their resource name, to remove synthetic traffic such as health checks from reporting traces to Datadog.  This and other security and fine-tuning configurations can be found on the [Security][5] page.
+Traces can be excluded based on their resource name, to remove synthetic traffic such as health checks from reporting traces to Datadog.  This and other security and fine-tuning configurations can be found on the [Security][7] page.
 
 ## Further Reading
 
@@ -132,4 +153,6 @@ Traces can be excluded based on their resource name, to remove synthetic traffic
 [2]: /tracing/visualization/#span-tags
 [3]: /tracing/visualization/#spans
 [4]: /tracing/visualization/trace/?tab=spantags#more-information
-[5]: /tracing/security
+[5]: https://github.com/openzipkin/b3-propagation
+[6]: https://www.w3.org/TR/trace-context/#traceparent-header
+[7]: /tracing/security

--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -485,6 +485,25 @@ The following configuration variables are for features that are available for us
 : Enables improved resource names for web spans when set to `true`. Uses route template information where available, adds an additional span for ASP.NET Core integrations, and enables additional tags. Added in version 1.26.0. Enabled by default in 2.0.0<br>
 **Default**: `true`
 
+### Headers extraction and injection
+
+Datadog APM tracer supports [B3][9] and [W3C][10] headers extraction and injection for distributed tracing.
+
+Distributed headers injection and extraction is controlled by configuring injection/extraction styles. Currently two styles are supported:
+
+- Datadog: `Datadog`
+- B3: `B3`
+- W3C: `TraceParent`
+- B3 Single Header: `B3SingleHeader` or `B3 single header`
+
+Injection and extraction styles can be configured using:
+
+- Environment Variable: `DD_PROPAGATION_STYLE_INJECT=Datadog, B3, W3C`
+- Environment Variable: `DD_PROPAGATION_STYLE_EXTRACT=Datadog, B3, W3C`
+
+The values of these environment variables are comma separated lists of header styles that are enabled for injection or extraction. By default only `Datadog` injection style is enabled.
+
+If multiple extraction styles are enabled extraction attempt is done on the order those styles are configured and first successful extracted value is used.
 
 ## Custom instrumentation
 
@@ -666,3 +685,5 @@ When using `systemctl` to run .NET applications as a service, you can also set e
 [6]: /tracing/setup_overview/compatibility_requirements/dotnet-core#integrations
 [7]: /tracing/setup_overview/custom_instrumentation/dotnet/
 [8]: https://www.freedesktop.org/software/systemd/man/systemctl.html#set-environment%20VARIABLE=VALUE%E2%80%A6
+[9]: https://github.com/openzipkin/b3-propagation
+[10]: https://www.w3.org/TR/trace-context/#traceparent-header

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -453,6 +453,26 @@ The following configuration variables are for features that are available for us
 : Enables improved resource names for web spans when set to `true`. Uses route template information where available, adds an additional span for ASP.NET Core integrations, and enables additional tags. Added in version 1.26.0. Enabled by default in 2.0.0<br>
 **Default**: `true`
 
+### Headers extraction and injection
+
+Datadog APM tracer supports [B3][8] and [W3C][9] headers extraction and injection for distributed tracing.
+
+Distributed headers injection and extraction is controlled by configuring injection/extraction styles. Currently two styles are supported:
+
+- Datadog: `Datadog`
+- B3: `B3`
+- W3C: `TraceParent`
+- B3 Single Header: `B3SingleHeader` or `B3 single header`
+
+Injection and extraction styles can be configured using:
+
+- Environment Variable: `DD_PROPAGATION_STYLE_INJECT=Datadog, B3, W3C`
+- Environment Variable: `DD_PROPAGATION_STYLE_EXTRACT=Datadog, B3, W3C`
+
+The values of these environment variables are comma separated lists of header styles that are enabled for injection or extraction. By default only `Datadog` injection style is enabled.
+
+If multiple extraction styles are enabled extraction attempt is done on the order those styles are configured and first successful extracted value is used.
+
 ## Custom instrumentation
 
 Your setup for custom instrumentation depends on your automatic instrumentation and includes additional steps depending on the method:
@@ -544,3 +564,5 @@ dotnet.exe example.dll
 [5]: /tracing/faq/why-cant-i-see-my-correlated-logs-in-the-trace-id-panel#trace_id-option
 [6]: /tracing/setup_overview/compatibility_requirements/dotnet-framework/#integrations
 [7]: /tracing/setup_overview/custom_instrumentation/dotnet/
+[8]: https://github.com/openzipkin/b3-propagation
+[9]: https://www.w3.org/TR/trace-context/#traceparent-header


### PR DESCRIPTION
### What does this PR do?
This PR adds documentation for B3 headers injection for APM, in .NET.

### Motivation
It has been added recently

### Preview
https://docs-staging.datadoghq.com/pierre/add-b3/tracing/setup_overview/custom_instrumentation/dotnet

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
