### PR TITLE
added initctl comment. some Linux 6 systems use initctl instead of systemctl

### DIFF
--- a/content/en/agent/basic_agent_usage/redhat.md
+++ b/content/en/agent/basic_agent_usage/redhat.md
@@ -75,6 +75,7 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 
 * On `upstart`-based systems: `sudo start/stop/restart/status datadog-agent`
 * On `systemd`-based systems: `sudo systemctl start/stop/restart/status datadog-agent`
+* On `initctl`-based systems: `sudo initctl start/stop/restart/status datadog-agent`
 
 [Learn more about Service lifecycle commands][2]
 


### PR DESCRIPTION
On `initctl`-based systems: `sudo initctl start/stop/restart/status datadog-agent`

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
I worked with a customer where the command needed to be: sudo initctl start datadog-agent
in order for the trace agent and the process agent to also start properly on Red Hat Linux 6 ( 6.10 specifically )

So adding the comment:
sudo initctl start/stop/restart/status datadog-agent


### Motivation
<!-- What inspired you to submit this pull request?-->
Took a while during a PoV to solve this problem

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
