### PR TITLE
fixed end of tabs so that comments about systemctl initctl show all the time (for all languages)

### DIFF
--- a/content/en/agent/basic_agent_usage/redhat.md
+++ b/content/en/agent/basic_agent_usage/redhat.md
@@ -71,6 +71,10 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 | Display command usage              | `sudo service datadog-agent`                      |
 | Run a check                        | `sudo -u dd-agent -- dd-agent check <CHECK_NAME>` |
 
+{{% /tab %}}
+
+{{< /tabs >}}
+
 **Note**: If the `service` wrapper is not available on your system, use:
 
 * On `upstart`-based systems: `sudo start/stop/restart/status datadog-agent`
@@ -79,8 +83,9 @@ In Agent v6 and v7, the service manager provided by the operating system is resp
 
 [Learn more about Service lifecycle commands][2]
 
-{{% /tab %}}
-{{< /tabs >}}
+
+
+
 
 ## Configuration
 

--- a/content/fr/agent/basic_agent_usage/redhat.md
+++ b/content/fr/agent/basic_agent_usage/redhat.md
@@ -70,15 +70,18 @@ Avec les Agents v6 et v7, le gestionnaire de service fourni par le système d'ex
 | Afficher l'utilisation des commandes              | `sudo service datadog-agent`                      |
 | Exécuter un check                        | `sudo -u dd-agent -- dd-agent check <NOM_CHECK>` |
 
+{{% /tab %}}
+{{< /tabs >}}
+
 **Remarque** : si le wrapper de `service` n'est pas disponible sur votre système, utilisez :
 
 * Sur les systèmes basés sur `upstart` : `sudo start/stop/restart/status datadog-agent`
 * Sur les systèmes basés sur `systemd` : `sudo systemctl start/stop/restart/status datadog-agent`
+* Sur les systèmes basés sur `initctl` : `sudo initctl start/stop/restart/status datadog-agent`
 
 [En savoir plus sur les commandes de cycle de vie du service][2]
 
-{{% /tab %}}
-{{< /tabs >}}
+
 
 ## Configuration
 

--- a/content/ja/agent/basic_agent_usage/redhat.md
+++ b/content/ja/agent/basic_agent_usage/redhat.md
@@ -70,15 +70,18 @@ Agent v6 & v7 では、オペレーティングシステムから提供される
 | コマンドの使用方法の表示              | `sudo service datadog-agent`                      |
 | チェックの実行                        | `sudo -u dd-agent -- dd-agent check <CHECK_NAME>` |
 
+{{% /tab %}}
+{{< /tabs >}}
+
 **注**: ご使用のシステムで `service` ラッパーを使用できない場合は、以下を使用してください。
 
 * `upstart` ベースのシステムの場合: `sudo start/stop/restart/status datadog-agent`
 * `systemd` ベースのシステムの場合: `sudo systemctl start/stop/restart/status datadog-agent`
+* `initctl` ベースのシステムの場合: `sudo initctl start/stop/restart/status datadog-agent`
 
 [サービスライフサイクルコマンドについては、こちらを参照してください][2]。
 
-{{% /tab %}}
-{{< /tabs >}}
+
 
 ## コンフィギュレーション
 


### PR DESCRIPTION
fixed end of tabs so this comment shows for all agents

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Makes it show the comments about systemctl and initctl for all versions of the agent
(moved where the tabs markers end)

### Motivation
<!-- What inspired you to submit this pull request?-->
This used to only show for 'Agent 5' it applies to all versions of the agent. 

### Preview
<!-- Impacted pages preview links-->


<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
