### PR TITLE
Replace mentions of AppSec, Application Security to ASM

### DIFF
--- a/content/en/security_platform/detection_rules/_index.md
+++ b/content/en/security_platform/detection_rules/_index.md
@@ -28,7 +28,7 @@ For each of monitoring option, there are [default detection rules][1] that work 
 
 - With [Cloud Workload Security][5], the Datadog Agent actively monitors system activity and evaluates it against a set of detection rules.
 
-- [Application Security][6] leverages Datadog [APM][7], the [Datadog Agent][8], and detection rules to detect threats in your application environment.
+- [Application Security Monitoring][6] (ASM) leverages Datadog [APM][7], the [Datadog Agent][8], and detection rules to detect threats in your application environment.
 
 ## Creating and managing detection rules
 

--- a/layouts/shortcodes/appsec-getstarted-2.md
+++ b/layouts/shortcodes/appsec-getstarted-2.md
@@ -1,6 +1,6 @@
    The library collects security data from your application and sends it to the Agent, which sends it to Datadog, where [out-of-the-box detection rules][202] flag attacker techniques and potential misconfigurations so you can take steps to remediate. 
    
-1.  **To see Application Security threat detection in action, send known attack patterns to your application**. For example, trigger the [Security Scanner Detected][203] rule by running a file that contains the following curl script:
+1.  **To see Application Security Monitoring threat detection in action, send known attack patterns to your application**. For example, trigger the [Security Scanner Detected][203] rule by running a file that contains the following curl script:
     <div>
     <pre><code>for ((i=1;i<=200;i++)); <br>do<br># Target existing service’s routes<br>curl https://your-application-url/existing-route -A Arachni/v1.0;<br># Target non existing service’s routes<br>curl https://your-application-url/non-existing-route -A Arachni/v1.0;<br>done</code></pre></div>
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Rebrand AppSec, Application Security to Application Security Monitoring (ASM)

### Motivation
<!-- What inspired you to submit this pull request?-->

Rebranding of the product

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
