### PR TITLE
Temporarily disable validating integration content

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -636,12 +636,14 @@ class Integrations:
                 markdown_string = f.read()
                 markdown_with_replaced_images = self.replace_image_src(markdown_string, basename(dirname(file_name)))
                 updated_markdown = self.remove_markdown_section(markdown_with_replaced_images, '## Setup')
-                is_marketplace_integration_markdown_valid = self.validate_marketplace_integration_markdown(updated_markdown)
+                result = updated_markdown
 
-                if not is_marketplace_integration_markdown_valid:
-                    raise Exception('Potential setup or pricing information included in Marketplace Integration markdown.  Check {} for Setup or Pricing sections.'.format(file_name))
-                else:
-                    result = updated_markdown
+                # is_marketplace_integration_markdown_valid = self.validate_marketplace_integration_markdown(updated_markdown)
+
+                # if not is_marketplace_integration_markdown_valid:
+                #     raise Exception('Potential setup or pricing information included in Marketplace Integration markdown.  Check {} for Setup or Pricing sections.'.format(file_name))
+                # else:
+                #     result = updated_markdown
 
         ## Check if there is a integration tab logic in the integration file:
         if "<!-- xxx tabs xxx -->" in result:


### PR DESCRIPTION
### What does this PR do?
allow pricing and setup content to build for integrations pages

### Motivation
docs builds broken as a result of updated integrations content from another repo

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/fix-integrations/
https://docs-staging.datadoghq.com/brian.deutsch/fix-integrations/integrations/rapdev-snmp-profiles/

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
