### PR TITLE
Add custom landing page documentation

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2901,6 +2901,10 @@ main:
     url: account_management/org_settings/sensitive_data_detection
     parent: organization_settings
     weight: 205
+  - name: Custom Landing Page
+    url: account_management/org_settings/custom_landing
+    parent: organization_settings
+    weight: 206
   - name: RBAC
     url: account_management/rbac/
     parent: account_management

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2901,7 +2901,7 @@ main:
     url: account_management/org_settings/sensitive_data_detection
     parent: organization_settings
     weight: 205
-  - name: Custom Landing Page
+  - name: Custom Organization Landing Page
     url: account_management/org_settings/custom_landing
     parent: organization_settings
     weight: 206

--- a/content/en/account_management/org_settings/custom_landing.md
+++ b/content/en/account_management/org_settings/custom_landing.md
@@ -1,0 +1,42 @@
+---
+title: Custom Landing Page
+kind: documentation
+---
+
+## Overview
+
+Datadog allows administrators to set a dashboard as the default landing page for the organization. A custom landing page helps a large or small organization control the narrative for their users.
+
+You can customize a dashboard with the information you want your users to see when they first log on to Datadog. Use the Organization settings to set that dashboard as the custom landing page for your organization. That dashboard becomes the default page that users see when they access the Datadog site.
+
+If an organization does not set a custom landing page, Datadog sets a default landing page. In organizations that use APM, the APM homepage is the default landing page. If the organization does not use APM, the dashboard list is the default landing page.
+
+## Set a custom landing page
+
+Only users with the Datadog Admin Role or the Org Management (`org_management`) permission can set the custom landing page for an organization.
+
+To set a custom landing page, follow the steps below:
+
+1. Navigate to [Organization settings][1].
+2. In the left page menu, select **Preferences**.
+3. In the Datadog Homepage section, click the **Dashboard** button.
+4. Use the drop-down list to select a dashboard.
+5. Click the **Save** button.
+
+To set a custom landing page using the API, see the [TODO need link][2] API reference.
+
+## Use the default landing page
+
+Only users with the Datadog Admin Role or the Org Management (`org_management`) permission can change the landing page for an organization.
+
+To restore the default landing page of APM Home, follow the steps below:
+
+1. Navigate to [Organization settings][1].
+2. In the left page menu, select **Preferences**.
+3. In the Datadog Homepage section, click the **Default: APM Home** button.
+4. Click the **Save** button.
+
+To restore the default landing page using the API, see the [TODO need link][2] API reference.
+
+[1]: https://app.datadoghq.com/organization-settings/
+[2]: TODO

--- a/content/en/account_management/org_settings/custom_landing.md
+++ b/content/en/account_management/org_settings/custom_landing.md
@@ -18,12 +18,12 @@ Only users with the Datadog Admin Role or the Org Management (`org_management`) 
 To set a custom landing page, follow the steps below:
 
 1. Navigate to [Organization settings][1].
-2. In the left page menu, select **Preferences**.
+2. From the tabs on the left, select **Preferences**.
 3. In the Datadog Homepage section, click the **Dashboard** button.
 4. Use the drop-down list to select a dashboard.
 5. Click the **Save** button.
 
-To set a custom landing page using the API, see the [TODO need link][2] API reference.
+To set a custom landing page using the API, see the API reference for the [Update your organization][2] endpoint.
 
 ## Use the default landing page
 
@@ -32,11 +32,11 @@ Only users with the Datadog Admin Role or the Org Management (`org_management`) 
 To restore the default landing page of APM Home, follow the steps below:
 
 1. Navigate to [Organization settings][1].
-2. In the left page menu, select **Preferences**.
+2. From the tabs on the left, select **Preferences**.
 3. In the Datadog Homepage section, click the **Default: APM Home** button.
 4. Click the **Save** button.
 
-To restore the default landing page using the API, see the [TODO need link][2] API reference.
+To restore the default landing page using the API, see the API reference for the [Update your organization][2] endpoint.
 
 [1]: https://app.datadoghq.com/organization-settings/
-[2]: TODO
+[2]: /api/latest/organizations/#update-your-organization

--- a/content/en/account_management/org_settings/custom_landing.md
+++ b/content/en/account_management/org_settings/custom_landing.md
@@ -5,7 +5,7 @@ kind: documentation
 
 ## Overview
 
-The Datadog organization landing page is the first page your users see when they log on to Datadog or navigate to the Datadog root page. Datadog sets a default landing page for your organization. If you use APM, Datadog sets the APM root as the landing page. If you don’t use APM, then the list of dashboards is the default landing view.
+The Datadog organization landing page is the first page your users see when they log on to Datadog or navigate to the Datadog root page. Datadog sets a default landing page for your organization. If you use APM, Datadog sets the APM root as the landing page. If you don’t use APM, then the list of dashboards is the default landing page.
 
 As an alternative to the default page, Datadog allows administrators to set a dashboard as the landing page for the organization. A custom landing page helps a large or small organization control the narrative for their users.
 

--- a/content/en/account_management/org_settings/custom_landing.md
+++ b/content/en/account_management/org_settings/custom_landing.md
@@ -9,7 +9,7 @@ The Datadog organization landing page is the first page your users see when they
 
 As an alternative to the default page, Datadog allows administrators to set a dashboard as the landing page for the organization. A custom landing page helps a large or small organization control the narrative for their users.
 
-You can customize a dashboard with the information you want your users to see when they first log on to Datadog. Use Organization settings to set that dashboard as the custom landing page for your organization.
+You can customize a dashboard with the information you want your users to see when they first log on to Datadog. Use [Organization settings][1] to set that dashboard as the custom landing page for your organization.
 
 ## Set a custom landing page
 

--- a/content/en/account_management/org_settings/custom_landing.md
+++ b/content/en/account_management/org_settings/custom_landing.md
@@ -1,15 +1,15 @@
 ---
-title: Custom Landing Page
+title: Custom Organization Landing Page
 kind: documentation
 ---
 
 ## Overview
 
-Datadog allows administrators to set a dashboard as the default landing page for the organization. A custom landing page helps a large or small organization control the narrative for their users.
+The Datadog organization landing page is the first page your users see when they log on to Datadog or navigate to the Datadog root page. Datadog sets a default landing page for your organization. If you use APM, Datadog sets the APM root as the landing page. If you don’t use APM, then the list of dashboards is the default landing view.
 
-You can customize a dashboard with the information you want your users to see when they first log on to Datadog. Use the Organization settings to set that dashboard as the custom landing page for your organization. That dashboard becomes the default page that users see when they access the Datadog site.
+As an alternative to the default page, Datadog allows administrators to set a dashboard as the landing page for the organization. A custom landing page helps a large or small organization control the narrative for their users.
 
-If an organization does not set a custom landing page, Datadog sets a default landing page. In organizations that use APM, the APM homepage is the default landing page. If the organization does not use APM, the dashboard list is the default landing page.
+You can customize a dashboard with the information you want your users to see when they first log on to Datadog. Use Organization settings to set that dashboard as the custom landing page for your organization.
 
 ## Set a custom landing page
 
@@ -23,8 +23,6 @@ To set a custom landing page, follow the steps below:
 4. Use the drop-down list to select a dashboard.
 5. Click the **Save** button.
 
-To set a custom landing page using the API, see the API reference for the [Update your organization][2] endpoint.
-
 ## Use the default landing page
 
 Only users with the Datadog Admin Role or the Org Management (`org_management`) permission can change the landing page for an organization.
@@ -36,7 +34,4 @@ To restore the default landing page of APM Home, follow the steps below:
 3. In the Datadog Homepage section, click the **Default: APM Home** button.
 4. Click the **Save** button.
 
-To restore the default landing page using the API, see the API reference for the [Update your organization][2] endpoint.
-
 [1]: https://app.datadoghq.com/organization-settings/
-[2]: /api/latest/organizations/#update-your-organization


### PR DESCRIPTION
### What does this PR do?
Add a new page to document how to set a custom landing page for an org. Add the page to the left menu under Org Settings.

### Motivation
https://datadoghq.atlassian.net/browse/DOCS-3328
Feature is going GA this week.

### Preview
https://docs-staging.datadoghq.com/uchen/custom-landing/account_management/org_settings/custom_landing/

### Additional Notes
A screen recording of setting and unsetting a custom landing page can be found on Slack in the #org-configs channel. Here is a direct link: https://dd.enterprise.slack.com/files/U02SY76473J/F03BT2EF5RT/screen_recording_2022-04-12_at_12.50.20_pm.mov

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
