### PR TITLE
Update instructions pointing to How's my SSL

### DIFF
--- a/content/en/security/guide/tls_deprecation_1_2.md
+++ b/content/en/security/guide/tls_deprecation_1_2.md
@@ -14,7 +14,7 @@ These protocols are being deprecated to ensure that customers connect to Datadog
 
 ## Client compatibility
 
-Follow [How's my SSL? API check][9] instructions to check the client of your choice.
+Follow [How's my SSL? API][9] instructions to check the client of your choice.
 
 ## Browser support
 

--- a/content/en/security/guide/tls_deprecation_1_2.md
+++ b/content/en/security/guide/tls_deprecation_1_2.md
@@ -14,7 +14,7 @@ These protocols are being deprecated to ensure that customers connect to Datadog
 
 ## Client compatibility
 
-Using your client of choice, go to (`https://www.howsmyssl.com/s/api.html`[8]) and look at the `tls_version` key to determine the most recent supported version.
+Using your client of choice, go to [`https://www.howsmyssl.com/s/api.html`][9] and look at the `tls_version` key to determine the most recent supported version.
 ## Browser support
 
 Modern browsers have had support for TLS v1.2 for a while. See the "Can I use..." [compatibility matrix][2] to determine if your specific browser and version are affected.
@@ -119,3 +119,4 @@ On a 64 bit .Net Framework (version 4 and above):
 [6]: https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls
 [7]: https://github.com/markekraus/BetterTls
 [8]: https://docs.microsoft.com/en-us/officeonlineserver/enable-tls-1-1-and-tls-1-2-support-in-office-online-server
+[9]: https://www.howsmyssl.com/s/api.html

--- a/content/en/security/guide/tls_deprecation_1_2.md
+++ b/content/en/security/guide/tls_deprecation_1_2.md
@@ -14,7 +14,8 @@ These protocols are being deprecated to ensure that customers connect to Datadog
 
 ## Client compatibility
 
-Using your client of choice, go to [`https://www.howsmyssl.com/s/api.html`][9] and look at the `tls_version` key to determine the most recent supported version.
+Follow [How's my SSL? API check][9] instructions to check the client of your choice.
+
 ## Browser support
 
 Modern browsers have had support for TLS v1.2 for a while. See the "Can I use..." [compatibility matrix][2] to determine if your specific browser and version are affected.


### PR DESCRIPTION
### What does this PR do?

Update the docs to say that page contains the instructions to use their SSL check API and it is not the check API itself.

### Preview
https://docs-staging.datadoghq.com/albertvaka/fix-howmyssl-link/security/guide/tls_deprecation_1_2/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
