### PR TITLE
Unhide Azure DBM docs for postgres and mysql

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1829,16 +1829,21 @@ main:
     parent: dbm_setup_postgres
     identifier: dbm_setup_postgres_gcsql
     weight: 104
+  - name: Azure
+    url: database_monitoring/setup_postgres/azure
+    parent: dbm_setup_postgres
+    identifier: dbm_postgres_azure
+    weight: 105
   - name: Advanced Configuration
     url: database_monitoring/setup_postgres/advanced_configuration
     parent: dbm_setup_postgres
     identifier: dbm_postgres_advanced_configuration
-    weight: 105
+    weight: 106
   - name: Troubleshooting
     url: database_monitoring/setup_postgres/troubleshooting/
     parent: dbm_setup_postgres
     identifier: dbm_troubleshooting_postgres
-    weight: 106
+    weight: 107
   - name: Setting Up MySQL
     url: database_monitoring/setup_mysql/
     parent: dbm
@@ -1864,16 +1869,21 @@ main:
     parent: dbm_setup_mysql
     identifier: dbm_setup_mysql_gcsql
     weight: 104
+  - name: Azure
+    url: database_monitoring/setup_mysql/azure
+    parent: dbm_setup_mysql
+    identifier: dbm_mysql_azure
+    weight: 105
   - name: Advanced Configuration
     url: database_monitoring/setup_mysql/advanced_configuration
     parent: dbm_setup_mysql
     identifier: dbm_mysql_advanced_configuration
-    weight: 105
+    weight: 106
   - name: Troubleshooting
     url: database_monitoring/setup_mysql/troubleshooting/
     parent: dbm_setup_mysql
     identifier: dbm_troubleshooting_mysql
-    weight: 106
+    weight: 107
   - name: Setting Up SQL Server
     url: database_monitoring/setup_sql_server/
     parent: dbm

--- a/content/en/database_monitoring/setup_mysql/_index.md
+++ b/content/en/database_monitoring/setup_mysql/_index.md
@@ -11,11 +11,11 @@ disable_sidebar: true
 
 ### MySQL versions supported
 
-|  | Self-hosted | AWS RDS | AWS Aurora | Google Cloud SQL with >26GB RAM |
-|--|------------|---------|------------|------------------|
-| MySQL 5.6 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
-| MySQL 5.7 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
-| MySQL 8.0 | {{< X >}} | {{< X >}} |   | {{< X >}} |
+|  | Self-hosted | AWS RDS | AWS Aurora | Google Cloud SQL with >26GB RAM | Azure |
+|--|------------|---------|------------|------------------|---------|
+| MySQL 5.6 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |  |
+| MySQL 5.7 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
+| MySQL 8.0 | {{< X >}} | {{< X >}} |   | {{< X >}} | {{< X >}} |
 
 For setup instructions, select your hosting type:
 

--- a/content/en/database_monitoring/setup_mysql/azure.md
+++ b/content/en/database_monitoring/setup_mysql/azure.md
@@ -2,7 +2,6 @@
 title: Setting Up Database Monitoring for Azure Database for MySQL
 kind: documentation
 description: Install and configure Database Monitoring for MySQL managed on Azure.
-beta: true
 further_reading:
 - link: "/integrations/mysql/"
   tag: "Documentation"

--- a/content/en/database_monitoring/setup_postgres/_index.md
+++ b/content/en/database_monitoring/setup_postgres/_index.md
@@ -11,13 +11,13 @@ disable_sidebar: true
 
 ### Postgres versions supported
 
-|  | Self-hosted | AWS RDS | AWS Aurora | Google Cloud SQL |
-|--|------------|---------|------------|------------------|
-| Postgres 9.6 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
-| Postgres 10 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
-| Postgres 11 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
-| Postgres 12 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
-| Postgres 13 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
+|  | Self-hosted | AWS RDS | AWS Aurora | Google Cloud SQL | Azure |
+|--|------------|---------|------------|------------------|---------|
+| Postgres 9.6 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
+| Postgres 10 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
+| Postgres 11 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
+| Postgres 12 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
+| Postgres 13 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
 
 For setup instructions, select your hosting type:
 

--- a/content/en/database_monitoring/setup_postgres/azure.md
+++ b/content/en/database_monitoring/setup_postgres/azure.md
@@ -2,7 +2,6 @@
 title: Setting Up Database Monitoring for Azure Database for PostgreSQL
 kind: documentation
 description: Install and configure Database Monitoring for PostgreSQL managed on Azure.
-beta: true
 further_reading:
 - link: "/integrations/postgres/"
   tag: "Documentation"

--- a/layouts/partials/dbm/dbm-setup-mysql.html
+++ b/layouts/partials/dbm/dbm-setup-mysql.html
@@ -1,6 +1,6 @@
 {{ $dot := . }}
 <div class="dbm-setup-mysql">
-  <div class="container cards-dd col-num-2">
+  <div class="container cards-dd col-num-5">
     <div class="card-deck">
       <a class="card" href="/database_monitoring/setup_mysql/selfhosted">
         <div class="card-body text-center py-2 px-1">
@@ -21,6 +21,11 @@
       <a class="card" href="/database_monitoring/setup_mysql/gcsql">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/google_cloudsql.png" "class" "img-fluid" "alt" "Google Cloud SQL" "width" "175") }}
+        </div>
+      </a>
+      <a class="card" href="/database_monitoring/setup_mysql/azure">
+        <div class="card-body text-center py-2 px-1">
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/azure_db_for_mysql.png" "class" "img-fluid" "alt" "MySQL" "width" "175") }}
         </div>
       </a>
     </div>

--- a/layouts/partials/dbm/dbm-setup-postgres.html
+++ b/layouts/partials/dbm/dbm-setup-postgres.html
@@ -1,6 +1,6 @@
 {{ $dot := . }}
 <div class="dbm-setup-postgres">
-  <div class="container cards-dd col-num-2">
+  <div class="container cards-dd col-num-5">
     <div class="card-deck">
       <a class="card" href="/database_monitoring/setup_postgres/selfhosted">
         <div class="card-body text-center py-2 px-1">
@@ -21,6 +21,11 @@
       <a class="card" href="/database_monitoring/setup_postgres/gcsql">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/google_cloudsql.png" "class" "img-fluid" "alt" "Google Cloud SQL" "width" "175") }}
+        </div>
+      </a>
+      <a class="card" href="/database_monitoring/setup_postgres/azure">
+        <div class="card-body text-center py-2 px-1">
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/azure_db_for_postgresql.png" "class" "img-fluid" "alt" "PostgreSQL" "width" "175") }}
         </div>
       </a>
     </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Unhides/adds the new DBM Azure pages on MySQL and Postgres to the sidebar navigation, and respective index pages, and removes the beta tag in the front matter so that the pages are indexed and searchable.

### Motivation
Docs went live quietly, so you can view these pages if you have the URL, but we were asked to hide them from the sidebar navigation  and search until GA.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
