### PR TITLE
Fix the outdated link in SNMP FAQ

### DIFF
--- a/content/en/integrations/faq/snmp.md
+++ b/content/en/integrations/faq/snmp.md
@@ -5,7 +5,7 @@ private: true
 ---
 
 <div class="alert alert-danger">
-This version of the SNMP check works with Agent versions < 6.15. For the latest version, see the <a href="/integrations/snmp">SNMP integration documentation</a>.
+This version of the SNMP check works with Agent versions < 6.15. For the latest version, see the <a href="/network_monitoring/devices">Network Device Monitoring documentation</a>.
 </div>
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Fix the outdated link in SNMP FAQ

### Motivation
<!-- What inspired you to submit this pull request?-->

https://github.com/DataDog/documentation/issues/12461

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
