### PR TITLE
redirect security

### DIFF
--- a/content/en/security/_index.md
+++ b/content/en/security/_index.md
@@ -1,0 +1,4 @@
+---
+title: Security
+external_redirect: "/data_security/"
+---

--- a/content/en/security/_index.md
+++ b/content/en/security/_index.md
@@ -1,4 +1,8 @@
 ---
+# don't render so to allow alias to render here
 title: Security
-external_redirect: "/data_security/"
+headless: true
+_build:
+  list: false
+  render: false
 ---


### PR DESCRIPTION
### What does this PR do?

As the directory structure security has no index but has a nested folder it conflicts with the `/security/` alias defined in `/data_security/` and ends up being a blank page.

This PR brings back `_index.md` an external redirects it to data_security

### Motivation

Blank page with title `Securities` instead of a redirect without this change

### Preview

https://docs-staging.datadoghq.com/david.jones/security-redirect/security/
should go do `/data_security/`

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
