### PR TITLE
Remove tags from this guides index

### DIFF
--- a/content/en/developers/guide/_index.md
+++ b/content/en/developers/guide/_index.md
@@ -5,17 +5,17 @@ private: true
 ---
 
 {{< whatsnext desc="General:" >}}
-    {{< nextlink href="developers/guide/data-collection-resolution-retention" tag="General" >}}Datadog Data Collection, Resolution, and Retention{{< /nextlink >}}
-    {{< nextlink href="developers/guide/creating-a-jmx-integration" tag="Java">}}Creating a JMX integration{{< /nextlink >}}
+    {{< nextlink href="developers/guide/data-collection-resolution-retention">}}Datadog Data Collection, Resolution, and Retention{{< /nextlink >}}
+    {{< nextlink href="developers/guide/creating-a-jmx-integration">}}Creating a JMX integration{{< /nextlink >}}
 {{< /whatsnext >}}
 
 {{< whatsnext desc="Useful Guides to interact with Datadog APIs:" >}}
-    {{< nextlink href="developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags" tag="General" >}}What best practices are recommended for naming metrics and tags?{{< /nextlink >}}
-    {{< nextlink href="developers/guide/query-the-infrastructure-list-via-the-api" tag="API">}}Query the Infrastructure List with the API{{< /nextlink >}}
-    {{< nextlink href="getting_started/api/" tag="API">}}Using Postman With Datadog APIs{{< /nextlink >}}
-    {{< nextlink href="developers/guide/calling-on-datadog-s-api-with-the-webhooks-integration" tag="API">}}Calling on Datadog's API with the Webhooks Integration{{< /nextlink >}}
-    {{< nextlink href="developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell" tag="API">}}Dogshell{{< /nextlink >}}
-    {{< nextlink href="developers/guide/dogwrap" tag="API">}}Call commands and generate events from their results.{{< /nextlink >}}
-    {{< nextlink href="developers/guide/query-data-to-a-text-file-step-by-step" tag="API">}}Query data to a text file, step by step{{< /nextlink >}}
-    {{< nextlink href="developers/guide/custom-python-package" tag="API">}}Adding a custom Python package to the Agent{{< /nextlink >}}
+    {{< nextlink href="developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags">}}What best practices are recommended for naming metrics and tags?{{< /nextlink >}}
+    {{< nextlink href="developers/guide/query-the-infrastructure-list-via-the-api">}}Query the Infrastructure List with the API{{< /nextlink >}}
+    {{< nextlink href="getting_started/api/">}}Using Postman With Datadog APIs{{< /nextlink >}}
+    {{< nextlink href="developers/guide/calling-on-datadog-s-api-with-the-webhooks-integration">}}Calling on Datadog's API with the Webhooks Integration{{< /nextlink >}}
+    {{< nextlink href="developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell">}}Dogshell{{< /nextlink >}}
+    {{< nextlink href="developers/guide/dogwrap">}}Call commands and generate events from their results.{{< /nextlink >}}
+    {{< nextlink href="developers/guide/query-data-to-a-text-file-step-by-step">}}Query data to a text file, step by step{{< /nextlink >}}
+    {{< nextlink href="developers/guide/custom-python-package">}}Adding a custom Python package to the Agent{{< /nextlink >}}
 {{< /whatsnext >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Removes some tags that show up as text that looks like it hasn't actually been styled properly with CSS padding. And it looks like we're not using these tags on other guide indexes, especially since we seem to be breaking longer guide indexes out into categorized sections.... Anyway, this will make it prettier/less awful looking.

### Motivation

I am a mouse looking for cookies that are easy to eat

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jorie/remove-tags-guides-index

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
