### PR TITLE
Add sqlserver to list, make self-hosted usage consistent.

### DIFF
--- a/content/en/database_monitoring/_index.md
+++ b/content/en/database_monitoring/_index.md
@@ -25,7 +25,7 @@ Datadog Database Monitoring provides deep visibility into databases across all o
 
 ## Getting started
 
-Datadog Database Monitoring supports self-hosted and managed cloud versions of **Postgres** and **MySQL**. To get started with Datadog Database Monitoring, configure your database and install the Datadog Agent. For setup instructions, select your database technology:
+Datadog Database Monitoring supports self-hosted and managed cloud versions of **Postgres**, **MySQL**, and **SQL Server**. To get started with Datadog Database Monitoring, configure your database and install the Datadog Agent. For setup instructions, select your database technology:
 
 ### Postgres
 

--- a/layouts/partials/dbm/dbm-setup-mysql.html
+++ b/layouts/partials/dbm/dbm-setup-mysql.html
@@ -5,7 +5,7 @@
       <a class="card" href="/database_monitoring/setup_mysql/selfhosted">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/mysql.png" "class" "img-fluid" "alt" "Selfhosted" "width" "175") }}
-          <br/>Self hosted
+          <br/>Self-hosted
         </div>
       </a>
       <a class="card" href="/database_monitoring/setup_mysql/rds">

--- a/layouts/partials/dbm/dbm-setup-postgres.html
+++ b/layouts/partials/dbm/dbm-setup-postgres.html
@@ -5,7 +5,7 @@
       <a class="card" href="/database_monitoring/setup_postgres/selfhosted">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/postgres.png" "class" "img-fluid" "alt" "Selfhosted" "width" "175") }}
-          <br/>Self hosted
+          <br/>Self-hosted
         </div>
       </a>
       <a class="card" href="/database_monitoring/setup_postgres/rds">

--- a/layouts/partials/dbm/dbm-setup-sql-server.html
+++ b/layouts/partials/dbm/dbm-setup-sql-server.html
@@ -5,7 +5,7 @@
       <a class="card" href="/database_monitoring/setup_sql_server/selfhosted">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/sqlserver.png" "class" "img-fluid" "alt" "Selfhosted" "width" "175") }}
-          <br/>Self hosted
+          <br/>Self-hosted
         </div>
       </a>
       <a class="card" href="/database_monitoring/setup_sql_server/rds">


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Adds SQL Server to the list of self-hosted available dbm options, and since we're referring to it as "self-hosted" in the body, updates the link texts to also be "self-hosted" with the hyphen instead of a space.

### Motivation

nitpicky nitpicking

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/jorie/fix-dbm-text/database_monitoring/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
