### PR TITLE
Fix link to span tags in visualizations page

### DIFF
--- a/content/en/tracing/visualization/_index.md
+++ b/content/en/tracing/visualization/_index.md
@@ -202,7 +202,7 @@ When child spans are concurrent, execution time is calculated by dividing the ov
 [9]: /tracing/manual_instrumentation/
 [10]: /tracing/opentracing/
 [11]: /tracing/connect_logs_and_traces/
-[12]: /tracing/guide/adding_metadata_to_spans/
+[12]: /tracing/guide/add_span_md_and_graph_it/
 [13]: /tracing/runtime_metrics/
 [14]: /tracing/trace_explorer/
 [15]: /tracing/guide/metrics_namespace/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix link to adding span tags in the /tracing/visualization page

### Motivation
The previous link for span tags redirected to the custom instrumentation page, which is not very clear.

### Preview
<!-- Impacted pages preview links-->
N/A
<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
<!--https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>-->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
N/A
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
