### PR TITLE
Open OTLP ingest port on core agent rather than trace agent

### DIFF
--- a/content/en/tracing/setup_overview/open_standards/otlp_ingest_in_the_agent.md
+++ b/content/en/tracing/setup_overview/open_standards/otlp_ingest_in_the_agent.md
@@ -99,7 +99,7 @@ experimental:
    name: DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT # enables HTTP receiver on port 4318
    value: "0.0.0.0:4318"
    ```
-3. Map the container ports 4317 or 4318 to the host port for the trace Agent container:
+3. Map the container ports 4317 or 4318 to the host port for the core Agent container:
 
    For gPRC:
    ```
@@ -154,13 +154,13 @@ experimental:
 
    For gRPC:
    ```
-   --set 'agents.containers.traceAgent.ports[0].containerPort=4317,agents.containers.traceAgent.ports[0].hostPort=4317,agents.containers.traceAgent.ports[0].name=traceportgrpc,agents.containers.traceAgent.ports[0].protocol=TCP' 
+   --set 'agents.containers.agent.ports[0].containerPort=4317,agents.containers.agent.ports[0].hostPort=4317,agents.containers.agent.ports[0].name=traceportgrpc,agents.containers.agent.ports[0].protocol=TCP' 
 
    --set "datadog.env[0].name=DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT,datadog.env[0].value=0.0.0.0:4317"
    ```
    For HTTP:
    ```
-   --set 'agents.containers.traceAgent.ports[0].containerPort=4318,agents.containers.traceAgent.ports[0].hostPort=4318,agents.containers.traceAgent.ports[0].name=traceporthttp,agents.containers.traceAgent.ports[0].protocol=TCP'
+   --set 'agents.containers.agent.ports[0].containerPort=4318,agents.containers.agent.ports[0].hostPort=4318,agents.containers.agent.ports[0].name=traceporthttp,agents.containers.agent.ports[0].protocol=TCP'
 
    --set "datadog.env[0].name=DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT,datadog.env[0].value=0.0.0.0:4318"
    ```
@@ -181,7 +181,7 @@ experimental:
        value: "0.0.0.0:4318"
    ```
 
-3. Map the container ports (`4317` for gRPC or `4318` for HTTP) to the host port for the trace Agent container:
+3. Map the container ports (`4317` for gRPC or `4318` for HTTP) to the host port for the core Agent container:
 
    For gRPC:
    ```


### PR DESCRIPTION
### What does this PR do?
Open's otlp ingest port on the core agent, not the trace agent.

### Motivation
The otlp ingest port should be opened on the core agent, not the trace agent.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
