### PR TITLE
Update Further Reading for Getting Started w Logs

### DIFF
--- a/content/en/getting_started/logs/_index.md
+++ b/content/en/getting_started/logs/_index.md
@@ -2,9 +2,12 @@
 title: Getting Started with Logs
 kind: documentation
 further_reading:
-    - link: 'https://learn.datadoghq.com/enrol/index.php?id=15'
+    - link: 'https://learn.datadoghq.com/enrol/index.php?id=40'
       tag: 'Learning Center'
-      text: 'Introduction to Logs in Datadog'
+      text: 'Introduction to Log Management'
+    - link: 'https://learn.datadoghq.com/enrol/index.php?id=36'
+      tag: 'Learning Center'
+      text: 'Going Deeper with Logs: Processing'
     - link: '/logs/log_collection/'
       tag: 'Documentation'
       text: 'Log Collection & Integrations'


### PR DESCRIPTION

### What does this PR do?
Removes an outdated learning center link in Further Reading section. Added two valid courses.

### Motivation
The Learning Center link pointed me to a course that is no longer available to learners. Instead I found to relevant active courses for logs.

### Preview
https://docs-staging.datadoghq.com/KateYoak/patch-1/getting_started/logs/


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
