### PR TITLE
docs(status): add histogram buckets line in agent status documentation

### DIFF
--- a/content/en/agent/guide/agent-status-page.md
+++ b/content/en/agent/guide/agent-status-page.md
@@ -92,6 +92,7 @@ This section displays a list of running check instances, for example:
       Metric Samples: Last Run: 6, Total: 24
       Events: Last Run: 0, Total: 0
       Service Checks: Last Run: 0, Total: 0
+      Histogram Buckets: Last Run: 12, Total: 36
       Average Execution Time : 6ms
 ```
 
@@ -104,6 +105,7 @@ Terms and descriptions:
 | Metric Samples         | The number of fetched metrics.                                   |
 | Events                 | The number of triggered events.                                  |
 | Service Checks         | The number of service checks reported.                           |
+| Histogram Buckets      | The number of histogram buckets sent.                            |
 | Average Execution Time | The average time taken to run the instance.                      |
 | Last Run               | The number during the last check run.                            |
 | Total                  | The total number since the Agent's most recent start or restart. |


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update status page documentation.

### Motivation

This [PR](https://github.com/DataDog/datadog-agent/pull/11365) adds histogram buckets line to the Agent status page.


### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nicolas.guerguadj/add_histogram_buckets_in_status_page_documentation/agent/guide/agent-status-page/#collector

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Merge this after the 7.37 release.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
