### PR TITLE
[OpenTelemetry Collector] Update example with new configuration

### DIFF
--- a/content/en/tracing/setup_overview/open_standards/otel_collector_datadog_exporter.md
+++ b/content/en/tracing/setup_overview/open_standards/otel_collector_datadog_exporter.md
@@ -64,8 +64,9 @@ processors:
 exporters:
   datadog/api:
 
-    tags:
-      - example:tag
+    host_metadata:
+      tags:
+        - example:tag
 
     api:
       key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Change `tags` setting to reflect the new `host_metadata` section from open-telemetry/opentelemetry-collector-contrib/pull/9100, available from v0.49.0

### Motivation
<!-- What inspired you to submit this pull request?-->

As documented in open-telemetry/opentelemetry-collector-contrib/issues/9099, the `tags` setting is deprecated and will eventually be removed in favor of the `host_metadata::tags` section.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
