### PR TITLE
Profiler supports PHP 8.1 now

### DIFF
--- a/content/en/tracing/profiler/enabling/php.md
+++ b/content/en/tracing/profiler/enabling/php.md
@@ -25,8 +25,7 @@ The Datadog PHP Profiler is in public beta. Datadog recommends evaluating the pr
 The Datadog Profiler requires at least PHP 7.1, on 64-bit Linux.
 
 The following are **not** supported:
-- PHP 8.1
-- ZTS builds of PHP
+- PHP ZTS builds
 - PHP debug builds
 
 {{< tabs >}}


### PR DESCRIPTION
### What does this PR do?

Removes the note that PHP 8.1 isn't supported for profiling, as it is supported as of the v0.73.0 release (pending).

### Motivation
I added support for PHP 8.1 in the release.

### Preview
https://docs-staging.datadoghq.com/levi/profiling-php-8.1/tracing/profiler/enabling/php

### Additional Notes
I also made some of the other wording more consistent.

This should be merged once the v0.73.0 release is complete.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
