### PR TITLE
[DOCS-3322] Adding user info to traces for ASM

### DIFF
--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -287,18 +287,42 @@ trace.set_tag('usr.role', 'admin')
 trace.set_tag('usr.scope', 'read:message, write:files')
 ```
 
-
-
 {{< /programming-lang >}}
 
 {{< programming-lang lang="php" >}}
 
+Use the the PHP tracer's API for adding custom tags to a root span, and add user information so that you can monitor authenticated requests in the application.
+
+User monitoring tags are applied to the `meta` section of the root span and start with the prefix `usr` followed by the name of the field. For example, `usr.name` is a user monitoring tag that tracks the user’s name.
+
+The example below shows how to obtain the root span and add the relevant user monitoring tags:
+
+```php
+<?php
+$rootSpan = \DDTrace\root_span();
+
+ // Required unique identifier of the user.
+$rootSpan->meta['usr.id'] = ‘123456789’;
+
+// All other fields are optional.
+$rootSpan->meta['usr.name'] = ‘Jean Example’;
+$rootSpan->meta['usr.email'] = ‘jean.example@example.com’;
+$rootSpan->meta['usr.session_id'] = ‘987654321’;
+$rootSpan->meta['usr.role'] = ‘admin’;
+$rootSpan->meta['usr.scope'] = ‘read:message, write:files’;
+?>
+```
 
 {{< /programming-lang >}}
 
 {{< programming-lang lang="nodejs" >}}
 
+The Node tracer package provides the `tracer.setUser(user)` function, which allows you to monitor authenticated requests by adding user information to the trace. For information and options, read [the NodeJS tracer documentation][1].
 
+<p></p>
+
+
+[1]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md#user-identification
 {{< /programming-lang >}}
 
 {{< /programming-lang-wrapper >}}

--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -247,7 +247,7 @@ if ((span instanceof MutableSpan)) {
 {{< programming-lang lang="dotnet" >}}
 
 The .NET tracer package provides the `SetUser()` function, which allows you to monitor authenticated requests by adding user information to the trace. For information and options, read [the .NET tracer documentation][1].
-
+<p></p>
 
 [1]: https://github.com/DataDog/dd-trace-dotnet/tree/master/docs/Datadog.Trace#user-identification
 {{< /programming-lang >}}
@@ -255,7 +255,7 @@ The .NET tracer package provides the `SetUser()` function, which allows you to m
 {{< programming-lang lang="go" >}}
 
 The Go tracer package provides the `SetUser()` function, which allows you to monitor authenticated requests by adding user information to the trace. For information and options, read [the Go tracer documentation][1].
-
+<p></p>
 
 [1]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#SetUser
 {{< /programming-lang >}}

--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -204,13 +204,112 @@ You can monitor application security for NodeJS apps running in Docker, Kubernet
 
 {{< /programming-lang-wrapper >}}
 
+## Add user information to traces
+
+Instrument your services with the standardized user tags to track authenticated user activity, whether you're tracking application performance or application security.
+
+This way, you can identify bad actors that are generating suspicious security activity, review all their activity around this time frame, and prioritize handling the most advanced attacks and signals targeting your authenticated attack surface.
+
+You can [add custom tags to your root span][1], or use the instrumentation functions described below.
+
+{{< programming-lang-wrapper langs="java,dotnet,go,ruby,php,nodejs" >}}
+
+{{< programming-lang lang="java" >}}
+
+Use the the Java tracer's API for adding custom tags to a root span and add user information so that you can monitor authenticated requests in the application.
+
+User monitoring tags are applied on the root span and start with the prefix `usr` followed by the name of the field. For example, `usr.name` is a user monitoring tag that tracks the user’s name.
+
+**Note**: Check that you have added [necessary dependencies to your application][1].
+
+The example below shows how to obtain the root span and add the relevant user monitoring tags:
+
+```java
+// Get the active span
+final Span span = GlobalTracer.get().activeSpan();
+if ((span instanceof MutableSpan)) {
+   MutableSpan localRootSpan = ((MutableSpan) span).getLocalRootSpan();
+   // Setting the mandatory user id tag
+   localRootSpan.setTag("usr.id", "d131dd02c56eec4");
+   // Setting optional user monitoring tags
+   localRootSpan.setTag("usr.name", "Jean Example");
+   localRootSpan.setTag("usr.email", "jean.example@example.com");
+   localRootSpan.setTag("usr.session_id", "987654321");
+   localRootSpan.setTag("usr.role", "admin");
+   localRootSpan.setTag("usr.scope", "read:message, write:files");
+}
+```
+
+
+[1]: /tracing/setup_overview/open_standards/java/#setup
+{{< /programming-lang >}}
+
+{{< programming-lang lang="dotnet" >}}
+
+The .NET tracer package provides the `SetUser()` function, which allows you to monitor authenticated requests by adding user information to the trace. For information and options, read [the .NET tracer documentation][1].
+
+
+[1]: https://github.com/DataDog/dd-trace-dotnet/tree/master/docs/Datadog.Trace#user-identification
+{{< /programming-lang >}}
+
+{{< programming-lang lang="go" >}}
+
+The Go tracer package provides the `SetUser()` function, which allows you to monitor authenticated requests by adding user information to the trace. For information and options, read [the Go tracer documentation][1].
+
+
+[1]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#SetUser
+{{< /programming-lang >}}
+
+{{< programming-lang lang="ruby" >}}
+
+Use the the Ruby tracer's API for adding custom tags to a trace, and add user information so that you can monitor authenticated requests in the application.
+
+User monitoring tags are applied on the trace and start with the prefix `usr` followed by the name of the field. For example, `usr.name` is a user monitoring tag that tracks the user’s name.
+
+The example below shows how to obtain the root span and add relevant user monitoring tags:
+
+**Notes**:
+- Tag values must be strings.
+- The `usr.id` tag is mandatory.
+
+```ruby
+# Get the active trace
+trace = Datadog::Tracing.active_trace
+
+# Set mandatory user id tag
+trace.set_tag('usr.id', 'd131dd02c56eeec4')
+
+# Set optional user monitoring tags
+trace.set_tag('usr.name', 'Jean Example')
+trace.set_tag('usr.email', 'jean.example@example.com')
+trace.set_tag('usr.session_id', '987654321')
+trace.set_tag('usr.role', 'admin')
+trace.set_tag('usr.scope', 'read:message, write:files')
+```
+
+
+
+{{< /programming-lang >}}
+
+{{< programming-lang lang="php" >}}
+
+
+{{< /programming-lang >}}
+
+{{< programming-lang lang="nodejs" >}}
+
+
+{{< /programming-lang >}}
+
+{{< /programming-lang-wrapper >}}
+
 ## Data security considerations
 
 The data that you collect with Datadog can contain sensitive information that you want to filter out, obfuscate, scrub, filter, modify, or just not collect. Additionally, it may contain synthetic traffic that might cause your threat detection be inaccurate, or cause Datadog to not accurately indicate the security of your services.
 
 By default, ASM collects information from suspicious requests to help you understand why the request was flagged as suspicious. Before sending the data, ASM scans it for patterns and keywords that indicate that the data is sensitive. If the data is deemed sensitive, it is replaced with a `<redacted>` flag, so you observe that although the request was suspicious, the request data could not be collected because of data security concerns.
 
-To protect users' data, sensitive data scanning is activated by default in ASM. You can customize the configuration by using the following environment variables. The scanning is based on the [RE2 syntax][1], so to customize scanning, set the value of these environment variables to a valid RE2 patten:
+To protect users' data, sensitive data scanning is activated by default in ASM. You can customize the configuration by using the following environment variables. The scanning is based on the [RE2 syntax][2], so to customize scanning, set the value of these environment variables to a valid RE2 patten:
 
 * `DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP` - Pattern for scanning for keys whose values commonly contain sensitive data. If found, the key, all corresponding values, and any child nodes are redacted.
 * `DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP` - Pattern for scanning for values that could indicate sensitive data. If found, the value and all its child nodes are redacted.
@@ -228,7 +327,7 @@ The following are examples of data that are flagged as sensitive by default:
 * `BEGIN PRIVATE KEY`
 * `ssh-rsa`
 
-See [APM Data Security][2] for information about other mechanisms in the Datadog Agent and libraries that can also be used to remove sensitive data.
+See [APM Data Security][3] for information about other mechanisms in the Datadog Agent and libraries that can also be used to remove sensitive data.
 
 ## Exclusion filters
 
@@ -239,8 +338,8 @@ You can set an exclusion filter, which ignore events from a rule, to eliminate t
 
 To create an exclusion filter, do one of the following:
 
-- Click on a signal in [ASM Signals][3] and click the **Create Exclusion Filter** button in the top left corner. This method automatically generates a filter query for the targeted service.
-- Navigate to [Exclusion Filters Configuration][4] and manually configure a new exclusion filter based on your own filter query.
+- Click on a signal in [ASM Signals][4] and click the **Create Exclusion Filter** button in the top left corner. This method automatically generates a filter query for the targeted service.
+- Navigate to [Exclusion Filters Configuration][5] and manually configure a new exclusion filter based on your own filter query.
 
 **Note**: Requests (traces) matching an exclusion filter are not billed.
 
@@ -248,14 +347,15 @@ To create an exclusion filter, do one of the following:
 
 To disable ASM, remove the `DD_APPSEC_ENABLED=true` environment variable from your application configuration. Once it's removed, restart your service.
 
-If you need additional help, contact [Datadog support][5].
+If you need additional help, contact [Datadog support][6].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/google/re2/wiki/Syntax
-[2]: /tracing/setup_overview/configure_data_security/
-[3]: https://app.datadoghq.com/security/appsec/signals
-[4]: https://app.datadoghq.com/security/appsec/exclusions
-[5]: /help/
+[1]: /tracing/setup_overview/custom_instrumentation/
+[2]: https://github.com/google/re2/wiki/Syntax
+[3]: /tracing/setup_overview/configure_data_security/
+[4]: https://app.datadoghq.com/security/appsec/signals
+[5]: https://app.datadoghq.com/security/appsec/exclusions
+[6]: /help/


### PR DESCRIPTION

### What does this PR do?
Documents how to add authenticated user info to spans so that ASM (and APM) analysis can include user info.

### Motivation
DOCS-3322

### Preview

https://docs-staging.datadoghq.com/kari/docs-3322-asm-user-info/security_platform/application_security/setup_and_configure/#add-user-information-to-traces

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
