### PR TITLE
[doc] Include support of Glacier Instant Retrieval

### DIFF
--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -260,7 +260,7 @@ For Archives with a maximum scan size defined, all users need to estimate the sc
 
 You can [set a lifecycle configuration on your S3 bucket][1] to automatically transition your log archives to optimal storage classes.
 
-[Rehydration][2] supports all storage classes except for Glacier and Glacier Deep Archive. If you wish to rehydrate from archives in the Glacier or Glacier Deep Archive storage classes, you must first move them to a different storage class.
+[Rehydration][2] supports all storage classes except for Glacier and Glacier Deep Archive (Glacier Instant Retrieval is an exception). If you wish to rehydrate from archives in the Glacier or Glacier Deep Archive storage classes, you must first move them to a different storage class.
 
 [1]: https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-set-lifecycle-configuration-intro.html
 [2]: /logs/archives/rehydrating/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds that Glacier Instant Retrieval is supported to our archive documentation.

### Motivation
Cutsomer occasionally ask if this is supprted since our documentation mentions we don't support Glacier.

Approved by log pm Anshum Garg in [this #support-logs thread](https://dd.slack.com/archives/C6QR6DXJ4/p1650655075092819?thread_ts=1650578423.153339&cid=C6QR6DXJ4)

Tested by Stephen Lechner (used to be a product solutions architect for logs, no longer works here) and noted internally [here](https://datadoghq.atlassian.net/wiki/spaces/TS/pages/348525510/Logs+Archives+FAQ+Troubleshooting#:~:text=And%20btw%2C%20our%20rehydration%20does%20support%20the%20%E2%80%9CGlacier%20Instant%20Retrieval%E2%80%9D%20class%20(since%20it%E2%80%99s%20got%20the%20%E2%80%9CGlacier%E2%80%9D%20word%20in%20it%20and%20since%20we%20don%E2%80%99t%20support%20all%20Glacier%20classes%2C%20sometimes%20customers%20ask%20about%20that).).

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
