### PR TITLE
Update heat map widget event overlays instructions for Event Explorer

### DIFF
--- a/content/en/dashboards/widgets/heat_map.md
+++ b/content/en/dashboards/widgets/heat_map.md
@@ -31,15 +31,15 @@ Make a selection in the "`avg`/`max`/`min`/`sum by`/etc." control to see your da
 
 ### Options
 
-#### Event overlay
+#### Event overlays
 
-Add events from related systems to add more context to your graph. For example, you can add GitHub commits, Jenkins deploys, or Docker creation events. Expand the **Event Overlays** section and enter a query to display those events. Use the same query format as for the [Event Stream][1], for example:
+Add events from related systems to add more context to your graph. For example, you can add GitHub commits, events in the staging environment, or events from containers that match a prefix. Expand the **Event Overlays** section and enter a query to display those events. Use the same query format as for the [Event Explorer][1]. See the examples in the table below:
 
-| Query                       | Description                                                |
-|-----------------------------|------------------------------------------------------------|
-| `sources:jenkins`           | Shows all events from the Jenkins source.                  |
-| `tag:role:web`              | Shows all events with the tag `role:web`.                  |
-| `tags:$<TEMPLATE_VARIABLE>` | Shows all events from the selected [Template Variable][2]. |
+| Query                     | Description                                                      |
+|---------------------------|------------------------------------------------------------------|
+| `source:(github OR chef)` | Show events from GitHub OR Chef.                                 |
+| `env:staging`             | Show events with the tag `env:staging`.                          |
+| `container_id:foo*`       | Show events from all containers with an ID beginning with `foo`. |
 
 #### Y-axis controls
 
@@ -65,9 +65,9 @@ The following configuration options are available:
 
 ## API
 
-This widget can be used with the **Dashboards API**. See the [Dashboards API documentation][3] for additional reference.
+This widget can be used with the **Dashboards API**. See the [Dashboards API][2] for details.
 
-The dedicated [widget JSON schema definition][4] for the heat map widget is:
+See the table below for the [widget JSON schema definition][3] for the heat map widget:
 
 {{< dashboards-widgets-api >}}
 
@@ -75,7 +75,6 @@ The dedicated [widget JSON schema definition][4] for the heat map widget is:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /events/
-[2]: /dashboards/template_variables/
-[3]: /api/v1/dashboards/
-[4]: /dashboards/graphing_json/widget_json/
+[1]: /events/explorer/#search-syntax
+[2]: /api/v1/dashboards/
+[3]: /dashboards/graphing_json/widget_json/

--- a/content/en/dashboards/widgets/heat_map.md
+++ b/content/en/dashboards/widgets/heat_map.md
@@ -37,7 +37,7 @@ Add events from related systems to add more context to your graph. For example, 
 
 | Query                     | Description                                                      |
 |---------------------------|------------------------------------------------------------------|
-| `source:(github OR chef)` | Show events from GitHub OR Chef.                                 |
+| `source:(github OR chef)` | Show events from GitHub or Chef.                                 |
 | `env:staging`             | Show events with the tag `env:staging`.                          |
 | `container_id:foo*`       | Show events from all containers with an ID beginning with `foo`. |
 


### PR DESCRIPTION
### What does this PR do?
Updates the Event Overlays instructions for the heat map widget to use the new Event Explorer syntax. 
- Updates the table of examples. 
- Changes a link to go to the Event Explorer search syntax
- Minor wording fixes for problems I noticed while editing the page

### Motivation
The Event Explorer is now the system of record for Events in Datadog. All systems that rely on Events, including the heat map widget, now use the Event Explorer search syntax rather than the older Event Stream syntax.

Requested by a support engineer via Slack.

### Preview
https://docs-staging.datadoghq.com/uchen/heat-map/dashboards/widgets/heat_map/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
