### PR TITLE
Add Max Memory limit section for trace-agent

### DIFF
--- a/content/en/tracing/troubleshooting/agent_rate_limits.md
+++ b/content/en/tracing/troubleshooting/agent_rate_limits.md
@@ -37,4 +37,4 @@ CRITICAL | (pkg/trace/api/api.go:703 in watchdog) | Killing process. Memory thre
 CRITICAL | (pkg/trace/osutil/file.go:39 in Exitf) | OOM
 ```
 
-To increase the max memory limit for the Agent, configure the `max_memory` attribute within the Agent's configuration file (underneath the `apm_config:` section). For containerized deployments (for example, Docker or Kubernetes), use the `DD_APM_MAX_MEMORY` environment variable.
+To increase the max memory limit for the Agent, configure the `max_memory` attribute in the `apm_config` section of the Agent's configuration file. For containerized deployments (for example, Docker or Kubernetes), use the `DD_APM_MAX_MEMORY` environment variable.

--- a/content/en/tracing/troubleshooting/agent_rate_limits.md
+++ b/content/en/tracing/troubleshooting/agent_rate_limits.md
@@ -27,3 +27,14 @@ ERROR | (pkg/trace/logutil/throttled.go:38 in log) | http.Server: http: Accept e
 ```
 
 To increase the APM connection limit for the Agent, configure the `connection_limit` attribute within the Agent's configuration file (underneath the `apm_config:` section). For containerized deployments (for example, Docker or Kubernetes), use the `DD_APM_CONNECTION_LIMIT` environment variable.
+
+## Max memory limit
+
+If you encounter the following error message in your Agent logs, the max memory usage of Agent has been exceeded by 150%:
+
+```
+CRITICAL | (pkg/trace/api/api.go:703 in watchdog) | Killing process. Memory threshold exceeded: 8238.08M / 715.26M
+CRITICAL | (pkg/trace/osutil/file.go:39 in Exitf) | OOM
+```
+
+To increase the max memory limit for the Agent, configure the `max_memory` attribute within the Agent's configuration file (underneath the `apm_config:` section). For containerized deployments (for example, Docker or Kubernetes), use the `DD_APM_MAX_MEMORY` environment variable.

--- a/content/en/tracing/troubleshooting/agent_rate_limits.md
+++ b/content/en/tracing/troubleshooting/agent_rate_limits.md
@@ -30,7 +30,7 @@ To increase the APM connection limit for the Agent, configure the `connection_li
 
 ## Max memory limit
 
-If you encounter the following error message in your Agent logs, the max memory usage of Agent has been exceeded by 150%:
+If you encounter the following error message in your Agent logs, it means the Agent has exceeded the max memory usage by 150%:
 
 ```
 CRITICAL | (pkg/trace/api/api.go:703 in watchdog) | Killing process. Memory threshold exceeded: 8238.08M / 715.26M


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Document `apm_config.max_memory`.

### Motivation
<!-- What inspired you to submit this pull request?-->

`apm_config.max_memory` is only documented the [config_template.yaml](https://github.com/DataDog/datadog-agent/blob/9f8ee2e2c489eed9b4a47b1f9b704bb94d21939d/pkg/config/config_template.yaml#L1078-L1085).

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
