### PR TITLE
Document AD annotations v2 (Agent 7.36+)

### DIFF
--- a/content/en/agent/kubernetes/integrations.md
+++ b/content/en/agent/kubernetes/integrations.md
@@ -55,7 +55,78 @@ To set up integrations that are not compatible with standard Autodiscovery, you 
 ## Configuration
 
 {{< tabs >}}
-{{% tab "Kubernetes" %}}
+{{% tab "Kubernetes (AD v2)" %}}
+
+**Note:** AD Annotations v2 was introduced in Datadog Agent 7.36 to simplify integration configuration. For previous versions of the Datadog Agent, use AD Annotations v1.
+
+Integration templates can be stored in your Kubernetes pod annotations. With Autodiscovery, the Agent detects if it's running on Kubernetes and automatically searches all pod annotations for integration templates.
+
+To apply a specific configuration to a given container, Autodiscovery identifies containers by **name**, NOT image. It tries to match `<CONTAINER_IDENTIFIER>` to `.spec.containers[0].name`, not `.spec.containers[0].image`. To configure your Datadog integration Autodiscovery on a given `<CONTAINER_IDENTIFIER>` within your pod, add the following annotations to your pod:
+
+```yaml
+apiVersion: v1
+kind: Pod
+# (...)
+metadata:
+  name: '<POD_NAME>'
+  annotations:
+    ad.datadoghq.com/<CONTAINER_IDENTIFIER>.checks: |
+      {
+        "<INTEGRATION_NAME>": {
+          "init_config": <INIT_CONFIG>,
+          "instances": [<INSTANCE_CONFIG>]
+        }
+      }
+    # (...)
+spec:
+  containers:
+    - name: '<CONTAINER_IDENTIFIER>'
+# (...)
+```
+
+`init_config` is usually an empty `{}`, and with AD Annotations v2 it became optional.
+
+To apply two different integration templates to two different containers: `<CONTAINER_IDENTIFIER_1>` and `<CONTAINER_IDENTIFIER_2>` within your pod, add the following annotations to your pod:
+
+```yaml
+apiVersion: v1
+kind: Pod
+# (...)
+metadata:
+  name: '<POD_NAME>'
+  annotations:
+    ad.datadoghq.com/<CONTAINER_IDENTIFIER_1>.checks: |
+      {
+        "<INTEGRATION_NAME_1>": {
+          "init_config": <INIT_CONFIG_1>,
+          "instances": [<INSTANCE_CONFIG_1>]
+        }
+      }
+    ad.datadoghq.com/<CONTAINER_IDENTIFIER_2>.checks: |
+      {
+        "<INTEGRATION_NAME_2>": {
+          "init_config": <INIT_CONFIG_2>,
+          "instances": [<INSTANCE_CONFIG_2>]
+        }
+      }
+spec:
+  containers:
+    - name: '<CONTAINER_IDENTIFIER_1>'
+    # (...)
+    - name: '<CONTAINER_IDENTIFIER_2>'
+# (...)
+```
+
+If you define your Kubernetes pods directly with `kind: Pod`, add each pod's annotations directly under its `metadata` section. If you define pods indirectly with replication controllers, replica sets, or deployments, add pod annotations under `.spec.template.metadata`.
+
+**Note:** As a best practice in containerized environments, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][1] documentation.
+
+
+
+[1]: /getting_started/tagging/unified_service_tagging
+{{% /tab %}}
+
+{{% tab "Kubernetes (AD v1)" %}}
 
 Integration templates can be stored in your Kubernetes pod annotations. With Autodiscovery, the Agent detects if it's running on Kubernetes and automatically searches all pod annotations for integration templates.
 
@@ -105,22 +176,6 @@ spec:
 If you define your Kubernetes pods directly with `kind: Pod`, add each pod's annotations directly under its `metadata` section. If you define pods indirectly with replication controllers, replica sets, or deployments, add pod annotations under `.spec.template.metadata`.
 
 **Note:** As a best practice in containerized environments, Datadog recommends using unified service tagging when assigning tags. Unified service tagging ties Datadog telemetry together through the use of three standard tags: `env`, `service`, and `version`. To learn how to configure your environment with unified tagging, refer to the dedicated [unified service tagging][1] documentation.
-
-
-### Tolerate unready pods
-
-By default, `unready` pods are ignored when the Datadog Agent schedules checks, so metrics, service checks, and logs are not collected from these pods. To override this behavior, set the annotation `ad.datadoghq.com/tolerate-unready` to `"true"`. For example:
-
-```yaml
-apiVersion: v1
-kind: Pod
-# (...)
-metadata:
-  name: '<POD_NAME>'
-  annotations:
-    ad.datadoghq.com/tolerate-unready: "true"
-  ...
-```
 
 
 [1]: /getting_started/tagging/unified_service_tagging
@@ -266,12 +321,66 @@ See [Autodiscovery Container Identifiers][2] for information on the `<INTEGRATIO
 {{% /tab %}}
 {{< /tabs >}}
 
+### Tolerate unready pods
+
+By default, `unready` pods are ignored when the Datadog Agent schedules checks, so metrics, service checks, and logs are not collected from these pods. To override this behavior, set the annotation `ad.datadoghq.com/tolerate-unready` to `"true"`. For example:
+
+```yaml
+apiVersion: v1
+kind: Pod
+# (...)
+metadata:
+  name: '<POD_NAME>'
+  annotations:
+    ad.datadoghq.com/tolerate-unready: "true"
+  ...
+```
+
 ## Examples
 
 ### Datadog Redis integration
 
 {{< tabs >}}
-{{% tab "Kubernetes" %}}
+{{% tab "Kubernetes (AD v2)" %}}
+
+**Note:** AD Annotations v2 was introduced in Datadog Agent 7.36 to simplify integration configuration. For previous versions of the Datadog Agent, use AD Annotations v1.
+
+The following pod annotation defines the integration template for `redis` containers with a custom `password` parameter:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis
+  annotations:
+    ad.datadoghq.com/redis.checks: |
+      {
+        "redisdb": {
+          "instances": [
+            {
+              "host": "%%host%%",
+              "port":"6379",
+              "password":"%%env_REDIS_PASSWORD%%"
+            }
+          ]
+        }
+      }
+  labels:
+    name: redis
+spec:
+  containers:
+    - name: redis
+      image: redis:latest
+      ports:
+        - containerPort: 6379
+```
+
+**Note**: The `"%%env_<ENV_VAR>%%"` template variable logic is used to avoid storing the password in plain text, hence the `REDIS_PASSWORD` environment variable must be passed to the Agent. See the [Autodiscovery template variable documentation][1].
+
+[1]: /agent/faq/template_variables/
+{{% /tab %}}
+
+{{% tab "Kubernetes (AD v1)" %}}
 
 The following pod annotation defines the integration template for `redis` containers with a custom `password` parameter:
 
@@ -394,7 +503,53 @@ Configurations below apply to an Apache container image with the `<CONTAINER_IDE
 Check names are `apache`, `http_check`, their `<INIT_CONFIG>`, and `<INSTANCE_CONFIG>`. Full configurations can be found in their respective documentation page: [Datadog-Apache integration][10], [Datadog-HTTP check integration][11].
 
 {{< tabs >}}
-{{% tab "Kubernetes" %}}
+{{% tab "Kubernetes (AD v2)" %}}
+
+**Note:** AD Annotations v2 was introduced in Datadog Agent 7.36 to simplify integration configuration. For previous versions of the Datadog Agent, use AD Annotations v1.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: apache
+  annotations:
+    ad.datadoghq.com/apache.checks: |
+      {
+        "apache": {
+          "instances": [
+            {
+              "apache_status_url": "http://%%host%%/server-status?auto"
+            }
+          ]
+        },
+        "http_check": {
+          "instances": [
+            {
+              "name": "<WEBSITE_1>",
+              "url": "http://%%host%%/website_1",
+              "timeout": 1
+            },
+            {
+              "name": "<WEBSITE_2>",
+              "url": "http://%%host%%/website_2",
+              "timeout": 1
+            }
+          ]
+        }
+      }
+  labels:
+    name: apache
+spec:
+  containers:
+    - name: apache
+      image: httpd
+      ports:
+        - containerPort: 80
+```
+
+{{% /tab %}}
+
+{{% tab "Kubernetes (AD v1)" %}}
 
 ```yaml
 apiVersion: v1

--- a/content/en/agent/kubernetes/integrations.md
+++ b/content/en/agent/kubernetes/integrations.md
@@ -84,7 +84,7 @@ spec:
 # (...)
 ```
 
-`init_config` is usually an empty `{}`, and with AD Annotations v2 it became optional.
+`init_config` is usually an empty `{}`. In AD Annotations v2, it is optional.
 
 To apply two different integration templates to two different containers: `<CONTAINER_IDENTIFIER_1>` and `<CONTAINER_IDENTIFIER_2>` within your pod, add the following annotations to your pod:
 
@@ -323,7 +323,7 @@ See [Autodiscovery Container Identifiers][2] for information on the `<INTEGRATIO
 
 ### Tolerate unready pods
 
-By default, `unready` pods are ignored when the Datadog Agent schedules checks, so metrics, service checks, and logs are not collected from these pods. To override this behavior, set the annotation `ad.datadoghq.com/tolerate-unready` to `"true"`. For example:
+By default, `unready` pods are ignored when the Datadog Agent schedules checks. Therefore, metrics, service checks, and logs are not collected from these pods. To override this behavior, set the annotation `ad.datadoghq.com/tolerate-unready` to `"true"`. For example:
 
 ```yaml
 apiVersion: v1

--- a/content/en/getting_started/containers/autodiscovery.md
+++ b/content/en/getting_started/containers/autodiscovery.md
@@ -43,6 +43,39 @@ In the figure above, there is a host node with three pods, including a Redis pod
 
 The Redis spec in this example includes the following annotations:
 
+{{< tabs >}}
+
+{{% tab "AD Annotations v2 (Agent 7.36+)" %}}
+```yaml
+labels:
+  tags.datadoghq.com/redis.env: "prod"
+  tags.datadoghq.com/redis.service: "my-redis"
+  tags.datadoghq.com/redis.version: "6.0.3"
+annotations:
+  ad.datadoghq.com/redis.checks: |
+    {
+      "redisdb": {
+        "init_config": {},
+        "instances": [
+          {
+            "host": "%%host%%",
+            "port":"6379",
+            "password":"%%env_REDIS_PASSWORD%%"
+          }
+        ]
+      }
+    }
+  ad.datadoghq.com/redis.logs: '[{"source":"redis"}]'
+```
+
+In the example above, the `tags.datadoghq.com` labels set the `env`, `service`, and even `version` as tags for all logs and metrics emitted for the Redis pod. These standard labels are part of [Unified Service Tagging][1]. As a best practice, Datadog recommends using unified service tagging when configuring tags and environment variables.
+
+`redisdb` is the name of the check to run. `init_config` contains some configuration parameters, such as minimum collection interval, and is optional. Each item in `instances` represents the configuration to run for one instance of a check. **Note**: In this example, `%%host%%` is a template variable that is dynamically populated with your container's IP.
+
+[1]: /getting_started/tagging/unified_service_tagging
+{{% /tab %}}
+
+{{% tab "AD Annotations v1" %}}
 ```yaml
 labels:
   tags.datadoghq.com/redis.env: "prod"
@@ -62,9 +95,14 @@ annotations:
   ad.datadoghq.com/redis.logs: '[{"source":"redis"}]'
 ```
 
-In the example above, the `tags.datadoghq.com` labels set the `env`, `service`, and even `version` as tags for all logs and metrics emitted for the Redis pod. These standard labels are part of [Unified Service Tagging][3]. As a best practice, Datadog recommends using unified service tagging when configuring tags and environment variables.
+In the example above, the `tags.datadoghq.com` labels set the `env`, `service`, and even `version` as tags for all logs and metrics emitted for the Redis pod. These standard labels are part of [Unified Service Tagging][1]. As a best practice, Datadog recommends using unified service tagging when configuring tags and environment variables.
 
 `check_names` includes the names of the check to run, and `init_configs` contains some configuration parameters, such as minimum collection interval. Each item in `instances` represents the configuration to run for one instance of a check. **Note**: In this example, `%%host%%` is a template variable that is dynamically populated with your container's IP.
+
+[1]: /getting_started/tagging/unified_service_tagging
+{{% /tab %}}
+
+{{< /tabs >}}
 
 From this, the Agent generates a static check configuration.
 
@@ -73,7 +111,7 @@ From this, the Agent generates a static check configuration.
 Setting up Autodiscovery for your infrastructure requires the following two steps:
 
 1. [Enable Autodiscovery](#enable-autodiscovery) for your Datadog Agent.
-2. Create [integration-specific configuration templates](#integration-templates) for each service you wish to monitor. **Note**: Datadog provides auto-configuration templates for [some common containerized services][4], including Apache and Redis.
+2. Create [integration-specific configuration templates](#integration-templates) for each service you wish to monitor. **Note**: Datadog provides auto-configuration templates for [some common containerized services][3], including Apache and Redis.
 
 ### Enable Autodiscovery
 
@@ -93,50 +131,9 @@ The complete list of automatically detected features is available in the `datado
 
 ### Integration templates
 
-Once Autodiscovery is enabled, the Datadog Agent automatically attempts Autodiscovery for several [services][4], including Apache and Redis, based on default Autodiscovery configuration files.
+Once Autodiscovery is enabled, the Datadog Agent automatically attempts Autodiscovery for several [services][3], including Apache and Redis, based on default Autodiscovery configuration files.
 
-You can define an integration template in multiple forms: as Kubernetes pod annotations, Docker labels, a configuration file mounted within the Agent, a ConfigMap, and key-value stores.
-
-In the following example, the `tags.datadoghq.com` Kubernetes labels are used to tag pod's data with `env`, `service`, and `version`.
-
-The Redis integration template is defined through Kubernetes pod annotations. It contains a custom `password` parameter and tags all its logs with the correct `source`.
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  ## name of your Pod
-  name: my-redis
-  labels:
-    ## set standard labels for unified service tagging
-    tags.datadoghq.com/redis.env: prod
-    tags.datadoghq.com/redis.service: my-redis
-    tags.datadoghq.com/redis.version: "6.0.3"
-  annotations:
-    ## names of check; matches name in integrations_core repo
-    ad.datadoghq.com/redis.check_names: '["redisdb"]'
-    ## some configs, like minimum collection interval
-    ad.datadoghq.com/redis.init_configs: '[{}]'
-    ad.datadoghq.com/redis.instances: |
-      [
-        ## config to run for one instance of check
-        {
-          "host": "%%host%%",
-          "port":"6379",
-          "password":"%%env_REDIS_PASSWORD%%"
-        }
-      ]
-    ## setup for logs collection
-    ad.datadoghq.com/redis.logs: '[{"source":"redis"}]'
-spec:
-  containers:
-    - name: redis
-      image: httpd
-      ports:
-        - containerPort: 80
-```
-
-To use Autodiscovery with other services, define templates for the services you wish to monitor. See the [Autodiscovery Integration Templates][5] documentation for further details.
+You can define an integration template in multiple forms: as Kubernetes pod annotations, Docker labels, a configuration file mounted within the Agent, a ConfigMap, and key-value stores. See the [Autodiscovery Integration Templates][4] documentation for further details.
 
 ## Further Reading
 
@@ -144,6 +141,5 @@ To use Autodiscovery with other services, define templates for the services you 
 
 [1]: /agent/guide/ad_identifiers/
 [2]: /agent/faq/template_variables/
-[3]: /getting_started/tagging/unified_service_tagging
-[4]: /agent/faq/auto_conf/
-[5]: /agent/kubernetes/integrations/
+[3]: /agent/faq/auto_conf/
+[4]: /agent/kubernetes/integrations/


### PR DESCRIPTION
### What does this PR do?

Documents Autodiscovery Annotations v2, available when Agent 7.36 is released.

### Motivation

New feature implemented in https://github.com/DataDog/datadog-agent/pull/11274

### Preview

https://docs-staging.datadoghq.com/juliogreff/adv2/getting_started/agent/autodiscovery/
https://docs-staging.datadoghq.com/juliogreff/adv2/agent/kubernetes/integrations/

### Additional Notes

Merge this after the release of Agent 7.36.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
