### PR TITLE
Document backwards incompatible `kube_job` tag in KSM core

### DIFF
--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -133,6 +133,9 @@ The Kubernetes State Metrics Core check is not backward compatible, be sure to r
 `kubernetes_state.container.waiting` and `kubernetes_state.container.status_report.count.waiting`
 : These metrics no longer emit a 0 value if no pods are waiting. They only report non-zero values.
 
+`kube_job`
+: The `kube_job` tag in `kubernetes_state` contained the `CronJob` name if the `Job` had that as an owner, and otherwise it contained the `Job` name itself. In `kubernetes_state_core`, `kube_job` always contains the `Job` name itself, and a new `kube_cronjob` tag contains the `CronJob` name. When migrating to `kubernetes_state_core`, it's recommended to use the new tag, or by using `kube_job:foo*` (where `foo` is the `CronJob` name) in queries for filtering.
+
 {{< tabs >}}
 {{% tab "Helm" %}}
 

--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -134,7 +134,7 @@ The Kubernetes State Metrics Core check is not backward compatible, be sure to r
 : These metrics no longer emit a 0 value if no pods are waiting. They only report non-zero values.
 
 `kube_job`
-: The `kube_job` tag value in `kubernetes_state` is the `CronJob` name if the `Job` had that as an owner, otherwise it is the `Job` name. In `kubernetes_state_core`, the `kube_job` tag value is always the `Job` name, and a new `kube_cronjob` tag key is added with the `CronJob` name as the tag value. When migrating to `kubernetes_state_core`, it's recommended to use the new tag or `kube_job:foo*`, where `foo` is the `CronJob` name, for query filters.
+: In `kubernetes_state`, the `kube_job` tag value is the `CronJob` name if the `Job` had `CronJob` as an owner, otherwise it is the `Job` name. In `kubernetes_state_core`, the `kube_job` tag value is always the `Job` name, and a new `kube_cronjob` tag key is added with the `CronJob` name as the tag value. When migrating to `kubernetes_state_core`, it's recommended to use the new tag or `kube_job:foo*`, where `foo` is the `CronJob` name, for query filters.
 
 {{< tabs >}}
 {{% tab "Helm" %}}

--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -134,7 +134,7 @@ The Kubernetes State Metrics Core check is not backward compatible, be sure to r
 : These metrics no longer emit a 0 value if no pods are waiting. They only report non-zero values.
 
 `kube_job`
-: The `kube_job` tag in `kubernetes_state` contained the `CronJob` name if the `Job` had that as an owner, and otherwise it contained the `Job` name itself. In `kubernetes_state_core`, `kube_job` always contains the `Job` name itself, and a new `kube_cronjob` tag contains the `CronJob` name. When migrating to `kubernetes_state_core`, it's recommended to use the new tag, or by using `kube_job:foo*` (where `foo` is the `CronJob` name) in queries for filtering.
+: The `kube_job` tag value in `kubernetes_state` is the `CronJob` name if the `Job` had that as an owner, otherwise it is the `Job` name. In `kubernetes_state_core`, the `kube_job` tag value is always the `Job` name, and a new `kube_cronjob` tag key is added with the `CronJob` name as the tag value. When migrating to `kubernetes_state_core`, it's recommended to use the new tag or `kube_job:foo*`, where `foo` is the `CronJob` name, for query filters.
 
 {{< tabs >}}
 {{% tab "Helm" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Document backwards incompatible `kube_job` tag in KSM core

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/juliogreff/ksm-job/integrations/kubernetes_state_core/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
