### PR TITLE
Change enrichment table size limit for uploads

### DIFF
--- a/content/en/logs/guide/enrichment-tables.md
+++ b/content/en/logs/guide/enrichment-tables.md
@@ -31,7 +31,7 @@ Click **New Enrichment Table +**, then upload a CSV file, name the appropriate c
 
 {{< img src="logs/guide/enrichment-tables/configure-enrichment-table.png" alt="Create an Enrichment Table" style="width:100%;">}}
 
-**Note**: The manual CSV upload method supports files up to 5MB.
+**Note**: The manual CSV upload method supports files up to 4MB.
 
 {{% /tab %}}
 


### PR DESCRIPTION
### What does this PR do?
Update the size

### Motivation
The size limit was changed and we were still referring to the old one.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/nils/enrichment-tables-size-limit-update/logs/guide/enrichment-tables/?tab=manualupload#overview

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
