### PR TITLE
improve wording in agent dual shipping guide

### DIFF
--- a/content/en/agent/guide/dual-shipping.md
+++ b/content/en/agent/guide/dual-shipping.md
@@ -268,7 +268,7 @@ The `is_reliable` setting tells the Agent to treat this endpoint with the same p
 
 For example, if you're sending data to the main endpoint and an additional endpoint with `is_reliable: true`, and one endpoint becomes unavailable, data continues to flow to the other endpoint. If both endpoints become unavailable, the Agent stops reading and sending data until at least one endpoint recovers. This ensures all data makes it to at least one reliable endpoint.
 
-The `is_reliable` setting defaults to `false`. Datadog recommends that you set `is_reliable` to `true`. Unreliable endpoints only send data if at least one reliable endpoint is available. You may define multiple additional endpoints with mixed use of `is_reliable`.
+The `is_reliable` setting defaults to `false`. Datadog recommends that you set `is_reliable` to `true`. Unreliable endpoints only send data if at least one reliable endpoint is available. You may define multiple additional endpoints with a mixed usage of `is_reliable` values.
 
 You can add the YAML configuration to your `datadog.yaml` or launch the Agent with the appropriate environment variables.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Re-word a little bit. `logs` -> `data` since this applies to more features than just logs. 

### Motivation
Feedback from team. 

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/brian.floersch/dual-shipping-updates/agent/guide/dual-shipping/?tab=metricsservicechecks

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
