### PR TITLE
Fix the autodiscovery container link

### DIFF
--- a/content/en/agent/kubernetes/integrations.md
+++ b/content/en/agent/kubernetes/integrations.md
@@ -255,13 +255,14 @@ The `values.yaml` file contains a `confd` section to define both static and Auto
       instances:
         - <INSTANCES_CONFIG>
 ```
-See the [Autodiscovery Container Identifiers][1] documentation for information on the `<INTEGRATION_AUTODISCOVERY_IDENTIFIER>`.
+See [Autodiscovery Container Identifiers][2] for information on the `<INTEGRATION_AUTODISCOVERY_IDENTIFIER>`.
 
-**Note**: The Helm chart has two `confd` sections: one for Agent checks, and a second for cluster checks. If you are using the Cluster Agent and looking to configure Autodiscovery for a cluster check, follow the [cluster check configuration example][2] and make sure to include `cluster_check: true`. See the [Cluster Check documentation][3] for more context. 
+**Note**: The Helm chart has two `confd` sections: one for Agent checks, and a second for cluster checks. If you are using the Cluster Agent and looking to configure Autodiscovery for a cluster check, follow the [cluster check configuration example][3] and make sure to include `cluster_check: true`. See [Cluster Check][4] for more context.
 
 [1]: https://github.com/DataDog/helm-charts/blob/92fd908e3dd7b7149ce02de1fe859ae5ac717d03/charts/datadog/values.yaml#L315-L330
-[2]: https://github.com/DataDog/helm-charts/blob/92fd908e3dd7b7149ce02de1fe859ae5ac717d03/charts/datadog/values.yaml#L680-L689
-[3]: /agent/cluster_agent/clusterchecks
+[2]: /agent/guide/ad_identifiers/
+[3]: https://github.com/DataDog/helm-charts/blob/92fd908e3dd7b7149ce02de1fe859ae5ac717d03/charts/datadog/values.yaml#L680-L689
+[4]: /agent/cluster_agent/clusterchecks
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -379,7 +380,7 @@ The following configuration defines the integration template for Redis container
           port: 6379
           password: %%env_REDIS_PASSWORD%%
 ```
-As a result, the Agent now contains a `redis.yaml` file with the above configuration in the `/confd` directory.
+As a result, the Agent contains a `redis.yaml` file with the above configuration in the `/confd` directory.
 **Note**: The `"%%env_<ENV_VAR>%%"` template variable logic is used to avoid storing the password in plain text. Hence, you must pass the `REDIS_PASSWORD` environment variable to the Agent. See the [Autodiscovery template variable documentation][1].
 
 [1]: /agent/faq/template_variables/


### PR DESCRIPTION
### What does this PR do?
Adds a missing link target.

### Motivation
Support Engineer Mohammad Islam noticed this error. I examined the doc and concluded that the link target was missing. I added the missing link target and reordered the others on the Helm tab. Also fixed up some nearby wording to conform to our style guide.

DOCS-3417

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/uchen/short-image/agent/kubernetes/integrations/?tab=helm

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
