### PR TITLE
(DOCS-2988) Add cross-link banner for CI Vis and Synthetics

### DIFF
--- a/content/en/continuous_integration/_index.md
+++ b/content/en/continuous_integration/_index.md
@@ -22,6 +22,8 @@ further_reading:
 <div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
+<div class="alert alert-info">This page is about bringing your continuous integration (CI) metrics and data into Datadog dashboards. If you want to run Synthetic tests in your CI pipelines, see the <a href="/synthetics/cicd_integrations/" target="_blank">Synthetics and CI/CD</a> section.</div>
+
 Datadog Continuous Integration (CI) Visibility brings together information about CI test and pipeline results _plus_ data about CI performance, trends, and reliability, all into one place. Not only does it provide developers with the ability to dig into the reasons for a test or pipeline failure, to monitor trends in test suite execution times, or to see the effect a given commit has on the pipeline, it also gives build engineers visibility into cross-organization CI health and trends in pipeline performance over time.
 
 CI Visibility brings CI metrics and data into Datadog dashboards so you can communicate the health of your CI environment and focus your efforts in improving your team's ability to deliver quality code every time.

--- a/content/en/synthetics/cicd_integrations/_index.md
+++ b/content/en/synthetics/cicd_integrations/_index.md
@@ -27,6 +27,8 @@ further_reading:
 
 ---
 
+<div class="alert alert-info">This page is about running Synthetic tests in your continuous integration (CI) pipelines. If you want to bring your CI metrics and data into Datadog dashboards, see the <a href="/continuous_integration/" target="_blank">Continuous Integration Visibility</a> section.</div>
+
 ## Overview
 
 In addition to running tests at predefined intervals, you can run Datadog Synthetic tests on-demand by using the `@datadog/datadog-ci` package or the API. Run Datadog Synthetic tests in your continuous integration (CI) pipelines to block branches from being deployed and breaking your application in production.

--- a/content/en/synthetics/cicd_integrations/configuration.md
+++ b/content/en/synthetics/cicd_integrations/configuration.md
@@ -17,6 +17,8 @@ further_reading:
   text: "Use Datadog's GitHub Action to add Synthetic testing to workflows"
 ---
 
+<div class="alert alert-info">This page is about configuring Synthetic tests for your continuous integration (CI) pipelines. If you want to bring your CI metrics and data into Datadog dashboards, see the <a href="/continuous_integration/" target="_blank">Continuous Integration Visibility</a> section.</div>
+
 ## Overview
 
 Use the `@datadog-ci` NPM package to run Synthetic tests directly within your CI/CD pipeline. You can automatically halt a build, block a deployment, and roll back a deployment when a Synthetics test detects a regression. 


### PR DESCRIPTION
I added the banner to the 2 landing pages and the config page for
synthetics. The CI Visibility config pages didn't seem like they needed it
as much.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/heston/DOCS-2988/continuous_integration/
https://docs-staging.datadoghq.com/heston/DOCS-2988/synthetics/cicd_integrations/
https://docs-staging.datadoghq.com/heston/DOCS-2988/synthetics/cicd_integrations/configuration

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
