### PR TITLE
Fix link to DNS docs

### DIFF
--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -446,7 +446,7 @@ To set up on AWS ECS, see the [AWS ECS][1] documentation page.
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://docs.datadoghq.com/network_monitoring/dns/#setup
 [3]: https://www.redhat.com/en/blog/introduction-ebpf-red-hat-enterprise-linux-7
-[4]: /network_monitoring/performance/network_page#dns-resolution
+[4]: /network_monitoring/dns/
 [5]: https://docs.datadoghq.com/network_monitoring/performance/setup/?tab=agent#windows-systems
 [6]: https://docs.datadoghq.com/integrations/docker_daemon/
 [7]: https://docs.datadoghq.com/agent/kubernetes/


### PR DESCRIPTION
### What does this PR do?

Fixes an incorrect link to the NPM DNS docs 

### Motivation

It's currently the wrong link :(

### Preview


https://docs-staging.datadoghq.com/stephen.pinkerton/fix-npm-docs-link/network_monitoring/performance/setup/

