### PR TITLE
Correct typo of 'enabled' in cluster agent docs

### DIFF
--- a/content/en/agent/cluster_agent/setup.md
+++ b/content/en/agent/cluster_agent/setup.md
@@ -24,7 +24,7 @@ To set up the Datadog Cluster Agent on your Kubernetes cluster, follow these ste
 {{< tabs >}}
 {{% tab "Helm" %}}
 
-The Cluster Agent is enabeld by default since Helm Chart `2.7.0`.
+The Cluster Agent is enabled by default since Helm Chart `2.7.0`.
 
 To activate it on older versions or if you use a custom [datadog-values.yaml][1] overriding the `clusterAgent` key, update your [datadog-values.yaml][1] file with the following Cluster Agent configuration, then upgrade your Datadog Helm chart:
 
@@ -44,7 +44,7 @@ When set manually this token must be 32 alphanumeric characters.
 {{% /tab %}}
 {{% tab "Operator" %}}
 
-The Cluster Agent is enabeld by default since Datadog Operator `v0.7.0`.
+The Cluster Agent is enabled by default since Datadog Operator `v0.7.0`.
 
 To activate it explicitly, update your `DatadogAgent` object with the following configuration:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Corrects 2 minor typos of the word enabled on the cluster agent documentation

### Additional Notes
None
---

### Reviewer checklist
- [ ] Review the changed files.
- [NA] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
