### PR TITLE
Add  option to dogwrap command for EU

### DIFF
--- a/content/en/developers/guide/dogwrap.md
+++ b/content/en/developers/guide/dogwrap.md
@@ -21,9 +21,19 @@ To install from source:
 
 The minimum valid `dogwrap` command has the following layout:
 
+{{< site-region region="us,us3,us5,gov" >}}
 ```bash
 dogwrap -n <EVENT_TITLE> -k <DATADOG_API_KEY> "<COMMAND>"
 ```
+{{< /site-region >}}
+
+{{< site-region region="eu" >}}
+```bash
+dogwrap -n <EVENT_TITLE> -k <DATADOG_API_KEY> -s eu "<COMMAND>"
+```
+{{< /site-region >}}
+
+**Note**: The `dogwrap` command sends data to the US Datadog site by default. If you need to send data to the EU site, you must include the `-s eu` option.
 
 With the following placeholders:
 


### PR DESCRIPTION
Adds a note and adjusts the example command for the EU region.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/heston/DOCS-1917/developers/guide/dogwrap/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
