### PR TITLE
WEB-1761 - anchor link checking

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -367,6 +367,36 @@ manage_ignored_translations:on-schedule:
     - echo "Downloading ignored translation source files..."
     - manage_ignored_translation_files
 
+# This checks anchor links,
+# its too noisy to run all the time but we want some insight so its running on schedule
+link_checks:on-schedule:
+  <<: *base_template
+  <<: *live_rules
+  stage: post-deploy
+  cache: {}
+  environment: "live"
+  variables:
+    URL: ${LIVE_DOMAIN}
+    GIT_STRATEGY: none
+  dependencies:
+    - build_live
+  script:
+    - dog --config "$HOME/.dogrc" event post "documentation htmltest ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" --alert_type "info" --tags="${DEFAULT_TAGS}"
+    - find ./public -name "*.html" -exec sed -i -e "s#https://docs.datadoghq.com/#/#g" {} +
+    - find ./public -name "*.html" -exec sed -i -e "s#/api/v1/#/api/latest/#g" {} +
+    - find ./public -name "*.html" -exec sed -i -e "s#/api/v2/#/api/latest/#g" {} +
+    - "sed -i'' -e 's/CheckInternalHash: false/CheckInternalHash: true/' .htmltest.yml"
+    - htmltest
+  after_script:
+    - "[ -f /usr/local/bin/helpers.sh ] && source /usr/local/bin/helpers.sh"  # source helpers
+    - RESULT="⛈ htmltest result; the following issues were found:\n$(tail -n +2 ./tmp/.htmltest/htmltest.log)\n--------------------" # output all but first line
+    - if grep -q "not exist" tmp/.htmltest/htmltest.log; then notify_slack "${RESULT}" "#31b834"; fi
+  artifacts:
+    paths:
+      - ./tmp/.htmltest
+  interruptible: true
+  allow_failure: true
+
 test_missing_tms_live:
   <<: *base_template
   <<: *live_rules

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -12,7 +12,7 @@ CheckExternal: false
 CheckImages: false
 IgnoreAltMissing: true
 CheckInternal: true
-CheckInternalHash: true
+CheckInternalHash: false
 CheckMailto: false
 CheckMeta: false
 CheckScripts: false

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -12,7 +12,7 @@ CheckExternal: false
 CheckImages: false
 IgnoreAltMissing: true
 CheckInternal: true
-CheckInternalHash: false
+CheckInternalHash: true
 CheckMailto: false
 CheckMeta: false
 CheckScripts: false
@@ -26,6 +26,9 @@ IgnoreDirs:
   - api
   - fr
   - ja
+  - ko
+  - es
+  - security/default_rules
 IgnoreURLs:
   - "/?api/(v1|v2)/*"
   - play.google.com

--- a/layouts/shortcodes/integrations.html
+++ b/layouts/shortcodes/integrations.html
@@ -69,7 +69,7 @@
     <div id="integration-popper" class="dropdown-menu" style="display:none;" data-ref="mobilecontrols">
         <a data-ref="filter" data-filter="all" href="#all" class="dropdown-item sort-time">{{ i18n "all" }}</a>
         {{ range $i, $e := (sort ($.Scratch.Get "filters") "value" "asc") }}
-            <a data-ref="filter" data-filter=".cat-{{ replace $e "/" "" | urlize }}" href="#cat-{{ replace $e "/" "" | urlize }}" class="dropdown-item sort-time sort-{{ replace $e "/" "" | urlize }}">{{ $e | upper }}</a>
+            <a id="cat-{{ replace $e "/" "" | urlize }}" data-ref="filter" data-filter=".cat-{{ replace $e "/" "" | urlize }}" href="#cat-{{ replace $e "/" "" | urlize }}" class="dropdown-item sort-time sort-{{ replace $e "/" "" | urlize }}">{{ $e | upper }}</a>
         {{ end }}
     </div>
 </div>


### PR DESCRIPTION
### What does this PR do?

Enables the internal hash checks on a link checking job that runs on a schedule.
Its currently too noisy to run on every preview until we reduce the reports.

### Motivation

https://datadoghq.atlassian.net/browse/WEB-1761

### Preview

Not much to see but when released the scheduled run should trigger a full link check
https://docs-staging.datadoghq.com/david.jones/test-link/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
