### PR TITLE
Note Datadog Agent version requirement for Vector configuration

### DIFF
--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -38,6 +38,9 @@ it to Datadog and other destinations. Vector capabilities include:
 ## Configuration
 
 ### Agent configuration
+
+**Note:** below configuration requires Datadog Agent version >= 6/7.35.
+
 To send logs to Vector, update the Agent configuration file, `datadog.yaml`.
 For logs, update the following values in the `datadog.yaml` file:
 


### PR DESCRIPTION
These options were introduced in 6/7.35.

I'm not sure if there is a preferred way to call out notes like this.
Let me know if I should update it!

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
