### PR TITLE
[ci-visibility] Update `jest` instructions for `jest@28`

### DIFF
--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -73,7 +73,8 @@ module.exports = require('jest-environment-node')
 ```
 
 ### Jest@28
-If you are using `jest@28` and `jest-environment-node` you need to update the way the environment is required to follow [`jest` documentation][1]:
+
+If you are using `jest@28` and `jest-environment-node`, update your environment following the [`jest` documentation][1]:
 
 ```javascript
 
@@ -84,10 +85,8 @@ if (process.env.DD_ENV === 'ci') {
 module.exports = require('jest-environment-node').default
 ```
 
-
+Since `jest-environment-jsdom` is not included in `jest@28`, you need to install it separately.
 <div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-node</code>, <code>jest-environment-jsdom</code>, <code>jest-jasmine2</code>, and <code>jest-circus</code> (as of Jest 27) are installed together with <code>jest</code>, so they do not normally appear in your <code>package.json</code>. If you've extracted any of these libraries in your <code>package.json</code>, make sure the installed versions are the same as the one of <code>jest</code>.</div>
-
-<div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-jsdom</code> is no longer included in <code>jest@28</code>, so it must be installed separately.</div>
 
 
 Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -69,28 +69,25 @@ if (process.env.DD_ENV === 'ci') {
   require('dd-trace/ci/jest/env')
 }
 
-// jest-environment-jsdom is an option too
 module.exports = require('jest-environment-node')
 ```
 
 ### Jest@28
-If you are using `jest@28` and `jest-environment-node` you need to update the way the environment is required:
+If you are using `jest@28` and `jest-environment-node` you need to update the way the environment is required to follow [`jest` documentation][16]:
 
 ```javascript
 
-// Only activates test instrumentation on CI
 if (process.env.DD_ENV === 'ci') {
   require('dd-trace/ci/jest/env')
 }
 
-// jest-environment-jsdom is an option too
 module.exports = require('jest-environment-node').default
 ```
 
 
 <div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-node</code>, <code>jest-environment-jsdom</code>, <code>jest-jasmine2</code>, and <code>jest-circus</code> (as of Jest 27) are installed together with <code>jest</code>, so they do not normally appear in your <code>package.json</code>. If you've extracted any of these libraries in your <code>package.json</code>, make sure the installed versions are the same as the one of <code>jest</code>.</div>
 
-<div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-jsdom</code> is no longer included in <code>jest@28</code>, so it must be [installed separately][16].
+<div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-jsdom</code> is no longer included in <code>jest@28</code>, so it must be [installed separately][17].</div>
 
 
 Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -73,7 +73,7 @@ module.exports = require('jest-environment-node')
 ```
 
 ### Jest@28
-If you are using `jest@28` and `jest-environment-node` you need to update the way the environment is required to follow [`jest` documentation][16]:
+If you are using `jest@28` and `jest-environment-node` you need to update the way the environment is required to follow [`jest` documentation][1]:
 
 ```javascript
 
@@ -87,7 +87,7 @@ module.exports = require('jest-environment-node').default
 
 <div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-node</code>, <code>jest-environment-jsdom</code>, <code>jest-jasmine2</code>, and <code>jest-circus</code> (as of Jest 27) are installed together with <code>jest</code>, so they do not normally appear in your <code>package.json</code>. If you've extracted any of these libraries in your <code>package.json</code>, make sure the installed versions are the same as the one of <code>jest</code>.</div>
 
-<div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-jsdom</code> is no longer included in <code>jest@28</code>, so it must be [installed separately][17].</div>
+<div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-jsdom</code> is no longer included in <code>jest@28</code>, so it must be installed separately.</div>
 
 
 Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -68,7 +68,7 @@ module.exports = {
 if (process.env.DD_ENV === 'ci') {
   require('dd-trace/ci/jest/env')
 }
-
+// jest-environment-jsdom is an option too
 module.exports = require('jest-environment-node')
 ```
 

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -73,7 +73,25 @@ if (process.env.DD_ENV === 'ci') {
 module.exports = require('jest-environment-node')
 ```
 
+### Jest@28
+If you are using `jest@28` and `jest-environment-node` you need to update the way the environment is required:
+
+```javascript
+
+// Only activates test instrumentation on CI
+if (process.env.DD_ENV === 'ci') {
+  require('dd-trace/ci/jest/env')
+}
+
+// jest-environment-jsdom is an option too
+module.exports = require('jest-environment-node').default
+```
+
+
 <div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-node</code>, <code>jest-environment-jsdom</code>, <code>jest-jasmine2</code>, and <code>jest-circus</code> (as of Jest 27) are installed together with <code>jest</code>, so they do not normally appear in your <code>package.json</code>. If you've extracted any of these libraries in your <code>package.json</code>, make sure the installed versions are the same as the one of <code>jest</code>.</div>
+
+<div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-jsdom</code> is no longer included in <code>jest@28</code>, so it must be [installed separately][16].
+
 
 Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix instructions when using `jest@28`

### Motivation
Keep up to date with the latest `jest` release.

### Preview

https://docs-staging.datadoghq.com/juan-fernandez/update-jest-instructions/continuous_integration/setup_tests/javascript/?tab=jest

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
