### PR TITLE
fix head-based-default-mechanism links

### DIFF
--- a/content/en/tracing/guide/trace_ingestion_volume_control.md
+++ b/content/en/tracing/guide/trace_ingestion_volume_control.md
@@ -130,7 +130,7 @@ Read more about ingestion reasons in the [Ingestion Mechanisms documentation][2]
 [3]: /tracing/guide/metrics_namespace/
 [4]: /tracing/generate_metrics/
 [5]: /monitors/create/types/apm/?tab=analytics
-[6]: /tracing/trace_ingestion/mechanisms/#head-based-default-mechanism
+[6]: /tracing/trace_ingestion/mechanisms/#head-based-sampling
 [7]: /tracing/trace_retention/usage_metrics/
 [8]: /tracing/trace_ingestion/mechanisms#error-traces
 [9]: /tracing/trace_ingestion/mechanisms#rare-traces

--- a/content/en/tracing/trace_ingestion/mechanisms.md
+++ b/content/en/tracing/trace_ingestion/mechanisms.md
@@ -45,7 +45,7 @@ Set Agent's target traces-per-second in its main configuration file (`datadog.ya
 `ingestion_reason: rule`
 
 At the library level, more specific sampling configuration is available:
-- Set a specific sampling rate to apply to all root services, overriding the Agent's [default mechanism](#head-based-default-mechanism).
+- Set a specific sampling rate to apply to all root services, overriding the Agent's [default mechanism](#head-based-sampling).
 - Set a sampling rate for a specific root service.
 - Set a limit on the number of ingested traces per second.
 
@@ -104,7 +104,7 @@ span.SetTag(ext.ManualDrop, true)
 `ingestion_reason: analytic`
 
 <div class="alert alert-warning">
-On October 20, 2020, App Analytics was replaced by Tracing without Limits. This is a deprecated mechanism with configuration information relevant to legacy App Analytics. Instead, use new configuration options <a href="#head-based-default-mechanism">head-based sampling</a> to have full control over your data ingestion.
+On October 20, 2020, App Analytics was replaced by Tracing without Limits. This is a deprecated mechanism with configuration information relevant to legacy App Analytics. Instead, use new configuration options <a href="#head-based-sampling">head-based sampling</a> to have full control over your data ingestion.
 </div>
 
 If you need to sample a specific span, but don't need the full trace to be available, tracers allow a sampling rate to be configured for a single span. This span will be ingested at no less than the configured rate, even when the enclosing trace is dropped.

--- a/content/ja/tracing/guide/trace_ingestion_volume_control.md
+++ b/content/ja/tracing/guide/trace_ingestion_volume_control.md
@@ -130,7 +130,7 @@ _どの取り込みメカニズムが取り込み量の大部分を担ってい�
 [3]: /ja/tracing/guide/metrics_namespace/
 [4]: /ja/tracing/generate_metrics/
 [5]: /ja/monitors/create/types/apm/?tab=analytics
-[6]: /ja/tracing/trace_ingestion/mechanisms/#head-based-default-mechanism
+[6]: /ja/tracing/trace_ingestion/mechanisms/#head-based-sampling
 [7]: /ja/tracing/trace_retention/usage_metrics/
 [8]: /ja/tracing/trace_ingestion/mechanisms#error-traces
 [9]: /ja/tracing/trace_ingestion/mechanisms#rare-traces

--- a/content/ja/tracing/trace_ingestion/mechanisms.md
+++ b/content/ja/tracing/trace_ingestion/mechanisms.md
@@ -40,7 +40,7 @@ Agent のメインコンフィギュレーションファイル (`datadog.yaml`)
 `ingestion_reason: rule`
 
 ライブラリレベルでは、より具体的なサンプリング構成が可能です。
-- Agent の[デフォルトメカニズム](#head-based-default-mechanism)をオーバーライドし、すべてのルートサービスに適用する特定のサンプリングレートを設定します。
+- Agent の[デフォルトメカニズム](#head-based-sampling)をオーバーライドし、すべてのルートサービスに適用する特定のサンプリングレートを設定します。
 - 特定のルートサービスのサンプリングレートを設定します。
 - 1 秒間に取り込まれるトレース数の上限を設定します。
 
@@ -99,7 +99,7 @@ span.SetTag(ext.ManualDrop, true)
 `ingestion_reason: analytic`
 
 <div class="alert alert-warning">
-2020 年 10 月 20 日、App Analytics は Tracing without Limits に置き換わりました。これは、レガシーの App Analytics に関連する構成情報を持つ非推奨のメカニズムです。代わりに、新しい構成オプションの<a href="#head-based-default-mechanism">ヘッドベースサンプリング</a>を使用して、データ取り込みを完全に制御します。
+2020 年 10 月 20 日、App Analytics は Tracing without Limits に置き換わりました。これは、レガシーの App Analytics に関連する構成情報を持つ非推奨のメカニズムです。代わりに、新しい構成オプションの<a href="#head-based-sampling">ヘッドベースサンプリング</a>を使用して、データ取り込みを完全に制御します。
 </div>
 
 特定のスパンをサンプリングする必要があるが、トレース全体を利用する必要がない場合、トレーサーでは、単一のスパンに対してサンプリングレートを構成することが可能です。このスパンは、包含するトレースが削除された場合でも、構成されたレートを下回ることなく取り込まれます。


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fixes missing link.

### Motivation

The links to the head based sampling section of the ingestion mechanisms page were incorrect.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
