### PR TITLE
Change the Adevances configuration

### DIFF
--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -182,9 +182,9 @@ The autodiscovery configuration can be based on container names or kubernetes an
 ```yaml
 kubernetes_annotations:
   include:
-    - prometheus.io/scrape: "true"
+     prometheus.io/scrape: "true"
   exclude:
-    - prometheus.io/scrape: "false"
+     prometheus.io/scrape: "false"
 ```
 
 **Example:**


### PR DESCRIPTION
Changing the configuration example for this page https://docs.datadoghq.com/agent/kubernetes/prometheus/#advanced-configuration

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
The pr will delete two dashes from this configuration example https://docs.datadoghq.com/agent/kubernetes/prometheus/#advanced-configuration
The actual configuration is:
```
kubernetes_annotations:
  include:
    - prometheus.io/scrape: "true"
  exclude:
    - prometheus.io/scrape: "false"
```
but should be 
```
kubernetes_annotations:
  include:
     prometheus.io/scrape: "true"
  exclude:
     prometheus.io/scrape: "false"
```
### Motivation
<!-- What inspired you to submit this pull request?-->
the code is actually expecting a map of strings, and not array of map of strings.
https://github.com/DataDog/datadog-agent/blob/2aada62c3f6bc1776c6e72da11d34a2630024fa9/pkg/autodiscovery/common/types/prometheus.go#L139
This was also confirmed here: https://a.cl.ly/NQuNmng1
### Preview
<!-- Impacted pages preview links-->
https://docs.datadoghq.com/agent/kubernetes/prometheus/#advanced-configuration
<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
