### PR TITLE
[Tracer][W3C] Fix configuration know to use

### DIFF
--- a/content/en/tracing/setup_overview/setup/dotnet-core.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-core.md
@@ -487,15 +487,15 @@ The following configuration variables are for features that are available for us
 
 ### Headers extraction and injection
 
-The Datadog APM Tracer supports [B3][9] and [W3C][10] headers extraction and injection for distributed tracing.
+The Datadog APM Tracer supports [B3][9] and [W3C (TraceParent)][10] headers extraction and injection for distributed tracing.
 
-You can configure injection and extraction styles for distributed headers. 
+You can configure injection and extraction styles for distributed headers.
 
 The .NET Tracer supports the following styles:
 
 - Datadog: `Datadog`
 - B3: `B3`
-- W3C: `TraceParent`
+- W3C: `W3C`
 - B3 Single Header: `B3SingleHeader` or `B3 single header`
 
 You can use the following environment variables to configure injection and extraction styles:

--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -455,15 +455,15 @@ The following configuration variables are for features that are available for us
 
 ### Headers extraction and injection
 
-The Datadog APM Tracer supports [B3][8] and [W3C][9] headers extraction and injection for distributed tracing.
+The Datadog APM Tracer supports [B3][8] and [W3C (TraceParent)][9] headers extraction and injection for distributed tracing.
 
-You can configure injection and extraction styles for distributed headers. 
+You can configure injection and extraction styles for distributed headers.
 
 The .NET Tracer supports the following styles:
 
 - Datadog: `Datadog`
 - B3: `B3`
-- W3C: `TraceParent`
+- W3C: `W3C`
 - B3 Single Header: `B3SingleHeader` or `B3 single header`
 
 You can use the following environment variables to configure injection and extraction styles:


### PR DESCRIPTION
### What does this PR do?
Fixes the config value to use to rely on W3C headers

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/pierre/fix-b3/tracing/setup_overview/setup/dotnet-core?tab=windows

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
