### PR TITLE
APM: Update documentation for APM Ruby 1.0 release

### DIFF
--- a/content/en/agent/amazon_ecs/apm.md
+++ b/content/en/agent/amazon_ecs/apm.md
@@ -153,7 +153,7 @@ require 'ddtrace'
 require 'net/http'
 
 Datadog.configure do |c|
-  c.tracer hostname: Net::HTTP.get(URI('http://169.254.169.254/latest/meta-data/local-ipv4'))
+  c.agent.host = Net::HTTP.get(URI('http://169.254.169.254/latest/meta-data/local-ipv4'))
 end
 ```
 

--- a/content/en/agent/docker/apm.md
+++ b/content/en/agent/docker/apm.md
@@ -200,8 +200,8 @@ tracer.configure(
 
 ```ruby
 Datadog.configure do |c|
-  c.tracer hostname: 'datadog-agent',
-           port: 8126
+  c.agent.host = 'datadog-agent'
+  c.agent.port = 8126
 end
 ```
 

--- a/content/en/agent/guide/heroku-ruby.md
+++ b/content/en/agent/guide/heroku-ruby.md
@@ -670,7 +670,7 @@ Rails.application.configure do
 
   config.lograge.custom_options = lambda do |event|
     # Retrieves trace information for current thread
-    correlation = Datadog.tracer.active_correlation
+    correlation = Datadog::Tracing.correlation
 
     {
       # Adds IDs as tags to log output
@@ -707,7 +707,7 @@ Rails.application.configure do
 
   config.lograge.custom_options = lambda do |event|
     # Retrieves trace information for current thread
-    correlation = Datadog.tracer.active_correlation
+    correlation = Datadog::Tracing.correlation
 
     {
       # Adds IDs as tags to log output

--- a/content/en/continuous_integration/setup_tests/ruby.md
+++ b/content/en/continuous_integration/setup_tests/ruby.md
@@ -61,16 +61,16 @@ require 'datadog/ci'
 
 Datadog.configure do |c|
   # Only activates test instrumentation on CI
-  c.tracer.enabled = (ENV["DD_ENV"] == "ci")
+  c.tracing.enabled = (ENV["DD_ENV"] == "ci")
 
   # Configures the tracer to ensure results delivery
-  c.ci_mode.enabled = true
+  c.ci.enabled = true
 
   # The name of the service or library under test
   c.service = 'my-ruby-app'
 
   # Enables the Cucumber instrumentation
-  c.use :cucumber
+  c.ci.instrument :cucumber
 end
 ```
 
@@ -93,16 +93,16 @@ require 'datadog/ci'
 
 Datadog.configure do |c|
   # Only activates test instrumentation on CI
-  c.tracer.enabled = (ENV["DD_ENV"] == "ci")
+  c.tracing.enabled = (ENV["DD_ENV"] == "ci")
 
   # Configures the tracer to ensure results delivery
-  c.ci_mode.enabled = true
+  c.ci.enabled = true
 
   # The name of the service or library under test
   c.service = 'my-ruby-app'
 
   # Enables the RSpec instrumentation
-  c.use :rspec
+  c.ci.instrument :rspec
 end
 ```
 

--- a/content/en/security_platform/application_security/troubleshooting.md
+++ b/content/en/security_platform/application_security/troubleshooting.md
@@ -438,12 +438,12 @@ If the Rack integration was configured manually, sometimes a known issue prevent
 
 ```
 Datadog.configure do |c|
-  c.instrument :rails
+  c.tracing.instrument :rails
   ...
-  c.instrument :rack, web_service_name: "something", request_queuing: true
+  c.tracing.instrument :rack, web_service_name: "something", request_queuing: true
 ```
 
-If `c.instrument :rack` is present, remove it to see if the check passes.
+If `c.tracing.instrument :rack` is present, remove it to see if the check passes.
 
 #### Is ASM detecting HTTP request security threats?
 

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -320,12 +320,12 @@ def handler(event:, context:)
     Datadog::Lambda::wrap(event, context) do
         # Add custom tags to the lambda function span,
         # does NOT work when X-Ray tracing is enabled
-        current_span = Datadog.tracer.active_span
+        current_span = Datadog::Tracing.active_span
         current_span.set_tag('customer.id', '123456')
 
         some_operation()
 
-        Datadog.tracer.trace('hello.world') do |span|
+        Datadog::Tracing.trace('hello.world') do |span|
           puts "Hello, World!"
         end
 
@@ -342,7 +342,7 @@ end
 
 # Instrument the function
 def some_operation()
-    Datadog.tracer.trace('some_operation') do |span|
+    Datadog::Tracing.trace('some_operation') do |span|
         # Do something here
     end
 end

--- a/content/en/tracing/connect_logs_and_traces/ruby.md
+++ b/content/en/tracing/connect_logs_and_traces/ruby.md
@@ -19,77 +19,19 @@ In many cases, such as logging, it may be useful to correlate trace IDs to other
 
 #### Automatic injection
 
-For Rails applications using the default logger (`ActiveSupport::TaggedLogging`) or `lograge`, you can automatically enable trace correlation injection by setting the `rails` instrumentation configuration option `log_injection` to `true` or by setting environment variable `DD_LOGS_INJECTION=true`:
-
-```ruby
-# config/initializers/datadog.rb
-require 'ddtrace'
-
-Datadog.configure do |c|
-  c.use :rails, log_injection: true
-end
-```
-
-**Note:** For `lograge` users who have also defined `lograge.custom_options` in an `initializers/lograge.rb` configuration file, because Rails loads initializers in alphabetical order, automatic trace correlation may not take effect, since `initializers/datadog.rb` would be overwritten by the `initializers/lograge.rb` initializer. To support automatic trace correlation with _existing_ `lograge.custom_options`, use the [Manual Lograge](#lograge) configuration below.
+For Rails applications using the default logger (`ActiveSupport::TaggedLogging`), `lograge`, or `semantic_logger`, trace correlation injection is automatically configured.
 
 #### Manual injection
-##### Lograge
 
-After [setting up Lograge in a Rails application][1], manually modify the `custom_options` block in your environment configuration file (for example, `config/environments/production.rb`) to add the trace IDs.
-
-```ruby
-config.lograge.custom_options = lambda do |event|
-  # Retrieves trace information for current thread
-  correlation = Datadog.tracer.active_correlation
-
-  {
-    # Adds IDs as tags to log output
-    :dd => {
-      # To preserve precision during JSON serialization, use strings for large numbers
-      :trace_id => correlation.trace_id.to_s,
-      :span_id => correlation.span_id.to_s,
-      :env => correlation.env.to_s,
-      :service => correlation.service.to_s,
-      :version => correlation.version.to_s
-    },
-    :ddsource => ["ruby"],
-    :params => event.payload[:params].reject { |k| %w(controller action).include? k }
-  }
-end
-```
-
-##### `ActiveSupport::TaggedLogging`
-
-Rails applications that are configured with the default `ActiveSupport::TaggedLogging` logger can append correlation IDs as tags to log output. To enable Trace Correlation with `ActiveSupport::TaggedLogging`, in your Rails environment configuration file, add the following:
-
-```ruby
-Rails.application.configure do
-  config.log_tags = [proc { Datadog.tracer.active_correlation.to_s }]
-end
-
-# Given:
-# DD_ENV = 'production' (The name of the environment your application is running in.)
-# DD_SERVICE = 'billing-api' (Default service name of your application.)
-# DD_VERSION = '2.5.17' (The version of your application.)
-
-# Web requests will produce:
-# [dd.env=production dd.service=billing-api dd.version=2.5.17 dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Started GET "/articles" for 172.22.0.1 at 2019-01-16 18:50:57 +0000
-# [dd.env=production dd.service=billing-api dd.version=2.5.17 dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Processing by ArticlesController#index as */*
-# [dd.env=production dd.service=billing-api dd.version=2.5.17 dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206]   Article Load (0.5ms)  SELECT "articles".* FROM "articles"
-# [dd.env=production dd.service=billing-api dd.version=2.5.17 dd.trace_id=7110975754844687674 dd.span_id=7518426836986654206] Completed 200 OK in 7ms (Views: 5.5ms | ActiveRecord: 0.5ms)
-```
-
-### Logging in Ruby applications
-
-To add correlation IDs to your logger, add a log formatter which retrieves the correlation IDs with `Datadog.tracer.active_correlation`, then add them to the message.
+To add correlation IDs to your logger, add a log formatter which retrieves the correlation IDs with `Datadog::Tracing.correlation`, then add them to the message.
 
 To properly correlate with Datadog logging, be sure the following is present in the log message, in order as they appear:
 
- - `dd.env=<ENV>`: Where `<ENV>` is equal to `Datadog.tracer.active_correlation.env`. Omit if no environment is configured.
- - `dd.service=<SERVICE>`: Where `<SERVICE>` is equal to `Datadog.tracer.active_correlation.service`. Omit if no default service name is configured.
- - `dd.version=<VERSION>`: Where `<VERSION>` is equal to `Datadog.tracer.active_correlation.version`. Omit if no application version is configured.
- - `dd.trace_id=<TRACE_ID>`: Where `<TRACE_ID>` is equal to `Datadog.tracer.active_correlation.trace_id` or `0` if no trace is active during logging.
- - `dd.span_id=<SPAN_ID>`: Where `<SPAN_ID>` is equal to `Datadog.tracer.active_correlation.span_id` or `0` if no trace is active during logging.
+ - `dd.env=<ENV>`: Where `<ENV>` is equal to `Datadog::Tracing.correlation.env`. Omit if no environment is configured.
+ - `dd.service=<SERVICE>`: Where `<SERVICE>` is equal to `Datadog::Tracing.correlation.service`. Omit if no default service name is configured.
+ - `dd.version=<VERSION>`: Where `<VERSION>` is equal to `Datadog::Tracing.correlation.version`. Omit if no application version is configured.
+ - `dd.trace_id=<TRACE_ID>`: Where `<TRACE_ID>` is equal to `Datadog::Tracing.correlation.trace_id` or `0` if no trace is active during logging.
+ - `dd.span_id=<SPAN_ID>`: Where `<SPAN_ID>` is equal to `Datadog::Tracing.correlation.span_id` or `0` if no trace is active during logging.
 
 By default, `Datadog::Correlation::Identifier#to_s` will return `dd.env=<ENV> dd.service=<SERVICE> dd.version=<VERSION> dd.trace_id=<TRACE_ID> dd.span_id=<SPAN_ID>`.
 
@@ -108,7 +50,7 @@ ENV['DD_VERSION'] = '2.5.17'
 logger = Logger.new(STDOUT)
 logger.progname = 'my_app'
 logger.formatter  = proc do |severity, datetime, progname, msg|
-  "[#{datetime}][#{progname}][#{severity}][#{Datadog.tracer.active_correlation}] #{msg}\n"
+  "[#{datetime}][#{progname}][#{severity}][#{Datadog::Tracing.log_correlation}] #{msg}\n"
 end
 
 # When no trace is active
@@ -116,7 +58,7 @@ logger.warn('This is an untraced operation.')
 # [2019-01-16 18:38:41 +0000][my_app][WARN][dd.env=production dd.service=billing-api dd.version=2.5.17 dd.trace_id=0 dd.span_id=0] This is an untraced operation.
 
 # When a trace is active
-Datadog.tracer.trace('my.operation') { logger.warn('This is a traced operation.') }
+Datadog::Tracing.trace('my.operation') { logger.warn('This is a traced operation.') }
 # [2019-01-16 18:38:41 +0000][my_app][WARN][dd.env=production dd.service=billing-api dd.version=2.5.17 dd.trace_id=8545847825299552251 dd.span_id=3711755234730770098] This is a traced operation.
 ```
 ## Further Reading

--- a/content/en/tracing/faq/trace_sampling_and_storage.md
+++ b/content/en/tracing/faq/trace_sampling_and_storage.md
@@ -172,7 +172,7 @@ def handler():
 Manually keep a trace:
 
 ```ruby
-Datadog.tracer.trace(name, options) do |span|
+Datadog::Tracing.trace(name, options) do |span|
 
   # Always Keep the Trace
   span.set_tag(Datadog::Ext::ManualTracing::TAG_KEEP, true)
@@ -183,7 +183,7 @@ end
 Manually drop a trace:
 
 ```ruby
-Datadog.tracer.trace(name, options) do |span|
+Datadog::Tracing.trace(name, options) do |span|
   # Always Drop the Trace
   span.set_tag(Datadog::Ext::ManualTracing::TAG_DROP, true)
   # method impl follows

--- a/content/en/tracing/guide/add_span_md_and_graph_it.md
+++ b/content/en/tracing/guide/add_span_md_and_graph_it.md
@@ -92,10 +92,8 @@ require 'ddtrace'
 class ShoppingCartController < ApplicationController
   # GET /shopping_cart
   def index
-    # Get the active span
-    current_span = Datadog.tracer.active_span
-    # customer_id -> 254889
-    current_span.set_tag('customer.id', params.permit([:customer_id])) unless current_span.nil?
+    # Get the active span and set customer_id -> 254889
+    Datadog::Tracing.active_span&.set_tag('customer.id', params.permit([:customer_id]))
 
     # [...]
   end

--- a/content/en/tracing/guide/instrument_custom_method.md
+++ b/content/en/tracing/guide/instrument_custom_method.md
@@ -149,10 +149,10 @@ require 'ddtrace'
 class BackupLedger
 
   def write(transactions)
-    # Use global `Datadog.tracer.trace` to trace blocks of inline code
-    Datadog.tracer.trace('BackupLedger.write') do |method_span|
+    # Use global `Datadog::Tracing.trace` to trace blocks of inline code
+    Datadog::Tracing.trace('BackupLedger.write') do |method_span|
       transactions.each do |transaction|
-        Datadog.tracer.trace('BackupLedger.persist') do |span|
+        Datadog::Tracing.trace('BackupLedger.persist') do |span|
           # Add custom metadata to the "persist_transaction" span
           span.set_tag('transaction.id', transaction.id)
           ledger[transaction.id] = transaction

--- a/content/en/tracing/legacy_app_analytics/_index.md
+++ b/content/en/tracing/legacy_app_analytics/_index.md
@@ -173,7 +173,7 @@ App Analytics can be enabled for specific integrations.
 To do so, set either `DD_<INTEGRATION>_ANALYTICS_ENABLED=true` in your environment, or configure with:
 
 ```ruby
-Datadog.configure { |c| c.use :integration, analytics_enabled: true }
+Datadog.configure { |c| c.tracing.instrument :integration, analytics_enabled: true }
 ```
 
 Where `integration` is the name of the integration. See the [list of available integrations][1] for options.
@@ -289,7 +289,7 @@ Database tracing is not captured by App Analytics by default and you must enable
 Database tracing is not captured by App Analytics by default and you must enable collection manually for each integration. For example:
 
 ```ruby
-Datadog.configure { |c| c.use :mongo, analytics_enabled: true }
+Datadog.configure { |c| c.tracing.instrument :mongo, analytics_enabled: true }
 ```
 
 {{< /programming-lang >}}
@@ -397,7 +397,7 @@ def my_method():
 Applications with custom instrumentation can enable App Analytics by setting the `ANALYTICS_KEY` tag on a span:
 
 ```ruby
-Datadog.tracer.trace('my.task') do |span|
+Datadog::Tracing.trace('my.task') do |span|
   # Set the analytics sample rate to 1.0
   span.set_tag(Datadog::Ext::Analytics::TAG_ENABLED, true)
 end

--- a/content/en/tracing/profiler/enabling/ruby.md
+++ b/content/en/tracing/profiler/enabling/ruby.md
@@ -88,7 +88,7 @@ end
     If starting the application via `ddtracerb exec` is not an option (eg. when using the Phusion Passenger web server), you can alternatively start the profiler by adding the following to your application entry point such as `config.ru` for a web application:
 
     ```ruby
-    require 'ddtrace/profiling/preload'
+    require 'datadog/profiling/preload'
     ```
 
 

--- a/content/en/tracing/runtime_metrics/ruby.md
+++ b/content/en/tracing/runtime_metrics/ruby.md
@@ -40,7 +40,7 @@ Datadog.configure do |c|
   # Optionally, you can configure the DogStatsD instance used for sending runtime metrics.
   # DogStatsD is automatically configured with default settings if `dogstatsd-ruby` is available.
   # You can configure with host and port of Datadog agent; defaults to 'localhost:8125'.
-  c.runtime_metrics statsd: Datadog::Statsd.new
+  c.runtime_metrics.statsd = Datadog::Statsd.new
 end
 ```
 

--- a/content/en/tracing/setup_overview/compatibility_requirements/ruby.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/ruby.md
@@ -23,7 +23,8 @@ The Ruby Datadog Trace library is open source - view the [GitHub repository][1] 
 
 | Type  | Documentation              | Version | Support type                         | Gem version support |
 | ----- | -------------------------- | -----   | ------------------------------------ | ------------------- |
-| MRI   | https://www.ruby-lang.org/ | 3.0     | Full                                 | Latest              |
+| MRI   | https://www.ruby-lang.org/ | 3.1     | Full                                 | Latest              |
+|       |                            | 3.0     | Full                                 | Latest              |
 |       |                            | 2.7     | Full                                 | Latest              |
 |       |                            | 2.6     | Full                                 | Latest              |
 |       |                            | 2.5     | Full                                 | Latest              |
@@ -65,7 +66,7 @@ Many popular libraries and frameworks are supported out-of-the-box, which can be
 ```ruby
 Datadog.configure do |c|
   # Activates and configures an integration
-  c.use :integration_name, options
+  c.tracing.instrument :integration_name, options
 end
 ```
 
@@ -74,118 +75,139 @@ end
 For a list of available integrations, and their configuration options, please refer to the following:
 
 | Name                     | Key                        | Versions Supported: MRI  | Versions Supported: JRuby | How to configure                    | Gem source                                                                     |
-| ------------------------ | -------------------------- | ------------------------ | --------------------------| ----------------------------------- | ------------------------------------------------------------------------------ |
+| -------------------------- | -------------------------- |-------------------------|---------------------------|------------------|--------------|
 | Action Cable             | `action_cable`             | `>= 5.0`                 | `>= 5.0`                  | *[Link][2]*              | *[Link][3]*             |
-| Action View              | `action_view`              | `>= 3.0`                 | `>= 3.0`                  | *[Link][4]*              | *[Link][5]*             |
-| Active Model Serializers | `active_model_serializers` | `>= 0.9`                 | `>= 0.9`                  | *[Link][6]*              |  *[Link][7]*            |
-| Action Pack              | `action_pack`              | `>= 3.0`                 | `>= 3.0`                  | *[Link][8]*              | *[Link][9]*             |
-| Active Record            | `active_record`            | `>= 3.0`                 | `>= 3.0`                  | *[Link][10]*             | *[Link][11]*            |
-| Active Support           | `active_support`           | `>= 3.0`                 | `>= 3.0`                  | *[Link][12]*             | *[Link][13]*            |
-| AWS                      | `aws`                      | `>= 2.0`                 | `>= 2.0`                  | *[Link][14]*             | *[Link][15]*            |
-| Concurrent Ruby          | `concurrent_ruby`          | `>= 0.9`                 | `>= 0.9`                  | *[Link][16]*             | *[Link][17]*            |
-| Dalli                    | `dalli`                    | `>= 2.0`                 | `>= 2.0`                  | *[Link][18]*             | *[Link][19]*            |
-| DelayedJob               | `delayed_job`              | `>= 4.1`                 | `>= 4.1`                  | *[Link][20]*             | *[Link][21]*            |
-| Elasticsearch            | `elasticsearch`            | `>= 1.0`                 | `>= 1.0`                  | *[Link][22]*             | *[Link][23]*            |
-| Ethon                    | `ethon`                    | `>= 0.11`                | `>= 0.11`                 | *[Link][24]*             | *[Link][25]*            |
-| Excon                    | `excon`                    | `>= 0.50`                | `>= 0.50`                 | *[Link][26]*             | *[Link][27]*            |
-| Faraday                  | `faraday`                  | `>= 0.14`                | `>= 0.14`                 | *[Link][28]*             | *[Link][29]*            |
-| Grape                    | `grape`                    | `>= 1.0`                 | `>= 1.0`                  | *[Link][30]*             | *[Link][31]*            |
-| GraphQL                  | `graphql`                  | `>= 1.7.9`               | `>= 1.7.9`                | *[Link][32]*             | *[Link][33]*            |
-| gRPC                     | `grpc`                     | `>= 1.7`                 | *gem not available*       | *[Link][34]*             | *[Link][35]*            |
-| http.rb                  | `httprb`                   | `>= 2.0`                 | `>= 2.0`                  | *[Link][36]*             | *[Link][37]*            |
-| Kafka                    | `ruby-kafka`               | `>= 0.7.10`              | `>= 0.7.10`               | *[Link][38]*             | *[Link][39]*            |
-| MongoDB                  | `mongo`                    | `>= 2.1`                 | `>= 2.1`                  | *[Link][40]*             | *[Link][41]*            |
-| MySQL2                   | `mysql2`                   | `>= 0.3.21`              | *gem not available*       | *[Link][42]*             | *[Link][43]*            |
-| Net/HTTP                 | `http`                     | *(Any supported Ruby)*   | *(Any supported Ruby)*    | *[Link][44]*             | *[Link][45]*            |
-| Presto                   | `presto`                   | `>= 0.5.14`              | `>= 0.5.14`               | *[Link][46]*             | *[Link][47]*            |
-| Racecar                  | `racecar`                  | `>= 0.3.5`               | `>= 0.3.5`                | *[Link][48]*             | *[Link][49]*            |
-| Rack                     | `rack`                     | `>= 1.1`                 | `>= 1.1`                  | *[Link][50]*             | *[Link][51]*            |
-| Rails                    | `rails`                    | `>= 3.0`                 | `>= 3.0`                  | *[Link][52]*             | *[Link][53]*            |
-| Rake                     | `rake`                     | `>= 12.0`                | `>= 12.0`                 | *[Link][54]*             | *[Link][55]*            |
-| Redis                    | `redis`                    | `>= 3.2`                 | `>= 3.2`                  | *[Link][56]*             | *[Link][57]*            |
-| Resque                   | `resque`                   | `>= 1.0, < 2.0`          | `>= 1.0, < 2.0`           | *[Link][58]*             | *[Link][59]*            |
-| Rest Client              | `rest-client`              | `>= 1.8`                 | `>= 1.8`                  | *[Link][60]*             | *[Link][61]*            |
-| Sequel                   | `sequel`                   | `>= 3.41`                | `>= 3.41`                 | *[Link][62]*             | *[Link][63]*            |
-| Shoryuken                | `shoryuken`                | `>= 3.2`                 | `>= 3.2`                  | *[Link][64]*             | *[Link][65]*            |
-| Sidekiq                  | `sidekiq`                  | `>= 3.5.4`               | `>= 3.5.4`                | *[Link][66]*             | *[Link][67]*            |
-| Sinatra                  | `sinatra`                  | `>= 1.4`                 | `>= 1.4`                  | *[Link][68]*             | *[Link][69]*            |
-| Sneakers                 | `sneakers`                 | `>= 2.12.0`              | `>= 2.12.0`               | *[Link][70]*             | *[Link][71]*            |
-| Sucker Punch             | `sucker_punch`             | `>= 2.0`                 | `>= 2.0`                  | *[Link][72]*             | *[Link][73]*            |
+| Action Mailer              | `action_mailer`            | `>= 5.0`                | `>= 5.0`                  | *[Link][4]*      | *[Link][5]*  |
+| Action Pack                | `action_pack`              | `>= 3.2`                | `>= 3.2`                  | *[Link][6]*      | *[Link][7]*  |
+| Action View                | `action_view`              | `>= 3.2`                | `>= 3.2`                  | *[Link][8]*      | *[Link][9]*  |
+| Active Job                 | `active_job`               | `>= 4.2`                | `>= 4.2`                  | *[Link][10]*     | *[Link][11]* |
+| Active Model Serializers   | `active_model_serializers` | `>= 0.9`                | `>= 0.9`                  | *[Link][12]*     | *[Link][13]* |
+| Active Record              | `active_record`            | `>= 3.2`                | `>= 3.2`                  | *[Link][14]*     | *[Link][15]* |
+| Active Support             | `active_support`           | `>= 3.2`                | `>= 3.2`                  | *[Link][16]*     | *[Link][17]* |
+| AWS                        | `aws`                      | `>= 2.0`                | `>= 2.0`                  | *[Link][18]*     | *[Link][19]* |
+| Concurrent Ruby            | `concurrent_ruby`          | `>= 0.9`                | `>= 0.9`                  | *[Link][20]*     | *[Link][21]* |
+| Dalli                      | `dalli`                    | `>= 2.0`                | `>= 2.0`                  | *[Link][22]*     | *[Link][23]* |
+| DelayedJob                 | `delayed_job`              | `>= 4.1`                | `>= 4.1`                  | *[Link][24]*     | *[Link][25]* |
+| Elasticsearch              | `elasticsearch`            | `>= 1.0`                | `>= 1.0`                  | *[Link][26]*     | *[Link][27]* |
+| Ethon                      | `ethon`                    | `>= 0.11`               | `>= 0.11`                 | *[Link][28]*     | *[Link][29]* |
+| Excon                      | `excon`                    | `>= 0.50`               | `>= 0.50`                 | *[Link][30]*     | *[Link][31]* |
+| Faraday                    | `faraday`                  | `>= 0.14`               | `>= 0.14`                 | *[Link][32]*     | *[Link][33]* |
+| Grape                      | `grape`                    | `>= 1.0`                | `>= 1.0`                  | *[Link][34]*     | *[Link][35]* |
+| GraphQL                    | `graphql`                  | `>= 1.7.9`              | `>= 1.7.9`                | *[Link][36]*     | *[Link][37]* |
+| gRPC                       | `grpc`                     | `>= 1.7`                | *gem not available*       | *[Link][38]*     | *[Link][39]* |
+| http.rb                    | `httprb`                   | `>= 2.0`                | `>= 2.0`                  | *[Link][40]*     | *[Link][41]* |
+| httpclient                 | `httpclient`               | `>= 2.2`                | `>= 2.2`                  | *[Link][42]*     | *[Link][43]* |
+| httpx                      | `httpx`                    | `>= 0.11`               | `>= 0.11`                 | *[Link][44]*     | *[Link][45]* |
+| Kafka                      | `ruby-kafka`               | `>= 0.7.10`             | `>= 0.7.10`               | *[Link][46]*     | *[Link][47]* |
+| Makara (via Active Record) | `makara`                   | `>= 0.3.5`              | `>= 0.3.5`                | *[Link][48]*     | *[Link][49]* |
+| MongoDB                    | `mongo`                    | `>= 2.1`                | `>= 2.1`                  | *[Link][50]*     | *[Link][51]* |
+| MySQL2                     | `mysql2`                   | `>= 0.3.21`             | *gem not available*       | *[Link][52]*     | *[Link][53]* |
+| Net/HTTP                   | `http`                     | *(Any supported Ruby)*  | *(Any supported Ruby)*    | *[Link][54]*     | *[Link][55]* |
+| Presto                     | `presto`                   | `>= 0.5.14`             | `>= 0.5.14`               | *[Link][56]*     | *[Link][57]* |
+| Qless                      | `qless`                    | `>= 0.10.0`             | `>= 0.10.0`               | *[Link][58]*     | *[Link][59]* |
+| Que                        | `que`                      | `>= 1.0.0.beta2`        | `>= 1.0.0.beta2`          | *[Link][60]*     | *[Link][61]* |
+| Racecar                    | `racecar`                  | `>= 0.3.5`              | `>= 0.3.5`                | *[Link][62]*     | *[Link][63]* |
+| Rack                       | `rack`                     | `>= 1.1`                | `>= 1.1`                  | *[Link][64]*     | *[Link][65]* |
+| Rails                      | `rails`                    | `>= 3.2`                | `>= 3.2`                  | *[Link][66]*     | *[Link][67]* |
+| Rake                       | `rake`                     | `>= 12.0`               | `>= 12.0`                 | *[Link][68]*     | *[Link][69]* |
+| Redis                      | `redis`                    | `>= 3.2`                | `>= 3.2`                  | *[Link][70]*     | *[Link][71]* |
+| Resque                     | `resque`                   | `>= 1.0`                | `>= 1.0`                  | *[Link][72]*     | *[Link][73]* |
+| Rest Client                | `rest-client`              | `>= 1.8`                | `>= 1.8`                  | *[Link][74]*     | *[Link][75]* |
+| Sequel                     | `sequel`                   | `>= 3.41`               | `>= 3.41`                 | *[Link][76]*     | *[Link][77]* |
+| Shoryuken                  | `shoryuken`                | `>= 3.2`                | `>= 3.2`                  | *[Link][78]*     | *[Link][79]* |
+| Sidekiq                    | `sidekiq`                  | `>= 3.5.4`              | `>= 3.5.4`                | *[Link][80]*     | *[Link][81]* |
+| Sinatra                    | `sinatra`                  | `>= 1.4`                | `>= 1.4`                  | *[Link][82]*     | *[Link][83]* |
+| Sneakers                   | `sneakers`                 | `>= 2.12.0`             | `>= 2.12.0`               | *[Link][84]*     | *[Link][85]* |
+| Sucker Punch               | `sucker_punch`             | `>= 2.0`                | `>= 2.0`                  | *[Link][86]*     | *[Link][87]* |
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/dd-trace-rb
-[2]: /tracing/setup/ruby/#action-cable
+[2]: /tracing/setup_overview/setup/ruby/#action-cable
 [3]: https://github.com/rails/rails/tree/master/actioncable
-[4]: /tracing/setup/ruby/#action-view
-[5]: https://github.com/rails/rails/tree/master/actionview
-[6]: /tracing/setup/ruby/#active-model-serializers
-[7]: https://github.com/rails-api/active_model_serializers
-[8]: /tracing/setup/ruby/#action-pack
-[9]: https://github.com/rails/rails/tree/master/actionpack
-[10]: /tracing/setup/ruby/#active-record
-[11]: https://github.com/rails/rails/tree/master/activerecord
-[12]: /tracing/setup/ruby/#active-support
-[13]: https://github.com/rails/rails/tree/master/activesupport
-[14]: /tracing/setup/ruby/#aws
-[15]: https://github.com/aws/aws-sdk-ruby
-[16]: /tracing/setup/ruby/#concurrent-ruby
-[17]: https://github.com/ruby-concurrency/concurrent-ruby
-[18]: /tracing/setup/ruby/#dalli
-[19]: https://github.com/petergoldstein/dalli
-[20]: /tracing/setup/ruby/#delayedjob
-[21]: https://github.com/collectiveidea/delayed_job
-[22]: /tracing/setup/ruby/#elasticsearch
-[23]: https://github.com/elastic/elasticsearch-ruby
-[24]: /tracing/setup/ruby/#ethon
-[25]: https://github.com/typhoeus/ethon
-[26]: /tracing/setup/ruby/#excon
-[27]: https://github.com/excon/excon
-[28]: /tracing/setup/ruby/#faraday
-[29]: https://github.com/lostisland/faraday
-[30]: /tracing/setup/ruby/#grape
-[31]: https://github.com/ruby-grape/grape
-[32]: /tracing/setup/ruby/#graphql
-[33]: https://github.com/rmosolgo/graphql-ruby
-[34]: /tracing/setup/ruby/#grpc
-[35]: https://github.com/grpc/grpc/tree/master/src/rubyc
-[36]: https://github.com/httprb/http
-[37]: /tracing/setup/ruby/#http-rb
-[38]: https://github.com/zendesk/ruby-kafka
-[39]: /tracing/setup/ruby/#kafka
-[40]: /tracing/setup/ruby/#mongodb
-[41]: https://github.com/mongodb/mongo-ruby-driver
-[42]: /tracing/setup/ruby/#mysql2
-[43]: https://github.com/brianmario/mysql2
-[44]: /tracing/setup/ruby/#nethttp
-[45]: https://ruby-doc.org/stdlib-2.4.0/libdoc/net/http/rdoc/Net/HTTP.html
-[46]: /tracing/setup/ruby/#presto
-[47]: https://github.com/treasure-data/presto-client-ruby
-[48]: /tracing/setup/ruby/#racecar
-[49]: https://github.com/zendesk/racecar
-[50]: /tracing/setup/ruby/#rack
-[51]: https://github.com/rack/rack
-[52]: /tracing/setup/ruby/#rails
-[53]: https://github.com/rails/rails
-[54]: /tracing/setup/ruby/#rake
-[55]: https://github.com/ruby/rake
-[56]: /tracing/setup/ruby/#redis
-[57]: https://github.com/redis/redis-rb
-[58]: /tracing/setup/ruby/#resque
-[59]: https://github.com/resque/resque
-[60]: /tracing/setup/ruby/#rest-client
-[61]: https://github.com/rest-client/rest-client
-[62]: /tracing/setup/ruby/#sequel
-[63]: https://github.com/jeremyevans/sequel
-[64]: /tracing/setup/ruby/#shoryuken
-[65]: https://github.com/phstc/shoryuken
-[66]: /tracing/setup/ruby/#sidekiq
-[67]: https://github.com/mperham/sidekiq
-[68]: /tracing/setup/ruby/#sinatra
-[69]: https://github.com/sinatra/sinatra
-[70]: https://github.com/jondot/sneakers
-[71]: /tracing/setup/ruby/#sneakers
-[72]: /tracing/setup/ruby/#sucker-punch
-[73]: https://github.com/brandonhilkert/sucker_punch
+[4]: /tracing/setup_overview/setup/ruby/#action-mailer
+[5]: https://github.com/rails/rails/tree/master/actionmailer
+[6]: /tracing/setup_overview/setup/ruby/#action-pack
+[7]: https://github.com/rails/rails/tree/master/actionpack
+[8]: /tracing/setup_overview/setup/ruby/#action-view
+[9]: https://github.com/rails/rails/tree/master/actionview
+[10]: /tracing/setup_overview/setup/ruby/#active-job
+[11]: https://github.com/rails/rails/tree/master/activejob
+[12]: /tracing/setup_overview/setup/ruby/#active-model-serializers
+[13]: https://github.com/rails-api/active_model_serializers
+[14]: /tracing/setup_overview/setup/ruby/#active-record
+[15]: https://github.com/rails/rails/tree/master/activerecord
+[16]: /tracing/setup_overview/setup/ruby/#active-support
+[17]: https://github.com/rails/rails/tree/master/activesupport
+[18]: /tracing/setup_overview/setup/ruby/#aws
+[19]: https://github.com/aws/aws-sdk-ruby
+[20]: /tracing/setup_overview/setup/ruby/#concurrent-ruby
+[21]: https://github.com/ruby-concurrency/concurrent-ruby
+[22]: /tracing/setup_overview/setup/ruby/#dalli
+[23]: https://github.com/petergoldstein/dalli
+[24]: /tracing/setup_overview/setup/ruby/#delayedjob
+[25]: https://github.com/collectiveidea/delayed_job
+[26]: /tracing/setup_overview/setup/ruby/#elasticsearch
+[27]: https://github.com/elastic/elasticsearch-ruby
+[28]: /tracing/setup_overview/setup/ruby/#ethon
+[29]: https://github.com/typhoeus/ethon
+[30]: /tracing/setup_overview/setup/ruby/#excon
+[31]: https://github.com/excon/excon
+[32]: /tracing/setup_overview/setup/ruby/#faraday
+[33]: https://github.com/lostisland/faraday
+[34]: /tracing/setup_overview/setup/ruby/#grape
+[35]: https://github.com/ruby-grape/grape
+[36]: /tracing/setup_overview/setup/ruby/#graphql
+[37]: https://github.com/rmosolgo/graphql-ruby
+[38]: /tracing/setup_overview/setup/ruby/#grpc
+[39]: https://github.com/grpc/grpc/tree/master/src/rubyc
+[40]: /tracing/setup_overview/setup/ruby/#httprb
+[41]: https://github.com/httprb/http
+[42]: /tracing/setup_overview/setup/ruby/#httpclient
+[43]: https://github.com/nahi/httpclient
+[44]: /tracing/setup_overview/setup/ruby/#httpx
+[45]: https://gitlab.com/honeyryderchuck/httpx
+[46]: /tracing/setup_overview/setup/ruby/#kafka
+[47]: https://github.com/zendesk/ruby-kafka
+[48]: /tracing/setup_overview/setup/ruby/#active-record
+[49]: https://github.com/instacart/makara
+[50]: /tracing/setup_overview/setup/ruby/#mongodb
+[51]: https://github.com/mongodb/mongo-ruby-driver
+[52]: /tracing/setup_overview/setup/ruby/#mysql2
+[53]: https://github.com/brianmario/mysql2
+[54]: /tracing/setup_overview/setup/ruby/#nethttp
+[55]: https://ruby-doc.org/stdlib-2.4.0/libdoc/net/http/rdoc/Net/HTTP.html
+[56]: /tracing/setup_overview/setup/ruby/#presto
+[57]: https://github.com/treasure-data/presto-client-ruby
+[58]: /tracing/setup_overview/setup/ruby/#qless
+[59]: https://github.com/seomoz/qless
+[60]: /tracing/setup_overview/setup/ruby/#que
+[61]: https://github.com/que-rb/que
+[62]: /tracing/setup_overview/setup/ruby/#racecar
+[63]: https://github.com/zendesk/racecar
+[64]: /tracing/setup_overview/setup/ruby/#rack
+[65]: https://github.com/rack/rack
+[66]: /tracing/setup_overview/setup/ruby/#rails
+[67]: https://github.com/rails/rails
+[68]: /tracing/setup_overview/setup/ruby/#rake
+[69]: https://github.com/ruby/rake
+[70]: /tracing/setup_overview/setup/ruby/#redis
+[71]: https://github.com/redis/redis-rb
+[72]: /tracing/setup_overview/setup/ruby/#resque
+[73]: https://github.com/resque/resque
+[74]: /tracing/setup_overview/setup/ruby/#rest-client
+[75]: https://github.com/rest-client/rest-client
+[76]: /tracing/setup_overview/setup/ruby/#sequel
+[77]: https://github.com/jeremyevans/sequel
+[78]: /tracing/setup_overview/setup/ruby/#shoryuken
+[79]: https://github.com/phstc/shoryuken
+[80]: /tracing/setup_overview/setup/ruby/#sidekiq
+[81]: https://github.com/mperham/sidekiq
+[82]: /tracing/setup_overview/setup/ruby/#sinatra
+[83]: https://github.com/sinatra/sinatra
+[84]: /tracing/setup_overview/setup/ruby/#sneakers
+[85]: https://github.com/jondot/sneakers
+[86]: /tracing/setup_overview/setup/ruby/#sucker-punch
+[87]: https://github.com/brandonhilkert/sucker_punch

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -50,10 +50,10 @@ You can override the default logger and replace it with a custom one by using th
 ```ruby
 f = File.new("<FILENAME>.log", "w+")           # Log messages should go there
 Datadog.configure do |c|
-  c.tracer log: Logger.new(f)                 # Overriding the default tracer
+  c.logger.instance = Logger.new(f)                 # Overriding the default tracer
 end
 
-Datadog::Tracer.log.info { "this is typically called by tracing code" }
+Datadog::Tracing.logger.info { "this is typically called by tracing code" }
 ```
 
 See [the API documentation][1] for more details.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

The Ruby APM tracer team is [preparing to release](https://github.com/DataDog/dd-trace-rb/milestone/99?closed=1) `ddtrace` version 1.0.

This new version has a few API braking changes. This PR addresses these changes.


### Preview

https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/agent/amazon_ecs/apm
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/agent/docker/apm
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/agent/guide/heroku-ruby
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/continuous_integration/setup_tests/ruby
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/security_platform/application_security/troubleshooting
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/serverless/installation/ruby
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/tracing/connect_logs_and_traces/ruby
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/tracing/faq/trace_sampling_and_storage
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/tracing/guide/add_span_md_and_graph_it
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/tracing/guide/instrument_custom_method
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/tracing/legacy_app_analytics/_index
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/tracing/profiler/enabling/ruby
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/tracing/runtime_metrics/ruby
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/tracing/setup_overview/compatibility_requirements/ruby
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/tracing/setup_overview/custom_instrumentation/ruby
https://docs-staging.datadoghq.com/marcotc/apm-ddtrace-1.0/tracing/troubleshooting/tracer_debug_logs

### Additional Notes

This PR should ideally go live as close as possible to the 1.0.0 [release of ddtrace](https://github.com/DataDog/dd-trace-rb/releases).

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
