### PR TITLE
Remove the note about CW logs subscription limitataion

### DIFF
--- a/content/en/logs/guide/lambda-logs-collection-troubleshooting-guide.md
+++ b/content/en/logs/guide/lambda-logs-collection-troubleshooting-guide.md
@@ -64,8 +64,6 @@ For logs to be forwarded, the forwarder Lambda function needs to have triggers (
 
 4. Set triggers [automatically][7] or [manually][8].
 
-Note, AWS doesn't allow for more than one resource to be subscribed to a log source. If your log source is already subscribed by a different resource, you need to remove that subscription first.
-
 For CloudWatch log group, you can use the following metrics within the Datadog platform to confirm whether logs are delivered from the log group to the forwarder Lambda function. Use the `log_group` tag to filter the data when viewing the metrics.
 
 | Metric                          | Description                                                                                        |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Remove the note about CW logs subscriptions.

### Motivation
<!-- What inspired you to submit this pull request?-->

[Amazon CloudWatch Logs now supports two subscription filters per log group](https://aws.amazon.com/about-aws/whats-new/2020/10/amazon-cloudwatch-logs-now-supports-two-subscription-filters-per-log-group/)

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
