### PR TITLE
[CIAPP] Update supported Jenkins versions per plugin versions.

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -20,7 +20,8 @@ further_reading:
 ## Compatibility
 
 Supported Jenkins versions:
-* Jenkins >= 2.164.1
+* For 3.x versions of the plugin: Jenkins >= 2.164.1
+* For 4.x versions of the plugin: Jenkins >= 2.303.3
 
 ## Prerequisite
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR adds a breakdown of the supported Jenkins versions per plugin versions.

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/drodriguezhdez/update_jenkins_versions/continuous_integration/setup_pipelines/jenkins/?tab=usingui

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
