### PR TITLE
Fix Ruby supported versions for AppSec

### DIFF
--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -140,7 +140,7 @@ To install the above requirements:
 
 The Datadog Ruby library supports the latest gem for the following Ruby interpreters:
 
-- MRI (https://www.ruby-lang.org/) versions 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1
+- MRI (https://www.ruby-lang.org/) versions 2.1 to 3.1
 
 These are supported on the following architectures:
 - Linux (GNU) x86-64, aarch64
@@ -276,7 +276,7 @@ For information and options, read [the .NET tracer documentation][1].
 
 {{< programming-lang lang="go" >}}
 
-The Go tracer package provides the `SetUser()` function, which allows you to monitor authenticated requests by adding user information to the trace. For more options, see [the Go tracer documentation][1]. 
+The Go tracer package provides the `SetUser()` function, which allows you to monitor authenticated requests by adding user information to the trace. For more options, see [the Go tracer documentation][1].
 
 This example shows how to retrieve the current tracer span and use it to set user monitoring tags:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add 3.0 and 3.1 + simplify as range instead of listing each version.

### Motivation

Incorrect list

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/fix-ruby-supported-versions/documentation/content/en/security_platform/application_security/setup_and_configure

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
