### PR TITLE
Ruby profiler documentation improvements

### DIFF
--- a/content/en/tracing/profiler/enabling/ruby.md
+++ b/content/en/tracing/profiler/enabling/ruby.md
@@ -23,7 +23,11 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 ## Requirements
 
-The Datadog Profiler requires MRI Ruby 2.1+. **Wall time profiling is available for users on every platform (including macOS and Windows), but CPU time profiles are currently only available on Linux platforms**.
+The Datadog Profiler requires MRI Ruby 2.1+.
+
+The following operating systems and architectures are supported:
+- Linux (GNU libc) x86-64, aarch64
+- Alpine Linux (musl libc) x86-64, aarch64
 
 Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
 

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -189,8 +189,11 @@ If you've configured the profiler and don't see profiles in the profile search p
 
 ## Application triggers "stack level too deep (SystemStackError)" errors
 
-The profiler instruments the Ruby VM to track thread creation.
-This instrumentation is compatible with most other Ruby gems that also instrument thread creation, with a few exceptions.
+This issue is not expected to happen since [`dd-trace-rb` version `0.54.0`][3].
+If you're still running into it, [open a support ticket][2] taking care to include the full backtrace leading to the error.
+
+Prior to version `0.54.0`, the profiler needed to instrument the Ruby VM to track thread creation, which clashed
+with similar instrumentation from other gems.
 
 If you're using any of the below gems:
 
@@ -198,22 +201,20 @@ If you're using any of the below gems:
 * `logging`: Disable `logging`'s thread context inheritance by setting the `LOGGING_INHERIT_CONTEXT` environment
   variable to `false`.
 
-If you're still experiencing `SystemStackError` errors after following the above instructions,
-[open a support ticket][2] taking care to include the full backtrace leading to the error.
-
 ## Missing profiles for Resque jobs
 
-When profiling [Resque][3] jobs, you should set the `RUN_AT_EXIT_HOOKS` environment
+When profiling [Resque][4] jobs, you should set the `RUN_AT_EXIT_HOOKS` environment
 variable to `1`, as described in the
-[Resque documentation][4].
+[Resque documentation][5].
 
 Without this flag, profiles for short-lived Resque jobs will be unavailable.
 
 
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/
-[3]: https://github.com/resque/resque
-[4]: https://github.com/resque/resque/blob/v2.0.0/docs/HOOKS.md#worker-hooks
+[3]: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.54.0
+[4]: https://github.com/resque/resque
+[5]: https://github.com/resque/resque/blob/v2.0.0/docs/HOOKS.md#worker-hooks
 {{< /programming-lang >}}
 {{< programming-lang lang="dotnet" >}}
 

--- a/content/en/tracing/setup_overview/_index.md
+++ b/content/en/tracing/setup_overview/_index.md
@@ -33,7 +33,7 @@ In containerized, serverless, or certain other environments, there may be APM-sp
 
 To instrument an application written in a language that does not yet have official library support, see the list of [community tracing libraries][2].
 
-After you set up tracing, you are [one step from accessing profiling data by enabling Continuous Profiler][3]. Profiler is available for Java, Python, Go, and (beta) Ruby.
+After you set up tracing, you are [one step from accessing profiling data by enabling Continuous Profiler][3]. Profiler is available for Java, Python, Go, Ruby, Node.js, (beta) PHP, (beta) .NET, and (beta) Linux.
 
 [1]: /tracing/visualization/#trace
 [2]: /developers/community/libraries/#apm-tracing-client-libraries


### PR DESCRIPTION
### What does this PR do?
* Update list of languages that Profiler is available for
* Remove references to Windows and macOS from Ruby profiler docs
* Update Ruby SystemStackError profiler troubleshooting instructions

### Motivation
I was reviewing the Ruby profiler documentation and spotted these issues/improvements.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/ivoanjo/profiling-doc-improvements

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
