### PR TITLE
Typo fix: `mutiple` fixed to `multiple`

### DIFF
--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -91,7 +91,7 @@ sources:
     type: datadog_agent
     # The <VECTOR_PORT> mentioned above should be set to the port value used here
     address: "[::]:8080"
-    mutiple_outputs: true # To automatically separate metrics and logs
+    multiple_outputs: true # To automatically separate metrics and logs
 
 transforms:
   tag_logs:


### PR DESCRIPTION
fixed typo flagged by a customer. `mutiple` fixed to `multiple`

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/<BRANCH_NAME>/<PATH>

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
