### PR TITLE
Add syntax highlighting to application security onboarding pages

### DIFF
--- a/content/en/security_platform/application_security/getting_started/dotnet.md
+++ b/content/en/security_platform/application_security/getting_started/dotnet.md
@@ -88,7 +88,7 @@ net start w3svc
 ```
 
 **Or**, to avoid editing registry keys, edit the application settings in the `web.config` file of your application: 
-```
+```xml
 <configuration>
   <appSettings>
         <add key="DD_APPSEC_ENABLED" value="true"/>
@@ -97,7 +97,7 @@ net start w3svc
 ```
 
 This can also be done at the IIS application pools level in the `applicationHost.config` file, usually in `C:\Windows\System32\inetsrv\config\`: 
-```
+```xml
 <system.applicationHost>
 
     <applicationPools>
@@ -112,7 +112,7 @@ This can also be done at the IIS application pools level in the `applicationHost
 {{% tab "Linux" %}}
 
 Add the following to your application configuration: 
-```
+```shell
 DD_APPSEC_ENABLED=true
 ```
 {{% /tab %}}
@@ -120,7 +120,7 @@ DD_APPSEC_ENABLED=true
 
 Update your configuration container for APM by adding the following argument in your `docker run` command: 
 
-```
+```shell
 docker run [...] -e DD_APPSEC_ENABLED=true [...] 
 ```
 
@@ -129,7 +129,7 @@ docker run [...] -e DD_APPSEC_ENABLED=true [...]
 
 Add the following environment variable value to your container Dockerfile:
 
-```
+```shell
 ENV DD_APPSEC_ENABLED=true
 ```
 
@@ -138,7 +138,7 @@ ENV DD_APPSEC_ENABLED=true
 
 Update your deployment configuration file for APM and add the ASM environment variable:
 
-```
+```yaml
 spec:
   template:
     spec:
@@ -155,7 +155,7 @@ spec:
 
 Update your ECS task definition JSON file, by adding this in the environment section:
 
-```
+```json
 "environment": [
   ...,
   {
@@ -169,7 +169,7 @@ Update your ECS task definition JSON file, by adding this in the environment sec
 {{% tab "AWS Fargate" %}}
 
 Add the following line to your container Dockerfile:
-```
+```shell
 ENV DD_APPSEC_ENABLED=true
 ```
 

--- a/content/en/security_platform/application_security/getting_started/go.md
+++ b/content/en/security_platform/application_security/getting_started/go.md
@@ -56,7 +56,7 @@ $ docker run -e DD_APPSEC_ENABLED=true [...]
 
 Add the following environment variable value to your container Dockerfile:
 
-```
+```shell
 ENV DD_APPSEC_ENABLED=true
 ```
 
@@ -65,7 +65,7 @@ ENV DD_APPSEC_ENABLED=true
 
 Update your deployment configuration file for APM and add the ASM environment variable:
 
-```
+```yaml
 spec:
   template:
     spec:
@@ -82,7 +82,7 @@ spec:
 
 Update your ECS task definition JSON file, by adding this in the environment section:
 
-```
+```json
 "environment": [
   ...,
   {

--- a/content/en/security_platform/application_security/getting_started/java.md
+++ b/content/en/security_platform/application_security/getting_started/java.md
@@ -24,14 +24,14 @@ You can monitor application security for Java apps running in Docker, Kubernetes
 ## Get started
 
 1. **Update your [Datadog Java library][1]** to at least version 0.94.0:
-   ```
+   ```shell
    wget -O dd-java-agent.jar 'https://github.com/DataDog/dd-trace-java/releases/latest/download/dd-java-agent.jar'
    ```
 
    For information about which language and framework versions are supported by the library, see [Compatibility][2].
 
 2. **Run your Java application with ASM enabled.** From the command line:
-   ```
+   ```shell
    java -javaagent:/path/to/dd-java-agent.jar -Ddd.appsec.enabled=true -Ddd.service=<MY SERVICE> -Ddd.env=<MY_ENV> -jar path/to/app.jar
    ```
 
@@ -42,7 +42,7 @@ You can monitor application security for Java apps running in Docker, Kubernetes
 
 Update your configuration container for APM by adding the following argument in your `docker run` command: 
 
-```
+```shell
 docker run [...] -e DD_APPSEC_ENABLED=true [...] 
 ```
 
@@ -51,7 +51,7 @@ docker run [...] -e DD_APPSEC_ENABLED=true [...]
 
 Add the following environment variable value to your container Dockerfile:
 
-```
+```shell
 ENV DD_APPSEC_ENABLED=true
 ```
 
@@ -60,7 +60,7 @@ ENV DD_APPSEC_ENABLED=true
 
 Update your deployment configuration file for APM and add the ASM environment variable:
 
-```
+```yaml
 spec:
   template:
     spec:
@@ -77,7 +77,7 @@ spec:
 
 Update your ECS task definition JSON file, by adding this in the environment section:
 
-```
+```json
 "environment": [
   ...,
   {
@@ -92,7 +92,7 @@ Update your ECS task definition JSON file, by adding this in the environment sec
 
 Set the `-Ddd.appsec.enabled` flag or the `DD_APPSEC_ENABLED` environment variable to `true` in your service invocation:
 
-```
+```shell
 java -javaagent:dd-java-agent.jar \
      -Ddd.appsec.enabled=true \
      -jar <YOUR_SERVICE>.jar \

--- a/content/en/security_platform/application_security/getting_started/nodejs.md
+++ b/content/en/security_platform/application_security/getting_started/nodejs.md
@@ -23,11 +23,11 @@ You can monitor application security for NodeJS apps running in Docker, Kubernet
 ## Get started
 
 1. **Update your Datadog NodeJS library package** to at least version 2.0.0, by running:
-   ```
+   ```shell
    npm install dd-trace
    ```
    or to update from a previously installed 1.x version:
-   ```
+   ```shell
    npm install dd-trace@2
    ```
    Use this [migration guide][1] to assess any breaking changes if you upgraded your library from 1.x to 2.x.
@@ -69,11 +69,11 @@ import `dd-trace/init`;
 {{< /tabs >}}
 
    **Or** if you initialize the APM library on the command line using the `--require` option to Node.js:
-   ```sh
+   ```shell
    node --require dd-trace/init app.js
    ```
    Then use environment variables to enable ASM:
-   ```
+   ```shell
    DD_APPSEC_ENABLED=true node app.js
    ```
    How you do this varies depending on where your service runs:
@@ -82,7 +82,7 @@ import `dd-trace/init`;
 
 Update your configuration container for APM by adding the following argument in your `docker run` command: 
 
-```
+```shell
 docker run [...] -e DD_APPSEC_ENABLED=true [...] 
 ```
 
@@ -91,7 +91,7 @@ docker run [...] -e DD_APPSEC_ENABLED=true [...]
 
 Add the following environment variable value to your container Dockerfile:
 
-```
+```shell
 ENV DD_APPSEC_ENABLED=true
 ```
 
@@ -100,7 +100,7 @@ ENV DD_APPSEC_ENABLED=true
 
 Update your configuration yaml file container for APM and add the AppSec env variable:
 
-```
+```yaml
 spec:
   template:
     spec:
@@ -117,7 +117,7 @@ spec:
 
 Update your ECS task definition JSON file, by adding this in the  environment section:
 
-```
+```json
 "environment": [
   ...,
   {
@@ -131,7 +131,7 @@ Update your ECS task definition JSON file, by adding this in the  environment se
 {{% tab "AWS Fargate" %}}
 
 Initialize ASM in your code or set `DD_APPSEC_ENABLED` environment variable to `true` in your service invocation:
-```
+```shell
 DD_APPSEC_ENABLED=true node app.js
 ```
 

--- a/content/en/security_platform/application_security/getting_started/php.md
+++ b/content/en/security_platform/application_security/getting_started/php.md
@@ -26,7 +26,7 @@ You can monitor application security for PHP apps running in Docker, Kubernetes,
 ## Get started
 
 1. **Install the latest Datadog PHP library** by downloading and running the installer:
-   ```
+   ```shell
    wget https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php -O datadog-setup.php
    php datadog-setup.php --php-bin all --enable-appsec
    ```
@@ -38,7 +38,7 @@ You can monitor application security for PHP apps running in Docker, Kubernetes,
 
 Update your configuration container for APM by adding the following argument in your `docker run` command: 
 
-```
+```shell
 docker run [...] -e DD_APPSEC_ENABLED=true [...] 
 ```
 
@@ -47,7 +47,7 @@ docker run [...] -e DD_APPSEC_ENABLED=true [...]
 
 Add the following environment variable value to your container Dockerfile:
 
-```
+```shell
 ENV DD_APPSEC_ENABLED=true
 ```
 
@@ -56,7 +56,7 @@ ENV DD_APPSEC_ENABLED=true
 
 Update your configuration yaml file container for APM and add the AppSec env variable:
 
-```
+```yaml
 spec:
   template:
     spec:
@@ -73,7 +73,7 @@ spec:
 
 Update your ECS task definition JSON file, by adding this in the environment section:
 
-```
+```json
 "environment": [
   ...,
   {

--- a/content/en/security_platform/application_security/getting_started/ruby.md
+++ b/content/en/security_platform/application_security/getting_started/ruby.md
@@ -24,7 +24,7 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
 
 1. **Update your Gemfile to include the Datadog library**:
 
-   ```
+   ```ruby
    gem 'ddtrace', '~> 1.0'
    ```
 
@@ -38,13 +38,13 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
 {{% tab "Rails" %}}
    Either enable the tracer through auto-instrumentation by updating your Gemfile:
 
-   ```
+   ```ruby
    gem 'ddtrace', '~> 1.0', require: 'ddtrace/auto_instrument'
    ```
 
    Or enable the tracer by adding an initializer in your application code:
 
-   ```
+   ```ruby
    # config/initializers/datadog.rb
 
    require 'datadog/appsec'
@@ -63,7 +63,7 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
 {{% tab "Sinatra" %}}
    Enable the tracer by adding the following to your application's startup:
 
-   ```
+   ```ruby
    require 'ddtrace'
    require 'datadog/appsec'
 
@@ -81,7 +81,7 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
 {{% tab "Rack" %}}
    Enable the tracer by adding the following to your `config.ru` file:
 
-   ```
+   ```ruby
    require 'ddtrace'
    require 'datadog/appsec'
 
@@ -108,7 +108,7 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
 
 Update your configuration container for APM by adding the following argument in your `docker run` command:
 
-```
+```shell
 docker run [...] -e DD_APPSEC_ENABLED=true [...]
 ```
 
@@ -117,7 +117,7 @@ docker run [...] -e DD_APPSEC_ENABLED=true [...]
 
 Add the following environment variable value to your container Dockerfile:
 
-```
+```shell
 ENV DD_APPSEC_ENABLED=true
 ```
 
@@ -126,7 +126,7 @@ ENV DD_APPSEC_ENABLED=true
 
 Update your configuration yaml file container for APM and add the AppSec env variable:
 
-```
+```yaml
 spec:
   template:
     spec:
@@ -143,7 +143,7 @@ spec:
 
 Update your ECS task definition JSON file, by adding this in the  environment section:
 
-```
+```json
 "environment": [
   ...,
   {
@@ -157,7 +157,7 @@ Update your ECS task definition JSON file, by adding this in the  environment se
 {{% tab "AWS Fargate" %}}
 
 Initialize ASM in your code or set `DD_APPSEC_ENABLED` environment variable to true in your service invocation:
-```
+```shell
 env DD_APPSEC_ENABLED=true rails server
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add syntax highlighting to application security onboarding pages.

### Motivation
I noticed these were missing in these pages, so did a quick pass to
add them.

### Preview
<!-- Impacted pages preview links-->

* https://docs-staging.datadoghq.com/ivoanjo/syntax-highlight-asm-onboarding/security_platform/application_security/getting_started/ruby/
* https://docs-staging.datadoghq.com/ivoanjo/syntax-highlight-asm-onboarding/security_platform/application_security/getting_started/java/
* https://docs-staging.datadoghq.com/ivoanjo/syntax-highlight-asm-onboarding/security_platform/application_security/getting_started/dotnet/
* https://docs-staging.datadoghq.com/ivoanjo/syntax-highlight-asm-onboarding/security_platform/application_security/getting_started/php/
* https://docs-staging.datadoghq.com/ivoanjo/syntax-highlight-asm-onboarding/security_platform/application_security/getting_started/nodejs/
* https://docs-staging.datadoghq.com/ivoanjo/syntax-highlight-asm-onboarding/security_platform/application_security/getting_started/go/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
