### PR TITLE
fix(python): typo in API query snippet

### DIFF
--- a/static/resources/python/api_query_data.py
+++ b/static/resources/python/api_query_data.py
@@ -13,7 +13,7 @@ start = end - 3600
 query = 'system.cpu.idle{*}'  # Enter the metric you want, see your list here: https://app.datadoghq.com/metric/summary.
                               # Optionally, enter your host to filter the data, see here: https://app.datadoghq.com/infrastructure
 
-results = api.Metric.query(start=start - 3600, end=end, query=query)
+results = api.Metric.query(start=start, end=end, query=query)
 
 with open("output.json", "w") as f:
   dump(results, f)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This change fixes a typo in the Python API query snippet.

### Motivation

I was following the documentation on how to query metrics values and discovered a typo in the sample snippet.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/gabriele.tornetta/fix-query-snippet/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
