### PR TITLE
tracing/runtime_metrics/go.md: clarify the configuration of dogstatsd including UDS.

### DIFF
--- a/content/en/tracing/runtime_metrics/go.md
+++ b/content/en/tracing/runtime_metrics/go.md
@@ -27,7 +27,7 @@ tracer.Start(tracer.WithRuntimeMetrics())
 
 View runtime metrics in correlation with your Go services on the [Service page][1] in Datadog.
 
-By default, runtime metrics from your application are sent every 10 seconds to the Datadog Agent with DogStatsD. Make sure that [DogStatsD is enabled for the Agent][2]. If your Datadog Agent DogStatsD address differs from the default `localhost:8125`, use the [`WithDogstatsdAddress`][3] option or the environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`.
+By default, runtime metrics from your application are sent every 10 seconds to the Datadog Agent with DogStatsD. Make sure that [DogStatsD is enabled for the Agent][2]. If your Datadog Agent DogStatsD address differs from the default `localhost:8125`, use the [`WithDogstatsdAddress`][3] option (available starting in 1.18.0) or the environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`.
 
 If `WithDogstatsdAddress` is not used, the Tracer attempts to determine the address of the statsd service according to the following rules:
   1. Look for /var/run/datadog/dsd.socket and use it if present. IF NOT, continue to #2.

--- a/content/en/tracing/runtime_metrics/go.md
+++ b/content/en/tracing/runtime_metrics/go.md
@@ -30,9 +30,9 @@ View runtime metrics in correlation with your Go services on the [Service page][
 By default, runtime metrics from your application are sent every 10 seconds to the Datadog Agent with DogStatsD. Make sure that [DogStatsD is enabled for the Agent][2]. If your Datadog Agent DogStatsD address differs from the default `localhost:8125`, use the [`WithDogstatsdAddress`][3] option (available starting in 1.18.0) or the environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`.
 
 If `WithDogstatsdAddress` is not used, the Tracer attempts to determine the address of the statsd service according to the following rules:
-  1. Look for /var/run/datadog/dsd.socket and use it if present. IF NOT, continue to #2.
-  2. The host is determined by DD_AGENT_HOST, and defaults to "localhost".
-  3. The port is retrieved from the agent. If not present, it is determined by DD_DOGSTATSD_PORT, and defaults to 8125.
+  1. Look for `/var/run/datadog/dsd.socket` and use it if present. IF NOT, continue to #2.
+  2. The host is determined by **DD_AGENT_HOST**, and defaults to "localhost".
+  3. The port is retrieved from the agent. If not present, it is determined by **DD_DOGSTATSD_PORT**, and defaults to 8125.
 
 If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][4], and that port `8125` is open on the Agent. Additionally, for:
 

--- a/content/en/tracing/runtime_metrics/go.md
+++ b/content/en/tracing/runtime_metrics/go.md
@@ -27,12 +27,12 @@ tracer.Start(tracer.WithRuntimeMetrics())
 
 View runtime metrics in correlation with your Go services on the [Service page][1] in Datadog.
 
-By default, runtime metrics from your application are sent every 10 seconds to the Datadog Agent with DogStatsD. Make sure that [DogStatsD is enabled for the Agent][2]. If your Datadog Agent DogStatsD address differs from the default `localhost:8125`, use the [`WithDogstatsdAddress`][3] option (available starting in 1.18.0) or the environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`.
+By default, runtime metrics from your application are sent every 10 seconds to the Datadog Agent with DogStatsD. Make sure that [DogStatsD is enabled for the Agent][2]. If your Datadog Agent's DogStatsD address differs from the default `localhost:8125`, use the [`WithDogstatsdAddress`][3] option (available starting in 1.18.0) or the environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`.
 
 If `WithDogstatsdAddress` is not used, the Tracer attempts to determine the address of the statsd service according to the following rules:
   1. Look for `/var/run/datadog/dsd.socket` and use it if present. IF NOT, continue to #2.
   2. The host is determined by **DD_AGENT_HOST**, and defaults to "localhost".
-  3. The port is retrieved from the agent. If not present, it is determined by **DD_DOGSTATSD_PORT**, and defaults to 8125.
+  3. The port is retrieved from the agent. If not present, it is determined by **DD_DOGSTATSD_PORT**, and defaults to `8125`.
 
 If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][4], and that port `8125` is open on the Agent. Additionally, for:
 

--- a/content/en/tracing/runtime_metrics/go.md
+++ b/content/en/tracing/runtime_metrics/go.md
@@ -31,8 +31,8 @@ By default, runtime metrics from your application are sent every 10 seconds to t
 
 If `WithDogstatsdAddress` is not used, the Tracer attempts to determine the address of the statsd service according to the following rules:
   1. Look for /var/run/datadog/dsd.socket and use it if present. IF NOT, continue to #2.
-  2. The host is determined by DD_AGENT_HOST, and defaults to "localhost"
-  3. The port is retrieved from the agent. If not present, it is determined by DD_DOGSTATSD_PORT, and defaults to 8125
+  2. The host is determined by DD_AGENT_HOST, and defaults to "localhost".
+  3. The port is retrieved from the agent. If not present, it is determined by DD_DOGSTATSD_PORT, and defaults to 8125.
 
 If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][4], and that port `8125` is open on the Agent. Additionally, for:
 

--- a/content/en/tracing/runtime_metrics/go.md
+++ b/content/en/tracing/runtime_metrics/go.md
@@ -27,12 +27,17 @@ tracer.Start(tracer.WithRuntimeMetrics())
 
 View runtime metrics in correlation with your Go services on the [Service page][1] in Datadog.
 
-By default, runtime metrics from your application are sent every 10 seconds to the Datadog Agent with DogStatsD. Make sure that [DogStatsD is enabled for the Agent][2]. If your Datadog Agent DogStatsD address differs from the default `localhost:8125`, use the `WithDogstatsdAddress` option or the environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`. See the `WithDogstatsdAddress` documentation for information on how to configure the connection to [DogStatsD][3]
+By default, runtime metrics from your application are sent every 10 seconds to the Datadog Agent with DogStatsD. Make sure that [DogStatsD is enabled for the Agent][2]. If your Datadog Agent DogStatsD address differs from the default `localhost:8125`, use the `WithDogstatsdAddress` option or the environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`.
 
-If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][4], and that port `8125` is open on the Agent. Additionally, for:
+If `WithDogstatsdAddress` is not used, the Tracer attempts to determine the address of the statsd service according to the following rules:
+  1. Look for /var/run/datadog/dsd.socket and use it if present. IF NOT, continue to #2.
+  2. The host is determined by DD_AGENT_HOST, and defaults to "localhost"
+  3. The port is retrieved from the agent. If not present, it is determined by DD_DOGSTATSD_PORT, and defaults to 8125
 
-- **Kubernetes**: You _must_ [bind the DogstatsD port to a host port][5].
-- **ECS**: [Set the appropriate flags in your task definition][6].
+If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][3], and that port `8125` is open on the Agent. Additionally, for:
+
+- **Kubernetes**: You _must_ [bind the DogstatsD port to a host port][4].
+- **ECS**: [Set the appropriate flags in your task definition][5].
 
 ## Data Collected
 
@@ -40,7 +45,7 @@ The following metrics are collected by default after enabling Go metrics.
 
 {{< get-metrics-from-git "go" >}}
 
-Along with displaying these metrics in your APM Service Page, Datadog provides a [default Go Runtime Dashboard][7].
+Along with displaying these metrics in your APM Service Page, Datadog provides a [default Go Runtime Dashboard][6].
 
 ## Further Reading
 
@@ -48,8 +53,7 @@ Along with displaying these metrics in your APM Service Page, Datadog provides a
 
 [1]: https://app.datadoghq.com/apm/services
 [2]: /developers/dogstatsd/#setup
-[3]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#WithDogstatsdAddress
-[4]: /agent/docker/#dogstatsd-custom-metrics
-[5]: /developers/dogstatsd/?tab=kubernetes#agent
-[6]: /agent/amazon_ecs/#create-an-ecs-task
-[7]: https://app.datadoghq.com/dash/integration/30587/go-runtime-metrics
+[3]: /agent/docker/#dogstatsd-custom-metrics
+[4]: /developers/dogstatsd/?tab=kubernetes#agent
+[5]: /agent/amazon_ecs/#create-an-ecs-task
+[6]: https://app.datadoghq.com/dash/integration/30587/go-runtime-metrics

--- a/content/en/tracing/runtime_metrics/go.md
+++ b/content/en/tracing/runtime_metrics/go.md
@@ -27,17 +27,17 @@ tracer.Start(tracer.WithRuntimeMetrics())
 
 View runtime metrics in correlation with your Go services on the [Service page][1] in Datadog.
 
-By default, runtime metrics from your application are sent every 10 seconds to the Datadog Agent with DogStatsD. Make sure that [DogStatsD is enabled for the Agent][2]. If your Datadog Agent DogStatsD address differs from the default `localhost:8125`, use the `WithDogstatsdAddress` option or the environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`.
+By default, runtime metrics from your application are sent every 10 seconds to the Datadog Agent with DogStatsD. Make sure that [DogStatsD is enabled for the Agent][2]. If your Datadog Agent DogStatsD address differs from the default `localhost:8125`, use the [`WithDogstatsdAddress`][3] option or the environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`.
 
 If `WithDogstatsdAddress` is not used, the Tracer attempts to determine the address of the statsd service according to the following rules:
   1. Look for /var/run/datadog/dsd.socket and use it if present. IF NOT, continue to #2.
   2. The host is determined by DD_AGENT_HOST, and defaults to "localhost"
   3. The port is retrieved from the agent. If not present, it is determined by DD_DOGSTATSD_PORT, and defaults to 8125
 
-If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][3], and that port `8125` is open on the Agent. Additionally, for:
+If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][4], and that port `8125` is open on the Agent. Additionally, for:
 
-- **Kubernetes**: You _must_ [bind the DogstatsD port to a host port][4].
-- **ECS**: [Set the appropriate flags in your task definition][5].
+- **Kubernetes**: You _must_ [bind the DogstatsD port to a host port][5].
+- **ECS**: [Set the appropriate flags in your task definition][6].
 
 ## Data Collected
 
@@ -45,7 +45,7 @@ The following metrics are collected by default after enabling Go metrics.
 
 {{< get-metrics-from-git "go" >}}
 
-Along with displaying these metrics in your APM Service Page, Datadog provides a [default Go Runtime Dashboard][6].
+Along with displaying these metrics in your APM Service Page, Datadog provides a [default Go Runtime Dashboard][7].
 
 ## Further Reading
 
@@ -53,7 +53,8 @@ Along with displaying these metrics in your APM Service Page, Datadog provides a
 
 [1]: https://app.datadoghq.com/apm/services
 [2]: /developers/dogstatsd/#setup
-[3]: /agent/docker/#dogstatsd-custom-metrics
-[4]: /developers/dogstatsd/?tab=kubernetes#agent
-[5]: /agent/amazon_ecs/#create-an-ecs-task
-[6]: https://app.datadoghq.com/dash/integration/30587/go-runtime-metrics
+[3]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#WithDogstatsdAddress
+[4]: /agent/docker/#dogstatsd-custom-metrics
+[5]: /developers/dogstatsd/?tab=kubernetes#agent
+[6]: /agent/amazon_ecs/#create-an-ecs-task
+[7]: https://app.datadoghq.com/dash/integration/30587/go-runtime-metrics

--- a/content/en/tracing/runtime_metrics/go.md
+++ b/content/en/tracing/runtime_metrics/go.md
@@ -27,12 +27,12 @@ tracer.Start(tracer.WithRuntimeMetrics())
 
 View runtime metrics in correlation with your Go services on the [Service page][1] in Datadog.
 
-By default, runtime metrics from your application are sent every 10 seconds to the Datadog Agent with DogStatsD. Make sure that [DogStatsD is enabled for the Agent][2]. If your Datadog Agent's DogStatsD address differs from the default `localhost:8125`, use the [`WithDogstatsdAddress`][3] option (available starting in 1.18.0) or the environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`.
+By default, runtime metrics from your application are sent every 10 seconds to the Datadog Agent with DogStatsD. Make sure that [DogStatsD is enabled for the Agent][2]. If your Datadog Agent DogStatsD address differs from the default `localhost:8125`, use the [`WithDogstatsdAddress`][3] option (available starting in 1.18.0) or the environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`.
 
-If `WithDogstatsdAddress` is not used, the Tracer attempts to determine the address of the statsd service according to the following rules:
+If `WithDogstatsdAddress` is not used, the tracer attempts to determine the address of the statsd service according to the following rules:
   1. Look for `/var/run/datadog/dsd.socket` and use it if present. IF NOT, continue to #2.
   2. The host is determined by `DD_AGENT_HOST`, and defaults to "localhost".
-  3. The port is retrieved from the agent. If not present, it is determined by `DD_DOGSTATSD_PORT`, and defaults to `8125`.
+  3. The port is retrieved from the Agent. If not present, it is determined by `DD_DOGSTATSD_PORT`, and defaults to `8125`.
 
 If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][4], and that port `8125` is open on the Agent. Additionally, for Kubernetes or ECS, follow the guidelines below:
 

--- a/content/en/tracing/runtime_metrics/go.md
+++ b/content/en/tracing/runtime_metrics/go.md
@@ -27,12 +27,12 @@ tracer.Start(tracer.WithRuntimeMetrics())
 
 View runtime metrics in correlation with your Go services on the [Service page][1] in Datadog.
 
-By default, runtime metrics from your application are sent every 10 seconds to the Datadog Agent with DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][2]. If your Datadog Agent DogStatsD address differs from the default `localhost:8125`, use the `WithDogstatsdAddress` option or the environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`.
+By default, runtime metrics from your application are sent every 10 seconds to the Datadog Agent with DogStatsD. Make sure that [DogStatsD is enabled for the Agent][2]. If your Datadog Agent DogStatsD address differs from the default `localhost:8125`, use the `WithDogstatsdAddress` option or the environment variables `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT`. See the `WithDogstatsdAddress` documentation for information on how to configure the connection to [DogStatsD][3]
 
-If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][3], and that port `8125` is open on the Agent. Additionally, for:
+If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][4], and that port `8125` is open on the Agent. Additionally, for:
 
-- **Kubernetes**: You _must_ [bind the DogstatsD port to a host port][4].
-- **ECS**: [Set the appropriate flags in your task definition][5].
+- **Kubernetes**: You _must_ [bind the DogstatsD port to a host port][5].
+- **ECS**: [Set the appropriate flags in your task definition][6].
 
 ## Data Collected
 
@@ -40,7 +40,7 @@ The following metrics are collected by default after enabling Go metrics.
 
 {{< get-metrics-from-git "go" >}}
 
-Along with displaying these metrics in your APM Service Page, Datadog provides a [default Go Runtime Dashboard][6].
+Along with displaying these metrics in your APM Service Page, Datadog provides a [default Go Runtime Dashboard][7].
 
 ## Further Reading
 
@@ -48,7 +48,8 @@ Along with displaying these metrics in your APM Service Page, Datadog provides a
 
 [1]: https://app.datadoghq.com/apm/services
 [2]: /developers/dogstatsd/#setup
-[3]: /agent/docker/#dogstatsd-custom-metrics
-[4]: /developers/dogstatsd/?tab=kubernetes#agent
-[5]: /agent/amazon_ecs/#create-an-ecs-task
-[6]: https://app.datadoghq.com/dash/integration/30587/go-runtime-metrics
+[3]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#WithDogstatsdAddress
+[4]: /agent/docker/#dogstatsd-custom-metrics
+[5]: /developers/dogstatsd/?tab=kubernetes#agent
+[6]: /agent/amazon_ecs/#create-an-ecs-task
+[7]: https://app.datadoghq.com/dash/integration/30587/go-runtime-metrics

--- a/content/en/tracing/runtime_metrics/go.md
+++ b/content/en/tracing/runtime_metrics/go.md
@@ -31,10 +31,10 @@ By default, runtime metrics from your application are sent every 10 seconds to t
 
 If `WithDogstatsdAddress` is not used, the Tracer attempts to determine the address of the statsd service according to the following rules:
   1. Look for `/var/run/datadog/dsd.socket` and use it if present. IF NOT, continue to #2.
-  2. The host is determined by **DD_AGENT_HOST**, and defaults to "localhost".
-  3. The port is retrieved from the agent. If not present, it is determined by **DD_DOGSTATSD_PORT**, and defaults to `8125`.
+  2. The host is determined by `DD_AGENT_HOST`, and defaults to "localhost".
+  3. The port is retrieved from the agent. If not present, it is determined by `DD_DOGSTATSD_PORT`, and defaults to `8125`.
 
-If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][4], and that port `8125` is open on the Agent. Additionally, for:
+If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` [is set to true][4], and that port `8125` is open on the Agent. Additionally, for Kubernetes or ECS, follow the guidelines below:
 
 - **Kubernetes**: You _must_ [bind the DogstatsD port to a host port][5].
 - **ECS**: [Set the appropriate flags in your task definition][6].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This clarifies the configuration of DogStatsD for use with runtime metrics in the Go tracer.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/knusbaum/update-dogstatsd-doc/tracing/runtime_metrics/go

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
