### PR TITLE
[Github Action] Automatically generate preview links

### DIFF
--- a/.github/workflows/preview_link.yml
+++ b/.github/workflows/preview_link.yml
@@ -1,0 +1,46 @@
+name: Post preview link
+on:
+  pull_request:
+    paths:
+      - 'content/en/**.md'
+
+jobs:
+  preview-link:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Find changed files
+      id: changed_files
+      uses: jitterbit/get-changed-files@v1
+      continue-on-error: true
+    - name: Generate links
+      id: comment_body
+      run: |
+        for file in ${{ steps.changed_files.outputs.added_modified }}; do
+          echo "Checking file ${file}..."
+          if [[ "$file" =~ ^content/en/(.*).md$ ]]; then
+            body="${body}https://docs-staging.datadoghq.com/${{ github.head_ref }}/${BASH_REMATCH[1]}\n"
+          fi
+        done
+        printf "Preview links:\n$body"
+        # This terrible syntax is so we can pass a multi-line body to the "post comment" action
+        printf "COMMENT_BODY<<EOF\n" >> $GITHUB_ENV
+        printf "$body" >> $GITHUB_ENV
+        printf "EOF\n" >> $GITHUB_ENV
+    - name: Find existing comment
+      uses: peter-evans/find-comment@v2.0.0
+      id: find_comment
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: "Preview links:"
+    - name: Post comment
+      uses: peter-evans/create-or-update-comment@v2.0.0
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-id: ${{ steps.find_comment.outputs.comment-id }}
+        edit-mode: replace
+        body: |
+          Preview links:
+          ${{ env.COMMENT_BODY }}


### PR DESCRIPTION
### What does this PR do?
Adds a Github action that automatically posts a comment with preview (staging) links for all files changed or added on a PR, if they match the pattern `content/en/**.md`. 

This is how it looks:

<img width="907" alt="Screen Shot 2022-05-03 at 23 22 38" src="https://user-images.githubusercontent.com/980842/166569247-028e0153-b461-4a22-8d7c-d34bc1399dec.png">

When more commits are pushed to the same PR, the same comment gets updated with the new list of files.

If I'm not mistaken, this Action should only trigger for PRs from this same repo (not external PRs from forks) which are the ones that will have a preview on staging.

### Motivation
Not having to create the preview links manually, at least in most cases.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
