### PR TITLE
[CIAPP] Remove beta warning from Codefresh docs

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/codefresh.md
+++ b/content/en/continuous_integration/setup_pipelines/codefresh.md
@@ -14,8 +14,6 @@ further_reading:
 <div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-<div class="alert alert-info">The Codefresh integration is in beta. There are no billing implications for activating the Codefresh integration during this period.</div>
-
 ## Configure the Datadog integration
 
 The steps to activate the Datadog integration for [Codefresh][1] are:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Remove the beta status warning from the Codefresh CI Visibility integration documentation page.

### Motivation
This is part of the plan to GA and start billing for codefresh.

### Preview
<!-- Impacted pages preview links-->

<!-- This only works if you are part of the Datadog organization and working off of a branch - it will not work with a fork.

Replace the branch name and add the complete path: -->
https://docs-staging.datadoghq.com/carlos.gonzalez/codefresh-remove-no-billing-notice/continuous_integration/setup_pipelines/codefresh/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
