### PR TITLE
Update preview_links action

### DIFF
--- a/.github/workflows/preview_link.yml
+++ b/.github/workflows/preview_link.yml
@@ -42,7 +42,6 @@ jobs:
         comment-id: ${{ steps.find_comment.outputs.comment-id }}
         edit-mode: replace
         body: |
-          Preview links:
+          Preview links (active after the `build_preview` check completes):
           ${{ env.COMMENT_BODY }}
 
-          Links are active after the `build_preview` check completes.

--- a/.github/workflows/preview_link.yml
+++ b/.github/workflows/preview_link.yml
@@ -44,3 +44,5 @@ jobs:
         body: |
           Preview links:
           ${{ env.COMMENT_BODY }}
+
+          Links are active after the `build_preview` check completes.


### PR DESCRIPTION
Users are confused when the preview links in the GitHub comment don't immediately work. They're only available once the `build_preview` check passes.

![Screen Shot 2022-05-04 at 9 53 26 AM](https://user-images.githubusercontent.com/21250475/166736446-a6fcb007-bf08-4720-a804-50ae116c8f9f.png)

~~Note: I'm going to make a small edit to a markdown file to check if this is working. I'll back the change out when I'm done.~~