### PR TITLE
Adding Example On How to Inject OTEL IDs in .NET

### DIFF
--- a/content/en/tracing/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/connect_logs_and_traces/opentelemetry.md
@@ -328,9 +328,9 @@ func convertTraceID(id string) string {
 
 {{< programming-lang lang="dotnet" >}}
 
-To manually correlate your traces with your logs, convert the OpenTelemetry `TraceId` and `SpanId` into the format used by Datadog, then add those to your logs under the `dd_trace_id` and `dd_span_id` attributes. The following example shows how to convert the OTEL (System.DiagnosticSource.Activity) Trace & Span IDs into Datadog's required format and injects those into [Serilog][1] logs.
+To manually correlate your traces with your logs, convert the OpenTelemetry `TraceId` and `SpanId` into the format used by Datadog, then add those to your logs under the `dd_trace_id` and `dd_span_id` attributes. The following example shows how to convert the OTEL (System.DiagnosticSource.Activity) Trace & Span IDs into Datadog's required format,and then how you can inject those into your [Serilog][1] log.
 
-```dotnet
+```csharp
 var stringTraceId = Activity.Current.TraceId.ToString();
 var stringSpanId = Activity.Current.SpanId.ToString();
 

--- a/content/en/tracing/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/connect_logs_and_traces/opentelemetry.md
@@ -328,13 +328,23 @@ func convertTraceID(id string) string {
 
 {{< programming-lang lang="dotnet" >}}
 
-For trace and log correlation in .NET, modify the [Datadog SDK .NET examples][1] to include the additional steps discussed above. 
+To manually correlate your traces with your logs, convert the OpenTelemetry `TraceId` and `SpanId` into the format used by Datadog, then add those to your logs under the `dd_trace_id` and `dd_span_id` attributes. The following example shows how to convert the OTEL (System.DiagnosticSource.Activity) Trace & Span IDs into Datadog's required format and injects those into [Serilog][1] logs.
 
-[Contact Datadog support][2] with any questions.
+```dotnet
+var stringTraceId = Activity.Current.TraceId.ToString();
+var stringSpanId = Activity.Current.SpanId.ToString();
 
+var ddTraceId = Convert.ToUInt64(stringTraceId.Substring(16), 16).ToString();
+var ddSpanId = Convert.ToUInt64(stringSpanId, 16).ToString();
 
-[1]: /tracing/connect_logs_and_traces/dotnet/
-[2]: /help/
+using (LogContext.PushProperty("dd_trace_id", ddTraceId))
+using (LogContext.PushProperty("dd_span_id", ddSpanId))
+{
+    Serilog.Log.Logger.Information("Example log line with trace correlation info");
+}
+```
+
+[1]: https://serilog.net/
 {{< /programming-lang >}}
 
 {{< /programming-lang-wrapper >}}

--- a/content/en/tracing/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/connect_logs_and_traces/opentelemetry.md
@@ -328,7 +328,8 @@ func convertTraceID(id string) string {
 
 {{< programming-lang lang="dotnet" >}}
 
-To manually correlate your traces with your logs, convert the OpenTelemetry `TraceId` and `SpanId` into the format used by Datadog, then add those to your logs under the `dd_trace_id` and `dd_span_id` attributes. The following example shows how to convert the OTEL (System.DiagnosticSource.Activity) Trace & Span IDs into Datadog's required format,and then how you can inject those into your [Serilog][1] log.
+To manually correlate traces with logs, convert the OpenTelemetry `TraceId` and `SpanId` into the format used by Datadog. Add those IDs to your logs under the `dd_trace_id` and `dd_span_id` attributes. The following example shows how to convert the OTel (`System.DiagnosticSource.Activity`) trace and span IDs into Datadog's required format, and how 
+ to inject them into your [Serilog][1] log.
 
 ```csharp
 var stringTraceId = Activity.Current.TraceId.ToString();


### PR DESCRIPTION
### What does this PR do?

Updates the current docs to show customer's an example of how to convert their .NET OTEL trace & span IDs into the Datadog used format.

### Motivation

Customer reached out asking bout how they could do this.

### Preview

https://docs-staging.datadoghq.com/maximo/otel-traces-logs-injection-dotnet/tracing/connect_logs_and_traces/opentelemetry/

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
