### PR TITLE
zachg update how to set debug logging with Python tracer >1.0

### DIFF
--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -32,12 +32,11 @@ To enable debug mode for the Datadog Java Tracer, set the flag `-Ddd.trace.debug
 
 To enable debug mode for the Datadog Python Tracer, set the environment variables `DD_TRACE_DEBUG=true` and `DD_CALL_BASIC_CONFIG=true` when using `ddtrace-run`.
 
-If you have an existing logging configuration, we recommend enabling debug logging in your application code.
+If you have an existing logging configuration, enable debug logging in your application code.
 ```
 log = logging.getLogger("ddtrace.tracer")
 log.setLevel(logging.DEBUG)
 ```
-<p></p>
 
 {{< /programming-lang >}}
 

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -30,7 +30,13 @@ To enable debug mode for the Datadog Java Tracer, set the flag `-Ddd.trace.debug
 
 {{< programming-lang lang="python" >}}
 
-To enable debug mode for the Datadog Python Tracer, set the environment variable `DD_TRACE_DEBUG=true` when using `ddtrace-run`.
+To enable debug mode for the Datadog Python Tracer, set the environment variables `DD_TRACE_DEBUG=true` and `DD_CALL_BASIC_CONFIG=true` when using `ddtrace-run`.
+
+If you have an existing logging configuration, we recommend enabling debug logging in your application code.
+```
+log = logging.getLogger("ddtrace.tracer")
+log.setLevel(logging.DEBUG)
+```
 <p></p>
 
 {{< /programming-lang >}}


### PR DESCRIPTION
### What does this PR do?
With the 1.0 release of the Python tracer we stopped automatically calling logging.basic_config(), which means that we need customers to enable it via an envar in order for us to enable debug logging via an envar. 

The code snippet way of doing this is for customers who already have a logging configuration.

### Motivation
Just setting `DD_TRACE_DEBUG=true` for Python tracer >1.0 won't enable debug logging.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
