### PR TITLE
Note on scope of list-of-api-source-attribute-value

### DIFF
--- a/content/en/integrations/faq/list-of-api-source-attribute-value.md
+++ b/content/en/integrations/faq/list-of-api-source-attribute-value.md
@@ -11,6 +11,8 @@ Post events for specific integrations using the [Events API][1] and the `source_
 
 Search for events in the event stream using `sources:<SEARCH_TERM>`.
 
+**Note** that the list below includes sources from core Datadog integrations only. Additional sources may come from [community][2] and [marketplace][3] integrations. 
+
 
 ## Parameters
 
@@ -325,3 +327,5 @@ Search for events in the event stream using `sources:<SEARCH_TERM>`.
 
 
 [1]: /api/latest/events/
+[2]: https://docs.datadoghq.com/integrations/
+[3]: https://app.datadoghq.com/marketplace/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a note that indicates, the sources on this page are only a partial list.

### Motivation
When researching source_type_name values, I came upon this list that seems to imply that it's exhaustive, which is not true. Revamping the list is a bigger task, but a note will avoid confusion among partners and SEs.

### Preview
https://docs-staging.datadoghq.com/KateYoak/patch-1/integrations/faq/list-of-api-source-attribute-value/
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
