### PR TITLE
add note for All groups option

### DIFF
--- a/content/en/monitors/notify/downtimes.md
+++ b/content/en/monitors/notify/downtimes.md
@@ -46,6 +46,8 @@ When constraining a downtime to a simple alert monitor, the `Group scope` field 
 
 If a multi-alert monitor is included, it is only silenced for groups covered by the scope. For example, if a downtime is scoped for `host:X` and a multi-alert is triggered on both `host:X` and `host:Y`, Datadog generates a monitor notification for `host:Y`, but not `host:X`.
 
+If you would like to include all groups in the scope of a Downtime which applies to multi-alert monitors, you select `All` for the `Group scope`.
+
 The examples below show how `Group scope` may be applied to multi-alert monitors.
 
 {{< tabs >}}

--- a/content/en/monitors/notify/downtimes.md
+++ b/content/en/monitors/notify/downtimes.md
@@ -46,7 +46,7 @@ When constraining a downtime to a simple alert monitor, the `Group scope` field 
 
 If a multi-alert monitor is included, it is only silenced for groups covered by the scope. For example, if a downtime is scoped for `host:X` and a multi-alert is triggered on both `host:X` and `host:Y`, Datadog generates a monitor notification for `host:Y`, but not `host:X`.
 
-If you would like to include all groups in the scope of a Downtime which applies to multi-alert monitors, you select `All` for the `Group scope`.
+If you would like to include all groups in the scope of a Downtime which applies to multi-alert monitors, you should select `All` for the `Group scope`.
 
 The examples below show how `Group scope` may be applied to multi-alert monitors.
 

--- a/content/en/monitors/notify/downtimes.md
+++ b/content/en/monitors/notify/downtimes.md
@@ -46,7 +46,7 @@ When constraining a downtime to a simple alert monitor, the `Group scope` field 
 
 If a multi-alert monitor is included, it is only silenced for groups covered by the scope. For example, if a downtime is scoped for `host:X` and a multi-alert is triggered on both `host:X` and `host:Y`, Datadog generates a monitor notification for `host:Y`, but not `host:X`.
 
-If you would like to include all groups in the scope of a Downtime which applies to multi-alert monitors, you should select `All` for the `Group scope`.
+To include all groups in the scope of a Downtime that applies to multi-alert monitors, select `All` for the `Group scope`.
 
 The examples below show how `Group scope` may be applied to multi-alert monitors.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds a note for how to apply a Downtime to All groups of a multi-alert monitor

### Motivation
<!-- What inspired you to submit this pull request?-->
Zendesk ticket `803387`

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
