### PR TITLE
make the preview_link fetch all links

### DIFF
--- a/.github/workflows/preview_link.yml
+++ b/.github/workflows/preview_link.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Generate links
       id: comment_body
       run: |
-        for file in ${{ steps.changed_files.outputs.added_modified }}; do
+        for file in ${{ steps.changed_files.outputs.all }}; do
           echo "Checking file ${file}..."
           if [[ "$file" =~ ^content/en/(.*).md$ ]]; then
             body="${body}https://docs-staging.datadoghq.com/${{ github.head_ref }}/${BASH_REMATCH[1]}\n"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
previously this workflow only showed links to content that had been added or modified, but i wanted to check aliases too. so the workflow now should print all changed files (added, modified, removed, renamed)

### Motivation
let the devil make work of these idle hands

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
