### PR TITLE
update to hugo 0.98.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "del": "4.1.1",
         "docsearch.js": "^2.6.3",
         "fancy-log": "^1.3.3",
-        "hugo-bin": "0.84.0",
+        "hugo-bin": "0.86.0",
         "jquery": "3.5.1",
         "js-cookie": "^2.2.1",
         "js-yaml": "^3.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5544,10 +5544,10 @@ https-proxy-agent@^2.2.1:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
-hugo-bin@0.84.0:
-  version "0.84.0"
-  resolved "https://registry.yarnpkg.com/hugo-bin/-/hugo-bin-0.84.0.tgz#e28af45ce993ef00f6b11316e786d78537df6a1a"
-  integrity sha512-1krqEkEPLmQqFBkilbECo1oPaJwWEExiTfhL7S4iKrSgCxbHvE7d//y9piFZZ86rOxYOKFVcnDXCmnRUdCDLmA==
+hugo-bin@0.86.0:
+  version "0.86.0"
+  resolved "https://registry.yarnpkg.com/hugo-bin/-/hugo-bin-0.86.0.tgz#65346703bfcc899f6f0c6670740fd1b4660af1ec"
+  integrity sha512-n71L2J9yckQ8fLZAQmWdUqNkIuwVMrjsx45911cJH7ORF3BPwVgWvw0EYiC1UjWsmolqvEcen7CceFde9VletA==
   dependencies:
     bin-wrapper "^4.1.0"
     picocolors "^1.0.0"


### PR DESCRIPTION
### What does this PR do?

This PR updates Hugo from version `0.96.0` to version `0.98.0`
See https://github.com/gohugoio/hugo/releases for changelog

### Motivation

Keeping hugo up to date and making use of new features

### Preview

Various pages need spot checking that no new issues have crept in
https://docs-staging.datadoghq.com/david.jones/hugo-updatelatest/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
