### PR TITLE
Adds Java snippet for DogstatsD set metric

### DIFF
--- a/content/en/metrics/custom_metrics/dogstatsd_metrics_submission.md
+++ b/content/en/metrics/custom_metrics/dogstatsd_metrics_submission.md
@@ -446,6 +446,30 @@ func main() {
 ```
 {{< /programming-lang >}}
 
+{{< programming-lang lang="java" >}}
+```java
+import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
+import com.timgroup.statsd.StatsDClient;
+import java.util.Random;
+
+public class DogStatsdClient {
+
+    public static void main(String[] args) throws Exception {
+
+        StatsDClient Statsd = new NonBlockingStatsDClientBuilder()
+            .prefix("statsd").
+            .hostname("localhost")
+            .port(8125)
+            .build();
+        for (int i = 0; i < 10; i++) {
+            Statsd.recordSetValue("example_metric.set", i, new String[]{"environment:dev"});
+            Thread.sleep(random.NextInt(10000));
+        }
+    }
+}
+```
+{{< /programming-lang >}}
+
 {{< programming-lang lang=".NET" >}}
 ```csharp
 using StatsdClient;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a Java snippet to emit a SET metric-stored as a GAUGE metric-to Datadog.
### Motivation
Missing code snippet from internal #cake thread making the Java wrapper failing to display the snippet and defaulting to Python

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Snippet based on my understanding of the equivalent Python snippet

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
