### PR TITLE
Update docs for AppSec on Ruby 1.1.0

### DIFF
--- a/content/en/security_platform/application_security/getting_started/ruby.md
+++ b/content/en/security_platform/application_security/getting_started/ruby.md
@@ -16,7 +16,7 @@ further_reading:
       text: "Troubleshooting Application Security Monitoring"
 ---
 
-You can monitor application security for Ruby apps running in Docker, Kubernetes, AWS ECS, and AWS Fargate. 
+You can monitor application security for Ruby apps running in Docker, Kubernetes, AWS ECS, and AWS Fargate.
 
 {{% appsec-getstarted %}}
 
@@ -25,7 +25,7 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
 1. **Update your Gemfile to include the Datadog library**:
 
    ```ruby
-   gem 'ddtrace', '~> 1.0'
+   gem 'ddtrace', '~> 1.1'
    ```
 
    For information about which language and framework versions are supported by the library, see [Compatibility][1].
@@ -33,16 +33,13 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
    For more information about upgrading from a `dd-trace` 0.x version, see [the Ruby tracer upgrade guide][2].
 
 2. **Enable ASM**, either in your code:
+
+   Note: ASM currently requires the APM tracer to be enabled; a quick setup covering the most common cases is described below, see [the Ruby tracer documentation][3] for more details.
+
    {{< tabs >}}
 
 {{% tab "Rails" %}}
-   Either enable the tracer through auto-instrumentation by updating your Gemfile:
-
-   ```ruby
-   gem 'ddtrace', '~> 1.0', require: 'ddtrace/auto_instrument'
-   ```
-
-   Or enable the tracer by adding an initializer in your application code:
+   Enable the APM tracer manually by adding an initializer in your application code:
 
    ```ruby
    # config/initializers/datadog.rb
@@ -51,19 +48,43 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
 
    Datadog.configure do |c|
      # enable the APM tracer
-     # not needed if `gem 'ddtrace', require: 'ddtrace/auto_instrument' is used
      c.tracing.instrument :rails
 
+     # enable ASM
      c.appsec.enabled = true
      c.appsec.instrument :rails
    end
    ```
+
+   Or enable the APM tracer through auto-instrumentation by updating your Gemfile to auto-instrument:
+
+   ```ruby
+   gem 'ddtrace', '~> 1.1', require: 'ddtrace/auto_instrument'
+   ```
+
+   And also enable AppSec:
+
+   ```ruby
+   # config/initializers/datadog.rb
+
+   require 'datadog/appsec'
+
+   Datadog.configure do |c|
+     # the APM tracer is enabled by auto-instrumentation
+
+     # enable ASM
+     c.appsec.enabled = true
+     c.appsec.instrument :rails
+   end
+   ```
+
 {{% /tab %}}
 
 {{% tab "Sinatra" %}}
-   Enable the tracer by adding the following to your application's startup:
+   Enable the APM tracer by adding the following to your application's startup:
 
    ```ruby
+   require 'sinatra'
    require 'ddtrace'
    require 'datadog/appsec'
 
@@ -71,7 +92,22 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
      # enable the APM tracer
      c.tracing.instrument :sinatra
 
-     # enable appsec for Sinatra
+     # enable ASM for Sinatra
+     c.appsec.enabled = true
+     c.appsec.instrument :sinatra
+   end
+   ```
+
+   Or enable the APM tracer through auto-instrumentation:
+
+   ```ruby
+   require 'sinatra'
+   require 'ddtrace/auto_instrument'
+
+   Datadog.configure do |c|
+     # the APM tracer is enabled by auto-instrumentation
+
+     # enable ASM for Sinatra
      c.appsec.enabled = true
      c.appsec.instrument :sinatra
    end
@@ -79,7 +115,7 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
 {{% /tab %}}
 
 {{% tab "Rack" %}}
-   Enable the tracer by adding the following to your `config.ru` file:
+   Enable the APM tracer by adding the following to your `config.ru` file:
 
    ```ruby
    require 'ddtrace'
@@ -89,7 +125,7 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
      # enable the APM tracer
      c.tracing.instrument :rack
 
-     # enable appsec for Rack
+     # enable ASM for Rack
      c.appsec.enabled = true
      c.appsec.instrument :rack
    end
@@ -141,7 +177,7 @@ spec:
 {{% /tab %}}
 {{% tab "AWS ECS" %}}
 
-Update your ECS task definition JSON file, by adding this in the  environment section:
+Update your ECS task definition JSON file, by adding this in the environment section:
 
 ```json
 "environment": [
@@ -175,3 +211,4 @@ env DD_APPSEC_ENABLED=true rails server
 
 [1]: /security_platform/application_security/setup_and_configure/?code-lang=ruby#compatibility
 [2]: https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#from-0x-to-10
+[3]: /tracing/setup_overview/setup/ruby/

--- a/content/en/security_platform/application_security/getting_started/ruby.md
+++ b/content/en/security_platform/application_security/getting_started/ruby.md
@@ -39,7 +39,7 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
    {{< tabs >}}
 
 {{% tab "Rails" %}}
-   Enable the APM tracer manually by adding an initializer in your application code:
+   Enable the APM tracer by adding an initializer in your application code:
 
    ```ruby
    # config/initializers/datadog.rb

--- a/content/en/security_platform/application_security/getting_started/ruby.md
+++ b/content/en/security_platform/application_security/getting_started/ruby.md
@@ -32,9 +32,9 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
 
    For more information about upgrading from a `dd-trace` 0.x version, see [the Ruby tracer upgrade guide][2].
 
-2. **Enable ASM**, either in your code:
+2. **Enable ASM** by enabling the APM tracer. The following options describe a quick setup that covers the most common cases. Read [the Ruby tracer documentation][3] for more details.
 
-   Note: ASM currently requires the APM tracer to be enabled; a quick setup covering the most common cases is described below, see [the Ruby tracer documentation][3] for more details.
+   You can enable ASM either in your code:
 
    {{< tabs >}}
 
@@ -62,7 +62,7 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
    gem 'ddtrace', '~> 1.1', require: 'ddtrace/auto_instrument'
    ```
 
-   And also enable AppSec:
+   And also enable `appsec`:
 
    ```ruby
    # config/initializers/datadog.rb

--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -292,13 +292,13 @@ if span, ok := tracer.SpanFromContext(request.Context()); ok {
 
 {{< programming-lang lang="ruby" >}}
 
-Use either API to add user information to a trace so that you can monitor authenticated requests in the application.
+Use one of the following APIs to add user information to a trace so that you can monitor authenticated requests in the application:
 
 {{< tabs >}}
 
-{{% tab "Using `Datadog::Kit::Identity.set_user` %}}
+{{% tab "set_user" %}}
 
-Starting with `ddtrace` 1.1.0, a convenience `set_user` method is available:
+Starting with `ddtrace` 1.1.0, the `Datadog::Kit::Identity.set_user` method is available. This is the recommended API for adding user information to traces:
 
 ```ruby
 # Get the active trace
@@ -328,11 +328,9 @@ Datadog::Kit::Identity.set_user(
 
 {{% /tab %}}
 
-{{% tab "Using trace `set_tag`" %}}
+{{% tab "set_tag" %}}
 
-Note: `Datadog::Kit::Identity.set_user` is the recommended way to set user information.
-
-Use the the Ruby tracer's API for adding custom tags to a trace, and add user information so that you can monitor authenticated requests in the application.
+If `Datadog::Kit::Identity.set_user` does not meet your needs, you can use `set_tag` instead.
 
 User monitoring tags are applied on the trace and start with the prefix `usr.` followed by the name of the field. For example, `usr.name` is a user monitoring tag that tracks the user’s name.
 
@@ -438,11 +436,9 @@ To protect users' data, sensitive data scanning is activated by default in ASM. 
 * `DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP` - Pattern for scanning for keys whose values commonly contain sensitive data. If found, the values and any child nodes associated with the key are redacted.
 * `DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP` - Pattern for scanning for values that could indicate sensitive data. If found, the value and all its child nodes are redacted.
 
-{{< programming-lang-wrapper langs="ruby" >}}
+<div class="alert alert-info"><strong>For Ruby only, starting in <code>ddtrace</code> version 1.1.0</strong> 
 
-{{< programming-lang lang="ruby" >}}
-
-It is also possible to configure these patterns from code:
+<p>You can also configure scanning patterns in code:</p>
 
 ```ruby
 Datadog.configure do |c|
@@ -454,11 +450,7 @@ Datadog.configure do |c|
 end
 ```
 
-Note: this feature is available starting with `ddtrace` 1.1.0.
-
-{{< /programming-lang >}}
-
-{{< /programming-lang-wrapper >}}
+</div>
 
 
 The following are examples of data that are flagged as sensitive by default:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fixes some elements, and adds 1.1.0 features.

### Motivation

Upcoming ddtrace 1.1.0 for Ruby release.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Do not merge until 1.1.0 is released.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
