### PR TITLE
[ci-visibility] Clarify `jest` version compatibility 

### DIFF
--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -20,6 +20,7 @@ Supported test frameworks:
 * Jest >= 24.8.0
   * Only `jsdom` (in package `jest-environment-jsdom`) and `node` (in package `jest-environment-node`) are supported as test environments. Custom environments like `@jest-runner/electron/environment` in `jest-electron-runner` are not supported.
   * Only [`jest-circus`][1] and [`jest-jasmine2`][2] are supported as [`testRunner`][3].
+  * Jest >= 28 is only supported from `dd-trace>=2.7.0`
 * Mocha >= 5.2.0
   * Mocha >= 9.0.0 has [partial support](#known-limitations).
 * Cucumber-js >= 7.0.0
@@ -85,7 +86,8 @@ if (process.env.DD_ENV === 'ci') {
 module.exports = require('jest-environment-node').default
 ```
 
-Since `jest-environment-jsdom` is not included in `jest@28`, you need to install it separately.
+Since `jest-environment-jsdom` is not included in `jest@28`, you need to install it separately. Also, `jest>=28` is only supported from `dd-trace>=2.7.0`.
+
 <div class="alert alert-warning"><strong>Note</strong>: <code>jest-environment-node</code>, <code>jest-environment-jsdom</code>, <code>jest-jasmine2</code>, and <code>jest-circus</code> (as of Jest 27) are installed together with <code>jest</code>, so they do not normally appear in your <code>package.json</code>. If you've extracted any of these libraries in your <code>package.json</code>, make sure the installed versions are the same as the one of <code>jest</code>.</div>
 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Clarify compatibility with latest version of `jest`

### Motivation
Let users know that if they want `jest@28` support they have to use a specific version of `dd-trace`

https://docs-staging.datadoghq.com/juan-fernandez/clarify-jest-compatibility/continuous_integration/setup_tests/javascript/?tab=jest

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
