### PR TITLE
(DOCS-3392) Add shortcode for AWS permissions

### DIFF
--- a/layouts/shortcodes/aws-permissions.md
+++ b/layouts/shortcodes/aws-permissions.md
@@ -1,0 +1,96 @@
+## Datadog Permissions
+
+These IAM permissions enable Datadog to collect metrics, tags, CloudWatch events, and other data necessary to monitor your AWS environment. The permissions listed below are included in the policy document using wild cards such as `List*` and `Get*`. If you require strict policies, use the complete action names as listed and reference the Amazon API documentation for the services you require.
+
+### AWS Integration IAM Policy
+
+If you are not comfortable with granting this list of permissions, at the very least use the existing policies named **AmazonEC2ReadOnlyAccess** and **CloudWatchReadOnlyAccess**.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "apigateway:GET",
+                "autoscaling:Describe*",
+                "backup:List*",
+                "budgets:ViewBudget",
+                "cloudfront:GetDistributionConfig",
+                "cloudfront:ListDistributions",
+                "cloudtrail:DescribeTrails",
+                "cloudtrail:GetTrailStatus",
+                "cloudtrail:LookupEvents",
+                "cloudwatch:Describe*",
+                "cloudwatch:Get*",
+                "cloudwatch:List*",
+                "codedeploy:List*",
+                "codedeploy:BatchGet*",
+                "directconnect:Describe*",
+                "dynamodb:List*",
+                "dynamodb:Describe*",
+                "ec2:Describe*",
+                "ecs:Describe*",
+                "ecs:List*",
+                "elasticache:Describe*",
+                "elasticache:List*",
+                "elasticfilesystem:DescribeFileSystems",
+                "elasticfilesystem:DescribeTags",
+                "elasticfilesystem:DescribeAccessPoints",
+                "elasticloadbalancing:Describe*",
+                "elasticmapreduce:List*",
+                "elasticmapreduce:Describe*",
+                "es:ListTags",
+                "es:ListDomainNames",
+                "es:DescribeElasticsearchDomains",
+                "fsx:DescribeFileSystems",
+                "fsx:ListTagsForResource",
+                "health:DescribeEvents",
+                "health:DescribeEventDetails",
+                "health:DescribeAffectedEntities",
+                "kinesis:List*",
+                "kinesis:Describe*",
+                "lambda:GetPolicy",
+                "lambda:List*",
+                "logs:DeleteSubscriptionFilter",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
+                "logs:DescribeSubscriptionFilters",
+                "logs:FilterLogEvents",
+                "logs:PutSubscriptionFilter",
+                "logs:TestMetricFilter",
+                "organizations:DescribeOrganization",
+                "rds:Describe*",
+                "rds:List*",
+                "redshift:DescribeClusters",
+                "redshift:DescribeLoggingStatus",
+                "route53:List*",
+                "s3:GetBucketLogging",
+                "s3:GetBucketLocation",
+                "s3:GetBucketNotification",
+                "s3:GetBucketTagging",
+                "s3:ListAllMyBuckets",
+                "s3:PutBucketNotification",
+                "ses:Get*",
+                "sns:List*",
+                "sns:Publish",
+                "sqs:ListQueues",
+                "states:ListStateMachines",
+                "states:DescribeStateMachine",
+                "support:DescribeTrustedAdvisor*",
+                "support:RefreshTrustedAdvisorCheck",
+                "tag:GetResources",
+                "tag:GetTagKeys",
+                "tag:GetTagValues",
+                "xray:BatchGetTraces",
+                "xray:GetTraceSummaries"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ]
+}
+```
+### AWS Security Audit Policy
+
+You must attach the <a href="https://console.aws.amazon.com/iam/home#policies/arn:aws:iam::aws:policy/SecurityAudit" target="_blank">AWS SecurityAudit Policy</a> to your Datadog IAM role if you would like to use <a href="https://docs.datadoghq.com/integrations/amazon_web_services/#resource-collection" target="_blank">Cloud Security Posture Management</a>.

--- a/layouts/shortcodes/aws-permissions.md
+++ b/layouts/shortcodes/aws-permissions.md
@@ -1,10 +1,10 @@
 ## Datadog Permissions
 
-These IAM permissions enable Datadog to collect metrics, tags, CloudWatch events, and other data necessary to monitor your AWS environment. The permissions listed below are included in the policy document using wild cards such as `List*` and `Get*`. If you require strict policies, use the complete action names as listed and reference the Amazon API documentation for the services you require.
+IAM permissions allow Datadog to collect metrics, tags, CloudWatch events, and data that are necessary to monitor your AWS environment. The following permissions included in the policy document use wild cards such as `List*` and `Get*`. If you require strict policies, use the complete action names as listed and reference the Amazon API documentation for your respective services.
 
 ### AWS Integration IAM Policy
 
-If you are not comfortable with granting this list of permissions, at the very least use the existing policies named **AmazonEC2ReadOnlyAccess** and **CloudWatchReadOnlyAccess**.
+If you are not comfortable granting this list of permissions, use the existing **AmazonEC2ReadOnlyAccess** and **CloudWatchReadOnlyAccess** policies.
 
 ```json
 {
@@ -93,4 +93,4 @@ If you are not comfortable with granting this list of permissions, at the very l
 ```
 ### AWS Security Audit Policy
 
-You must attach the <a href="https://console.aws.amazon.com/iam/home#policies/arn:aws:iam::aws:policy/SecurityAudit" target="_blank">AWS SecurityAudit Policy</a> to your Datadog IAM role if you would like to use <a href="https://docs.datadoghq.com/integrations/amazon_web_services/#resource-collection" target="_blank">Cloud Security Posture Management</a>.
+To use <a href="https://docs.datadoghq.com/integrations/amazon_web_services/#resource-collection" target="_blank">Cloud Security Posture Management</a>, attach the <a href="https://console.aws.amazon.com/iam/home#policies/arn:aws:iam::aws:policy/SecurityAudit" target="_blank">AWS SecurityAudit Policy</a> to your Datadog IAM role.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds the permissions used by the AWS integration

### Motivation
DOCS-3392

<!-- ### Preview -->
https://docs-staging.datadoghq.com/bryce/add-aws-permissions/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
