### PR TITLE
Fix bash syntax in preview_link workflow

### DIFF
--- a/.github/workflows/preview_link.yml
+++ b/.github/workflows/preview_link.yml
@@ -21,7 +21,7 @@ jobs:
         for file in ${{ steps.changed_files.outputs.all }}; do
           echo "Checking file ${file}..."
           if [[ "$file" =~ ^content/en/(.*).md$ ]]; then
-            fname = $( echo ${BASH_REMATCH[1]} | sed "s/_index//")
+            fname=$( echo ${BASH_REMATCH[1]} | sed "s/_index//")
             body="${body}https://docs-staging.datadoghq.com/${{ github.head_ref }}/${fname}\n"
           fi
         done


### PR DESCRIPTION
Fixes `line 4: fname: command not found` in workflow run