### PR TITLE
Update preview links workflow conditional

### DIFF
--- a/.github/workflows/preview_link.yml
+++ b/.github/workflows/preview_link.yml
@@ -3,22 +3,22 @@ on:
   pull_request:
     paths:
       - 'content/en/**.md'
+      - .github/workflows/preview_link.yml
 
 jobs:
   preview-link:
-    if: contains(${{ github.head_ref }}, "/")
+    if: contains(github.head_ref, '/')
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Find changed files
       id: changed_files
-      uses: jitterbit/get-changed-files@v1
-      continue-on-error: true
+      uses: tj-actions/changed-files@v19
     - name: Generate links
       id: comment_body
       run: |
-        for file in ${{ steps.changed_files.outputs.all }}; do
+        for file in ${{ steps.changed_files.outputs.all_modified_files }}; do
           echo "Checking file ${file}..."
           if [[ "$file" =~ ^content/en/(.*).md$ ]]; then
             fname=$( echo ${BASH_REMATCH[1]} | sed "s/_index//")


### PR DESCRIPTION
Removing the curly braces and using single quotes seems to fix the
conditional. I've added the workflow file to `paths` so it always runs
when we make modifications.

Also, I've switched out `jitterbit/get-changed-files` for
`tj-actions/changed-files`, which has an open issue to fix our renamed
files issue.