### PR TITLE
Audit log monitor notifications - Fixes

### DIFF
--- a/content/en/monitors/create/types/audit_logs.md
+++ b/content/en/monitors/create/types/audit_logs.md
@@ -36,7 +36,7 @@ You can also choose to never resolve, or to automatically resolve, an event from
 
 ### Say what's happening
 
-Create a notification name. For example, `API requests threshold met for {{@usr.id}}`. You can use [template variables][3] to automatically populate a username, email, etc. in the title to quickly gain insight into which account or user is triggering an alert.
+Create a notification name. For example, `API requests threshold met for {{[@usr.id].name}}`. You can use [variables][3] to automatically populate a username, email, etc. in the title to quickly gain insight into which account or user is triggering an alert.
 
 Create a monitor message. This can include the steps required for team members to resolve an incident if one is occurring.
 
@@ -54,4 +54,4 @@ You can also select if you want to notify a service or team when an alert is mod
 
 [1]: https://app.datadoghq.com/monitors/create/audit
 [2]: /logs/explorer/search_syntax/
-[3]: /getting_started/monitors/#say-whats-happening
+[3]: /monitors/notify/variables/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR fixes the name of a variable supported in audit log monitors and changes a link.

### Motivation
<!-- What inspired you to submit this pull request?-->
User confusion

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
