### PR TITLE
only show dbm endpoint for regions that have it

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -31,14 +31,6 @@ All Agent traffic is sent over SSL. The destination is dependent on the Datadog 
 [APM][1]
 : `trace.agent.`{{< region-param key="dd_site" code="true" >}}
 
-{{< site-region region="us,eu,us3" >}}
-[Database Monitoring][2]
-: `dbm-metrics-intake.`{{< region-param key="dd_site" code="true" >}}<br>
-`dbquery-intake.`{{< region-param key="dd_site" code="true" >}}
-
-[2]: /database_monitoring/
-{{< /site-region >}}
-
 [Live Containers][3] & [Live Process][4]
 : `process.`{{< region-param key="dd_site" code="true" >}}
 
@@ -60,6 +52,14 @@ All Agent traffic is sent over SSL. The destination is dependent on the Datadog 
 API test results for worker v>0.1.6 `intake.synthetics.`{{< region-param key="dd_site" code="true" >}}<br>
 Browser test results for worker v>0.2.0 `intake-v2.synthetics.`{{< region-param key="dd_site" code="true" >}}<br>
 API test results for worker v<0.1.5 `api.`{{< region-param key="dd_site" code="true" >}}
+
+{{< site-region region="us,eu,us3" >}}
+[Database Monitoring][2]
+: `dbm-metrics-intake.`{{< region-param key="dd_site" code="true" >}}<br>
+`dbquery-intake.`{{< region-param key="dd_site" code="true" >}}
+
+[2]: /database_monitoring/
+{{< /site-region >}}
 
 {{< site-region region="us" >}}
 

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -35,6 +35,7 @@ All Agent traffic is sent over SSL. The destination is dependent on the Datadog 
 [Database Monitoring][2]
 : `dbm-metrics-intake.`{{< region-param key="dd_site" code="true" >}}<br>
 `dbquery-intake.`{{< region-param key="dd_site" code="true" >}}
+
 [2]: /database_monitoring/
 {{< /site-region >}}
 

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -31,9 +31,12 @@ All Agent traffic is sent over SSL. The destination is dependent on the Datadog 
 [APM][1]
 : `trace.agent.`{{< region-param key="dd_site" code="true" >}}
 
+{{< site-region region="us,eu,us3" >}}
 [Database Monitoring][2]
 : `dbm-metrics-intake.`{{< region-param key="dd_site" code="true" >}}<br>
 `dbquery-intake.`{{< region-param key="dd_site" code="true" >}}
+[2]: /database_monitoring/
+{{< /site-region >}}
 
 [Live Containers][3] & [Live Process][4]
 : `process.`{{< region-param key="dd_site" code="true" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
makes the database monitoring endpoints only show up for the regions that have database monitoring.

and moved it down so it looks less wonky

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
