### PR TITLE
Update archives.md

### DIFF
--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -150,6 +150,8 @@ Add the following two permission statements to your IAM policies attached to the
 }
 ```
 
+Note: The Resource under the `s3:PutObject` and `s3:GetObject` actions should end with `/*` because these permissions get applied to objects within the buckets. 
+
 [1]: /logs/archives/rehydrating/
 {{% /tab %}}
 {{% tab "Azure Storage" %}}

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -150,7 +150,7 @@ Add the following two permission statements to your IAM policies attached to the
 }
 ```
 
-Note: The Resource under the `s3:PutObject` and `s3:GetObject` actions should end with `/*` because these permissions get applied to objects within the buckets. 
+**Note**: Ensure that the resource value under the `s3:PutObject` and `s3:GetObject` actions ends with `/*` because these permissions are applied to objects within the buckets. 
 
 [1]: /logs/archives/rehydrating/
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Reiterates the Resource under the s3:PutObject and s3:GetObject actions should end with /*

### Motivation
I've seen a couple of tickets where the customer didn't do that and that was the root cause of S3 Permission denied issue - Here is one example: https://datadog.zendesk.com/agent/tickets/805798

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Here is a KB that specifies this configuration: https://datadoghq.atlassian.net/wiki/spaces/TS/pages/348525510/Logs+Archives+FAQ+Troubleshooting#Tips-on-AWS-S3---IAM-Policies


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
