### PR TITLE
Update SCI documentation with latest agent information

### DIFF
--- a/content/en/agent/docker/tag.md
+++ b/content/en/agent/docker/tag.md
@@ -24,29 +24,30 @@ If you are running the Agent as a binary on a host, configure your tag extractio
 The Agent can autodiscover and attach tags to all data emitted by containers. The list of tags attached depends on the Agent [cardinality configuration][1].
 
 | Tag                 | Cardinality  | Requirement                                 |
-|---------------------|--------------|---------------------------------------------|
-| `container_name`    | High         | N/A                                         |
-| `container_id`      | High         | N/A                                         |
-| `rancher_container` | High         | Rancher environment                         |
-| `mesos_task`        | Orchestrator | Mesos environment                           |
-| `docker_image`      | Low          | N/A                                         |
-| `image_name`        | Low          | N/A                                         |
-| `short_image`       | Low          | N/A                                         |
-| `image_tag`         | Low          | N/A                                         |
-| `swarm_service`     | Low          | Swarm environment                           |
-| `swarm_namespace`   | Low          | Swarm environment                           |
-| `rancher_stack`     | Low          | Rancher environment                         |
-| `rancher_service`   | Low          | Rancher environment                         |
-| `env`               | Low          | [Unified service tagging][2] enabled        |
-| `version`           | Low          | [Unified service tagging][2] enabled        |
-| `service`           | Low          | [Unified service tagging][2] enabled        |
-| `marathon_app`      | Low          | Marathon environment                        |
-| `chronos_job`       | Low          | Mesos environment                           |
-| `chronos_job_owner` | Low          | Mesos environment                           |
-| `nomad_task`        | Low          | Nomad environment                           |
-| `nomad_job`         | Low          | Nomad environment                           |
-| `nomad_group`       | Low          | Nomad environment                           |
-| `git.commit.sha`    | Low          | [org.opencontainers.image.revision][3] used |
+|----------------------|--------------|---------------------------------------------|
+| `container_name`     | High         | N/A                                         |
+| `container_id`       | High         | N/A                                         |
+| `rancher_container`  | High         | Rancher environment                         |
+| `mesos_task`         | Orchestrator | Mesos environment                           |
+| `docker_image`       | Low          | N/A                                         |
+| `image_name`         | Low          | N/A                                         |
+| `short_image`        | Low          | N/A                                         |
+| `image_tag`          | Low          | N/A                                         |
+| `swarm_service`      | Low          | Swarm environment                           |
+| `swarm_namespace`    | Low          | Swarm environment                           |
+| `rancher_stack`      | Low          | Rancher environment                         |
+| `rancher_service`    | Low          | Rancher environment                         |
+| `env`                | Low          | [Unified service tagging][2] enabled        |
+| `version`            | Low          | [Unified service tagging][2] enabled        |
+| `service`            | Low          | [Unified service tagging][2] enabled        |
+| `marathon_app`       | Low          | Marathon environment                        |
+| `chronos_job`        | Low          | Mesos environment                           |
+| `chronos_job_owner`  | Low          | Mesos environment                           |
+| `nomad_task`         | Low          | Nomad environment                           |
+| `nomad_job`          | Low          | Nomad environment                           |
+| `nomad_group`        | Low          | Nomad environment                           |
+| `git.commit.sha`     | Low          | [org.opencontainers.image.revision][3] used |
+| `git.repository_url` | Low          | [org.opencontainers.image.source][3] used   |
 
 ### Unified service tagging
 
@@ -159,5 +160,5 @@ docker_env_as_tags:
 
 [1]: /agent/docker/tag/#extract-environment-variables-as-tags
 [2]: /getting_started/tagging/unified_service_tagging
-[3]: https://github.com/opencontainers/image-spec/blob/859973e32ccae7b7fc76b40b762c9fff6e912f9e/annotations.md#pre-defined-annotation-keys
+[3]: https://github.com/opencontainers/image-spec/blob/02efb9a75ee11e05937b535cc5f228f9343ab2f5/annotations.md#pre-defined-annotation-keys
 [4]: /agent/docker/?tab=standard#tagging

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -27,7 +27,7 @@ Combined with the GitHub Apps integrations, you can see inline code snippets in 
 <div class="alert alert-info">
 The source code integration supports Go and all JVM languages.
 <br>
-Datadog Agent 7.33.0 or higher is required.
+Datadog Agent 7.35.0 or higher is required.
 </div>
 
 To map telemetry data with your source code:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR updates the source code integration documentation page and the docker tags page to take into account the agent auto-discovering the `git.repository_url` tag. ([PR](https://github.com/DataDog/datadog-agent/pull/10966))

See agent version 7.35 release notes:
https://github.com/DataDog/datadog-agent/releases/tag/7.35.0

### Motivation
<!-- What inspired you to submit this pull request?-->

Up-to-date documentation.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
N/A

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
