### PR TITLE
WEB-2367 - hardcoded ootb rules

### DIFF
--- a/layouts/security_rules/list.html
+++ b/layouts/security_rules/list.html
@@ -4,8 +4,7 @@
 {{ $scratch := .Scratch }}
 
 <!-- From data file -->
-{{ $list := (where (sort .Pages) ".Params.is_hardcoded" "!=" true) }}
-{{ $hardcodedList := (where (sort .Pages) ".Params.is_hardcoded" "==" true) }}
+{{ $list := sort .Pages }}
 
 <!-- build filters -->
 {{ $.Scratch.Set "filters" (slice)}}
@@ -67,32 +66,6 @@
                             {{ else }}
                                 <img height="17" src="{{ partial "img-resource.html" (dict "context" $dot "src" (print "images/svg-icons/agent.svg")) }}" alt="{{ $v.Key }}" />
                             {{ end }}
-                            <span class="pl-1">{{ .Title }}</span><br />
-                        </a>
-                    {{ end }}
-                </div>
-            </div>
-        {{ end }}
-    </div>
-
-    <!-- Hardcoded -->
-    <div class="list-group">
-      <div class="js-empty-results d-none font-semibold"></div>
-        {{ range $i, $v := $hardcodedList.GroupByParam "source" }}
-            <div class="js-group js-group-{{ $i }}">
-                <div class="js-group-header mb-1 active">
-                    <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2 py-1">
-                        <img height="17" src="{{ partial "img-resource.html" (dict "context" $dot "src" (print "images/svg-icons/agent.svg")) }}?w=80&auto-enhance 2x" />
-                    </div>
-                    <div class="d-inline font-semibold ml-1">
-                        Multi Log Sources
-                    </div>
-                    <div class="js-group-header__arrow">></div>
-                </div>
-                <div class="group-{{ .Key }} mb-2 ml-4 d-none">
-                    {{ range $v.Pages }}
-                        <a class="mb-1 font-semibold mix js-single-rule {{ range $i, $e := .Params.rule_category }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" href="{{.Permalink}}" data-name="{{ lower .Title }} {{ .File.TranslationBaseName }}">
-                            <img height="17" src="{{ partial "img-resource.html" (dict "context" $dot "src" (print "images/svg-icons/agent.svg")) }}" alt="{{ $v.Key }}" />
                             <span class="pl-1">{{ .Title }}</span><br />
                         </a>
                     {{ end }}

--- a/layouts/security_rules/list.html
+++ b/layouts/security_rules/list.html
@@ -4,7 +4,8 @@
 {{ $scratch := .Scratch }}
 
 <!-- From data file -->
-{{ $list := sort .Pages }}
+{{ $list := (where (sort .Pages) ".Params.is_hardcoded" "!=" true) }}
+{{ $hardcodedList := (where (sort .Pages) ".Params.is_hardcoded" "==" true) }}
 
 <!-- build filters -->
 {{ $.Scratch.Set "filters" (slice)}}
@@ -29,7 +30,7 @@
     </div>
     <div class="list-group">
         <div class="js-empty-results d-none font-semibold"></div>
-        {{ range $i, $v := .Pages.GroupByParam "source" }}
+        {{ range $i, $v := $list.GroupByParam "source" }}
             <div class="js-group js-group-{{ $i }}">
                 <div class="js-group-header mb-1 active">
                     <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2 py-1">
@@ -66,6 +67,32 @@
                             {{ else }}
                                 <img height="17" src="{{ partial "img-resource.html" (dict "context" $dot "src" (print "images/svg-icons/agent.svg")) }}" alt="{{ $v.Key }}" />
                             {{ end }}
+                            <span class="pl-1">{{ .Title }}</span><br />
+                        </a>
+                    {{ end }}
+                </div>
+            </div>
+        {{ end }}
+    </div>
+
+    <!-- Hardcoded -->
+    <div class="list-group">
+      <div class="js-empty-results d-none font-semibold"></div>
+        {{ range $i, $v := $hardcodedList.GroupByParam "source" }}
+            <div class="js-group js-group-{{ $i }}">
+                <div class="js-group-header mb-1 active">
+                    <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2 py-1">
+                        <img height="17" src="{{ partial "img-resource.html" (dict "context" $dot "src" (print "images/svg-icons/agent.svg")) }}?w=80&auto-enhance 2x" />
+                    </div>
+                    <div class="d-inline font-semibold ml-1">
+                        Multi Log Sources
+                    </div>
+                    <div class="js-group-header__arrow">></div>
+                </div>
+                <div class="group-{{ .Key }} mb-2 ml-4 d-none">
+                    {{ range $v.Pages }}
+                        <a class="mb-1 font-semibold mix js-single-rule {{ range $i, $e := .Params.rule_category }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" href="{{.Permalink}}" data-name="{{ lower .Title }} {{ .File.TranslationBaseName }}">
+                            <img height="17" src="{{ partial "img-resource.html" (dict "context" $dot "src" (print "images/svg-icons/agent.svg")) }}" alt="{{ $v.Key }}" />
                             <span class="pl-1">{{ .Title }}</span><br />
                         </a>
                     {{ end }}

--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -173,10 +173,11 @@ def security_rules(content, content_dir):
                             page_data["control"] = data.get('control', '')
                             page_data["scope"] = tech
 
-                        # Hardcoded rules which can span several different log sources do not include a source tag
-                        is_hardcoded = not page_data.get("source", None)
-                        if is_hardcoded:
-                            page_data["source"] = "multi Log Sources"
+                        # Hardcoded rules in cloud siem which can span several different log sources do not include a source tag
+                        if 'security-monitoring' in relative_path:
+                            is_hardcoded = not page_data.get("source", None)
+                            if is_hardcoded:
+                                page_data["source"] = "multi Log Sources"
 
                         # lowercase them
                         if page_data.get("source", None):

--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -173,10 +173,10 @@ def security_rules(content, content_dir):
                             page_data["control"] = data.get('control', '')
                             page_data["scope"] = tech
 
-                        is_hardcoded = data.get('options', {}).get('detectionMethod', '') == 'hardcoded'
+                        # Hardcoded rules which can span several different log sources do not include a source tag
+                        is_hardcoded = not page_data.get("source", None)
                         if is_hardcoded:
-                            page_data["source"] = "Multi Log Sources"
-                            page_data["scope"] = "Multi Log Sources"
+                            page_data["source"] = "multi Log Sources"
 
                         # lowercase them
                         if page_data.get("source", None):

--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -72,7 +72,7 @@ def security_rules(content, content_dir):
     global_aliases = []
     for file_name in chain.from_iterable(glob.glob(pattern, recursive=True) for pattern in content["globs"]):
         data = None
-        
+
         if file_name.endswith(".json"):
             with open(file_name, mode="r+") as f:
                 try:
@@ -123,7 +123,8 @@ def security_rules(content, content_dir):
                                 f"/security_monitoring/default_rules/{p.stem}"
                             ],
                             "rule_category": [],
-                            "integration_id": ""
+                            "integration_id": "",
+                            "is_hardcoded": data.get('options', {}).get('detectionMethod', '') == 'hardcoded'
                         }
 
                         # we need to get the path relative to the repo root for comparisons

--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -123,8 +123,7 @@ def security_rules(content, content_dir):
                                 f"/security_monitoring/default_rules/{p.stem}"
                             ],
                             "rule_category": [],
-                            "integration_id": "",
-                            "is_hardcoded": data.get('options', {}).get('detectionMethod', '') == 'hardcoded'
+                            "integration_id": ""
                         }
 
                         # we need to get the path relative to the repo root for comparisons
@@ -173,6 +172,11 @@ def security_rules(content, content_dir):
                             page_data["framework"] = data.get('framework', {}).get('name', '')
                             page_data["control"] = data.get('control', '')
                             page_data["scope"] = tech
+
+                        is_hardcoded = data.get('options', {}).get('detectionMethod', '') == 'hardcoded'
+                        if is_hardcoded:
+                            page_data["source"] = "Multi Log Sources"
+                            page_data["scope"] = "Multi Log Sources"
 
                         # lowercase them
                         if page_data.get("source", None):


### PR DESCRIPTION
### What does this PR do?

Hardcoded rules appear under their own group under Cloud SIem.
This works by processing rules with no source to be grouped together.

> Hardcoded rules can span several different log sources because they may not focus on a specific log source such as Cloudtrail or Apache. Instead they do not include a source

### Motivation

https://datadoghq.atlassian.net/browse/WEB-2367

### Preview

See `Multi Log Sources`
https://docs-staging.datadoghq.com/david.jones/hardcoded/security_platform/default_rules/?q=#cat-cloud-siem

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
