### PR TITLE
(DOCS-3111) Update manual trigger steps

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -106,10 +106,13 @@ If you are collecting logs from a CloudWatch log group, configure the trigger to
 {{< tabs >}}
 {{% tab "AWS console" %}}
 
-
-
-1. Select the corresponding CloudWatch Log Group, add the trigger, and optionally add a filter name.
-2. Once done, go into your [Datadog Log section][1] to start exploring your logs.
+1. In the AWS console, go to **Lambda**. 
+2. Click **Functions**, then select the Datadog Forwarder.
+3. Click **Add trigger**, then select **CloudWatch Logs**.
+4. Select the log group from the drop-down menu.
+5. Enter a name for your filter, and optionally specify a filter pattern.
+6. Click **Add**.
+7. Go to the [Datadog Log section][1] to explore any new log events sent to your log group.
 
 [1]: https://app.datadoghq.com/logs
 {{% /tab %}}

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -107,8 +107,8 @@ If you are collecting logs from a CloudWatch log group, configure the trigger to
 {{% tab "AWS console" %}}
 
 1. In the AWS console, go to **Lambda**. 
-2. Click **Functions**, then select the Datadog Forwarder.
-3. Click **Add trigger**, then select **CloudWatch Logs**.
+2. Click **Functions** and select the Datadog Forwarder.
+3. Click **Add trigger** and select **CloudWatch Logs**.
 4. Select the log group from the drop-down menu.
 5. Enter a name for your filter, and optionally specify a filter pattern.
 6. Click **Add**.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the section for manually adding triggers to the Datadog Forwarder.

### Motivation
DOCS-3111

### Preview
https://docs-staging.datadoghq.com/bryce/update-manual-triggers/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/?tab=awsconsole#manually-set-up-triggers

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Changes have been validated by a member of the serverless team.
### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
