### PR TITLE
Correct grant for select on performance_schema

### DIFF
--- a/content/en/database_monitoring/setup_mysql/selfhosted.md
+++ b/content/en/database_monitoring/setup_mysql/selfhosted.md
@@ -101,7 +101,7 @@ Create the `datadog` user and grant basic permissions:
 CREATE USER datadog@'%' IDENTIFIED BY '<UNIQUEPASSWORD>';
 GRANT REPLICATION CLIENT ON *.* TO datadog@'%' WITH MAX_USER_CONNECTIONS 5;
 GRANT PROCESS ON *.* TO datadog@'%';
-GRANT SELECT ON performance_schema_max_sql_text_length.* TO datadog@'%';
+GRANT SELECT ON performance_schema.* TO datadog@'%';
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
### What does this PR do?
Correct an error in the documentation for setting up MySQL 5.7 database performance monitoring.

### Motivation
I spent over an hour trying to work out why performance monitoring was not working, triple checking settings, repeating all steps, debugging the python code of the agent... until I worked out the instructions were incorrect.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
