### PR TITLE
Revert incorrect changes to DBM config variables

### DIFF
--- a/content/en/database_monitoring/setup_mysql/selfhosted.md
+++ b/content/en/database_monitoring/setup_mysql/selfhosted.md
@@ -89,7 +89,7 @@ CREATE USER datadog@'%' IDENTIFIED WITH mysql_native_password by '<UNIQUEPASSWOR
 ALTER USER datadog@'%' WITH MAX_USER_CONNECTIONS 5;
 GRANT REPLICATION CLIENT ON *.* TO datadog@'%';
 GRANT PROCESS ON *.* TO datadog@'%';
-GRANT SELECT ON performance_schema_max_sql_text_length.* TO datadog@'%';
+GRANT SELECT ON performance_schema.* TO datadog@'%';
 ```
 
 {{% /tab %}}
@@ -101,7 +101,7 @@ Create the `datadog` user and grant basic permissions:
 CREATE USER datadog@'%' IDENTIFIED BY '<UNIQUEPASSWORD>';
 GRANT REPLICATION CLIENT ON *.* TO datadog@'%' WITH MAX_USER_CONNECTIONS 5;
 GRANT PROCESS ON *.* TO datadog@'%';
-GRANT SELECT ON performance_schema_max_sql_text_length.* TO datadog@'%';
+GRANT SELECT ON performance_schema.* TO datadog@'%';
 ```
 
 {{% /tab %}}
@@ -147,14 +147,14 @@ GRANT EXECUTE ON PROCEDURE <YOUR_SCHEMA>.explain_statement TO datadog@'%';
 ```
 
 ### Runtime setup consumers
-Datadog recommends that you create the following procedure to give the Agent the ability to enable `performance_schema_max_sql_text_length.events_statements_*` consumers at runtime.
+Datadog recommends that you create the following procedure to give the Agent the ability to enable `performance_schema.events_statements_*` consumers at runtime.
 
 ```SQL
 DELIMITER $$
 CREATE PROCEDURE datadog.enable_events_statements_consumers()
     SQL SECURITY DEFINER
 BEGIN
-    UPDATE performance_schema_max_sql_text_length.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%';
+    UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%';
 END $$
 DELIMITER ;
 GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers TO datadog@'%';


### PR DESCRIPTION
### What does this PR do?
Reverts the changes made on PR [13660](https://github.com/DataDog/documentation/pull/13660)

### Motivation
A user tried to set up DBM, but it failed. I talked to the DBM Engineering team. Justin Iso investigated and determined that the PR 13660 introduced some bad configuration.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
