### PR TITLE
[CI Visibility] Add instructions to download standalone version of dd-trace

### DIFF
--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -17,13 +17,13 @@ further_reading:
 ## Compatibility
 
 Supported .NET versions:
-* .NET Core >= 2.1 and >= 3.0
-* .NET >= 5.0
+* .NET Framework 4.6.1 and above
+* .NET Core 2.1, 3.1, .NET 5, and .NET 6
 
 Supported test frameworks:
-* xUnit >= 2.2
-* NUnit >= 3.0
-* MsTest V2 >= 14
+* xUnit 2.2 and above
+* NUnit 3.0 and above
+* MsTestV2 14 and above
 
 ## Prerequisites
 
@@ -33,13 +33,20 @@ Supported test frameworks:
 Agentless mode is in beta. To test this feature, follow the <a href="/continuous_integration/setup_tests/dotnet#agentless-beta">instructions</a> on this page.
 </div>
 
-## Installing the .NET tracer
+## Installing the .NET tracer CLI
 
-To install or update the `dd-trace` command globally on the machine, run:
+Install or update the `dd-trace` command using one of the following ways:
 
-{{< code-block lang="bash" >}}
-dotnet tool update -g dd-trace
-{{< /code-block >}}
+- Using the .NET SDK by running the command:
+   ```
+   dotnet tool update -g dd-trace
+   ```
+- By downloading the appropriate version:
+    * Win-x64: [https://dtdg.co/dd-trace-dotnet-win-x64][7]
+    * Linux-x64: [https://dtdg.co/dd-trace-dotnet-linux-x64][8]
+    * Linux-musl-x64 (Alpine): [https://dtdg.co/dd-trace-dotnet-linux-musl-x64][9]
+ 
+- Or by downloading [from the github release page][10].
 
 ## Instrumenting tests
 
@@ -189,3 +196,7 @@ Additionally, configure which [Datadog site][6] to which you want to send data. 
 [4]: /tracing/setup_overview/custom_instrumentation/dotnet/
 [5]: https://app.datadoghq.com/organization-settings/api-keys
 [6]: /getting_started/site/
+[7]: https://dtdg.co/dd-trace-dotnet-win-x64
+[8]: https://dtdg.co/dd-trace-dotnet-linux-x64
+[9]: https://dtdg.co/dd-trace-dotnet-linux-musl-x64
+[10]: https://github.com/DataDog/dd-trace-dotnet/releases

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -64,7 +64,7 @@ dd-trace ci run --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
 
 {{% tab "VSTest.Console" %}}
 
-By using [VSTest.Console.exe][11]
+By using <a href="https://docs.microsoft.com/en-us/visualstudio/test/vstest-console-options?view=vs-2022">VSTest.Console.exe</a>
 
 {{< code-block lang="bash" >}}
 dd-trace ci run --dd-service=my-dotnet-app --dd-env=ci -- VSTest.Console.exe {test_assembly}.dll
@@ -218,4 +218,3 @@ Additionally, configure which [Datadog site][6] to which you want to send data. 
 [8]: https://dtdg.co/dd-trace-dotnet-linux-x64
 [9]: https://dtdg.co/dd-trace-dotnet-linux-musl-x64
 [10]: https://github.com/DataDog/dd-trace-dotnet/releases
-[11]: https://docs.microsoft.com/en-us/visualstudio/test/vstest-console-options?view=vs-2022

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -52,9 +52,27 @@ Install or update the `dd-trace` command using one of the following ways:
 
 To instrument your test suite, prefix your test command with `dd-trace ci run`, providing the name of the service or library under test as the `--dd-service` parameter, and the environment where tests are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) as the `--dd-env` parameter. For example:
 
+{{< tabs >}}
+
+{{% tab "dotnet test" %}}
+
 {{< code-block lang="bash" >}}
 dd-trace ci run --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
 {{< /code-block >}}
+
+{{% /tab %}}
+
+{{% tab "VSTest.Console" %}}
+
+By using [VSTest.Console.exe][11]
+
+{{< code-block lang="bash" >}}
+dd-trace ci run --dd-service=my-dotnet-app --dd-env=ci -- VSTest.Console.exe {test_assembly}.dll
+{{< /code-block >}}
+
+{{% /tab %}}
+
+{{< /tabs >}}
 
 All tests are automatically instrumented.
 
@@ -200,3 +218,4 @@ Additionally, configure which [Datadog site][6] to which you want to send data. 
 [8]: https://dtdg.co/dd-trace-dotnet-linux-x64
 [9]: https://dtdg.co/dd-trace-dotnet-linux-musl-x64
 [10]: https://github.com/DataDog/dd-trace-dotnet/releases
+[11]: https://docs.microsoft.com/en-us/visualstudio/test/vstest-console-options?view=vs-2022

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -56,6 +56,8 @@ To instrument your test suite, prefix your test command with `dd-trace ci run`, 
 
 {{% tab "dotnet test" %}}
 
+By using <a href="https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test">dotnet test</a>
+
 {{< code-block lang="bash" >}}
 dd-trace ci run --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
 {{< /code-block >}}
@@ -64,7 +66,7 @@ dd-trace ci run --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
 
 {{% tab "VSTest.Console" %}}
 
-By using <a href="https://docs.microsoft.com/en-us/visualstudio/test/vstest-console-options?view=vs-2022">VSTest.Console.exe</a>
+By using <a href="https://docs.microsoft.com/en-us/visualstudio/test/vstest-console-options">VSTest.Console.exe</a>
 
 {{< code-block lang="bash" >}}
 dd-trace ci run --dd-service=my-dotnet-app --dd-env=ci -- VSTest.Console.exe {test_assembly}.dll


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
The PR adds instructions to download the standalone version of the `dd-trace` CLI tool.

### Motivation
<!-- What inspired you to submit this pull request?-->
The APM tracer team started to release the standalone version of the tool, because CI Visibility uses the tool we update the documentation to give that option to customers.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
