### PR TITLE
WEB-2282 - add languages to legacy config

### DIFF
--- a/translate.yaml
+++ b/translate.yaml
@@ -44,7 +44,7 @@ sources:
   dst: "content/{lang}/agent/faq/certificate_verify_failed-error.md"
 
 # Legacy params
-# TODO: remove when old sync job is deprecated. 
+# TODO: remove when old sync job is deprecated.
 enabled: true
 enabled_send: true
 enabled_receive: true
@@ -61,6 +61,10 @@ langs:
   lang: "fr"
 - lang_country: "ja"
   lang: "ja"
+- lang_country: "es_ES"
+  lang: "es"
+- lang_country: "ko_KR"
+  lang: "ko"
 github:
   org: 'DataDog'
   repo: 'documentation'


### PR DESCRIPTION
### What does this PR do?

adds languages to legacy translation config before its phased out

### Motivation

To support further languages
https://datadoghq.atlassian.net/browse/WEB-2282

### Preview

There is no change to the site
https://docs-staging.datadoghq.com/david.jones/translate-config-update/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
