### PR TITLE
Specify length of cluster agent token in documentation

### DIFF
--- a/content/en/agent/kubernetes/installation.md
+++ b/content/en/agent/kubernetes/installation.md
@@ -259,7 +259,7 @@ To install the Datadog Agent on your Kubernetes cluster:
     ```shell
     echo -n '<Your API key>' | base64
     ```
-4. In the `secret-cluster-agent-token.yaml` manifest, replace `PUT_A_BASE64_ENCODED_RANDOM_STRING_HERE` with a random string encoded in base64. Length of this string must be 32 or more. To get the base64 version of it, you can run:
+4. In the `secret-cluster-agent-token.yaml` manifest, replace `PUT_A_BASE64_ENCODED_RANDOM_STRING_HERE` with a random string encoded in base64. This string must be 32 or more chars long. To get the base64 version of it, you can run:
 
     ```shell
     echo -n 'Random string' | base64

--- a/content/en/agent/kubernetes/installation.md
+++ b/content/en/agent/kubernetes/installation.md
@@ -259,7 +259,7 @@ To install the Datadog Agent on your Kubernetes cluster:
     ```shell
     echo -n '<Your API key>' | base64
     ```
-4. In the `secret-cluster-agent-token.yaml` manifest, replace `PUT_A_BASE64_ENCODED_RANDOM_STRING_HERE` with a random string encoded in base64. To get the base64 version of it, you can run:
+4. In the `secret-cluster-agent-token.yaml` manifest, replace `PUT_A_BASE64_ENCODED_RANDOM_STRING_HERE` with a random string encoded in base64. Length of this string must be 32 or more. To get the base64 version of it, you can run:
 
     ```shell
     echo -n 'Random string' | base64


### PR DESCRIPTION
Length of this cluster agent token must be 32 or more. Had below error:
```
2022-05-13 18:29:22 UTC | CORE | ERROR | (pkg/workloadmeta/collectors/kubemetadata/kubemetadata.go:72 in Start) | Could not initialise the communication with the cluster agent: temporary failure in clusterAgentClient, will retry later: cluster agent authentication token length must be greater than 32, curently: 26
```

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update documentation

### Motivation
Spent a couple of hours figuring out why node agents were not communicating with cluster agent.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
