### PR TITLE
[agent] Document DD_CONTAINER_LABELS_AS_TAGS and DD_CONTAINER_ENV_AS_TAGS

### DIFF
--- a/content/en/agent/docker/_index.md
+++ b/content/en/agent/docker/_index.md
@@ -188,11 +188,11 @@ As a best practice, Datadog recommends using [unified service tagging][22] when 
 
 Datadog automatically collects common tags from Docker, Kubernetes, ECS, Swarm, Mesos, Nomad, and Rancher. To extract even more tags, use the following options:
 
-| Env Variable               | Description                                               |
-|----------------------------|-----------------------------------------------------------|
-| `DD_DOCKER_LABELS_AS_TAGS` | Extract Docker container labels                           |
-| `DD_DOCKER_ENV_AS_TAGS`    | Extract Docker container environment variables            |
-| `DD_COLLECT_EC2_TAGS`      | Extract custom EC2 tags without using the AWS integration |
+| Env Variable                  | Description                                                                                             |
+|-------------------------------|---------------------------------------------------------------------------------------------------------|
+| `DD_CONTAINER_LABELS_AS_TAGS` | Extract container labels. This env is equivalent to the old `DD_DOCKER_LABELS_AS_TAGS` env.             |
+| `DD_CONTAINER_ENV_AS_TAGS`    | Extract container environment variables. This env is equivalent to the old `DD_DOCKER_ENV_AS_TAGS` env. |
+| `DD_COLLECT_EC2_TAGS`         | Extract custom EC2 tags without using the AWS integration.                                              |
 
 See the [Docker Tag Extraction][23] documentation to learn more.
 

--- a/content/en/agent/docker/tag.md
+++ b/content/en/agent/docker/tag.md
@@ -60,34 +60,36 @@ Starting with Agent v6.0+, the Agent can collect labels for a given container an
 {{< tabs >}}
 {{% tab "Containerized Agent" %}}
 
-To extract a given Docker label `<LABEL_NAME>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
+To extract a given container label `<LABEL_NAME>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
 
 ```shell
-DD_DOCKER_LABELS_AS_TAGS='{"<LABEL_NAME>": "<TAG_KEY>"}'
+DD_CONTAINER_LABELS_AS_TAGS='{"<LABEL_NAME>": "<TAG_KEY>"}'
 ```
 
 For example, you could set up:
 
 ```shell
-DD_DOCKER_LABELS_AS_TAGS='{"com.docker.compose.service":"service_name"}'
+DD_CONTAINER_LABELS_AS_TAGS='{"com.docker.compose.service":"service_name"}'
 ```
 
-**Note**: `<LABEL_NAME>` is not case-sensitive. For example, if you have labels named `foo` and `FOO`, and you set `DD_DOCKER_LABELS_AS_TAGS='{"foo": "bar"}'`, both `foo` and `FOO` are mapped to `bar`.
+**Note**: `<LABEL_NAME>` is not case-sensitive. For example, if you have labels named `foo` and `FOO`, and you set `DD_CONTAINER_LABELS_AS_TAGS='{"foo": "bar"}'`, both `foo` and `FOO` are mapped to `bar`.
+
+**Note**: `DD_CONTAINER_LABELS_AS_TAGS` is equivalent to the old `DD_DOCKER_LABELS_AS_TAGS`, and `DD_CONTAINER_ENV_AS_TAGS` to `DD_DOCKER_ENV_AS_TAGS`.
 
 {{% /tab %}}
 {{% tab "Agent" %}}
 
-To extract a given Docker label `<LABEL_NAME>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
+To extract a given container label `<LABEL_NAME>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
 
 ```yaml
-docker_labels_as_tags:
+container_labels_as_tags:
   <LABEL_NAME>: <TAG_KEY>
 ```
 
 For example, you could set up:
 
 ```yaml
-docker_labels_as_tags:
+container_labels_as_tags:
   com.docker.compose.service: service_name
 ```
 
@@ -100,15 +102,15 @@ docker_labels_as_tags:
 
 Datadog automatically collects common tags from [Docker, Kubernetes, ECS, Swarm, Mesos, Nomad, and Rancher][4]. To extract even more tags, use the following options:
 
-| Environment Variable               | Description                                    |
-|------------------------------------|------------------------------------------------|
-| `DD_DOCKER_LABELS_AS_TAGS`         | Extract docker container labels                |
-| `DD_DOCKER_ENV_AS_TAGS`            | Extract docker container environment variables |
-| `DD_KUBERNETES_POD_LABELS_AS_TAGS` | Extract pod labels                             |
-| `DD_CHECKS_TAG_CARDINALITY`        | Add tags to check metrics                      |
-| `DD_DOGSTATSD_TAG_CARDINALITY`     | Add tags to custom metrics                     |
+| Environment Variable               | Description                             |
+|------------------------------------|-----------------------------------------|
+| `DD_CONTAINER_LABELS_AS_TAGS`      | Extract container labels                |
+| `DD_CONTAINER_ENV_AS_TAGS`         | Extract container environment variables |
+| `DD_KUBERNETES_POD_LABELS_AS_TAGS` | Extract pod labels                      |
+| `DD_CHECKS_TAG_CARDINALITY`        | Add tags to check metrics               |
+| `DD_DOGSTATSD_TAG_CARDINALITY`     | Add tags to custom metrics              |
 
-Starting with Agent v7.20+, a containerized Agent can Autodiscover tags from Docker labels. This process allows the Agent to associate custom tags to all data emitted by a container without modifying the Agent `datadog.yaml` file.
+Starting with Agent v7.20+, a containerized Agent can Autodiscover tags from container labels. This process allows the Agent to associate custom tags to all data emitted by a container without modifying the Agent `datadog.yaml` file.
 
 Tags should be added using the following format:
 
@@ -121,32 +123,32 @@ With Agent v6.0+, the Agent can collect environment variables for a given contai
 {{< tabs >}}
 {{% tab "Containerized Agent" %}}
 
-To extract a given Docker environment variable `<ENVVAR_NAME>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
+To extract a given container environment variable `<ENVVAR_NAME>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
 
 ```shell
-DD_DOCKER_ENV_AS_TAGS='{"<ENVVAR_NAME>": "<TAG_KEY>"}'
+DD_CONTAINER_ENV_AS_TAGS='{"<ENVVAR_NAME>": "<TAG_KEY>"}'
 ```
 
 For example, you could set up:
 
 ```shell
-DD_DOCKER_ENV_AS_TAGS='{"ENVIRONMENT":"env"}'
+DD_CONTAINER_ENV_AS_TAGS='{"ENVIRONMENT":"env"}'
 ```
 
 {{% /tab %}}
 {{% tab "Agent" %}}
 
-To extract a given Docker environment variable `<ENVVAR_NAME>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
+To extract a given container environment variable `<ENVVAR_NAME>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
 
 ```yaml
-docker_env_as_tags:
+container_env_as_tags:
   <ENVVAR_NAME>: <TAG_KEY>
 ```
 
 For example, you could set up:
 
 ```yaml
-docker_env_as_tags:
+container_env_as_tags:
   ENVIRONMENT: env
 ```
 

--- a/content/en/agent/guide/environment-variables.md
+++ b/content/en/agent/guide/environment-variables.md
@@ -51,12 +51,12 @@ In general, use the following rules:
 
 * The nesting of config options with **user-defined** keys must be JSON-formatted:
    ```yaml
-      docker_env_as_tags:
+      container_env_as_tags:
         ENVVAR_NAME: tag_name
-      # DD_DOCKER_ENV_AS_TAGS='{"ENVVAR_NAME": "tag_name"}'
+      # DD_CONTAINER_ENV_AS_TAGS='{"ENVVAR_NAME": "tag_name"}'
    ```
 
-**Note**: Specifying a nested option with an environment variable overrides _all_ the nested options specified under the config option. The exception to this rule is the `proxy` config option. Reference the [Agent proxy documentation][3] for more details. 
+**Note**: Specifying a nested option with an environment variable overrides _all_ the nested options specified under the config option. The exception to this rule is the `proxy` config option. Reference the [Agent proxy documentation][3] for more details.
 
 ### Exceptions
 

--- a/content/en/getting_started/tagging/assigning_tags.md
+++ b/content/en/getting_started/tagging/assigning_tags.md
@@ -164,19 +164,19 @@ After installing the containerized Datadog Agent, you can set your host tags usi
 
 Datadog automatically collects common tags from [Docker, Kubernetes, ECS, Swarm, Mesos, Nomad, and Rancher][6]. To extract even more tags, use the following options:
 
-| Environment Variable               | Description                                          |
-|------------------------------------|------------------------------------------------------|
-| `DD_DOCKER_LABELS_AS_TAGS`         | Extract docker container labels                      |
-| `DD_DOCKER_ENV_AS_TAGS`            | Extract docker container environment variables       |
-| `DD_KUBERNETES_POD_LABELS_AS_TAGS` | Extract pod labels                                   |
-| `DD_CHECKS_TAG_CARDINALITY`        | Add tags to check metrics (low, orchestrator, high)  |
-| `DD_DOGSTATSD_TAG_CARDINALITY`     | Add tags to custom metrics (low, orchestrator, high) |
+| Environment Variable               | Description                                                                                             |
+|------------------------------------|---------------------------------------------------------------------------------------------------------|
+| `DD_CONTAINER_LABELS_AS_TAGS`      | Extract container labels. This env is equivalent to the old `DD_DOCKER_LABELS_AS_TAGS` env.             |
+| `DD_CONTAINER_ENV_AS_TAGS`         | Extract container environment variables. This env is equivalent to the old `DD_DOCKER_ENV_AS_TAGS` env. |
+| `DD_KUBERNETES_POD_LABELS_AS_TAGS` | Extract pod labels                                                                                      |
+| `DD_CHECKS_TAG_CARDINALITY`        | Add tags to check metrics (low, orchestrator, high)                                                     |
+| `DD_DOGSTATSD_TAG_CARDINALITY`     | Add tags to custom metrics (low, orchestrator, high)                                                    |
 
 **Examples:**
 
 ```shell
 DD_KUBERNETES_POD_LABELS_AS_TAGS='{"app":"kube_app","release":"helm_release"}'
-DD_DOCKER_LABELS_AS_TAGS='{"com.docker.compose.service":"service_name"}'
+DD_CONTAINER_LABELS_AS_TAGS='{"com.docker.compose.service":"service_name"}'
 ```
 
 When using `DD_KUBERNETES_POD_LABELS_AS_TAGS`, you can use wildcards in the format:
@@ -187,17 +187,17 @@ When using `DD_KUBERNETES_POD_LABELS_AS_TAGS`, you can use wildcards in the form
 
 For example, `{"app*": "kube_%%label%%"}` resolves to the tag name `kube_application` for the label `application`. Further, `{"*": "kube_%%label%%"}` adds all pod labels as tags prefixed with `kube_`.
 
-When using the `DD_DOCKER_LABELS_AS_TAGS` variable within a Docker Swarm `docker-compose.yaml` file, remove the apostrophes, for example:
+When using the `DD_CONTAINER_LABELS_AS_TAGS` variable within a Docker Swarm `docker-compose.yaml` file, remove the apostrophes, for example:
 
 ```shell
-DD_DOCKER_LABELS_AS_TAGS={"com.docker.compose.service":"service_name"}
+DD_CONTAINER_LABELS_AS_TAGS={"com.docker.compose.service":"service_name"}
 ```
 
 When adding labels to Docker containers, the placement of the `labels:` keyword inside the `docker-compose.yaml` file is important. To avoid issues, follow the [Docker unified service tagging][2] documentation.
 
  If the container needs to be labeled outside of this configuration, place the `labels:` keyword **inside** the `services:` section **not** inside the `deploy:` section. Place the `labels:` keyword inside the `deploy:` section only when the service needs to be labeled. The Datadog Agent does not have any labels to extract from the containers without this placement.
 
-Below is a sample, working `docker-compose.yaml` file that shows this. In the example below, the labels in the `myapplication:` section, `my.custom.label.project` and `my.custom.label.version` each have unique values. Using the `DD_DOCKER_LABELS_AS_TAGS` environment variable in the `datadog:` section extracts the labels and produces these tags for the `myapplication` container:
+Below is a sample, working `docker-compose.yaml` file that shows this. In the example below, the labels in the `myapplication:` section, `my.custom.label.project` and `my.custom.label.version` each have unique values. Using the `DD_CONTAINER_LABELS_AS_TAGS` environment variable in the `datadog:` section extracts the labels and produces these tags for the `myapplication` container:
 
 Inside the `myapplication` container the labels are: `my.custom.label.project` and `my.custom.label.version`
 
@@ -216,7 +216,7 @@ services:
       - '/sys/fs/cgroup/:/host/sys/fs/cgroup:ro'
     environment:
       - DD_API_KEY= "<DATADOG_API_KEY>"
-      - DD_DOCKER_LABELS_AS_TAGS={"my.custom.label.project":"projecttag","my.custom.label.version":"versiontag"}
+      - DD_CONTAINER_LABELS_AS_TAGS={"my.custom.label.project":"projecttag","my.custom.label.version":"versiontag"}
       - DD_TAGS="key1:value1 key2:value2 key3:value3"
     image: 'gcr.io/datadoghq/agent:latest'
     deploy:


### PR DESCRIPTION
### What does this PR do?

Documents the `DD_CONTAINER_LABELS_AS_TAGS` and `DD_CONTAINER_ENV_AS_TAGS`. These are equivalent to the old envs `DD_DOCKER_LABELS_AS_TAGS` and `DD_DOCKER_ENV_AS_TAGS`.

`DD_CONTAINER_LABELS_AS_TAGS` and `DD_CONTAINER_ENV_AS_TAGS` were introduced to make it clearer that Docker is not the only container runtime supported. We also support containerd and Podman.

Refs:
https://github.com/DataDog/datadog-agent/pull/9054
https://github.com/DataDog/datadog-agent/pull/9542

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
