### PR TITLE
Add blog post link to OTLP ingest doc

### DIFF
--- a/content/en/tracing/setup_overview/open_standards/otlp_ingest_in_the_agent.md
+++ b/content/en/tracing/setup_overview/open_standards/otlp_ingest_in_the_agent.md
@@ -3,6 +3,9 @@ title: OTLP Trace Ingestion by the Datadog Agent
 kind: documentation
 description: 'Ingest OTLP trace data through the Datadog Agent'
 further_reading:
+- link: "https://www.datadoghq.com/about/latest-news/press-releases/datadog-announces-opentelemetry-protocol-support/"
+  tag: "Blog"
+  text: "OTLP ingestion in the Agent"
 aliases:
 ---
 
@@ -238,6 +241,10 @@ experimental:
 {{< /tabs >}}
 
 There are many other environment variables and settings supported in the Datadog Agent. To get an overview of them all, see [the configuration template][5].
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://opentelemetry.io/docs/instrumentation/
 [2]: /metrics/otlp/


### PR DESCRIPTION

### What does this PR do?
Adds a link about the OTLP Trace Ingestion blog post to the OTLP Ingestion doc.

### Motivation
Docs team Tuesday tasks.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
