### PR TITLE
Updated docs for parsing to make Grok Parser inputs more clear

### DIFF
--- a/content/en/logs/log_configuration/parsing.md
+++ b/content/en/logs/log_configuration/parsing.md
@@ -25,7 +25,7 @@ further_reading:
 Datadog automatically parses JSON-formatted logs. For other formats, Datadog allows you to enrich your logs with the help of Grok Parser.
 The Grok syntax provides an easier way to parse logs than pure regular expressions. The Grok Parser enables you to extract attributes from semi-structured text messages.
 
-Grok comes with reusable patterns to parse integers, IP addresses, hostnames, etc. Note: These values must be sent into the Grok Parser as strings.
+Grok comes with reusable patterns to parse integers, IP addresses, hostnames, etc. These values must be sent into the grok parser as strings.
 
 You can write parsing rules with the `%{MATCHER:EXTRACT:FILTER}` syntax:
 

--- a/content/en/logs/log_configuration/parsing.md
+++ b/content/en/logs/log_configuration/parsing.md
@@ -25,7 +25,7 @@ further_reading:
 Datadog automatically parses JSON-formatted logs. For other formats, Datadog allows you to enrich your logs with the help of Grok Parser.
 The Grok syntax provides an easier way to parse logs than pure regular expressions. The Grok Parser enables you to extract attributes from semi-structured text messages.
 
-Grok comes with reusable patterns to parse integers, IP addresses, hostnames, etc.
+Grok comes with reusable patterns to parse integers, IP addresses, hostnames, etc. Note: These values must be sent into the Grok Parser as strings.
 
 You can write parsing rules with the `%{MATCHER:EXTRACT:FILTER}` syntax:
 


### PR DESCRIPTION
Added note that makes it clear that integers must be sent into Grok Parser as strings. Grok Parser only works on strings.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Added note that made it clear that Grok Parser can only parse strings.
### Motivation
<!-- What inspired you to submit this pull request?-->
Logs backend eng and support folks reached out to product about customers being confused by not being able to parse ints with the Grok Parser. We want to make clear that it can parse numerical values, they just must be sent in as strings.
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
