### PR TITLE
Adding Fiber Framework to the Documentation

### DIFF
--- a/content/en/tracing/setup_overview/compatibility_requirements/go.md
+++ b/content/en/tracing/setup_overview/compatibility_requirements/go.md
@@ -38,6 +38,7 @@ Integrate the Go tracer with the following list of web frameworks using one of t
 | [chi][10]         | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/go-chi/chi][11] |
 | [echo v4][12]     | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/labstack/echo.v4][13]           |
 | [echo v3][12]     | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/labstack/echo][14]              |
+| [Fiber][74]     | Fully Supported | [gopkg.in/DataDog/dd-trace-go.v1/contrib/gofiber/fiber.v2][73]              |
 
 #### Library compatibility
 
@@ -157,3 +158,5 @@ import "gopkg.in/DataDog/dd-trace-go.v1/contrib/<PACKAGE_DIR>/<PACKAGE_NAME>"
 [70]: https://github.com/DataDog/dd-trace-go#support-policy
 [71]: https://github.com/DataDog/dd-trace-go#support-maintenance
 [72]: https://www.datadoghq.com/support/
+[73]: https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/gofiber/fiber.v2
+[74]: https://github.com/gofiber/fiber


### PR DESCRIPTION
- Customer wants the Fiber Framework in the Officially Supported Documentation.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updates the GoLang Supported Frameworks list, adding our Fiber Tracer Library to the list

### Motivation
<!-- What inspired you to submit this pull request?-->
During a trial, the customer asked for the official documentation showing we support Fiber Framework on Golang.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Tracer Library is https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/gofiber/fiber.v2

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
