### PR TITLE
(DOCS-3460) Add hosted config file for Windows

### DIFF
--- a/static/config/99datadog-windows.config
+++ b/static/config/99datadog-windows.config
@@ -1,0 +1,18 @@
+# .ebextensions/99datadog-windows.config
+packages:
+  msi:
+    DotnetAPM: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.8.0/datadog-dotnet-apm-2.8.0-x64.msi
+files:
+  "c:\\DatadogAgent\\datadog-agent-7-latest.amd64.msi":
+    source: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
+
+commands:
+  01_setup-datadog-agent:
+    command: start /wait msiexec /qn /i datadog-agent-7-latest.amd64.msi APIKEY="YOUR API KEY" SITE="datadoghq.com"
+    cwd: c:/DatadogAgent
+
+  02_setup-APM1:
+    command: net stop /y was
+
+  03_setup-APM2:
+    command: net start w3svc

--- a/static/config/99datadog-windows.config
+++ b/static/config/99datadog-windows.config
@@ -3,13 +3,16 @@ packages:
   msi:
     DotnetAPM: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.8.0/datadog-dotnet-apm-2.8.0-x64.msi
 files:
-  "c:\\DatadogAgent\\datadog-agent-7-latest.amd64.msi":
+  "c:\\Datadog\\datadog-agent-7-latest.amd64.msi":
     source: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
 
 commands:
+  00_setup-env1: # Eg: Sets .NET APM's tracing library configuration to env:dev
+    command: setx -m DD_ENV dev
+
   01_setup-datadog-agent:
     command: start /wait msiexec /qn /i datadog-agent-7-latest.amd64.msi APIKEY="YOUR API KEY" SITE="datadoghq.com"
-    cwd: c:/DatadogAgent
+    cwd: c:/Datadog
 
   02_setup-APM1:
     command: net stop /y was


### PR DESCRIPTION
This is a config file that users with Windows nodes can use to
configure their Elastic Beanstalk environments. This accompanies a
separate PR that guides a user through the configuration steps.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
