### PR TITLE
Add a recommendation to use LTS JDK versions

### DIFF
--- a/content/en/tracing/profiler/enabling/java.md
+++ b/content/en/tracing/profiler/enabling/java.md
@@ -21,7 +21,8 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 ## Requirements
 
 The Datadog Profiler requires [JDK Flight Recorder][2]. The Datadog Profiler library is supported in OpenJDK 11+, Oracle JDK 11+, [OpenJDK 8 (version 8u262+)][3] and Azul Zulu 8+ (version 8u212+). It is not supported in OpenJ9 as it doesn't support the [JDK Flight Recorder][2].
-LTS (Long Term Support) JDK versions (8, 11 and 17) are recommended as the non-LTS versions might be missing stability and performance fixes related to Datadog Profiler library.
+
+Because non-LTS JDK versions may not contain stability and performance fixes related to the Datadog Profiler library, use versions 8, 11, and 17 of the Long Term Support JDK.
 
 All JVM-based languages, such as Java, Scala, Groovy, Kotlin, and Clojure are supported.
 

--- a/content/en/tracing/profiler/enabling/java.md
+++ b/content/en/tracing/profiler/enabling/java.md
@@ -21,6 +21,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 ## Requirements
 
 The Datadog Profiler requires [JDK Flight Recorder][2]. The Datadog Profiler library is supported in OpenJDK 11+, Oracle JDK 11+, [OpenJDK 8 (version 8u262+)][3] and Azul Zulu 8+ (version 8u212+). It is not supported in OpenJ9 as it doesn't support the [JDK Flight Recorder][2].
+LTS (Long Term Support) JDK versions (8, 11 and 17) are recommended as the non-LTS versions might be missing stability and performance fixes related to Datadog Profiler library.
 
 All JVM-based languages, such as Java, Scala, Groovy, Kotlin, and Clojure are supported.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a short recommendation to use the Datadog Profiler library with a LTS JDK version.

### Motivation
Non-LTS versions are not getting any new fixes backported and as such having users running on such versions results in weird bugs originating in JDK reported to Datadog.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
