### PR TITLE
fix popper js error

### DIFF
--- a/assets/scripts/components/platforms.js
+++ b/assets/scripts/components/platforms.js
@@ -1,18 +1,10 @@
 document.addEventListener('DOMContentLoaded', function () {
-    var ref = document.querySelector('.my-button');
-    var pop = document.getElementById('popper');
+    const ref = document.querySelector('.my-button');
+    const pop = document.getElementById('popper');
     if(ref && pop) {
         ref.addEventListener('click', function (e) {
+            e.preventDefault();
             pop.style.display = (pop.style.display === 'none') ? 'block' : 'none';
-            var p = new Popper(ref, pop, {
-                placement: "start-bottom",
-                modifiers: {
-                    preventOverflow: {enabled: false},
-                    hide: {
-                        enabled: false
-                    }
-                }
-            });
             return false;
         });
     }


### PR DESCRIPTION
### What does this PR do?

Fix Javascript reference error for popper we are receiving.

This occurs when you are on mobile at `/agent/` and choose a platform. A popup appears but throws an error at the same time. Functionally you shouldn't see a difference between this pr and production as it still works despite the error.

### Motivation

reduce noise / fix js error

### Preview

https://docs-staging.datadoghq.com/david.jones/popper-fix/agent/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
