### PR TITLE
[Doc] Removing single quotes from new api syntax

### DIFF
--- a/content/en/events/guides/migrating_to_new_events_features.md
+++ b/content/en/events/guides/migrating_to_new_events_features.md
@@ -162,7 +162,7 @@ EC2 Instance marked for maintenance
 : Legacy syntax </br>
 `events('priority:all "Upcoming AWS maintenance event"').by('name,host').rollup('count').last('2d') >= 1`
 : New syntax </br>
-`events('"Upcoming AWS maintenance event"').rollup("count").by("name,host").last("2d") >= 1`
+`events("Upcoming AWS maintenance event").rollup("count").by("name,host").last("2d") >= 1`
 
 Zabbix or Prometheus has triggered an alert for a service today
 : Legacy syntax </br>


### PR DESCRIPTION
single quotes were a mistake, new api does not use them.
Fellow SE was trying to make an api request and it would not run, but upon removing single quotes, api request was functioning normally.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
