### PR TITLE
Add the event explorer search syntax to "Using Tags"

### DIFF
--- a/content/en/getting_started/tagging/using_tags.md
+++ b/content/en/getting_started/tagging/using_tags.md
@@ -22,9 +22,9 @@ After [assigning tags][1], start using them to filter and group your data in you
 
 ## Events
 
-The [Events stream][2] shows the events from your environment over a specified time period. Use tags to filter the events list and focus on a subset of events. Enter `tags:` followed by a tag to see all the events coming from a host, [integration][3], or service with that tag. In the example below, `tags:service:coffee-house` is used to search for the tag `service:coffee-house`. To search multiple tags inclusively, separate each tag with OR: `tags:service:coffee-house OR host:coffeehouseprod`. To search multiple tags exclusively, separate each tag using commas: `tags:service:coffee-house,host:coffeehouseprod.`
+The [Events Explorer][2] shows the events from your environment over a specified time period. Use tags to filter the events list and focus on a subset of events. Enter `tags:` followed by a tag to see all the events coming from a host, [integration][3], or service with that tag. For example, use `tags:service:coffee-house` to search for the tag `service:coffee-house`.
 
-{{< img src="tagging/using_tags/eventtags.png" alt="Events List and Tags" style="width:80%;">}}
+To search multiple tags inclusively, use parentheses and separate each tag with OR: `tags:(service:coffee-house OR host:coffeehouseprod)`. To search multiple tags exclusively, separate each tag with AND: `tags:(service:coffee-house AND host:coffeehouseprod)`.
 
 ## Dashboards
 
@@ -356,7 +356,7 @@ Tags can be used in various ways with the [API][15]. See the list below for link
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /getting_started/tagging/assigning_tags/
-[2]: /events/
+[2]: /events/explorer
 [3]: /integrations/
 [4]: /infrastructure/hostmap/
 [5]: /infrastructure/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the Event search examples on the "Using Tags" getting started guide to use the new Event Explorer syntax. 

### Motivation
Reported by Solutions Engineer Ollie Harrison on https://datadoghq.atlassian.net/browse/DOCS-3520

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
