### PR TITLE
(Docs) Enable Nodejs Runtime Services Examples

### DIFF
--- a/content/en/tracing/runtime_metrics/nodejs.md
+++ b/content/en/tracing/runtime_metrics/nodejs.md
@@ -25,6 +25,32 @@ This feature is currently in private beta. <a href="https://docs.datadoghq.com/h
 
 Runtime metrics collection can be enabled with one configuration parameter in the tracing client either through the tracer option: `tracer.init({ runtimeMetrics: true })` or through the environment variable: `DD_RUNTIME_METRICS_ENABLED=true`
 
+
+   {{< tabs >}}
+{{% tab "Environment variables" %}}
+
+```shell
+export DD_RUNTIME_METRICS_ENABLED=true
+export DD_ENV=prod
+export DD_SERVICE=my-web-app
+export DD_VERSION=1.0.3
+```
+
+{{% /tab %}}
+{{% tab "In code" %}}
+
+```js
+const tracer = require('dd-trace').init({
+  env: 'prod',
+  service: 'my-web-app',
+  version: '1.0.3',
+  runtimeMetrics: true
+})
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 Runtime metrics can be viewed in correlation with your Node services. See the [Service page][1] in Datadog.
 
 By default, runtime metrics from your application are sent to the Datadog Agent with DogStatsD over port `8125`. Make sure that [DogStatsD is enabled for the Agent][2].


### PR DESCRIPTION
instructions on how to enable the runtime metrics are a bit confusing so I added tabs for Environment and In code similar to how we did it for profiling.

https://docs.datadoghq.com/tracing/profiler/enabling/nodejs/?tab=incode

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
