### PR TITLE
Update go docs to mention the `DD_TRACE_AGENT_PORT` envar

### DIFF
--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -105,6 +105,10 @@ Override the default trace Agent host address for trace submission.
 : **Default**: `8125` <br>
 Override the default trace Agent port for DogStatsD metric submission.
 
+`DD_TRACE_AGENT_PORT`
+: **Default**: `8126` <br>
+Override the default trace Agent port for datadog trace submission.
+
 `DD_TRACE_SAMPLE_RATE`
 : Enable ingestion rate control.
 

--- a/content/en/tracing/setup_overview/setup/go.md
+++ b/content/en/tracing/setup_overview/setup/go.md
@@ -107,7 +107,7 @@ Override the default trace Agent port for DogStatsD metric submission.
 
 `DD_TRACE_AGENT_PORT`
 : **Default**: `8126` <br>
-Override the default trace Agent port for datadog trace submission.
+Override the default trace Agent port for Datadog trace submission.
 
 `DD_TRACE_SAMPLE_RATE`
 : Enable ingestion rate control.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a mention of the `DD_TRACE_AGENT_PORT` environment variable used by dd-trace-go. The current documentation mentions only the `DD_DOGSTATSD_PORT`, which only applied to dogstatsd metrics, not DD APM traces.

### Motivation
The docs around environment variable configuration for the dd-trace-go library are incomplete.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
