### PR TITLE
[RUMF-1262] add centralized documentation on page activity

### DIFF
--- a/content/en/real_user_monitoring/browser/data_collected.md
+++ b/content/en/real_user_monitoring/browser/data_collected.md
@@ -256,7 +256,7 @@ Source errors include code-level information about the error. More information a
 [3]: /help/
 [4]: /real_user_monitoring/browser/modifying_data_and_context/#identify-user-sessions
 [5]: /synthetics/browser_tests/
-[6]: /real_user_monitoring/browser/monitoring_page_performance/#how-is-loading-time-calculated
+[6]: /real_user_monitoring/browser/monitoring_page_performance/#how-loading-time-is-calculated
 [7]: https://www.w3.org/TR/paint-timing/#sec-terminology
 [8]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming/domInteractive
 [9]: https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event

--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -80,21 +80,21 @@ To account for modern web applications, loading time watches for network request
 - **Initial Load**: Loading Time is equal to _whichever is longer_:
 
   - The difference between `navigationStart` and `loadEventEnd`.
-  - Or the difference between `navigationStart` and the first time the page has no activity (see [next section][18] for details).
+  - Or the difference between `navigationStart` and the first time the page has no activity. Read [How page activity is calculated](#how-page-activity-is-calculated) for details.
 
-- **SPA Route Change**: Loading Time is equal to the difference between the user click and the first time the page has no activity (see [next section][18] for details).
+- **SPA Route Change**: Loading Time is equal to the difference between the user click and the first time the page has no activity. Read [How page activity is calculated](#how-page-activity-is-calculated) for details.
 
-### How is page activity calculated?
+### How page activity is calculated
 
-Whenever a navigation or a click occurs, we start tracking the page activity to estimate the time until the interface is stable again. We consider that a page has activity by looking at network requests and DOM mutations. The page activity stops when there is no ongoing requests and no DOM mutation for more than 100ms. We consider that there was no activity if no requests or DOM mutation occurred in 100ms.
+Whenever a navigation or a click occurs, the RUM SDK tracks the page activity to estimate the time until the interface is stable again. The page is deemed to have activity by looking at network requests and DOM mutations. The page activity ends when there are no ongoing requests and no DOM mutation for more than 100ms. The page is determined to have no activity if no requests or DOM mutation occurred in 100ms.
 
 This approach works fine most of the time, but sometimes requests made by the application do not reflect actual activity as they don't have impact on the interface. In particular, we identified two problematic use cases:
 
-- When the application is collecting analytics by sending requests to an API periodically or following every click.
+- The application collects analytics by sending requests to an API periodically or after every click.
 
-- When the application is using "[comet][17]" techniques (that is, streaming or long polling), the request stays on hold for an indefinite time.
+- The application uses "[comet][17]" techniques (that is, streaming or long polling), and the request stays on hold for an indefinite time.
 
-Such request have a negative impact on the page activity computed by RUM. To improve its accuracy, the RUM Browser SDK allows to provide a list of URLs of resources to exclude when computing the page activity. Example:
+To improve the accuracy of activity determination in these cases, specify `excludedActivityUrls`, a list of resources for the RUM SDK to exclude when computing the page activity:
 
 ```javascript
 DD_RUM.init({
@@ -159,4 +159,3 @@ Once the timing is sent, the timing will be accessible as `@view.custom_timings.
 [15]: https://developer.mozilla.org/en-US/docs/Web/API/History
 [16]: /real_user_monitoring/explorer/?tab=measures#setup-facets-and-measures
 [17]: https://en.wikipedia.org/wiki/Comet_(programming)
-[18]: #how-is-page-activity-calculated

--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -88,7 +88,7 @@ To account for modern web applications, loading time watches for network request
 
 Whenever a navigation or a click occurs, the RUM SDK tracks the page activity to estimate the time until the interface is stable again. The page is deemed to have activity by looking at network requests and DOM mutations. The page activity ends when there are no ongoing requests and no DOM mutation for more than 100ms. The page is determined to have no activity if no requests or DOM mutation occurred in 100ms.
 
-This approach works fine most of the time, but sometimes requests made by the application do not reflect actual activity as they don't have impact on the interface. In particular, we identified two problematic use cases:
+The criteria of 100ms since last request or DOM mutation might not be an accurate determination of activity in the following scenarios:
 
 - The application collects analytics by sending requests to an API periodically or after every click.
 

--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -86,7 +86,7 @@ To account for modern web applications, loading time watches for network request
 
 ### How page activity is calculated
 
-Whenever a navigation or a click occurs, the RUM SDK tracks the page activity to estimate the time until the interface is stable again. The page is deemed to have activity by looking at network requests and DOM mutations. The page activity ends when there are no ongoing requests and no DOM mutation for more than 100ms. The page is determined to have no activity if no requests or DOM mutation occurred in 100ms.
+Whenever a navigation or a click occurs, the Browser RUM SDK tracks the page activity to estimate the time until the interface is stable again. The page is deemed to have activity by looking at network requests and DOM mutations. The page activity ends when there are no ongoing requests and no DOM mutation for more than 100ms. The page is determined to have no activity if no requests or DOM mutation occurred in 100ms.
 
 The criteria of 100ms since last request or DOM mutation might not be an accurate determination of activity in the following scenarios:
 
@@ -94,7 +94,7 @@ The criteria of 100ms since last request or DOM mutation might not be an accurat
 
 - The application uses "[comet][16])" techniques (that is, streaming or long polling), and the request stays on hold for an indefinite time.
 
-To improve the accuracy of activity determination in these cases, specify `excludedActivityUrls`, a list of resources for the RUM SDK to exclude when computing the page activity:
+To improve the accuracy of activity determination in these cases, specify `excludedActivityUrls`, a list of resources for the Browser RUM SDK to exclude when computing the page activity:
 
 ```javascript
 DD_RUM.init({
@@ -134,7 +134,7 @@ document.addEventListener("scroll", function handler() {
 });
 ```
 
-Once the timing is sent, the timing will be accessible as `@view.custom_timings.<timing_name>` (For example, `@view.custom_timings.first_scroll`). You must [create a measure][17] before graphing it in RUM analytics or in dashboards.
+Once the timing is sent, the timing is accessible as `@view.custom_timings.<timing_name>`, for example: `@view.custom_timings.first_scroll`. You must [create a measure][17] before graphing it in RUM Analytics or in dashboards.
 
 **Note**: For Single Page Applications, the `addTiming` API issues a timing relative to the start of the current RUM view. For example, if a user lands on your application (initial load), then goes on a different page after 5 seconds (route change) and finally triggers `addTiming` after 8 seconds, the timing will equal 8-5 = 3 seconds.
 

--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -73,7 +73,7 @@ For single page applications (SPAs), the RUM SDK differentiates between `initial
 
 Datadog provides a unique performance metric, `loading_time`, which calculates the time needed for a page to load. This metric works for both `initial_load` and `route_change` navigation.
 
-### How is loading time calculated?
+### How loading time is calculated
 
 To account for modern web applications, loading time watches for network requests and DOM mutations.
 
@@ -92,7 +92,7 @@ The criteria of 100ms since last request or DOM mutation might not be an accurat
 
 - The application collects analytics by sending requests to an API periodically or after every click.
 
-- The application uses "[comet][17]" techniques (that is, streaming or long polling), and the request stays on hold for an indefinite time.
+- The application uses "[comet][16])" techniques (that is, streaming or long polling), and the request stays on hold for an indefinite time.
 
 To improve the accuracy of activity determination in these cases, specify `excludedActivityUrls`, a list of resources for the RUM SDK to exclude when computing the page activity:
 
@@ -134,7 +134,7 @@ document.addEventListener("scroll", function handler() {
 });
 ```
 
-Once the timing is sent, the timing will be accessible as `@view.custom_timings.<timing_name>` (For example, `@view.custom_timings.first_scroll`). You must [create a measure][16] before graphing it in RUM analytics or in dashboards.
+Once the timing is sent, the timing will be accessible as `@view.custom_timings.<timing_name>` (For example, `@view.custom_timings.first_scroll`). You must [create a measure][17] before graphing it in RUM analytics or in dashboards.
 
 **Note**: For Single Page Applications, the `addTiming` API issues a timing relative to the start of the current RUM view. For example, if a user lands on your application (initial load), then goes on a different page after 5 seconds (route change) and finally triggers `addTiming` after 8 seconds, the timing will equal 8-5 = 3 seconds.
 
@@ -150,12 +150,12 @@ Once the timing is sent, the timing will be accessible as `@view.custom_timings.
 [6]: https://web.dev/fid/
 [7]: https://web.dev/cls/
 [8]: /synthetics/browser_tests/
-[9]: /real_user_monitoring/browser/monitoring_page_performance/#how-is-loading-time-calculated
+[9]: /real_user_monitoring/browser/monitoring_page_performance/#how-loading-time-is-calculated
 [10]: https://www.w3.org/TR/paint-timing/#sec-terminology
 [11]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming/domInteractive
 [12]: https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event
 [13]: https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event
 [14]: https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event
 [15]: https://developer.mozilla.org/en-US/docs/Web/API/History
-[16]: /real_user_monitoring/explorer/?tab=measures#setup-facets-and-measures
-[17]: https://en.wikipedia.org/wiki/Comet_(programming)
+[16]: https://en.wikipedia.org/wiki/Comet_(programming
+[17]: /real_user_monitoring/explorer/?tab=measures#setup-facets-and-measures

--- a/content/en/real_user_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/browser/tracking_user_actions.md
@@ -51,7 +51,7 @@ For information about the default attributes for all RUM event types, see [Data 
 
 ### How action loading time is calculated
 
-The RUM Browser SDK watches the page activity following every click. The action is considered finished when the page has no more activity. See [How page activity is calculated][4] for details.
+The Browser RUM SDK watches the page activity following every click. The action is considered finished when the page has no more activity. See [How page activity is calculated][4] for details.
 
 ## Action attributes
 

--- a/content/en/real_user_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/browser/tracking_user_actions.md
@@ -34,7 +34,7 @@ You can extend the collection of user interactions by [sending your own custom a
 ## What interactions are being tracked?
 
 The Browser SDK automatically tracks clicks. A click action is created if **all** of the following conditions are met:
-* Activity following the click is detected. See [How is page activity calculated?][4] for details.
+* Activity following the click is detected. See [How page activity is calculated][4] for details.
 * The click does not lead to a new page being loaded, in which case the Browser SDK generates a new RUM View event.
 * A name can be computed for the action. ([Learn more about action naming](#declaring-a-name-for-click-actions))
 
@@ -51,7 +51,7 @@ For information about the default attributes for all RUM event types, see [Data 
 
 ### How action loading time is calculated
 
-The RUM Browser SDK is watching the page activity following every clicks. The action is considered finished once the page has no more activity. See [How is page activity calculated?][4] for details.
+The RUM Browser SDK watches the page activity following every click. The action is considered finished when the page has no more activity. See [How page activity is calculated][4] for details.
 
 ## Action attributes
 
@@ -163,4 +163,4 @@ window.DD_RUM &&
 [1]: /real_user_monitoring/browser/modifying_data_and_context/
 [2]: /real_user_monitoring/browser/data_collected/#default-attributes
 [3]: https://github.com/DataDog/browser-sdk/blob/main/CHANGELOG.md#v2160
-[4]: /real_user_monitoring/browser/monitoring_page_performance/#how-is-page-activity-calculated
+[4]: /real_user_monitoring/browser/monitoring_page_performance/#how-page-activity-is-calculated

--- a/content/en/real_user_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/browser/tracking_user_actions.md
@@ -34,7 +34,7 @@ You can extend the collection of user interactions by [sending your own custom a
 ## What interactions are being tracked?
 
 The Browser SDK automatically tracks clicks. A click action is created if **all** of the following conditions are met:
-* Activity is detected within 100ms of click being handled (activity being defined as the start of a network request or a DOM mutation).
+* Activity following the click is detected. See [How is page activity calculated?][4] for details.
 * The click does not lead to a new page being loaded, in which case the Browser SDK generates a new RUM View event.
 * A name can be computed for the action. ([Learn more about action naming](#declaring-a-name-for-click-actions))
 
@@ -51,7 +51,7 @@ For information about the default attributes for all RUM event types, see [Data 
 
 ### How action loading time is calculated
 
-Once an interaction is detected, the RUM SDK watches for network requests and DOM mutations. The action is considered finished once the page has no activity for more than 100ms (activity being defined as ongoing network requests or DOM mutations).
+The RUM Browser SDK is watching the page activity following every clicks. The action is considered finished once the page has no more activity. See [How is page activity calculated?][4] for details.
 
 ## Action attributes
 
@@ -163,3 +163,4 @@ window.DD_RUM &&
 [1]: /real_user_monitoring/browser/modifying_data_and_context/
 [2]: /real_user_monitoring/browser/data_collected/#default-attributes
 [3]: https://github.com/DataDog/browser-sdk/blob/main/CHANGELOG.md#v2160
+[4]: /real_user_monitoring/browser/monitoring_page_performance/#how-is-page-activity-calculated


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add detailed documentation on Page Activity and how to use the `excludedActivityUrls` initialization parameter.

### Motivation

We are introducing the new `excludedActivityUrls` initialization parameter, and we need to give more context, example and use cases on how to use it, since it's rather technical.

### Preview
https://docs-staging.datadoghq.com/benoit/page-activity-documentation/real_user_monitoring/browser/monitoring_page_performance/#how-is-page-activity-calculated

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
