### PR TITLE
Update slanted quotes to straight ones under go custom_instrumentation

### DIFF
--- a/content/en/tracing/setup_overview/custom_instrumentation/go.md
+++ b/content/en/tracing/setup_overview/custom_instrumentation/go.md
@@ -119,22 +119,22 @@ There are two functions available to create spans. API details are available for
 
 ```go
 //Create a span with a resource name, which is the child of parentSpan.
-span := tracer.StartSpan(“mainOp”, tracer.ResourceName("/user"), tracer.ChildOf(parentSpan))
+span := tracer.StartSpan("mainOp", tracer.ResourceName("/user"), tracer.ChildOf(parentSpan))
 
 // Create a span which will be the child of the span in the Context ctx, if there is a span in the context.
 // Returns the new span, and a new context containing the new span.
-span, ctx := tracer.StartSpanFromContext(ctx, “mainOp”, tracer.ResourceName("/user"))
+span, ctx := tracer.StartSpanFromContext(ctx, "mainOp", tracer.ResourceName("/user"))
 ```
 
 ### Asynchronous traces
 
 ```go
 func main() {
-	span, ctx := tracer.StartSpanFromContext(context.Background(), “mainOp”)
+	span, ctx := tracer.StartSpanFromContext(context.Background(), "mainOp")
 	defer span.Finish()
 
 	go func() {
-		asyncSpan := tracer.StartSpanFromContext(ctx, “asyncOp”)
+		asyncSpan := tracer.StartSpanFromContext(ctx, "asyncOp")
 		defer asyncSpan.Finish()
 		performOp()
 	}()


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
There are some slanted quotes under the tracing custom_instrumentation documentations for go that won't compile properly if users directly copy/paste the code. Updates these slanted quotes to use straight quotes instead.

### Motivation
Makes it easier for users to directly copy/paste code.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
