### PR TITLE
it was a double redirect

### DIFF
--- a/content/en/agent/guide/can-i-set-up-the-dd-agent-mysql-check-on-my-google-cloudsql.md
+++ b/content/en/agent/guide/can-i-set-up-the-dd-agent-mysql-check-on-my-google-cloudsql.md
@@ -3,6 +3,7 @@ title: Can I set up the dd-agent mysql check on my Google CloudSQL?
 kind: guide
 aliases:
   - /agent/faq/can-i-set-up-the-dd-agent-mysql-check-on-my-google-cloudsql/
+  - /integrations/faq/can-i-set-up-the-dd-agent-mysql-check-on-my-google-cloudsql/
 ---
 
 Much like the "Native" [AWS RDS Integration][1] with MySQL, you can set up a Datadog Agent's MySQL integration to monitor on a MySQL instance running in Google CloudSQL. With this setup, you can complement the metrics you would otherwise get from Datadog's [Google CloudSQL Integration][2] with the metrics available from the Datadog Agent's [MySQL integration][3].


### PR DESCRIPTION
https://docs.datadoghq.com/integrations/faq/can-i-set-up-the-dd-agent-mysql-check-on-my-google-cloudsql/ is broken too

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
