### PR TITLE
Fix: Mention git.repository_url

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -38,7 +38,7 @@ To map telemetry data with your source code:
 
 ### Tag your telemetry
 
-To link data to a specific commit, tag your telemetry with a `git.commit.sha` tag.
+To link data to a specific commit, tag your telemetry with `git.commit.sha` and `git.repository_url` tags.
 
 {{< tabs >}}
 {{% tab "Docker Runtime" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix the wording of a sentence only mentioning the `git.commit.sha` tag while just above both tags were mentioned.

### Motivation
<!-- What inspired you to submit this pull request?-->

Fix SCI doc.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
