### PR TITLE
add examples for new group delay and composite

### DIFF
--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -183,20 +183,20 @@ Examples:
 
 1. Composite with different new group delays on child monitors:
 
-* monitor A: new_group_delay=120s
-* monitor B: new_group_delay=60s
-* composite: `A&&B`
+    * monitor A: new_group_delay=120s
+    * monitor B: new_group_delay=60s
+    * composite: `A&&B`
 
-When a new group appears, immediately, the composite monitor has this new group in OK state. After `60s`, the new group has the state from B in the composite monitor. After `120s`, the new group has its worst status among A and B in the composite. 
+    When a new group appears, immediately, the composite monitor has this new group in OK state. After `60s`, the new group has the state from B in the composite monitor. After `120s`, the new group has its worst status among A and B in the composite. 
 
 2. Composite with new group delay
 
-* monitor A: new_group_delay=120s
-* monitor B: new_group_delay=60s
-* composite: new_group_delay=200s
-* composite: `A&&B`
+    * monitor A: new_group_delay=120s
+    * monitor B: new_group_delay=60s
+    * composite: new_group_delay=200s
+    * composite: `A&&B`
 
-When a new group appears, immediately, the composite monitor has this new group in OK state. After `200s`, the new group has its worst status among A and B in the composite. 
+    When a new group appears, immediately, the composite monitor has this new group in OK state. After `200s`, the new group has its worst status among A and B in the composite. 
 
 
 ## Further Reading

--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -176,6 +176,29 @@ For example, if monitor `1` is a multi-alert per `device,host`, and monitor `2` 
 However, consider monitor `3`, a multi-alert per `host,url`. Monitor `1` and monitor `3` may not create a composite result because the groupings are too different:
 {{< img src="monitors/monitor_types/composite/multi-alert-2.png" alt="writing notification"  style="width:80%;">}}
 
+### New Group Delay and composite
+
+Setting [new_group_delay][4] is possible in composite monitors and it then overrides the value set on the child monitors.
+Examples:
+
+1. Composite with different new group delays on child monitors:
+
+* monitor A: new_group_delay=120s
+* monitor B: new_group_delay=60s
+* composite: `A&&B`
+
+When a new group appears, immediately, the composite monitor has this new group in OK state. After `60s`, the new group has the state from B in the composite monitor. After `120s`, the new group has its worst status among A and B in the composite. 
+
+2. Composite with new group delay
+
+* monitor A: new_group_delay=120s
+* monitor B: new_group_delay=60s
+* composite: new_group_delay=200s
+* composite: `A&&B`
+
+When a new group appears, immediately, the composite monitor has this new group in OK state. After `200s`, the new group has its worst status among A and B in the composite. 
+
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -183,3 +206,4 @@ However, consider monitor `3`, a multi-alert per `host,url`. Monitor `1` and mon
 [1]: https://app.datadoghq.com/monitors#create/composite
 [2]: /monitors/create/configuration/#advanced-alert-conditions
 [3]: /monitors/notify/
+[4]: /monitors/create/configuration/?tab=thresholdalert#new-group-delay


### PR DESCRIPTION
### What does this PR do?
Add examples on how new_group_delay works for composite monitors

### Motivation
new group delay was not supported so far for composite monitors and was recently added. 
It's behaviour in case of conflict with child monitors needed to be explicit.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/nils/new-group-delay-composite/monitors/create/types/composite

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
