### PR TITLE
Adds the 32 characters requirement on the Cluster Agent Token

### DIFF
--- a/content/en/agent/kubernetes/installation.md
+++ b/content/en/agent/kubernetes/installation.md
@@ -265,6 +265,8 @@ To install the Datadog Agent on your Kubernetes cluster:
     echo -n 'Random string' | base64
     ```
 
+    **Note**: The random string must contain at least 32 alphanumeric characters to secure Cluster Agent to Agent communication.
+
 5. **Set your Datadog site** to {{< region-param key="dd_site" code="true" >}} using the `DD_SITE` environment variable in the `datadog-agent.yaml` manifest.
 
     **Note**: If the `DD_SITE` environment variable is not explicitly set, it defaults to the `US` site `datadoghq.com`. If you are using one of the other sites (`EU`, `US3`, or `US1-FED`) this will result in an invalid API key message. Use the [documentation site selector][20] to see documentation appropriate for the site you're using.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Specifies for the DaemonSet installation of the Agent (on Kubernetes) that the Cluster Agent Auth token should be at least 32 characters long.
### Motivation
<!-- What inspired you to submit this pull request?-->
* A shorter token will lead to an error message in the logs such as `Could not initialise the communication with the cluster agent: temporary failure in clusterAgentClient, will retry later: cluster agent authentication token length must be greater than 32, curently: 23`
* Lines up with other documentation specifying this requirement : 
    * https://docs.datadoghq.com/agent/cluster_agent/commands/#cluster-agent-options : `DD_CLUSTER_AGENT_AUTH_TOKEN` ***32 characters long token that needs to be shared between the node Agent and the Datadog Cluster Agent.***
    * https://docs.datadoghq.com/agent/cluster_agent/setup/?tab=daemonset#secure-cluster-agent-to-agent-communication ***To create this token run this one line command to generate a Secret named datadog-cluster-agent with a token set. Replace the <TOKEN> with 32 alphanumeric characters.***
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
