### PR TITLE
[WEB-2096]bump module version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.3.31
+require github.com/DataDog/websites-modules v1.3.34
 
 // replace github.com/DataDog/websites-modules => /Users/carlos.santos/GitHub/websites-modules

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/DataDog/websites-modules v1.3.31 h1:zT0r4DfIw6rntObtO56oW5epTULssmRsPwEGlN5dEkE=
-github.com/DataDog/websites-modules v1.3.31/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
 github.com/DataDog/websites-modules v1.3.34 h1:GEgcmwzYc56hnphSnFAeP7s7h8fPIBqDKJOfSjwxoBM=
 github.com/DataDog/websites-modules v1.3.34/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/DataDog/websites-modules v1.3.31 h1:zT0r4DfIw6rntObtO56oW5epTULssmRsPwEGlN5dEkE=
 github.com/DataDog/websites-modules v1.3.31/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.3.34 h1:GEgcmwzYc56hnphSnFAeP7s7h8fPIBqDKJOfSjwxoBM=
+github.com/DataDog/websites-modules v1.3.34/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
hugo module changes update localStorage values to include a time-to-live
there should be no change visible on documentation

### Motivation
<!-- What inspired you to submit this pull request?-->
changes were made to modules to meet this request: https://datadoghq.atlassian.net/browse/WEB-2096
the documentation site should be unaffected - there are no references to locally stored values
this is a sync to bump the module version being consumed

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/brooklyne.finni/bump_mod_version/


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
