### PR TITLE
Fixed a couple incorrect link references in k8s docs

### DIFF
--- a/content/en/agent/kubernetes/installation.md
+++ b/content/en/agent/kubernetes/installation.md
@@ -337,19 +337,20 @@ where `<USER_ID>` is the UID to run the agent and `<DOCKER_GROUP_ID>` is the gro
 
 ## Next steps
 
-To configure Live Containers, see [Live Containers][2].
+To configure Live Containers, see [Live Containers][3].
 
-To collect events, override proxy settings, send custom metrics with DogStatsD, configure container allowlists and blocklists, or reference the full list of available environment variables, see [Configure the Datadog Agent on Kubernetes][3].
+To collect events, override proxy settings, send custom metrics with DogStatsD, configure container allowlists and blocklists, or reference the full list of available environment variables, see [Configure the Datadog Agent on Kubernetes][4].
 
-To configure integrations, see [Integrations & Autodiscovery][4].
+To configure integrations, see [Integrations & Autodiscovery][5].
 
-To set up APM, see [Kubernetes Trace Collection][5].
+To set up APM, see [Kubernetes Trace Collection][6].
 
-To set up log collection, see [Kubernetes Log Collection][6].
+To set up log collection, see [Kubernetes Log Collection][7].
 
-[1]: /agent/kubernetes/control_plane
-[2]: /infrastructure/livecontainers/?tab=helm#configuration
-[3]: /agent/kubernetes/configuration/
-[4]: /agent/kubernetes/integrations/
-[5]: /agent/kubernetes/apm/
-[6]: /agent/kubernetes/log/
+[1]: /agent/kubernetes/distributions
+[2]: /agent/kubernetes/control_plane
+[3]: /infrastructure/livecontainers/configuration/
+[4]: /agent/kubernetes/configuration/
+[5]: /agent/kubernetes/integrations/
+[6]: /agent/kubernetes/apm/
+[7]: /agent/kubernetes/log/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes some incorrect link references in k8s docs. 

### Motivation
I clicked on a link for more information about monitoring the control plane, and ended up in the live containers overview page.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
