### PR TITLE
Composite and new group delay

### DIFF
--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -178,8 +178,9 @@ However, consider monitor `3`, a multi-alert per `host,url`. Monitor `1` and mon
 
 ### New Group Delay and composite
 
-Setting [new_group_delay][4] is possible in composite monitors and it then overrides the value set on the child monitors.
-Examples:
+Setting [new_group_delay][4] is possible in composite monitors and if set and bigger than the value on the child monitors, it then overrides the value set on the child monitors.
+
+**Examples:**
 
 1. Composite with different new group delays on child monitors:
 


### PR DESCRIPTION
### What does this PR do?
Fix the wording to explain that the value is overriden only if the value is higher on the composite.

### Motivation
It was slightly misleading in case the value was lower on the composite than on the child. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
