### PR TITLE
Add additional config documentation for cloud Azure/GCP cloud instances

### DIFF
--- a/content/en/database_monitoring/setup_mysql/azure.md
+++ b/content/en/database_monitoring/setup_mysql/azure.md
@@ -21,7 +21,7 @@ The Agent collects telemetry directly from the database by logging in as a read-
 1. [Configure database parameters](#configure-mysql-settings)
 1. [Grant the Agent access to the database](#grant-the-agent-access)
 1. [Install the Agent](#install-the-agent)
-1. [Install the RDS integration](#install-the-rds-integration)
+1. [Install the Azure MySQL integration](#install-the-azure-mysql-integration)
 
 ## Before you begin
 
@@ -149,6 +149,11 @@ instances:
     port: 3306
     username: datadog
     password: '<YOUR_CHOSEN_PASSWORD>' # from the CREATE USER step earlier
+
+     # After adding your project and instance, configure the Datadog Azure integration to pull additional cloud data such as CPU, Memory, etc.
+    azure:
+      deployment_type: '<DEPLOYMENT_TYPE>'
+      name: '<YOUR_INSTANCE_NAME>'
 ```
 
 **Note**: Wrap your password in single quotes in case a special character is present.
@@ -183,7 +188,11 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "host": "<AZURE_INSTANCE_ENDPOINT>",
     "port": 3306,
     "username": "datadog",
-    "password": "<UNIQUEPASSWORD>"
+    "password": "<UNIQUEPASSWORD>",
+    "azure": {
+      "deployment_type": "<DEPLOYMENT_TYPE>",
+      "name": "<YOUR_INSTANCE_NAME>"
+    }
   }]' \
   datadog/agent:${DD_AGENT_VERSION}
 ```
@@ -197,7 +206,7 @@ FROM datadog/agent:7.36.0
 
 LABEL "com.datadoghq.ad.check_names"='["mysql"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AZURE_INSTANCE_ENDPOINT>", "port": 3306,"username": "datadog","password": "<UNIQUEPASSWORD>"}]'
+LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AZURE_INSTANCE_ENDPOINT>", "port": 3306,"username": "datadog","password": "<UNIQUEPASSWORD>", "azure": {"deployment_type": "<DEPLOYMENT_TYPE>", "name": "<YOUR_INSTANCE_NAME>"}}]'
 ```
 
 To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][2] and declare the password using the `ENC[]` syntax, or see the [Autodiscovery template variables documentation][3] to learn how to pass the password as an environment variable.
@@ -231,7 +240,10 @@ instances:
     host: <INSTANCE_ADDRESS>
     port: 3306
     username: datadog
-    password: <UNIQUEPASSWORD" \
+    password: "<UNIQUEPASSWORD>"
+    azure:
+      deployment_type: "<DEPLOYMENT_TYPE>"
+      name: "<YOUR_INSTANCE_NAME>" \
   datadog/datadog
 ```
 
@@ -248,6 +260,10 @@ instances:
     port: 3306
     username: datadog
     password: '<UNIQUEPASSWORD>'
+    # After adding your project and instance, configure the Datadog Azure integration to pull additional cloud data such as CPU, Memory, etc.
+    azure:
+      deployment_type: '<DEPLOYMENT_TYPE>'
+      name: '<YOUR_INSTANCE_NAME>'
 ```
 
 ### Configure with Kubernetes service annotations
@@ -273,7 +289,11 @@ metadata:
           "host": "<AZURE_INSTANCE_ENDPOINT>",
           "port": 3306,
           "username": "datadog",
-          "password": "<UNIQUEPASSWORD>"
+          "password": "<UNIQUEPASSWORD>",
+          "azure": {
+            "deployment_type": "<DEPLOYMENT_TYPE>",
+            "name": "<YOUR_INSTANCE_NAME>"
+          }
         }
       ]
 spec:

--- a/content/en/database_monitoring/setup_mysql/gcsql.md
+++ b/content/en/database_monitoring/setup_mysql/gcsql.md
@@ -195,6 +195,11 @@ instances:
     port: 3306
     username: datadog
     password: '<UNIQUEPASSWORD>' # from the CREATE USER step earlier
+
+    # After adding your project and instance, configure the Datadog GCP integration to pull additional cloud data such as CPU, Memory, etc.
+    gcp:
+      project_id: '<PROJECT_ID>'
+      instance_id: '<INSTANCE_NAME>'
 ```
 
 **Note**: Wrap your password in single quotes in case a special character is present.
@@ -229,7 +234,11 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "host": "<INSTANCE_ADDRESS>",
     "port": 3306,
     "username": "datadog",
-    "password": "<UNIQUEPASSWORD>"
+    "password": "<UNIQUEPASSWORD>",
+    "gcp": {
+      "project_id": "<PROJECT_ID>",
+      "instance_id": "<INSTANCE_NAME>"
+    }
   }]' \
   gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
@@ -243,7 +252,7 @@ FROM gcr.io/datadoghq/agent:7.36.0
 
 LABEL "com.datadoghq.ad.check_names"='["mysql"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<INSTANCE_ADDRESS>", "port": 3306,"username": "datadog","password": "<UNIQUEPASSWORD>"}]'
+LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<INSTANCE_ADDRESS>", "port": 5432,"username": "datadog","password": "<UNIQUEPASSWORD>", "gcp": {"project_id": "<PROJECT_ID>", "instance_id": "<INSTANCE_NAME>"}}]'
 ```
 
 To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][2] and declare the password using the `ENC[]` syntax, or see the [Autodiscovery template variables documentation][3] to learn how to pass the password as an environment variable.
@@ -277,7 +286,10 @@ instances:
     host: <INSTANCE_ADDRESS>
     port: 3306
     username: datadog
-    password: <UNIQUEPASSWORD" \
+    password: <UNIQUEPASSWORD"
+    gcp:
+      project_id: '<PROJECT_ID>'
+      instance_id: '<INSTANCE_NAME>' \
   datadog/datadog
 ```
 
@@ -294,6 +306,10 @@ instances:
     port: 3306
     username: datadog
     password: '<UNIQUEPASSWORD>'
+    # After adding your project and instance, configure the Datadog GCP integration to pull additional cloud data such as CPU, Memory, etc.
+    gcp:
+      project_id: '<PROJECT_ID>'
+      instance_id: '<INSTANCE_NAME>'
 ```
 
 ### Configure with Kubernetes service annotations
@@ -318,7 +334,11 @@ metadata:
           "host": "<INSTANCE_ADDRESS>",
           "port": 3306,
           "username": "datadog",
-          "password": "<UNIQUEPASSWORD>"
+          "password": "<UNIQUEPASSWORD>",
+          "gcp": {
+            "project_id": "<PROJECT_ID>",
+            "instance_id": "<INSTANCE_NAME>"
+          }
         }
       ]
 spec:

--- a/content/en/database_monitoring/setup_mysql/gcsql.md
+++ b/content/en/database_monitoring/setup_mysql/gcsql.md
@@ -286,10 +286,10 @@ instances:
     host: <INSTANCE_ADDRESS>
     port: 3306
     username: datadog
-    password: <UNIQUEPASSWORD"
+    password: "<UNIQUEPASSWORD>"
     gcp:
-      project_id: '<PROJECT_ID>'
-      instance_id: '<INSTANCE_NAME>' \
+      project_id: "<PROJECT_ID>"
+      instance_id: "<INSTANCE_NAME>" \
   datadog/datadog
 ```
 

--- a/content/en/database_monitoring/setup_postgres/azure.md
+++ b/content/en/database_monitoring/setup_postgres/azure.md
@@ -315,7 +315,7 @@ instances:
     host: <AZURE_INSTANCE_ENDPOINT>
     port: 5432
     username: datadog
-    password: "<UNIQUEPASSWORD"
+    password: "<UNIQUEPASSWORD>"
     azure:
       deployment_type: "<DEPLOYMENT_TYPE>"
       name: "<YOUR_INSTANCE_NAME>" \

--- a/content/en/database_monitoring/setup_postgres/azure.md
+++ b/content/en/database_monitoring/setup_postgres/azure.md
@@ -20,7 +20,7 @@ The Agent collects telemetry directly from the database by logging in as a read-
 1. [Configure database parameters](#configure-postgres-settings)
 1. [Grant the Agent access to the database](#grant-the-agent-access)
 1. [Install the Agent](#install-the-agent)
-1. [Install the RDS integration](#install-the-rds-integration)
+1. [Install the Azure PostgreSQL integration](#install-the-azure-postgresql-integration)
 
 ## Before you begin
 
@@ -214,6 +214,11 @@ To configure collecting Database Monitoring metrics for an Agent running on a ho
        # pg_stat_activity_view: datadog.pg_stat_activity()
        ## Optional: Connect to a different database if needed for `custom_queries`
        # dbname: '<DB_NAME>'
+
+       # After adding your project and instance, configure the Datadog Azure integration to pull additional cloud data such as CPU, Memory, etc.
+       azure:
+        deployment_type: '<DEPLOYMENT_TYPE>'
+        name: '<YOUR_INSTANCE_NAME>'
    ```
 2. [Restart the Agent][2].
 
@@ -244,7 +249,11 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "host": "<AZURE_INSTANCE_ENDPOINT>",
     "port": 5432,
     "username": "datadog",
-    "password": "<UNIQUEPASSWORD>"
+    "password": "<UNIQUEPASSWORD>",
+    "azure": {
+      "deployment_type": "<DEPLOYMENT_TYPE>",
+      "name": "<YOUR_INSTANCE_NAME>"
+    }
   }]' \
   datadog/agent:${DD_AGENT_VERSION}
 ```
@@ -265,7 +274,7 @@ FROM datadog/agent:7.36.0
 
 LABEL "com.datadoghq.ad.check_names"='["postgres"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AZURE_INSTANCE_ENDPOINT>", "port": 5432,"username": "datadog","password": "<UNIQUEPASSWORD>"}]'
+LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AZURE_INSTANCE_ENDPOINT>", "port": 3306,"username": "datadog","password": "<UNIQUEPASSWORD>", "azure": {"deployment_type": "<DEPLOYMENT_TYPE>", "name": "<YOUR_INSTANCE_NAME>"}}]'
 ```
 
 For Postgres 9.6, add the following settings to the instance config where host and port are specified:
@@ -306,7 +315,10 @@ instances:
     host: <AZURE_INSTANCE_ENDPOINT>
     port: 5432
     username: datadog
-    password: <UNIQUEPASSWORD" \
+    password: "<UNIQUEPASSWORD"
+    azure:
+      deployment_type: "<DEPLOYMENT_TYPE>"
+      name: "<YOUR_INSTANCE_NAME>" \
   datadog/datadog
 ```
 
@@ -330,6 +342,11 @@ instances:
     port: 5432
     username: datadog
     password: '<PASSWORD>'
+    # After adding your project and instance, configure the Datadog Azure integration to pull additional cloud data such as CPU, Memory, etc.
+    azure:
+      deployment_type: '<DEPLOYMENT_TYPE>'
+      name: '<YOUR_INSTANCE_NAME>'
+
     ## Required: For Postgres 9.6, uncomment these lines to use the functions created in the setup
     # pg_stat_statements_view: datadog.pg_stat_statements()
     # pg_stat_activity_view: datadog.pg_stat_activity()
@@ -358,7 +375,11 @@ metadata:
           "host": "<AZURE_INSTANCE_ENDPOINT>",
           "port": 5432,
           "username": "datadog",
-          "password": "<UNIQUEPASSWORD>"
+          "password": "<UNIQUEPASSWORD>",
+          "azure": {
+            "deployment_type": "<DEPLOYMENT_TYPE>",
+            "name": "<YOUR_INSTANCE_NAME>"
+          }
         }
       ]
 spec:

--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -198,6 +198,11 @@ To configure Database Monitoring metrics collection for an Agent running on a ho
        # pg_stat_activity_view: datadog.pg_stat_activity()
        ## Optional: Connect to a different database if needed for `custom_queries`
        # dbname: '<DB_NAME>'
+
+       # After adding your project and instance, configure the Datadog GCP integration to pull additional cloud data such as CPU, Memory, etc.
+       gcp:
+        project_id: '<PROJECT_ID>'
+        instance_id: '<INSTANCE_NAME>'
    ```
 2. [Restart the Agent][2].
 
@@ -228,7 +233,11 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "host": "<INSTANCE_ADDRESS>",
     "port": 5432,
     "username": "datadog",
-    "password": "<UNIQUEPASSWORD>"
+    "password": "<UNIQUEPASSWORD>",
+    "gcp": {
+      "project_id": "<PROJECT_ID>",
+      "instance_id": "<INSTANCE_NAME>"
+    }
   }]' \
   gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
@@ -249,7 +258,7 @@ FROM gcr.io/datadoghq/agent:7.36.0
 
 LABEL "com.datadoghq.ad.check_names"='["postgres"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<INSTANCE_ADDRESS>", "port": 5432,"username": "datadog","password": "<UNIQUEPASSWORD>"}]'
+LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<INSTANCE_ADDRESS>", "port": 5432,"username": "datadog","password": "<UNIQUEPASSWORD>", "gcp": {"project_id": "<PROJECT_ID>", "instance_id": "<INSTANCE_NAME>"}}]'
 ```
 
 For Postgres 9.6, add the following settings to the instance config where host and port are specified:
@@ -290,7 +299,10 @@ instances:
     host: <INSTANCE_ADDRESS>
     port: 5432
     username: datadog
-    password: <UNIQUEPASSWORD" \
+    password: <UNIQUEPASSWORD"
+    gcp:
+      project_id: '<PROJECT_ID>'
+      instance_id: '<INSTANCE_NAME>' \
   datadog/datadog
 ```
 
@@ -314,6 +326,11 @@ instances:
     port: 5432
     username: datadog
     password: '<PASSWORD>'
+    # After adding your project and instance, configure the Datadog GCP integration to pull additional cloud data such as CPU, Memory, etc.
+    gcp:
+      project_id: '<PROJECT_ID>'
+      instance_id: '<INSTANCE_NAME>'
+
     ## Required: For Postgres 9.6, uncomment these lines to use the functions created in the setup
     # pg_stat_statements_view: datadog.pg_stat_statements()
     # pg_stat_activity_view: datadog.pg_stat_activity()
@@ -341,7 +358,11 @@ metadata:
           "host": "<INSTANCE_ADDRESS>",
           "port": 5432,
           "username": "datadog",
-          "password": "<UNIQUEPASSWORD>"
+          "password": "<UNIQUEPASSWORD>",
+          "gcp": {
+            "project_id": "<PROJECT_ID>",
+            "instance_id": "<INSTANCE_NAME>"
+          }
         }
       ]
 spec:

--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -299,10 +299,10 @@ instances:
     host: <INSTANCE_ADDRESS>
     port: 5432
     username: datadog
-    password: <UNIQUEPASSWORD"
+    password: "<UNIQUEPASSWORD>"
     gcp:
-      project_id: '<PROJECT_ID>'
-      instance_id: '<INSTANCE_NAME>' \
+      project_id: "<PROJECT_ID>"
+      instance_id: "<INSTANCE_NAME>" \
   datadog/datadog
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds config doc for new cloud related configs that were added to support proper DBM -> cloud resource linking for displaying metrics that are collected by DD crawlers like CPU, IO, memory, etc in the new DB list page 

Example doc from the [agent spec](https://github.com/DataDog/integrations-core/blob/master/postgres/assets/configuration/spec.yaml#L446-L474) 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
