### PR TITLE
DOCS-3506 Run Synthetic Tests from Private Locations Edits

### DIFF
--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -415,9 +415,9 @@ Because Datadog already integrates with Kubernetes and AWS, it is ready-made to 
 
 {{< /tabs >}}
 
-#### Set up health checks, liveness, and readiness probes
+#### Set up liveness and readiness probes
 
-Add a [health check][10] mechanism so your orchestrator can ensure the workers are running correctly.
+Add a liveness or readiness probe so your orchestrator can ensure the workers are running correctly.
 
 For readiness probes, you need to enable private location status probes on port `8080` in your private location deployment. For more information, see [Advanced configuration][15].
 
@@ -536,6 +536,8 @@ readinessProbe:
 {{< /tabs >}}
 
 #### Additional health check configurations
+
+<div class="alert alert-danger">This method of adding private location health checks is no longer supported. Datadog recommends using liveness and readiness probes.</div>
 
 The `/tmp/liveness.date` file of private location containers gets updated after every successful poll from Datadog (2s by default). The container is considered unhealthy if no poll has been performed in a while, for example: no fetch in the last minute.
 

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -415,11 +415,128 @@ Because Datadog already integrates with Kubernetes and AWS, it is ready-made to 
 
 {{< /tabs >}}
 
-#### Set up health checks
+#### Set up health checks, liveness and readiness probes
 
 Add a [health check][10] mechanism so your orchestrator can ensure the workers are running correctly.
 
-If your container orchestrator of choice requires a health check endpoint, enable private location status probes on port `8080` in your private location deployment. For more information, see [Advanced configuration][15].
+For readiness probes, you first need to enable private location status probes on port `8080` in your private location deployment. For more information, see [Advanced configuration][15].
+
+{{< tabs >}}
+
+{{% tab "Docker Compose" %}}
+
+```yaml
+healthcheck:
+  retries: 3
+  test: [
+    "CMD", "curl", "-f", "http://localhost:8080"
+  ]
+  timeout: 2s
+  interval: 10s
+  start_period: 30s
+```
+
+{{% /tab %}}
+
+{{% tab "Kubernetes Deployment" %}}
+
+```yaml
+livenessProbe:
+  exec:
+    command:
+      - /bin/sh
+      - -c
+      - '[ $(expr $(cat /tmp/liveness.date) + 300000) -gt $(date +%s%3N) ]'
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+readinessProbe:
+  tcpSocket:
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+```
+
+{{% /tab %}}
+
+{{% tab "Helm Chart" %}}
+
+```yaml
+livenessProbe:
+  exec:
+    command:
+      - /bin/sh
+      - -c
+      - '[ $(expr $(cat /tmp/liveness.date) + 300000) -gt $(date +%s%3N) ]'
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+readinessProbe:
+  tcpSocket:
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+```
+
+{{% /tab %}}
+
+{{% tab "ECS" %}}
+
+```json
+"healthCheck": {
+  "retries": 3,
+  "command": [
+    "CMD-SHELL", "/bin/sh -c '[ $(expr $(cat /tmp/liveness.date) + 300000) -gt $(date +%s%3N) ]'"
+  ],
+  "timeout": 2,
+  "interval": 10,
+  "startPeriod": 30
+}
+```
+
+{{% /tab %}}
+
+{{% tab "Fargate" %}}
+
+```json
+"healthCheck": {
+  "retries": 3,
+  "command": [
+    "CMD-SHELL", "curl -f http://localhost/8080 || exit 1"
+  ],
+  "timeout": 2,
+  "interval": 10,
+  "startPeriod": 30
+}
+```
+
+{{% /tab %}}
+
+{{% tab "EKS" %}}
+
+```yaml
+livenessProbe:
+  exec:
+    command:
+      - /bin/sh
+      - -c
+      - '[ $(expr $(cat /tmp/liveness.date) + 300000) -gt $(date +%s%3N) ]'
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+readinessProbe:
+  tcpSocket:
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+```
+
+{{% /tab %}}
+
+{{< /tabs >}}
 
 #### Additional health check configurations
 

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -415,13 +415,17 @@ Because Datadog already integrates with Kubernetes and AWS, it is ready-made to 
 
 {{< /tabs >}}
 
-#### Set up healthchecks
+#### Set up health checks
 
-Add a [healthcheck][10] mechanism so your orchestrator can ensure the workers are running correctly.
+Add a [health check][10] mechanism so your orchestrator can ensure the workers are running correctly.
+
+If your container orchestrator of choice requires a health check endpoint, enable private location status probes on port `8080` in your private location deployment. For more information, see [Advanced configuration][15].
+
+#### Additional health check configurations
 
 The `/tmp/liveness.date` file of private location containers gets updated after every successful poll from Datadog (2s by default). The container is considered unhealthy if no poll has been performed in a while, for example: no fetch in the last minute.
 
-Use the configuration below to set up healthchecks on your containers with:
+Use the configuration below to set up health checks on your containers with `livenessProbe`:
 
 {{< tabs >}}
 
@@ -524,10 +528,6 @@ livenessProbe:
 {{% /tab %}}
 
 {{< /tabs >}}
-
-#### Additional health check configurations
-
-If your container orchestrator of choice requires a health check endpoint, enable private location status probes on port `8080` in your private location deployment. For more information, see [Advanced configurations][15].
 
 ### Test your internal endpoint
 

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -415,11 +415,11 @@ Because Datadog already integrates with Kubernetes and AWS, it is ready-made to 
 
 {{< /tabs >}}
 
-#### Set up health checks, liveness and readiness probes
+#### Set up health checks, liveness, and readiness probes
 
 Add a [health check][10] mechanism so your orchestrator can ensure the workers are running correctly.
 
-For readiness probes, you first need to enable private location status probes on port `8080` in your private location deployment. For more information, see [Advanced configuration][15].
+For readiness probes, you need to enable private location status probes on port `8080` in your private location deployment. For more information, see [Advanced configuration][15].
 
 {{< tabs >}}
 
@@ -429,7 +429,7 @@ For readiness probes, you first need to enable private location status probes on
 healthcheck:
   retries: 3
   test: [
-    "CMD", "curl", "-f", "http://localhost:8080"
+    "CMD", "wget", "-O", "/dev/null", "-q", "http://localhost:8080/liveness"
   ]
   timeout: 2s
   interval: 10s
@@ -442,20 +442,19 @@ healthcheck:
 
 ```yaml
 livenessProbe:
-  exec:
-    command:
-      - /bin/sh
-      - -c
-      - '[ $(expr $(cat /tmp/liveness.date) + 300000) -gt $(date +%s%3N) ]'
+  httpGet:
+    path: /liveness
+    port: 8080
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 2
-  failureThreshold: 3
 readinessProbe:
-  tcpSocket:
-    port: 8080
-  initialDelaySeconds: 5
+  initialDelaySeconds: 30
   periodSeconds: 10
+  timeoutSeconds: 2
+  httpGet:
+    path: /readiness
+    port: 8080
 ```
 
 {{% /tab %}}
@@ -464,20 +463,19 @@ readinessProbe:
 
 ```yaml
 livenessProbe:
-  exec:
-    command:
-      - /bin/sh
-      - -c
-      - '[ $(expr $(cat /tmp/liveness.date) + 300000) -gt $(date +%s%3N) ]'
+  httpGet:
+    path: /liveness
+    port: 8080
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 2
-  failureThreshold: 3
 readinessProbe:
-  tcpSocket:
-    port: 8080
-  initialDelaySeconds: 5
+  initialDelaySeconds: 30
   periodSeconds: 10
+  timeoutSeconds: 2
+  httpGet:
+    path: /readiness
+    port: 8080
 ```
 
 {{% /tab %}}
@@ -488,7 +486,7 @@ readinessProbe:
 "healthCheck": {
   "retries": 3,
   "command": [
-    "CMD-SHELL", "/bin/sh -c '[ $(expr $(cat /tmp/liveness.date) + 300000) -gt $(date +%s%3N) ]'"
+    "CMD-SHELL", "/usr/bin/wget", "-O", "/dev/null", "-q", "http://localhost:8080/liveness"
   ],
   "timeout": 2,
   "interval": 10,
@@ -504,7 +502,7 @@ readinessProbe:
 "healthCheck": {
   "retries": 3,
   "command": [
-    "CMD-SHELL", "curl -f http://localhost/8080 || exit 1"
+    "CMD-SHELL", "wget -O /dev/null -q http://localhost:8080/liveness || exit 1"
   ],
   "timeout": 2,
   "interval": 10,
@@ -518,20 +516,19 @@ readinessProbe:
 
 ```yaml
 livenessProbe:
-  exec:
-    command:
-      - /bin/sh
-      - -c
-      - '[ $(expr $(cat /tmp/liveness.date) + 300000) -gt $(date +%s%3N) ]'
+  httpGet:
+    path: /liveness
+    port: 8080
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 2
-  failureThreshold: 3
 readinessProbe:
-  tcpSocket:
-    port: 8080
-  initialDelaySeconds: 5
+  initialDelaySeconds: 30
   periodSeconds: 10
+  timeoutSeconds: 2
+  httpGet:
+    path: /readiness
+    port: 8080
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Shifts around the recommended method of installing private locations with status probes + updates the code snippets in the Additional Health Check Configurations section.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-3506

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
