### PR TITLE
Remove `datadog.trace_agent.receiver.traces_dropped`

### DIFF
--- a/content/en/tracing/troubleshooting/agent_apm_metrics.md
+++ b/content/en/tracing/troubleshooting/agent_apm_metrics.md
@@ -110,10 +110,6 @@ Number of traces received and accepted.
 : **Type**: Count<br>
 Total bytes of payloads accepted by the Agent.
 
-`datadog.trace_agent.receiver.traces_dropped`
-: **Type**: Count<br>
-Traces dropped due to normalization errors.
-
 `datadog.trace_agent.receiver.traces_filtered`
 : **Type**: Count<br>
 Traces filtered by ignored resources (as defined in `datadog.yaml` file).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Remove `datadog.trace_agent.receiver.traces_dropped` from [APM metrics sent by the Datadog Agent](https://docs.datadoghq.com/tracing/troubleshooting/agent_apm_metrics/)

### Motivation
<!-- What inspired you to submit this pull request?-->

`datadog.trace_agent.receiver.traces_dropped` has not been reported since https://github.com/DataDog/datadog-agent/pull/3738 was released. The metric was switched to `datadog.trace_agent.normalizer.traces_dropped`.

![trace-agent more permissive trace normalization with metrics   logs by djova · Pull Request #3738 · DataDogdatadog-agent 2022-05-27 at 10 28 55 AM](https://user-images.githubusercontent.com/41987730/170610403-57cd3e80-3468-4fcc-b75b-ba24e855a113.jpg)


<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
