### PR TITLE
Bumping Kafka max context to 500

### DIFF
--- a/content/en/integrations/faq/troubleshooting-and-deep-dive-for-kafka.md
+++ b/content/en/integrations/faq/troubleshooting-and-deep-dive-for-kafka.md
@@ -84,7 +84,7 @@ To remedy, specify the correct partition for your topic. This correlates to this
 
 ### Partition context limitation
 
-The number of partition contexts collection is limited to 200. If you require more contexts, contact [Datadog support][11].
+The number of partition contexts collection is limited to 500. If you require more contexts, contact [Datadog support][11].
 
 [1]: https://kafka.apache.org
 [2]: https://sookocheff.com/post/kafka/kafka-in-a-nutshell


### PR DESCRIPTION
### What does this PR do?
Match the Kafka context limitation to match our integration : 

https://github.com/DataDog/integrations-core/blob/c943a73bb72bfd23d2e9c20914650c90ca7eeef7/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py#L33

https://github.com/DataDog/integrations-core/blob/c943a73bb72bfd23d2e9c20914650c90ca7eeef7/kafka_consumer/datadog_checks/kafka_consumer/constants.py#L6

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
