### PR TITLE
Update SQLServer RDS docs for DD user creation + remove support for 2012

### DIFF
--- a/content/en/database_monitoring/setup_sql_server/azure.md
+++ b/content/en/database_monitoring/setup_sql_server/azure.md
@@ -63,12 +63,29 @@ CREATE USER datadog FOR LOGIN datadog;
 
 Create a read-only login to connect to your server and grant the required permissions:
 
+#### For SQL Server versions 2014+
+
 ```SQL
 CREATE LOGIN datadog WITH PASSWORD = '<PASSWORD>';
 CREATE USER datadog FOR LOGIN datadog;
 GRANT CONNECT ANY DATABASE to datadog;
 GRANT VIEW SERVER STATE to datadog;
 GRANT VIEW ANY DEFINITION to datadog;
+```
+
+#### For SQL Server 2012
+
+```SQL
+CREATE LOGIN datadog WITH PASSWORD = '<PASSWORD>';
+CREATE USER datadog FOR LOGIN datadog;
+GRANT VIEW SERVER STATE to datadog;
+GRANT VIEW ANY DEFINITION to datadog;
+```
+
+Create the `datadog` user in each additional application database:
+```SQL
+USE [database_name];
+CREATE USER datadog FOR LOGIN datadog;
 ```
 
 {{% /tab %}}

--- a/content/en/database_monitoring/setup_sql_server/azure.md
+++ b/content/en/database_monitoring/setup_sql_server/azure.md
@@ -80,10 +80,8 @@ CREATE LOGIN datadog WITH PASSWORD = '<PASSWORD>';
 CREATE USER datadog FOR LOGIN datadog;
 GRANT VIEW SERVER STATE to datadog;
 GRANT VIEW ANY DEFINITION to datadog;
-```
 
-Create the `datadog` user in each additional application database:
-```SQL
+-- Create the `datadog` user in each additional application database:
 USE [database_name];
 CREATE USER datadog FOR LOGIN datadog;
 ```

--- a/content/en/database_monitoring/setup_sql_server/azure.md
+++ b/content/en/database_monitoring/setup_sql_server/azure.md
@@ -29,6 +29,9 @@ Do the following steps to enable Database Monitoring with your database:
 
 ## Before you begin
 
+Supported SQL Server versions
+: 2012, 2014, 2016, 2017, 2019
+
 {{% dbm-sqlserver-before-you-begin %}}
 
 ## Grant the Agent access

--- a/content/en/database_monitoring/setup_sql_server/gcsql.md
+++ b/content/en/database_monitoring/setup_sql_server/gcsql.md
@@ -26,6 +26,9 @@ Complete the following steps to enable Database Monitoring with your database:
 
 ## Before you begin
 
+Supported SQL Server versions
+: 2012, 2014, 2016, 2017, 2019
+
 {{% dbm-sqlserver-before-you-begin %}}
 
 ## Grant the Agent access

--- a/content/en/database_monitoring/setup_sql_server/rds.md
+++ b/content/en/database_monitoring/setup_sql_server/rds.md
@@ -29,6 +29,9 @@ Do the following steps to enable Database Monitoring with your database:
 
 ## Before you begin
 
+Supported SQL Server versions
+: 2014, 2016, 2017, 2019
+
 {{% dbm-sqlserver-before-you-begin %}}
 
 ## Grant the Agent access
@@ -38,10 +41,18 @@ The Datadog Agent requires read-only access to the database server to collect st
 Create a read-only login to connect to your server and grant the required permissions:
 
 ```SQL
+USE [master];
 CREATE LOGIN datadog WITH PASSWORD = '<PASSWORD>';
+GO
+--Set context to msdb database and create datadog user
+USE [msdb];
 CREATE USER datadog FOR LOGIN datadog;
+GO
+--Switch back to master and grant datadog user server permissions
+USE [master];
 GRANT VIEW SERVER STATE to datadog;
 GRANT VIEW ANY DEFINITION to datadog;
+GO
 ```
 
 Create the `datadog` user in each additional application database:

--- a/content/en/database_monitoring/setup_sql_server/selfhosted.md
+++ b/content/en/database_monitoring/setup_sql_server/selfhosted.md
@@ -28,6 +28,9 @@ Do the following steps to enable Database Monitoring with your database:
 
 ## Before you begin
 
+Supported SQL Server versions
+: 2012, 2014, 2016, 2017, 2019
+
 {{% dbm-sqlserver-before-you-begin %}}
 
 ## Grant the Agent access

--- a/content/en/database_monitoring/setup_sql_server/selfhosted.md
+++ b/content/en/database_monitoring/setup_sql_server/selfhosted.md
@@ -39,6 +39,9 @@ The Datadog Agent requires read-only access to the database server in order to c
 
 Create a read-only login to connect to your server and grant the required permissions:
 
+{{< tabs >}}
+{{% tab "SQL Server 2014+" %}}
+
 ```SQL
 CREATE LOGIN datadog WITH PASSWORD = '<PASSWORD>';
 CREATE USER datadog FOR LOGIN datadog;
@@ -46,6 +49,23 @@ GRANT CONNECT ANY DATABASE to datadog;
 GRANT VIEW SERVER STATE to datadog;
 GRANT VIEW ANY DEFINITION to datadog;
 ```
+{{% /tab %}}
+{{% tab "SQL Server 2012" %}}
+
+```SQL
+CREATE LOGIN datadog WITH PASSWORD = '<PASSWORD>';
+CREATE USER datadog FOR LOGIN datadog;
+GRANT VIEW SERVER STATE to datadog;
+GRANT VIEW ANY DEFINITION to datadog;
+```
+
+Create the `datadog` user in each additional application database:
+```SQL
+USE [database_name];
+CREATE USER datadog FOR LOGIN datadog;
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Install the Agent
 

--- a/layouts/shortcodes/dbm-sqlserver-before-you-begin.md
+++ b/layouts/shortcodes/dbm-sqlserver-before-you-begin.md
@@ -1,6 +1,3 @@
-Supported SQL Server versions
-: 2012, 2014, 2016, 2017, 2019
-
 Supported Agent versions
 : 7.35.0+
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This makes the following changes: 

1. Updates SQLServer for RDS setup docs to correctly create the DD user without getting an error in the script. RDS does not allow even the root user to create users in the master database, and requires that this be done in the special `msdb` database. 

[RDS docs on creating a user](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.SQLServer.CommonDBATasks.CreateUser.html)

2. Removes official support for SQLServer 2012 on RDS. Amazon has deprecated this support (and requiring upgrades by end of year), and we can no longer provision any instances with this version so we not able to fully support it. Microsoft is EOL'ing support for this version by the end of the year.  
3. Fixes self-hosted and azure MI docs for versions that are older than 2014 (`GRANT CONNECT ANY DATABASE` only works for versions 2014+)

### Motivation
<!-- What inspired you to submit this pull request?-->

Fixing set up docs for this [support ticket](https://datadoghq.atlassian.net/browse/SDBM-87)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
