### PR TITLE
Remove beta notice from GitHub Actions integration

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/github.md
+++ b/content/en/continuous_integration/setup_pipelines/github.md
@@ -17,8 +17,6 @@ further_reading:
 <div class="alert alert-warning">The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported.</div>
 {{< /site-region >}}
 
-<div class="alert alert-info">The GitHub Actions integration is in beta. There are no billing implications for activating the GitHub Actions integration during this period.</div>
-
 ## Compatibility
 
 Supported GitHub versions:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Removes the warning box at the top of the page that says the integration is in beta.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
