### PR TITLE
made a small update to the wording for the APM integration with synthetics 

### DIFF
--- a/content/en/synthetics/apm/_index.md
+++ b/content/en/synthetics/apm/_index.md
@@ -27,7 +27,7 @@ Having network-related specifics (thanks to your test) as well as backend, infra
 
 ## Usage
 
-Statements on this page apply to both [API][1] and [browser tests][2] for APM except where noted.
+Statements on this page apply to [HTTP API tests][20], [Multistep API tests][21], and [browser tests][2] for APM.
 
 ### Prerequisites
 
@@ -109,3 +109,6 @@ These traces are retained [just like your classical APM traces][19].
 [17]: /tracing/setup_overview/setup/dotnet-core/
 [18]: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.18.2
 [19]: /tracing/trace_retention/
+[20]: /synthetics/api_tests/http_tests/?tab=requestoptions
+[21]: /synthetics/multistep?tab=requestoptions
+


### PR DESCRIPTION
changed "Statements on this page apply to both [API][1] and [browser tests][2] for APM except where noted." 

to 

"Statements on this page apply to [HTTP API tests][20], [Multistep API tests][21], and [browser tests][2] for APM."

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
