### PR TITLE
Update the integrations build script to support the moving of a manifest v2 key

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -911,7 +911,9 @@ class Integrations:
             manifest_json["integration_id"] = manifest_json.get("app_id", "")
             categories = []
             supported_os = []
-            for tag in manifest_json.get("classifier_tags", []):
+            # Classifier tags key is migrating to be under the `tile` key in the manifest
+            classifier_tags = manifest_json.get("tile", {}).get("classifier_tags", []) or manifest_json.get("classifier_tags", [])
+            for tag in classifier_tags:
                 # in some cases tag was null/None
                 if tag:
                     key, value = tag.split("::")


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update the integrations docs build to support the fact that `classifier_tags` is moving under the `tile` key

This maintains backwards compatibility while we migrate existing manifests, in that it looks for the new value first, then falls back on the existing location. Once all manifests are migrated, this should be updated to stop looking at the old path. 

### Motivation
<!-- What inspired you to submit this pull request?-->
The `classifier_tags` key was meant to go under `tile`, but an issue occurred that we're working to resolve :) 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
