### PR TITLE
Change "Network" group name to "Web Access"

### DIFF
--- a/content/en/logs/log_configuration/attributes_naming_convention.md
+++ b/content/en/logs/log_configuration/attributes_naming_convention.md
@@ -91,7 +91,7 @@ The default standard attribute list is split into the functional domains:
 - [Syslog and log shippers](#syslog-and-log-shippers)
 - [DNS](#dns)
 
-#### Network
+#### Web Access
 
 The following attributes are related to the data used in network communication. All fields and metrics are prefixed by `network`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Change "Network" group name to "Web Access"

### Motivation
Unify naming between the doc and the platform, where all attributes are under the "Web Access" group

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
