### PR TITLE
NGINX Example configuration profile intake.

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -527,7 +527,7 @@ stream {
     server {
         listen 3836; #listen for profiles
         proxy_ssl on;
-        proxy_pass profile.agent.{{< region-param key="dd_site" >}}:443;
+        proxy_pass intake.profile.{{< region-param key="dd_site" >}}:443;
     }
     server {
         listen 3837; #listen for processes


### PR DESCRIPTION
The intake where we receive profiles has changed as per the network traffic documentation:
https://docs.datadoghq.com/agent/guide/network/?tab=agentv6v7

It used to be profile.agent.datadoghq.com while now it is intake.profile.datadoghq.com

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Changes the intake link in the NGINX example configuration

### Motivation
The intake has changed.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
