### PR TITLE
Add information about tlsVerify: false on AKS with new Agent versions

### DIFF
--- a/content/en/agent/kubernetes/distributions.md
+++ b/content/en/agent/kubernetes/distributions.md
@@ -105,7 +105,7 @@ datadog:
         fieldRef:
           fieldPath: spec.nodeName
     hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
-    tlsVerify: false # Since Agent 7.35, tlsVerify: false is currently required as Kubelet certificates in AKS do not have any SAN (Subject Alternative Name) set
+    tlsVerify: false # Required as of Agent 7.35. See Notes.
 ```
 
 {{% /tab %}}
@@ -129,7 +129,7 @@ spec:
           fieldRef:
             fieldPath: spec.nodeName
         hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
-        tlsVerify: false # Since Agent 7.35, tlsVerify: false is currently required as Kubelet certificates in AKS do not have any SAN (Subject Alternative Name) set
+        tlsVerify: false # Required as of Agent 7.35. See Notes.
   clusterAgent:
     image:
       name: "gcr.io/datadoghq/cluster-agent:latest"
@@ -145,7 +145,7 @@ spec:
 
 **Notes**:
 
-- Since Agent 7.35, tlsVerify: false is currently required as Kubelet certificates in AKS do not have any SAN (Subject Alternative Name) set.
+- As of Agent 7.35, `tlsVerify: false` is required because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
 
 - In some setups, DNS resolution for `spec.nodeName` inside Pods may not work in AKS. This has been reported on all AKS Windows nodes and when cluster is setup in a Virtual Network using custom DNS on Linux nodes. In this case, removing the `agent.config.kubelet.host` field (defaults to `status.hostIP`) and using `tlsVerify: false` is **required**. Using the `DD_KUBELET_TLS_VERIFY=false` environment variable also resolves this issue. Both of these options deactivate verification of the server certificate.
 

--- a/content/en/agent/kubernetes/distributions.md
+++ b/content/en/agent/kubernetes/distributions.md
@@ -105,7 +105,7 @@ datadog:
         fieldRef:
           fieldPath: spec.nodeName
     hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
-    # tlsVerify: false # If Kubelet integration fails with provided configuration
+    tlsVerify: false # Since Agent 7.35, tlsVerify: false is currently required as Kubelet certificates in AKS do not have any SAN (Subject Alternative Name) set
 ```
 
 {{% /tab %}}
@@ -129,7 +129,7 @@ spec:
           fieldRef:
             fieldPath: spec.nodeName
         hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
-        # tlsVerify: false # If Kubelet integration fails with provided configuration
+        tlsVerify: false # Since Agent 7.35, tlsVerify: false is currently required as Kubelet certificates in AKS do not have any SAN (Subject Alternative Name) set
   clusterAgent:
     image:
       name: "gcr.io/datadoghq/cluster-agent:latest"
@@ -143,7 +143,9 @@ spec:
 {{% /tab %}}
 {{< /tabs >}}
 
-**Notes**: 
+**Notes**:
+
+- Since Agent 7.35, tlsVerify: false is currently required as Kubelet certificates in AKS do not have any SAN (Subject Alternative Name) set.
 
 - In some setups, DNS resolution for `spec.nodeName` inside Pods may not work in AKS. This has been reported on all AKS Windows nodes and when cluster is setup in a Virtual Network using custom DNS on Linux nodes. In this case, removing the `agent.config.kubelet.host` field (defaults to `status.hostIP`) and using `tlsVerify: false` is **required**. Using the `DD_KUBELET_TLS_VERIFY=false` environment variable also resolves this issue. Both of these options deactivate verification of the server certificate.
 
@@ -191,7 +193,7 @@ datadog:
   # Avoid deploying kube-state-metrics chart.
   # The new `kubernetes_state_core` doesn't require to deploy the kube-state-metrics anymore.
   kubeStateMetricsEnabled: false
-  
+
   containers:
     agent:
       # resources for the Agent container


### PR DESCRIPTION
### What does this PR do?
Change documentation around `tlsVerify` on AKS.

### Motivation
Improve documentation.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
