### PR TITLE
Explain that JSON events are parsed

### DIFF
--- a/content/en/events/guides/migrating_to_new_events_features.md
+++ b/content/en/events/guides/migrating_to_new_events_features.md
@@ -76,7 +76,7 @@ The new query search allows you to use complex queries in event monitors with ne
 
 ### Pipelines
 
-With pipelines, events are parsed and enriched by chaining them sequentially through processors. Processors extract meaningful information or attributes from semi-structured text to reuse as facets. Each event that comes through the pipelines is tested against every pipeline filter. If it matches a filter, then all the processors are applied sequentially before moving to the next pipeline.
+Datadog automatically parses JSON-formatted events. When events are not JSON-formatted, with pipelines, events are parsed and enriched by chaining them sequentially through processors. Processors extract meaningful information or attributes from semi-structured text to reuse as facets. Each event that comes through the pipelines is tested against every pipeline filter. If it matches a filter, then all the processors are applied sequentially before moving to the next pipeline.
 
 ## What Changed?
 

--- a/content/en/events/guides/migrating_to_new_events_features.md
+++ b/content/en/events/guides/migrating_to_new_events_features.md
@@ -76,7 +76,7 @@ The new query search allows you to use complex queries in event monitors with ne
 
 ### Pipelines
 
-Datadog automatically parses JSON-formatted events. When events are not JSON-formatted, with pipelines, events are parsed and enriched by chaining them sequentially through processors. Processors extract meaningful information or attributes from semi-structured text to reuse as facets. Each event that comes through the pipelines is tested against every pipeline filter. If it matches a filter, then all the processors are applied sequentially before moving to the next pipeline.
+Datadog automatically parses JSON-formatted events. When events are not JSON-formatted, they are parsed and enriched by chaining them sequentially through a processing pipeline. Processors extract meaningful information or attributes from semi-structured text to reuse as facets. Each event that comes through the pipelines is tested against every pipeline filter. If it matches a filter, then all the processors are applied sequentially before moving to the next pipeline.
 
 ## What Changed?
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Explain that JSON events are automatically parsed in new event feature.

### Motivation
Some customers are seeing issue in v2 monitors because their JSON event is getting parsed automatically by Datadog and text search does not work for event attribute. (They need to manually add Facet for automatically parsed event attribute to make it work.) 
Need to clarify that JSON is parsed automatically like Logs document.
Logs document says "Datadog automatically parses JSON-formatted logs. When logs are not JSON-formatted, you can add value to your raw logs by sending them through a processing pipeline."

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
