### PR TITLE
All classifier tags are moved, stop looking at old location

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -911,8 +911,7 @@ class Integrations:
             manifest_json["integration_id"] = manifest_json.get("app_id", "")
             categories = []
             supported_os = []
-            # Classifier tags key is migrating to be under the `tile` key in the manifest
-            classifier_tags = manifest_json.get("tile", {}).get("classifier_tags", []) or manifest_json.get("classifier_tags", [])
+            classifier_tags = manifest_json.get("tile", {}).get("classifier_tags", [])
             for tag in classifier_tags:
                 # in some cases tag was null/None
                 if tag:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
All classifier tags are now moved under the `tile` key. We should be clear to stop looking under the old location! 

### Motivation
<!-- What inspired you to submit this pull request?-->
Completes the classifier_tag migration and removes dead code. 


<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
