### PR TITLE
[WEB-2198] synthetics API test page style update

### DIFF
--- a/assets/styles/base/_helpers.scss
+++ b/assets/styles/base/_helpers.scss
@@ -97,3 +97,8 @@ table {
 .cursor-pointer {
     cursor: pointer;
 }
+
+// Sizing
+.mw-50 {
+    max-width: 50%;
+}

--- a/assets/styles/components/_cards.scss
+++ b/assets/styles/components/_cards.scss
@@ -111,12 +111,15 @@
 
 .network-layers {
   .cards-dd {
-    @include media-breakpoint-only(xs) {
-      .card {   
-        .img-fluid {
-          max-height: 150px;
-          width: auto;
-        }
+    @include media-breakpoint-up(lg) {
+      .card img {
+        max-width: 80%;
+      }
+    }
+
+    @include media-breakpoint-up(xl) {
+      .card img {
+        max-width: 50%;
       }
     }
   }

--- a/layouts/partials/synthetics/network-layers.html
+++ b/layouts/partials/synthetics/network-layers.html
@@ -1,6 +1,6 @@
 {{ $dot := . }}
 <div class="logs-containers network-layers">
-    <div class="container cards-dd col-num-8">
+    <div class="container cards-dd col-num-4">
         <div class="card-deck">
             <a class="card" href="/synthetics/api_tests/http_tests">
                 <div class="card-body text-center py-2 px-1">

--- a/layouts/partials/synthetics/network-layers.html
+++ b/layouts/partials/synthetics/network-layers.html
@@ -4,42 +4,42 @@
         <div class="card-deck">
             <a class="card" href="/synthetics/api_tests/http_tests">
                 <div class="card-body text-center py-2 px-1">
-                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/http-test1.png" "class" "img-fluid" "alt" "HTTP" "width" "400") }}
+                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/http-test1.png" "class" "h-auto mw-50" "alt" "HTTP" "width" "400") }}
                 </div>
             </a>
             <a class="card" href="/synthetics/api_tests/ssl_tests">
                 <div class="card-body text-center py-2 px-1">
-                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/ssl-test1.png" "class" "img-fluid" "alt" "SSL" "width" "400") }}
+                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/ssl-test1.png" "class" "h-auto mw-50" "alt" "SSL" "width" "400") }}
                 </div>
             </a>
             <a class="card" href="/synthetics/api_tests/dns_tests">
                 <div class="card-body text-center py-2 px-1">
-                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/dns-test1.png" "class" "img-fluid" "alt" "DNS" "width" "400") }}
+                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/dns-test1.png" "class" "h-auto mw-50" "alt" "DNS" "width" "400") }}
                 </div>
             </a>
             <a class="card" href="/synthetics/api_tests/websocket_tests">
                 <div class="card-body text-center py-2 px-1">
-                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/websocket-test3.png" "class" "img-fluid" "alt" "WebSocket" "width" "400") }}
+                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/websocket-test3.png" "class" "h-auto mw-50" "alt" "WebSocket" "width" "400") }}
                 </div>
             </a>
             <a class="card" href="/synthetics/api_tests/tcp_tests">
                 <div class="card-body text-center py-2 px-1">
-                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/tcp-test1.png" "class" "img-fluid" "alt" "TCP" "width" "400") }}
+                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/tcp-test1.png" "class" "h-auto mw-50" "alt" "TCP" "width" "400") }}
                 </div>
             </a>
             <a class="card" href="/synthetics/api_tests/udp_tests">
                 <div class="card-body text-center py-2 px-1">
-                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/udp-test1.png" "class" "img-fluid" "alt" "UDP" "width" "400") }}
+                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/udp-test1.png" "class" "h-auto mw-50" "alt" "UDP" "width" "400") }}
                 </div>
             </a>
             <a class="card" href="/synthetics/api_tests/icmp_tests">
                 <div class="card-body text-center py-2 px-1">
-                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/icmp-test3.png" "class" "img-fluid" "alt" "ICMP" "width" "400") }}
+                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/icmp-test3.png" "class" "h-auto mw-50" "alt" "ICMP" "width" "400") }}
                 </div>
             </a>
             <a class="card" href="/synthetics/api_tests/grpc_tests">
                 <div class="card-body text-center py-2 px-1">
-                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/grpc-test1.png" "class" "img-fluid" "alt" "gRPC Health Check" "width" "400") }}
+                    {{ partial "img.html" (dict "root" . "src" "synthetics/api_tests/grpc-test1.png" "class" "h-auto mw-50" "alt" "gRPC Health Check" "width" "400") }}
                 </div>
             </a>
         </div>


### PR DESCRIPTION
### What does this PR do?
updates cards/icon style on synthetics API tests docs page

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2198

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/synth-api-test-subtypes/synthetics/api_tests/

### Additional Notes
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
