### PR TITLE
Clarify that GHES is not supported

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/github.md
+++ b/content/en/continuous_integration/setup_pipelines/github.md
@@ -24,7 +24,7 @@ further_reading:
 Supported GitHub versions:
 * GitHub.com (SaaS)
 
-GitHub Enterprise is not supported.
+GitHub Enterprise Server is not supported.
 
 ## Configuring the Datadog integration
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Clarifies that GHES is not supported.

### Motivation
<!-- What inspired you to submit this pull request?-->
The working is a bit confusing as GitHub SaaS has Enterprise accounts. This improves the wording so it is clear that we do not support the self-hosted version.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
