### PR TITLE
Fix API generated menus

### DIFF
--- a/assets/scripts/build-api-pages.js
+++ b/assets/scripts/build-api-pages.js
@@ -27,7 +27,8 @@ const updateMenu = (specData, specs, languages) => {
     // now add back in all the auto generated menu items from specs
     apiYaml.tags.forEach((tag) => {
 
-      const existingMenuItemIndex = newMenuArray.findIndex((i) => i.identifier === getTagSlug(tag.name));
+      const tagSlug = getTagSlug(tag.name);
+      const existingMenuItemIndex = newMenuArray.findIndex((i) => i.identifier === tagSlug);
       if(existingMenuItemIndex > -1) {
         // already exists
         // newMenuArray[existingMenuItemIndex].params["versions"].push()
@@ -35,8 +36,8 @@ const updateMenu = (specData, specs, languages) => {
         // doesn't exist lets add it
         newMenuArray.push({
           name: tag.name,
-          url: (language === 'en' ? `/api/latest/${getTagSlug(tag.name)}/` : `/${language}/api/latest/${getTagSlug(tag.name)}/` ),
-          identifier: getTagSlug(tag.name),
+          url: (language === 'en' ? `/api/latest/${tagSlug}/` : `/${language}/api/latest/${tagSlug}/` ),
+          identifier: tagSlug,
           generated: true
         });
       }
@@ -48,7 +49,8 @@ const updateMenu = (specData, specs, languages) => {
         .reduce((obj, item) => ([...obj, ...item]), [])
         .forEach((action) => {
 
-          const existingSubMenuItemIndex = newMenuArray.findIndex((i) => i.identifier === getTagSlug(action.summary));
+          const actionSlug = getTagSlug(action.summary);
+          const existingSubMenuItemIndex = newMenuArray.findIndex((i) => i.identifier === actionSlug && i.parent == tagSlug);
           if(existingSubMenuItemIndex > -1) {
             // already exists
             const existingParams = newMenuArray[existingSubMenuItemIndex].params;
@@ -63,12 +65,12 @@ const updateMenu = (specData, specs, languages) => {
             }
           } else {
             // instead of push we need to insert after last parent: tag.name
-            const indx = newMenuArray.findIndex((i) => i.identifier === getTagSlug(tag.name));
+            const indx = newMenuArray.findIndex((i) => i.identifier === tagSlug);
             const item = {
               name: action.summary,
-              url: `#` + getTagSlug(action.summary),
-              identifier: `${getTagSlug(action.summary)}`,
-              parent: getTagSlug(tag.name),
+              url: `#` + actionSlug,
+              identifier: actionSlug,
+              parent: tagSlug,
               generated: true,
               params: {
                 "versions": [apiVersion],

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -4856,10 +4856,8 @@ api:
     params:
       versions:
         - v1
-        - v2
       operationids:
         - UpdatePagerDutyIntegrationService
-        - UpdateOpsgenieService
       unstable: []
       order: 3
   - name: Get a single service object
@@ -4870,10 +4868,8 @@ api:
     params:
       versions:
         - v1
-        - v2
       operationids:
         - GetPagerDutyIntegrationService
-        - GetOpsgenieService
       unstable: []
       order: 2
   - name: Delete a single service object
@@ -4884,10 +4880,8 @@ api:
     params:
       versions:
         - v1
-        - v2
       operationids:
         - DeletePagerDutyIntegrationService
-        - DeleteOpsgenieService
       unstable: []
       order: 4
   - name: Create a new service object
@@ -4898,10 +4892,8 @@ api:
     params:
       versions:
         - v1
-        - v2
       operationids:
         - CreatePagerDutyIntegrationService
-        - CreateOpsgenieService
       unstable: []
       order: 1
   - name: Screenboards
@@ -7310,6 +7302,54 @@ api:
     url: /api/latest/opsgenie-integration/
     identifier: opsgenie-integration
     generated: true
+  - name: Update a single service object
+    url: '#update-a-single-service-object'
+    identifier: update-a-single-service-object
+    parent: opsgenie-integration
+    generated: true
+    params:
+      versions:
+        - v2
+      operationids:
+        - UpdateOpsgenieService
+      unstable: []
+      order: 4
+  - name: Get a single service object
+    url: '#get-a-single-service-object'
+    identifier: get-a-single-service-object
+    parent: opsgenie-integration
+    generated: true
+    params:
+      versions:
+        - v2
+      operationids:
+        - GetOpsgenieService
+      unstable: []
+      order: 3
+  - name: Delete a single service object
+    url: '#delete-a-single-service-object'
+    identifier: delete-a-single-service-object
+    parent: opsgenie-integration
+    generated: true
+    params:
+      versions:
+        - v2
+      operationids:
+        - DeleteOpsgenieService
+      unstable: []
+      order: 5
+  - name: Create a new service object
+    url: '#create-a-new-service-object'
+    identifier: create-a-new-service-object
+    parent: opsgenie-integration
+    generated: true
+    params:
+      versions:
+        - v2
+      operationids:
+        - CreateOpsgenieService
+      unstable: []
+      order: 2
   - name: Get all service objects
     url: '#get-all-service-objects'
     identifier: get-all-service-objects


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Actions can have the same summary under different API. This just
happened with OpsGenie operation, this fixes it.


### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
