### PR TITLE
Add backslashes to multiline shell example

### DIFF
--- a/content/en/logs/guide/how-to-set-up-only-logs.md
+++ b/content/en/logs/guide/how-to-set-up-only-logs.md
@@ -43,10 +43,10 @@ docker run -d --name datadog-agent \
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
            -e DD_CONTAINER_EXCLUDE="name:datadog-agent" \
-           -e DD_ENABLE_PAYLOADS_EVENTS=false
-           -e DD_ENABLE_PAYLOADS_SERIES=false
-           -e DD_ENABLE_PAYLOADS_SERVICE_CHECKS=false
-           -e DD_ENABLE_PAYLOADS_SKETCHES=false
+           -e DD_ENABLE_PAYLOADS_EVENTS=false \
+           -e DD_ENABLE_PAYLOADS_SERIES=false \
+           -e DD_ENABLE_PAYLOADS_SERVICE_CHECKS=false \
+           -e DD_ENABLE_PAYLOADS_SKETCHES=false \
            -v /var/run/docker.sock:/var/run/docker.sock:ro \
            -v /proc/:/host/proc/:ro \
            -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This adds backslashes to the shell example, to correctly escape its newlines.

### Motivation
I was using this documentation, and noticed the shell example did not correctly escape all newlines.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
