### PR TITLE
 Update 'Aggregating Multiple Agents Using Vector' to align with Obs Pipelines docs

### DIFF
--- a/content/en/agent/vector_aggregation.md
+++ b/content/en/agent/vector_aggregation.md
@@ -1,5 +1,5 @@
 ---
-title: Aggregating Multiple Agents Using Vector
+title: Collecting logs and metrics from the Datadog Agent using Vector
 kind: documentation
 further_reading:
 - link: "/logs/"
@@ -16,19 +16,11 @@ further_reading:
 
 ## Overview
 
-The Datadog Agent can be used along with [Vector][1]. In this scenario Agents send data
-to Vector, which aggregates data from multiple upstream Agents:
+The Datadog Agent can be used along with [Vector][1]. In this scenario, Datadog Agents send
+observability data to Vector, which aggregates data from multiple upstream Agents, and ultimately
+routes the data to Datadog:
 
 `Agents -> Vector -> Datadog`
-
-This scenario differs from using a [proxy][2] since Vector is able to process data before sending
-it to Datadog and other destinations. Vector capabilities include:
-
-* [Log parsing, structuring, and enrichment][3]
-* Cost reduction through [sampling][4]
-* [Redaction of PII][5] and sensitive data before it leaves your network
-* [Deriving metrics from logs][6] for cost effective analysis
-* [Routing to multiple destinations][7]
 
 **Notes**:
 
@@ -76,14 +68,7 @@ If you are using Docker, add the following to your Agent configuration file.
 ```
 
 ### Vector configuration
-To receive logs or metrics from the Datadog Agent, configure Vector with a [datadog_agent source][10]. To send logs to
-Datadog, Vector must be configured with at least one [datadog_logs sink][11]. Similarly to send metrics to Datadog,
-Vector must be configured with at least one [datadog_metrics sink][12].
-
-See the official [Vector documentation][13] for all available configuration parameters and transforms that can be
-applied to logs while they are processed by Vector.
-
-Here is a configuration example that adds a tag to every log and metric using the Vector Remap Language:
+To receive logs or metrics from the Datadog Agent, configure Vector with a [datadog_agent source][10]:
 
 ```yaml
 sources:
@@ -92,38 +77,12 @@ sources:
     # The <VECTOR_PORT> mentioned above should be set to the port value used here
     address: "[::]:8080"
     multiple_outputs: true # To automatically separate metrics and logs
-
-transforms:
-  tag_logs:
-    type: remap
-    inputs:
-      - datadog_agents.logs
-    source: |
-      # The `!` shorthand is used here with the `string` function, it errors if
-      # .ddtags is not a "string".
-      # The .ddtags field is always expected to be a string.
-      .ddtags = string!(.ddtags) + ",sender:vector"
-  tag_metrics:
-    type: remap
-    inputs:
-      - datadog_agents.metrics
-    source: |
-      .tags.sender = "vector"
-
-sinks:
-  log_to_datadog:
-    type: datadog_logs
-    inputs:
-       - tag_logs
-    default_api_key: "${DATADOG_API_KEY_ENV_VAR}"
-    encoding:
-      codec: json
-  metrics_to_datadog:
-    type: datadog_metrics
-    inputs:
-       - tag_metrics
-    default_api_key: "${DATADOG_API_KEY_ENV_VAR}"
 ```
+
+To send logs and metrics to Datadog, Vector must be configured with at least one [datadog_logs sink][11]
+and at least one [datadog_metrics sink][12], respectively. See [routing logs to Datadog][4] and
+[routing metrics to Datadog][5] for details on sending logs and metrics to Datadog using Vector.
+
 
 ### Using Kubernetes
 
@@ -137,12 +96,6 @@ Vector provides an [official chart for aggregating data][15] that comes with a D
 logs source preconfigured. For more information about installing Vector using Helm,
 see to the [official Vector documentation][16].
 
-To send logs to Datadog, a `datadog_logs` sink needs to be added to the Vector configuration. Similarly, to send metrics
-to Datadog, a `datadog_metrics` sinks needs to be added to Vector configuration. Vector's chart can hold any valid Vector
-configuration in the `values.yaml` file using the `customConfig` field. To enable `datadog_logs`, the same kind of
-configuration as described under [Vector configuration](#vector-configuration) can be directly included as-is in the
-Vector chart configuration.
-
 ## Manipulating Datadog logs and metrics with Vector
 
 Logs and metrics sent to Vector can benefit from the full capabilities of Vector, including [Vector Remap Language][3]
@@ -152,7 +105,8 @@ When received by Vector, logs sent by the Datadog Agent are structured using the
 using the Datadog API, see the [API documentation][17] for a complete schema description.
 
 Logs and metrics collected by Vector from other sources can be [fully enriched][8]. VRL can be used to adjust logs
-and metrics to fill relevant fields according to the expected schema.
+and metrics to fill relevant fields according to the expected schema. See [working with data][6] to learn how to
+leverage Vector transforms to manipulate observability data.
 
 ## Further Reading
 
@@ -161,9 +115,9 @@ and metrics to fill relevant fields according to the expected schema.
 [1]: https://vector.dev/
 [2]: /agent/proxy
 [3]: https://vector.dev/docs/reference/configuration/transforms/remap/
-[4]: https://vector.dev/docs/reference/configuration/transforms/sample/
-[5]: https://vector.dev/docs/reference/vrl/functions/#redact
-[6]: https://vector.dev/docs/reference/configuration/transforms/log_to_metric/
+[4]: 
+[5]: 
+[6]: 
 [7]: https://vector.dev/docs/reference/configuration/transforms/route/
 [8]: /getting_started/tagging
 [9]: https://vector.dev/docs/reference/vrl/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update this guide to focus on collecting data from Datadog agents using Vector instead of collection + transformation + routing, as we'll be writing specific docs for sending data from Vector to Datadog.

### NOTES
The links must be updated once the other docs are published. Please don't merge this until the links have been updated. This doc will also be moved to Obs Pipelines docs after these changes are merged. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
