### PR TITLE
DBM-1360: Add MySQL query activity troubleshooting

### DIFF
--- a/content/en/database_monitoring/setup_mysql/aurora.md
+++ b/content/en/database_monitoring/setup_mysql/aurora.md
@@ -140,6 +140,7 @@ CREATE PROCEDURE datadog.enable_events_statements_consumers()
     SQL SECURITY DEFINER
 BEGIN
     UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%';
+    UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name = 'events_waits_current';
 END $$
 DELIMITER ;
 GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers TO datadog@'%';

--- a/content/en/database_monitoring/setup_mysql/gcsql.md
+++ b/content/en/database_monitoring/setup_mysql/gcsql.md
@@ -151,6 +151,7 @@ CREATE PROCEDURE datadog.enable_events_statements_consumers()
     SQL SECURITY DEFINER
 BEGIN
     UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%';
+    UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name = 'events_waits_current';
 END $$
 DELIMITER ;
 GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers TO datadog@'%';

--- a/content/en/database_monitoring/setup_mysql/rds.md
+++ b/content/en/database_monitoring/setup_mysql/rds.md
@@ -150,6 +150,7 @@ CREATE PROCEDURE datadog.enable_events_statements_consumers()
     SQL SECURITY DEFINER
 BEGIN
     UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%';
+    UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name = 'events_waits_current';
 END $$
 DELIMITER ;
 GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers TO datadog@'%';

--- a/content/en/database_monitoring/setup_mysql/selfhosted.md
+++ b/content/en/database_monitoring/setup_mysql/selfhosted.md
@@ -155,6 +155,7 @@ CREATE PROCEDURE datadog.enable_events_statements_consumers()
     SQL SECURITY DEFINER
 BEGIN
     UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%';
+    UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name = 'events_waits_current';
 END $$
 DELIMITER ;
 GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers TO datadog@'%';

--- a/content/en/database_monitoring/setup_mysql/troubleshooting.md
+++ b/content/en/database_monitoring/setup_mysql/troubleshooting.md
@@ -180,7 +180,7 @@ Before following these steps to diagnose missing query activity, ensure the Agen
 #### `performance-schema-consumer-events-waits-current` is not enabled {#events-waits-current-not-enabled}
 The Agent requires the `performance-schema-consumer-events-waits-current` option to be enabled. It is disabled by default by MySQL, but may be enabled by your cloud provider. Follow the [setup instructions][1] for enabling it.
 
-Note, this option additionally requires `performance_schema` to be enabled as well.
+Note, this option additionally requires `performance_schema` to be enabled.
 
 <!-- TODO: add a custom query recipe for getting the max sql text length -->
 

--- a/content/en/database_monitoring/setup_mysql/troubleshooting.md
+++ b/content/en/database_monitoring/setup_mysql/troubleshooting.md
@@ -173,7 +173,14 @@ performance_schema_max_digest_length=4096
 performance_schema_max_sql_text_length=4096
 ```
 
-Most workloads are able to capture most queries by raising this value to 4096, but you may need to set a higher value for particularly long and complex queries.
+### Query activity is missing
+
+Before following these steps to diagnose missing query activity, ensure the Agent is running successfully and you have followed [the steps to diagnose missing agent data](#no-data-is-showing-after-configuring-database-monitoring). Below are possible causes for missing query activity.
+
+#### `performance-schema-consumer-events-waits-current` is not enabled {#events-waits-current-not-enabled}
+The Agent requires the `performance-schema-consumer-events-waits-current` option to be enabled. It is disabled by default by MySQL, but may be enabled by your cloud provider. Follow the [setup instructions][1] for enabling it.
+
+Note, this option additionally requires `performance_schema` to be enabled as well.
 
 <!-- TODO: add a custom query recipe for getting the max sql text length -->
 

--- a/content/en/database_monitoring/setup_mysql/troubleshooting.md
+++ b/content/en/database_monitoring/setup_mysql/troubleshooting.md
@@ -180,7 +180,7 @@ Before following these steps to diagnose missing query activity, ensure the Agen
 #### `performance-schema-consumer-events-waits-current` is not enabled {#events-waits-current-not-enabled}
 The Agent requires the `performance-schema-consumer-events-waits-current` option to be enabled. It is disabled by default by MySQL, but may be enabled by your cloud provider. Follow the [setup instructions][1] for enabling it.
 
-Note, this option additionally requires `performance_schema` to be enabled.
+**Note:** This option additionally requires `performance_schema` to be enabled.
 
 <!-- TODO: add a custom query recipe for getting the max sql text length -->
 

--- a/content/en/database_monitoring/setup_mysql/troubleshooting.md
+++ b/content/en/database_monitoring/setup_mysql/troubleshooting.md
@@ -178,9 +178,23 @@ performance_schema_max_sql_text_length=4096
 Before following these steps to diagnose missing query activity, ensure the Agent is running successfully and you have followed [the steps to diagnose missing agent data](#no-data-is-showing-after-configuring-database-monitoring). Below are possible causes for missing query activity.
 
 #### `performance-schema-consumer-events-waits-current` is not enabled {#events-waits-current-not-enabled}
-The Agent requires the `performance-schema-consumer-events-waits-current` option to be enabled. It is disabled by default by MySQL, but may be enabled by your cloud provider. Follow the [setup instructions][1] for enabling it.
+The Agent requires the `performance-schema-consumer-events-waits-current` option to be enabled. It is disabled by default by MySQL, but may be enabled by your cloud provider. Follow the [setup instructions][1] for enabling it. Alternatively, to avoid bouncing your database, consider setting up a runtime setup consumer. Create the following procedure to give the Agent the ability to enable `performance_schema.events_statements_*` consumers at runtime.
+
+
+```SQL
+DELIMITER $$
+CREATE PROCEDURE datadog.enable_events_statements_consumers()
+    SQL SECURITY DEFINER
+BEGIN
+    UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%';
+    UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name = 'events_waits_current';
+END $$
+DELIMITER ;
+GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers TO datadog@'%';
+```
 
 **Note:** This option additionally requires `performance_schema` to be enabled.
+
 
 <!-- TODO: add a custom query recipe for getting the max sql text length -->
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds troubleshooting docs for MySQL query activity.

Added [docs](https://docs-staging.datadoghq.com/alex.barksdale/add-mysql-query-activity-troubleshooting/database_monitoring/setup_mysql/troubleshooting/#query-activity-is-missing)

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
