### PR TITLE
[WEB-2260] Code tabs refactor

### DIFF
--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -1,5 +1,5 @@
 import { updateTOC, buildTOCMap } from './table-of-contents';
-import codeTabs from './codetabs';
+import initCodeTabs from './codetabs';
 import { redirectToRegion } from '../region-redirects';
 import { initializeIntegrations } from './integrations';
 import { initializeSecurityRules } from './security-rules';
@@ -184,7 +184,7 @@ function loadPage(newUrl) {
 
             // sets query params if code tabs are present
 
-            codeTabs();
+            initCodeTabs();
 
             const regionSelector = document.querySelector('.js-region-select');
 

--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -1,49 +1,22 @@
 import { getQueryParameterByName } from '../helpers/browser';
 
-const codeTabNodeList = document.querySelectorAll('.code-tabs')
+const codeTabsList = document.querySelectorAll('.code-tabs')
+const tabQueryParameter = getQueryParameterByName('tab')
 
-const initTabs = () => {
-    const tab = getQueryParameterByName('tab')
-    // const codeTabNodeList = document.querySelectorAll('.code-tabs')
-
-    // create tabs dynamically
-    createTabs()
-
-    activateTabOnLoad()
-
-    addTabEventListeners()
-
-    // activate tab on page load
-    if (tab) {
-        const selectedLanguageTab = document.querySelector(`a[data-lang="${tab}"]`);
-
-        if (selectedLanguageTab) {
-            selectedLanguageTab.click()
-        }
-    } else {            
-        codeTabNodeList.forEach(codeTab => {
-            const navTabs = codeTab.querySelector('.nav-tabs')
-            const firstTabLink = navTabs.querySelectorAll('a').item(0)
-            activateTab(firstTabLink)
-        })
-    }
-
-    const allTabLinksNodeList = document.querySelectorAll('.code-tabs li a')
-
-    allTabLinksNodeList.forEach(link => {
-        link.addEventListener('click', () => {
-            console.log(link)
-            event.preventDefault()
-            activateTab(link)
-        })
-    })
+const initCodeTabs = () => {
+    renderCodeTabElements()
+    addEventListeners()
+    activateTabsOnLoad()
 }
 
-const createTabs = () => {
-    if (codeTabNodeList.length > 0) {
-        codeTabNodeList.forEach(codeTab => {
-            const navTabsElement = codeTab.querySelector('.nav-tabs')
-            const tabContent = codeTab.querySelector('.tab-content')
+/**
+  * Renders code tabs on the page at run time
+*/
+const renderCodeTabElements = () => {
+    if (codeTabsList.length > 0) {
+        codeTabsList.forEach(codeTabsElement => {
+            const navTabsElement = codeTabsElement.querySelector('.nav-tabs')
+            const tabContent = codeTabsElement.querySelector('.tab-content')
             const tabPaneNodeList = tabContent.querySelectorAll('.tab-pane')
 
             tabPaneNodeList.forEach(tabPane => {
@@ -61,80 +34,83 @@ const createTabs = () => {
     }
 }
 
-const activateTab = (element) => {
-    const activeLang = element.getAttribute('data-lang')
+/**
+  * Adds active class to the selected tab and shows the related tab pane. 
+  * @param {object} tabAnchorElement - Reference to the HTML DOM node representing the anchor tag within each tab.
+*/
+const activateCodeTab = (tabAnchorElement) => {
+    const activeLang = tabAnchorElement.getAttribute('data-lang')
 
     if (activeLang) {
-        const allActiveTabLangs = document.querySelectorAll(`a[data-lang="${activeLang}"]`)
+        codeTabsList.forEach(codeTabsElement => {
+            const tabsList = codeTabsElement.querySelectorAll('.nav-tabs li')
+            const tabPanesList = codeTabsElement.querySelectorAll('.tab-pane')
+            const activeLangTab = codeTabsElement.querySelector(`a[data-lang="${activeLang}"]`)
+            const activePane = codeTabsElement.querySelector(`.tab-pane[data-lang="${activeLang}"]`)
 
-        allActiveTabLangs.forEach(tab => {
-            const parentLi = tab.closest('li')
-            parentLi.classList.add('active')
+            if (activeLangTab && activePane) {
+                // Hide all tab content and remove 'active' class from all tab elements.
+                tabsList.forEach(tab => tab.classList.remove('active'))
+                tabPanesList.forEach(pane => pane.classList.remove('active', 'show'))
+
+                // Show the active content and highlight active tab.
+                activeLangTab.closest('li').classList.add('active')
+                activePane.classList.add('active', 'show')
+            }
+            
+            const currentActiveTab = codeTabsElement.querySelector('.nav-tabs li.active')
+
+            // If we got this far and no tabs are highlighted, activate the first tab in the list of code tabs.
+            if (!currentActiveTab) {
+                const firstTab = tabsList.item(0)
+                const firstTabActiveLang = firstTab.querySelector('a').dataset.lang
+                const firstTabPane = codeTabsElement.querySelector(`.tab-pane[data-lang="${firstTabActiveLang}"]`)
+                firstTab.classList.add('active')
+                firstTabPane.classList.add('active', 'show')
+            }
         })
+    }
 
-        // find closest tab that has the data lang
-        const tabPanes = document.querySelectorAll(`.tab-pane[data-lang="${activeLang}"]`)
+    updateUrl(activeLang)
+}
 
-        tabPanes.forEach(pane => {
-            pane.classList.add('active')
-            pane.classList.add('show')
-        })
+const activateTabsOnLoad = () => {
+    if (tabQueryParameter) {
+        const selectedLanguageTab = document.querySelector(`a[data-lang="${tabQueryParameter}"]`);
+
+        if (selectedLanguageTab) {
+            selectedLanguageTab.click()
+        }
+    } else {
+        const firstTab = document.querySelectorAll('.code-tabs .nav-tabs a').item(0)
+        activateCodeTab(firstTab)
     }
 }
 
-const codeTabs = () => {
-    initTabs()
+const addEventListeners = () => {
+    const allTabLinksNodeList = document.querySelectorAll('.code-tabs li a')
+
+    allTabLinksNodeList.forEach(link => {
+        link.addEventListener('click', () => {
+            event.preventDefault()
+            activateCodeTab(link)
+        })
+    })
 }
 
-// function codeTabs() {
-//     const tab = getQueryParameterByName('tab');
+/**
+  * Append the active lang to the URL as a query parameter. 
+*/
+const updateUrl = (activeLang) => {
+    const url = window.location.href
+        .replace(window.location.hash, '')
+        .replace(window.location.search, '');
 
-//     if ($('.code-tabs').length > 0) {
-//         // clicking a tab open them all
-//         $('.code-tabs .nav-tabs a').click(function (e) {
-//             e.preventDefault();
+    window.history.replaceState(
+        null,
+        null,
+        `${url}?tab=${activeLang}${window.location.hash}`
+    );
+}
 
-//             // find all
-//             const lang = $(this).data('lang');
-//             $('.code-tabs .nav-tabs').each(function () {
-//                 const navtabs = $(this);
-//                 const links = $(this).find('a:first');
-//                 const langLinks = $(this).find(`a[data-lang="${lang}"]`);
-//                 if (langLinks.length) {
-//                     langLinks.each(function () {
-//                         activateTab($(this));
-//                     });
-//                 } else if (navtabs.find('.active').length === 0) {
-//                     // set first lang selected if nothing selected
-//                     links.each(function () {
-//                         activateTab($(this));
-//                     });
-//                 }
-//             });
-
-//             const url = window.location.href
-//                 .replace(window.location.hash, '')
-//                 .replace(window.location.search, '');
-//             window.history.replaceState(
-//                 null,
-//                 null,
-//                 `${url}?tab=${lang}${window.location.hash}`
-//             );
-//         });
-// }
-
-// function activateTab(el) {
-//     const tab = el.parent();
-//     const tabIndex = tab.index();
-//     const tabPanel = el.closest('.code-tabs');
-//     const tabPane = tabPanel.find('.tab-pane').eq(tabIndex);
-//     tabPanel.find('.active').removeClass('active');
-//     tab.addClass('active');
-//     tabPane.addClass('active');
-//     tabPane.addClass('show');
-//     el.closest('.code-tabs')
-//         .find('.nav-tabs-mobile .title-dropdown')
-//         .text(tab.text());
-// }
-
-export default codeTabs;
+export default initCodeTabs;

--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -1,96 +1,140 @@
 import { getQueryParameterByName } from '../helpers/browser';
 
-function codeTabs() {
-    const tab = getQueryParameterByName('tab');
+const codeTabNodeList = document.querySelectorAll('.code-tabs')
 
-    if ($('.code-tabs').length > 0) {
-        // page load set code tab titles
-        $('.code-tabs .tab-content')
-            .find('.tab-pane')
-            .each(function () {
-                const navTabsMobile = $(this)
-                    .closest('.code-tabs')
-                    .find('.nav-tabs-mobile .dropdown-menu');
-                const navTabs = $(this).closest('.code-tabs').find('.nav-tabs');
-                const title = $(this).attr('title');
-                const lang = $(this).data('lang');
-                navTabs.append(
-                    `<li><a href="#" data-lang="${lang}">${title}</a></li>`
-                );
-                navTabsMobile.append(
-                    `<a class="dropdown-item" href="#" data-lang="${lang}">${title}</a>`
-                );
-            });
+const initTabs = () => {
+    const tab = getQueryParameterByName('tab')
+    // const codeTabNodeList = document.querySelectorAll('.code-tabs')
 
-        // clicking a tab open them all
-        $('.code-tabs .nav-tabs a').click(function (e) {
-            e.preventDefault();
+    // create tabs dynamically
+    createTabs()
 
-            // find all
-            const lang = $(this).data('lang');
-            $('.code-tabs .nav-tabs').each(function () {
-                const navtabs = $(this);
-                const links = $(this).find('a:first');
-                const langLinks = $(this).find(`a[data-lang="${lang}"]`);
-                if (langLinks.length) {
-                    langLinks.each(function () {
-                        activateTab($(this));
-                    });
-                } else if (navtabs.find('.active').length === 0) {
-                    // set first lang selected if nothing selected
-                    links.each(function () {
-                        activateTab($(this));
-                    });
-                }
-            });
+    activateTabOnLoad()
 
-            const url = window.location.href
-                .replace(window.location.hash, '')
-                .replace(window.location.search, '');
-            window.history.replaceState(
-                null,
-                null,
-                `${url}?tab=${lang}${window.location.hash}`
-            );
-        });
+    addTabEventListeners()
 
-        // mobile tabs trigger desktop ones
-        $('.code-tabs .nav-tabs-mobile .dropdown-menu a').click(function (e) {
-            e.preventDefault();
-            const ctabs = $(this).parents('.code-tabs');
-            const lang = $(this).data('lang');
-            const desktopTab = ctabs.find(`.nav-tabs a[data-lang="${lang}"]`);
-            if (desktopTab) {
-                desktopTab.click();
-            }
-        });
+    // activate tab on page load
+    if (tab) {
+        const selectedLanguageTab = document.querySelector(`a[data-lang="${tab}"]`);
 
-        if (tab !== '') {
-            const selectedLanguageTab = document.querySelector(`a[data-lang="${tab}"]`);
-
-            if (selectedLanguageTab) {
-                selectedLanguageTab.click();
-            } else {
-                document.querySelector('.code-tabs .nav-tabs li a').click();
-            }
-        } else {
-            document.querySelector('.code-tabs .nav-tabs li a').click();
+        if (selectedLanguageTab) {
+            selectedLanguageTab.click()
         }
+    } else {            
+        codeTabNodeList.forEach(codeTab => {
+            const navTabs = codeTab.querySelector('.nav-tabs')
+            const firstTabLink = navTabs.querySelectorAll('a').item(0)
+            activateTab(firstTabLink)
+        })
+    }
+
+    const allTabLinksNodeList = document.querySelectorAll('.code-tabs li a')
+
+    allTabLinksNodeList.forEach(link => {
+        link.addEventListener('click', () => {
+            console.log(link)
+            event.preventDefault()
+            activateTab(link)
+        })
+    })
+}
+
+const createTabs = () => {
+    if (codeTabNodeList.length > 0) {
+        codeTabNodeList.forEach(codeTab => {
+            const navTabsElement = codeTab.querySelector('.nav-tabs')
+            const tabContent = codeTab.querySelector('.tab-content')
+            const tabPaneNodeList = tabContent.querySelectorAll('.tab-pane')
+
+            tabPaneNodeList.forEach(tabPane => {
+                const title = tabPane.getAttribute('title')
+                const lang = tabPane.getAttribute('data-lang')
+                const li = document.createElement('li')
+                const anchor = document.createElement('a')
+                anchor.dataset.lang = lang
+                anchor.href = '#'
+                anchor.innerText = title
+                li.appendChild(anchor)
+                navTabsElement.appendChild(li)
+            })
+        })
     }
 }
 
-function activateTab(el) {
-    const tab = el.parent();
-    const tabIndex = tab.index();
-    const tabPanel = el.closest('.code-tabs');
-    const tabPane = tabPanel.find('.tab-pane').eq(tabIndex);
-    tabPanel.find('.active').removeClass('active');
-    tab.addClass('active');
-    tabPane.addClass('active');
-    tabPane.addClass('show');
-    el.closest('.code-tabs')
-        .find('.nav-tabs-mobile .title-dropdown')
-        .text(tab.text());
+const activateTab = (element) => {
+    const activeLang = element.getAttribute('data-lang')
+
+    if (activeLang) {
+        const allActiveTabLangs = document.querySelectorAll(`a[data-lang="${activeLang}"]`)
+
+        allActiveTabLangs.forEach(tab => {
+            const parentLi = tab.closest('li')
+            parentLi.classList.add('active')
+        })
+
+        // find closest tab that has the data lang
+        const tabPanes = document.querySelectorAll(`.tab-pane[data-lang="${activeLang}"]`)
+
+        tabPanes.forEach(pane => {
+            pane.classList.add('active')
+            pane.classList.add('show')
+        })
+    }
 }
+
+const codeTabs = () => {
+    initTabs()
+}
+
+// function codeTabs() {
+//     const tab = getQueryParameterByName('tab');
+
+//     if ($('.code-tabs').length > 0) {
+//         // clicking a tab open them all
+//         $('.code-tabs .nav-tabs a').click(function (e) {
+//             e.preventDefault();
+
+//             // find all
+//             const lang = $(this).data('lang');
+//             $('.code-tabs .nav-tabs').each(function () {
+//                 const navtabs = $(this);
+//                 const links = $(this).find('a:first');
+//                 const langLinks = $(this).find(`a[data-lang="${lang}"]`);
+//                 if (langLinks.length) {
+//                     langLinks.each(function () {
+//                         activateTab($(this));
+//                     });
+//                 } else if (navtabs.find('.active').length === 0) {
+//                     // set first lang selected if nothing selected
+//                     links.each(function () {
+//                         activateTab($(this));
+//                     });
+//                 }
+//             });
+
+//             const url = window.location.href
+//                 .replace(window.location.hash, '')
+//                 .replace(window.location.search, '');
+//             window.history.replaceState(
+//                 null,
+//                 null,
+//                 `${url}?tab=${lang}${window.location.hash}`
+//             );
+//         });
+// }
+
+// function activateTab(el) {
+//     const tab = el.parent();
+//     const tabIndex = tab.index();
+//     const tabPanel = el.closest('.code-tabs');
+//     const tabPane = tabPanel.find('.tab-pane').eq(tabIndex);
+//     tabPanel.find('.active').removeClass('active');
+//     tab.addClass('active');
+//     tabPane.addClass('active');
+//     tabPane.addClass('show');
+//     el.closest('.code-tabs')
+//         .find('.nav-tabs-mobile .title-dropdown')
+//         .text(tab.text());
+// }
 
 export default codeTabs;

--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -1,116 +1,122 @@
 import { getQueryParameterByName } from '../helpers/browser';
 
-const codeTabsList = document.querySelectorAll('.code-tabs')
-const tabQueryParameter = getQueryParameterByName('tab')
-
 const initCodeTabs = () => {
-    renderCodeTabElements()
-    addEventListeners()
-    activateTabsOnLoad()
-}
+    const codeTabsList = document.querySelectorAll('.code-tabs')
+    const tabQueryParameter = getQueryParameterByName('tab')
 
-/**
-  * Renders code tabs on the page at run time
-*/
-const renderCodeTabElements = () => {
-    if (codeTabsList.length > 0) {
-        codeTabsList.forEach(codeTabsElement => {
-            const navTabsElement = codeTabsElement.querySelector('.nav-tabs')
-            const tabContent = codeTabsElement.querySelector('.tab-content')
-            const tabPaneNodeList = tabContent.querySelectorAll('.tab-pane')
+    const init = () => {
+        renderCodeTabElements()
+        addEventListeners()
+        activateTabsOnLoad()
+    }
 
-            tabPaneNodeList.forEach(tabPane => {
-                const title = tabPane.getAttribute('title')
-                const lang = tabPane.getAttribute('data-lang')
-                const li = document.createElement('li')
-                const anchor = document.createElement('a')
-                anchor.dataset.lang = lang
-                anchor.href = '#'
-                anchor.innerText = title
-                li.appendChild(anchor)
-                navTabsElement.appendChild(li)
+    /**
+     * Renders code tabs on the page at run time
+    */
+    const renderCodeTabElements = () => {
+        if (codeTabsList.length > 0) {
+            codeTabsList.forEach(codeTabsElement => {
+                const navTabsElement = codeTabsElement.querySelector('.nav-tabs')
+                const tabContent = codeTabsElement.querySelector('.tab-content')
+                const tabPaneNodeList = tabContent.querySelectorAll('.tab-pane')
+
+                tabPaneNodeList.forEach(tabPane => {
+                    const title = tabPane.getAttribute('title')
+                    const lang = tabPane.getAttribute('data-lang')
+                    const li = document.createElement('li')
+                    const anchor = document.createElement('a')
+                    anchor.dataset.lang = lang
+                    anchor.href = '#'
+                    anchor.innerText = title
+                    li.appendChild(anchor)
+                    navTabsElement.appendChild(li)
+                })
+            })
+        }
+    }
+
+    /**
+     * Adds active class to the selected tab and shows the related tab pane. 
+     * @param {object} tabAnchorElement - Reference to the HTML DOM node representing the anchor tag within each tab.
+    */
+    const activateCodeTab = (tabAnchorElement) => {
+        const activeLang = tabAnchorElement.getAttribute('data-lang')
+
+        if (activeLang) {
+            codeTabsList.forEach(codeTabsElement => {
+                const tabsList = codeTabsElement.querySelectorAll('.nav-tabs li')
+                const tabPanesList = codeTabsElement.querySelectorAll('.tab-pane')
+                const activeLangTab = codeTabsElement.querySelector(`a[data-lang="${activeLang}"]`)
+                const activePane = codeTabsElement.querySelector(`.tab-pane[data-lang="${activeLang}"]`)
+
+                if (activeLangTab && activePane) {
+                    // Hide all tab content and remove 'active' class from all tab elements.
+                    tabsList.forEach(tab => tab.classList.remove('active'))
+                    tabPanesList.forEach(pane => pane.classList.remove('active', 'show'))
+
+                    // Show the active content and highlight active tab.
+                    activeLangTab.closest('li').classList.add('active')
+                    activePane.classList.add('active', 'show')
+                }
+                
+                const currentActiveTab = codeTabsElement.querySelector('.nav-tabs li.active')
+
+                // If we got this far and no tabs are highlighted, activate the first tab in the list of code tabs.
+                if (!currentActiveTab) {
+                    const firstTab = tabsList.item(0)
+                    const firstTabActiveLang = firstTab.querySelector('a').dataset.lang
+                    const firstTabPane = codeTabsElement.querySelector(`.tab-pane[data-lang="${firstTabActiveLang}"]`)
+                    firstTab.classList.add('active')
+                    firstTabPane.classList.add('active', 'show')
+                }
+            })
+        }
+
+        updateUrl(activeLang)
+    }
+
+    const activateTabsOnLoad = () => {
+        if (tabQueryParameter) {
+            const selectedLanguageTab = document.querySelector(`a[data-lang="${tabQueryParameter}"]`);
+
+            if (selectedLanguageTab) {
+                selectedLanguageTab.click()
+            }
+        } else {
+            if (codeTabsList.length > 0) {
+                const firstTab = document.querySelectorAll('.code-tabs .nav-tabs a').item(0)
+                activateCodeTab(firstTab)
+            }
+        }
+    }
+
+    const addEventListeners = () => {
+        const allTabLinksNodeList = document.querySelectorAll('.code-tabs li a')
+
+        allTabLinksNodeList.forEach(link => {
+            link.addEventListener('click', () => {
+                event.preventDefault()
+                activateCodeTab(link)
             })
         })
     }
-}
 
-/**
-  * Adds active class to the selected tab and shows the related tab pane. 
-  * @param {object} tabAnchorElement - Reference to the HTML DOM node representing the anchor tag within each tab.
-*/
-const activateCodeTab = (tabAnchorElement) => {
-    const activeLang = tabAnchorElement.getAttribute('data-lang')
+    /**
+     * Append the active lang to the URL as a query parameter. 
+    */
+    const updateUrl = (activeLang) => {
+        const url = window.location.href
+            .replace(window.location.hash, '')
+            .replace(window.location.search, '');
 
-    if (activeLang) {
-        codeTabsList.forEach(codeTabsElement => {
-            const tabsList = codeTabsElement.querySelectorAll('.nav-tabs li')
-            const tabPanesList = codeTabsElement.querySelectorAll('.tab-pane')
-            const activeLangTab = codeTabsElement.querySelector(`a[data-lang="${activeLang}"]`)
-            const activePane = codeTabsElement.querySelector(`.tab-pane[data-lang="${activeLang}"]`)
-
-            if (activeLangTab && activePane) {
-                // Hide all tab content and remove 'active' class from all tab elements.
-                tabsList.forEach(tab => tab.classList.remove('active'))
-                tabPanesList.forEach(pane => pane.classList.remove('active', 'show'))
-
-                // Show the active content and highlight active tab.
-                activeLangTab.closest('li').classList.add('active')
-                activePane.classList.add('active', 'show')
-            }
-            
-            const currentActiveTab = codeTabsElement.querySelector('.nav-tabs li.active')
-
-            // If we got this far and no tabs are highlighted, activate the first tab in the list of code tabs.
-            if (!currentActiveTab) {
-                const firstTab = tabsList.item(0)
-                const firstTabActiveLang = firstTab.querySelector('a').dataset.lang
-                const firstTabPane = codeTabsElement.querySelector(`.tab-pane[data-lang="${firstTabActiveLang}"]`)
-                firstTab.classList.add('active')
-                firstTabPane.classList.add('active', 'show')
-            }
-        })
+        window.history.replaceState(
+            null,
+            null,
+            `${url}?tab=${activeLang}${window.location.hash}`
+        );
     }
 
-    updateUrl(activeLang)
-}
-
-const activateTabsOnLoad = () => {
-    if (tabQueryParameter) {
-        const selectedLanguageTab = document.querySelector(`a[data-lang="${tabQueryParameter}"]`);
-
-        if (selectedLanguageTab) {
-            selectedLanguageTab.click()
-        }
-    } else {
-        const firstTab = document.querySelectorAll('.code-tabs .nav-tabs a').item(0)
-        activateCodeTab(firstTab)
-    }
-}
-
-const addEventListeners = () => {
-    const allTabLinksNodeList = document.querySelectorAll('.code-tabs li a')
-
-    allTabLinksNodeList.forEach(link => {
-        link.addEventListener('click', () => {
-            event.preventDefault()
-            activateCodeTab(link)
-        })
-    })
-}
-
-/**
-  * Append the active lang to the URL as a query parameter. 
-*/
-const updateUrl = (activeLang) => {
-    const url = window.location.href
-        .replace(window.location.hash, '')
-        .replace(window.location.search, '');
-
-    window.history.replaceState(
-        null,
-        null,
-        `${url}?tab=${activeLang}${window.location.hash}`
-    );
+    init()
 }
 
 export default initCodeTabs;

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -1,7 +1,7 @@
 import { initializeIntegrations } from './components/integrations';
 import { initializeSecurityRules } from './components/security-rules';
 import { updateTOC, buildTOCMap, onScroll, closeMobileTOC } from './components/table-of-contents';
-import codeTabs from './components/codetabs';
+import initCodeTabs from './components/codetabs';
 import configDocs from './config/config-docs';
 import { loadPage } from './components/async-loading';
 import { updateMainContentAnchors, gtag } from './helpers/helpers';
@@ -91,7 +91,7 @@ $(document).ready(function () {
     }
 
     if (document.querySelector('.code-tabs')) {
-        codeTabs();
+        initCodeTabs();
     }
 });
 

--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -550,7 +550,8 @@ h5 {
 
     & > ul {
         list-style-type: none;
-        padding: 0;
+        padding-top: 6px;
+        
         li {
             padding-bottom: 6px;
 
@@ -568,19 +569,25 @@ h5 {
             }
             &.active {
                 a {
-                    color: $ddpurple;
-                    border-bottom: 1px solid $ddpurple;
-                    font-weight: 600;
+                    box-shadow: 2px 5px 12px rgba(0, 0, 0, 0.1);
+                    border-radius: 3px;
+                    background-color: $ddpurple;
+                    color: white;
                 }
             }
             a {
-                color: $ddgray;
+                background: #ffffff;
+                border: transparent;
+                padding: 6px 10px 7px 10px;
                 font-weight: 600;
-                padding: 10px 22px 10px 22px;
-                border-bottom: 1px solid $ddgray;
+                font-size: 16px;
+                border-radius: 3px;
                 display: inline-block;
+                margin-right: 0.625rem;
+
                 &:hover {
-                    color: $ddpurple;
+                    box-shadow: 2px 5px 12px rgba(0, 0, 0, 0.1);
+                    border: none;
                 }
             }
         }
@@ -595,7 +602,7 @@ h5 {
         padding-left: 0 !important;
     }
     .tab-content {
-        padding-top: 26px;
+        padding-top: 12px;
         h2 > a,
         h3 > a,
         h4 > a,

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,11 +1,4 @@
 <div class='code-tabs'>
-  <ul class="nav nav-tabs d-none d-sm-flex"></ul>
-  <ul class="nav nav-tabs-mobile d-block d-sm-none">
-    <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle title-dropdown" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">Dropdown</a>
-      <div class="dropdown-menu">
-      </div>
-    </li>
-  </ul>
+  <ul class="nav nav-tabs d-flex"></ul>
   <div class="tab-content">{{ .Inner }}</div>
 </div>

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,4 +1,4 @@
-<div class='code-tabs' role="navigation">
+<div class='code-tabs'>
   <ul class="nav nav-tabs d-flex"></ul>
   <div class="tab-content">{{ .Inner }}</div>
 </div>

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,4 +1,4 @@
-<div class='code-tabs'>
+<div class='code-tabs' role="navigation">
   <ul class="nav nav-tabs d-flex"></ul>
   <div class="tab-content">{{ .Inner }}</div>
 </div>


### PR DESCRIPTION
### What does this PR do?
- Updates `code-tabs` shortcode style to be more consistent with `code-lang-tabs`.
- Refactors related jQuery code to vanilla JS.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2260

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/tab-style-update/tracing/setup_overview/setup/dotnet-framework/

- when no `tab` query param is present in URL, the first tab in each code tabs should be selected.  a `tab` query parameter should be appended to the URL with the title of the first tab on the page.  i.e. `windows` in this example: https://docs-staging.datadoghq.com/brian.deutsch/tab-style-update/tracing/setup_overview/setup/dotnet-framework

- when a `tab` query param IS present, those tabs should be selected on page load (`response` tabs should be active here): https://docs-staging.datadoghq.com/brian.deutsch/tab-style-update/account_management/authn_mapping/?tab=response

- clicking on a tab should activate any other tabs on the page with the same title: https://docs-staging.datadoghq.com/brian.deutsch/tab-style-update/account_management/rbac/?tab=datadogapplication

- async loading should still work (use the side bar nav, go to a page with tabs and make sure they still work as expected.  agent -> proxy is an example).

- the tabs should look good at all screen sizes

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
