### PR TITLE
Update live and preview deploy order for woff files

### DIFF
--- a/config/live/config.yaml
+++ b/config/live/config.yaml
@@ -5,6 +5,8 @@ enableGitInfo: true
 
 deployment:
     order:
+      - ".woff2$"
+      - ".woff$"
       - ".css$"
       - ".js$"
       - ".jpg$"

--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -5,6 +5,8 @@ enableGitInfo: true
 
 deployment:
     order:
+      - ".woff2$"
+      - ".woff$"
       - ".css$"
       - ".js$"
       - ".jpg$"


### PR DESCRIPTION
### What does this PR do?
Updates deploy config to upload woff font files first. These can be referenced in CSS and need to exist prior to any changes to dependent files

### Motivation
There's an issue with order of operations when the iconfont gets uploaded after being modified.

The situation exists where the CSS and HTML files pointing to the new iconfont are updated prior to the font update existing. As a result, we get the old font being requested with the new hash and cached, requiring a manual CloudFront invalidation.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
