### PR TITLE
Test changing tag to type in whats-next div

### DIFF
--- a/content/en/getting_started/agent/_index.md
+++ b/content/en/getting_started/agent/_index.md
@@ -106,8 +106,8 @@ For help troubleshooting the Agent:
 ## Next steps
 
 {{< whatsnext desc="After the Agent is installed:">}}
-{{< nextlink href="/getting_started/integrations" type="Documentation" >}}Learn about Integrations{{< /nextlink >}}
-{{< nextlink href="/getting_started/application" type="Documentation" >}}Learn about the Datadog UI{{< /nextlink >}}
+{{< nextlink href="/getting_started/integrations" >}}Learn about Integrations{{< /nextlink >}}
+{{< nextlink href="/getting_started/application" >}}Learn about the Datadog UI{{< /nextlink >}}
 {{< /whatsnext >}}
 
 [1]: /integrations/

--- a/content/en/getting_started/agent/_index.md
+++ b/content/en/getting_started/agent/_index.md
@@ -106,8 +106,8 @@ For help troubleshooting the Agent:
 ## Next steps
 
 {{< whatsnext desc="After the Agent is installed:">}}
-{{< nextlink href="/getting_started/integrations" tag="Documentation" >}}Learn about Integrations{{< /nextlink >}}
-{{< nextlink href="/getting_started/application" tag="Documentation" >}}Learn about the Datadog UI{{< /nextlink >}}
+{{< nextlink href="/getting_started/integrations" type="Documentation" >}}Learn about Integrations{{< /nextlink >}}
+{{< nextlink href="/getting_started/application" type="Documentation" >}}Learn about the Datadog UI{{< /nextlink >}}
 {{< /whatsnext >}}
 
 [1]: /integrations/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes the "tags" from this whats next section at the end of this page. It's styled weirdly and the tags are not needed anyway. I removed these from another page a while back but forgot to go looking for other instances of it and came across this one.

### Motivation
This bothers me:
<img width="347" alt="Screen Shot 2022-06-10 at 3 11 26 PM" src="https://user-images.githubusercontent.com/605271/173134366-806371ec-dc4f-421a-8f05-dfcb2b4d9e44.png">


<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
