### PR TITLE
Fix old link

### DIFF
--- a/data/partials/requests.yaml
+++ b/data/partials/requests.yaml
@@ -21,7 +21,7 @@ requests:
     image: "int_apm.png"
   - name: "Custom Metrics"
     description: "Custom metrics can be submitted for business stats using developer tools like the API and DogStatsD."
-    link: "/developers/metrics"
+    link: "metrics/custom_metrics"
     image: "int_custom_metrics.png"
   - name: "Custom Integrations"
     description: "Datadog Agent integrations are Python files querying for metrics. All Agent code is open source, so it's possible to write your own custom Agent integration. The integrations-extras GitHub repository contains many community developed custom Agent integrations."


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fixes an old link to where metrics used to live. It got missed because it lives in partials.

### Motivation
It actually 404's on staging previews...which is kinda weird. Otherwise I probably wouldn't have found it.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
