### PR TITLE
Updating deprecated tag name

### DIFF
--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -100,7 +100,7 @@ Here is the mapping between deprecated tags and the official tags that have repl
 | deprecated tag        | official tag                |
 |-----------------------|-----------------------------|
 | cluster_name          | kube_cluster_name           |
-| container             | kube_container_name         |
+| container_name        | kube_container_name         |
 | cronjob               | kube_cronjob                |
 | daemonset             | kube_daemon_set             |
 | deployment            | kube_deployment             |


### PR DESCRIPTION
Shouldn't it be container_name instead of container ?

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
