### PR TITLE
Bryce/fix integration faq links

### DIFF
--- a/content/en/integrations/faq/_index.md
+++ b/content/en/integrations/faq/_index.md
@@ -73,64 +73,64 @@ aliases:
 ## Kafka
 
 
-* [Troubleshooting and Deep Dive for Kafka][30]
+* [Troubleshooting and Deep Dive for Kafka][29]
 
 ## Kubernetes
 
-* [Client Authentication against the apiserver and kubelet][31]
+* [Client Authentication against the apiserver and kubelet][30]
 
 ## MySQL & SQL
 
-* [Connection Issues with the SQL Server Integration][32]
-* [MySQL Localhost Error - Localhost VS 127.0.0.1][33]
-* [Can I use a named instance in the SQL Server integration?][34]
-* [MySQL Custom Queries][35]
-* [Can I collect SQL Server performance metrics beyond what is available in the sys.dm_os_performance_counters table?][36]
-* [How can I collect more metrics from my SQL Server integration?][37]
-* [Database user lacks privileges][38]
+* [Connection Issues with the SQL Server Integration][31]
+* [MySQL Localhost Error - Localhost VS 127.0.0.1][32]
+* [Can I use a named instance in the SQL Server integration?][33]
+* [MySQL Custom Queries][34]
+* [Can I collect SQL Server performance metrics beyond what is available in the sys.dm_os_performance_counters table?][35]
+* [How can I collect more metrics from my SQL Server integration?][36]
+* [Database user lacks privileges][37]
 
 ## Network
 
-* [How to send TCP/UDP host metrics via the Datadog API ?][39]
+* [How to send TCP/UDP host metrics via the Datadog API ?][38]
 
 ## Postgres
 
-* [Postgres custom metric collection explained][40]
+* [Postgres custom metric collection explained][39]
 
 ## RabbitMQ
 
-* [Tagging RabbitMQ queues by tag family][41]
+* [Tagging RabbitMQ queues by tag family][40]
 
 ## Redis
 
-* [Redis Integration Error: "unknown command 'CONFIG'"][42]
+* [Redis Integration Error: "unknown command 'CONFIG'"][41]
 
 ## SNMP
 
-* [For SNMP, does Datadog have a list of commonly used/compatible OIDs?  ][43]
+* [For SNMP, does Datadog have a list of commonly used/compatible OIDs?  ][42]
 
 ## Unix
 
-* [How can I gather metrics from the UNIX shell?][44]
+* [How can I gather metrics from the UNIX shell?][43]
 
 ## Vertica
 
-* [How to collect metrics from custom Vertica queries][45]
+* [How to collect metrics from custom Vertica queries][44]
 
 ## VSphere
 
-* [Troubleshooting duplicated hosts with vSphere][46]
+* [Troubleshooting duplicated hosts with vSphere][45]
 
 ## Webhooks
 
-* [How to make a Trello Card using Webhooks][47]
+* [How to make a Trello Card using Webhooks][46]
 
 ## Windows
 
-* [How to add event log files to the `Win32_NTLogEvent` WMI class][48]
-* [Collect Custom Windows Performance Counters over WMI][49]
-* [Windows Status Based Check][50]
-* [How to retrieve WMI metrics][51]
+* [How to add event log files to the `Win32_NTLogEvent` WMI class][47]
+* [Collect Custom Windows Performance Counters over WMI][48]
+* [Windows Status Based Check][49]
+* [How to retrieve WMI metrics][50]
 
 [1]: /integrations/faq/aws-integration-and-cloudwatch-faq/
 [2]: /integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration/
@@ -139,46 +139,46 @@ aliases:
 [5]: /integrations/faq/why-is-there-a-delay-in-receiving-my-data/
 [6]: /integrations/faq/integration-setup-ecs-fargate/
 [7]: /integrations/faq/error-datadog-not-authorized-sts-assume-role/
-[9]: /integrations/faq/issues-with-apache-integration/
-[10]: /integrations/faq/apache-ssl-certificate-issues/
-[11]: /integrations/faq/my-azure-vm-is-powered-down-why-is-it-still-listed-in-my-infrastructure-list/
-[12]: /integrations/faq/azure-vms-are-showing-up-in-the-app-but-not-reporting-metrics/
-[13]: /integrations/faq/azure-status-metric/
-[14]: /integrations/faq/azure-troubleshooting/
-[15]: /integrations/faq/compose-and-the-datadog-agent/
-[16]: /integrations/faq/why-isn-t-elasticsearch-sending-all-my-metrics/
-[17]: /integrations/faq/elastic-agent-can-t-connect/
-[18]: /integrations/faq/why-events-don-t-appear-to-be-showing-up-in-the-event-stream-with-my-github-integration/
-[19]: /integrations/faq/hadoop-distributed-file-system-hdfs-integration-error/
-[20]: /integrations/faq/haproxy-multi-process/
-[21]: /integrations/faq/i-ve-set-up-the-jira-integration-now-how-do-i-get-events-and-tickets-created/
-[22]: /integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect/
-[23]: /integrations/faq/collecting-composite-type-jmx-attributes/
-[24]: /integrations/faq/how-to-run-jmx-commands-in-windows/
-[25]: /integrations/faq/jmx-yaml-error-include-section/
-[26]: /integrations/faq/troubleshooting-jmx-integrations/
-[27]: /integrations/faq/view-jmx-data-in-jconsole-and-set-up-your-jmx-yaml-to-collect-them/
-[28]: /integrations/faq/both-my-jmx-and-aws-integrations-use-name-tags-what-do-i-do/
-[29]: /integrations/faq/jboss-eap-7-datadog-monitoring-via-jmx/
-[30]: /integrations/faq/troubleshooting-and-deep-dive-for-kafka/
-[31]: /integrations/faq/client-authentication-against-the-apiserver-and-kubelet/
-[32]: /integrations/faq/connection-issues-with-the-sql-server-integration/
-[33]: /integrations/faq/mysql-localhost-error-localhost-vs-127-0-0-1/
-[34]: /integrations/faq/can-i-use-a-named-instance-in-the-sql-server-integration/
-[35]: /integrations/faq/how-to-collect-metrics-from-custom-mysql-queries/
-[36]: /integrations/faq/can-i-collect-sql-server-performance-metrics-beyond-what-is-available-in-the-sys-dm-os-performance-counters-table-try-wmi/
-[37]: /integrations/faq/how-can-i-collect-more-metrics-from-my-sql-server-integration/
-[38]: /integrations/faq/database-user-lacks-privileges/
-[39]: /integrations/faq/how-to-send-tcp-udp-host-metrics-via-the-datadog-api/
-[40]: /integrations/faq/postgres-custom-metric-collection-explained/
-[41]: /integrations/faq/tagging-rabbitmq-queues-by-tag-family/
-[42]: /integrations/faq/redis-integration-error-unknown-command-config/
-[43]: /integrations/faq/for-snmp-does-datadog-have-a-list-of-commonly-used-compatible-oids/
-[44]: https://github.com/DataDog/Miscellany/tree/master/custom_check_shell
-[45]: /integrations/faq/how-to-collect-metrics-from-custom-vertica-queries/
-[46]: /integrations/faq/troubleshooting-duplicated-hosts-with-vsphere/
-[47]: /integrations/faq/how-to-make-trello-card-using-webhooks/
-[48]: /integrations/faq/how-to-add-event-log-files-to-the-win32-ntlogevent-wmi-class/
-[49]: /integrations/faq/collect-custom-windows-performance-counters-over-wmi/
-[50]: /integrations/faq/windows-status-based-check/
-[51]: /integrations/faq/how-to-retrieve-wmi-metrics/
+[8]: /integrations/faq/issues-with-apache-integration/
+[9]: /integrations/faq/apache-ssl-certificate-issues/
+[10]: /integrations/faq/my-azure-vm-is-powered-down-why-is-it-still-listed-in-my-infrastructure-list/
+[11]: /integrations/faq/azure-vms-are-showing-up-in-the-app-but-not-reporting-metrics/
+[12]: /integrations/faq/azure-status-metric/
+[13]: /integrations/faq/azure-troubleshooting/
+[14]: /integrations/faq/compose-and-the-datadog-agent/
+[15]: /integrations/faq/why-isn-t-elasticsearch-sending-all-my-metrics/
+[16]: /integrations/faq/elastic-agent-can-t-connect/
+[17]: /integrations/faq/why-events-don-t-appear-to-be-showing-up-in-the-event-stream-with-my-github-integration/
+[18]: /integrations/faq/hadoop-distributed-file-system-hdfs-integration-error/
+[19]: /integrations/faq/haproxy-multi-process/
+[20]: /integrations/faq/i-ve-set-up-the-jira-integration-now-how-do-i-get-events-and-tickets-created/
+[21]: /integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect/
+[22]: /integrations/faq/collecting-composite-type-jmx-attributes/
+[23]: /integrations/faq/how-to-run-jmx-commands-in-windows/
+[24]: /integrations/faq/jmx-yaml-error-include-section/
+[25]: /integrations/faq/troubleshooting-jmx-integrations/
+[26]: /integrations/faq/view-jmx-data-in-jconsole-and-set-up-your-jmx-yaml-to-collect-them/
+[27]: /integrations/faq/both-my-jmx-and-aws-integrations-use-name-tags-what-do-i-do/
+[28]: /integrations/faq/jboss-eap-7-datadog-monitoring-via-jmx/
+[29]: /integrations/faq/troubleshooting-and-deep-dive-for-kafka/
+[30]: /integrations/faq/client-authentication-against-the-apiserver-and-kubelet/
+[31]: /integrations/faq/connection-issues-with-the-sql-server-integration/
+[32]: /integrations/faq/mysql-localhost-error-localhost-vs-127-0-0-1/
+[33]: /integrations/faq/can-i-use-a-named-instance-in-the-sql-server-integration/
+[34]: /integrations/faq/how-to-collect-metrics-from-custom-mysql-queries/
+[35]: /integrations/faq/can-i-collect-sql-server-performance-metrics-beyond-what-is-available-in-the-sys-dm-os-performance-counters-table-try-wmi/
+[36]: /integrations/faq/how-can-i-collect-more-metrics-from-my-sql-server-integration/
+[37]: /integrations/faq/database-user-lacks-privileges/
+[38]: /integrations/faq/how-to-send-tcp-udp-host-metrics-via-the-datadog-api/
+[39]: /integrations/faq/postgres-custom-metric-collection-explained/
+[40]: /integrations/faq/tagging-rabbitmq-queues-by-tag-family/
+[41]: /integrations/faq/redis-integration-error-unknown-command-config/
+[42]: /integrations/faq/for-snmp-does-datadog-have-a-list-of-commonly-used-compatible-oids/
+[43]: https://github.com/DataDog/Miscellany/tree/master/custom_check_shell
+[44]: /integrations/faq/how-to-collect-metrics-from-custom-vertica-queries/
+[45]: /integrations/faq/troubleshooting-duplicated-hosts-with-vsphere/
+[46]: /integrations/faq/how-to-make-trello-card-using-webhooks/
+[47]: /integrations/faq/how-to-add-event-log-files-to-the-win32-ntlogevent-wmi-class/
+[48]: /integrations/faq/collect-custom-windows-performance-counters-over-wmi/
+[49]: /integrations/faq/windows-status-based-check/
+[50]: /integrations/faq/how-to-retrieve-wmi-metrics/

--- a/content/en/integrations/faq/_index.md
+++ b/content/en/integrations/faq/_index.md
@@ -139,7 +139,6 @@ aliases:
 [5]: /integrations/faq/why-is-there-a-delay-in-receiving-my-data/
 [6]: /integrations/faq/integration-setup-ecs-fargate/
 [7]: /integrations/faq/error-datadog-not-authorized-sts-assume-role/
-[8]: /integrations/faq/aws-integration-with-terraform/
 [9]: /integrations/faq/issues-with-apache-integration/
 [10]: /integrations/faq/apache-ssl-certificate-issues/
 [11]: /integrations/faq/my-azure-vm-is-powered-down-why-is-it-still-listed-in-my-infrastructure-list/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes the links in the integrations FAQ index page to point to the correct pages

### Motivation
Noticed the links were wrong

### Preview
https://docs-staging.datadoghq.com/bryce/fix-integration-faq-links/integrations/faq/

<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
