### PR TITLE
(DOCS-3484) Update link to point to guide

### DIFF
--- a/content/en/integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect.md
+++ b/content/en/integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect.md
@@ -84,7 +84,7 @@ Reach out to [Datadog Support team][7] if you are still having issues.
 [1]: /integrations/faq/troubleshooting-jmx-integrations/
 [2]: /integrations/faq/view-jmx-data-in-jconsole-and-set-up-your-jmx-yaml-to-collect-them/
 [3]: /integrations/faq/jmx-yaml-error-include-section/
-[4]: /integrations/faq/collecting-composite-type-jmx-attributes/
+[4]: /integrations/guide/collecting-composite-type-jmx-attributes/
 [5]: /integrations/faq/how-to-run-jmx-commands-in-windows/
 [6]: /agent/guide/agent-log-files/
 [7]: /help/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the link for collecting composite-type JMX attributes to point to its new location in the `guide` directory

### Motivation
DOCS-3484

### Preview
https://docs-staging.datadoghq.com/bryce/update-jmx-composite-attribute-faq-link/integrations/faq/i-have-a-matching-bean-for-my-jmx-integration-but-nothing-on-collect/

<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Depends on the following PR being merged in first:
https://github.com/DataDog/documentation/pull/14284

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
