### PR TITLE
[live containers] Update the compatibility matrix

### DIFF
--- a/content/en/infrastructure/livecontainers/configuration.md
+++ b/content/en/infrastructure/livecontainers/configuration.md
@@ -126,18 +126,23 @@ The following table presents the list of collected resources and the minimal Age
 
 | Resource | Minimal Agent version | Minimal Cluster Agent version | Minimal Helm chart version |
 |---|---|---|---|
+| ClusterRoleBindings | 7.27.0 | 1.19.0 | 2.30.9 |
+| ClusterRoles | 7.27.0 | 1.19.0 | 2.30.9 |
 | Clusters | 7.27.0 | 1.12.0 | 2.10.0 |
-| Deployments | 7.27.0 | 1.11.0 | 2.10.0 |
-| Nodes | 7.27.0 | 1.11.0 | 2.10.0 |
-| Pods | 7.27.0 | 1.11.0 | 2.10.0 |
-| ReplicaSets | 7.27.0 | 1.11.0 | 2.10.0 |
-| Services | 7.27.0 | 1.11.0 | 2.10.0 |
-| Jobs | 7.27.0 | 1.13.1 | 2.15.5 |
 | CronJobs | 7.27.0 | 1.13.1 | 2.15.5 |
 | DaemonSets | 7.27.0 | 1.14.0 | 2.16.3 |
-| Statefulsets | 7.27.0 | 1.15.0 | 2.20.1 |
+| Deployments | 7.27.0 | 1.11.0 | 2.10.0 |
+| Jobs | 7.27.0 | 1.13.1 | 2.15.5 |
+| Nodes | 7.27.0 | 1.11.0 | 2.10.0 |
 | PersistentVolumes | 7.27.0 | 1.18.0 | 2.30.4 |
 | PersistentVolumeClaims | 7.27.0 | 1.18.0 | 2.30.4 |
+| Pods | 7.27.0 | 1.11.0 | 2.10.0 |
+| ReplicaSets | 7.27.0 | 1.11.0 | 2.10.0 |
+| RoleBindings | 7.27.0 | 1.19.0 | 2.30.9 |
+| Roles | 7.27.0 | 1.19.0 | 2.30.9 |
+| ServiceAccounts | 7.27.0 | 1.19.0 | 2.30.9 |
+| Services | 7.27.0 | 1.11.0 | 2.10.0 |
+| Statefulsets | 7.27.0 | 1.15.0 | 2.20.1 |
 
 ### Instructions for previous Agent and Cluster Agent versions.
 
@@ -312,7 +317,7 @@ To prevent the leaking of sensitive data, you can scrub sensitive words in conta
 - `credentials`
 - `stripetoken`
 
-You can set additional sensitive words by providing a list of words to the environment variable `DD_ORCHESTRATOR_EXPLORER_CUSTOM_SENSITIVE_WORDS`. This adds to, and does not overwrite, the default words. 
+You can set additional sensitive words by providing a list of words to the environment variable `DD_ORCHESTRATOR_EXPLORER_CUSTOM_SENSITIVE_WORDS`. This adds to, and does not overwrite, the default words.
 
 **Note**: The additional sensitive words must be in lowercase, as the Agent compares the text with the pattern in lowercase. This means `password` scrubs `MY_PASSWORD` to `MY_*******`, while `PASSWORD` does not.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
It updates the compatibility matrix for live containers monitoring now that we collect new resources.
Also, reordered by name for clarity.

### Motivation
<!-- What inspired you to submit this pull request?-->
The matrix is outdated, we're missing resources collected by default for cluster agents >= 1.19.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Link to relevant PRs:
- https://github.com/DataDog/datadog-agent/pull/10856
- https://github.com/DataDog/helm-charts/pull/356

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
