### PR TITLE
[WEB-2396] TOC should be scrollable when content overflows

### DIFF
--- a/assets/styles/components/_table-of-contents.scss
+++ b/assets/styles/components/_table-of-contents.scss
@@ -81,7 +81,7 @@ body > header.scrolled ~ .container .mobile-toc-toggle {
     .toc {
         margin-right: auto;
         top: 100px;
-        max-height: 100vh;
+        max-height: calc(100vh - 150px);
         padding-bottom: 150px;
         overflow-x: hidden;
         overflow-y: auto;


### PR DESCRIPTION
### What does this PR do?
Allow the TOC to become scrollable if content overflows the viewport

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2396

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/toc-height/logs/log_configuration/processors/?tab=ui

- TOC should be scrollable (note the original issue may not be reproducible on an external monitor, but should be on a laptop screen).
- There should be no unexpected side effects on TOCs across the site

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
