### PR TITLE
Updated table with new usage metrics under Custom Metrics

### DIFF
--- a/content/en/account_management/billing/usage_metrics.md
+++ b/content/en/account_management/billing/usage_metrics.md
@@ -24,7 +24,8 @@ Estimated usage metrics are generally available for the following usage types:
 |-------------------------------|------------------------------------------|
 | Infrastructure Hosts          | `datadog.estimated_usage.hosts`          |
 | Containers                    | `datadog.estimated_usage.containers`     |
-| Custom Metrics                | `datadog.estimated_usage.metrics.custom` |
+| Custom Metrics (Indexed)      | `datadog.estimated_usage.metrics.custom`, `datadog.estimated_usage.metrics.custom.by_tag`, `datadog.estimated_usage.metrics.custom.by_metric` |
+| Custom Metrics (Ingested)     | `datadog.estimated_usage.metrics.custom.ingested`, `datadog.estimated_usage.metrics.custom.ingested.by_tag`, `datadog.estimated_usage.metrics.custom.ingested.by_metric` |
 | Logs Ingested Bytes           | `datadog.estimated_usage.logs.ingested_bytes`          |
 | Logs Ingested Events          | `datadog.estimated_usage.logs.ingested_events`   |
 | Analyzed Logs (security)      | `datadog.estimated_usage.security_monitoring.analyzed_bytes`   |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR addresses a change to usage_metrics.md. New usage metrics added to the metrics list. 

datadog.estimated_usage.metrics.custom.by_tag, datadog.estimated_usage.metrics.custom.by_metric

datadog.estimated_usage.metrics.custom.ingested, datadog.estimated_usage.metrics.custom.ingested.by_tag, datadog.estimated_usage.metrics.custom.ingested.by_metric

### Motivation
Keeping our documentations up-to-date

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
