### PR TITLE
Add obs pipelines integration doc to nav bar

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -527,6 +527,11 @@ main:
     parent: observability_pipelines
     identifier: observability_pipelines_integrations
     weight: 104
+  - name: Integrate Vector with Datadog
+    url: /agent/vector_aggregation/
+    parent: observability_pipelines
+    identifier: observability_pipelines_integrate_vector_with_datadog
+    weight: 105
   - name: Guides
     url: integrations/guide/
     identifier: integration_guides

--- a/content/en/integrations/observability_pipelines/setup.md
+++ b/content/en/integrations/observability_pipelines/setup.md
@@ -29,12 +29,14 @@ To set up Observability Pipelines, first [install Vector](#install-vector) and [
 
 ### Quick start
 
+#### Terminal
 Run the following OS-agnostic command in the terminal, which guides you through setting up Vector:
 
 ```
 curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash
 ```
 
+#### Containers
 For containerized production environments, run the following command to download and install Vector:
 
 ```


### PR DESCRIPTION
### What does this PR do?

- Add an Obs pipelines integration doc to the nav bar now that Obs Pipelines has its own section. Plan is for the doc to be updated and moved under Obs Pipelines folder structure in the near future.

- Add headers to install instructions.

### Motivation

PM Request

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
