### PR TITLE
DOCS-3603 Expo Support for React Native Monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ content/en/real_user_monitoring/ios/*
 content/en/real_user_monitoring/reactnative/_index.md
 content/en/real_user_monitoring/reactnative/integrated_libraries.md
 content/en/real_user_monitoring/reactnative/mobile_vitals.md
+content/en/real_user_monitoring/reactnative/expo.md
 content/en/real_user_monitoring/flutter/_index.md
 
 # Synthetics

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,8 @@ clean-auto-doc: ##Remove all doc automatically created
 	rm -f content/en/real_user_monitoring/reactnative/integrated_libraries.md ;fi
 	@if [ content/en/real_user_monitoring/reactnative/mobile_vitals.md ]; then \
 	rm -f content/en/real_user_monitoring/reactnative/mobile_vitals.md ;fi
+	@if [ content/en/real_user_monitoring/reactnative/expo.md ]; then \
+	rm -f content/en/real_user_monitoring/reactnative/expo.md ;fi
 	@if [ content/en/real_user_monitoring/flutter/_index.md ]; then \
 	rm -f content/en/real_user_monitoring/flutter/_index.md ;fi
 	@if [ content/en/tracing/setup/ruby.md ]; then \

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2643,6 +2643,11 @@ main:
     parent: rum_reactnative
     identifier: rum_reactnative_mobile_vitals
     weight: 401
+  - name: Expo
+    url: real_user_monitoring/reactnative/expo/
+    parent: rum_reactnative
+    identifier: rum_reactnative_expo
+    weight: 402
   - name: Flutter Monitoring
     url: real_user_monitoring/flutter/
     parent: rum

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -745,7 +745,26 @@
             - link: "https://www.datadoghq.com/blog/react-native-monitoring/"
               tag: "Blog"
               text: "Monitor your React Native applications"     
-
+    - action: pull-and-push-file
+      branch: main
+      globs:
+      - 'docs/expo_development.md'
+      options:
+        dest_path: '/real_user_monitoring/reactnative/'
+        file_name: 'expo.md'
+        front_matters:
+          title: Expo
+          kind: documentation
+          beta: true
+          description: "Monitor your React Native projects using Expo and Expo Go with Datadog."
+          dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/docs/expo_development.md"]
+          further_reading:
+            - link: "https://github.com/DataDog/dd-sdk-reactnative"
+              tag: "GitHub"
+              text: "dd-sdk-reactnative Source code"
+            - link: "real_user_monitoring/explorer/"
+              tag: "Documentation"
+              text: "Learn how to explore your RUM data"
   - repo_name: dd-sdk-flutter
     contents:
     - action: pull-and-push-file

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -744,7 +744,27 @@
               text: "Learn how to explore your RUM data"
             - link: "https://www.datadoghq.com/blog/react-native-monitoring/"
               tag: "Blog"
-              text: "Monitor your React Native applications"     
+              text: "Monitor your React Native applications"
+    - action: pull-and-push-file
+      branch: louiszawadzki/rumm-2219/write-expo-documentation
+      globs:
+      - 'docs/expo_development.md'
+      options:
+        dest_path: '/real_user_monitoring/reactnative/'
+        file_name: 'expo.md'
+        front_matters:
+          title: Expo
+          kind: documentation
+          beta: true
+          description: "Monitor your React Native projects using Expo and Expo Go with Datadog."
+          dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/louiszawadzki/rumm-2219/write-expo-documentation/docs/expo_development.md"]
+          further_reading:
+            - link: "https://github.com/DataDog/dd-sdk-reactnative"
+              tag: "GitHub"
+              text: "dd-sdk-reactnative Source code"
+            - link: "real_user_monitoring/explorer/"
+              tag: "Documentation"
+              text: "Learn how to explore your RUM data"
           
   - repo_name: dd-sdk-flutter
     contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -746,7 +746,7 @@
               tag: "Blog"
               text: "Monitor your React Native applications"
     - action: pull-and-push-file
-      branch: louiszawadzki/rumm-2219/write-expo-documentation
+      branch: main
       globs:
       - 'docs/expo_development.md'
       options:
@@ -757,7 +757,7 @@
           kind: documentation
           beta: true
           description: "Monitor your React Native projects using Expo and Expo Go with Datadog."
-          dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/louiszawadzki/rumm-2219/write-expo-documentation/docs/expo_development.md"]
+          dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/docs/expo_development.md"]
           further_reading:
             - link: "https://github.com/DataDog/dd-sdk-reactnative"
               tag: "GitHub"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds Expo and Expo Go in React Native Monitoring (https://github.com/DataDog/dd-sdk-reactnative/pull/216) and single sourcing logic for the child page.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-3603

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Remember to apply changes to the `pull_config.yaml` file before merging!

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
