### PR TITLE
[DOCS-3585] Move Vector guide under Obs Pipelines

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -533,6 +533,11 @@ main:
     identifier: observability_pipelines_integrate_vector_with_datadog
     weight: 105
   - name: Guides
+    url: integrations/observability_pipelines/guide/
+    parent: observability_pipelines
+    identifier: observability_pipelines_guides
+    weight: 106
+  - name: Guides
     url: integrations/guide/
     identifier: integration_guides
     parent: integrations_top_level

--- a/content/en/integrations/observability_pipelines/guide/_index.md
+++ b/content/en/integrations/observability_pipelines/guide/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Custom Metrics Guides
+title: Observability Pipelines Guides
 kind: guide
 ---
 

--- a/content/en/integrations/observability_pipelines/guide/custom-metrics-governance-drop-metrics-missing-specific-tags.md
+++ b/content/en/integrations/observability_pipelines/guide/custom-metrics-governance-drop-metrics-missing-specific-tags.md
@@ -1,6 +1,8 @@
 ---
 title: Custom Metrics Governance - Drop Metrics Missing Specific Tags
 kind: guide
+aliases:
+  - /metrics/custom_metrics/guide/custom-metrics-governance-drop-metrics-missing-specific-tags
 further_reading:
 - link: "https://vector.dev/docs/setup/going-to-prod/"
   tag: "Documentation"


### PR DESCRIPTION
### What does this PR do?

- Moves Vector guide under Obs PIpelines. Currently under custom metrics.
- Add Guides to nav bar for Obs PIpelines

### Motivation

DOCS-3585 / PM request


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
