### PR TITLE
 Update multi-alert group limit

### DIFF
--- a/content/en/monitors/create/types/event.md
+++ b/content/en/monitors/create/types/event.md
@@ -35,7 +35,7 @@ As you define the search query, the top graph updates.
     * **Monitor over measure**: If a measure is selected, the monitor alerts over the numerical value of the event facet (similar to a metric monitor) and aggregation needs to be selected (`min`, `avg`, `sum`, `median`, `pc75`, `pc90`, `pc95`, `pc98`, `pc99`, or `max`).
 3. Configure the alert grouping strategy (optional):
     * **Simple-Alert**: Simple alerts aggregate over all reporting sources. You receive one alert when the aggregated value meets the set conditions. This works best to monitor a metric from a single host or the sum of a metric across many hosts. This strategy may be selected to reduce notification noise.
-    * **Multi-Alert**: Multi alerts apply the alert to each source according to your group parameters, up to 100 matching groups. An alerting event is generated for each group that meets the set conditions. For example, you can group by `host` to receive separate alerts for each host.
+    * **Multi-Alert**: Multi alerts apply the alert to each source according to your group parameters, up to 1000 matching groups. An alerting event is generated for each group that meets the set conditions. For example, you can group by `host` to receive separate alerts for each host.
 
 ### Set alert conditions
 


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update multi-alert group limit for Event Monitor.
According to the event migration document, limit is up to 1000 instead of 100.

### Motivation
<!-- What inspired you to submit this pull request?-->

https://docs.datadoghq.com/events/guides/migrating_to_new_events_features/#you-can-group-by-only-up-to-4-facets
> One facet results in a limit of 1000 top values.
> Two facets results in a limit of 30 top values per facet (at most 900 groups)
> Three facets results in a limit of 10 top values per facet (at most 1000 groups)
> Four facets results in a limit of 5 top values per group (at most 625 groups)
> 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
