### PR TITLE
Adds DaemonSet configuration for prometheusScrape

### DIFF
--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -272,6 +272,7 @@ In this example we're defining an advanced configuration targeting a container n
   value: "2"
 ```
 
+[14]: https://github.com/DataDog/integrations-core/blob/7.27.x/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -280,7 +281,7 @@ In this example we're defining an advanced configuration targeting a container n
 
 By default, all metrics retrieved by the generic Prometheus check are considered custom metrics. If you are monitoring off-the-shelf software and think it deserves an official integration, don't hesitate to [contribute][5]!
 
-Official integrations have their own dedicated directories. There's a default instance mechanism in the generic check to hardcode the default configuration and metrics metadata. For example, reference the [kube-proxy][16] integration.
+Official integrations have their own dedicated directories. There's a default instance mechanism in the generic check to hardcode the default configuration and metrics metadata. For example, reference the [kube-proxy][15] integration.
 
 ## Further Reading
 
@@ -299,6 +300,4 @@ Official integrations have their own dedicated directories. There's a default in
 [11]: /resources/yaml/prometheus.yaml
 [12]: https://app.datadoghq.com/metric/summary
 [13]: /agent/faq/template_variables/
-[14]: https://github.com/DataDog/integrations-core/blob/7.27.x/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
-[15]: https://github.com/DataDog/integrations-core/blob/7.27.x/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
-[16]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy
+[15]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy

--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -189,6 +189,9 @@ This configuration generates a check that collects all metrics exposed using the
 
 #### Advanced configuration
 
+{{< tabs >}}
+{{% tab "Helm" %}}
+
 You can define advanced OpenMetrics check configurations or custom Autodiscovery rules other than native Prometheus annotations with the `additionalConfigs` configuration field in `values.yaml`.
 
 `additionalConfigs` is a list of structures containing OpenMetrics check configurations and Autodiscovery rules.
@@ -220,6 +223,7 @@ datadog:
   # (...)
   prometheusScrape:
     enabled: true
+    serviceEndpoints: true
     additionalConfigs:
       -
         configurations:
@@ -232,6 +236,45 @@ datadog:
             include:
               app: my-app
 ```
+
+{{% /tab %}}
+{{% tab "DaemonSet" %}}
+
+You can define advanced OpenMetrics check configurations or custom Autodiscovery rules other than native Prometheus annotations with the `DD_PROMETHEUS_SCRAPE_CHECKS` environment variable in the Agent and Cluster Agent manifests.
+
+`DD_PROMETHEUS_SCRAPE_CHECKS` is a list of structures containing OpenMetrics check configurations and Autodiscovery rules.
+
+Every [configuration field][14] supported by the OpenMetrics check can be passed in the configurations list.
+
+The autodiscovery configuration can be based on container names or kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
+
+`kubernetes_container_names` is a list of container names to target, it supports the `*` wildcard.
+
+`kubernetes_annotations` contains two maps of labels to define the discovery rules: `include` and `exclude`.
+
+**Note:** The default value of `kubernetes_annotations` in the Datadog Agent configuration is the following:
+
+```yaml
+- name: DD_PROMETHEUS_SCRAPE_CHECKS
+  value: "[{\"autodiscovery\":{\"kubernetes_annotations\":{\"exclude\":{\"prometheus.io/scrape\":\"false\"},\"include\":{\"prometheus.io/scrape\":\"true\"}}}}]"
+```
+
+**Example:**
+
+In this example we're defining an advanced configuration targeting a container named `my-app` running in a pod labeled `app=my-app`. We're customizing the OpenMetrics check configuration as well, by enabling the `send_distribution_buckets` option and defining a custom timeout of 5 seconds.
+
+```yaml
+- name: DD_PROMETHEUS_SCRAPE_ENABLED
+  value: "true"
+- name: DD_PROMETHEUS_SCRAPE_CHECKS
+  value: "[{\"autodiscovery\":{\"kubernetes_annotations\":{\"include\":{\"app\":\"my-app\"}},\"kubernetes_container_names\":[\"my-app\"]},\"configurations\":[{\"send_distribution_buckets\":true,\"timeout\":5}]}]"
+- name: DD_PROMETHEUS_SCRAPE_VERSION
+  value: "2"
+```
+
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## From custom to official integration
 

--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -143,8 +143,8 @@ With Prometheus Autodiscovery, the Datadog Agent is able to detect native Promet
 
 #### Basic configuration
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Helm" xxx -->
+{{< tabs >}}
+{{% tab "Helm" %}}
 
 In your Helm `values.yaml`, add the following:
 
@@ -156,8 +156,8 @@ datadog:
     serviceEndpoints: true
   # (...)
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DaemonSet" xxx -->
+{{% /tab %}}
+{{% tab "DaemonSet" %}}
 
 In your DaemonSet manifest for the Agent `daemonset.yaml`, add the following environment variables for the Agent container:
 ```yaml
@@ -174,8 +174,8 @@ If the Cluster Agent is enabled, inside its manifest `cluster-agent-deployment.y
   value: "true" 
 ```
 
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
+{{% /tab %}}
+{{< /tabs >}}
 
 This instructs the Datadog Agent to detect the pods that have native Prometheus annotations and generate corresponding OpenMetrics checks.
 

--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -244,7 +244,7 @@ You can define advanced OpenMetrics check configurations or custom Autodiscovery
 
 `DD_PROMETHEUS_SCRAPE_CHECKS` is a list of structures containing OpenMetrics check configurations and Autodiscovery rules.
 
-Every [configuration field][14] supported by the OpenMetrics check can be passed in the configurations list.
+Every [configuration field][15] supported by the OpenMetrics check can be passed in the configurations list.
 
 The autodiscovery configuration can be based on container names or kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
@@ -280,7 +280,7 @@ In this example we're defining an advanced configuration targeting a container n
 
 By default, all metrics retrieved by the generic Prometheus check are considered custom metrics. If you are monitoring off-the-shelf software and think it deserves an official integration, don't hesitate to [contribute][5]!
 
-Official integrations have their own dedicated directories. There's a default instance mechanism in the generic check to hardcode the default configuration and metrics metadata. For example, reference the [kube-proxy][15] integration.
+Official integrations have their own dedicated directories. There's a default instance mechanism in the generic check to hardcode the default configuration and metrics metadata. For example, reference the [kube-proxy][16] integration.
 
 ## Further Reading
 
@@ -300,4 +300,5 @@ Official integrations have their own dedicated directories. There's a default in
 [12]: https://app.datadoghq.com/metric/summary
 [13]: /agent/faq/template_variables/
 [14]: https://github.com/DataDog/integrations-core/blob/7.27.x/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
-[15]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy
+[15]: https://github.com/DataDog/integrations-core/blob/7.27.x/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+[16]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy

--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -143,6 +143,9 @@ With Prometheus Autodiscovery, the Datadog Agent is able to detect native Promet
 
 #### Basic configuration
 
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Helm" xxx -->
+
 In your Helm `values.yaml`, add the following:
 
 ```yaml
@@ -150,8 +153,29 @@ datadog:
   # (...)
   prometheusScrape:
     enabled: true
+    serviceEndpoints: true
   # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DaemonSet" xxx -->
+
+In your DaemonSet manifest for the Agent `daemonset.yaml`, add the following environment variables for the Agent container:
+```yaml
+- name: DD_PROMETHEUS_SCRAPE_ENABLED
+  value: "true"
+- name: DD_PROMETHEUS_SCRAPE_VERSION
+  value: "2"
+```
+If the Cluster Agent is enabled, inside its manifest `cluster-agent-deployment.yaml`, add the following environment variables for the Cluster Agent container:
+```yaml
+- name: DD_PROMETHEUS_SCRAPE_ENABLED
+  value: "true"
+- name: DD_PROMETHEUS_SCRAPE_SERVICE_ENDPOINTS
+  value: "true" 
+```
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 This instructs the Datadog Agent to detect the pods that have native Prometheus annotations and generate corresponding OpenMetrics checks.
 

--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -196,7 +196,7 @@ You can define advanced OpenMetrics check configurations or custom Autodiscovery
 
 `additionalConfigs` is a list of structures containing OpenMetrics check configurations and Autodiscovery rules.
 
-Every [configuration field][14] supported by the OpenMetrics check can be passed in the configurations list.
+Every [configuration field][1] supported by the OpenMetrics check can be passed in the configurations list.
 
 The autodiscovery configuration can be based on container names or kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
@@ -237,6 +237,8 @@ datadog:
               app: my-app
 ```
 
+
+[1]: https://github.com/DataDog/integrations-core/blob/7.27.x/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
 {{% /tab %}}
 {{% tab "DaemonSet" %}}
 
@@ -244,7 +246,7 @@ You can define advanced OpenMetrics check configurations or custom Autodiscovery
 
 `DD_PROMETHEUS_SCRAPE_CHECKS` is a list of structures containing OpenMetrics check configurations and Autodiscovery rules.
 
-Every [configuration field][15] supported by the OpenMetrics check can be passed in the configurations list.
+Every [configuration field][1] supported by the OpenMetrics check can be passed in the configurations list.
 
 The autodiscovery configuration can be based on container names or kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
@@ -272,8 +274,8 @@ In this example we're defining an advanced configuration targeting a container n
   value: "2"
 ```
 
-[14]: https://github.com/DataDog/integrations-core/blob/7.27.x/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
 
+[1]: https://github.com/DataDog/integrations-core/blob/7.27.x/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -281,7 +283,7 @@ In this example we're defining an advanced configuration targeting a container n
 
 By default, all metrics retrieved by the generic Prometheus check are considered custom metrics. If you are monitoring off-the-shelf software and think it deserves an official integration, don't hesitate to [contribute][5]!
 
-Official integrations have their own dedicated directories. There's a default instance mechanism in the generic check to hardcode the default configuration and metrics metadata. For example, reference the [kube-proxy][15] integration.
+Official integrations have their own dedicated directories. There's a default instance mechanism in the generic check to hardcode the default configuration and metrics metadata. For example, reference the [kube-proxy][14] integration.
 
 ## Further Reading
 
@@ -300,4 +302,4 @@ Official integrations have their own dedicated directories. There's a default in
 [11]: /resources/yaml/prometheus.yaml
 [12]: https://app.datadoghq.com/metric/summary
 [13]: /agent/faq/template_variables/
-[15]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy
+[14]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy

--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -248,7 +248,7 @@ You can define advanced OpenMetrics check configurations or custom Autodiscovery
 
 Every [configuration field][1] supported by the OpenMetrics check can be passed in the configurations list.
 
-The autodiscovery configuration can be based on container names or kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
+The Autodiscovery configuration can be based on container names or Kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
 `kubernetes_container_names` is a list of container names to target, it supports the `*` wildcard.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds DaemonSet configuration when using `prometheusScrape` option, i.e. automatic Prometheus pods scraping

### Motivation
Support
Configuration missing despite being supported in DaemonSet

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
`serviceEndpoints: true` added in the Helm configuration (and DaemonSet) to align with the quote in the article : 
> It also instructs the Datadog Cluster Agent (if enabled) to detect the services that have native Prometheus annotations and generate corresponding OpenMetrics checks.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
