### PR TITLE
Remove beta message from Watchdog Insights for RUM page

### DIFF
--- a/content/en/real_user_monitoring/explorer/watchdog_insights.md
+++ b/content/en/real_user_monitoring/explorer/watchdog_insights.md
@@ -18,10 +18,6 @@ further_reading:
 
 Datadog Real User Monitoring (RUM) offers Watchdog Insights to help you navigate to the root cause of problems with contextual insights in the RUM Explorer. Watchdog Insights complement your expertise and instincts by recommending outliers and potential performance bottlenecks impacting a subset of users. 
 
-<div class="alert alert-warning">
-Watchdog Insights for RUM is in beta. Access to this feature is provisioned to customers using Real User Monitoring. If you have feedback, contact <a href="https://docs.datadoghq.com/help/">Datadog support</a>.
-</div>
-
 In this example, Watchdog Insights identifies that the deployed application instance on `view.url_host:www.shopist.io` caused most of the errors in a given time range (for example, the past day).
 
 {{< img src="real_user_monitoring/explorer/watchdog_insights/overview.png" alt="Watchdog Insights" style="width:100%;" >}}


### PR DESCRIPTION
### What does this PR do?
Removes an outdated beta notice on the Watchdog Insights for RUM page. Watchdog Insights has been GA for months.

### Motivation
Noticed an outdated beta notice. Confirmed with the PM, Samir, that the product is GA.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
