### PR TITLE
fix incorrect Python CDK variable

### DIFF
--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -193,7 +193,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
         python_layer_version={{< latest-lambda-layer-version layer="python" >}},
         extension_layer_version={{< latest-lambda-layer-version layer="extension" >}},
         site="<DATADOG_SITE>",
-        apiKeySecretArn="<DATADOG_API_KEY_SECRET_ARN>",
+        api_key_secret_arn="<DATADOG_API_KEY_SECRET_ARN>",
       )
     datadog.add_lambda_functions([<LAMBDA_FUNCTIONS>])
     ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes a copy-pasted variable that the python CDK construct doesn't accept.

### Motivation
Wanting the variable to be correct.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
