### PR TITLE
Update interpolation.md

### DIFF
--- a/content/en/dashboards/functions/interpolation.md
+++ b/content/en/dashboards/functions/interpolation.md
@@ -36,6 +36,7 @@ The `default_zero()` function is intended to address the following use cases (th
 - Aligning gauges as 0 when performing arithmetic on sparse metrics (note: `COUNT` or `RATE` type metrics queried `as_count()` or `as_rate()` are _always_ aligned as 0, so using `default_zero()` does not change how they are aligned; it only affects `GAUGE` type metrics).
 - Resolving monitors from a no-data condition. This works for both simple and multi-alerts, but the value 0 must not cause the monitor to trigger. For example, this would not work for a monitor with the query `avg(last_10m):avg:system.cpu.idle{*} < 10` because this monitor triggers (instead of resolving) when it evaluates to 0. Avoid using this function for error rate monitors with `as_count()` queries. See the [as_count() in Monitor Evaluations guide][2] for more details.
 - Filling in empty intervals in sparse (but nonempty) series for visual reasons or to affect the min/max/average of a timeseries in a monitor evaluation.
+- For use in monitors, `default_zero()` only works if there are data points. If the evaluation window doesn't contain a point of data, `default_zero()` doesn't take effect.
 - Showing the value 0 on the timeseries widget when there is no data.
 
 ### Example

--- a/content/en/dashboards/functions/interpolation.md
+++ b/content/en/dashboards/functions/interpolation.md
@@ -35,8 +35,7 @@ The `default_zero()` function is intended to address the following use cases (th
 
 - Aligning gauges as 0 when performing arithmetic on sparse metrics (note: `COUNT` or `RATE` type metrics queried `as_count()` or `as_rate()` are _always_ aligned as 0, so using `default_zero()` does not change how they are aligned; it only affects `GAUGE` type metrics).
 - Resolving monitors from a no-data condition. This works for both simple and multi-alerts, but the value 0 must not cause the monitor to trigger. For example, this would not work for a monitor with the query `avg(last_10m):avg:system.cpu.idle{*} < 10` because this monitor triggers (instead of resolving) when it evaluates to 0. Avoid using this function for error rate monitors with `as_count()` queries. See the [as_count() in Monitor Evaluations guide][2] for more details.
-- Filling in empty intervals in sparse (but nonempty) series for visual reasons or to affect the min/max/average of a timeseries in a monitor evaluation.
-- For use in monitors, `default_zero()` only works if there are data points. If the evaluation window doesn't contain a point of data, `default_zero()` doesn't take effect.
+- Filling in empty intervals in sparse (but nonempty) series for visual reasons or to affect the min/max/average of a timeseries in a monitor evaluation. If the evaluation window doesn't contain any points of data, `default_zero()` has no effect.
 - Showing the value 0 on the timeseries widget when there is no data.
 
 ### Example


### PR DESCRIPTION
Added clarification on how default_zero() works with monitors. Many times customers expect default_zero() to have the same effect in monitors that it does in Dashboards. This is not the case, as there must be data in the evaluation window for default_zero() to work in a monitor.

Hopefully, adding this information to the doc can help better clarify any future confusion.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the doc with more information on how default_zero() behaves in the context of monitors. It has lead to confusion as many customers expect default_zero() to act in monitors the same way it does Timeseries graphs.

### Motivation
There have been multiple tickets where customer's ask about why monitors alerted, expecting default_zero() to prevent any No Data alerts. Recently, this ticket: https://datadog.zendesk.com/agent/tickets/836669

When clarifying with the monitors team, I received the following clarification:

_default_zero only works if there are data points. In other words, if the evaluation window doesn't have data points, default_zero doesn't act. It should just be one data point that is required within in the evaluation window._

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
