### PR TITLE
(DOCS-3550) Add template variable detail and new example

### DIFF
--- a/content/en/dashboards/template_variables.md
+++ b/content/en/dashboards/template_variables.md
@@ -91,7 +91,7 @@ To query based on just a prefix or suffix, use a wildcard character (`*`) at the
 
 When you change the value of a template variable, the dashboard URL updates to reflect the template variable value with the format `&tpl_var_<TEMPLATE_VARIABLE_NAME>=<TEMPLATE_VARIABLE_VALUE>`. For example, a dashboard with the template variable `$env` changed to `prod` would have the URL parameter `&tpl_var_env=prod`.
 
-To include just the value in the query, use the syntax `$<TEMPLATE_VARIABLE_NAME>.value` at the end of the template. For example, with a template variable named `service`, use `env:staging-$service.value`.
+To include just the value in the query, append it with the syntax `$<TEMPLATE_VARIABLE_NAME>.value`. For example, with a template variable named `service`, use `env:staging-$service.value`.
 
 #### Associated template variables
 When selecting a template variable value, the **Associated Values** and **Other Values** sections are displayed. Associated values are calculated from the other template variable values selected on the page, and seamlessly identify the related values without any configuration.

--- a/content/en/dashboards/template_variables.md
+++ b/content/en/dashboards/template_variables.md
@@ -91,7 +91,7 @@ To query based on just a prefix or suffix, use a wildcard character (`*`) at the
 
 When you change the value of a template variable, the dashboard URL updates to reflect the template variable value with the format `&tpl_var_<TEMPLATE_VARIABLE_NAME>=<TEMPLATE_VARIABLE_VALUE>`. For example, a dashboard with the template variable `$env` changed to `prod` would have the URL parameter `&tpl_var_env=prod`.
 
-To include just the value in the query, use the syntax `$<TEMPLATE_VARIABLE_NAME>.value`. For example, with a template variable named `env`, use `environment:$env.value`.
+To include just the value in the query, use the syntax `$<TEMPLATE_VARIABLE_NAME>.value` at the end of the template. For example, with a template variable named `service`, use `env:staging-$service.value`.
 
 #### Associated template variables
 When selecting a template variable value, the **Associated Values** and **Other Values** sections are displayed. Associated values are calculated from the other template variable values selected on the page, and seamlessly identify the related values without any configuration.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Modifies the description and example for using dynamic template variable values in widget queries. Provides a new example to better illustrate the limitation of needing to place these values at the end of the template.

### Motivation
DOCS-3564

### Preview
https://docs-staging.datadoghq.com/bryce/clarify-template-variable-syntax/dashboards/template_variables/#widgets

<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
