### PR TITLE
Reshuffling Tile Order in Product Landing Page

### DIFF
--- a/layouts/partials/rum/rum-getting-started.html
+++ b/layouts/partials/rum/rum-getting-started.html
@@ -12,20 +12,9 @@
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/android_large.svg" "class" "img-fluid" "alt" "android" "width" "200") }}
         </div>
       </a>
-      <a class="card" href="/real_user_monitoring/android/">
-        <div class="card-body text-center py-2 px-1">
-          {{ partial "img.html" (dict "root" . "src" "integrations_logos/android_tv_large.svg" "class" "img-fluid" "alt" "android tv" "width" "200") }}
-        </div>
-      </a>
       <a class="card" href="/real_user_monitoring/ios/">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/ios_large.svg" "class" "img-fluid" "alt" "ios" "width" "200") }}
-        </div>
-      </a>
-      <br>
-      <a class="card" href="/real_user_monitoring/ios/">
-        <div class="card-body text-center py-2 px-1">
-          {{ partial "img.html" (dict "root" . "src" "integrations_logos/tv_os_large.svg" "class" "img-fluid" "alt" "tv OS" "width" "200") }}
         </div>
       </a>
       <a class="card" href="/real_user_monitoring/reactnative/">
@@ -33,6 +22,7 @@
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/react-native_large.svg" "class" "img-fluid" "alt" "react native" "width" "200") }}
         </div>
       </a>
+      <br>
       <a class="card" href="/real_user_monitoring/flutter/">
         <div class="card-banner border-bottom position-absolute text-center">
           <p class="font-primary font-weight-bold text-uppercase">
@@ -41,6 +31,16 @@
         </div>
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/flutter_large.svg" "class" "img-fluid" "alt" "flutter" "width" "200") }}
+        </div>
+      </a>
+      <a class="card" href="/real_user_monitoring/android/">
+        <div class="card-body text-center py-2 px-1">
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/android_tv_large.svg" "class" "img-fluid" "alt" "android tv" "width" "200") }}
+        </div>
+      </a>
+      <a class="card" href="/real_user_monitoring/ios/">
+        <div class="card-body text-center py-2 px-1">
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/tv_os_large.svg" "class" "img-fluid" "alt" "tv OS" "width" "180") }}
         </div>
       </a>
     </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Reshuffles ordering of RUM getting started partial.

### Motivation
<!-- What inspired you to submit this pull request?-->

#rum-docs Slack

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
