### PR TITLE
Improve preview links action

### DIFF
--- a/.github/workflows/preview_link.yml
+++ b/.github/workflows/preview_link.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     paths:
     - 'content/en/**.md'
-    - .github/workflows/preview_link.yml
 
 jobs:
   preview-link:

--- a/.github/workflows/preview_link.yml
+++ b/.github/workflows/preview_link.yml
@@ -2,8 +2,8 @@ name: Post preview link
 on:
   pull_request:
     paths:
-      - 'content/en/**.md'
-      - .github/workflows/preview_link.yml
+    - 'content/en/**.md'
+    - .github/workflows/preview_link.yml
 
 jobs:
   preview-link:
@@ -12,24 +12,35 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - run: pip install Mako  
+    
     - name: Find changed files
       id: changed_files
-      uses: tj-actions/changed-files@v19
+      uses: tj-actions/changed-files@v23
+      with: 
+        include_all_old_new_renamed_files: true      
+    
     - name: Generate links
+      env:
+        branch: ${{ github.head_ref }}
       id: comment_body
       run: |
-        for file in ${{ steps.changed_files.outputs.all_modified_files }}; do
-          echo "Checking file ${file}..."
-          if [[ "$file" =~ ^content/en/(.*).md$ ]]; then
-            fname=$( echo ${BASH_REMATCH[1]} | sed "s/_index//")
-            body="${body}https://docs-staging.datadoghq.com/${{ github.head_ref }}/${fname}\n"
-          fi
-        done
-        printf "Preview links:\n$body"
-        # This terrible syntax is so we can pass a multi-line body to the "post comment" action
-        printf "COMMENT_BODY<<EOF\n" >> $GITHUB_ENV
-        printf "$body" >> $GITHUB_ENV
-        printf "EOF\n" >> $GITHUB_ENV
+        python local/bin/py/preview_links.py --deleted='${{ steps.changed_files.outputs.deleted_files }}' \
+        --renamed='${{ steps.changed_files.outputs.renamed_files }}' \
+        --modified='${{ steps.changed_files.outputs.modified_files }}' \
+        --added='${{ steps.changed_files.outputs.added_files }}'
+
+    - name: Render template
+      id: template
+      uses: chuhlomin/render-template@v1.4
+      with:
+        template: .github/preview-links-template.md
+
     - name: Find existing comment
       uses: peter-evans/find-comment@v2.0.0
       id: find_comment
@@ -37,13 +48,11 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'github-actions[bot]'
         body-includes: "Preview links ("
+    
     - name: Post comment
       uses: peter-evans/create-or-update-comment@v2.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find_comment.outputs.comment-id }}
         edit-mode: replace
-        body: |
-          Preview links (active after the `build_preview` check completes):
-          ${{ env.COMMENT_BODY }}
-
+        body: ${{ steps.template.outputs.result }}

--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,9 @@ static/images/integrations_logos/2020w2.pdf
 resources/_gen/
 static/jsconfig.json
 
+# Generated from GitHub actions
+.github/preview-links-template.md
+
 # yarn v2 or greater
 # Not using zero installs
 # https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored

--- a/local/bin/py/preview-links-template.mako
+++ b/local/bin/py/preview-links-template.mako
@@ -1,0 +1,53 @@
+preview-links-template.md.mako
+<%
+import re
+import os
+
+h2 = "##"
+h3 = '###'
+p = re.compile('content/en/(.*?).md')
+
+branch = os.environ["branch"]
+%>
+
+${h2} Preview links (active after the `build_preview` check completes)
+
+% if added:
+${h3} New or renamed files
+    % for filename in added:
+        % if p.match(filename):
+<% filename = filename.replace('content/en/', '').replace('_index', '').replace('.md', '') %>\
+* https://docs-staging.datadoghq.com/${branch}/${filename}
+        % endif         
+    % endfor
+% endif
+
+% if deleted:
+${h3} Removed or renamed files (these should redirect)
+    % for filename in deleted:
+        % if p.match(filename):
+<% filename = filename.replace('content/en/', '').replace('_index', '').replace('.md', '') %>\
+* https://docs-staging.datadoghq.com/${branch}/${filename}     
+        % endif         
+    % endfor
+% endif
+
+% if renamed:
+${h3} Renamed files
+    % for filename in renamed:
+        % if p.match(filename):
+<% filename = filename.replace('content/en/', '').replace('_index', '').replace('.md', '') %>\
+* https://docs-staging.datadoghq.com/${branch}/${filename} 
+        % endif         
+    % endfor
+% endif
+
+% if modified:
+${h3} Modified Files
+    % for filename in modified:
+        % if p.match(filename):
+<% filename = filename.replace('content/en/', '').replace('_index', '').replace('.md', '') %>\
+* https://docs-staging.datadoghq.com/${branch}/${filename}
+        % endif         
+    % endfor
+% endif

--- a/local/bin/py/preview_links.py
+++ b/local/bin/py/preview_links.py
@@ -1,0 +1,24 @@
+from mako.template import Template
+import argparse
+
+parser=argparse.ArgumentParser()
+
+parser.add_argument('--deleted', help="A list of deleted files")
+parser.add_argument('--renamed', help="A list of renamed files")
+parser.add_argument('--modified', help="A list of modified files")
+parser.add_argument('--added', help="A list of added files")
+
+args=parser.parse_args()
+
+comment_template = Template(filename='local/bin/py/preview-links-template.mako')
+
+# It looks like renamed files are counted as removed/added. I'm going to leave "renamed" in for
+# now to see if this behavior is consistent. 
+with open('.github/preview-links-template.md', 'w') as f:
+    f.write(comment_template.render(
+                deleted = args.deleted.split(" ") if args.deleted else False,
+                renamed = args.renamed.split(" ") if args.renamed else False,
+                modified = args.modified.split(" ") if args.modified else False,
+                added = args.added.split(" ") if args.added else False            
+                )
+            )


### PR DESCRIPTION
This replaces the bash script in the workflow with a call to a python script. The script builds a markdown template with categories, which makes it easier to figure out what happened in the PR, and what to expect when you click on a preview link.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
