### PR TITLE
[developers/dogstatsd] fix dogstatsd_queue_size value

### DIFF
--- a/content/en/developers/dogstatsd/high_throughput.md
+++ b/content/en/developers/dogstatsd/high_throughput.md
@@ -378,7 +378,7 @@ Another thing to look at to limit the maximum memory usage is to reduce the buff
 This example decreases the max memory usage of DogStatsD to approximately 384MB:
 
 ```yaml
-dogstatsd_queue_size: 512
+dogstatsd_queue_size: 384
 ```
 
 See the next section on burst detection to help you detect bursts of metrics from your applications.

--- a/content/fr/developers/dogstatsd/high_throughput.md
+++ b/content/fr/developers/dogstatsd/high_throughput.md
@@ -370,7 +370,7 @@ Pour limiter l'utilisation maximale de la mémoire, pensez également à réduir
 Cet exemple réduit l'utilisation maximale de la mémoire de DogStatsD à environ 384 Mo :
 
 ```yaml
-dogstatsd_queue_size: 512
+dogstatsd_queue_size: 384
 ```
 
 Consultez la section suivante dédiée à la détection des salves pour découvrir comment détecter les salves de métriques de vos applications.

--- a/content/ja/developers/dogstatsd/high_throughput.md
+++ b/content/ja/developers/dogstatsd/high_throughput.md
@@ -377,7 +377,7 @@ Agent は、DogStatsD クライアントから送信されたメトリクスの�
 この例では、DogStatsD の最大メモリ使用量を約 384MB に減らします。
 
 ```yaml
-dogstatsd_queue_size: 512
+dogstatsd_queue_size: 384
 ```
 
 バースト検知を使用してアプリケーションからメトリクスのバーストを検知するには、次のセクションを参照してください。


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Set 384 to `dogstatsd_queue_size` in the document.

### Motivation
<!-- What inspired you to submit this pull request?-->

![Screen Shot 2022-06-20 at 15 09 39](https://user-images.githubusercontent.com/41987730/174536042-df55e096-62a5-4b67-bad9-009c8f51752c.png)

"This example decreases the max memory usage of DogStatsD to approximately 384MB" is inconsistent with the value set in the code snippet because it is 512. It should be 384.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
