### PR TITLE
Helm chart admission controller on by default

### DIFF
--- a/content/en/agent/cluster_agent/admission_controller.md
+++ b/content/en/agent/cluster_agent/admission_controller.md
@@ -25,8 +25,9 @@ Datadog's admission controller is `MutatingAdmissionWebhook` type. For more deta
 ## Configuration
 
 ### Helm chart
+Starting from Helm chart v2.35.0, Datadog Admission controller is activated by default. No extra configuration is needed to enable the admission controller.
 
-To enable the admission controller for Helm chart, set the parameter `clusterAgent.admissionController.enabled` to `true`:
+To enable the admission controller for Helm chart v2.34.6 and earlier, set the parameter `clusterAgent.admissionController.enabled` to `true`:
 
 {{< code-block lang="yaml" filename="values.yaml" disable_copy="true" >}}
 [...]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update doc as Admission controller is on by default with Helm chart 2.35.0 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
