### PR TITLE
Update dual shipping instructions for CI Visibility API

### DIFF
--- a/content/en/agent/guide/dual-shipping.md
+++ b/content/en/agent/guide/dual-shipping.md
@@ -119,7 +119,7 @@ DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_ADDITIONAL_ENDPOINTS='{\"https://mydomain.
 
 {{% tab "CI Visibility" %}}
 
-Requires Agent v6.38+ or v7.38+.
+<div class="alert alert-info">Requires Agent v6.38+ or v7.38+.</div>
 
 ### YAML configuration
 In `datadog.yaml`: 

--- a/content/en/agent/guide/dual-shipping.md
+++ b/content/en/agent/guide/dual-shipping.md
@@ -12,7 +12,7 @@ Dual shipping can impact billing if you are sending data to multiple Datadog org
 If you wish to send data to more than one destination, such as a second Datadog organization or other internal infrastructure, you can configure the Agent to send data to additional endpoints. To set up the Agent to send different kinds of data to multiple endpoints or API keys, use the following configurations.
 
 
-## Metrics, APM, Live Processes, Orchestrator
+## Metrics, APM, Live Processes, Orchestrator, CI Visibility
 
 You can add the YAML configuration to your `datadog.yaml` or launch the Agent with the appropriate environment variables.
 
@@ -113,6 +113,31 @@ orchestrator_explorer:
 
 ```bash
 DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_ADDITIONAL_ENDPOINTS='{\"https://mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://mydomain.datadoghq.eu\": [\"apikey4\"]}'
+```
+
+{{% /tab %}}
+
+{{% tab "CI Visibility" %}}
+
+Requires Agent v6.38+ or v7.38+.
+
+### YAML configuration
+In `datadog.yaml`: 
+```yaml
+evp_proxy_config:
+  [...]
+  additional_endpoints:
+    "https://datadoghq.com":
+    - apikey2
+    - apikey3
+    "https://datadoghq.eu":
+    - apikey4
+```
+
+### Environment variable configuration
+
+```bash
+DD_EVP_PROXY_CONFIG_ADDITIONAL_ENDPOINTS='{\"https://datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://datadoghq.eu\": [\"apikey4\"]}'
 ```
 
 {{% /tab %}}

--- a/content/en/agent/guide/dual-shipping.md
+++ b/content/en/agent/guide/dual-shipping.md
@@ -127,17 +127,17 @@ In `datadog.yaml`:
 evp_proxy_config:
   [...]
   additional_endpoints:
-    "https://datadoghq.com":
+    "https://mydomain.datadoghq.com":
     - apikey2
     - apikey3
-    "https://datadoghq.eu":
+    "https://mydomain.datadoghq.eu":
     - apikey4
 ```
 
 ### Environment variable configuration
 
 ```bash
-DD_EVP_PROXY_CONFIG_ADDITIONAL_ENDPOINTS='{\"https://datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://datadoghq.eu\": [\"apikey4\"]}'
+DD_EVP_PROXY_CONFIG_ADDITIONAL_ENDPOINTS='{\"https://mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://mydomain.datadoghq.eu\": [\"apikey4\"]}'
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
### What does this PR do?
Add a section about how to configure CI Visibility for dual shipping.

**DO NOT MERGE**: There's no Agent nor tracer version released that uses this yet.

### Motivation
API added in https://github.com/DataDog/datadog-agent/pull/12271

### Additional Notes
We might use it for other products in the future, but the first user will
be CI Visibility so I've documented it like that.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
