### PR TITLE
Typo Fix for Composite Monitor page

### DIFF
--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -117,7 +117,7 @@ The Boolean operators used (`&&`, `||`, `!`) operate on the alert-worthiness of 
 * If `A || B` is alert-worthy, the result is the **most** severe status between A and B.
 * If `A` is `No Data`, `!A` is `No Data`
 * If `A` is alert-worthy, `!A` is `OK`
-* If `A` is no alert-worthy, `!A` is `Alert`
+* If `A` is not alert-worthy, `!A` is `Alert`
 
 Consider a composite monitor that uses two individual monitors: `A` and `B`. The following table shows the resulting status of the composite monitor given the trigger condition (`&&` or `||`), and the different statuses for its individual monitors (alert-worthiness is indicated with T or F):
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Changing "If `A` is no alert-worthy" to "If `A` is not alert-worthy".

### Motivation
<!-- What inspired you to submit this pull request?-->
Reviewing composite monitor page to send to client, noticed this.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
