### PR TITLE
[WEB-2451] Updates url when code lang tab is clicked

### DIFF
--- a/assets/scripts/components/code-languages.js
+++ b/assets/scripts/components/code-languages.js
@@ -69,9 +69,9 @@ function redirectCodeLang(codeLang = '') {
         // if cookie is not set, default to python
         newCodeLang = 'python';
         Cookies.set('code-lang', newCodeLang, { path: '/' });
-
-        toggleCodeBlocks(newCodeLang);
     }
+
+    toggleCodeBlocks(newCodeLang);
 }
 
 redirectCodeLang();

--- a/assets/scripts/components/code-languages.js
+++ b/assets/scripts/components/code-languages.js
@@ -71,9 +71,6 @@ function redirectCodeLang(codeLang = '') {
         Cookies.set('code-lang', newCodeLang, { path: '/' });
         toggleCodeBlocks(newCodeLang);
     }
-
-    queryParams.set('code-lang', newCodeLang);
-    window.history.replaceState({}, '', `${window.location.pathname}?${queryParams}`);
 }
 
 redirectCodeLang();

--- a/assets/scripts/components/code-languages.js
+++ b/assets/scripts/components/code-languages.js
@@ -69,9 +69,11 @@ function redirectCodeLang(codeLang = '') {
         // if cookie is not set, default to python
         newCodeLang = 'python';
         Cookies.set('code-lang', newCodeLang, { path: '/' });
+        toggleCodeBlocks(newCodeLang);
     }
 
-    toggleCodeBlocks(newCodeLang);
+    queryParams.set('code-lang', newCodeLang);
+    window.history.replaceState({}, '', `${window.location.pathname}?${queryParams}`);
 }
 
 redirectCodeLang();

--- a/assets/scripts/components/code-languages.js
+++ b/assets/scripts/components/code-languages.js
@@ -94,26 +94,21 @@ function codeLangTabHoverHandler(event) {
 function codeLangTabClickHandler(event) {
     const queryParams = new URLSearchParams(window.location.search);
     const codeLang = event.target.dataset.codeLangTrigger;
-
     const { currentSection, baseUrl } = document.documentElement.dataset;
 
     event.preventDefault();
 
-    if (queryParams.get('code-lang')) {
-        queryParams.set('code-lang', codeLang);
-        window.history.replaceState({}, '', `${window.location.pathname}?${queryParams}`);
-        Cookies.set('code-lang', codeLang, { path: '/' });
-        toggleCodeBlocks(codeLang);
-    } else if (
-        document.documentElement.dataset.type === 'multi-code-lang' &&
+    if (document.documentElement.dataset.type === 'multi-code-lang' &&
         (document.body.classList.contains('kind-section') || document.body.classList.contains('kind-page'))
     ) {
         Cookies.set('code-lang', codeLang, { path: '/' });
         loadPage(`${baseUrl}${currentSection}${codeLang}`);
         window.history.replaceState({}, '', `${baseUrl}${currentSection}${codeLang}`);
     } else {
-        toggleCodeBlocks(codeLang);
         Cookies.set('code-lang', codeLang, { path: '/' });
+        toggleCodeBlocks(codeLang);
+        queryParams.set('code-lang', codeLang);
+        window.history.replaceState({}, '', `${window.location.pathname}?${queryParams}`);
     }
 }
 

--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -109,10 +109,13 @@ const initCodeTabs = () => {
             .replace(window.location.hash, '')
             .replace(window.location.search, '');
 
+        const queryParams = new URLSearchParams(window.location.search);
+        queryParams.set('tabs', activeLang)
+
         window.history.replaceState(
             null,
             null,
-            `${url}?tab=${activeLang}${window.location.hash}`
+            `${url}?${queryParams}${window.location.hash}`
         );
     }
 


### PR DESCRIPTION
### What does this PR do?
Updates URL after a code lang tab has been clicked, appending a query string to the URL so it will be easier to share the link out.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2451

### Preview
- https://docs-staging.datadoghq.com/brian.deutsch/tab-update-url/security_platform/application_security/setup_and_configure
- https://docs-staging.datadoghq.com/brian.deutsch/tab-update-url/developers/dogstatsd

click on a different programming language tab, the URL should be updated with a query param containing the selected language.

### Additional Notes
I chose not to set this query param when the page first loads.    Not every docs page with tabs has the same languages list.   So a user could have their cookie set to `python`, go to a page that doesn't have `python` and on page load their cookie could get changed to something else unexpectedly.    We can iterate on this later if needed as I have a longer term card to do with the tabs.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
