### PR TITLE
DOCS-3635 move dd_logs_injection config setting to auto section

### DIFF
--- a/content/en/tracing/setup_overview/setup/dotnet-framework.md
+++ b/content/en/tracing/setup_overview/setup/dotnet-framework.md
@@ -351,11 +351,6 @@ Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_T
 : Sets the TCP port where the Agent is listening for connections. Use `DD_TRACE_AGENT_URL`, which has precedence over this parameter. <br>
 **Default**: `8126`
 
-`DD_LOGS_INJECTION`
-: **TracerSettings property**: `LogsInjectionEnabled` <br>
-Enables or disables automatic injection of correlation identifiers into application logs. <br>
-Your logger needs to have a `source` that sets the `trace_id` mapping correctly. The default source for .NET Applications, `csharp`, does this automatically. For more information, see [correlated logs in the Trace ID panel][5].
-
 `DD_TRACE_SAMPLE_RATE`
 : **TracerSettings property**: `GlobalSamplingRate` <br>
 **Default**: Defaults to the rates returned by the Datadog Agent<br>
@@ -426,6 +421,11 @@ Enables or disables all automatic instrumentation. Setting the environment varia
 `DD_HTTP_SERVER_ERROR_STATUSES`
 : Sets status code ranges that will cause HTTP server spans to be marked as errors. <br>
 **Default**: `500-599`
+
+`DD_LOGS_INJECTION`
+: **TracerSettings property**: `LogsInjectionEnabled` <br>
+Enables or disables automatic injection of correlation identifiers into application logs. <br>
+Your logger needs to have a `source` that sets the `trace_id` mapping correctly. The default source for .NET Applications, `csharp`, does this automatically. For more information, see [correlated logs in the Trace ID panel][5].
 
 `DD_RUNTIME_METRICS_ENABLED`
 : Enables .NET runtime metrics. Valid values are `true` or `false`. <br>


### PR DESCRIPTION

### What does this PR do?
Moves the .NET tracing config option DD_LOGS_INJECTION from Optional to Auto-Instrumentation Optional section

### Motivation
DOCS-3635

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
