### PR TITLE
Add test.bundle to documented test configuration tags in junit upload

### DIFF
--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -206,6 +206,10 @@ You can specify these special tags using the `--tags` parameter when calling `da
 
 All of these tags are optional, and only the ones you specify will be used to differentiate between environment configurations.
 
+`test.bundle`
+: Used to execute groups of test suites separately.<br/>
+**Examples**: `ApplicationUITests`, `ModelTests`
+
 `os.platform`
 : Name of the operating system.<br/>
 **Examples**: `windows`, `linux`, `darwin`
@@ -244,10 +248,6 @@ For mobile apps (Swift, Android):
 : The name of the device being tested.<br/>
 **Examples**: `iPhone 12 Pro Simulator`, `iPhone 13 (QA team)`
 
-<!-- TODO: uncomment once added in backend
-`test.bundle`
-: Used to execute groups of test suites separately.<br/>
-**Examples**: `ApplicationUITests`, `ModelTests` -->
 
 ## Providing metadata through `<property>` elements
 

--- a/content/fr/continuous_integration/setup_tests/junit_upload.md
+++ b/content/fr/continuous_integration/setup_tests/junit_upload.md
@@ -150,6 +150,10 @@ Vous pouvez spécifier ces tags spéciaux à l'aide du paramètre `--tags` lorsq
 
 Tous ces tags sont facultatifs, et seuls ceux que vous spécifiez seront utilisés pour identifier les différentes configurations de l'environnement.
 
+`test.bundle`
+: Permet d'exécuter des groupes de suites de tests séparément.<br/>
+**Exemples** : `ApplicationUITests`, `ModelTests`
+
 `os.platform`
 : Nom du système d'exploitation.<br/>
 **Exemples** : `windows`, `linux`, `darwin`
@@ -188,10 +192,6 @@ Pour les applications mobiles (Swift, Android) :
 : Nom de l'appareil testé.<br/>
 **Exemples** : `iPhone 12 Pro Simulator`, `iPhone 13 (QA team)`
 
-<!-- TODO: uncomment once added in backend
-`test.bundle`
-: Permet d'exécuter des groupes de suites de tests séparément.<br/>
-**Exemples** : `ApplicationUITests`, `ModelTests` -->
 
 ## Ajouter des métadonnées via des éléments `<property>`
 

--- a/content/ja/continuous_integration/setup_tests/junit_upload.md
+++ b/content/ja/continuous_integration/setup_tests/junit_upload.md
@@ -67,7 +67,7 @@ datadog-ci version
 Invoke-WebRequest -Uri "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_win-x64.exe" -OutFile "datadog-ci.exe"
 {{< /code-block >}}
 
-次に、`Start-Process -FilePath "datadog-ci.exe"` と任意のコマンドを実行します: 
+次に、`Start-Process -FilePath "datadog-ci.exe"` と任意のコマンドを実行します:
 {{< code-block lang="powershell" >}}
 Start-Process -FilePath "./datadog-ci.exe" -ArgumentList version
 {{< /code-block >}}
@@ -205,6 +205,10 @@ Datadog では、特別な専用タグを使用して、OS、ランタイム、�
 
 これらのタグはすべて任意であり、指定したものだけが環境構成の区別に使用されます。
 
+`test.bundle`
+: テストスイートのグループを個別に実行するために使用します。<br/>
+**例**: `ApplicationUITests`、`ModelTests`
+
 `os.platform`
 : オペレーティングシステムの名称。<br/>
 **例**: `windows`、`linux`、`darwin`
@@ -243,10 +247,6 @@ Datadog では、特別な専用タグを使用して、OS、ランタイム、�
 : テストするデバイスの名前。<br/>
 **例**: `iPhone 12 Pro Simulator`、`iPhone 13 (QA team)`
 
-<!-- TODO: バックエンドに追加された後、コメント解除する
-`test.bundle`
-: テストスイートのグループを個別に実行するために使用します。<br/>
-**例**: `ApplicationUITests`、`ModelTests` -->
 
 ## `<property>` 要素によるメタデータの提供
 


### PR DESCRIPTION
### What does this PR do?
Add `test.bundle` tag to the list of test configuration tags that users can specify manually in junit upload.

### Motivation
We had this temporarily hidden while we did some internal changes, but now it works like the others and should be documented.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
