### PR TITLE
DOCS-3666 Fix docker-compose integration installation doc

### DIFF
--- a/content/en/agent/guide/compose-and-the-datadog-agent.md
+++ b/content/en/agent/guide/compose-and-the-datadog-agent.md
@@ -40,6 +40,7 @@ services:
     image: redis
   datadog:
     build: datadog
+    privileged: true
     environment:
      - DD_API_KEY=${DD_API_KEY}
      - DD_SITE={{< region-param key="dd_site" >}}
@@ -80,6 +81,7 @@ services:
       com.datadoghq.ad.logs: '[{"source": "redis", "service": "redis"}]'
   datadog:
     build: datadog
+    privileged: true
     environment:
      - DD_API_KEY=${DD_API_KEY}
      - DD_SITE={{< region-param key="dd_site" >}}

--- a/content/en/agent/guide/compose-and-the-datadog-agent.md
+++ b/content/en/agent/guide/compose-and-the-datadog-agent.md
@@ -40,7 +40,7 @@ services:
     image: redis
   datadog:
     build: datadog
-    privileged: true
+    pid: host
     environment:
      - DD_API_KEY=${DD_API_KEY}
      - DD_SITE={{< region-param key="dd_site" >}}
@@ -81,7 +81,7 @@ services:
       com.datadoghq.ad.logs: '[{"source": "redis", "service": "redis"}]'
   datadog:
     build: datadog
-    privileged: true
+    pid: host
     environment:
      - DD_API_KEY=${DD_API_KEY}
      - DD_SITE={{< region-param key="dd_site" >}}


### PR DESCRIPTION
### What does this PR do?

When installing the agent on my personal host, using docker-compose, I used the provided snippet, but it was not working.

This PR add `privileged: true` to allow collection of other containers data.
In the [Docker agent installation doc](https://docs.datadoghq.com/agent/docker/?tab=standard) it states that agent should be run with `--cgroupns host`, which is `privileged: true` in compose.

I wanted to change `build: datadog` which is supposed to be used to build a local container to `image: datadog/agent` which pulls the image from docker repository, but did not.
I'm balanced between the "it works out of the box" approach (`image: datadog/agent`) and the "in the real world you will customise it anyway" one (`image:` + `Dockerfile`).

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
