### PR TITLE
Remove `timestamp_start` clicked time bucket docs

### DIFF
--- a/content/en/dashboards/guide/context-links.md
+++ b/content/en/dashboards/guide/context-links.md
@@ -67,7 +67,7 @@ To define custom links or override the default links, specify the link name in t
 
 Available variable types for context links include:
 
-* **Time range variables** `{{timestamp_start}}` and `{{timestamp_end}}`. These variables correspond to the time range of the widget. For timeseries and heat map widgets, these variables correspond to the time range of the clicked time bucket.
+* **Time range variables** `{{timestamp_start}}` and `{{timestamp_end}}`. These variables correspond to the time range of the widget. 
 * **Query variables** (`{{@MerchantTier}}` and `{{@MerchantTier.value}}` in the example above). These variables are for widgets with grouped queries, and identify the specific group a user clicks on.
 * **Dashboard template variables** (`{{$env}}` and `{{$env.value}}` in the example above). These variables identify the current value in use for the template variable when user clicks.
 * **`{{tags}}`**, the default combination of all the variables above.


### PR DESCRIPTION
No matter what, the timeseries widget context links `timestamp_(start|end)` refer to the time range of the widget, not the clicked time bucket. Thus, this language is incorrect:

`For timeseries and heat map widgets, these variables correspond to the time range of the clicked time bucket.`

I've reached out to support on this and was informed that the current behavior is the expected behavior, making this documentation misleading, so this extra sentence should be removed.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
