### PR TITLE
[WEB-2462] Safe html in tab titles

### DIFF
--- a/content/en/agent/docker/prometheus.md
+++ b/content/en/agent/docker/prometheus.md
@@ -47,7 +47,7 @@ docker run -d --cgroupns host \
 ```
 
 {{% /tab %}}
-{{% tab "Amazon Linux version <2" %}}
+{{% tab "Amazon Linux version < 2" %}}
 
 ```shell
 docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro \

--- a/content/en/continuous_integration/setup_pipelines/gitlab.md
+++ b/content/en/continuous_integration/setup_pipelines/gitlab.md
@@ -36,7 +36,7 @@ Configure the integration on a [project][1] or [group][2] by going to **Settings
 [1]: https://docs.gitlab.com/ee/user/admin_area/settings/project_integration_management.html#use-custom-settings-for-a-group-or-project-integration
 [2]: https://docs.gitlab.com/ee/user/admin_area/settings/project_integration_management.html#manage-group-level-default-settings-for-a-project-integration
 {{% /tab %}}
-{{% tab "GitLab >= 14.1" %}}
+{{% tab "GitLab &gt;&equals; 14.1" %}}
 
 Configure the integration on a [project][1] or [group][2] by going to **Settings > Integrations > Datadog** for each project or group you want to instrument.
 
@@ -46,7 +46,7 @@ You can also activate the integration at the GitLab [instance][3] level, by goin
 [2]: https://docs.gitlab.com/ee/user/admin_area/settings/project_integration_management.html#manage-group-level-default-settings-for-a-project-integration
 [3]: https://docs.gitlab.com/ee/user/admin_area/settings/project_integration_management.html#manage-instance-level-default-settings-for-a-project-integration
 {{% /tab %}}
-{{% tab "GitLab < 14.1" %}}
+{{% tab "GitLab &lt; 14.1" %}}
 
 Enable the `datadog_ci_integration` [feature flag][1] to activate the integration. Run one of the following commands, which use GitLab's [Rails Runner][2], depending on your installation type:
 

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,3 +1,3 @@
-<div data-lang="{{ replace (.Get 0 | lower | anchorize) "-" "" }}" class="tab-pane fade" role="tabpanel" title="{{ .Get 0 }}">
+<div data-lang="{{ replace (.Get 0 | lower | anchorize) "-" "" }}" class="tab-pane fade" role="tabpanel" title="{{ .Get 0 | safeHTML }}">
   {{ .Inner }}
 </div>


### PR DESCRIPTION
### What does this PR do?
set `safeHTML` on tab titles to allow special chars

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2462

### Preview 
https://docs-staging.datadoghq.com/brian.deutsch/gitlab-tabs/continuous_integration/setup_pipelines/gitlab/?tab=gitlabcom

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
