### PR TITLE
[synthetics] add synthetics-private-location ip ranges in documented JSON schema

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -163,24 +163,25 @@ The information is structured as JSON following this schema:
 
 {{< code-block lang="text" disable_copy="true" >}}
 {
-    "version": 1,                       // <-- incremented every time this information is changed
-    "modified": "YYYY-MM-DD-HH-MM-SS",  // <-- timestamp of the last modification
-    "agents": {                         // <-- the IPs used by the Agent to submit metrics to Datadog
-        "prefixes_ipv4": [              // <-- list of IPv4 CIDR blocks
+    "version": 1,                          // <-- incremented every time this information is changed
+    "modified": "YYYY-MM-DD-HH-MM-SS",     // <-- timestamp of the last modification
+    "agents": {                            // <-- the IPs used by the Agent to submit metrics to Datadog
+        "prefixes_ipv4": [                 // <-- list of IPv4 CIDR blocks
             "a.b.c.d/x",
             ...
         ],
-        "prefixes_ipv6": [              // <-- list of IPv6 CIDR blocks
+        "prefixes_ipv6": [                 // <-- list of IPv6 CIDR blocks
             ...
         ]
     },
-    "api": {...},                       // <-- same for non-critical Agent functionality (querying information from API)
-    "apm": {...},                       // <-- same structure as "agents" but IPs used for the APM Agent data
-    "logs": {...},                      // <-- same for the logs Agent data
-    "process": {...},                   // <-- same for the process Agent data
-    "orchestrator": {...},              // <-- same for the process Agent data
-    "synthetics": {...},                // <-- not used for Agent traffic (Datadog source IPs of bots for synthetic tests)
-    "webhooks": {...}                   // <-- not used for Agent traffic (Datadog source IPs delivering webhooks)
+    "api": {...},                          // <-- same for non-critical Agent functionality (querying information from API)
+    "apm": {...},                          // <-- same structure as "agents" but IPs used for the APM Agent data
+    "logs": {...},                         // <-- same for the logs Agent data
+    "process": {...},                      // <-- same for the process Agent data
+    "orchestrator": {...},                 // <-- same for the process Agent data
+    "synthetics": {...},                   // <-- not used for Agent traffic (Datadog source IPs of bots for synthetic tests)
+    "synthetics-private-locations": {...}, // <-- not used for Agent traffic (Datadog intake IPs for synthetics private locations)
+    "webhooks": {...}                      // <-- not used for Agent traffic (Datadog source IPs delivering webhooks)
 }
 {{< /code-block >}}
 

--- a/content/fr/agent/guide/network.md
+++ b/content/fr/agent/guide/network.md
@@ -76,24 +76,25 @@ Les informations sont structurées au format JSON selon le schéma suivant :
 
 {{< code-block lang="text" disable_copy="true" >}}
 {
-    "version": 1,                       // <-- valeur incrémentée chaque fois que cette information est modifiée
-    "modified": "YYYY-MM-DD-HH-MM-SS",  // <-- timestamp de la dernière modification
-    "agents": {                         // <-- adresses IP utilisées par l'Agent pour envoyer des métriques à Datadog
-        "prefixes_ipv4": [              // <-- liste des blocs CIDR IPv4
+    "version": 1,                          // <-- valeur incrémentée chaque fois que cette information est modifiée
+    "modified": "YYYY-MM-DD-HH-MM-SS",     // <-- timestamp de la dernière modification
+    "agents": {                            // <-- adresses IP utilisées par l'Agent pour envoyer des métriques à Datadog
+        "prefixes_ipv4": [                 // <-- liste des blocs CIDR IPv4
             "a.b.c.d/x",
             ...
         ],
-        "prefixes_ipv6": [              // <-- liste des blocs CIDR IPv6
+        "prefixes_ipv6": [                 // <-- liste des blocs CIDR IPv6
             ...
         ]
     },
-    "api": {...},                       // <-- même chose, mais pour une fonctionnalité non essentielle de l'Agent (demande d'informations à partir de l'API)
-    "apm": {...},                       // <-- même structure que « agents », mais il s'agit des adresses IP utilisées pour les données de l'Agent APM
-    "logs": {...},                      // <-- même chose, mais pour les données de l'Agent de log
-    "process": {...},                   // <-- même chose, mais pour les données de l'Agent de processus
-    "orchestrator": {...},              // <-- même chose, mais pour les données de l'Agent de processus
-    "synthetics": {...},                // <-- non utilisé pour le trafic de l'Agent (adresses IP sources de Datadog pour les bots utilisés pour les tests Synthetic)
-    "webhooks": {...}                   // <-- non utilisé pour le trafic de l'Agent (adresses IP sources de Datadog pour les webhooks)
+    "api": {...},                          // <-- même chose, mais pour une fonctionnalité non essentielle de l'Agent (demande d'informations à partir de l'API)
+    "apm": {...},                          // <-- même structure que « agents », mais il s'agit des adresses IP utilisées pour les données de l'Agent APM
+    "logs": {...},                         // <-- même chose, mais pour les données de l'Agent de log
+    "process": {...},                      // <-- même chose, mais pour les données de l'Agent de processus
+    "orchestrator": {...},                 // <-- même chose, mais pour les données de l'Agent de processus
+    "synthetics": {...},                   // <-- non utilisé pour le trafic de l'Agent (adresses IP sources de Datadog pour les bots utilisés pour les tests Synthetic)
+    "synthetics-private-locations": {...}, // <-- non utilisé pour le trafic de l'Agent (adresses IP destinations pour l'ingestion des résultats Synthetics des emplacements privés)
+    "webhooks": {...}                      // <-- non utilisé pour le trafic de l'Agent (adresses IP sources de Datadog pour les webhooks)
 }
 {{< /code-block >}}
 

--- a/content/ja/agent/guide/network.md
+++ b/content/ja/agent/guide/network.md
@@ -163,24 +163,25 @@ v6.1.0 以降、Agent は Datadog の API にもクエリを実行、重要で�
 
 {{< code-block lang="text" disable_copy="true" >}}
 {
-    "version": 1,                       // <-- incremented every time this information is changed
-    "modified": "YYYY-MM-DD-HH-MM-SS",  // <-- timestamp of the last modification
-    "agents": {                         // <-- the IPs used by the Agent to submit metrics to Datadog
-        "prefixes_ipv4": [              // <-- list of IPv4 CIDR blocks
+    "version": 1,                          // <-- incremented every time this information is changed
+    "modified": "YYYY-MM-DD-HH-MM-SS",     // <-- timestamp of the last modification
+    "agents": {                            // <-- the IPs used by the Agent to submit metrics to Datadog
+        "prefixes_ipv4": [                 // <-- list of IPv4 CIDR blocks
             "a.b.c.d/x",
             ...
         ],
-        "prefixes_ipv6": [              // <-- list of IPv6 CIDR blocks
+        "prefixes_ipv6": [                 // <-- list of IPv6 CIDR blocks
             ...
         ]
     },
-    "api": {...},                       // <-- same for non-critical Agent functionality (querying information from API)
-    "apm": {...},                       // <-- same structure as "agents" but IPs used for the APM Agent data
-    "logs": {...},                      // <-- same for the logs Agent data
-    "process": {...},                   // <-- same for the process Agent data
-    "orchestrator": {...},              // <-- same for the process Agent data
-    "synthetics": {...},                // <-- not used for Agent traffic (Datadog source IPs of bots for synthetic tests)
-    "webhooks": {...}                   // <-- not used for Agent traffic (Datadog source IPs delivering webhooks)
+    "api": {...},                          // <-- same for non-critical Agent functionality (querying information from API)
+    "apm": {...},                          // <-- same structure as "agents" but IPs used for the APM Agent data
+    "logs": {...},                         // <-- same for the logs Agent data
+    "process": {...},                      // <-- same for the process Agent data
+    "orchestrator": {...},                 // <-- same for the process Agent data
+    "synthetics": {...},                   // <-- not used for Agent traffic (Datadog source IPs of bots for synthetic tests)
+    "synthetics-private-locations": {...}, // <-- not used for Agent traffic (Datadog intake IPs for synthetics private locations)
+    "webhooks": {...}                      // <-- not used for Agent traffic (Datadog source IPs delivering webhooks)
 }
 {{< /code-block >}}
 


### PR DESCRIPTION
### Motivation and what does this PR do?

We are updating the advertised IP ranges pointing to the Synthetics Private Location endpoints. This PR update the docs to change JSON format our customers will expect.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
