### PR TITLE
Update java.md

### DIFF
--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -244,7 +244,7 @@ Configure a file appender in `logback.xml`:
     <immediateFlush>true</immediateFlush>
 
     <encoder>
-      <pattern>Logback %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %X{dd.trace_id} %X{dd.span_id} - %m%n</pattern>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %X{dd.trace_id} %X{dd.span_id} - %m%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
Customer found an issue where if you include the text "logback" the parsing fails, simply removing the word logback and the following space character the parsing works correctly

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes the word "logback" from the sample provided for parsing logback 

### Motivation
With "logback" included there is no match, after removing "logback" there is a match

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
![image](https://user-images.githubusercontent.com/33157322/175315504-27b10f8b-9703-46cf-a8ee-4fdc30626ef8.png)

---

### Reviewer checklist
- [ X] Review the changed files.
- [X ] Review the URLs listed in the [Preview](#preview) section.
- [ X] Check images for PII
- [ X] Review any mentions of "Contact Datadog support" for internal support documentation.
