### PR TITLE
Replace curly quotes in list to array parser rule

### DIFF
--- a/content/en/logs/log_configuration/parsing.md
+++ b/content/en/logs/log_configuration/parsing.md
@@ -485,7 +485,7 @@ Users [John, Oliver, Marc, Tom] have been added to the database
 **Rule**:
 
 ```text
-myParsingRule Users %{data:users:array(“[]“,”,“)} have been added to the database
+myParsingRule Users %{data:users:array("[]",",")} have been added to the database
 ```
 
 {{< img src="logs/processing/parsing/array_parsing.png" alt="Parsing example 6"  style="width:80%;" >}}


### PR DESCRIPTION
curly quotes cause a formatting error for users when copying/pasting into parsing rule configuration

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
