### PR TITLE
[CI Visibility] Add `Test Statuses Numbers` section for CI Visibility Troubleshooting.

### DIFF
--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -101,6 +101,36 @@ This is done using the following algorithm:
 #### Possible issues with wall time calculation
 If you're using a library for testing time-dependent code, like [timecop][7] for Ruby or [FreezeGun][8] for Python, it is possible that test timestamps are wrong, and therefore calculated wall times. If this is the case, make sure that modifications to time are rolled back before finishing your tests.
 
+### The test status numbers are not what is expected
+
+The test status numbers are calculated based on the unique tests that were collected. The uniqueness of a test is defined, not only by its suite and name, but by its test parameters and test configurations as well.
+
+#### The numbers are lower than expected
+
+If the numbers are lower than expected it is likely that either the library or the tool you used to collect Test data could not collect test parameters and/or some test configurations.
+
+1. If you are uploading JUnit test report files:
+  a. If you are running the same tests in different environment configurations, [make sure you are setting those configuration tags during the upload][9].
+  b. If you are running parameterized tests, it's very likely that the JUnit report has not that information. [Try to use a native library to report test data][10].
+2. If you still don't see the expected results, [contact Support][1] for troubleshooting help.
+
+#### The passed/failed/skipped numbers are different than expected
+
+If the same test is collected several times for the same commit but with different status, the aggregated result will follow the next algorithm:
+
+| **Test Status - Retry #1** | **Test Status - Retry #2** | **Result** |
+|----------------------------|----------------------------|------------|
+| `Passed`                   | `Passed`                   | `Passed`   |
+| `Passed`                   | `Failed`                   | `Passed`   |
+| `Passed`                   | `Skipped`                  | `Passed`   |
+| `Failed`                   | `Passed`                   | `Passed`   |
+| `Failed`                   | `Failed`                   | `Failed`   |
+| `Failed`                   | `Skipped`                  | `Failed`   |
+| `Skipped`                  | `Passed`                   | `Passed`   |
+| `Skipped`                  | `Failed`                   | `Failed`   |
+| `Skipped`                  | `Skipped`                  | `Skipped`  |
+
+
 ### Need further help?
 
 Still need help? Contact [Datadog support][1].
@@ -114,3 +144,5 @@ Still need help? Contact [Datadog support][1].
 [6]: /continuous_integration/setup_tests/containers/
 [7]: https://github.com/travisjeffery/timecop
 [8]: https://github.com/spulec/freezegun
+[9]: https://docs.datadoghq.com/continuous_integration/setup_tests/junit_upload/?tabs=linux#collecting-environment-configuration-metadata
+[10]: https://docs.datadoghq.com/continuous_integration/setup_tests/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR adds a new section for the CI Visibility Troubleshooting section related to how the `Test Statuses Numbers` are calculated.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
