### PR TITLE
Small tweak to groups mention on the monitor-based SLO page

### DIFF
--- a/content/en/monitors/service_level_objectives/monitor.md
+++ b/content/en/monitors/service_level_objectives/monitor.md
@@ -37,7 +37,7 @@ Under **Define the source**, select **Monitor Based**.
 
 In the search box, start typing the name of a monitor. A list of matching monitors appears. Click on a monitor name to add it to the source list. 
 
-If you’re only using a single multi-alert monitor in an SLO, you can optionally select “Calculate on selected groups” and pick up to 20 groups. By default, the SLO is calculated on all groups. Group selection is not supported for SLOs that contain multiple monitors. 
+If you’re only using a single multi-alert monitor in an SLO, you can optionally select “Calculate on selected groups” and pick up to 20 groups. By default, the SLO is calculated using the 5 groups with the worst SLO status. Group selection is not supported for SLOs that contain multiple monitors. 
 
 
 ### Set your SLO targets

--- a/content/en/monitors/service_level_objectives/monitor.md
+++ b/content/en/monitors/service_level_objectives/monitor.md
@@ -37,7 +37,7 @@ Under **Define the source**, select **Monitor Based**.
 
 In the search box, start typing the name of a monitor. A list of matching monitors appears. Click on a monitor name to add it to the source list. 
 
-If you’re only using a single multi-alert monitor in an SLO, you can optionally select “Calculate on selected groups” and pick up to 20 groups. By default, the SLO is calculated using the 5 groups with the worst SLO status. Group selection is not supported for SLOs that contain multiple monitors. 
+If you’re only using a single multi-alert monitor in an SLO, you can optionally select “Calculate on selected groups” and pick up to 20 groups. By default, the SLO is calculated using five groups with the worst SLO statuses. Group selection is not supported for SLOs that contain multiple monitors. 
 
 
 ### Set your SLO targets


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix sentence in monitor-based SLO page

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
https://docs-staging.datadoghq.com/kai/monitor-based-slo-groups/monitors/service_level_objectives/monitor/#define-queries

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
