### PR TITLE
Add reserved attributes to event migration doc

### DIFF
--- a/content/en/events/guides/migrating_to_new_events_features.md
+++ b/content/en/events/guides/migrating_to_new_events_features.md
@@ -80,13 +80,13 @@ Datadog automatically parses JSON-formatted events. When events are not JSON-for
 
 ## Reserved attributes
 
-Below is a list of reserved attributes that are automatically ingested with events:
+This list describes automatically ingested reserved attributes with events.
 
 | Attribute | Description                                                                                                                                                                                                                                |
 |-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `host`    | The name of the originating host as defined in metrics. Datadog automatically retrieves corresponding host tags from the matching host in Datadog and applies them to your events. The Agent sets this value automatically.                          |
-| `source`  | This corresponds to the integration name: the technology from which the event originated. When it matches an integration name, Datadog automatically installs the corresponding parsers and facets. For example: `nginx`, `postgresql`, etc. |
-| `status`  | This corresponds to the level/severity of a event.      |
+| `source`  | This corresponds to the integration name, or the technology from which the event originated. When it matches an integration name, Datadog automatically installs the corresponding parsers and facets. For example: `nginx`, `postgresql`, and more. |
+| `status`  | This corresponds to the level or severity of an event.      |
 | `service` | The name of the application or service generating the events. |
                                                                                                                          |
 | `message` | By default, Datadog ingests the value of the `message` attribute as the body of the event entry. 

--- a/content/en/events/guides/migrating_to_new_events_features.md
+++ b/content/en/events/guides/migrating_to_new_events_features.md
@@ -78,6 +78,20 @@ The new query search allows you to use complex queries in event monitors with ne
 
 Datadog automatically parses JSON-formatted events. When events are not JSON-formatted, they are parsed and enriched by chaining them sequentially through a processing pipeline. Processors extract meaningful information or attributes from semi-structured text to reuse as facets. Each event that comes through the pipelines is tested against every pipeline filter. If it matches a filter, then all the processors are applied sequentially before moving to the next pipeline.
 
+## Reserved attributes
+
+Below is a list of reserved attributes that are automatically ingested with events:
+
+| Attribute | Description                                                                                                                                                                                                                                |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `host`    | The name of the originating host as defined in metrics. Datadog automatically retrieves corresponding host tags from the matching host in Datadog and applies them to your events. The Agent sets this value automatically.                          |
+| `source`  | This corresponds to the integration name: the technology from which the event originated. When it matches an integration name, Datadog automatically installs the corresponding parsers and facets. For example: `nginx`, `postgresql`, etc. |
+| `status`  | This corresponds to the level/severity of a event.      |
+| `service` | The name of the application or service generating the events. |
+                                                                                                                         |
+| `message` | By default, Datadog ingests the value of the `message` attribute as the body of the event entry. 
+|                     
+
 ## What Changed?
 
 **Note:** The process for sending events remains the same. You can continue sending events using the API, the Agent, or the events via email feature as before.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds more details about reserved attributes in events.

### Motivation
We have had several escalations and questions from customers asking why they could not filter by or create a facet on the attributes they didn't know were reserved.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
