### PR TITLE
Update link to latest openmetrics v2 check configuration

### DIFF
--- a/content/en/agent/kubernetes/prometheus.md
+++ b/content/en/agent/kubernetes/prometheus.md
@@ -238,7 +238,7 @@ datadog:
 ```
 
 
-[1]: https://github.com/DataDog/integrations-core/blob/7.27.x/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+[1]: https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
 {{% /tab %}}
 {{% tab "DaemonSet" %}}
 
@@ -275,7 +275,7 @@ In this example we're defining an advanced configuration targeting a container n
 ```
 
 
-[1]: https://github.com/DataDog/integrations-core/blob/7.27.x/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+[1]: https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update the link referenced as: 
> Every [configuration field](https://github.com/DataDog/integrations-core/blob/7.27.x/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example) supported by the OpenMetrics check can be passed in the configurations list.

To link to the `master` branch of this instead of pinning to `7.27.x`. This is done in both the `Helm` and `DaemonSet` tab.

### Motivation
<!-- What inspired you to submit this pull request?-->
This was previously pinned to `7.27.x` as the Prometheus Scrape integration was creating the `openmetrics` checks with `prometheus_url` as the endpoint, so it was using the old OpenMetrics V1 version of the check. So it made sense to pin these docs to the old check configuration in `7.27.x`.

In `7.34.0` the Agent was upgraded to use `openmetrics_endpoint` so it is now creating these using the now OpenMetrics V2 version of the check. So it this should be updated to reference the correct check configuration in the latest / master branch.

As otherwise customers may try to use the old V1 configuration, such as `ignore_metrics` - whereas they need to use the V2 configuration which in this case is looking for `exclude_metrics`. 

### Preview 
https://docs-staging.datadoghq.com/jack.davenport/prometheus_scrape_link/agent/kubernetes/prometheus/?tabs=helm#advanced-configuration

### Additional Notes
<!-- Anything else we should know when reviewing?-->
PR: For that Agent change in 7.34.0

- https://github.com/DataDog/datadog-agent/pull/9355

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
