### PR TITLE
missed redirect from the FAQ migration project

### DIFF
--- a/content/en/dashboards/guide/_index.md
+++ b/content/en/dashboards/guide/_index.md
@@ -4,6 +4,7 @@ kind: guide
 private: true
 aliases:
     - /graphing/guide/
+    - /faq/treemap-graph-visualization-can-i-use-this-elsewhere/
 ---
 
 {{< whatsnext desc="General Guides:" >}}


### PR DESCRIPTION
### What does this PR do?
Quick add of a redirect because this page 404s https://docs.datadoghq.com/dashboards/faq/treemap-graph-visualization-can-i-use-this-elsewhere/

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
