### PR TITLE
Update SCI documentation

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -27,7 +27,7 @@ Datadog Agent 7.35.0 or higher is required.
 To map telemetry data with your source code:
 
 1. Add `git.commit.sha` and `git.repository_url` tags to your containers, or directly on your telemetry.
-2. a. [install a GitHub App][2] to display inline source code snippets.
+2. a. Install Datadog's [GitHub Apps integration][2] to display inline source code snippets.
 2. b. Alternatively, upload metadata about your git repository by running [`datadog-ci git-metadata upload`][1] in your CI pipeline.
 
 ### Tag your telemetry

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -81,14 +81,13 @@ export DD_TAGS="git.commit.sha:<GIT_COMMIT_SHA> git.repository_url=<REPOSITORY_U
 ### Configure repositories
 
 {{< tabs >}}
-
 {{% tab "Configure a GitHub App" %}}
+
 If you are a GitHub SaaS user, install Datadog's [GitHub Apps integration][2] in order to link your telemetry to your source code.
 When specifying your permissions in the integration tile, enable Datadog read permissions to Contents.
-
 {{% /tab %}}
-
 {{% tab "Upload your git metadata" %}}
+
 If you are not using GitHub, Datadog collects information for every commit SHA from your git repository with the [`datadog-ci git-metadata upload`][1] command in order to link your telemetry to your source code.
 
 When you run `datadog-ci git-metadata upload` within a git repository, Datadog receives the repository URL, the commit SHA of the current branch, and a list of tracked file paths.
@@ -103,11 +102,10 @@ You can expect to see the following output:
 Reporting commit 007f7f466e035b052415134600ea899693e7bb34 from repository git@github.com:DataDog/datadog-ci.git.
 180 tracked file paths will be reported.
 ✅  Handled in 0.077 seconds.
-{{% /tab %}}
-
-{{< /tabs >}}
-
 ```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Links to Git
 

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -104,7 +104,7 @@ When specifying your permissions in the integration tile, enable Datadog read pe
 {{% /tab %}}
 {{% tab "Other Git Providers" %}}
 
-If you are not using GitHub, Datadog collects information for every commit SHA from your git repository with the [`datadog-ci git-metadata upload`][1] command in order to link your telemetry to your source code.
+To link telemetry to your source code, Datadog collects information for every commit SHA from your git repository with the [`datadog-ci git-metadata upload`][1] command.
 
 When you run `datadog-ci git-metadata upload` within a git repository, Datadog receives the repository URL, the commit SHA of the current branch, and a list of tracked file paths.
 

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -83,8 +83,11 @@ export DD_TAGS="git.commit.sha:<GIT_COMMIT_SHA> git.repository_url=<REPOSITORY_U
 {{< tabs >}}
 {{% tab "Configure a GitHub App" %}}
 
-If you are a GitHub SaaS user, install Datadog's [GitHub Apps integration][2] in order to link your telemetry to your source code.
+If you are a GitHub SaaS user, install Datadog's [GitHub Apps integration][1] in the [GitHub Apps integration tile][2] in order to link your telemetry to your source code.
 When specifying your permissions in the integration tile, enable Datadog read permissions to Contents.
+
+[1]: https://docs.datadoghq.com/integrations/github_apps/
+[2]: https://app.datadoghq.com/account/settings#integrations/github-apps
 {{% /tab %}}
 {{% tab "Upload your git metadata" %}}
 
@@ -99,11 +102,12 @@ To ensure the data is being collected, run `datadog-ci git-metadata upload` in y
 You can expect to see the following output:
 
 ```
-Reporting commit 007f7f466e035b052415134600ea899693e7bb34 from repository git@github.com:DataDog/datadog-ci.git.
+Reporting commit 007f7f466e035b052415134600ea899693e7bb34 from repository git@github.com:my-org/my-repository.git.
 180 tracked file paths will be reported.
 ✅  Handled in 0.077 seconds.
 ```
 
+[1]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/git-metadata
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -136,7 +140,7 @@ For more information, see [GitHub Apps & OAuth Apps][4].
 
 #### Continuous Profiler
 
-In the [Continuous Profiler][2], you can directly access traces in the source repository on GitHub.
+In the [Continuous Profiler][5], you can directly access traces in the source repository on GitHub.
 
 1. Navigate to **APM** > **Profile Search**.
 2. Click on a profile and hover your cursor over a method in the flamegraph. A kebab icon with the **More actions** label appears to the right.
@@ -152,4 +156,4 @@ In the [Continuous Profiler][2], you can directly access traces in the source re
 [2]: https://app.datadoghq.com/account/settings#integrations/github-apps
 [3]: https://app.datadoghq.com/apm/error-tracking
 [4]: https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps
-[5]: https://docs.datadoghq.com/integrations/github_apps/
+[5]: https://docs.datadoghq.com/tracing/profiler/search_profiles/

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -16,12 +16,6 @@ The source code integration is an integration with Git that enables you to link 
 
 Combined with the GitHub Apps integrations, you can see inline code snippets in your errors. For more information, see [Inline Source Code](#inline-source-code).
 
-| Integration Name            | Stack Trace Links | Issue and PR Previews | Inline Code Snippets |
-|-----------------------------|-------------------|-----------------------|----------------------|
-| Source Code                 | {{< X >}}         | X                     | X                    |
-| GitHub Apps                 | X                 | {{< X >}}             | X                    |
-| Source Code and GitHub Apps | {{< X >}}         | {{< X >}}             | {{< X >}}            |
-
 ## Configuration
 
 <div class="alert alert-info">
@@ -33,8 +27,8 @@ Datadog Agent 7.35.0 or higher is required.
 To map telemetry data with your source code:
 
 1. Add `git.commit.sha` and `git.repository_url` tags to your containers, or directly on your telemetry.
-2. Upload metadata about your git repository by running [`datadog-ci git-metadata upload`][1] in your CI pipeline.
-3. Optionally, [install a GitHub App][2] to display inline source code snippets.
+2. a. [install a GitHub App][2] to display inline source code snippets.
+2. b. Alternatively, upload metadata about your git repository by running [`datadog-ci git-metadata upload`][1] in your CI pipeline.
 
 ### Tag your telemetry
 
@@ -84,9 +78,18 @@ export DD_TAGS="git.commit.sha:<GIT_COMMIT_SHA> git.repository_url=<REPOSITORY_U
 {{% /tab %}}
 {{< /tabs >}}
 
-### Upload your git metadata
+### Configure repositories
 
-In order to link your telemetry to your source code, Datadog collects information for every commit SHA from your git repository with the [`datadog-ci git-metadata upload`][1] command.
+{{< tabs >}}
+
+{{% tab "Configure a GitHub App" %}}
+If you are a GitHub SaaS user, install Datadog's [GitHub Apps integration][2] in order to link your telemetry to your source code.
+When specifying your permissions in the integration tile, enable Datadog read permissions to Contents.
+
+{{% /tab %}}
+
+{{% tab "Upload your git metadata" %}}
+If you are not using GitHub, Datadog collects information for every commit SHA from your git repository with the [`datadog-ci git-metadata upload`][1] command in order to link your telemetry to your source code.
 
 When you run `datadog-ci git-metadata upload` within a git repository, Datadog receives the repository URL, the commit SHA of the current branch, and a list of tracked file paths.
 
@@ -100,6 +103,10 @@ You can expect to see the following output:
 Reporting commit 007f7f466e035b052415134600ea899693e7bb34 from repository git@github.com:DataDog/datadog-ci.git.
 180 tracked file paths will be reported.
 ✅  Handled in 0.077 seconds.
+{{% /tab %}}
+
+{{< /tabs >}}
+
 ```
 
 ## Links to Git
@@ -147,3 +154,4 @@ In the [Continuous Profiler][2], you can directly access traces in the source re
 [2]: https://app.datadoghq.com/account/settings#integrations/github-apps
 [3]: https://app.datadoghq.com/apm/error-tracking
 [4]: https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps
+[5]: https://docs.datadoghq.com/integrations/github_apps/

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -26,9 +26,22 @@ Datadog Agent 7.35.0 or higher is required.
 
 To map telemetry data with your source code:
 
+{{< tabs >}}
+{{% tab "GitHub" %}}
+
 1. Add `git.commit.sha` and `git.repository_url` tags to your containers, or directly on your telemetry.
-2. a. Install Datadog's [GitHub Apps integration][2] to display inline source code snippets.
-2. b. Alternatively, upload metadata about your git repository by running [`datadog-ci git-metadata upload`][1] in your CI pipeline.
+2. Install Datadog's [GitHub Apps integration][2] to display inline source code snippets.
+
+[1]: https://app.datadoghq.com/account/settings#integrations/github-apps
+{{% /tab %}}
+{{% tab "Other Git Providers" %}}
+
+1. Add `git.commit.sha` and `git.repository_url` tags to your containers, or directly on your telemetry.
+2. Upload metadata about your git repository by running [`datadog-ci git-metadata upload`][1] in your CI pipeline.
+
+[1]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/git-metadata
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Tag your telemetry
 
@@ -81,7 +94,7 @@ export DD_TAGS="git.commit.sha:<GIT_COMMIT_SHA> git.repository_url=<REPOSITORY_U
 ### Configure repositories
 
 {{< tabs >}}
-{{% tab "Configure a GitHub App" %}}
+{{% tab "GitHub" %}}
 
 If you are a GitHub SaaS user, install Datadog's [GitHub Apps integration][1] in the [GitHub Apps integration tile][2] in order to link your telemetry to your source code.
 When specifying your permissions in the integration tile, enable Datadog read permissions to Contents.
@@ -89,7 +102,7 @@ When specifying your permissions in the integration tile, enable Datadog read pe
 [1]: https://docs.datadoghq.com/integrations/github_apps/
 [2]: https://app.datadoghq.com/account/settings#integrations/github-apps
 {{% /tab %}}
-{{% tab "Upload your git metadata" %}}
+{{% tab "Other Git Providers" %}}
 
 If you are not using GitHub, Datadog collects information for every commit SHA from your git repository with the [`datadog-ci git-metadata upload`][1] command in order to link your telemetry to your source code.
 

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -30,7 +30,7 @@ To map telemetry data with your source code:
 {{% tab "GitHub" %}}
 
 1. Add `git.commit.sha` and `git.repository_url` tags to your containers, or directly on your telemetry.
-2. Install Datadog's [GitHub Apps integration][2] to display inline source code snippets.
+2. Install Datadog's [GitHub Apps integration][1] to display inline source code snippets.
 
 [1]: https://app.datadoghq.com/account/settings#integrations/github-apps
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the [Source Code Integration documentation page](https://docs.datadoghq.com/integrations/guide/source-code-integration) to favour setting up the GitHub Apps integration.

### Motivation
<!-- What inspired you to submit this pull request?-->
New alternative setup.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Still a draft as the feature is not enabled to customers yet.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
