### PR TITLE
barbara-bontempo/Fix typo that is under rare traces

### DIFF
--- a/content/en/tracing/trace_ingestion/mechanisms.md
+++ b/content/en/tracing/trace_ingestion/mechanisms.md
@@ -185,7 +185,7 @@ The rare sampler sends a set of rare spans to Datadog. Rare sampling is also a d
 In Agent version 7.33 and forward, you can disable the rare sampler in the Agent main configuration file (`datadog.yaml`) or with an environment variable:
 
 ```
-@params apm_config.disable_rare_sample - boolean - optional - default: false
+@params apm_config.disable_rare_sampler - boolean - optional - default: false
 @env DD_APM_DISABLE_RARE_SAMPLER - boolean - optional - default: false
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
It should NOT be (what we have in our docs):
@params apm_config.disable_rare_sample - boolean - optional - default: false

But instead it SHOULD be (add an r to sampler):
@params apm_config.disable_rare_sampler - boolean - optional - default: false

### Motivation
Just noticed that we have a typo in our ingestion control page under the rare traces here: 
https://docs.datadoghq.com/tracing/trace_ingestion/mechanisms/?tab=environmentvariables&tabs=environmentvariables#rare-traces
Had a ticket where customer was setting @params apm_config.disable_rare_sample and no changes were happening. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
