### PR TITLE
Update PHP APM configuration documentation for version 0.76.0

### DIFF
--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -394,7 +394,7 @@ Set an application’s version in traces and logs, for example: `1.2.3`, `6c44da
 `DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED`
 : **INI**: `datadog.trace.http_url_query_param_allowed`<br>
 **Default**: `*`<br>
-A comma-separated list of query parameters to be collected as part of the URL, this can be empty to prevent collecting any parameters or `*` to collect all parameters. Added in version `0.74.0`
+A comma-separated list of query parameters to be collected as part of the URL, this can also be empty to prevent collecting any parameters or `*` to collect all parameters. Added in version `0.74.0`.
 
 `DD_TRACE_CLIENT_IP_HEADER_DISABLED`
 : **INI**: `datadog.trace.client_ip_header_disabled`<br>

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -391,6 +391,21 @@ Enable URL's as resource names (see [Map resource names to normalized URI](#map-
 **Default**: `null`<br>
 Set an application’s version in traces and logs, for example: `1.2.3`, `6c44da20`, `2020.02.13`. Added in version `0.47.0`.
 
+`DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED`
+: **INI**: `datadog.trace.http_url_query_param_allowed`<br>
+**Default**: `*`<br>
+A comma-separated list of query parameters to be collected as part of the URL, this can be empty to prevent collecting any parameters or `*` to collect all parameters. Added in version `0.74.0`
+
+`DD_TRACE_CLIENT_IP_HEADER_DISABLED`
+: **INI**: `datadog.trace.client_ip_header_disabled`<br>
+**Default**: `0`<br>
+Disable client IP collection from relevant IP headers. Added in version `0.76.0`.
+
+`DD_TRACE_CLIENT_IP_HEADER`
+: **INI**: `datadog.trace.client_ip_header`<br>
+**Default**: `null`<br>
+The IP header to be used for client IP collection, for example: `x-forwarded-for`. Added in version `0.76.0`.
+
 #### Integration names
 
 The table below specifies the default service names for each integration. Change the service names with `DD_SERVICE_MAPPING`.

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -408,8 +408,11 @@ The IP header to be used for client IP collection, for example: `x-forwarded-for
 
 `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP`
 : **INI**: `datadog.trace.obfuscation_query_string_regexp`<br>
-**Default**: `(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\s|%20)*(?:=|%3D)[^&]+|(?:"|%22)(?:\s|%20)*(?::|%3A)(?:\s|%20)*(?:"|%22)(?:%2[^2]|%[^2]|[^"%])+(?:"|%22))|bearer(?:\s|%20)+[a-z0-9\._\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\w=-]|%3D)+\.ey[I-L](?:[\w=-]|%3D)+(?:\.(?:[\w.+\/=-]|%3D|%2F|%2B)+)?|[\-]{5}BEGIN(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY[\-]{5}[^\-]+[\-]{5}END(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY|ssh-rsa(?:\s|%20)*(?:[a-z0-9\/\.+]|%2F|%5C|%2B){100,}`<br>
-Regular expression used to obfuscate the query string included as part of the URL. Added in version `0.76.0`.
+**Default**: 
+  ```
+  (?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\s|%20)*(?:=|%3D)[^&]+|(?:"|%22)(?:\s|%20)*(?::|%3A)(?:\s|%20)*(?:"|%22)(?:%2[^2]|%[^2]|[^"%])+(?:"|%22))|bearer(?:\s|%20)+[a-z0-9\._\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\w=-]|%3D)+\.ey[I-L](?:[\w=-]|%3D)+(?:\.(?:[\w.+\/=-]|%3D|%2F|%2B)+)?|[\-]{5}BEGIN(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY[\-]{5}[^\-]+[\-]{5}END(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY|ssh-rsa(?:\s|%20)*(?:[a-z0-9\/\.+]|%2F|%5C|%2B){100,}
+  ```
+  Regular expression used to obfuscate the query string included as part of the URL. Added in version `0.76.0`.
 
 #### Integration names
 

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -394,7 +394,7 @@ Set an application’s version in traces and logs, for example: `1.2.3`, `6c44da
 `DD_TRACE_HTTP_URL_QUERY_PARAM_ALLOWED`
 : **INI**: `datadog.trace.http_url_query_param_allowed`<br>
 **Default**: `*`<br>
-A comma-separated list of query parameters to be collected as part of the URL, this can also be empty to prevent collecting any parameters or `*` to collect all parameters. Added in version `0.74.0`.
+A comma-separated list of query parameters to be collected as part of the URL. Set to empty to prevent collecting any parameters, or `*` to collect all parameters. Added in version `0.74.0`.
 
 `DD_TRACE_CLIENT_IP_HEADER_DISABLED`
 : **INI**: `datadog.trace.client_ip_header_disabled`<br>

--- a/content/en/tracing/setup_overview/setup/php.md
+++ b/content/en/tracing/setup_overview/setup/php.md
@@ -406,6 +406,11 @@ Disable client IP collection from relevant IP headers. Added in version `0.76.0`
 **Default**: `null`<br>
 The IP header to be used for client IP collection, for example: `x-forwarded-for`. Added in version `0.76.0`.
 
+`DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP`
+: **INI**: `datadog.trace.obfuscation_query_string_regexp`<br>
+**Default**: `(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\s|%20)*(?:=|%3D)[^&]+|(?:"|%22)(?:\s|%20)*(?::|%3A)(?:\s|%20)*(?:"|%22)(?:%2[^2]|%[^2]|[^"%])+(?:"|%22))|bearer(?:\s|%20)+[a-z0-9\._\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\w=-]|%3D)+\.ey[I-L](?:[\w=-]|%3D)+(?:\.(?:[\w.+\/=-]|%3D|%2F|%2B)+)?|[\-]{5}BEGIN(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY[\-]{5}[^\-]+[\-]{5}END(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY|ssh-rsa(?:\s|%20)*(?:[a-z0-9\/\.+]|%2F|%5C|%2B){100,}`<br>
+Regular expression used to obfuscate the query string included as part of the URL. Added in version `0.76.0`.
+
 #### Integration names
 
 The table below specifies the default service names for each integration. Change the service names with `DD_SERVICE_MAPPING`.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR updates the PHP APM configuration section to include new environment variables which the user should be aware of in order to opt-out of the new tags introduced for backend ASM.

### Motivation
Provide the user the option to disable some of the new tags introduced for backend ASM.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
