### PR TITLE
move deprecation warning for trace metrics page

### DIFF
--- a/content/en/tracing/guide/metrics_namespace.md
+++ b/content/en/tracing/guide/metrics_namespace.md
@@ -20,7 +20,6 @@ further_reading:
 aliases:
     - /tracing/getting_further/metrics_namespace
 ---
-<div class="alert alert-warning">This method of using trace metrics is outdated. Instead, <a href="/tracing/guide/ddsketch_trace_metrics/">tracing distribution metrics using DDSketch</a> is recommended.</div>
 
 ## Overview
 
@@ -102,6 +101,8 @@ With the following definitions:
 
 ### Duration
 
+<div class="alert alert-warning">This method of using trace metrics is outdated. Instead, <a href="/tracing/guide/ddsketch_trace_metrics/">tracing distribution metrics using DDSketch</a> is recommended.</div>
+
 `trace.<SPAN_NAME>.duration`
 : **Prerequisite:** This metric exists for any APM service.<br>
 **Description:** [LEGACY] Measure the total time for a collection of spans within a time interval, including child spans seen in the collecting service. This metric used to generate the "% exec time for downstream services" graph. When `trace.<SPAN_NAME>.duration` is divided by `trace.<SPAN_NAME>.hits`, the result can yield an average latency, but this is not the recommended approach for calculating the average latency. Instead, refer to the [Latency Distribution](#latency-distribution) section for average latency calculations. <br>
@@ -109,6 +110,8 @@ With the following definitions:
 **Tags:** `env`, `service`, `resource`, `http.status_code`, all host tags from the Datadog Host Agent, and [the second primary tag][4].
 
 ### Duration by
+
+<div class="alert alert-warning">This method of using trace metrics is outdated. Instead, <a href="/tracing/guide/ddsketch_trace_metrics/">tracing distribution metrics using DDSketch</a> is recommended.</div>
 
 `trace.<SPAN_NAME>.duration.by_http_status`
 : **Prerequisite:** This metric exists for HTTP/WEB APM services if http metadata exists.<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Right now the "outdated" warning applies to all metrics, but it only affects the ones related to latency distribution/percentiles that have a DDSketch variant.

### Motivation
<!-- What inspired you to submit this pull request?-->

To improve clarification which metrics to use.
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->



---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
