### PR TITLE
Update outdated event function parameters

### DIFF
--- a/content/en/events/guides/dogstatsd.md
+++ b/content/en/events/guides/dogstatsd.md
@@ -21,7 +21,7 @@ aliases:
 After [installing DogStatsD][1], you can emit events to your [Datadog event stream][2] with the following function:
 
 ```text
-event(<TITLE>, <TEXT>, <TIMESTAMP>, <HOSTNAME>, <AGGREGATION_KEY>, <PRIORITY>, <SOURCE_TYPE_NAME>, <ALERT_TYPE>, <TAGS>)
+event(<title>, <message>, <alert_type>, <aggregation_key>, <source_type_name>, <date_happened>, <priority>, <tags>, <hostname>)
 ```
 
 **Definitions**:


### PR DESCRIPTION
Issue #14457

Update event function parameters in documentation to reflect the order and name of the event function parameters in the datadogpy codebase.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR updates the statsd.event() function documentation to reflect the order and name of the parameters in the codebase.

edit klh: In the [codebase](https://github.com/DataDog/datadogpy/blob/0957786a1cac70b53bdc4af1cdc574b6ae4d9026/datadog/dogstatsd/base.py#L923), the event() function parameters are listed as follows:

def event(
        self,
        title,
        message,
        alert_type=None,
        aggregation_key=None,
        source_type_name=None,
        date_happened=None,
        priority=None,
        tags=None,
        hostname=None,
    ):

### Motivation
I was attempting to use the statsd.event() function to report events to DataDog. I had created a dictionary with keys of the same names as the event parameters listed in the documentation. I encountered an internal StatsD error when I attempted to unpack the dictionary as arguments in the event() function. Upon examining the codebase, I observed that there is an inconsistency between the actual event() function and its documentation. I promptly created issue #14457, which this PR addresses.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Thank you for being open-source!


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
