### PR TITLE
Removes Beta Banner for Frustration Signals

### DIFF
--- a/content/en/real_user_monitoring/frustration_signals/_index.md
+++ b/content/en/real_user_monitoring/frustration_signals/_index.md
@@ -15,10 +15,6 @@ further_reading:
 
 ## Overview
 
-<div class="alert alert-warning">
-For access to frustration signals, contact <a href="/help">Datadog Support</a>.
-</div>
-
 Frustration signals help you identify your application's highest points of user friction by surfacing moments when users exhibit frustration.
 
 RUM collects three types of frustration signals:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Frustration Signals is going GA on Thursday, June 30.

### Motivation
<!-- What inspired you to submit this pull request?-->

#rum-docs Slack

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
