### PR TITLE
add uds to connection errors doc

### DIFF
--- a/content/en/tracing/troubleshooting/connection_errors.md
+++ b/content/en/tracing/troubleshooting/connection_errors.md
@@ -211,8 +211,8 @@ See the table below for example setups. Some require setting up additional netwo
 | [AWS EKS on Fargate][9] | Do not set `DD_AGENT_HOST` |
 | [AWS Elastic Beanstalk - Single Container][10] | Gateway IP (usually `172.17.0.1`) |
 | [AWS Elastic Beanstalk - Multiple Containers][11] | Link pointing to the Datadog Agent container name |
-| [Kubernetes][12] | 1) [Unix Domain Socket][20], 2) [`status.hostIP`][13] added manually, 3) through the [Admission Controller][14] |
-| [AWS EKS (non Fargate)][15] | [`status.hostIP`][13] added manually or through the [Admission Controller][14] |
+| [Kubernetes][12] | 1) [Unix Domain Socket][20], 2) [`status.hostIP`][13] added manually, or 3) through the [Admission Controller][14] |
+| [AWS EKS (non Fargate)][15] | 1) [Unix Domain Socket][20], 2) [`status.hostIP`][13] added manually, or 3) through the [Admission Controller][14] |
 | [Datadog Agent and Application Docker Containers][16] | Datadog Agent container |
 
 

--- a/content/en/tracing/troubleshooting/connection_errors.md
+++ b/content/en/tracing/troubleshooting/connection_errors.md
@@ -211,7 +211,7 @@ See the table below for example setups. Some require setting up additional netwo
 | [AWS EKS on Fargate][9] | Do not set `DD_AGENT_HOST` |
 | [AWS Elastic Beanstalk - Single Container][10] | Gateway IP (usually `172.17.0.1`) |
 | [AWS Elastic Beanstalk - Multiple Containers][11] | Link pointing to the Datadog Agent container name |
-| [Kubernetes][12] | [`status.hostIP`][13] added manually or through the [Admission Controller][14] |
+| [Kubernetes][12] | 1) [Unix Domain Socket][20], 2) [`status.hostIP`][13] added manually, 3) through the [Admission Controller][14] |
 | [AWS EKS (non Fargate)][15] | [`status.hostIP`][13] added manually or through the [Admission Controller][14] |
 | [Datadog Agent and Application Docker Containers][16] | Datadog Agent container |
 
@@ -274,3 +274,4 @@ If the configuration is correct, but you’re still seeing connection errors, [c
 [17]: /tracing/setup_overview/setup/php/?tab=containers#apache
 [18]: /tracing/setup_overview/setup/php/?tab=containers#nginx
 [19]: /agent/troubleshooting/send_a_flare/?tab=agentv6v7#trace-agent
+[20]: /containers/kubernetes/apm/?tabs=daemonsetuds#configure-the-datadog-agent-to-accept-traces


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

For the tracers that work with UDS, they will detect the unix domain sockets if configured for Kubernetes: https://docs.datadoghq.com/containers/kubernetes/apm/?tabs=uds#configure-your-application-pods-to-submit-traces-to-datadog-agent, so this is an option to add to the connection setup . (Exception listed for now is PHP).


### Motivation
<!-- What inspired you to submit this pull request?-->

Show another path for Kubernetes users. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
