### PR TITLE
remove ie11 from docs

### DIFF
--- a/content/en/getting_started/synthetics/private_location.md
+++ b/content/en/getting_started/synthetics/private_location.md
@@ -17,7 +17,7 @@ further_reading:
 ---
 
 <div class="alert alert-info">
-If you would like to be added to the Windows Private Location beta, which allows you to run IE11 browser tests, reach out to <a href="https://docs.datadoghq.com/help/">Datadog support</a>.
+If you would like to be added to the Windows Private Location beta, reach out to <a href="https://docs.datadoghq.com/help/">Datadog support</a>.
 </div>
 
 ## Overview

--- a/content/en/real_user_monitoring/session_replay/_index.md
+++ b/content/en/real_user_monitoring/session_replay/_index.md
@@ -56,7 +56,7 @@ datadogRum.startSessionReplayRecording();
 
 Replace the Browser SDK URL `https://www.datadoghq-browser-agent.com/datadog-rum.js` with `https://www.datadoghq-browser-agent.com/datadog-rum-v4.js`. When `DD_RUM.init()` is called, the Session Replay recording does not start until `DD_RUM.startSessionReplayRecording()` is also called.
 
-The Session Replay recorder supports all browsers supported by the RUM Browser SDK. For more information, see the [browser support table][3].
+The Session Replay recorder supports all browsers supported by the RUM Browser SDK with the exception of IE11. For more information, see the [browser support table][3].
 
 ### Configuration
 

--- a/content/en/real_user_monitoring/session_replay/_index.md
+++ b/content/en/real_user_monitoring/session_replay/_index.md
@@ -56,7 +56,7 @@ datadogRum.startSessionReplayRecording();
 
 Replace the Browser SDK URL `https://www.datadoghq-browser-agent.com/datadog-rum.js` with `https://www.datadoghq-browser-agent.com/datadog-rum-v4.js`. When `DD_RUM.init()` is called, the Session Replay recording does not start until `DD_RUM.startSessionReplayRecording()` is also called.
 
-The Session Replay recorder supports all browsers supported by the RUM Browser SDK with the exception of IE11. For more information, see the [browser support table][3].
+The Session Replay recorder supports all browsers supported by the RUM Browser SDK. For more information, see the [browser support table][3].
 
 ### Configuration
 

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -92,7 +92,7 @@ Define the configuration of your browser test.
 
 3. **Name**: The name of your browser test.
 4. **Select tags**: The `env` and related tags attached to your browser test. Use the `<KEY>:<VALUE>` format to filter on a `<VALUE>` for a given `<KEY>`.
-5. **Browsers & Devices**: The browsers (such as `Chrome`, `Firefox`, `Edge`, and `Internet Explorer 11`), and devices (such as `Laptop Large`, `Tablet`, and `Mobile Small`) to run your test on. 
+5. **Browsers & Devices**: The browsers (such as `Chrome`, `Firefox`, and `Edge`), and devices (such as `Laptop Large`, `Tablet`, and `Mobile Small`) to run your test on. 
    - For a large laptop device, the dimensions are 1440 pixels x 1100 pixels. 
    - For a tablet device, the dimensions are 768 pixels x 1020 pixels.
    - For a small mobile device, the dimensions are 320 pixels x 550 pixels.  

--- a/content/en/synthetics/guide/identify_synthetics_bots.md
+++ b/content/en/synthetics/guide/identify_synthetics_bots.md
@@ -97,13 +97,13 @@ if (window._DATADOG_SYNTHETICS_BROWSER === undefined) {
 }
 ```
 
-If you use the browser variable to identify Synthetic bots on Firefox and Internet Explorer 11, Datadog cannot guarantee that the browser variable is set before your code executes. 
+If you use the browser variable to identify Synthetic bots on Firefox, Datadog cannot guarantee that the browser variable is set before your code executes. 
 
 ## Cookies
 
 Cookies that are applied in your browser include `datadog-synthetics-public-id` and `datadog-synthetics-result-id`.
 
-These cookies are available for all steps in Firefox and Internet Explorer 11. For Edge and Google Chrome, these cookies are set only for the start URL.
+These cookies are available for all steps in Firefox. For Edge and Google Chrome, these cookies are set only for the start URL.
 
 ## Further Reading
 

--- a/content/en/synthetics/guide/identify_synthetics_bots.md
+++ b/content/en/synthetics/guide/identify_synthetics_bots.md
@@ -103,7 +103,7 @@ If you use the browser variable to identify Synthetic bots on Firefox, Datadog c
 
 Cookies that are applied in your browser include `datadog-synthetics-public-id` and `datadog-synthetics-result-id`.
 
-These cookies are available for all steps in Firefox. For Edge and Google Chrome, these cookies are set only for the start URL.
+These cookies are available for all steps in Firefox. For Microsoft Edge and Google Chrome, these cookies are set only for the start URL.
 
 ## Further Reading
 

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -24,7 +24,7 @@ further_reading:
 ---
 
 <div class="alert alert-info">
-If you would like to be added to the Windows Private Location beta, which allows you to run IE11 browser tests, reach out to <a href="https://docs.datadoghq.com/help/">Datadog support</a>.
+If you would like to be added to the Windows Private Location beta, reach out to <a href="https://docs.datadoghq.com/help/">Datadog support</a>.
 </div>
 
 ## Overview

--- a/content/en/synthetics/settings/_index.md
+++ b/content/en/synthetics/settings/_index.md
@@ -159,7 +159,7 @@ When you are done selecting locations, click **Save Default Locations**.
 
 Choose the default browser and device types for your [browser test][5] details.
 
-Your options for browsers include Google Chrome, Firefox, Microsoft Edge, and Internet Explorer 11. Your options for devices include a large laptop, a tablet, and a small mobile device.
+Your options for browsers include Google Chrome, Firefox, and Microsoft Edge. Your options for devices include a large laptop, a tablet, and a small mobile device.
 
 When you are done selecting browsers and devices, click **Save Default Browsers & Devices**.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
