### PR TITLE
[DOCS-2979] Add Github action to check for GIFs (second try)

### DIFF
--- a/.github/workflows/gif_check.yml
+++ b/.github/workflows/gif_check.yml
@@ -1,0 +1,25 @@
+name: "No GIFs"
+
+on:
+  pull_request:
+    paths:
+    - 'static/images/**'
+
+jobs:
+  file_existence:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Check file existence
+        id: check_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "static/images/**/*.gif"
+
+      - name: GIF file exists
+        if: steps.check_files.outputs.files_exists == 'true'
+        run: |
+          echo "GIF file(s) found! Use MP4 format for videos."
+          exit 1


### PR DESCRIPTION
### What does this PR do?

Adds a Github action that will fail if a GIF is uploaded in a pull request.

### Motivation

We are only using MP4s for videos.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
