### PR TITLE
replace replaySampleRate (deprecated) with premiumSampleRate

### DIFF
--- a/content/en/real_user_monitoring/session_replay/_index.md
+++ b/content/en/real_user_monitoring/session_replay/_index.md
@@ -134,7 +134,7 @@ Session Replay follows the same 30 days retention policy as normal RUM sessions.
 ### How do you disable Session Replay?
 
 - Remove `startSessionReplayRecording()` to stop session recordings.
-- Set `replaySampleRate` to `0` to stop collecting the Browser Premium plan for RUM & Session Replay, which includes replays, resources, and long tasks.
+- Set `premiumSampleRate` to `0` to stop collecting the Browser Premium plan for RUM & Session Replay, which includes replays, resources, and long tasks.
 
 In order to apply these configurations, upgrade the [Browser RUM SDK][2] to a version >= 3.6.
 

--- a/content/en/real_user_monitoring/session_replay/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/privacy_options.md
@@ -37,7 +37,7 @@ datadogRum.init({
     //  env: 'production',
     //  version: '1.0.0',
     sampleRate: 100,
-    replaySampleRate: 100,
+    premiumSampleRate: 100,
     trackInteractions: true,
     defaultPrivacyLevel: 'mask-user-input' | 'mask' | 'allow' 
 });


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
`replaySampleRate` is a deprecated configuration for RUM, this replaces some instances of the old deprecated option with the current option `premiumSampleRate`.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
