### PR TITLE
external metrics - use port 8443

### DIFF
--- a/content/en/containers/cluster_agent/external_metrics.md
+++ b/content/en/containers/cluster_agent/external_metrics.md
@@ -96,7 +96,7 @@ To enable the Custom Metrics Server, first follow the instructions to [set up th
 
 Once the Datadog Cluster Agent is up and running, apply some additional RBAC policies and set up the `Service` to route the corresponding requests.
 
-1. Create a `Service` named `datadog-custom-metrics-server`, exposing the port `443` with the following `custom-metric-server.yaml` manifest:
+1. Create a `Service` named `datadog-custom-metrics-server`, exposing the port `8443` with the following `custom-metric-server.yaml` manifest:
 
     ```yaml
     kind: Service
@@ -108,10 +108,10 @@ Once the Datadog Cluster Agent is up and running, apply some additional RBAC pol
         app: datadog-cluster-agent
       ports:
       - protocol: TCP
-        port: 443
-        targetPort: 443
+        port: 8443
+        targetPort: 8443
     ```
-    **Note:** The Cluster Agent by default is expecting these requests over port `443`. However, if your Cluster Agent `Deployment` has set the environment variable `DD_EXTERNAL_METRICS_PROVIDER_PORT` to some other port value, change the `targetPort` of this `Service` accordingly.
+    **Note:** The Cluster Agent by default is expecting these requests over port `8443`. However, if your Cluster Agent `Deployment` has set the environment variable `DD_EXTERNAL_METRICS_PROVIDER_PORT` to some other port value, change the `targetPort` of this `Service` accordingly.
 
     Apply this `Service` by running `kubectl apply -f custom-metric-server.yaml`
 2. Download the [`rbac-hpa.yaml` RBAC rules file][2].


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This updates the docs to use port 8443  as it is the default for the cluster agent. This change makes things consistent with the helm chart, operator, and generated daemonset manifests.

### Motivation
<!-- What inspired you to submit this pull request?-->
This is more clear for customers using custom external metrics deployments.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
