### PR TITLE
Need to exclude aws-sdk

### DIFF
--- a/content/en/serverless/guide/serverless_tracing_and_webpack.md
+++ b/content/en/serverless/guide/serverless_tracing_and_webpack.md
@@ -41,7 +41,7 @@ Datadog's tracing libraries (`dd-trace`) are known to be not compatible with [we
             - dd-trace
             - datadog-lambda-js
       esbuild: # for esbuild
-        exclude: ["dd-trace", "datadog-lambda-js"]
+        exclude: ["dd-trace", "datadog-lambda-js", "aws-sdk"] # including aws-sdk, as it is the default value for `exclude`
     ```
 
     **Note:** This exclusion may not be sufficient if you have any transitive dependencies on `datadog-lambda-js` or `dd-trace`. In these cases, **forceExclude** does not avoid the inclusion of one of these libraries. If this is your case, you can try to remove them manually using something like the following:

--- a/content/en/serverless/guide/serverless_tracing_and_webpack.md
+++ b/content/en/serverless/guide/serverless_tracing_and_webpack.md
@@ -41,7 +41,7 @@ Datadog's tracing libraries (`dd-trace`) are known to be not compatible with [we
             - dd-trace
             - datadog-lambda-js
       esbuild: # for esbuild
-        exclude: ["dd-trace", "datadog-lambda-js", "aws-sdk"] # including aws-sdk, as it is the default value for `exclude`
+        exclude: ["dd-trace", "datadog-lambda-js", "aws-sdk"] # aws-sdk is included because it is the default for `exclude`
     ```
 
     **Note:** This exclusion may not be sufficient if you have any transitive dependencies on `datadog-lambda-js` or `dd-trace`. In these cases, **forceExclude** does not avoid the inclusion of one of these libraries. If this is your case, you can try to remove them manually using something like the following:


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
According to https://floydspace.github.io/serverless-esbuild/#configure, `aws-sdk` is the default value for the `exclude` field, so it needs to be included, otherwise by defining `exclude` explicitly people are effectively dropping `aws-sdk` from the `exclude` list.

### Motivation
<!-- What inspired you to submit this pull request?-->

Realized this issue based on a customer report.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
