### PR TITLE
DOCS-2578 Track Browser Errors Edits

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/browser_errors.md
+++ b/content/en/real_user_monitoring/error_tracking/browser_errors.md
@@ -2,33 +2,42 @@
 title: Track Browser Errors
 kind: documentation
 further_reading:
+- link: "https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps"
+  tag: "GitHub"
+  text: "datadog-ci Source code"
+- link: "https://app.datadoghq.com/error-tracking"
+  tag: "Documentation"
+  text: "Learn about Error Tracking"
 - link: "/real_user_monitoring/error_tracking/explorer"
   tag: "Documentation"
-  text: "Error Tracking Explorer"
-- link: "https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps"
-  tag: "Documentation"
-  text: "Official repository of the Datadog CLI"
-- link: "/real_user_monitoring/guide/upload-javascript-source-maps"
-  tag: "Guide"
-  text: "Upload javascript source maps"
-- link: "https://app.datadoghq.com/error-tracking"
-  tag: "UI"
-  text: "Error tracking"
+  text: "Learn about the Error Tracking Explorer"
 ---
 
-Error Tracking processes errors collected from the browser by the RUM SDK: whenever a [source][1] or [custom][2] error containing a stack trace is collected, Error Tracking processes and groups it under an issue (group of similar errors). To quickly get started with error tracking:
+## Overview
 
-1. Download the latest version of the [RUM Browser SDK][3].
-2. Configure the __version__, the __env__ and the __service__ when [initializing your SDK][4].
-3. Upload JavaScript source maps [following our guide][5] to get unminified stack traces.
+Error Tracking processes errors collected from the browser by the RUM Browser SDK. Whenever a [source][1] or [custom][2] error containing a stack trace is collected, Error Tracking processes and groups it under an issue, or group of similar errors. 
+
+Your crash reports appear in [**Error Tracking**][3].
+
+## Setup
+
+If you have not set up the Browser SDK yet, follow the [in-app setup instructions][4] or see the [Browser RUM setup documentation][5].
+
+1. Download the latest version of the [RUM Browser SDK][6].
+2. Configure your application's `version`, `env`, and `service` when [initializing the SDK][7].
+3. [Upload your JavaScript source maps][8] to access unminified stack traces.
 
 ## Link errors with your source code
 
-In addition to sending source maps, the new version of the [Datadog CLI][6] reports Git information such as the commit hash, the repository URL, and the list of tracked file paths in the code repository. Using this information, Error Tracking and RUM can correlate an error with the source code, and you can pivot from any stack trace frame to the related line of code in [GitHub][7], [GitLab][8] and [Bitbucket][9]. 
+In addition to sending source maps, the [Datadog CLI][9] reports Git information such as the commit hash, repository URL, and a list of tracked file paths in the code repository. 
+
+Error Tracking and RUM can use this information to correlate errors with your source code, allowing you to pivot from any stack trace frame to the related line of code in [GitHub][10], [GitLab][11] and [Bitbucket][12]. 
 
 {{< img src="real_user_monitoring/error_tracking/link_to_git_js_example.mp4" alt="Link from a stack frame to the source code" video=true >}}
 
 <div class="alert alert-info">Linking from stack frames to source code is supported in the <a href="https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command">Datadog CLI</a> version <code>0.12.0</code> version and later.</div>
+
+For more information, see the [Datadog Source Code Integration][13].
 
 ## Further Reading
 
@@ -36,10 +45,14 @@ In addition to sending source maps, the new version of the [Datadog CLI][6] repo
 
 [1]: /real_user_monitoring/browser/data_collected/?tab=error#source-errors
 [2]: /real_user_monitoring/browser/collecting_browser_errors/?tab=npm#collect-errors-manually
-[3]: https://www.npmjs.com/package/@datadog/browser-rum
-[4]: /real_user_monitoring/browser/#initialization-parameters
-[5]: /real_user_monitoring/guide/upload-javascript-source-maps
-[6]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command
-[7]: https://github.com
-[8]: https://about.gitlab.com
-[9]: https://bitbucket.org/product
+[3]: https://app.datadoghq.com/rum/error-tracking
+[4]: https://app.datadoghq.com/rum/application/create
+[5]: /real_user_monitoring/browser/#setup
+[6]: https://www.npmjs.com/package/@datadog/browser-rum
+[7]: /real_user_monitoring/browser/#initialization-parameters
+[8]: /real_user_monitoring/guide/upload-javascript-source-maps
+[9]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command
+[10]: https://github.com
+[11]: https://about.gitlab.com
+[12]: https://bitbucket.org/product
+[13]: /integrations/guide/source-code-integration/

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -505,8 +505,8 @@
           kind: documentation
           further_reading:
           - link: '/real_user_monitoring/error_tracking/'
-            tag: 'Error Tracking'
-            text: 'Get started with Error Tracking'
+            tag: 'GitHub'
+            text: 'Learn about Error Tracking'
           - link: '/real_user_monitoring/error_tracking/explorer'
             tag: 'Documentation'
             text: 'Visualize Error Tracking data in the Explorer'

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -504,6 +504,9 @@
           title: Android Error Tracking
           kind: documentation
           further_reading:
+          - link: 'https://www.datadoghq.com/blog/debug-android-crashes/'
+            tag: 'Blog'
+            text: 'Debug Android crashes faster with Datadog'
           - link: '/real_user_monitoring/error_tracking/'
             tag: 'GitHub'
             text: 'Learn about Error Tracking'


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Batch formatting update for RUM Error Tracking docs.
 
### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-2578

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
