### PR TITLE
Tweak ruby sample to show standard tags adding

### DIFF
--- a/content/en/metrics/custom_metrics/dogstatsd_metrics_submission.md
+++ b/content/en/metrics/custom_metrics/dogstatsd_metrics_submission.md
@@ -82,12 +82,13 @@ while(1):
 ```ruby
 require 'datadog/statsd'
 
-statsd = Datadog::Statsd.new('localhost', 8125)
+statsd = Datadog::Statsd.new('localhost', 8125, tags: ['environment:dev'])
 
 while true do
-    statsd.increment('example_metric.increment', tags: ['environment:dev'])
-    statsd.decrement('example_metric.decrement', tags: ['environment:dev'])
-    statsd.count('example_metric.count', 2, tags: ['environment:dev'])
+    statsd.increment('example_metric.increment')
+    statsd.increment('example_metric.increment', tags: ['another': 'tag'])
+    statsd.decrement('example_metric.decrement')
+    statsd.count('example_metric.count', 2)
     sleep 10
 end
 ```


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The sample made it look like you had to repeat environment tag for every metric you send, but especially for the `environment` tag it would make a lot of sense to set it when instantiating the sender, I think.

### Motivation

Code samples matter a lot for how users approach new tools.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
