### PR TITLE
Updates RUM config to disable tracking across subdomains

### DIFF
--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -25,7 +25,6 @@ if (window.DD_RUM) {
             enableExperimentalFeatures: ["frustration-signals"],
             sampleRate: 50,
             premiumSampleRate: 50,
-            trackSessionAcrossSubdomains: true, 
             allowedTracingOrigins: [window.location.origin]
         });
         window.DD_RUM.startSessionReplayRecording();
@@ -41,7 +40,6 @@ if (window.DD_LOGS) {
         forwardErrorsToLogs: true,
         env,
         service: 'docs',
-        trackSessionAcrossSubdomains: true,
         version: CI_COMMIT_SHORT_SHA
     });
     // global context


### PR DESCRIPTION
### What does this PR do?
Temporary removal of `trackSessionAcrossSubdomains` config for DD RUM

### Motivation
requested via Slack 

### Additional Notes
No visual impact 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
