### PR TITLE
[DOCS-3317] Update AWS services log collection section

### DIFF
--- a/content/en/integrations/amazon_cloudhsm.md
+++ b/content/en/integrations/amazon_cloudhsm.md
@@ -7,7 +7,7 @@ description: Gather your HSM audit logs in your Datadog organization.
 has_logo: true
 dependencies:
     ['https://github.com/DataDog/documentation/blob/master/content/en/integrations/amazon_cloudhsm.md']
-integration_title: AWS Cloudhsm
+integration_title: AWS CloudHSM
 is_public: true
 kind: integration
 name: amazon_cloudhsm
@@ -32,18 +32,22 @@ Audit logs are enabled by default for CloudHSM.
 
 #### Send your logs to Datadog
 
-1. If you haven't already, set up the [Datadog log collection AWS Lambda function][1].
-2. Once the lambda function is installed, manually add a trigger on the Cloudwatch Log group that contains your CloudHSM logs in the AWS console:
-   {{< img src="integrations/amazon_cloudwatch/cloudwatch_log_collection_1.png" alt="cloudwatch log group" popup="true" style="width:70%;">}}
-   Select the corresponding CloudWatch Log group, add a filter name (but feel free to leave the filter empty) and add the trigger.
-   {{< img src="integrations/amazon_cloudwatch/cloudwatch_log_collection_2.png" alt="cloudwatch trigger" popup="true" style="width:70%;">}}
+1. If you haven't already, set up the [Datadog Forwarder Lambda function][1] in your AWS account.
+2. Once setup, go to the Datadog Forwarder Lambda function. In the Function Overview section, click **Add Trigger**. 
+3. Select the **CloudWatch Logs** trigger for the Trigger Configuration.
+4. Select the CloudWatch log group that contains your CloudHSM logs.
+5. Enter a name for the filter.
+6. Click **Add** to add the trigger to your Lambda.
 
-Once done, go in your [Datadog Log section][2] to start exploring your logs!
+Go to [Log Explorer][2] to start exploring your logs.
+
+For more information on collecting AWS Services logs, see [Send AWS Services Logs with the Datadog Lambda Function][3].
 
 ## Troubleshooting
 
-Need help? Contact [Datadog Support][3].
+Need help? Contact [Datadog Support][4].
 
-[1]: /logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/
+[1]: /logs/guide/forwarder/
 [2]: https://app.datadoghq.com/logs
-[3]: /help/
+[3]: /logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/
+[4]: /help/

--- a/content/en/integrations/amazon_cloudhsm.md
+++ b/content/en/integrations/amazon_cloudhsm.md
@@ -33,13 +33,13 @@ Audit logs are enabled by default for CloudHSM.
 #### Send your logs to Datadog
 
 1. If you haven't already, set up the [Datadog Forwarder Lambda function][1] in your AWS account.
-2. Once setup, go to the Datadog Forwarder Lambda function. In the Function Overview section, click **Add Trigger**. 
+2. Once set up, go to the Datadog Forwarder Lambda function. In the Function Overview section, click **Add Trigger**. 
 3. Select the **CloudWatch Logs** trigger for the Trigger Configuration.
 4. Select the CloudWatch log group that contains your CloudHSM logs.
 5. Enter a name for the filter.
 6. Click **Add** to add the trigger to your Lambda.
 
-Go to [Log Explorer][2] to start exploring your logs.
+Go to the [Log Explorer][2] to start exploring your logs.
 
 For more information on collecting AWS Services logs, see [Send AWS Services Logs with the Datadog Lambda Function][3].
 

--- a/content/en/integrations/amazon_guardduty.md
+++ b/content/en/integrations/amazon_guardduty.md
@@ -44,12 +44,12 @@ Datadog integrates with AWS GuardDuty through a Lambda function that ships Guard
 #### Send your logs to Datadog
 
 1. If you haven't already, set up the [Datadog Forwarder Lambda function][1] in your AWS account.
-2. Once setup, go to the Datadog Forwarder Lambda function. In the Function Overview section, click **Add Trigger**. 
+2. Once set up, go to the Datadog Forwarder Lambda function. In the Function Overview section, click **Add Trigger**. 
 3. Select the **EventBridge (CloudWatch Events)** trigger for the Trigger Configuration.
 4. Select your GuardDuty rule.
 5. Click **Add** to add the trigger to your Lambda.
 
- Go to [Log Explorer][2] to start exploring your logs.
+ Go to the [Log Explorer][2] to start exploring your logs.
 
 For more information on collecting AWS Services logs, see [Send AWS Services Logs with the Datadog Lambda Function][3].
 

--- a/content/en/integrations/amazon_guardduty.md
+++ b/content/en/integrations/amazon_guardduty.md
@@ -33,7 +33,7 @@ Datadog integrates with AWS GuardDuty through a Lambda function that ships Guard
 
     {{< img src="integrations/amazon_guardduty/aws_gd_1.png" alt="aws gd 1" style="width:75%;" >}}
 
-2. If you haven't already, set up the [Datadog log collection AWS Lambda function][1].
+2. If you haven't already, set up the [Datadog Forwarder Lambda function][1].
 
 3. Once the Lambda function is created, define the Datadog Lambda function as the target:
 
@@ -43,13 +43,16 @@ Datadog integrates with AWS GuardDuty through a Lambda function that ships Guard
 
 #### Send your logs to Datadog
 
-1. If you haven't already, set up the [Datadog log collection AWS Lambda function][1].
+1. If you haven't already, set up the [Datadog Forwarder Lambda function][1] in your AWS account.
+2. Once setup, go to the Datadog Forwarder Lambda function. In the Function Overview section, click **Add Trigger**. 
+3. Select the **EventBridge (CloudWatch Events)** trigger for the Trigger Configuration.
+4. Select your GuardDuty rule.
+5. Click **Add** to add the trigger to your Lambda.
 
-2. After setting up the Lambda function, add GuardDuty as a trigger by choosing **CloudWatch Events** as a trigger and creating a `GuardDutyRule`:
+ Go to [Log Explorer][2] to start exploring your logs.
 
-    {{< img src="integrations/amazon_guardduty/aws_gd_3.png" alt="aws gd 3" style="width:75%;">}}
+For more information on collecting AWS Services logs, see [Send AWS Services Logs with the Datadog Lambda Function][3].
 
-3. Once done, see the [Datadog Log section][2] to start exploring your logs!
-
-[1]: /logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/
+[1]: /logs/guide/forwarder/
 [2]: https://app.datadoghq.com/logs
+[3]: /logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/


### PR DESCRIPTION
### What does this PR do?

- Updates the logs collection section for AWS services docs because they are out of date.
- Removes images because they are out of date. We shouldn't include images of third-party apps in our docs, because it's difficult to maintain.

### Motivation

DOCS-3317

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
