### PR TITLE
cluster troubleshooting - update port to 8443

### DIFF
--- a/content/en/containers/cluster_agent/troubleshooting.md
+++ b/content/en/containers/cluster_agent/troubleshooting.md
@@ -245,7 +245,7 @@ autoscaling/v2beta1
 external.metrics.k8s.io/v1beta1
 ```
 
-The latter shows up if the Datadog Cluster Agent properly registers as an External Metrics Provider—and if you have the same service name referenced in the APIService for the External Metrics Provider, as well as the one for the Datadog Cluster Agent on port `443`. Also make sure you have created the RBAC from the [Register the External Metrics Provider][1] step.
+The latter shows up if the Datadog Cluster Agent properly registers as an External Metrics Provider—and if you have the same service name referenced in the APIService for the External Metrics Provider, as well as the one for the Datadog Cluster Agent on port `8443`. Also make sure you have created the RBAC from the [Register the External Metrics Provider][1] step.
 
 If you see the following error when describing the HPA manifest:
 
@@ -253,7 +253,7 @@ If you see the following error when describing the HPA manifest:
 Warning  FailedComputeMetricsReplicas  3s (x2 over 33s)  horizontal-pod-autoscaler  failed to get nginx.net.request_per_s external metric: unable to get external metric default/nginx.net.request_per_s/&LabelSelector{MatchLabels:map[string]string{kube_container_name: nginx,},MatchExpressions:[],}: unable to fetch metrics from external metrics API: the server is currently unable to handle the request (get nginx.net.request_per_s.external.metrics.k8s.io)
 ```
 
-Make sure the Datadog Cluster Agent is running, and the service exposing the port `443`, whose name is registered in the APIService, is up.
+Make sure the Datadog Cluster Agent is running, and the service exposing the port `8443`, whose name is registered in the APIService, is up.
 
 ### Differences of value between Datadog and Kubernetes
 


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Changes port for Cluster Agent to 8443 to be consistent with other docs and defaults.

### Motivation
<!-- What inspired you to submit this pull request?-->
Making the docs consistent and less confusing.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
