### PR TITLE
Better syntax for rails initializer

### DIFF
--- a/content/en/logs/log_collection/ruby.md
+++ b/content/en/logs/log_collection/ruby.md
@@ -81,7 +81,7 @@ This section describes the minimum setup required to forward your Rails applicat
     config.colorize_logging = false
 
     # Log to a dedicated file
-    config.lograge.logger = ActiveSupport::Logger.new(File.join(Rails.root, 'log', "#{Rails.env}.log"))
+    config.lograge.logger = ActiveSupport::Logger.new(Rails.root.join('log', "#{Rails.env}.log"))
 
     # This is useful if you want to log query parameters
     config.lograge.custom_options = lambda do |event|


### PR DESCRIPTION
Rails.root support `#join` method 