### PR TITLE
[CIAPP] Add `CODEOWNERS` control section for CITest monitors.

### DIFF
--- a/content/en/monitors/create/types/ci.md
+++ b/content/en/monitors/create/types/ci.md
@@ -107,6 +107,26 @@ The following example is a test error rate monitor using a formula that calculat
 {{< img src="monitors/monitor_types/ci_tests/define-the-search-query-fnf.png" alt="Monitor being defined with steps a, b, and c, where steps a and b are queries and step c calculates the rate from them." style="width:80%;" >}}
 
 <div class="alert alert-info"><strong>Note</strong>: A maximum of two queries can be used to build the evaluation formula per monitor.</div>
+
+#### Using CODEOWNERS for notifications
+
+You can send the notification to different teams using the `CODEOWNERS` information available in the test event. 
+
+In the following example we are configuring the notification with the next logic:
+* If the test code owner is `MyOrg/my-team`, then send the notification to the `my-team-channel` Slack channel.
+* If the test code owner is `MyOrg/my-other-team`, then send the notification to the `my-other-team-channel` Slack channel.
+
+{{< code-block lang="text" >}}
+{{#is_match "citest.attributes.test.codeowners" "MyOrg/my-team"}}
+  @slack-my-team-channel
+{{/is_match}}
+{{#is_match "citest.attributes.test.codeowners" "MyOrg/my-other-team"}}
+  @slack-my-other-team-channel
+{{/is_match}}
+{{< /code-block >}}
+
+You need to add a similar code snippet in the `Notification message` of your monitor when you are editing it. You can add as many `is_match` clauses you need to configure your monitor.
+
 {{% /tab %}}
 {{< /tabs >}}
 ### Set alert conditions

--- a/content/en/monitors/create/types/ci.md
+++ b/content/en/monitors/create/types/ci.md
@@ -112,7 +112,7 @@ The following example is a test error rate monitor using a formula that calculat
 
 You can send the notification to different teams using the `CODEOWNERS` information available in the test event. 
 
-In the following example we are configuring the notification with the next logic:
+The example below configures the notification with the following logic:
 * If the test code owner is `MyOrg/my-team`, then send the notification to the `my-team-channel` Slack channel.
 * If the test code owner is `MyOrg/my-other-team`, then send the notification to the `my-other-team-channel` Slack channel.
 
@@ -125,7 +125,7 @@ In the following example we are configuring the notification with the next logic
 {{/is_match}}
 {{< /code-block >}}
 
-You need to add a similar code snippet in the `Notification message` of your monitor when you are editing it. You can add as many `is_match` clauses you need to configure your monitor.
+In the `Notification message` section of your monitor, add text similar to the code snippet above to configure monitor notifications. You can add as many `is_match` clauses as you need.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR adds a section to indicate how to leverage `test.codeowners` info to select to which team the notification needs to be sent. This section is added in the CITest monitors tab on the CI monitors page.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
