### PR TITLE
left nav redesign - [WEB-2460]

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1,8 +1,33 @@
 main:
+  - name: Essentials
+    identifier: essentials_heading
+    weight: 1000000
+  - name: In The App
+    identifier: platform_heading
+    weight: 2000000
+  - name: Infrastructure
+    identifier: infrastructure_heading
+    weight: 3000000
+  - name: APM
+    identifier: apm_heading
+    weight: 4000000
+  - name: Log Management
+    identifier: log_management_heading
+    weight: 5000000
+  - name: Security Platform
+    identifier: security_platform_heading
+    weight: 6000000
+  - name: UX Monitoring
+    identifier: ux_monitoring_heading
+    weight: 7000000
+  - name: Administration
+    identifier: administration_heading
+    weight: 8000000
   - name: Getting Started
     identifier: getting_started
     url: getting_started/
     pre: hex-ringed
+    parent: essentials_heading
     weight: 10000
   - name: Datadog
     identifier: getting_started_datadog
@@ -134,6 +159,7 @@ main:
   - name: Agent
     url: agent/
     pre: agent-fill
+    parent: essentials_heading
     weight: 30000
     identifier: agent
   - name: Basic Agent Usage
@@ -323,6 +349,7 @@ main:
   - name: Containers
     url: containers/
     identifier: containers
+    parent: infrastructure_heading
     weight: 40000
     pre: container
   - name: Docker
@@ -511,6 +538,7 @@ main:
     url: integrations/
     identifier: integrations_top_level
     pre: integrations
+    parent: essentials_heading
     weight: 45000
   - name: Observability Pipelines
     url: integrations/observability_pipelines/
@@ -556,6 +584,7 @@ main:
     url: watchdog/
     identifier: watchdog_top_level
     pre: watchdog
+    parent: platform_heading
     weight: 50000
   - name: Alerts
     url: watchdog/alerts
@@ -581,6 +610,7 @@ main:
     url: events/
     identifier: events_top_level
     pre: events
+    parent: platform_heading
     weight: 60000
   - name: Stream
     url: events/stream/
@@ -617,6 +647,7 @@ main:
     url: dashboards/
     pre: dashboard
     identifier: dashboards
+    parent: platform_heading
     weight: 70000
   - name: Widgets
     url: dashboards/widgets/
@@ -816,11 +847,13 @@ main:
     url: mobile/
     identifier: mobile
     pre: mobile
+    parent: platform_heading
     weight: 80000
   - name: Infrastructure
     url: infrastructure/
     identifier: infrastructure
     pre: host-map
+    parent: infrastructure_heading
     weight: 90000
   - name: Infrastructure List
     url: infrastructure/list/
@@ -861,6 +894,7 @@ main:
     url: serverless
     pre: serverless
     identifier: serverless
+    parent: infrastructure_heading
     weight: 100000
   - name: Installation
     url: serverless/installation
@@ -977,6 +1011,7 @@ main:
     url: metrics/
     identifier: metrics_top_level
     pre: metric
+    parent: platform_heading
     weight: 110000
   - name: Explorer
     url: metrics/explorer/
@@ -1048,11 +1083,13 @@ main:
     url: notebooks/
     identifier: notebooks
     pre: notebook
+    parent: platform_heading
     weight: 120000
   - name: Alerting
     url: monitors/
     pre: monitor
     identifier: alerting
+    parent: platform_heading
     weight: 130000
   - name: Create Monitors
     url: monitors/create/
@@ -1258,6 +1295,7 @@ main:
     url: tracing/
     pre: apm
     identifier: tracing
+    parent: apm_heading
     weight: 140000
   - name: Send traces to Datadog
     url: tracing/setup_overview/
@@ -1776,6 +1814,7 @@ main:
     url: continuous_integration/
     pre: ci
     identifier: ci
+    parent: apm_heading
     weight: 150000
   - name: Tracing Tests
     url: continuous_integration/setup_tests/
@@ -1891,6 +1930,7 @@ main:
     url: database_monitoring/
     pre: database-2
     identifier: dbm
+    parent: apm_heading
     weight: 160000
   - name: Setting Up Postgres
     url: database_monitoring/setup_postgres/
@@ -2026,6 +2066,7 @@ main:
     url: logs/
     pre: log
     identifier: log_management
+    parent: log_management_heading
     weight: 170000
   - name: Log Collection & Integrations
     url: logs/log_collection/
@@ -2199,6 +2240,7 @@ main:
     url: security_platform/
     pre: security-platform
     identifier: security_platform
+    parent: security_platform_heading
     weight: 180000
   - name: Cloud SIEM
     url: security_platform/cloud_siem/
@@ -2402,6 +2444,7 @@ main:
     url: synthetics/
     pre: synthetics
     identifier: synthetics
+    parent: ux_monitoring_heading
     weight: 190000
   - name: API Tests
     url: synthetics/api_tests/
@@ -2552,6 +2595,7 @@ main:
     url: real_user_monitoring/
     pre: rum
     identifier: rum
+    parent: ux_monitoring_heading
     weight: 155000
   - name: Browser Monitoring
     url: real_user_monitoring/browser/
@@ -2817,6 +2861,7 @@ main:
     url: network_monitoring/
     pre: network
     identifier: nm_parent
+    parent: infrastructure_heading
     weight: 200000
   - name: Network Performance Monitoring
     url: network_monitoring/performance/
@@ -2882,6 +2927,7 @@ main:
     url: developers/
     pre: dev-code
     identifier: dev_tools
+    parent: essentials_heading
     weight: 210000
   - name: DogStatsD
     url: developers/dogstatsd/
@@ -2997,11 +3043,13 @@ main:
     url: api/
     pre: api
     identifier: api
+    parent: essentials_heading
     weight: 220000
   - name: Account Management
     url: account_management/
     pre: cog-2
     identifier: account_management
+    parent: administration_heading
     weight: 230000
   - name: Switching Between Orgs
     url: account_management/org_switching/
@@ -3105,6 +3153,7 @@ main:
     url: data_security/
     pre: security-lock
     identifier: data_security
+    parent: administration_heading
     weight: 240000
   - name: Agent
     url: data_security/agent/
@@ -3130,6 +3179,7 @@ main:
     url: help/
     pre: info-fill
     identifier: help_top_level
+    parent: administration_heading
     weight: 240000
   - name: Aggregating Agents
     url: agent/vector_aggregation/

--- a/layouts/partials/nav/left-nav.html
+++ b/layouts/partials/nav/left-nav.html
@@ -21,80 +21,83 @@
 {{ $branchPath := trim ($.Scratch.Get "branch_path") "/" }}
 {{ $url_without_anchor := "" }}
 
-<ul class="list-unstyled">
-    {{ $currentPage := . }}
-    {{ range $menu }}
-        {{ if .HasChildren }}
-            <li class="nav-top-level {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}
-            {{ if $currentPage.HasMenuCurrent "main" . }}active{{ end }}">
-                {{ $url_without_anchor = (index (split .URL "#") 0) }}
-                <a href="{{ .URL | relLangURL }}" class="d-flex align-items-center" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
-                    {{ if .Pre }}
-                      {{ partial "icon" (dict "name" .Pre "size" "18px" )}}
-                    {{ end }}
-                    <div>
-                      <span>{{ .Name }}</span>
-                    </div>
-                </a>
-                <ul class="list-unstyled sub-menu {{ if (or (eq .Name "Guides") (eq .Name "Widgets")) }} d-none {{ end }}">
-                    {{ range .Children }}
-                        <li class="{{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }} {{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }}">
-                            {{ $url_without_anchor = (index (split .URL "#") 0) }}
-                            <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
-                                {{ if .Pre }}
-                                  {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
-                                  {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}
-                                {{ end }}
-                                <span>{{ .Name }}</span>
-                            </a>
-                        {{ if .HasChildren }}
-                            <ul class="list-unstyled sub-menu {{ if (or (eq .Name "Guides") (eq .Name "Widgets")) }} d-none {{ end }}">
-                            {{ range .Children }}
-                                <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}" >
-                                    {{ $url_without_anchor = (index (split .URL "#") 0) }}
-                                    <a href="{{ .URL | relLangURL }}" data-type="{{- with site.GetPage .URL -}}{{- .Type -}}{{- end -}}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
-                                        {{ if .Pre }}
-                                          {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
-                                          {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}
-                                        {{ end }}
-                                        <span>{{ .Name }}</span>
-                                    </a>
-                                    {{/* 4th level, hide */}}
-                                    {{ if .HasChildren }}
-                                        <ul class="list-unstyled sub-menu d-none">
-                                        {{ range .Children }}
-                                            <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}" >
-                                                {{ $url_without_anchor = (index (split .URL "#") 0) }}
-                                                <a data-name="{{- delimit (last 1 (split (strings.TrimSuffix "/" .URL) "/")) "" -}}" href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
-                                                    {{ if .Pre }}
-                                                      {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
-                                                      {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}
-                                                    {{ end }}
-                                                    <span>{{ .Name }}</span>
-                                                </a>
-                                            </li>
-                                        {{ end }}
-                                        </ul>
-                                    {{ end }}
-                                </li>
-                            {{ end }}
-                            </ul>
+{{ $currentPage := . }}
+{{ range $menu }}
+    {{ if .HasChildren }}
+        <p class="h5 text-uppercase font-weight-bold">{{.Name}}</p>
+        <ul class="list-unstyled ml-3">
+            {{ range .Children }}
+                <li class="nav-top-level {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}
+                {{ if $currentPage.HasMenuCurrent "main" . }}active{{ end }}">
+                    {{ $url_without_anchor = (index (split .URL "#") 0) }}
+                    <a href="{{ .URL | relLangURL }}" class="d-flex align-items-center" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
+                        {{ if .Pre }}
+                        {{ partial "icon" (dict "name" .Pre "size" "18px" )}}
                         {{ end }}
-                        </li>
-                    {{ end }}
-                </ul>
-            </li>
-        {{ else }}
-            <li class="nav-top-level {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}">
-                <a href="{{ .URL | absLangURL }}" class="d-flex align-items-center" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
-                    {{ if .Pre }}
-                      {{ partial "icon" (dict "name" .Pre "size" "18px" )}}
-                    {{ end }}
-                    <div>
-                      <span>{{ .Name }}</span>
-                    </div>
-                </a>
-            </li>
-        {{ end }}
-    {{ end }}
-</ul>
+                        <div>
+                        <span>{{ .Name }}</span>
+                        </div>
+                    </a>
+                    <ul class="list-unstyled sub-menu {{ if (or (eq .Name "Guides") (eq .Name "Widgets")) }} d-none {{ end }}">
+                        {{ range .Children }}
+                            <li class="{{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }} {{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }}">
+                                {{ $url_without_anchor = (index (split .URL "#") 0) }}
+                                <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
+                                    {{ if .Pre }}
+                                    {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
+                                    {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}
+                                    {{ end }}
+                                    <span>{{ .Name }}</span>
+                                </a>
+                            {{ if .HasChildren }}
+                                <ul class="list-unstyled sub-menu {{ if (or (eq .Name "Guides") (eq .Name "Widgets")) }} d-none {{ end }}">
+                                {{ range .Children }}
+                                    <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}" >
+                                        {{ $url_without_anchor = (index (split .URL "#") 0) }}
+                                        <a href="{{ .URL | relLangURL }}" data-type="{{- with site.GetPage .URL -}}{{- .Type -}}{{- end -}}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
+                                            {{ if .Pre }}
+                                            {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
+                                            {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}
+                                            {{ end }}
+                                            <span>{{ .Name }}</span>
+                                        </a>
+                                        {{/* 4th level, hide */}}
+                                        {{ if .HasChildren }}
+                                            <ul class="list-unstyled sub-menu d-none">
+                                            {{ range .Children }}
+                                                <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}" >
+                                                    {{ $url_without_anchor = (index (split .URL "#") 0) }}
+                                                    <a data-name="{{- delimit (last 1 (split (strings.TrimSuffix "/" .URL) "/")) "" -}}" href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
+                                                        {{ if .Pre }}
+                                                        {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
+                                                        {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}
+                                                        {{ end }}
+                                                        <span>{{ .Name }}</span>
+                                                    </a>
+                                                </li>
+                                            {{ end }}
+                                            </ul>
+                                        {{ end }}
+                                    </li>
+                                {{ end }}
+                                </ul>
+                            {{ end }}
+                            </li>
+                        {{ end }}
+                    </ul>
+                </li>
+            {{ else }}
+                <li class="nav-top-level {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}">
+                    <a href="{{ .URL | absLangURL }}" class="d-flex align-items-center" data-path="{{ trim (print $branchPath ((print .URL) | relLangURL)) "/" }}">
+                        {{ if .Pre }}
+                        {{ partial "icon" (dict "name" .Pre "size" "18px" )}}
+                        {{ end }}
+                        <div>
+                        <span>{{ .Name }}</span>
+                        </div>
+                    </a>
+                </li>
+            {{ end }} 
+        </ul>
+    {{ end }}   
+{{ end }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Edits `menu.en.yaml` file to include headings that group top-level nav items for the left navigation.
Assigns top-level nav items (weight: X*10000) to a parent heading (weight: W*1000000)
Adjusts `/nav/left-nav.html` partial to include the parent headings 

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-2460

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Documentation to be updated: https://github.com/DataDog/documentation/wiki/Main-navigation

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
