### PR TITLE
fix a subtle link bug

### DIFF
--- a/content/en/serverless/configuration/_index.md
+++ b/content/en/serverless/configuration/_index.md
@@ -30,7 +30,7 @@ First, [install][1] Datadog serverless monitoring to begin collecting metrics, t
 
 ### APM
 - [Configure the Datadog tracer](#configure-the-datadog-tracer)
-- [Choose APM tracing sampling rates](#select-sampling-rates-for-ingesting-APM-spans)
+- [Choose APM tracing sampling rates](#select-sampling-rates-for-ingesting-apm-spans)
 - [Filter or scrub sensitive information from traces](#filter-or-scrub-sensitive-information-from-traces)
 - [Disable trace collection](#disable-trace-collection)
 - [Collect the request and response payloads](#collect-the-request-and-response-payloads)


### PR DESCRIPTION
hey! so i'm not sure if everyone else knew this already, but here's a thing i didn't know you had to do in markdown!

basically: remember that when you are using anchor links, it has to all be lowercase

if your heading is something like `We love APM`, your anchor link is `#we-love-apm`. (it is probably documented somewhere that all heading ids in markdown are lowercased, but i'm gonna be honest here, i have not read the markdown documentation.) urls are case-sensitive, so linking to `#we-love-APM` will not work.

actually now that i'm thinking about it i suspect all urls have to be lowercased