### PR TITLE
Clarify configcheck

### DIFF
--- a/content/en/agent/guide/secrets-management.md
+++ b/content/en/agent/guide/secrets-management.md
@@ -431,7 +431,7 @@ Source: File Configuration Provider
 Instance 1:
 host: <decrypted_host>
 port: <decrypted_port>
-password: <decrypted_password>
+password: <obfuscated_password>
 ~
 ===
 
@@ -440,7 +440,7 @@ Source: File Configuration Provider
 Instance 1:
 host: <decrypted_host2>
 port: <decrypted_port2>
-password: <decrypted_password2>
+password: <obfuscated_password2>
 ~
 ===
 ```


### PR DESCRIPTION
Clarify that `configcheck` does not print decrypted passwords

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
