### PR TITLE
fix wrong key in sqlserver docs

### DIFF
--- a/content/en/database_monitoring/setup_sql_server/azure.md
+++ b/content/en/database_monitoring/setup_sql_server/azure.md
@@ -143,7 +143,7 @@ instances:
     username: datadog
     password: '<PASSWORD>'
     connector: adodbapi
-    provider: MSOLEDBSQL
+    adoprovider: MSOLEDBSQL
     tags:  # optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
@@ -166,7 +166,7 @@ Use the `service` and `env` tags to link your database telemetry to other teleme
 The recommended [ADO][6] provider is [Microsoft OLE DB Driver][7]. Ensure the driver is installed on the host where the agent is running.
 ```yaml
 connector: adodbapi
-provider: MSOLEDBSQL
+adoprovider: MSOLEDBSQL
 ```
 
 The other two providers, `SQLOLEDB` and `SQLNCLI`, are considered deprecated by Microsoft and should no longer be used.

--- a/layouts/shortcodes/dbm-sqlserver-agent-setup-windows.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-setup-windows.md
@@ -10,7 +10,7 @@ instances:
     username: datadog
     password: '<PASSWORD>'
     connector: adodbapi
-    provider: MSOLEDBSQL
+    adoprovider: MSOLEDBSQL
     tags:  # optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
@@ -27,7 +27,7 @@ Use the `service` and `env` tags to link your database telemetry to other teleme
 The recommended [ADO][9] provider is [Microsoft OLE DB Driver][2]. Ensure the driver is installed on the host where the agent is running.
 ```yaml
 connector: adodbapi
-provider: MSOLEDBSQL
+adoprovider: MSOLEDBSQL
 ```
 
 The other two providers, `SQLOLEDB` and `SQLNCLI`, are considered deprecated by Microsoft and should no longer be used.


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

The ADO Provider is configured using the `adoprovider` key, not the `provider` key.

### Motivation

Fix wrong docs. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
