### PR TITLE
Use the dd_site parameter instead

### DIFF
--- a/content/en/serverless/installation/dotnet.md
+++ b/content/en/serverless/installation/dotnet.md
@@ -47,8 +47,7 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
     Specify the [Datadog site][2] where the telemetry should be sent to. The default is `datadoghq.com`.
 
     ```sh
-    # ensure the correct SITE is selected on the right
-    export DATADOG_SITE="{{< region-param key="dd_site" >}}"
+    export DATADOG_SITE="<DD_SITE>" # such as datadoghq.com, datadoghq.eu or ddog-gov.com
     ```
 
 5. Configure the Datadog API key

--- a/content/en/serverless/installation/dotnet.md
+++ b/content/en/serverless/installation/dotnet.md
@@ -47,8 +47,8 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
     Specify the [Datadog site][2] where the telemetry should be sent to. The default is `datadoghq.com`.
 
     ```sh
-    # select the correct SITE using the selector on the right
-    export DATADOG_SITE="{{< region-param key="dd_site" code="true" >}}"
+    # ensure the correct SITE is selected on the right
+    export DATADOG_SITE="{{< region-param key="dd_site" >}}"
     ```
 
 5. Configure the Datadog API key
@@ -144,7 +144,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 
 3. Set the required environment variables
 
-    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
+    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Set the environment variable `DD_API_KEY_SECRET_ARN` with the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
 
 [1]: https://gallery.ecr.aws/datadog/lambda-extension
@@ -172,7 +172,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
     - Set `CORECLR_PROFILER` to `{846F5F1C-F9AE-4B07-969E-05C26BC060D8}`.
     - Set `CORECLR_PROFILER_PATH` to `/opt/datadog/Datadog.Trace.ClrProfiler.Native.so`.
     - Set `DD_DOTNET_TRACER_HOME` to `/opt/datadog`.
-    - Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
+    - Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Set `DD_API_KEY_SECRET_ARN` to the ARN of the AWS secret where your [Datadog API key][3] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html

--- a/content/en/serverless/installation/dotnet.md
+++ b/content/en/serverless/installation/dotnet.md
@@ -47,7 +47,8 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
     Specify the [Datadog site][2] where the telemetry should be sent to. The default is `datadoghq.com`.
 
     ```sh
-    export DATADOG_SITE="<DD_SITE>" # such as datadoghq.com, datadoghq.eu or ddog-gov.com
+    # select the correct SITE using the selector on the right
+    export DATADOG_SITE="{{< region-param key="dd_site" code="true" >}}"
     ```
 
 5. Configure the Datadog API key
@@ -143,7 +144,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 
 3. Set the required environment variables
 
-    - Set the environment variable `DD_SITE` with your [Datadog site][3] to send the telemetry to.
+    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
     - Set the environment variable `DD_API_KEY_SECRET_ARN` with the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
 
 [1]: https://gallery.ecr.aws/datadog/lambda-extension
@@ -171,7 +172,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
     - Set `CORECLR_PROFILER` to `{846F5F1C-F9AE-4B07-969E-05C26BC060D8}`.
     - Set `CORECLR_PROFILER_PATH` to `/opt/datadog/Datadog.Trace.ClrProfiler.Native.so`.
     - Set `DD_DOTNET_TRACER_HOME` to `/opt/datadog`.
-    - Set `DD_SITE` to your [Datadog site][2] to send the telemetry to.
+    - Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
     - Set `DD_API_KEY_SECRET_ARN` to the ARN of the AWS secret where your [Datadog API key][3] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -77,7 +77,7 @@ Replace `<AWS_REGION>` with a valid AWS region, such as `us-east-1`.
 
 ### Configure the required environment variables
 
-- Set `DD_SITE` to your [Datadog site][2] to send the telemetry to.
+- Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
 - Set `DD_API_KEY_SECRET_ARN` to the ARN of the AWS secret where your [Datadog API key][3] is securely stored. The key needs to be stored as a plaintext string string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html

--- a/content/en/serverless/installation/go.md
+++ b/content/en/serverless/installation/go.md
@@ -77,7 +77,7 @@ Replace `<AWS_REGION>` with a valid AWS region, such as `us-east-1`.
 
 ### Configure the required environment variables
 
-- Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
+- Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
 - Set `DD_API_KEY_SECRET_ARN` to the ARN of the AWS secret where your [Datadog API key][3] is securely stored. The key needs to be stored as a plaintext string string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -68,7 +68,7 @@ Datadog offers many different ways to enable instrumentation for your serverless
     - Set `JAVA_TOOL_OPTIONS` to `-javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1`
     - Set `DD_JMXFETCH_ENABLED` to `false`
     - Set `DD_TRACE_ENABLED` to `true`
-    - Set `DD_SITE` to your [Datadog site][3] to send the telemetry to.
+    - Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
     - Set `DD_API_KEY_SECRET_ARN` to the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
 
 [1]: https://gallery.ecr.aws/datadog/lambda-extension
@@ -115,7 +115,7 @@ Datadog offers many different ways to enable instrumentation for your serverless
     - Set `JAVA_TOOL_OPTIONS` to `-javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1`
     - Set `DD_JMXFETCH_ENABLED` to `false`
     - Set `DD_TRACE_ENABLED` to `true`
-    - Set `DD_SITE` to your [Datadog site][3] to send the telemetry to.
+    - Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
     - Set `DD_API_KEY_SECRET_ARN` to the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -68,7 +68,7 @@ Datadog offers many different ways to enable instrumentation for your serverless
     - Set `JAVA_TOOL_OPTIONS` to `-javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1`
     - Set `DD_JMXFETCH_ENABLED` to `false`
     - Set `DD_TRACE_ENABLED` to `true`
-    - Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
+    - Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Set `DD_API_KEY_SECRET_ARN` to the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
 
 [1]: https://gallery.ecr.aws/datadog/lambda-extension
@@ -115,7 +115,7 @@ Datadog offers many different ways to enable instrumentation for your serverless
     - Set `JAVA_TOOL_OPTIONS` to `-javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1`
     - Set `DD_JMXFETCH_ENABLED` to `false`
     - Set `DD_TRACE_ENABLED` to `true`
-    - Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
+    - Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Set `DD_API_KEY_SECRET_ARN` to the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -55,8 +55,8 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
     Specify the [Datadog site][2] where the telemetry should be sent to. The default is `datadoghq.com`.
 
     ```sh
-    # select the correct SITE using the selector on the right
-    export DATADOG_SITE="{{< region-param key="dd_site" code="true" >}}"
+    # ensure the correct SITE is selected on the right
+    export DATADOG_SITE="{{< region-param key="dd_site" >}}"
     ```
 
 5. Configure the Datadog API key
@@ -247,7 +247,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 
 4. Configure the Datadog site and API key
 
-    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
+    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Set the environment variable `DD_API_KEY_SECRET_ARN` with the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
 
 
@@ -313,7 +313,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 
 4. Configure Datadog site and API key
 
-    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
+    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Set the environment variable `DD_API_KEY_SECRET_ARN` with the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -55,8 +55,7 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
     Specify the [Datadog site][2] where the telemetry should be sent to. The default is `datadoghq.com`.
 
     ```sh
-    # ensure the correct SITE is selected on the right
-    export DATADOG_SITE="{{< region-param key="dd_site" >}}"
+    export DATADOG_SITE="<DD_SITE>" # such as datadoghq.com, datadoghq.eu or ddog-gov.com
     ```
 
 5. Configure the Datadog API key

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -55,7 +55,8 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
     Specify the [Datadog site][2] where the telemetry should be sent to. The default is `datadoghq.com`.
 
     ```sh
-    export DATADOG_SITE="<DD_SITE>" # such as datadoghq.com, datadoghq.eu or ddog-gov.com
+    # select the correct SITE using the selector on the right
+    export DATADOG_SITE="{{< region-param key="dd_site" code="true" >}}"
     ```
 
 5. Configure the Datadog API key
@@ -246,7 +247,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 
 4. Configure the Datadog site and API key
 
-    - Set the environment variable `DD_SITE` with your [Datadog site][3] to send the telemetry to.
+    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
     - Set the environment variable `DD_API_KEY_SECRET_ARN` with the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
 
 
@@ -312,7 +313,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 
 4. Configure Datadog site and API key
 
-    - Set the environment variable `DD_SITE` with your [Datadog site][3] to send the telemetry to.
+    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
     - Set the environment variable `DD_API_KEY_SECRET_ARN` with the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
 
 [1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -50,8 +50,7 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
     Specify the [Datadog site][2] where the telemetry should be sent to. The default is `datadoghq.com`.
 
     ```sh
-    # ensure the correct SITE is selected on the right
-    export DATADOG_SITE="{{< region-param key="dd_site" >}}"
+    export DATADOG_SITE="<DD_SITE>" # such as datadoghq.com, datadoghq.eu or ddog-gov.com
     ```
 
 5. Configure the Datadog API key

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -50,7 +50,8 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
     Specify the [Datadog site][2] where the telemetry should be sent to. The default is `datadoghq.com`.
 
     ```sh
-    export DATADOG_SITE="<DD_SITE>" # such as datadoghq.com, datadoghq.eu or ddog-gov.com
+    # select the correct SITE using the selector on the right
+    export DATADOG_SITE="{{< region-param key="dd_site" code="true" >}}"
     ```
 
 5. Configure the Datadog API key
@@ -239,7 +240,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 
 4. Configure the Datadog site, API key, and tracing
 
-    - Set the environment variable `DD_SITE` with your [Datadog site][3] to send the telemetry to.
+    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
     - Set the environment variable `DD_API_KEY_SECRET_ARN` with the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
     - Set the environment variable `DD_TRACE_ENABLED` to `true`.
 
@@ -316,7 +317,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 
 4. Configure the Datadog site, API key, and tracing
 
-    - Set the environment variable `DD_SITE` with your [Datadog site][7] to send the telemetry to.
+    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
     - Set the environment variable `DD_API_KEY_SECRET_ARN` with the ARN of the AWS secret where your [Datadog API key][8] is securely stored. The key needs to be stored as a plaintext string, instead of being inside a json blob. The `secretsmanager:GetSecretValue` permission is required. For quick testings, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
     - Set the environment variable `DD_TRACE_ENABLED` to `true`.
 

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -50,8 +50,8 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
     Specify the [Datadog site][2] where the telemetry should be sent to. The default is `datadoghq.com`.
 
     ```sh
-    # select the correct SITE using the selector on the right
-    export DATADOG_SITE="{{< region-param key="dd_site" code="true" >}}"
+    # ensure the correct SITE is selected on the right
+    export DATADOG_SITE="{{< region-param key="dd_site" >}}"
     ```
 
 5. Configure the Datadog API key
@@ -240,7 +240,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 
 4. Configure the Datadog site, API key, and tracing
 
-    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
+    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Set the environment variable `DD_API_KEY_SECRET_ARN` with the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
     - Set the environment variable `DD_TRACE_ENABLED` to `true`.
 
@@ -317,7 +317,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 
 4. Configure the Datadog site, API key, and tracing
 
-    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (select the correct SITE using the selector on the right).
+    - Set the environment variable `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Set the environment variable `DD_API_KEY_SECRET_ARN` with the ARN of the AWS secret where your [Datadog API key][8] is securely stored. The key needs to be stored as a plaintext string, instead of being inside a json blob. The `secretsmanager:GetSecretValue` permission is required. For quick testings, you can use `DD_API_KEY` instead and set the Datadog API key in plaintext.
     - Set the environment variable `DD_TRACE_ENABLED` to `true`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Use the `{{< region-param key="dd_site" code="true" >}}` parameter to embed the correct DD_SITE value inline.

### Motivation

Currently people are linked to https://docs.datadoghq.com/getting_started/site/ and cause them to set the DD_SITE with the subdomain such as `app.` and break the installation.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
