### PR TITLE
Fix Grammar for Incident Responders

### DIFF
--- a/content/en/monitors/incident_management/incident_details.md
+++ b/content/en/monitors/incident_management/incident_details.md
@@ -108,7 +108,7 @@ In the Responders section, you can form your response team by adding other users
 
 1. `Incident Commander` - The individual responsible for leading the response team 
 2. `Communications Lead` - The individual responsible for managing stakeholder communications throughout the lifecycle of the incident
-3. `Responder` - An individual that is actively contribution to investigating an incident and resolving its underlying issue
+3. `Responder` - An individual that actively contributes to investigating an incident and resolving its underlying issue
 
 **Note:** There must always be exactly one `Incident Commander` at all times during an incident. If there is only one responder in an incident, this individual is assigned the `Incident Commander` role automatically. There is no limit to the number of individuals that are assigned the `Communications Lead` or `Responder` role in an incident.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes the grammar of a sentence about Incident Responders

### Motivation
<!-- What inspired you to submit this pull request?-->
Noticed the error while reading the docs

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
