### PR TITLE
support security-monitoring or cloud-siem directories rules

### DIFF
--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -140,7 +140,7 @@ def security_rules(content, content_dir):
                                 page_data['rule_category'].append('Workload Security')
 
                         # new categorization
-                        if 'security-monitoring' in relative_path:
+                        if any(sub_path in relative_path for sub_path in ['security-monitoring', 'cloud-siem']):
                             page_data['rule_category'].append('Cloud SIEM')
 
                         if 'posture-management' in relative_path:
@@ -174,7 +174,7 @@ def security_rules(content, content_dir):
                             page_data["scope"] = tech
 
                         # Hardcoded rules in cloud siem which can span several different log sources do not include a source tag
-                        if 'security-monitoring' in relative_path:
+                        if any(sub_path in relative_path for sub_path in ['security-monitoring', 'cloud-siem']):
                             is_hardcoded = not page_data.get("source", None)
                             if is_hardcoded:
                                 page_data["source"] = "multi Log Sources"

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -810,6 +810,8 @@
         - "workload-security/backend-rules/*.md"
         - "security-monitoring/*.json"
         - "security-monitoring/*.md"
+        - "cloud-siem/**/*.json"
+        - "cloud-siem/**/*.md"
         - "posture-management/**/*.json"
         - "posture-management/**/*.yaml"
         - "posture-management/**/*.yml"

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -814,6 +814,8 @@
         - "workload-security/backend-rules/*.md"
         - "security-monitoring/*.json"
         - "security-monitoring/*.md"
+        - "cloud-siem/**/*.json"
+        - "cloud-siem/**/*.md"
         - "posture-management/**/*.json"
         - "posture-management/**/*.yaml"
         - "posture-management/**/*.yml"


### PR DESCRIPTION
### What does this PR do?

Support both `/security-monitoring/` and `/cloud-siem/` directories for cloud siem rules. So that the upcoming reorganization doesn't cause any loss of displaying rules.

### Motivation

In preparation for https://github.com/DataDog/security-monitoring/pull/1450

### Preview

https://docs-staging.datadoghq.com/david.jones/cloud-siem-rule-reorg/security_platform/default_rules/#cat-cloud-siem


### Additional Notes

Sometime later we can remove the references to the security monitoring dir and just support the cloud siem dir

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
