### PR TITLE
Move autodiscovery redirect

### DIFF
--- a/content/en/containers/kubernetes/_index.md
+++ b/content/en/containers/kubernetes/_index.md
@@ -7,7 +7,6 @@ aliases:
     - /tracing/kubernetes/
     - /tracing/setup/kubernetes
     - /integrations/faq/using-rbac-permission-with-your-kubernetes-integration
-    - /agent/autodiscovery
     - /integrations/faq/can-i-install-the-agent-on-my-Kubernetes-master-node-s/
     - /integrations/faq/docker-ecs-kubernetes-events/
     - /integrations/faq/container-integration-event/

--- a/content/en/getting_started/containers/autodiscovery.md
+++ b/content/en/getting_started/containers/autodiscovery.md
@@ -4,6 +4,7 @@ kind: documentation
 aliases:
  - /agent/autodiscovery/basic_autodiscovery
  - /getting_started/agent/autodiscovery
+ - /agent/autodiscovery
 further_reading:
 - link: "/agent/kubernetes/integrations/"
   tag: "Documentation"


### PR DESCRIPTION
Moves autodiscovery redirect from Kubernetes to the containers GS

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
