### PR TITLE
Specify that using subdomain for API is misleading

### DIFF
--- a/content/en/account_management/multi_organization.md
+++ b/content/en/account_management/multi_organization.md
@@ -52,7 +52,7 @@ For example, the URL `https://app.datadoghq.com/event/event?id=1` is associated 
 
 **Note**: If you have a custom Datadog subdomain, manually edit the links from the Datadog documentation with your subdomain name. For example, a link redirecting to `https://**app**.datadoghq.com/account/settings` becomes `https://**<custom_sub-domain_name>**.datadoghq.com/account/settings`.
 
-**Note**: Even though you _can_ replace API urls like `https://api.datadoghq.eu/api/v2/series` with `https://org-a.datadoghq.eu/api/v2` that could be misleading, because only the API key is used to select the organization. So that URL used together with an API key for org-b would submit the data to org-b, disregaring the URL's subdomain.
+**Note**: Even though you _can_ replace API urls like `https://api.datadoghq.eu/api/v2/series` with `https://org-a.datadoghq.eu/api/v2/series` that could be misleading, because only the API key is used to select the organization. So that URL used together with an API key for org-b would submit the data to org-b, disregaring the URL's subdomain.
 
 ## Set up SAML
 

--- a/content/en/account_management/multi_organization.md
+++ b/content/en/account_management/multi_organization.md
@@ -52,6 +52,8 @@ For example, the URL `https://app.datadoghq.com/event/event?id=1` is associated 
 
 **Note**: If you have a custom Datadog subdomain, manually edit the links from the Datadog documentation with your subdomain name. For example, a link redirecting to `https://**app**.datadoghq.com/account/settings` becomes `https://**<custom_sub-domain_name>**.datadoghq.com/account/settings`.
 
+**Note**: Even though you _can_ replace API urls like `https://api.datadoghq.eu/api/v2/series` with `https://org-a.datadoghq.eu/api/v2` that could be misleading, because only the API key is used to select the organization. So that URL used together with an API key for org-b would submit the data to org-b, disregaring the URL's subdomain.
+
 ## Set up SAML
 
 SAML setup is _not_ inherited by child-organizations from the parent-organization. SAML must be configured for each child-organization individually.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Clarifies that subdomains do not affect API usage.

### Motivation
It was not clear whether introducing a subdomain would affect API URLs. And that subdomain for API was _allowed_ but ignored was especially confusing.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
