### PR TITLE
Add PHP to Code Hotspots section of tracing/profiler/connect_traces_and_profiles

### DIFF
--- a/content/en/tracing/profiler/connect_traces_and_profiles.md
+++ b/content/en/tracing/profiler/connect_traces_and_profiles.md
@@ -94,6 +94,14 @@ Requires tracing library version 2.7.0 or greater.
 
 [1]: /tracing/profiler/enabling/dotnet
 {{< /programming-lang >}}
+{{< programming-lang lang="PHP" >}}
+
+Code Hotspots identification is enabled by default when you [turn on profiling for your service][1].
+
+Requires tracing library version 0.71 or greater.
+
+[1]: /tracing/profiler/enabling/php
+{{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 
 ### Link from a span to profiling data


### PR DESCRIPTION
### What does this PR do?
Adds the PHP tab to the Code Hotspots section now that it has rolled out to all regions. Note the PHP tracer minimum version is 0.71.

### Motivation
@crysmags pointed out to me that I had not yet done this task.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Endpoint Profiling is not yet available for PHP, so I left that part alone.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
