### PR TITLE
Fix value for track_io_timing with Amazon Postgres databases

### DIFF
--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -49,7 +49,7 @@ Configure the following [parameters][3] in the [DB parameter group][4] and then 
 | `track_activity_query_size` | `4096` | Required for collection of larger queries. Increases the size of SQL text in `pg_stat_activity` and `pg_stat_statements`. If left at the default value then queries longer than `1024` characters will not be collected. |
 | `pg_stat_statements.track` | `ALL` | Optional. Enables tracking of statements within stored procedures and functions. |
 | `pg_stat_statements.max` | `10000` | Optional. Increases the number of normalized queries tracked in `pg_stat_statements`. This setting is recommended for high-volume databases that see many different types of queries from many different clients. |
-| `track_io_timing` | `on` | Optional. Enables collection of block read and write times for queries. |
+| `track_io_timing` | `1` | Optional. Enables collection of block read and write times for queries. |
 
 
 ## Grant the Agent access

--- a/content/en/database_monitoring/setup_postgres/rds.md
+++ b/content/en/database_monitoring/setup_postgres/rds.md
@@ -49,7 +49,7 @@ Configure the following [parameters][3] in the [DB parameter group][4] and then 
 | `track_activity_query_size` | `4096` | Required for collection of larger queries. Increases the size of SQL text in `pg_stat_activity` and `pg_stat_statements`. If left at the default value then queries longer than `1024` characters will not be collected. |
 | `pg_stat_statements.track` | `ALL` | Optional. Enables tracking of statements within stored procedures and functions. |
 | `pg_stat_statements.max` | `10000` | Optional. Increases the number of normalized queries tracked in `pg_stat_statements`. This setting is recommended for high-volume databases that see many different types of queries from many different clients. |
-| `track_io_timing` | `on` | Optional. Enables collection of block read and write times for queries. |
+| `track_io_timing` | `1` | Optional. Enables collection of block read and write times for queries. |
 
 
 ## Grant the Agent access


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

The previous PR which added the `track_io_timing` config parameter (#14567) had the wrong value for Amazon databases.  This PR fixes that value.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
