### PR TITLE
[WEB-2435] Allow img shortcode to render height and width parameters

### DIFF
--- a/content/en/dashboards/widgets/timeseries.md
+++ b/content/en/dashboards/widgets/timeseries.md
@@ -17,11 +17,11 @@ further_reading:
 
 The timeseries visualization allows you to display the evolution of one or more metrics, log events, or Indexed Spans over time. The time window depends on what is selected on the [timeboard][1] or [screenboard][2]:
 
-{{< img src="dashboards/widgets/timeseries/timeseries.png" alt="Timeseries" >}}
+{{< img src="dashboards/widgets/timeseries/timeseries.png" alt="Timeseriesx" height="318" width="794" >}}
 
 ## Setup
 
-{{< img src="dashboards/widgets/timeseries/timeseries_setup.png" alt="Timeseries setup" style="width:80%;" >}}
+{{< img src="dashboards/widgets/timeseries/timeseries_setup.png" alt="Timeseries setup" style="width:80%;" height="543" width="635" >}}
 
 ### Configuration
 

--- a/content/en/dashboards/widgets/timeseries.md
+++ b/content/en/dashboards/widgets/timeseries.md
@@ -17,7 +17,7 @@ further_reading:
 
 The timeseries visualization allows you to display the evolution of one or more metrics, log events, or Indexed Spans over time. The time window depends on what is selected on the [timeboard][1] or [screenboard][2]:
 
-{{< img src="dashboards/widgets/timeseries/timeseries.png" alt="Timeseriesx" height="318" width="794" >}}
+{{< img src="dashboards/widgets/timeseries/timeseries.png" alt="Timeseries" height="318" width="794" >}}
 
 ## Setup
 

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -78,7 +78,13 @@
         <img class="img-fluid" src="{{ (print $img_resource | safeURL) }}" {{ if .Get "style" }} style="{{- with .Get "style" -}}{{ . | safeCSS }}{{- end -}}" {{ end }} {{ if .Get "alt" }} alt="{{- with .Get "alt" -}}{{.}}{{- end -}}" {{ end }} />
     {{- else -}}
       <picture class="" {{ if .Get "style" }} style="{{- with .Get "style" -}}{{- . | safeCSS -}}{{- end -}}" {{ end }} >
-      <img loading="lazy" class="img-fluid" srcset="{{ $e }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{ end }}" {{ end }} {{ if .Get "alt" }} alt="{{- with .Get "alt" -}}{{.}}{{- end -}}" {{ end }} />
+        <img loading="lazy" 
+            class="img-fluid" 
+            srcset="{{ $e }}" 
+            {{ if .Get "style" }}style="{{ with .Get "style" }}{{ . | safeCSS }}{{ end }}" {{ end }} 
+            {{- with $img_width -}} width="{{ . }}" {{- end -}}
+            {{- with $img_height -}} height="{{ . }}" {{- end -}}
+            {{ if .Get "alt" }} alt="{{- with .Get "alt" -}}{{.}}{{- end -}}" {{ end }} />
       </picture>
     {{- end -}}
 {{- end -}}


### PR DESCRIPTION
### What does this PR do?
- Allows `img.html` shortcode to render height and width parameters.
- Update timeseries widget docs page images to include height and width parameters, improving CLS score from yellow to green.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2435
Google Search Console core web vitals report identified this page as having a CLS score needing improvement

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/cwv-fixes/dashboards/widgets/timeseries/

- running Lighthouse for Desktop should show CLS score in green (~0.01), opposed to the live version of this page which is in yellow (needs improvement).
- the image size and quality should be unchanged.

### Additional Notes
This was the only page specifically identified by the report, but we'll keep an eye out as Google validates our pages for CWV frequently.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
