### PR TITLE
Don't suggest only x86_64 architecture in agent offline install instructions

### DIFF
--- a/content/en/agent/guide/installing-the-agent-on-a-server-with-limited-internet-connectivity.md
+++ b/content/en/agent/guide/installing-the-agent-on-a-server-with-limited-internet-connectivity.md
@@ -25,14 +25,14 @@ For servers with no direct internet access, the Agent can be configured to route
 
 If the target system is blocked from accessing the package repository directly, download the package from the repository using another server, then transfer it over to the target system for a local install.
 
-The RPM packages for Agent 6 are available at [https://yum.datadoghq.com/stable/6/x86_64/][3], for Agent 7 at [https://yum.datadoghq.com/stable/7/x86_64/][4], and DEB packages are available at [https://apt.datadoghq.com/pool/d/da/][5].
+The RPM packages for Agent 6 are available at [https://yum.datadoghq.com/stable/6/][3], for Agent 7 at [https://yum.datadoghq.com/stable/7/][4], and DEB packages are available at [https://apt.datadoghq.com/pool/d/da/][5].
 
 **Note**: The package bundles all resources necessary to run the Agent and checks (whether the integration is enabled or not). In terms of hard requirements, Python 2.7+ and sysstat are required; other dependencies are mandatory depending on what checks are enabled.
 
 Once the package has been transferred to the target system, it can be installed locally by using the appropriate package manager command. For yum, the command would follow the pattern:  
 
 ```bash
-sudo yum localinstall datadog-agent-<AGENT_VERSION>-1.x86_64.rpm
+sudo yum localinstall datadog-agent-<AGENT_VERSION>-1.<CPU_ARCHITECTURE>.rpm
 ```
 
 To install a deb file in the current director for Debian based distributions:
@@ -55,8 +55,8 @@ Then, [start the Agent][7] using the appropriate command for your system.
 
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: /agent/proxy
-[3]: https://yum.datadoghq.com/stable/6/x86_64
-[4]: https://yum.datadoghq.com/stable/7/x86_64
+[3]: https://yum.datadoghq.com/stable/6
+[4]: https://yum.datadoghq.com/stable/7
 [5]: https://apt.datadoghq.com/pool/d/da
 [6]: https://app.datadoghq.com/organization-settings/api-keys
 [7]: /agent/guide/agent-commands/#start-the-agent


### PR DESCRIPTION
### What does this PR do?

Removes the explicit `x86_64` part in reference to Agent RPM download. We support other CPU architectures as well and referencing only `x86_64` explicitly makes some users think they should install these RPM even on other architectures. By removing the `x86_64` part, the users will land at a page where they will first be able to choose their CPU architecture and then download and install the proper RPM.

### Motivation

A user was following this document and ended up asking how to use the x86_64 RPM on aarch64, because they thought that's what they should've done.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
