### PR TITLE
DOCS-3230 - isDeprecated also removes rule

### DIFF
--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -97,7 +97,8 @@ def security_rules(content, content_dir):
             if message_file_name.exists():
                 # delete file or skip if staged
                 # any() will return True when at least one of the elements is Truthy
-                if len(data.get('restrictedToOrgs', [])) > 0 or data.get('isStaged', False) or data.get('isDeleted', False) or not data.get('isEnabled', True):
+                if len(data.get('restrictedToOrgs', [])) > 0 or data.get('isStaged', False) \
+                    or data.get('isDeleted', False) or not data.get('isEnabled', True) or data.get('isDeprecated', False):
                     if p.exists():
                         logger.info(f"removing file {p.name}")
                         global_aliases.append(f"/security_monitoring/default_rules/{p.stem}")


### PR DESCRIPTION
### What does this PR do?

For OOTB rules, we need a way to DEPRECATE a rule, keep the markdown available inside the product but not show on the documentation.

This PR updates the documentation to no longer display rules that have a `isDeprecated` flag set to true.

The logic is as follows, If one or more of these occurs in the file `isStaged:true`, `isDeleted:true`, `isEnabled:false`, `isDeprecated: true` then the rule does not display

### Motivation

https://datadoghq.atlassian.net/browse/DOCS-3230

### Preview

Nothing to see as of yet as rules haven't been updated.
https://docs-staging.datadoghq.com/david.jones/deprecate-rule/security_platform/default_rules/

### Additional Notes

(upstream) So the process is essentially:
- Update markdown with deprecation warning
- Update the rule with `isDeprecated: true`
- Wait X days until deprecation date
- Set `isEnabled: false` on rule
- Wait 18 months
- Set `isDeleted: true`

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
