### PR TITLE
Specify utf-8 encoding without BOM explicitly in log4net config

### DIFF
--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -198,9 +198,10 @@ Once the library is installed, attach the following layout to any target. Edit t
       <appender-ref ref="JsonFileAppender" />
     </root>
     <appender name="JsonFileAppender" type="log4net.Appender.FileAppender">
-    <threshold value="DEBUG"/>
-    <file value="application-logs.json" />
-    <appendToFile value="true" />
+      <threshold value="DEBUG"/>
+      <file value="application-logs.json" />
+      <encoding type="System.Text.UTF8Encoding" />
+      <appendToFile value="true" />
       <layout type="log4net.Layout.SerializedLayout, log4net.Ext.Json">
         <decorator type="log4net.Layout.Decorators.StandardTypesDecorator, log4net.Ext.Json" />
         <default />


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

log4net can by default write to the log file in utf-8 _with_ a BOM, which the logs agent
currently does not support.

To ensure the log4net config works OOTB with the logs agent, explicitly specify
in its config that it should log in utf-8 without a BOM.

Also, fix the tabulation of the XML config (purely cosmetic).

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
