### PR TITLE
Add flag to allow avoiding re-pulling dependent repos on each build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,13 @@ clean-exe:  ## Remove execs.
 clean-extracted-repos:  ## Remove built integrations files.
 	@if [ "${CLEAN_EXTRACTED_REPOS}" == "true" ] || [ -z ${CLEAN_EXTRACTED_REPOS} ] ; \
 		then echo "\033[31m\033[1mCleaning all extracted repos, to persist these between builds, set CLEAN_EXTRACTED_REPOS=false in your Makefile.config \033[0m"; \
+		rm -rf ./integrations_data/; \
 	else \
 	  echo "\033[31m\033[1mSkipping cleaning extracted repos, to clean these between builds, set CLEAN_EXTRACTED_REPOS=true in your Makefile.config \033[0m"; \
 	  exit 0; \
 	fi
 
 
-	@rm -rf ./integrations_data/
 	@if [ -d data/integrations ]; then \
 		find ./data/integrations -type f -maxdepth 1 \
 	    -a -not -name '*.fr.yaml' \

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ clean-exe:  ## Remove execs.
 	@rm -rf ${EXE_LIST}
 
 clean-extracted-repos:  ## Remove built integrations files.
-	@if [ "${CLEAN_EXTRACTED_REPOS}" == "true" ]; \
+	@if [ "${CLEAN_EXTRACTED_REPOS}" == "true" ] || [ -z ${CLEAN_EXTRACTED_REPOS} ] ; \
 		then echo "\033[31m\033[1mCleaning all extracted repos, to persist these between builds, set CLEAN_EXTRACTED_REPOS=false in your Makefile.config \033[0m"; \
 	else \
 	  echo "\033[31m\033[1mSkipping cleaning extracted repos, to clean these between builds, set CLEAN_EXTRACTED_REPOS=true in your Makefile.config \033[0m"; \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # make
-.PHONY: clean clean-all clean-build clean-examples clean-go-examples clean-java-examples clean-exe clean-integrations clean-auto-doc clean-node clean-virt help start stop
+.PHONY: clean clean-all clean-build clean-examples clean-go-examples clean-java-examples clean-exe clean-extracted-repos clean-auto-doc clean-node clean-virt help start stop
 .DEFAULT_GOAL := help
 PY3=$(shell if [ `which pyenv` ]; then \
 				if [ `pyenv which python3` ]; then \
@@ -24,13 +24,13 @@ help:
 clean: stop  ## Clean all make installs.
 	@echo "cleaning up..."
 	make clean-build
-	make clean-integrations
+	make clean-extracted-repos
 	make clean-auto-doc
 
 clean-all: stop  ## Clean everything.
 	make clean-build
 	make clean-exe
-	make clean-integrations
+	make clean-extracted-repos
 	make clean-auto-doc
 	make clean-node
 	make clean-virt
@@ -44,7 +44,15 @@ clean-build:  ## Remove build artifacts.
 clean-exe:  ## Remove execs.
 	@rm -rf ${EXE_LIST}
 
-clean-integrations:  ## Remove built integrations files.
+clean-extracted-repos:  ## Remove built integrations files.
+	@if [ "${CLEAN_EXTRACTED_REPOS}" == "true" ]; \
+		then echo "\033[31m\033[1mCleaning all extracted repos, to persist these between builds, set CLEAN_EXTRACTED_REPOS=false in your Makefile.config \033[0m"; \
+	else \
+	  echo "\033[31m\033[1mSkipping cleaning extracted repos, to clean these between builds, set CLEAN_EXTRACTED_REPOS=true in your Makefile.config \033[0m"; \
+	  exit 0; \
+	fi
+
+
 	@rm -rf ./integrations_data/
 	@if [ -d data/integrations ]; then \
 		find ./data/integrations -type f -maxdepth 1 \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # make
 .PHONY: clean clean-all clean-build clean-examples clean-go-examples clean-java-examples clean-exe clean-extracted-repos clean-auto-doc clean-node clean-virt help start stop
 .DEFAULT_GOAL := help
+CLEAN_EXTRACTED_REPOS ?= true
 PY3=$(shell if [ `which pyenv` ]; then \
 				if [ `pyenv which python3` ]; then \
 					printf `pyenv which python3`; \
@@ -21,11 +22,16 @@ include $(CONFIG_FILE)
 help:
 	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
 
+ifeq ($(CLEAN_EXTRACTED_REPOS),true)
 clean: stop  ## Clean all make installs.
 	@echo "cleaning up..."
 	make clean-build
 	make clean-extracted-repos
 	make clean-auto-doc
+else
+clean:
+	echo "\033[31m\033[1mSkipping cleaning extracted repos, to clean these between builds, set CLEAN_EXTRACTED_REPOS=true in your Makefile.config \033[0m";
+endif
 
 clean-all: stop  ## Clean everything.
 	make clean-build
@@ -45,15 +51,9 @@ clean-exe:  ## Remove execs.
 	@rm -rf ${EXE_LIST}
 
 clean-extracted-repos:  ## Remove built integrations files.
-	@if [ "${CLEAN_EXTRACTED_REPOS}" == "true" ] || [ -z ${CLEAN_EXTRACTED_REPOS} ] ; \
-		then echo "\033[31m\033[1mCleaning all extracted repos, to persist these between builds, set CLEAN_EXTRACTED_REPOS=false in your Makefile.config \033[0m"; \
-		rm -rf ./integrations_data/; \
-	else \
-	  echo "\033[31m\033[1mSkipping cleaning extracted repos, to clean these between builds, set CLEAN_EXTRACTED_REPOS=true in your Makefile.config \033[0m"; \
-	  exit 0; \
-	fi
+	@echo "\033[31m\033[1mCleaning all extracted repos, to persist these between builds, set CLEAN_EXTRACTED_REPOS=false in your Makefile.config \033[0m"; \
 
-
+	@rm -rf ./integrations_data/
 	@if [ -d data/integrations ]; then \
 		find ./data/integrations -type f -maxdepth 1 \
 	    -a -not -name '*.fr.yaml' \

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -19,3 +19,4 @@ LOCALETC := local/etc
 EXEDIR := /usr/local/bin
 EXE_LIST := `find local/bin -type f -exec sh -c "echo ${EXEDIR}/{} | sed s@${LOCALBIN}/@@" \;`
 VIRENV=hugpython
+CLEAN_EXTRACTED_REPOS=true

--- a/local/bin/py/build/content_manager.py
+++ b/local/bin/py/build/content_manager.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import os
-
+import glob
 import requests
 
 from github_connect import GitHub
@@ -61,6 +61,22 @@ def update_globs(new_path, globs):
     return new_globs
 
 
+def extracted_files_exist(extracted_dir, globs):
+    """
+    Determines if the extracted globs already exist in a dir
+    if there are at least as many files as there are globs then its likely we have everything we need.
+    :param: extracted_dir dir containing already extracted files
+    :param globs: list of globs
+    :return: boolean
+    """
+    files = []
+    glob_count = len(globs)
+    for pattern in globs:
+        files = files + glob.glob(os.path.join(extracted_dir, pattern), recursive=True)
+    files = list(filter(lambda x: not x.endswith('.pickle'), files))
+    return len(files) >= glob_count
+
+
 def local_or_upstream(github_token, extract_dir, list_of_contents):
     """
     This goes through the list_of_contents and check for each repo specified in order:
@@ -80,7 +96,7 @@ def local_or_upstream(github_token, extract_dir, list_of_contents):
                 local_repo_path,
                 content["globs"],
             )
-        elif isdir(repo_path_last_extract):
+        elif isdir(repo_path_last_extract) and extracted_files_exist(repo_path_last_extract, content["globs"]):
             print(
                 f"\x1b[32mINFO\x1b[0m: Local version of {content['repo_name']} found from previous extract in:"
                 f" {repo_path_last_extract} "

--- a/local/bin/py/build/content_manager.py
+++ b/local/bin/py/build/content_manager.py
@@ -57,33 +57,42 @@ def update_globs(new_path, globs):
     """
     new_globs = []
     for item in globs:
-        new_globs.append("{}{}".format(new_path, item))
+        new_globs.append(os.path.join(new_path, item))
     return new_globs
 
 
 def local_or_upstream(github_token, extract_dir, list_of_contents):
     """
-    This goes through the list_of_contents and check for each repo specified
-    If a local version exists otherwise we download it from the upstream repo on Github
-    Local version of the repo should be in the same folder as the documentation/ folder.
+    This goes through the list_of_contents and check for each repo specified in order:
+      * Check if a locally cloned version is on this developer machine; one level above this documentation repo
+      * Check if this docs build has already pulled and stored the repos in an extract folder
+      * If neither of the above exist, pull the remote repo to use and store in the extract folder
     :param github_token: A valide Github token to download content with the Github Class
     :param extract_dir: Directory into which to put all content downloaded.
     :param list_of_content: List of content to check if available locally or if it needs to be downloaded from Github
     """
     for content in list_of_contents:
-        repo_name = "../" + content["repo_name"] + sep
-        if isdir(repo_name):
-            print("\x1b[32mINFO\x1b[0m: Local version of {} found".format(
-                content["repo_name"]))
+        local_repo_path = os.path.join("..", content["repo_name"])
+        repo_path_last_extract = os.path.join(extract_dir, content["repo_name"])
+        if isdir(local_repo_path):
+            print(f"\x1b[32mINFO\x1b[0m: Local version of {content['repo_name']} found in: {local_repo_path}")
             content["globs"] = update_globs(
-                repo_name,
+                local_repo_path,
+                content["globs"],
+            )
+        elif isdir(repo_path_last_extract):
+            print(
+                f"\x1b[32mINFO\x1b[0m: Local version of {content['repo_name']} found from previous extract in:"
+                f" {repo_path_last_extract} "
+            )
+            content["globs"] = update_globs(
+                repo_path_last_extract,
                 content["globs"],
             )
         elif github_token != "false":
             print(
-                "\x1b[32mINFO\x1b[0m: No local version of {} found, downloading content from upstream version".format(
-                    content["repo_name"]
-                )
+                f"\x1b[32mINFO\x1b[0m: No local version of {content['repo_name']} found, downloading content from "
+                "upstream version "
             )
             download_from_repo(github_token,
                                content["org_name"],
@@ -166,12 +175,12 @@ def prepare_content(configuration, github_token, extract_dir):
     try:
         list_of_contents = local_or_upstream(
             github_token, extract_dir, extract_config(configuration))
-    except:
+    except Exception as e:
         if getenv("LOCAL") == 'True':
             print(
-                "\x1b[33mWARNING\x1b[0m: Downloading files failed, documentation is now in degraded mode.")
+                f"\x1b[33mWARNING\x1b[0m: Downloading files failed, documentation is now in degraded mode. Error: {e}")
         else:
             print(
-                "\x1b[31mERROR\x1b[0m: Downloading files failed, stopping build.")
+                f"\x1b[31mERROR\x1b[0m: Downloading files failed, stopping build. Error: {e}")
             sys.exit(1)
     return list_of_contents


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* Adds some extra logging of exceptions when they occur to have a better idea of the underlying issue
* Renames the `clean-integration` make command to `clean-external-repos`; this better reflects what its cleaning up. While I believe this used to be integration folders, its grown a lot and now includes a lot of other cloned repositories.
* The biggest part of this PR is the addition of a new `CLEAN_EXTRACTED_REPOS` flag. Before PR, every local build would re-pull every dependent repository and then build the docs site. If this is flipped to `false` in your Makefile.config, it'll reuse what the last build pulled. Locally for me, this cut the build down to about 9 seconds. 

### Motivation
<!-- What inspired you to submit this pull request?-->
While working on adding a different change, I ran into some longer local build times and timeouts from pulling all the external repositories this build depends on. 


<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
