### PR TITLE
Update build.gradle dd-trace-api implementation

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/dd_libraries/java.md
@@ -291,7 +291,7 @@ Add the `dd-trace-api` dependency to your project. For Maven, add this to `pom.x
 For Gradle, add:
 
 ```gradle
-implementation group: 'com.datadoghq', name: 'dd-trace-api', version: {version}
+implementation 'com.datadoghq:dd-trace-api:{version}'
 ```
 
 Now add `@Trace` to methods to have them be traced when running with `dd-java-agent.jar`. If the Agent is not attached, this annotation does not affect your application.


### PR DESCRIPTION
Previous implementation "group: 'com.datadoghq', name: 'dd-trace-api', version: {version}" resulted in build errors as the endpoint returned 404.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
