### PR TITLE
[CIAPP] add clarification on pipelines list

### DIFF
--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -136,7 +136,7 @@ If the same test is collected several times for the same commit but with differe
 
 The default branch is used to power some features of the products, namely:
 
-Default branches list: This list only displays default branches. Setting the wrong default branch can result in missing or incorrect data in the default branches list.
+- Default branches list: This list only displays default branches. Setting the wrong default branch can result in missing or incorrect data in the default branches list.
 
 - Wall Time comparison for non-default branches: in the Branches list page, the **VS Default** column is calculated comparing wall time for the current branch against wall time for the default branch.
 

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -136,7 +136,7 @@ If the same test is collected several times for the same commit but with differe
 
 The default branch is used to power some features of the products, namely:
 
-- Tests Default branches list: This list only displays default branches. Setting the wrong default branch can result in missing or incorrect data in the default branches list.
+- Default branches list on the Tests page: This list only displays default branches. Setting the wrong default branch can result in missing or incorrect data in the default branches list.
 
 - Tests Wall Time comparison for non-default branches: in the Tests Branches list page, the **VS Default** column is calculated comparing wall time for the current branch against wall time for the default branch.
 

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -136,13 +136,13 @@ If the same test is collected several times for the same commit but with differe
 
 The default branch is used to power some features of the products, namely:
 
-- Default branches list: only default branches are displayed there, so a branch that is not results in a missing item from this table or the wrong branch being displayed.
+Default branches list: This list only displays default branches. Setting the wrong default branch can result in missing or incorrect data in the default branches list.
 
 - Wall Time comparison for non-default branches: in the Branches list page, the **VS Default** column is calculated comparing wall time for the current branch against wall time for the default branch.
 
 - New flaky tests: Tests that are not currently classified as flaky in the default branch. If the default branch is not properly set, this could lead to a wrong number of detected new flaky tests.
 
-- Pipelines list: only default branches are displayed there, so a branch that is not results in a missing item from this table or the wrong branch being displayed.
+- Pipelines list: The pipelines list only displays default branches. Setting the wrong default branch can result in missing or incorrect data in the pipelines list.
 
 #### How to fix the default branch
 

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -142,6 +142,8 @@ The default branch is used to power some features of the products, namely:
 
 - New flaky tests: Tests that are not currently classified as flaky in the default branch. If the default branch is not properly set, this could lead to a wrong number of detected new flaky tests.
 
+- Pipelines list: only default branches are displayed there, so a branch that is not results in a missing item from this table or the wrong branch being displayed.
+
 #### How to fix the default branch
 
 If you have admin access, you can update it from the [Repository Settings Page][11].

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -138,7 +138,7 @@ The default branch is used to power some features of the products, namely:
 
 - Default branches list on the Tests page: This list only displays default branches. Setting the wrong default branch can result in missing or incorrect data in the default branches list.
 
-- Tests Wall Time comparison for non-default branches: in the Tests Branches list page, the **VS Default** column is calculated comparing wall time for the current branch against wall time for the default branch.
+- Wall time comparison for non-default branches: On the Tests page, in the Branches view, the **VS Default** column is calculated by comparing wall time for the current branch against wall time for the default branch.
 
 - New flaky tests: Tests that are not currently classified as flaky in the default branch. If the default branch is not properly set, this could lead to a wrong number of detected new flaky tests.
 

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -136,9 +136,9 @@ If the same test is collected several times for the same commit but with differe
 
 The default branch is used to power some features of the products, namely:
 
-- Default branches list: This list only displays default branches. Setting the wrong default branch can result in missing or incorrect data in the default branches list.
+- Tests Default branches list: This list only displays default branches. Setting the wrong default branch can result in missing or incorrect data in the default branches list.
 
-- Wall Time comparison for non-default branches: in the Branches list page, the **VS Default** column is calculated comparing wall time for the current branch against wall time for the default branch.
+- Tests Wall Time comparison for non-default branches: in the Tests Branches list page, the **VS Default** column is calculated comparing wall time for the current branch against wall time for the default branch.
 
 - New flaky tests: Tests that are not currently classified as flaky in the default branch. If the default branch is not properly set, this could lead to a wrong number of detected new flaky tests.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This PR clarifies that only default branches are displayed in the Pipelines list. This follows a change that we are doing to remove non-default branches from that list.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
