### PR TITLE
update istio sampling wording

### DIFF
--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -575,6 +575,8 @@ of the higher-level `CronJob`.
 
 To control the volume of traces starting from Istio that are sent to Datadog, specify a sampling rate by setting the parameter `DD_TRACE_SAMPLING_RULES` to a value between `0.0` (0%) and `1.0` (100%). If no value is specified, 100% of traces starting from Istio are sent.
 
+**Note:** These sampling environment variables rules work if `--set values.pilot.traceSampling=100.0` has been configured.
+
 To use the [Datadog Agent calculated sampling rates][9] (10 traces per second per Agent) and ignore the default sampling rule set to 100%, set the parameter `DD_TRACE_SAMPLING_RULES` to an empty array:
 
 ```

--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -575,7 +575,7 @@ of the higher-level `CronJob`.
 
 To control the volume of traces starting from Istio that are sent to Datadog, specify a sampling rate by setting the parameter `DD_TRACE_SAMPLING_RULES` to a value between `0.0` (0%) and `1.0` (100%). If no value is specified, 100% of traces starting from Istio are sent.
 
-**Note:** These sampling environment variables rules work if `--set values.pilot.traceSampling=100.0` has been configured.
+Note that these environment variables apply only to the subset of traces indicated by the `values.pilot.traceSampling` setting, hence the required `--set values.pilot.traceSampling=100.0` during Istio configuration.
 
 To use the [Datadog Agent calculated sampling rates][9] (10 traces per second per Agent) and ignore the default sampling rule set to 100%, set the parameter `DD_TRACE_SAMPLING_RULES` to an empty array:
 

--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -575,7 +575,7 @@ of the higher-level `CronJob`.
 
 To control the volume of traces starting from Istio that are sent to Datadog, specify a sampling rate by setting the parameter `DD_TRACE_SAMPLING_RULES` to a value between `0.0` (0%) and `1.0` (100%). If no value is specified, 100% of traces starting from Istio are sent.
 
-Note that these environment variables apply only to the subset of traces indicated by the `values.pilot.traceSampling` setting, hence the required `--set values.pilot.traceSampling=100.0` during Istio configuration.
+**Note**: These environment variables apply only to the subset of traces indicated by the `values.pilot.traceSampling` setting, hence the required `--set values.pilot.traceSampling=100.0` during Istio configuration.
 
 To use the [Datadog Agent calculated sampling rates][9] (10 traces per second per Agent) and ignore the default sampling rule set to 100%, set the parameter `DD_TRACE_SAMPLING_RULES` to an empty array:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Clarifies that `--set values.pilot.traceSampling=100.0` must be configured when trying to follow the Istio sampling section. 

### Motivation
<!-- What inspired you to submit this pull request?-->

Ensure that `--set values.pilot.traceSampling=100.0` is set for Istio. If it isn't, then the defaul sampling mechanism will lead to the `DD_TRACE_SAMPLING_RULES` parameter being ignored.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
