### PR TITLE
Fix a typo in a terraform example

### DIFF
--- a/content/en/monitors/service_level_objectives/burn_rate.md
+++ b/content/en/monitors/service_level_objectives/burn_rate.md
@@ -147,7 +147,7 @@ resource "datadog_monitor" "metric-based-slo" {
     EOT
 
     message = "Example monitor message"
-    monitor_thresholds = {
+    monitor_thresholds {
       critical = 14.4
     }
     tags = ["foo:bar", "baz"]


### PR DESCRIPTION
### What does this PR do?
Fix a typo, otherwise terraform throws an error for this syntax. The example in https://github.com/DataDog/documentation/blob/master/content/en/monitors/service_level_objectives/error_budget.md is correct. With this fix, terraform succeded.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
