### PR TITLE
Make sure key in example reflects image below

### DIFF
--- a/content/en/logs/log_configuration/parsing.md
+++ b/content/en/logs/log_configuration/parsing.md
@@ -44,7 +44,7 @@ john connected on 11/08/2017
 With the following parsing rule:
 
 ```text
-MyParsingRule %{word:user} connected on %{date("MM/dd/yyyy"):connect_date}
+MyParsingRule %{word:user} connected on %{date("MM/dd/yyyy"):date}
 ```
 
 After processing, the following structured log is generated:


### PR DESCRIPTION
The extraction in the image is "date" for the example "MyParsingRule %{word:user} connected on %{date("MM/dd/yyyy"):connect_date}"

Remove "connect_" to reflect the key in the image.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Changing documentation for the example at the top of the page to reflect the key in the image below it.

### Motivation
Noticing the key wasn't connect_date in the image.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
