### PR TITLE
Update python.md to correct DD_DOGSTATSD_URL protocol

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/python.md
+++ b/content/en/tracing/trace_collection/dd_libraries/python.md
@@ -108,7 +108,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 
    If a different configuration is required, the `DD_DOGSTATSD_URL` environment variable can be used. Some examples:
    ```
-   DD_DOGSTATSD_URL=http://custom-hostname:1234
+   DD_DOGSTATSD_URL=udp://custom-hostname:1234
    DD_DOGSTATSD_URL=unix:///var/run/datadog/dsd.socket
    ```
    The connection for stats can also be configured in code:

--- a/content/en/tracing/trace_collection/dd_libraries/python.md
+++ b/content/en/tracing/trace_collection/dd_libraries/python.md
@@ -118,7 +118,7 @@ Install and configure the Datadog Agent to receive traces from your now instrume
 
    # Network socket
    tracer.configure(
-     dogstatsd_url="http://localhost:8125",
+     dogstatsd_url="udp://localhost:8125",
    )
 
    # Unix domain socket configuration


### PR DESCRIPTION
protocol is incorrect and if followed generates error:
```
/lib/python3.7/site-packages/ddtrace/internal/dogstatsd.py", line 28, in get_dogstatsd_client
    raise ValueError("Unknown scheme `%s` for DogStatsD URL `{}`".format(parsed.scheme))
ValueError: Unknown scheme `%s` for DogStatsD URL `http`
```

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
fixes incorrect documentation example of env var

### Motivation
fix incorrect information

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
