### PR TITLE
[DOCS-3709] Add dependencies for obs pipelines docs

### DIFF
--- a/content/en/integrations/observability_pipelines/guide/_index.md
+++ b/content/en/integrations/observability_pipelines/guide/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Observability Pipelines Guides
 kind: guide
+private: true
+disable_sidebar: true
 ---
 
 {{< whatsnext desc="General guides:" >}}

--- a/content/en/integrations/observability_pipelines/guide/_index.md
+++ b/content/en/integrations/observability_pipelines/guide/_index.md
@@ -2,7 +2,7 @@
 title: Observability Pipelines Guides
 kind: guide
 private: true
-disable_sidebar: true
+disable_toc: true
 ---
 
 {{< whatsnext desc="General guides:" >}}

--- a/content/en/integrations/observability_pipelines/guide/custom-metrics-governance-drop-metrics-missing-specific-tags.md
+++ b/content/en/integrations/observability_pipelines/guide/custom-metrics-governance-drop-metrics-missing-specific-tags.md
@@ -1,6 +1,8 @@
 ---
 title: Custom Metrics Governance - Drop Metrics Missing Specific Tags
 kind: guide
+dependencies:
+  ["https://github.com/DataDog/documentation/blob/master/content/en/integrations/observability_pipelines/guide/custom-metrics-governance-drop-metrics-missing-specific-tags.md"]
 aliases:
   - /metrics/custom_metrics/guide/custom-metrics-governance-drop-metrics-missing-specific-tags
 further_reading:

--- a/content/en/integrations/observability_pipelines/integrations.md
+++ b/content/en/integrations/observability_pipelines/integrations.md
@@ -1,6 +1,8 @@
 ---
 title: Integrations
 kind: Documentation
+dependencies:
+  ["https://github.com/DataDog/documentation/blob/master/content/en/integrations/observability_pipelines/integrations.md"]
 ---
 ## Overview
 

--- a/content/en/integrations/observability_pipelines/setup.md
+++ b/content/en/integrations/observability_pipelines/setup.md
@@ -1,6 +1,8 @@
 ---
 title: Set up Observability Pipelines
 kind: Documentation
+dependencies:
+  ["https://github.com/DataDog/documentation/blob/master/content/en/integrations/observability_pipelines/setup.md"]
 further_reading:
   - link: /integrations/observability_pipelines/vector_configurations/
     tag: Documentation

--- a/content/en/integrations/observability_pipelines/vector_configurations.md
+++ b/content/en/integrations/observability_pipelines/vector_configurations.md
@@ -1,6 +1,8 @@
 ---
 title: Vector Configurations
 kind: Documentation
+dependencies:
+  ["https://github.com/DataDog/documentation/blob/master/content/en/integrations/observability_pipelines/vector_configurations.md"]
 further_reading:
   - link: /integrations/observability_pipelines/working_with_data/
     tag: Documentation

--- a/content/en/integrations/observability_pipelines/working_with_data.md
+++ b/content/en/integrations/observability_pipelines/working_with_data.md
@@ -1,6 +1,8 @@
 ---
 title: Working with Data
 kind: Documentation
+dependencies:
+  ["https://github.com/DataDog/documentation/blob/master/content/en/integrations/observability_pipelines/working_with_data.md"]
 further_reading:
   - link: https://vector.dev/docs/reference/configuration/transforms/aws_ec2_metadata/
     tag: Documentation


### PR DESCRIPTION
### What does this PR do?

The Observability Pipelines are currently under Integrations, and because of how the Integrations are setup, those docs don't have an Edit button. I added dependencies to the frontmatter so that there is an Edit button for Obs Pipelines docs.

Also made the Guide index private and disabled the sidebar, because it looks like that's what it should be based on other Guide indexes.

### Motivation

DOCS-3709

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
