### PR TITLE
[WEB-2482] fix jest tests + add to preview pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,7 @@ build_preview:
     #- sync_integration_descriptions_cached
     - placehold_translations
     - update_preview_baseurl
-    - yarn run test
+    - jest assets/scripts/tests
     - yarn run prebuild
     - yarn run build:preview
     # remove service_checks json as we don't need to s3 push that..

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ build_preview:
     - placehold_translations
     - update_preview_baseurl
     # - yarn run jest
-    - jest assets/scripts/tests/lang-redirects.test.js 
+    - ./node_modules/.bin/jest assets/scripts/tests/lang-redirects.test.js 
     - yarn run prebuild
     - yarn run build:preview
     # remove service_checks json as we don't need to s3 push that..

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,6 @@ build_preview:
     - make BRANCH=${CI_COMMIT_REF_NAME} examples
     - sync_integration_descriptions
     - ./local/bin/py/build/pull_rbac.py $(get_secret 'dd-api-key') $(get_secret 'dd-app-key')
-    #- sync_integration_descriptions_cached
     - placehold_translations
     - update_preview_baseurl
     - yarn run jest-test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,8 @@ build_preview:
     #- sync_integration_descriptions_cached
     - placehold_translations
     - update_preview_baseurl
-    - yarn run jest
+    # - yarn run jest
+    - jest assets/scripts/tests/lang-redirects.test.js 
     - yarn run prebuild
     - yarn run build:preview
     # remove service_checks json as we don't need to s3 push that..

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,7 @@ build_preview:
     #- sync_integration_descriptions_cached
     - placehold_translations
     - update_preview_baseurl
-    - jest assets/scripts/tests
+    - yarn run test
     - yarn run prebuild
     - yarn run build:preview
     # remove service_checks json as we don't need to s3 push that..

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,8 +85,7 @@ build_preview:
     #- sync_integration_descriptions_cached
     - placehold_translations
     - update_preview_baseurl
-    # - yarn run jest
-    - ./node_modules/.bin/jest assets/scripts/tests/lang-redirects.test.js 
+    - yarn run jest
     - yarn run prebuild
     - yarn run build:preview
     # remove service_checks json as we don't need to s3 push that..

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ build_preview:
     - ./local/bin/py/build/pull_rbac.py $(get_secret 'dd-api-key') $(get_secret 'dd-app-key')
     - placehold_translations
     - update_preview_baseurl
-    - yarn run jest-test
+    - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
     - yarn run prebuild
     - yarn run build:preview
     # remove service_checks json as we don't need to s3 push that..

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,7 @@ build_preview:
     #- sync_integration_descriptions_cached
     - placehold_translations
     - update_preview_baseurl
-    - yarn run jest
+    - yarn run jest-test
     - yarn run prebuild
     - yarn run build:preview
     # remove service_checks json as we don't need to s3 push that..

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,7 @@ build_preview:
     #- sync_integration_descriptions_cached
     - placehold_translations
     - update_preview_baseurl
-    - yarn run test
+    - yarn run jest
     - yarn run prebuild
     - yarn run build:preview
     # remove service_checks json as we don't need to s3 push that..

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,15 +84,15 @@ build_preview:
     - ./local/bin/py/build/pull_rbac.py $(get_secret 'dd-api-key') $(get_secret 'dd-app-key')
     - placehold_translations
     - update_preview_baseurl
-    - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
+    # - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
     - yarn run prebuild
     - yarn run build:preview
     # remove service_checks json as we don't need to s3 push that..
-    - rm -rf data/service_checks
-    - in-isolation deploy_preview > logs/deploy.txt
-    # remove static images so we can skip from artifact passed in gitlab
-    - remove_static_from_repo
-    - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_REF_NAME}> is ready for preview. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." "#31b834"
+    # - rm -rf data/service_checks
+    # - in-isolation deploy_preview > logs/deploy.txt
+    # # remove static images so we can skip from artifact passed in gitlab
+    # - remove_static_from_repo
+    # - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_REF_NAME}> is ready for preview. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." "#31b834"
   artifacts:
     paths:
       - ${ARTIFACT_RESOURCE}
@@ -105,9 +105,40 @@ build_preview:
     - /.+?\/[a-zA-Z0-9_-]+/
   interruptible: true
 
+test_preview:
+  <<: *base_template
+  stage: build
+  needs: ["build_preview"]
+  environment: "preview"
+  script:
+    - echo "Test test preview"
+    - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
+  only:
+    - /.+?\/[a-zA-Z0-9_-]+/
+  interruptible: true
+
+deploy_preview:
+  <<: *base_template
+  stage: build
+  needs: ["build_preview"]
+  cache:
+    - *yarn_cache_pull_push
+  environment: "preview"
+  script:
+    - echo "Test deploy preview"
+    # - rm -rf data/service_checks
+    # - in-isolation deploy_preview > logs/deploy.txt
+    # # remove static images so we can skip from artifact passed in gitlab
+    # - remove_static_from_repo
+    # - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_REF_NAME}> is ready for preview. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." "#31b834"
+  only:
+    - /.+?\/[a-zA-Z0-9_-]+/
+  interruptible: true
+
 link_checks_preview:
   <<: *base_template
-  stage: post-deploy
+  stage: build
+  needs: ["build_preview"]
   cache: {}
   environment: "preview"
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,15 +84,15 @@ build_preview:
     - ./local/bin/py/build/pull_rbac.py $(get_secret 'dd-api-key') $(get_secret 'dd-app-key')
     - placehold_translations
     - update_preview_baseurl
-    # - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
+    - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
     - yarn run prebuild
     - yarn run build:preview
     # remove service_checks json as we don't need to s3 push that..
-    # - rm -rf data/service_checks
-    # - in-isolation deploy_preview > logs/deploy.txt
-    # # remove static images so we can skip from artifact passed in gitlab
-    # - remove_static_from_repo
-    # - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_REF_NAME}> is ready for preview. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." "#31b834"
+    - rm -rf data/service_checks
+    - in-isolation deploy_preview > logs/deploy.txt
+    # remove static images so we can skip from artifact passed in gitlab
+    - remove_static_from_repo
+    - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_REF_NAME}> is ready for preview. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." "#31b834"
   artifacts:
     paths:
       - ${ARTIFACT_RESOURCE}
@@ -105,40 +105,9 @@ build_preview:
     - /.+?\/[a-zA-Z0-9_-]+/
   interruptible: true
 
-test_preview:
-  <<: *base_template
-  stage: build
-  needs: ["build_preview"]
-  environment: "preview"
-  script:
-    - echo "Test test preview"
-    - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
-  only:
-    - /.+?\/[a-zA-Z0-9_-]+/
-  interruptible: true
-
-deploy_preview:
-  <<: *base_template
-  stage: build
-  needs: ["build_preview"]
-  cache:
-    - *yarn_cache_pull_push
-  environment: "preview"
-  script:
-    - echo "Test deploy preview"
-    # - rm -rf data/service_checks
-    # - in-isolation deploy_preview > logs/deploy.txt
-    # # remove static images so we can skip from artifact passed in gitlab
-    # - remove_static_from_repo
-    # - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_REF_NAME}> is ready for preview. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." "#31b834"
-  only:
-    - /.+?\/[a-zA-Z0-9_-]+/
-  interruptible: true
-
 link_checks_preview:
   <<: *base_template
-  stage: build
-  needs: ["build_preview"]
+  stage: post-deploy
   cache: {}
   environment: "preview"
   variables:
@@ -276,7 +245,6 @@ build_live:
     expire_in: 1 week
   only:
     - master
-
 
 index_internal_doc:
   stage: post-deploy
@@ -446,16 +414,6 @@ test_pa11y:
     - node ./local/bin/js/pa11y.js --env live --dd_api_key $(get_secret 'dd-api-key')
   only:
     - schedules
-
-#rollback_live:
-#  <<: *base_template
-#  stage: cleanup
-#  environment: "live"
-#  when: on_failure
-#  script:
-#    - rollback_env
-#  only:
-#    - master
 
 tag_successful_live_pipeline:
   <<: *base_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,6 +85,7 @@ build_preview:
     #- sync_integration_descriptions_cached
     - placehold_translations
     - update_preview_baseurl
+    - yarn run test
     - yarn run prebuild
     - yarn run build:preview
     # remove service_checks json as we don't need to s3 push that..

--- a/assets/scripts/tests/api-redirect.test.js
+++ b/assets/scripts/tests/api-redirect.test.js
@@ -51,5 +51,4 @@ describe(`Check if current page is an old API page, and redirect if able`, () =>
 
         expect(actual).toEqual(expected);
     });
-
 });

--- a/assets/scripts/tests/build-api-pages.test.js
+++ b/assets/scripts/tests/build-api-pages.test.js
@@ -19,7 +19,6 @@ describe(`createResources`, () => {
 });
 
 describe(`getSchema`, () => {
-
   it('should return the schema object with non application/json formatted first key', () => {
     const expected = {
         "description": "This is a test",
@@ -80,7 +79,6 @@ describe(`getSchema`, () => {
 });
 
 describe(`getTagSlug`, () => {
-
   it('should return lowercase', () => {
       const expected = "integration";
       const actual = bp.getTagSlug("Integration");
@@ -107,7 +105,7 @@ describe(`getTagSlug`, () => {
 
 });
 
-describe(`isTagMatch `, () => {
+describe(`isTagMatch`, () => {
 
   let pathObj;
 
@@ -241,7 +239,6 @@ rule_name_2 bar
 });
 
 describe(`getJsonWrapChars `, () => {
-
   it('should return array chars when data.items', () => {
     const mockInput = {
       "type": "array",
@@ -780,8 +777,9 @@ describe(`filterExampleJson`, () => {
       },
       "type": "object"
     };
+
     const actual = bp.filterExampleJson("request", mockSchema);
-    const expected = {"service_hooks": [{"account": "Main_Account", "url": "https://hooks.slack.com/services/1/1/1"},{"account": "doghouse", "url": "https://hooks.slack.com/services/2/2/2"}]};
+    const expected = {"service_hooks": [{"account": "doghouse", "url": "https://hooks.slack.com/services/2/2/2"}]}
     expect(actual).toEqual(expected);
   });
 

--- a/package.json
+++ b/package.json
@@ -37,16 +37,6 @@
     "engines": {
         "node": ">= 14.16.0"
     },
-    "jest": {
-        "collectCoverage": true,
-        "collectCoverageFrom": [
-            "./assets/scripts/tests/*.js",
-            "!**/node_modules/**",
-            "!**/examples/**",
-            "!**/*.ts",
-            "!**/*.test.ts"
-        ]
-    },
     "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^8.0.0",
         "@babel/polyfill": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "engines": {
         "node": ">= 14.16.0"
     },
+    "jest": {
+        "coveragePathIgnorePatterns": ["<rootDir>/examples/"]
+    },
     "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^8.0.0",
         "@babel/polyfill": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "deploy:live": "./node_modules/.bin/hugo deploy --target live -e live --maxDeletes -1 --log --verbose --debug",
         "build:apiPages": "node -e 'require(\"./assets/scripts/build-api-pages.js\").init()'",
         "dereference": "node ./assets/scripts/dereference.js",
-        "test": "./node_modules/.bin/jest assets/scripts/tests"
+        "test": "./node_modules/.bin/jest",
+        "jest": "./node_modules/.bin/jest ./assets/scripts/tests"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,12 @@
         "node": ">= 14.16.0"
     },
     "jest": {
-        "coveragePathIgnorePatterns": ["*/examples/*"]
+        "collectCoverage": true,
+        "collectCoverageFrom": [
+            "./assets/scripts/tests/*.js",
+            "!**/node_modules/**",
+            "!**/examples/**"
+        ]
     },
     "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "deploy:live": "./node_modules/.bin/hugo deploy --target live -e live --maxDeletes -1 --log --verbose --debug",
         "build:apiPages": "node -e 'require(\"./assets/scripts/build-api-pages.js\").init()'",
         "dereference": "node ./assets/scripts/dereference.js",
-        "test": "./node_modules/.bin/jest"
+        "test": "./node_modules/.bin/jest assets/scripts/tests"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "node": ">= 14.16.0"
     },
     "jest": {
-        "coveragePathIgnorePatterns": ["<rootDir>/examples/"]
+        "coveragePathIgnorePatterns": ["examples/datadog-api-client-typescript/tests/api/deserialization.test.ts"]
     },
     "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "deploy:live": "./node_modules/.bin/hugo deploy --target live -e live --maxDeletes -1 --log --verbose --debug",
         "build:apiPages": "node -e 'require(\"./assets/scripts/build-api-pages.js\").init()'",
         "dereference": "node ./assets/scripts/dereference.js",
-        "jest": "./node_modules/.bin/jest ./assets/scripts/tests"
+        "jest-test": "./node_modules/.bin/jest ./assets/scripts/tests"
     },
     "repository": {
         "type": "git",
@@ -42,7 +42,9 @@
         "collectCoverageFrom": [
             "./assets/scripts/tests/*.js",
             "!**/node_modules/**",
-            "!**/examples/**"
+            "!**/examples/**",
+            "!**/*.ts",
+            "!**/*.test.ts"
         ]
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
         "deploy:live": "./node_modules/.bin/hugo deploy --target live -e live --maxDeletes -1 --log --verbose --debug",
         "build:apiPages": "node -e 'require(\"./assets/scripts/build-api-pages.js\").init()'",
         "dereference": "node ./assets/scripts/dereference.js",
-        "test": "./node_modules/.bin/jest",
         "jest": "./node_modules/.bin/jest ./assets/scripts/tests"
     },
     "repository": {
@@ -39,7 +38,7 @@
         "node": ">= 14.16.0"
     },
     "jest": {
-        "coveragePathIgnorePatterns": ["examples/datadog-api-client-typescript/tests/api/deserialization.test.ts"]
+        "coveragePathIgnorePatterns": ["*/examples/*"]
     },
     "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^8.0.0",


### PR DESCRIPTION
### What does this PR do?
fix jest tests and configure jest to run in the preview build pipeline

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2482

### Preview
n/a

- job ran successfully and unit tests passed: https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/153000483#L3969-L3979
- `yarn run jest-test` works locally

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
