### PR TITLE
Update instruction to ignore some apm resources ruby tracer

### DIFF
--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -236,7 +236,7 @@ The Ruby tracer has a post-processing pipeline that deletes traces that meet cer
 For example, if the resource name is `Api::HealthchecksController#index`, use the `trace.delete_if` method to delete traces that contain the resource name. This filter can also be used to match on other metadata available for the [span object][2].
 
 ```
-Datadog::Tracing::Pipeline.before_flush do |trace|
+Datadog::Tracing.before_flush do |trace|
   trace.delete_if { |span| span.resource =~ /Api::HealthchecksController#index/ }
 end
 ```


### PR DESCRIPTION
Reference https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#processing-pipeline

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
The old configuration block is no longer valid for version 1.x of Ruby ddtracer-rb. 
This is the link to the reference: https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#processing-pipeline 

### Motivation
<!-- What inspired you to submit this pull request?-->
I am a customer and suffering wrong configurations that affects my billing because this part is outdated. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
