### PR TITLE
[DOCS-3732] Update help page

### DIFF
--- a/content/en/account_management/faq/access-your-support-ticket.md
+++ b/content/en/account_management/faq/access-your-support-ticket.md
@@ -61,8 +61,8 @@ If you have opened at least one Datadog support ticket, follow this process to a
 {{< /site-region >}}
 
 ## Error: Refused to connect
-**Refused to connect** errors come from privacy settings that block third-party cookies. To solve this issue, make sure the browser allows third-party cookies from Zendesk. Find instructions on how to [Clear, enable, and manage cookies in Chrome][2] in Google Chrome Help.
+**Refused to connect** errors come from privacy settings that block third-party cookies. To solve this issue, make sure the browser allows third-party cookies from Zendesk. Find instructions on how to [Clear, enable, and manage cookies in Chrome][1] in Google Chrome Help.
 
 If your browser has ad-blockers, turn them off to see if this allows you to sign in. Some ad-blockers have their own list of exceptions. In this case, add **datadog.zendesk.com** to the allow list.
 
-[2]: https://support.google.com/chrome/answer/95647
+[1]: https://support.google.com/chrome/answer/95647

--- a/content/en/account_management/faq/access-your-support-ticket.md
+++ b/content/en/account_management/faq/access-your-support-ticket.md
@@ -1,5 +1,5 @@
 ---
-title: Access your support ticket
+title: Access Your Support Ticket
 kind: faq
 aliases:
   - /developers/faq/access-your-support-ticket

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -48,7 +48,7 @@
   },
 
   "email_support_sentence": {
-    "other": "You can contact our Support Team by visiting <a href=\"http://help.datadoghq.com\" target=\"_blank\" rel=\"noopener\">Datadog's Support Website</a>. (all sites)."
+    "other": "You can contact our Support Team by visiting <a href=\"http://help.datadoghq.com\" target=\"_blank\" rel=\"noopener\">Datadog's Support Website</a>. (all sites). <br><br> For details on how to log into the Support Website, see <a href=\"https://docs.datadoghq.com/account_management/faq/access-your-support-ticket\" target=\"_blank\"> Access Your Support Ticket</a>."
   },
 
   "live_chat_support_sentence": {


### PR DESCRIPTION
### What does this PR do?

- Adds info and link to page on how to log into Support Website.
- Title case for Access Your Support Ticket page, and fix link list.

### Motivation

DOCS-3732

Previews: 

https://docs-staging.datadoghq.com/may/update-help-page/help/
https://docs-staging.datadoghq.com/may/update-help-page/account_management/faq/access-your-support-ticket/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
