### PR TITLE
dbm: Add MySQL troubleshooting for missing event statements consumer

### DIFF
--- a/content/en/database_monitoring/setup_mysql/troubleshooting.md
+++ b/content/en/database_monitoring/setup_mysql/troubleshooting.md
@@ -89,16 +89,16 @@ DD_LOG_LEVEL=debug DBM_THREADED_JOB_RUN_SYNC=true agent check sqlserver -t 2
 Some or all queries may not have plans available. This can be due to unsupported query commands, queries made by unsupported client applications, an outdated Agent, or incomplete database setup. Below are possible causes for missing explain plans.
 
 #### Missing event statements consumer {#events-statements-consumer-missing}
-Enabling an event statements consumer is required to capture explain plans. To enable a consumer, add the following option to your configuration files (for example, `mysql.conf`):
+To capture explain plans, you must enable an event statements consumer. You can do this by adding the following option to your configuration files (for example, `mysql.conf`):
 ```
 performance-schema-consumer-events-statements-current=ON
 ```
 
-Datadog additionally recommends enabling:
+Datadog additionally recommends enabling the following:
 ```
 performance-schema-consumer-events-statements-history-long=ON
 ```
-This enables tracking of a larger number of recent queries across all threads. If enabled, it increases the likelihood of capturing execution details from infrequent queries.
+This option enables the tracking of a larger number of recent queries across all threads. Turning it on increases the likelihood of capturing execution details from infrequent queries.
 
 #### Missing explain plan procedure {#explain-plan-procedure-missing}
 The Agent requires the procedure `datadog.explain_statement(...)` to exist in the `datadog` schema. Read the [setup instructions][1] for details on the creation of the `datadog` schema.

--- a/content/en/database_monitoring/setup_mysql/troubleshooting.md
+++ b/content/en/database_monitoring/setup_mysql/troubleshooting.md
@@ -98,7 +98,7 @@ Datadog additionally recommends enabling:
 ```
 performance-schema-consumer-events-statements-history-long=ON
 ```
-This enables tracking of a larger number of recent queries across all threads. If enabled it increases the likelihood of capturing execution details from infrequent queries.
+This enables tracking of a larger number of recent queries across all threads. If enabled, it increases the likelihood of capturing execution details from infrequent queries.
 
 #### Missing explain plan procedure {#explain-plan-procedure-missing}
 The Agent requires the procedure `datadog.explain_statement(...)` to exist in the `datadog` schema. Read the [setup instructions][1] for details on the creation of the `datadog` schema.

--- a/content/en/database_monitoring/setup_mysql/troubleshooting.md
+++ b/content/en/database_monitoring/setup_mysql/troubleshooting.md
@@ -88,6 +88,18 @@ DD_LOG_LEVEL=debug DBM_THREADED_JOB_RUN_SYNC=true agent check sqlserver -t 2
 
 Some or all queries may not have plans available. This can be due to unsupported query commands, queries made by unsupported client applications, an outdated Agent, or incomplete database setup. Below are possible causes for missing explain plans.
 
+#### Missing event statements consumer {#events-statements-consumer-missing}
+Enabling an event statements consumer is required to capture explain plans. To enable a consumer, add the following option to your configuration files (for example, `mysql.conf`):
+```
+performance-schema-consumer-events-statements-current=ON
+```
+
+Datadog additionally recommends enabling:
+```
+performance-schema-consumer-events-statements-history-long=ON
+```
+This enables tracking of a larger number of recent queries across all threads. If enabled it increases the likelihood of capturing execution details from infrequent queries.
+
 #### Missing explain plan procedure {#explain-plan-procedure-missing}
 The Agent requires the procedure `datadog.explain_statement(...)` to exist in the `datadog` schema. Read the [setup instructions][1] for details on the creation of the `datadog` schema.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a troubleshooting guide for customers missing explain plans due to a missing event statements consumer. 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
