### PR TITLE
Fix OTEL example config URL

### DIFF
--- a/content/en/tracing/trace_collection/open_standards/otel_collector_datadog_exporter.md
+++ b/content/en/tracing/trace_collection/open_standards/otel_collector_datadog_exporter.md
@@ -317,7 +317,7 @@ This configuration ensures consistent host metadata and centralizes the configur
 [4]: https://opentelemetry.io/docs/collector/configuration/
 [5]: https://app.datadoghq.com/organization-settings/api-keys
 [6]: /getting_started/site/
-[7]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/example/config.yaml
+[7]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/collector.yaml
 [8]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/design.md#pipelines
 [9]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/examples
 [10]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor#batch-processor


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR is to fix the URL for the example configuration file for OTEL.
### Motivation
<!-- What inspired you to submit this pull request?-->
Looking into how to configure OTEL Collector to send traces by using DataDog exporter.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
