### PR TITLE
feat(dataviz): include treemap generated properties table in the Treemap documentation

### DIFF
--- a/content/en/dashboards/widgets/treemap.md
+++ b/content/en/dashboards/widgets/treemap.md
@@ -55,6 +55,10 @@ Viewing the pie chart widget in full-screen reveals the standard set of [full-sc
 
 This widget can be used with the [Dashboards API][6].
 
+The dedicated [widget JSON schema definition][8] for the treemap widget is:
+
+{{< dashboards-widgets-api >}}
+
 ## Pie chart widget
 
 Like the treemap widget, the [pie chart widget][7] can also be used to display nested proportions. The primary difference between the two is that the pie chart displays proportions in radial slices, and the treemap displays nested rectangles.
@@ -70,3 +74,4 @@ Like the treemap widget, the [pie chart widget][7] can also be used to display n
 [5]: /dashboards/widgets/#full-screen
 [6]: /api/latest/dashboards/
 [7]: /dashboards/widgets/pie_chart/
+[8]: /dashboards/graphing_json/widget_json/


### PR DESCRIPTION

### What does this PR do?

- Includes a table of "props" table from the OpenAPI definition for the treemap, similar to what we have for the [distributions](https://docs.datadoghq.com/dashboards/widgets/distribution/#api) widget.

### Motivation

- Improve understanding of the Treemap API for consumers that are programmatically defining their treemaps

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
