### PR TITLE
Fix variable check when API or app keys are null

### DIFF
--- a/local/bin/sh/run-site.sh
+++ b/local/bin/sh/run-site.sh
@@ -24,10 +24,11 @@ if [ ${RUN_SERVER} = true ]; then
 	if [ ${PULL_RBAC_PERMISSIONS} == true ]; then
 		echo "Pulling RBAC permissions."
 
-		if [ ${DD_API_KEY} != false ] && [ ${DD_APP_KEY} != false ]; then
+		if [ -n "${DD_API_KEY}" ] && [ -n "${DD_APP_KEY}" ]; then
+      echo "API key and application key variables found."
 			pull_rbac.py ${DD_API_KEY} ${DD_APP_KEY}
 		else
-			echo "Api or application keys were not found. Skipping RBAC permissions."
+			echo "API or application keys were not found. Skipping RBAC permissions."
 		fi
 	fi
 


### PR DESCRIPTION
Fixes this error when variables are unset:
/usr/local/bin/run-site.sh: line 27: [: !=: unary operator expected

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
