### PR TITLE
[WEB-2534] fixes nested links inside tab containers

### DIFF
--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -91,7 +91,7 @@ const initCodeTabs = () => {
     }
 
     const addEventListeners = () => {
-        const allTabLinksNodeList = document.querySelectorAll('.code-tabs li a')
+        const allTabLinksNodeList = document.querySelectorAll('.code-tabs .nav-tabs li a')
 
         allTabLinksNodeList.forEach(link => {
             link.addEventListener('click', () => {


### PR DESCRIPTION
### What does this PR do?
Fixes links inside tab containers.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2534

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/tab-links-1/logs/log_collection

- [x] tab headers still work as expected
- [x] clicking links inside the tab headers works as expected (see live issue with links here: https://docs.datadoghq.com/logs/log_collection/?tabs=host)
- [x] no related console errors are present
- [x] test a few other preview pages with tabs (https://docs-staging.datadoghq.com/brian.deutsch/tab-links-1/api/latest/authn-mappings/#get-an-authn-mapping-by-uuid, https://docs-staging.datadoghq.com/brian.deutsch/tab-links-1/synthetics/browser_tests/?tabs=requestoptions, etc)

### Additional Notes

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
