### PR TITLE
Adds Site parameter to reference this Getting started page in other docs

### DIFF
--- a/content/en/getting_started/site/_index.md
+++ b/content/en/getting_started/site/_index.md
@@ -5,7 +5,7 @@ kind: documentation
 
 Datadog offers different sites throughout the world. Each site is completely independent, and you cannot share data across sites. Each site gives you benefits (for example, government security regulations) or allows you to store your data in specific locations around the world.
 
-| Site    | Site URL                    | Site parameter      | Location |
+| Site    | Site URL                    | Site Parameter      | Location |
 |---------|-----------------------------|---------------------|----------|
 | US1     | `https://app.datadoghq.com` | `datadoghq.com`     | US       |
 | US3     | `https://us3.datadoghq.com` | `us3.datadoghq.com` | US       |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a `Site parameter` column to the table

### Motivation
<!-- What inspired you to submit this pull request?-->
Would like to reference this page in RUM/Logs SDK collection when setting up the `site` parameter instead of https://docs.datadoghq.com/agent/basic_agent_usage/?tabs=agentv6v7#datadog-site. However, the page as it is would not adequately reference the right parameter to add, which is the base URL (without the `app` for EU1 and US1 and without `https://` for other locations)
PR for more context : https://github.com/DataDog/browser-sdk/pull/1646

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
