### PR TITLE
[WEB-2528] tabs query param fix

### DIFF
--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -2,7 +2,7 @@ import { getQueryParameterByName } from '../helpers/browser';
 
 const initCodeTabs = () => {
     const codeTabsList = document.querySelectorAll('.code-tabs')
-    const tabQueryParameter = getQueryParameterByName('tab')
+    const tabQueryParameter = getQueryParameterByName('tab') || getQueryParameterByName('tabs')
 
     const init = () => {
         renderCodeTabElements()
@@ -91,7 +91,7 @@ const initCodeTabs = () => {
     }
 
     const addEventListeners = () => {
-        const allTabLinksNodeList = document.querySelectorAll('.code-tabs li a')
+        const allTabLinksNodeList = document.querySelectorAll('.code-tabs .nav-tabs li a')
 
         allTabLinksNodeList.forEach(link => {
             link.addEventListener('click', () => {
@@ -107,10 +107,14 @@ const initCodeTabs = () => {
     const updateUrl = (activeLang) => {
         const url = window.location.href
             .replace(window.location.hash, '')
-            .replace(window.location.search, '');
+            .replace(window.location.search, '')
 
-        const queryParams = new URLSearchParams(window.location.search);
-        queryParams.set('tabs', activeLang)
+        const queryParams = new URLSearchParams(window.location.search)
+        queryParams.set('tab', activeLang)
+
+        if (queryParams.get('tabs')) {
+            queryParams.delete('tabs')
+        }
 
         window.history.replaceState(
             null,


### PR DESCRIPTION
### What does this PR do?
fixes handling of tabs query parameter.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2528

### Preview
- https://docs-staging.datadoghq.com/brian.deutsch/tabs-query-param-fix/getting_started/tagging/unified_service_tagging/?tab=custommetrics#non-containerized-environment
- https://docs-staging.datadoghq.com/brian.deutsch/tabs-query-param-fix/getting_started/tagging/unified_service_tagging/?tabs=custommetrics#non-containerized-environment

- [ ] `Custom Metrics` tab is selected on page load, and the URL query parameter should be `?tab=custommetrics` in both cases.
- [ ] test another page with tabs using the left-side nav (async loading) to make sure tab query parameter is behaving properly

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
