### PR TITLE
[apm] Add Resource Panel information to the Service Page docs

### DIFF
--- a/content/en/tracing/services/service_page.md
+++ b/content/en/tracing/services/service_page.md
@@ -98,7 +98,7 @@ Below, there’s a list of [resources][11] associated with your service. Sort th
 
 {{< img src="tracing/visualization/service/resources_tab.jpg" alt="Resources"  style="width:100%;">}}
 
-Click on a resource to view a summary panel with the resource’s out-of-the-box graphs (Requests, Errors, Latency), the Resource Dependency Map, and Span Summary Table. Use keyboard navigation keys to toggle between resources on the resource list to compare resources in a service, and quickly identify issues without context switching. Click “Open Full Page” or use cmd-click or cntrl-click to view the full resource page in a new tab.
+Click on a resource to open a side panel that displays the resource's out-of-the-box graphs (about requests, errors, and latency), a resource dependency map, and a span summary table. Use keyboard navigation keys to toggle between resources on the **Resources** list and compare resources in a service. To view the full resource page, click **Open Full Page**.
 
 [Refer to the dedicated resource documentation to learn more][2].
 

--- a/content/en/tracing/services/service_page.md
+++ b/content/en/tracing/services/service_page.md
@@ -98,6 +98,8 @@ Below, there’s a list of [resources][11] associated with your service. Sort th
 
 {{< img src="tracing/visualization/service/resources_tab.jpg" alt="Resources"  style="width:100%;">}}
 
+Click on a resource to view a summary panel with the resource’s OOTB graphs (Requests, Errors, Latency), the Resource Dependency Map, and Span Summary Table. Use keyboard navigation keys to toggle between resources on the resource list to compare resources in a service, and quickly identify issues without context switching. Click “Open Full Page” or use cmd-click or cntrl-click to view the full resource page in a new tab.
+
 [Refer to the dedicated resource documentation to learn more][2].
 
 ### Columns

--- a/content/en/tracing/services/service_page.md
+++ b/content/en/tracing/services/service_page.md
@@ -98,7 +98,7 @@ Below, there’s a list of [resources][11] associated with your service. Sort th
 
 {{< img src="tracing/visualization/service/resources_tab.jpg" alt="Resources"  style="width:100%;">}}
 
-Click on a resource to view a summary panel with the resource’s OOTB graphs (Requests, Errors, Latency), the Resource Dependency Map, and Span Summary Table. Use keyboard navigation keys to toggle between resources on the resource list to compare resources in a service, and quickly identify issues without context switching. Click “Open Full Page” or use cmd-click or cntrl-click to view the full resource page in a new tab.
+Click on a resource to view a summary panel with the resource’s out-of-the-box graphs (Requests, Errors, Latency), the Resource Dependency Map, and Span Summary Table. Use keyboard navigation keys to toggle between resources on the resource list to compare resources in a service, and quickly identify issues without context switching. Click “Open Full Page” or use cmd-click or cntrl-click to view the full resource page in a new tab.
 
 [Refer to the dedicated resource documentation to learn more][2].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Adds a small paragraph to the Service Page docs explaining the new APM Resource Panel

### Motivation

The resource panel was recently GAed

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
