### PR TITLE
Update downtimes.md

### DIFF
--- a/content/en/monitors/notify/downtimes.md
+++ b/content/en/monitors/notify/downtimes.md
@@ -177,7 +177,7 @@ Monitors trigger events when they change between possible states: `ALERT`, `WARN
 
 ### Expiration
 
-If a monitor is in an alert-worthy state (`ALERT`, `WARNING`, or `NO DATA`) when a downtime expires, the monitor triggers a new notification. This applies to monitors that change state during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`), and to monitors that already have an alert-worthy state when downtime begins.
+If a monitor is in an alert-worthy state (`ALERT`, `WARNING`, or `NO DATA`) when a downtime expires, the monitor triggers a new notification. This applies to monitors that change state during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`), and to monitors that already have an alert-worthy state when downtime begins. If a downtime is manually canceled, notifications will not be sent, even if the monitor has entered an alert-worthy state.
 
 **Example 1:** If a monitor is in an alert state *before* downtime starts and *continues* for the duration of downtime:
 1. During downtime, notifications for this alert are suppressed.

--- a/content/en/monitors/notify/downtimes.md
+++ b/content/en/monitors/notify/downtimes.md
@@ -177,7 +177,7 @@ Monitors trigger events when they change between possible states: `ALERT`, `WARN
 
 ### Expiration
 
-If a monitor is in an alert-worthy state (`ALERT`, `WARNING`, or `NO DATA`) when a downtime expires, the monitor triggers a new notification. This applies to monitors that change state during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`), and to monitors that already have an alert-worthy state when downtime begins. If a downtime is manually canceled, notifications will not be sent, even if the monitor has entered an alert-worthy state.
+If a monitor is in an alert-worthy state (`ALERT`, `WARNING`, or `NO DATA`) when a downtime expires, the monitor triggers a new notification. This applies to monitors that change state during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`), and to monitors that already have an alert-worthy state when downtime begins. If a downtime is manually canceled, notifications are not sent, even if the monitor has entered an alert-worthy state.
 
 **Example 1:** If a monitor is in an alert state *before* downtime starts and *continues* for the duration of downtime:
 1. During downtime, notifications for this alert are suppressed.


### PR DESCRIPTION
Adding the information that when downtimes are manually canceled, no notifications are sent.

### What does this PR do?
Add the sentence, "If a downtime is manually canceled, notifications will not be sent, even if the monitor has entered an alert-worthy state."

### Motivation
A customer noticed that this functionality was not described in the documentation. This caused them to doubt their SE's statement that it was expected behavior and to think it was, instead, a bug. 
Here is the ticket in question: https://datadog.zendesk.com/agent/tickets/824143

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
Apologies; I didn't see the option to name my branch so I don't know if this preview will be created. Please let me know if I should cancel this request and retry.

### Additional Notes
I considered putting this under a separate heading of "Manual Cancelation," following the "Expiration" section, for maximum clarity, but decided against it since it's only one sentence.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
