### PR TITLE
Add note about 2 week Watchdog baseline

### DIFF
--- a/content/en/watchdog/_index.md
+++ b/content/en/watchdog/_index.md
@@ -44,7 +44,9 @@ Watchdog is an algorithmic feature for APM performance and infrastructure metric
   * [Amazon Web Services][5], for the [S3][6], [ELB/ALB/NLB][7], [CloudFront][8], and [DynamoDB][9] Amazon services.
   * [Alerting][10]
 
-Watchdog looks for irregularities in metrics, like a sudden spike in the hit rate. For each irregularity, the [Watchdog page][11] displays a Watchdog alert. Each alert includes a graph of the detected metric irregularity and gives more information about the relevant time frame and endpoint or endpoints. Watchdog automatically monitors data sent by the Datadog Agent or by integrations. 
+Watchdog looks for irregularities in metrics, like a sudden spike in the hit rate. For each irregularity, the [Watchdog page][11] displays a Watchdog alert. Each alert includes a graph of the detected metric irregularity and gives more information about the relevant time frame and endpoint or endpoints. Watchdog automatically monitors data sent by the Datadog Agent or by integrations.
+
+For any new source of metrics, logs, or other data, Watchdog requires two weeks of data to establish a baseline of expected behavior. After two weeks, Watchdog begins detecting anomalies.
 
 ## Watchdog in the services list
 

--- a/content/en/watchdog/_index.md
+++ b/content/en/watchdog/_index.md
@@ -46,7 +46,7 @@ Watchdog is an algorithmic feature for APM performance and infrastructure metric
 
 Watchdog looks for irregularities in metrics, like a sudden spike in the hit rate. For each irregularity, the [Watchdog page][11] displays a Watchdog alert. Each alert includes a graph of the detected metric irregularity and gives more information about the relevant time frame and endpoint or endpoints. Watchdog automatically monitors data sent by the Datadog Agent or by integrations.
 
-For any new source of metrics, logs, or other data, Watchdog requires two weeks of data to establish a baseline of expected behavior. After two weeks, Watchdog begins detecting anomalies.
+For any new source of metrics, logs, or other data, Watchdog requires two weeks of data to establish a baseline of expected behavior. Anomalies detected by Watchdog based on fewer than two weeks of data may contain inaccuracies.
 
 ## Watchdog in the services list
 

--- a/content/en/watchdog/_index.md
+++ b/content/en/watchdog/_index.md
@@ -46,7 +46,7 @@ Watchdog is an algorithmic feature for APM performance and infrastructure metric
 
 Watchdog looks for irregularities in metrics, like a sudden spike in the hit rate. For each irregularity, the [Watchdog page][11] displays a Watchdog alert. Each alert includes a graph of the detected metric irregularity and gives more information about the relevant time frame and endpoint or endpoints. Watchdog automatically monitors data sent by the Datadog Agent or by integrations.
 
-For any new source of metrics, logs, or other data, Watchdog requires two weeks of data to establish a baseline of expected behavior. Anomalies detected by Watchdog based on fewer than two weeks of data may contain inaccuracies.
+For any new source of metrics, logs, or other data, Watchdog requires two weeks of data to establish a baseline of expected behavior. Anomalies detected by Watchdog based on less than two weeks of data may contain inaccuracies.
 
 ## Watchdog in the services list
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a note to the top level Watchdog page saying that Watchdog requires two weeks of baseline data before it can report anomalies.

### Motivation
Discussion in #support-data-science Slack channel.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
