### PR TITLE
[Tracing Tests] More visibly recommend instrumentation over JUnitXML

### DIFF
--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -16,11 +16,11 @@ The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not suppo
 </div>
 {{< /site-region >}}
 
-<div class="alert alert-warning"><strong>Note</strong>: Datadog recommends the native instrumentation of tests over uploading JUnit XML files, since the native instrumentation provides more accurate time results, supports distributed traces on integration tests and supports structured stack traces.</div>
+<div class="alert alert-warning"><strong>Note</strong>: Datadog recommends the native instrumentation of tests over uploading JUnit XML files, as the native instrumentation provides more accurate time results, supports distributed traces on integration tests, and supports structured stack traces.</div>
 
-JUnit test report files are XML files that contain test execution information, such as test and suite names, pass/fail status, duration, and sometimes error logs. Although it was introduced by the [JUnit][1] testing framework, many other popular frameworks are able to output results using this format.
+JUnit test report files are XML files that contain test execution information, such as test and suite names, pass or fail status, duration, and sometimes error logs. Although introduced by the [JUnit][1] testing framework, many other popular frameworks are able to output results using this format.
 
-If your testing framework can generate JUnit XML test reports, these can be used as a lightweight alternative to [instrumenting your tests natively][8] using Datadog tracers. Test results imported from JUnit XML reports appear alongside test data reported by tracers.
+If your testing framework can generate JUnit XML test reports, you can use these as a lightweight alternative to [instrumenting your tests natively][8] using Datadog tracers. Test results imported from JUnit XML reports appear alongside test data reported by tracers.
 
 ## Installing the Datadog CI CLI
 

--- a/content/en/continuous_integration/setup_tests/junit_upload.md
+++ b/content/en/continuous_integration/setup_tests/junit_upload.md
@@ -16,11 +16,11 @@ The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not suppo
 </div>
 {{< /site-region >}}
 
+<div class="alert alert-warning"><strong>Note</strong>: Datadog recommends the native instrumentation of tests over uploading JUnit XML files, since the native instrumentation provides more accurate time results, supports distributed traces on integration tests and supports structured stack traces.</div>
+
 JUnit test report files are XML files that contain test execution information, such as test and suite names, pass/fail status, duration, and sometimes error logs. Although it was introduced by the [JUnit][1] testing framework, many other popular frameworks are able to output results using this format.
 
-As an alternative to instrumenting your tests natively using Datadog tracers, which is the recommended option as it provides the most comprehensive test results, you can also upload JUnit XML test reports.
-
-Test results imported from JUnit XML reports appear alongside test data reported by tracers. However, there are some limitations when using this method, such as the lack of distributed traces on integration tests or structured stack traces. For this reason, only use this method if there is no native support for the language or testing framework being used.
+If your testing framework can generate JUnit XML test reports, these can be used as a lightweight alternative to [instrumenting your tests natively][8] using Datadog tracers. Test results imported from JUnit XML reports appear alongside test data reported by tracers.
 
 ## Installing the Datadog CI CLI
 
@@ -297,3 +297,4 @@ To be processed, the `name` attribute in the `<property>` element must have the 
 [5]: /logs/
 [6]: /getting_started/site/
 [7]: https://git-scm.com/downloads
+[8]: https://docs.datadoghq.com/continuous_integration/setup_tests/


### PR DESCRIPTION
### What does this PR do?
* Makes more visible the recommendation to use native test instrumentation instead of JUnitXML.
* Rewords the text so it talks about the positives of using native instrumentation instead of the negatives of JUnitXML.
  
### Motivation

Test instrumentation provides a better user experience and we want to recommend it.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
