### PR TITLE
Updates the links to lead to the new LMS

### DIFF
--- a/content/en/getting_started/logs/_index.md
+++ b/content/en/getting_started/logs/_index.md
@@ -2,12 +2,12 @@
 title: Getting Started with Logs
 kind: documentation
 further_reading:
-    - link: 'https://learn.datadoghq.com/enrol/index.php?id=40'
+    - link: 'https://learn.datadoghq.com/courses/intro-to-log-management'
       tag: 'Learning Center'
       text: 'Introduction to Log Management'
-    - link: 'https://learn.datadoghq.com/enrol/index.php?id=36'
+    - link: 'https://learn.datadoghq.com/courses/going-deeper-with-logs-processing'
       tag: 'Learning Center'
-      text: 'Going Deeper with Logs: Processing'
+      text: 'Going Deeper with Logs Processing'
     - link: '/logs/log_collection/'
       tag: 'Documentation'
       text: 'Log Collection & Integrations'


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Links in the guides section pointed to our old LMS which we migrated from yesterday. This PR updates the links to point to the home of the new courses.


### Motivation
404's from current Guide links

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
There are probable other LMS links in Guides that are broken

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
