### PR TITLE
Update java.md to resolve broken links

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/java.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/java.md
@@ -85,7 +85,6 @@ try {
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-tab=jsonlogs#trace_id-option
 [1]: /logs/log_collection/java/
 [2]: /tracing/trace_collection/dd_libraries/java/
 [3]: /tracing/troubleshooting/correlated-logs-not-showing-up-in-the-trace-id-panel/?


### PR DESCRIPTION
remove line tab=jsonlogs#trace_id-option which is causing the URL references to be rendered as plaintext on the docs page

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Remove an unnecessary line causing link reference objects to be rendered as plaintext on the docs page.

### Motivation
Resolve broken links in the docs page to properly route readers to the proper documentation links

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
