### PR TITLE
update `network_devices` reverse proxy example

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -444,10 +444,12 @@ database_monitoring:
 
 network_devices:
     metadata:
-        dd_url: haproxy.example.com:3841
+        logs_dd_url: haproxy.example.com:3841
+        logs_no_ssl: true
     snmp_traps:
         forwarder:
-            dd_url: haproxy.example.com:3842
+            logs_dd_url: haproxy.example.com:3842
+            logs_no_ssl: true
 ```
 
 Then edit the `datadog.yaml` Agent configuration file and set `skip_ssl_validation` to `true`. This is needed to make the Agent ignore the discrepancy between the hostname on the SSL certificate ({{< region-param key="dd_full_site" code="true" >}}) and your HAProxy hostname:
@@ -639,10 +641,12 @@ database_monitoring:
 
 network_devices:
     metadata:
-        dd_url: nginx.example.com:3841
+        logs_dd_url: nginx.example.com:3841
+        logs_no_ssl: true
     snmp_traps:
         forwarder:
-            dd_url: nginx.example.com:3842
+            logs_dd_url: nginx.example.com:3842
+            logs_no_ssl: true
 
 appsec_config (deprecated):
     appsec_dd_url: "<PROXY_SERVER_DOMAIN>:3842"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Updates the Agent config example for NDM when using revere proxies (nginx, haproxy)
- Similar to #14704

### Motivation
- confirmation that `network_devices` also needs the same changes from ZD#858400

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
