### PR TITLE
Use correct jar location

### DIFF
--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -65,7 +65,7 @@ Datadog offers many different ways to enable instrumentation for your serverless
 
 4. Set the required environment variables
 
-    - Set `JAVA_TOOL_OPTIONS` to `-javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1`
+    - Set `JAVA_TOOL_OPTIONS` to `-javaagent:"/opt/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1`
     - Set `DD_JMXFETCH_ENABLED` to `false`
     - Set `DD_TRACE_ENABLED` to `true`
     - Set `DD_SITE` to {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).


### PR DESCRIPTION
In step 2 the DataDog agent jar is downloaded to `/opt/dd-java-agent.jar` but in step 4 the `javaagent` is set to `/opt/java/lib/dd-java-agent.jar`. 
This causes an error during runtime: 
`Error opening zip file or JAR manifest missing : /opt/java/lib/dd-java-agent.jar`

Alternatively the docker file section could be updated:

``` 
RUN mkdir -p /opt/java/lib
RUN wget -O /opt/java/lib/dd-java-agent.jar https://dtdg.co/latest-java-tracer
```

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the Java Serverless installation documentation.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
