### PR TITLE
Provide uninstall instructions for macOS systemwide installation

### DIFF
--- a/content/en/agent/guide/how-do-i-uninstall-the-agent.md
+++ b/content/en/agent/guide/how-do-i-uninstall-the-agent.md
@@ -141,7 +141,7 @@ sudo userdel dd-agent \
 ---
 
 ## macOS
-**Agent v6 & v7**
+**Agent v6 & v7 single user installation**
 
 1. Stop and close the Datadog Agent with the bone icon in the tray.
 2. Drag the Datadog application from the application folder to the trash bin.
@@ -152,6 +152,24 @@ sudo rm -rf /opt/datadog-agent
 sudo rm -rf /usr/local/bin/datadog-agent
 sudo rm -rf ~/.datadog-agent/**​ #to remove broken symlinks
 launchctl remove com.datadoghq.agent
+sudo rm -rf /var/log/datadog
+```
+
+Then, reboot your machine for changes to take effect.
+
+> This method removes the Agent, as well as all Agent configuration files.
+---
+**Agent v6 & v7 systemwide LaunchDaemon installation**
+
+1. Drag the Datadog application from the application folder to the trash bin.
+2. Run:
+
+```shell
+sudo rm -rf /opt/datadog-agent
+sudo rm -rf /usr/local/bin/datadog-agent
+sudo rm -rf ~/.datadog-agent/**​ #to remove broken symlinks
+sudo launchctl disable system/com.datadoghq.agent && sudo launchctl bootout system/com.datadoghq.agent
+sudo rm /Library/LaunchDaemons/com.datadoghq.agent.plist
 sudo rm -rf /var/log/datadog
 ```
 

--- a/content/en/agent/guide/how-do-i-uninstall-the-agent.md
+++ b/content/en/agent/guide/how-do-i-uninstall-the-agent.md
@@ -162,7 +162,7 @@ Then, reboot your machine for changes to take effect.
 **Agent v6 & v7 systemwide LaunchDaemon installation**
 
 1. Drag the Datadog application from the application folder to the trash bin.
-2. Run:
+2. To remove remaining files, run the following:
 
 ```shell
 sudo rm -rf /opt/datadog-agent
@@ -173,7 +173,7 @@ sudo rm /Library/LaunchDaemons/com.datadoghq.agent.plist
 sudo rm -rf /var/log/datadog
 ```
 
-Then, reboot your machine for changes to take effect.
+Reboot your machine for changes to take effect.
 
 > This method removes the Agent, as well as all Agent configuration files.
 ---


### PR DESCRIPTION
### What does this PR do?

Adds instructions to remove systemwide macOS installation. I introduced another section for this, because I think it's more comfortable for users to C&P instead of having to go through one set of instructions and figure out what instruction to run when.

### Motivation

We added the systemwide installation feature in https://github.com/DataDog/datadog-agent/pull/10621 and want to document how to uninstall agent in this scenario.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
