### PR TITLE
content/en/tracing/configure_data_security: add note about sql strings formatting.

### DIFF
--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -26,6 +26,7 @@ Datadog enforces several filtering mechanisms on spans as a baseline, to provide
 
 * **Environment variables are not collected by the Agent**
 * **SQL variables are obfuscated, even when not using prepared statements**: For example, the following `sql.query` attribute: `SELECT data FROM table WHERE key=123 LIMIT 10` has its variables obfuscated, to become the following Resource name: `SELECT data FROM table WHERE key = ? LIMIT ?`
+* **SQL strings are identified using standard ANSI SQL quotes**: This means strings should be surrounded in single quotes (`'`). Some SQL variants optionally support double-quotes (`"`) for strings, but most treat double-quoted things as identifiers. The Datadog obfuscator treats these as identifiers rather than strings and will not obfuscate them.
 * **Numbers in Resource names (for example, request URLs) are obfuscated** For example, the following `elasticsearch` attribute:
 
     ```text

--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -26,7 +26,7 @@ Datadog enforces several filtering mechanisms on spans as a baseline, to provide
 
 * **Environment variables are not collected by the Agent**
 * **SQL variables are obfuscated, even when not using prepared statements**: For example, the following `sql.query` attribute: `SELECT data FROM table WHERE key=123 LIMIT 10` has its variables obfuscated, to become the following Resource name: `SELECT data FROM table WHERE key = ? LIMIT ?`
-* **SQL strings are identified using standard ANSI SQL quotes**: This means strings should be surrounded in single quotes (`'`). Some SQL variants optionally support double-quotes (`"`) for strings, but most treat double-quoted things as identifiers. The Datadog obfuscator treats these as identifiers rather than strings and will not obfuscate them.
+* **SQL strings are identified using standard ANSI SQL quotes**: This means strings should be surrounded in single quotes (`'`). Some SQL variants optionally support double-quotes (`"`) for strings, but most treat double-quoted things as identifiers. The Datadog obfuscator treats these as identifiers rather than strings and does not obfuscate them.
 * **Numbers in Resource names (for example, request URLs) are obfuscated** For example, the following `elasticsearch` attribute:
 
     ```text


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This adds a small note about the required SQL string format for obfuscation.

### Motivation
Some customers were using double-quoted strings in their SQL statements and were unsure why their strings were not obfuscated as they expected.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
