### PR TITLE
Removes Pull-And-Push Folder Action for Error Tracking

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -670,16 +670,6 @@
         front_matters:
           dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
 
-    - action: pull-and-push-folder
-      branch: master
-      globs:
-        - docs/error_tracking/*
-      options:
-        dest_dir: '/real_user_monitoring/error_tracking/'
-        path_to_remove: 'docs/error_tracking/'
-        front_matters:
-          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/error_tracking/" ]
-
   - repo_name: dd-sdk-reactnative
     contents:
     - action: pull-and-push-file

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -674,16 +674,6 @@
         front_matters:
           dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/" ]
 
-    - action: pull-and-push-folder
-      branch: master
-      globs:
-        - docs/error_tracking/*
-      options:
-        dest_dir: '/real_user_monitoring/error_tracking/'
-        path_to_remove: 'docs/error_tracking/'
-        front_matters:
-          dependencies: [ "https://github.com/DataDog/dd-sdk-ios/blob/master/docs/error_tracking/" ]
-
   - repo_name: dd-sdk-reactnative
     contents:
     - action: pull-and-push-file


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Unnecessary action to single source this folder from the dd-sdk-ios repo that does not exist anymore.

### Motivation
<!-- What inspired you to submit this pull request?-->

Configuration Page Cleanup

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
