### PR TITLE
placeholder fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,8 @@ node_modules: package.json yarn.lock
 	@yarn install --immutable
 
 # All the requirements for a full build
-dependencies: clean hugpython all-examples data/permissions.json placeholders update_pre_build node_modules
+dependencies: clean hugpython all-examples data/permissions.json update_pre_build node_modules
+	@make placeholders
 
 # builds permissions json from rbac
 # Always run if PULL_RBAC_PERMISSIONS or we are running in gitlab e.g CI_COMMIT_REF_NAME exists


### PR DESCRIPTION
### What does this PR do?

With the makefile changes the placeholders need to run after completion of sourcing the other repos not at the same time.

### Motivation

some security rules pages were being deleted in other langs

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
