### PR TITLE
make more clear/obvious that service parameter needs to be adjusted

### DIFF
--- a/content/en/logs/log_collection/php.md
+++ b/content/en/logs/log_collection/php.md
@@ -192,7 +192,7 @@ logs:
 
   - type: file
     path: "/path/to/your/php/application-json.log"
-    service: php
+    service: "<SERVICE_NAME>"
     source: php
     sourcecategory: sourcecode
 ```

--- a/content/fr/logs/log_collection/php.md
+++ b/content/fr/logs/log_collection/php.md
@@ -192,7 +192,7 @@ logs:
 
   - type: file
     path: "/chemin/vers/votre/php/application-json.log"
-    service: php
+    service: "<SERVICE_NAME>"
     source: php
     sourcecategory: sourcecode
 ```

--- a/content/ja/logs/log_collection/php.md
+++ b/content/ja/logs/log_collection/php.md
@@ -192,7 +192,7 @@ logs:
 
   - type: file
     path: "/path/to/your/php/application-json.log"
-    service: php
+    service: "<SERVICE_NAME>"
     source: php
     sourcecategory: sourcecode
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Fix and make more obvious/clear that the service parameter in conf.yaml (for PHP) needs to be adjusted. 

### Motivation
<!-- What inspired you to submit this pull request?-->

I copied the configuration but didn't realized that this parameter needed adjustment. As it is written is looks like a "good default" instead of "you need to adjust this" kind of parameter.

So instead of 

> service: "php"

I propose

> service: "<SERVICE_NAME>"

to make it clearer.


<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
