### PR TITLE
Fix formatting for Reserved Attributes table

### DIFF
--- a/content/en/events/guides/migrating_to_new_events_features.md
+++ b/content/en/events/guides/migrating_to_new_events_features.md
@@ -88,9 +88,7 @@ This list describes automatically ingested reserved attributes with events.
 | `source`  | This corresponds to the integration name, or the technology from which the event originated. When it matches an integration name, Datadog automatically installs the corresponding parsers and facets. For example: `nginx`, `postgresql`, and more. |
 | `status`  | This corresponds to the level or severity of an event.      |
 | `service` | The name of the application or service generating the events. |
-                                                                                                                         |
-| `message` | By default, Datadog ingests the value of the `message` attribute as the body of the event entry. 
-|                     
+| `message` | By default, Datadog ingests the value of the `message` attribute as the body of the event entry. |                     
 
 ## What Changed?
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Reserved Attributes table has an extra line in the table: https://docs.datadoghq.com/events/guides/migrating_to_new_events_features/#reserved-attributes 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
