### PR TITLE
Add notes on reserved attributes to Events Explorer doc

### DIFF
--- a/content/en/events/explorer/_index.md
+++ b/content/en/events/explorer/_index.md
@@ -117,6 +117,13 @@ This list describes automatically ingested reserved attributes with events.
 | `service` | The name of the application or service generating the events. |
 | `message` | By default, Datadog ingests the value of the `message` attribute as the body of the event entry. |   
 
+To search a tag that has the same key as a reserved attribute, use the `tags` search syntax. 
+Example: `tags:("status:<status>")`
+
+To create a facet on a tag that has the same key as a reserved attribute:
+1. Use the [Remapper processor][4] to remap the tag to another tag or attribute.
+2. Create a [facet][5] on the new tag/attribute.
+
 ## Notifications
 
 Datadog supports `@notifications` in the messages of events when posted by the API. For example:
@@ -166,3 +173,5 @@ Use the query to control what’s displayed in your Events Analytics:
 [1]: /logs/explorer/search_syntax/
 [2]: https://www.datadoghq.com/blog/send-alerts-sms-customizable-webhooks-twilio
 [3]: /monitors/notify/
+[4]: https://docs.datadoghq.com/logs/log_configuration/processors/?tab=ui#remapper
+[5]: https://docs.datadoghq.com/events/explorer/#create-a-facet


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add steps on searching tags and creating facets for tags that share the same key as reserved attributes.

### Motivation
Customers have reported issues related to this

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
