### PR TITLE
Avoid continuously repulling dependent repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,11 @@ CONFIGURATION_FILE ?= "./local/bin/py/build/configurations/pull_config_preview.y
 help:
 	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
 
-clean-all: clean clean-examples ## Clean everything (environment, sourced repos, generated files)
-	rm -rf ./node_modules ./hugpython ./public ./integrations_data
+clean-all: clean clean-examples clean-dependent-repos ## Clean everything (environment, sourced repos, generated files)
+	rm -rf ./node_modules ./hugpython ./public
+
+clean-dependent-repos:
+	rm -rf ./integrations_data
 
 # remove build generated content
 # removing only git ignored files

--- a/README.md
+++ b/README.md
@@ -26,13 +26,20 @@ If you are a Datadog employee, add your [GitHub personal token][6]
 
 To run the documentation site locally, execute:
 
-| Command                   | Description                                                                                                                                                                                                                                                                                                                                                 |
-|---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `make start-no-pre-build` | Build the lightweight version of the documentation with no extra content                                                                                                                                                                                                                                                                                    |
-| `make start`              | Build the full documentation with all extra content (integrations, extra pulled files, localized content, etc). Only useful if you have a GitHub personal token setup in your `Makefile.config` or the extra content is available locally. If you are working with local content, the repo must be downloaded to the same folder as the documentation repo. |
-| `make start-docker`       | Build the documentation using the docker image. For more information see [Docker Development][15].                                                                                                                                                                                                                                                          |
+| Command                   | Description                                                                                                                                                                                                                                |
+|---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `make start-no-pre-build` | Build the lightweight version of the documentation with no extra content                                                                                                                                                                   |
+| `make start`*             | Build the full documentation with all extra content (integrations, extra pulled files, localized content, etc). Only useful if you have a GitHub personal token setup in your `Makefile.config` or the extra content is available locally. |
+| `make start-docker`       | Build the documentation using the docker image. For more information see [Docker Development][15].                                                                                                                                         |
 
 **Documentation is then available at `http://localhost:1313`**
+
+**NOTE**: `make start` attempts to pull all dependent repos from their origins or a local cache. The order it attempts to retrieve is:
+  * One directory above where this repo is cloned.
+  * `integrations_data`: A local pull of all dependent repos from the last successful build
+  * If neither of the above exist, an attempt is made to pull dependent repos from upstream.
+
+If you'd like to re-pull dependencies, run `make clean-all` and then try your `make` command again.
 
 To learn more about how the documentation is built, refer to the [Documentation Build Wiki][7].
 

--- a/local/bin/py/build/content_manager.py
+++ b/local/bin/py/build/content_manager.py
@@ -57,33 +57,43 @@ def update_globs(new_path, globs):
     """
     new_globs = []
     for item in globs:
-        new_globs.append("{}{}".format(new_path, item))
+        new_globs.append(os.path.join(new_path, item))
     return new_globs
 
 
 def local_or_upstream(github_token, extract_dir, list_of_contents):
     """
-    This goes through the list_of_contents and check for each repo specified
-    If a local version exists otherwise we download it from the upstream repo on Github
-    Local version of the repo should be in the same folder as the documentation/ folder.
+    This goes through the list_of_contents and check for each repo specified in order:
+      * [ONLY LOCAL DEV] Check if a locally cloned version is on this developer machine; one level above this documentation repo
+      * [ONLY LOCAL DEV] Check if this docs build has already pulled and stored the repos in an extract folder
+      * [LOCAL DEV AND CI] If neither of the above exist, pull the remote repo to use and store in the extract folder
     :param github_token: A valide Github token to download content with the Github Class
     :param extract_dir: Directory into which to put all content downloaded.
     :param list_of_content: List of content to check if available locally or if it needs to be downloaded from Github
     """
+    is_in_ci = os.getenv("CI_COMMIT_REF_NAME")
     for content in list_of_contents:
-        repo_name = "../" + content["repo_name"] + sep
-        if isdir(repo_name):
-            print("\x1b[32mINFO\x1b[0m: Local version of {} found".format(
-                content["repo_name"]))
+        local_repo_path = os.path.join("..", content["repo_name"])
+        repo_path_last_extract = os.path.join(extract_dir, content["repo_name"])
+        if isdir(local_repo_path) and not is_in_ci:
+            print(f"\x1b[32mINFO\x1b[0m: Local version of {content['repo_name']} found in: {local_repo_path}")
             content["globs"] = update_globs(
-                repo_name,
+                local_repo_path,
+                content["globs"],
+            )
+        elif isdir(repo_path_last_extract) and not is_in_ci:
+            print(
+                f"\x1b[32mINFO\x1b[0m: Local version of {content['repo_name']} found from previous extract in:"
+                f" {repo_path_last_extract} "
+            )
+            content["globs"] = update_globs(
+                repo_path_last_extract,
                 content["globs"],
             )
         elif github_token != "false":
             print(
-                "\x1b[32mINFO\x1b[0m: No local version of {} found, downloading content from upstream version".format(
-                    content["repo_name"]
-                )
+                f"\x1b[32mINFO\x1b[0m: No local version of {content['repo_name']} found, downloading content from "
+                f"upstream version and placing in: {extract_dir}"
             )
             download_from_repo(github_token,
                                content["org_name"],
@@ -103,7 +113,7 @@ def local_or_upstream(github_token, extract_dir, list_of_contents):
                 ),
                 content["globs"],
             )
-        elif not getenv("CI_COMMIT_REF_NAME"):
+        elif getenv("LOCAL") == 'True':
             print(
                 "\x1b[33mWARNING\x1b[0m: No local version of {} found, no GITHUB_TOKEN available. Documentation is now in degraded mode".format(content["repo_name"]))
             content["action"] = "Not Available"
@@ -166,10 +176,10 @@ def prepare_content(configuration, github_token, extract_dir):
     try:
         list_of_contents = local_or_upstream(
             github_token, extract_dir, extract_config(configuration))
-    except:
+    except Exception as e:
         if not getenv("CI_COMMIT_REF_NAME"):
             print(
-                "\x1b[33mWARNING\x1b[0m: Downloading files failed, documentation is now in degraded mode.")
+                f"\x1b[33mWARNING\x1b[0m: Downloading files failed, documentation is now in degraded mode. {e}")
         else:
             print(
                 "\x1b[31mERROR\x1b[0m: Downloading files failed, stopping build.")


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Followup to #14603 with a slightly different approach. 

Update the pre-build setup to check if dependent repos are available locally. (This was partially done before by checking if the user manually cloned them, but this can do one better by using the version of the repo pulled from the last local build)

There's an environment variable check that will ensure that all external repos get pulled on each build, so this behavior should only impact local dev

Updates the error handling during local dev to print out the underlying exception to aid in debugging

Updates the Makefile to make cleaning external repos its own target command, and updates the README to note this behavior. 

### Motivation
<!-- What inspired you to submit this pull request?-->
Speed up local builds when trying to build with external dependencies

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
