### PR TITLE
Document issue with installing profiler with older versions of GCC

### DIFF
--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -209,13 +209,14 @@ variable to `1`, as described in the
 
 Without this flag, profiles for short-lived Resque jobs will be unavailable.
 
-## Profiling does not turn on due to "Your ddtrace installation is missing support for the Continuous Profiler because compilation of the Ruby VM just-in-time header failed. Your C compiler or Ruby VM just-in-time compiler seem to be broken."
+## Profiling does not turn on due to "missing support" error
 
-There is a known incompatibility between Ruby 2.7 and older GCC versions (4.8 and below) that impacts the profiler ([upstream Ruby report][6], [`dd-trace-rb` bug report][7]).
+There is a known incompatibility between Ruby 2.7 and older GCC versions (4.8 and below) that impacts the profiler ([upstream Ruby report][6], [`dd-trace-rb` bug report][7]). This can result in the following error message: "Your ddtrace installation is missing support for the Continuous Profiler because compilation of the Ruby VM just-in-time header failed. Your C compiler or Ruby VM just-in-time compiler seem to be broken."
 
-To fix this, we recommend updating your operating system/docker image or GCC version.
 
-For further help with this issue, please contact support and include the output of running `DD_PROFILING_FAIL_INSTALL_IF_MISSING_EXTENSION=true gem install ddtrace`, as well as the resulting `mkmf.log` file.
+To fix this, update your operating system, Docker image, or GCC version to something more recent than v4.8.
+
+For further help with this issue, [contact support][2] and include the output of running `DD_PROFILING_FAIL_INSTALL_IF_MISSING_EXTENSION=true gem install ddtrace` and the resulting `mkmf.log` file.
 
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -209,12 +209,21 @@ variable to `1`, as described in the
 
 Without this flag, profiles for short-lived Resque jobs will be unavailable.
 
+## Profiling does not turn on due to "Your ddtrace installation is missing support for the Continuous Profiler because compilation of the Ruby VM just-in-time header failed. Your C compiler or Ruby VM just-in-time compiler seem to be broken."
+
+There is a known incompatibility between Ruby 2.7 and older GCC versions (4.8 and below) that impacts the profiler ([upstream Ruby report][6], [ddtrace bug report][7]).
+
+To fix this, we recommend updating your operating system/docker image or GCC version.
+
+For further help with this issue, please contact support and include the output of running `DD_PROFILING_FAIL_INSTALL_IF_MISSING_EXTENSION=true gem install ddtrace`, as well as the resulting `mkmf.log` file.
 
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/
 [3]: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.54.0
 [4]: https://github.com/resque/resque
 [5]: https://github.com/resque/resque/blob/v2.0.0/docs/HOOKS.md#worker-hooks
+[6]: https://bugs.ruby-lang.org/issues/18073
+[7]: https://github.com/DataDog/dd-trace-rb/issues/1799
 {{< /programming-lang >}}
 {{< programming-lang lang="dotnet" >}}
 

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -211,7 +211,7 @@ Without this flag, profiles for short-lived Resque jobs will be unavailable.
 
 ## Profiling does not turn on due to "Your ddtrace installation is missing support for the Continuous Profiler because compilation of the Ruby VM just-in-time header failed. Your C compiler or Ruby VM just-in-time compiler seem to be broken."
 
-There is a known incompatibility between Ruby 2.7 and older GCC versions (4.8 and below) that impacts the profiler ([upstream Ruby report][6], [ddtrace bug report][7]).
+There is a known incompatibility between Ruby 2.7 and older GCC versions (4.8 and below) that impacts the profiler ([upstream Ruby report][6], [`dd-trace-rb` bug report][7]).
 
 To fix this, we recommend updating your operating system/docker image or GCC version.
 

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -209,7 +209,7 @@ variable to `1`, as described in the
 
 Without this flag, profiles for short-lived Resque jobs will be unavailable.
 
-## Profiling does not turn on due to "missing support" error
+## Profiling does not turn on because compilation of the Ruby VM just-in-time header failed
 
 There is a known incompatibility between Ruby 2.7 and older GCC versions (4.8 and below) that impacts the profiler ([upstream Ruby report][6], [`dd-trace-rb` bug report][7]). This can result in the following error message: "Your ddtrace installation is missing support for the Continuous Profiler because compilation of the Ruby VM just-in-time header failed. Your C compiler or Ruby VM just-in-time compiler seem to be broken."
 

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -214,7 +214,7 @@ Without this flag, profiles for short-lived Resque jobs will be unavailable.
 There is a known incompatibility between Ruby 2.7 and older GCC versions (4.8 and below) that impacts the profiler ([upstream Ruby report][6], [`dd-trace-rb` bug report][7]). This can result in the following error message: "Your ddtrace installation is missing support for the Continuous Profiler because compilation of the Ruby VM just-in-time header failed. Your C compiler or Ruby VM just-in-time compiler seem to be broken."
 
 
-To fix this, update your operating system, Docker image, or GCC version to something more recent than v4.8.
+To fix this, update your operating system or Docker image so that the GCC version is something more recent than v4.8.
 
 For further help with this issue, [contact support][2] and include the output of running `DD_PROFILING_FAIL_INSTALL_IF_MISSING_EXTENSION=true gem install ddtrace` and the resulting `mkmf.log` file.
 


### PR DESCRIPTION
### What does this PR do?

Document an issue that has come up with running the Ruby profiler on older operating system images that include old versions of the GCC compiler.

### Motivation

This issue has come up a couple of times now, so I think it's time to add it to the troubleshooting doc.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
