### PR TITLE
feat(kubernetes): add compatibility matrix

### DIFF
--- a/content/en/containers/kubernetes/installation.md
+++ b/content/en/containers/kubernetes/installation.md
@@ -38,14 +38,14 @@ For dedicated documentation and examples for major Kubernetes distributions incl
 
 For dedicated documentation and examples for monitoring the Kubernetes control plane, see [Kubernetes control plane monitoring][2].
 
-### Minimum Agent and Cluster-Agent versions
+### Minimum Agent and Cluster Agent versions
 
-Some features relatives to recent Kubernetes evolutions require to use a minimum agent version.
+Some features related to later Kubernetes versions require a minimum Datadog Agent version.
 
-| Kubernetes Version | Agent Version  | Cluster Agent Version | Reasons                               |
+| Kubernetes version | Agent version  | Cluster Agent version | Reason                              |
 |--------------------|----------------|-----------------------|---------------------------------------|
-| 1.16.0+            | 7.19.0+        | 1.9.0+                | `Kubelet`'s metrics deprecation       |
-| 1.21.0+            | 7.36.0+        | 1.20.0+               | `Kubernetes` resources deprecation    |
+| 1.16.0+            | 7.19.0+        | 1.9.0+                | Kubelet metrics deprecation       |
+| 1.21.0+            | 7.36.0+        | 1.20.0+               | Kubernetes resource deprecation    |
 
 {{< tabs >}}
 {{% tab "Operator" %}}

--- a/content/en/containers/kubernetes/installation.md
+++ b/content/en/containers/kubernetes/installation.md
@@ -38,6 +38,15 @@ For dedicated documentation and examples for major Kubernetes distributions incl
 
 For dedicated documentation and examples for monitoring the Kubernetes control plane, see [Kubernetes control plane monitoring][2].
 
+### Minimum Agent and Cluster-Agent versions
+
+Some features relatives to recent Kubernetes evolutions require to use a minimum agent version.
+
+| Kubernetes Version | Agent Version  | Cluster Agent Version | Reasons                               |
+|--------------------|----------------|-----------------------|---------------------------------------|
+| 1.16.0+            | 7.19.0+        | 1.9.0+                | `Kubelet`'s metrics deprecation       |
+| 1.21.0+            | 7.36.0+        | 1.20.0+               | `Kubernetes` resources deprecation    |
+
 {{< tabs >}}
 {{% tab "Operator" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add a compatibility matrix between Kubernetes version and Datadog Agent/Cluster-Agent version.

If a lower Agent/Cluster-Agent version is use, some features will not work properly.


### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
