### PR TITLE
Update Reference Table with Delete feature

### DIFF
--- a/content/en/logs/guide/reference-tables.md
+++ b/content/en/logs/guide/reference-tables.md
@@ -92,7 +92,7 @@ Once the table is saved, the upserted rows are processed asynchronously and upda
 ## Delete a Reference Table
 
 To delete a Reference Table, select a table, click the gear icon in the top right corner and then click **Delete Table**.
-The table and all associated rows will be deleted.
+The table and all associated rows is deleted.
 
 If there is a Lookup Processor using a Reference Table for Log enrichment, then the enrichment stops. It may take up to 10 minutes for the enrichment to stop.
 

--- a/content/en/logs/guide/reference-tables.md
+++ b/content/en/logs/guide/reference-tables.md
@@ -91,7 +91,7 @@ Once the table is saved, the upserted rows are processed asynchronously and upda
 
 ## Delete a Reference Table
 
-To delete a Reference Table, select a table, click the gear icon in the top right corner and then click **Delete Table**.
+To delete a Reference Table, select a table, click the gear icon in the top right corner, and then click **Delete Table**.
 The table and all associated rows is deleted.
 
 If there is a Lookup Processor using a Reference Table for Log enrichment, then the enrichment stops. It may take up to 10 minutes for the enrichment to stop.

--- a/content/en/logs/guide/reference-tables.md
+++ b/content/en/logs/guide/reference-tables.md
@@ -94,7 +94,7 @@ Once the table is saved, the upserted rows are processed asynchronously and upda
 To delete a Reference Table, select a table, click the gear icon in the top right corner and then click **Delete Table**.
 The table and all associated rows will be deleted.
 
-If there is a Lookup Processor using a Reference Table for Log enrichment, then the enrichment will stop. It may take up to 10 minutes for the enrichment  to stop.
+If there is a Lookup Processor using a Reference Table for Log enrichment, then the enrichment stops. It may take up to 10 minutes for the enrichment to stop.
 
 ## Further Reading
 

--- a/content/en/logs/guide/reference-tables.md
+++ b/content/en/logs/guide/reference-tables.md
@@ -89,6 +89,13 @@ The selected CSV is upserted into the table, meaning that:
  
 Once the table is saved, the upserted rows are processed asynchronously and updated in the preview. It may take up to 10 minutes for the update to complete. 
 
+## Delete a Reference Table
+
+To delete a Reference Table, select a table, click the gear icon in the top right corner and then click **Delete Table**.
+The table and all associated rows will be deleted.
+
+If there is a Lookup Processor using a Reference Table for Log enrichment, then the enrichment will stop. It may take up to 10 minutes for the enrichment  to stop.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
Adding details on how to delete a Reference Table and implication on lookup processor.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds description on deleting Reference Tables

### Motivation
Added support for 'deleting' Reference tables

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
None

---

### Reviewer checklist
- [x ] Review the changed files.
- [x ] Review the URLs listed in the [Preview](#preview) section.
- [x ] Check images for PII
- [x ] Review any mentions of "Contact Datadog support" for internal support documentation.
