### PR TITLE
integrations link update

### DIFF
--- a/content/en/agent/troubleshooting/agent_check_status.md
+++ b/content/en/agent/troubleshooting/agent_check_status.md
@@ -142,7 +142,7 @@ sudo journalctl -u dd-agent.service
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /help/
+[1]: /integrations/
 [2]: /agent/troubleshooting/send_a_flare/
 [3]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands
 [4]: /integrations/

--- a/content/fr/agent/troubleshooting/agent_check_status.md
+++ b/content/fr/agent/troubleshooting/agent_check_status.md
@@ -141,6 +141,6 @@ sudo journalctl -u dd-agent.service
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /fr/help/
+[1]: /fr/integrations/
 [2]: /fr/agent/troubleshooting/send_a_flare/
 [3]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands

--- a/content/ja/agent/troubleshooting/agent_check_status.md
+++ b/content/ja/agent/troubleshooting/agent_check_status.md
@@ -142,7 +142,7 @@ sudo journalctl -u dd-agent.service
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /ja/help/
+[1]: /ja/integrations/
 [2]: /ja/agent/troubleshooting/send_a_flare/
 [3]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#service-lifecycle-commands
 [4]: /ja/integrations/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR updates the link to the integrations docs on the Agent Check Status page.
Previously, the current link would lead to the homepage of our docs.

### Motivation
A customer complained about this specific link, and I think it makes sense to update it.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
