### PR TITLE
docs(proxy): add ssl guidelines for communication between Agent and Datadog when using a proxy

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -949,8 +949,8 @@ http {
 
     proxy_ssl_trusted_certificate <PATH_TO_CERTIFICATES>;
 
-    ssl_certificate     <PATH_TO_PROXY_CERTIFICATE> 
-    ssl_certificate_key <PATH_TO_PROXY_CERTIFICATE_KEY>
+    ssl_certificate     <PATH_TO_PROXY_CERTIFICATE>; 
+    ssl_certificate_key <PATH_TO_PROXY_CERTIFICATE_KEY>;
 
     server {
         listen 3834 ssl; #listen for metrics
@@ -975,8 +975,8 @@ stream {
 
     proxy_ssl_trusted_certificate <PATH_TO_CERTIFICATES>;
 
-    ssl_certificate     <PATH_TO_PROXY_CERTIFICATE> 
-    ssl_certificate_key <PATH_TO_PROXY_CERTIFICATE_KEY>
+    ssl_certificate     <PATH_TO_PROXY_CERTIFICATE>;
+    ssl_certificate_key <PATH_TO_PROXY_CERTIFICATE_KEY>;
 
     server {
         listen 3835 ssl; #listen for traces

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -142,14 +142,16 @@ Do not forget to [restart the Agent][1] for the new settings to take effect.
 
 ## HAProxy
 
-[HAProxy][1] is a free, fast, and reliable solution offering proxying for TCP and HTTP applications. While HAProxy is usually used as a load balancer to distribute incoming requests to pools servers, you can also use it to proxy Agent traffic to Datadog from hosts that have no outside connectivity:
+[HAProxy][1] is a free, fast, and reliable solution offering proxying for TCP and HTTP applications. While HAProxy is usually used as a load balancer to distribute incoming requests to pool servers, you can also use it to proxy Agent traffic to Datadog from hosts that have no outside connectivity:
 
 `agent -> haproxy -> Datadog`
 
-This is the best option if you do not have a web proxy readily available in your network, and you wish to proxy a large number of Agents. In some cases, a single HAProxy instance is sufficient to handle local Agent traffic in your network as each proxy can accommodate upwards connections of 1000 Agents. **Note**: This figure is a conservative estimate based on the performance of `m3.xl` instances specifically. Numerous network-related and host-related variables can influence throughput of HAProxy so you should keep an eye on your proxy deployment both before and after being put into service. See the [HAProxy documentation][2] for additional information.
+This is the best option if you do not have a web proxy readily available in your network and you wish to proxy a large number of Agents. In some cases, a single HAProxy instance is sufficient to handle local Agent traffic in your network, because each proxy can accommodate upwards of 1000 Agents. 
 
-The communication between HAProxy and Datadog will always be encrypted by TLS. The communication between the Agent host and the HAProxy host is not encrypted by default as the proxy and the Agent are assumed to be on the same host. However, it is recommended that you secure this communication with TLS encryption if they are not located on the same isolated local network.
-In order to encrypt data between the Agent and HAProxy, you need to create a x509 certificate with the Subject Alternative Name (SAN) extension for the HAProxy host. This certificate bundle (*.pem) should contain both the public certificate and private key. See this [HAProxy blog post][3] for more information.
+**Note**: This figure is a conservative estimate based on the performance of `m3.xl` instances specifically. Numerous network-related and host-related variables can influence throughput of HAProxy so you should keep an eye on your proxy deployment both before and after putting it into service. See the [HAProxy documentation][2] for additional information.
+
+The communication between HAProxy and Datadog is always encrypted with TLS. The communication between the Agent host and the HAProxy host is not encrypted by default, because the proxy and the Agent are assumed to be on the same host. However, it is recommended that you secure this communication with TLS encryption if the HAproxy host and Agent host are not located on the same isolated local network.
+To encrypt data between the Agent and HAProxy, you need to create an x509 certificate with the Subject Alternative Name (SAN) extension for the HAProxy host. This certificate bundle (*.pem) should contain both the public certificate and private key. See this [HAProxy blog post][3] for more information.
 
 ### Proxy forwarding with HAProxy
 
@@ -302,7 +304,7 @@ frontend appsec-events-frontend
     option tcplog
     default_backend datadog-appsec-events
 
-# This is the Datadog server. In effect any TCP request coming
+# This is the Datadog server. In effect, any TCP request coming
 # to the forwarder frontends defined above are proxied to
 # Datadog's public endpoints.
 backend datadog-metrics
@@ -452,7 +454,7 @@ resolvers my-dns
     hold valid 10s
     hold obsolete 60s
 
-# This declares the endpoint where your Agents connects for
+# This declares the endpoint where your Agents connect for
 # sending metrics (for example, the value of "dd_url").
 frontend metrics-forwarder
     bind *:3834 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
@@ -463,7 +465,7 @@ frontend metrics-forwarder
     use_backend datadog-api if { path_beg -i  /api/v1/validate }
     use_backend datadog-flare if { path_beg -i  /support/flare/ }
 
-# This declares the endpoint where your Agents connects for
+# This declares the endpoint where your Agents connect for
 # sending traces (for example, the value of "endpoint" in the APM
 # configuration section).
 frontend traces-forwarder
@@ -472,7 +474,7 @@ frontend traces-forwarder
     option tcplog
     default_backend datadog-traces
 
-# This declares the endpoint where your Agents connects for
+# This declares the endpoint where your Agents connect for
 # sending profiles (for example, the value of "apm_config.profiling_dd_url").
 frontend profiles-forwarder
     bind *:3836 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
@@ -480,7 +482,7 @@ frontend profiles-forwarder
     option tcplog
     default_backend datadog-profiles
 
-# This declares the endpoint where your agents connects for
+# This declares the endpoint where your Agents connect for
 # sending processes (for example, the value of "url" in the process
 # configuration section).
 frontend processes-forwarder
@@ -489,7 +491,7 @@ frontend processes-forwarder
     option tcplog
     default_backend datadog-processes
 
-# This declares the endpoint where your Agents connects for
+# This declares the endpoint where your Agents connect for
 # sending Logs (e.g the value of "logs.config.logs_dd_url")
 # If sending logs with use_http: true
 frontend logs_http_frontend
@@ -505,7 +507,7 @@ frontend logs_http_frontend
 #    option tcplog
 #    default_backend datadog-logs
 
-# This declares the endpoint where your Agents connects for
+# This declares the endpoint where your Agents connect for
 # sending database monitoring metrics and activity (e.g the value of "database_monitoring.metrics.dd_url" and "database_monitoring.activity.dd_url")
 frontend database_monitoring_metrics_frontend
     bind *:3839 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
@@ -513,7 +515,7 @@ frontend database_monitoring_metrics_frontend
     option tcplog
     default_backend datadog-database-monitoring-metrics
 
-# This declares the endpoint where your Agents connects for
+# This declares the endpoint where your Agents connect for
 # sending database monitoring samples (e.g the value of "database_monitoring.samples.dd_url")
 frontend database_monitoring_samples_frontend
     bind *:3840 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
@@ -521,7 +523,7 @@ frontend database_monitoring_samples_frontend
     option tcplog
     default_backend datadog-database-monitoring-samples
 
-# This declares the endpoint where your Agents connects for
+# This declares the endpoint where your Agents connect for
 # sending Network Devices Monitoring metadata (e.g the value of "network_devices.metadata.dd_url")
 frontend network_devices_metadata_frontend
     bind *:3841 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
@@ -529,7 +531,7 @@ frontend network_devices_metadata_frontend
     option tcplog
     default_backend datadog-network-devices-metadata
 
-# This declares the endpoint where your Agents connects for
+# This declares the endpoint where your Agents connect for
 # sending Network Devices SNMP Traps data (e.g the value of "network_devices.snmp_traps.forwarder.dd_url")
 frontend network_devices_snmp_traps_frontend
     bind *:3842 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
@@ -687,7 +689,7 @@ This `dd_url` setting can be found in the `datadog.yaml` file.
 
 `dd_url: <SCHEME>://haproxy.example.com:3834`
 
-Replace `<SCHEME>` by `https` if you previously chose the HAProxy `HTTPS` configuration, or by `http` otherwise.
+Replace `<SCHEME>` with `https` if you previously chose the HAProxy HTTPS configuration, or with `http` if you did not choose HTTPS.
 
 To send traces, profiles, processes, and logs through the proxy, setup the following in the `datadog.yaml` file:
 
@@ -737,7 +739,7 @@ appsec_config (deprecated):
 ```
 
 When using encryption between the Agent and HAProxy, if the Agent does not have access to the proxy certificate, is unable to validate it, or the validation is not needed, you can edit the `datadog.yaml` Agent configuration file and set `skip_ssl_validation` to `true`.
-With this option set to `true`, the Agent will skip the certificate validation step so it will not verify the identity of the proxy but the communication will still be encrypted with SSL/TLS.
+With this option set to `true`, the Agent skips the certificate validation step and does not verify the identity of the proxy, but the communication is still encrypted with SSL/TLS.
 
 ```yaml
 skip_ssl_validation: true
@@ -802,8 +804,8 @@ To verify that everything is working properly, review the HAProxy statistics at 
 
 `agent ---> nginx ---> Datadog`
 
-The communication between NGINX and Datadog will always be encrypted by TLS. The communication between the Agent host and the NGINX host is not encrypted by default as the proxy and the Agent are assumed to be on the same host. However, it is recommended that you secure this communication with TLS encryption if they are not located on the same isolated local network.
-In order to encrypt data between the Agent and NGINX, you need to create a x509 certificate with the Subject Alternative Name (SAN) extension for the NGINX host.
+The communication between NGINX and Datadog is always encrypted with TLS. The communication between the Agent host and the NGINX host is not encrypted by default, because the proxy and the Agent are assumed to be on the same host. However, it is recommended that you secure this communication with TLS encryption if they are not located on the same isolated local network.
+In order to encrypt data between the Agent and NGINX, you need to create an x509 certificate with the Subject Alternative Name (SAN) extension for the NGINX host.
 
 ### Proxy forwarding with NGINX
 
@@ -920,7 +922,7 @@ stream {
 {{% tab "HTTPS" %}}
 
 
-This configuration adds SSL/TLS encryption on communication between the Agent and NGINX. The variable `<PATH_TO_PROXY_CERTIFICATE>` should be replaced by the path to the proxy public certificate and `<PATH_TO_PROXY_CERTIFICATE_KEY>` by the path to the private key.
+This configuration adds SSL/TLS encryption on communication between the Agent and NGINX. Replace `<PATH_TO_PROXY_CERTIFICATE>` with the path to the proxy public certificate and `<PATH_TO_PROXY_CERTIFICATE_KEY>` with the path to the private key.
 
 ```conf
 user nginx;
@@ -1048,7 +1050,7 @@ This `dd_url` setting can be found in the `datadog.yaml` file.
 
 `dd_url: "<SCHEME>://nginx.example.com:3834"`
 
-Replace `<SCHEME>` by `https` if you previously chose the NGINX `HTTPS` configuration, or by `http` otherwise.
+Replace `<SCHEME>` with `https` if you previously chose the HAProxy HTTPS configuration, or with `http` if you did not choose HTTPS.
 
 To send traces, profiles, processes, and logs through the proxy, setup the following in the `datadog.yaml` file:
 
@@ -1099,13 +1101,13 @@ appsec_config (deprecated):
 ```
 
 When using encryption between the Agent and NGINX, if the Agent does not have access to the proxy certificate, is unable to validate it, or the validation is not needed, you can edit the `datadog.yaml` Agent configuration file and set `skip_ssl_validation` to `true`.
-With this option set to `true`, the Agent will skip the certificate validation step so it will not verify the identity of the proxy but the communication will still be encrypted with SSL/TLS.
+With this option set to `true`, the Agent skips the certificate validation step and does not verify the identity of the proxy, but the communication is still encrypted with SSL/TLS.
 
 ```yaml
 skip_ssl_validation: true
 ```
 
-When sending logs over TCP, see <a href="/agent/logs/proxy">TCP Proxy for Logs</a>.
+When sending logs over TCP, see [TCP Proxy for Logs][5].
 
 ## Datadog Agent
 
@@ -1157,3 +1159,4 @@ It is recommended to use an actual proxy (a web proxy or HAProxy) to forward you
 [2]: http://www.haproxy.org/#perf
 [3]: https://www.haproxy.com/blog/haproxy-ssl-termination/
 [4]: https://www.nginx.com
+[5]: /agent/logs/proxy

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -144,11 +144,11 @@ Do not forget to [restart the Agent][1] for the new settings to take effect.
 
 [HAProxy][1] is a free, fast, and reliable solution offering proxying for TCP and HTTP applications. While HAProxy is usually used as a load balancer to distribute incoming requests to pool servers, you can also use it to proxy Agent traffic to Datadog from hosts that have no outside connectivity:
 
-`agent -> haproxy -> Datadog`
+`agent ---> haproxy ---> Datadog`
 
 This is the best option if you do not have a web proxy readily available in your network and you wish to proxy a large number of Agents. In some cases, a single HAProxy instance is sufficient to handle local Agent traffic in your network, because each proxy can accommodate upwards of 1000 Agents. 
 
-**Note**: This figure is a conservative estimate based on the performance of `m3.xl` instances specifically. Numerous network-related and host-related variables can influence throughput of HAProxy so you should keep an eye on your proxy deployment both before and after putting it into service. See the [HAProxy documentation][2] for additional information.
+**Note**: This figure is a conservative estimate based on the performance of `m3.xl` instances specifically. Numerous network-related and host-related variables can influence throughput of HAProxy, so you should keep an eye on your proxy deployment both before and after putting it into service. See the [HAProxy documentation][2] for additional information.
 
 The communication between HAProxy and Datadog is always encrypted with TLS. The communication between the Agent host and the HAProxy host is not encrypted by default, because the proxy and the Agent are assumed to be on the same host. However, it is recommended that you secure this communication with TLS encryption if the HAproxy host and Agent host are not located on the same isolated local network.
 To encrypt data between the Agent and HAProxy, you need to create an x509 certificate with the Subject Alternative Name (SAN) extension for the HAProxy host. This certificate bundle (*.pem) should contain both the public certificate and private key. See this [HAProxy blog post][3] for more information.
@@ -161,7 +161,7 @@ sudo apt-get install ca-certificates # (Debian, Ubuntu)
 yum install ca-certificates # (CentOS, Red Hat)
 ```
 
-The file might be located at `/etc/ssl/certs/ca-certificates.crt` for Debian, Ubuntu or `/etc/ssl/certs/ca-bundle.crt` for CentOS, Red Hat.
+The path to the certificate is `/etc/ssl/certs/ca-certificates.crt` for Debian and Ubuntu, or `/etc/ssl/certs/ca-bundle.crt` for CentOS and Red Hat.
 
 ### Proxy forwarding with HAProxy
 
@@ -423,7 +423,7 @@ backend datadog-appsec-events # deprecated
 {{% /tab %}}
 {{% tab "HTTPS" %}}
 
-This configuration adds SSL/TLS encryption on communication between the Agent and HAProxy. The variable `<PATH_TO_PROXY_CERTIFICATE_PEM>` should be replaced by the path to the proxy certificate bundle (*.pem).
+This configuration adds SSL/TLS encryption on communication between the Agent and HAProxy. Replace the variable `<PATH_TO_PROXY_CERTIFICATE_PEM>` with the path to the proxy certificate bundle (*.pem).
 
 ```conf
 # Basic configuration
@@ -816,7 +816,7 @@ sudo apt-get install ca-certificates # (Debian, Ubuntu)
 yum install ca-certificates # (CentOS, Red Hat)
 ```
 
-The file might be located at `/etc/ssl/certs/ca-certificates.crt` for Debian, Ubuntu or `/etc/ssl/certs/ca-bundle.crt` for CentOS, Red Hat.
+The path to the certificate is `/etc/ssl/certs/ca-certificates.crt` for Debian and Ubuntu or `/etc/ssl/certs/ca-bundle.crt` for CentOS and Red Hat.
 
 ### Proxy forwarding with NGINX
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -153,6 +153,16 @@ This is the best option if you do not have a web proxy readily available in your
 The communication between HAProxy and Datadog is always encrypted with TLS. The communication between the Agent host and the HAProxy host is not encrypted by default, because the proxy and the Agent are assumed to be on the same host. However, it is recommended that you secure this communication with TLS encryption if the HAproxy host and Agent host are not located on the same isolated local network.
 To encrypt data between the Agent and HAProxy, you need to create an x509 certificate with the Subject Alternative Name (SAN) extension for the HAProxy host. This certificate bundle (*.pem) should contain both the public certificate and private key. See this [HAProxy blog post][3] for more information.
 
+
+**Note**: Download the Datadog certificate with one of the following commands:
+
+```shell
+sudo apt-get install ca-certificates # (Debian, Ubuntu)
+yum install ca-certificates # (CentOS, Red Hat)
+```
+
+The file might be located at `/etc/ssl/certs/ca-certificates.crt` for Debian, Ubuntu or `/etc/ssl/certs/ca-bundle.crt` for CentOS, Red Hat.
+
 ### Proxy forwarding with HAProxy
 
 #### HAProxy configuration
@@ -311,103 +321,103 @@ backend datadog-metrics
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-api
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 api.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 api.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership api.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership api.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-flare
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 flare.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 flare.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership flare.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership flare.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-traces
     balance roundrobin
     mode tcp
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 trace.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 trace.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership trace.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership trace.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-profiles
     balance roundrobin
     mode tcp
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 intake.profile.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 intake.profile.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership profile.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership profile.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-processes
     balance roundrobin
     mode tcp
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 process.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 process.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership process.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership process.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-logs-http
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 agent-http-intake.logs.{{< region-param key="dd_site" >}}:443  check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 agent-http-intake.logs.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server datadog agent-http-intake.logs.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server datadog agent-http-intake.logs.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-database-monitoring-metrics
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 dbm-metrics-intake.{{< region-param key="dd_site" >}}:443  check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 dbm-metrics-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server datadog agent-http-intake.logs.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server datadog agent-http-intake.logs.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-database-monitoring-samples
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 dbquery-intake.{{< region-param key="dd_site" >}}:443  check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 dbquery-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server datadog agent-http-intake.logs.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server datadog agent-http-intake.logs.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-network-devices-metadata
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 ndm-intake.{{< region-param key="dd_site" >}}:443  check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 ndm-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership ndm-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership ndm-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-network-devices-snmp-traps
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 snmp-traps-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 snmp-traps-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership snmp-traps-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership snmp-traps-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-instrumentations-telemetry
     balance roundrobin
     mode tcp
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 instrumentation-telemetry-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 instrumentation-telemetry-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership instrumentation-telemetry-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership instrumentation-telemetry-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-appsec-events # deprecated
     balance roundrobin
     mode tcp
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 ```
 
 {{% /tab %}}
@@ -563,118 +573,110 @@ backend datadog-metrics
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-api
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 api.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 api.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership api.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership api.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-flare
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 flare.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 flare.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership flare.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership flare.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-traces
     balance roundrobin
     mode tcp
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 trace.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 trace.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership trace.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership trace.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-profiles
     balance roundrobin
     mode tcp
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 intake.profile.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 intake.profile.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership profile.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership profile.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-processes
     balance roundrobin
     mode tcp
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 process.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 process.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership process.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership process.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-logs-http
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 agent-http-intake.logs.{{< region-param key="dd_site" >}}:443  check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 agent-http-intake.logs.{{< region-param key="dd_site" >}}:443  check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server datadog agent-http-intake.logs.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server datadog agent-http-intake.logs.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-database-monitoring-metrics
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 dbm-metrics-intake.{{< region-param key="dd_site" >}}:443  check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 dbm-metrics-intake.{{< region-param key="dd_site" >}}:443  check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server datadog agent-http-intake.logs.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server datadog agent-http-intake.logs.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-database-monitoring-samples
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 dbquery-intake.{{< region-param key="dd_site" >}}:443  check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 dbquery-intake.{{< region-param key="dd_site" >}}:443  check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server datadog agent-http-intake.logs.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server datadog agent-http-intake.logs.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-network-devices-metadata
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 ndm-intake.{{< region-param key="dd_site" >}}:443  check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 ndm-intake.{{< region-param key="dd_site" >}}:443  check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership ndm-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership ndm-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-network-devices-snmp-traps
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 snmp-traps-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 snmp-traps-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership snmp-traps-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership snmp-traps-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-instrumentations-telemetry
     balance roundrobin
     mode tcp
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 instrumentation-telemetry-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 instrumentation-telemetry-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership instrumentation-telemetry-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership instrumentation-telemetry-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-appsec-events # deprecated
     balance roundrobin
     mode tcp
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify <PATH_TO_CERTIFICATES>
+    # server mothership appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 ```
 
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: Download the certificate with one of the following commands:
 
-```shell
-sudo apt-get install ca-certificates # (Debian, Ubuntu)
-yum install ca-certificates # (CentOS, Red Hat)
-```
-
-The file might be located at `/etc/ssl/certs/ca-certificates.crt` for Debian, Ubuntu or `/etc/ssl/certs/ca-bundle.crt` for CentOS, Red Hat.
-
-**Note**: You can use `ssl verify none` instead of `ssl verify <PATH_TO_CERTIFICATES>` if you are unable to get the certificates on the proxy host, but be aware that HAProxy will not be able to verify Datadog's intake certificate in that case.
+**Note**: You can use `verify none` instead of `verify required ca-file <PATH_TO_CERTIFICATES>` if you are unable to get the certificates on the proxy host, but be aware that HAProxy will not be able to verify Datadog's intake certificate in that case.
 
 HAProxy 1.8 and newer allow DNS service discovery to detect server changes and automatically apply them to your configuration.
 If you are using older version of HAProxy, you have to reload or restart HAProxy. **It is recommended to have a `cron` job reload HAProxy every 10 minutes** (such as `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case {{< region-param key="dd_full_site" code="true" >}} fails over to another IP.
@@ -806,6 +808,15 @@ To verify that everything is working properly, review the HAProxy statistics at 
 
 The communication between NGINX and Datadog is always encrypted with TLS. The communication between the Agent host and the NGINX host is not encrypted by default, because the proxy and the Agent are assumed to be on the same host. However, it is recommended that you secure this communication with TLS encryption if they are not located on the same isolated local network.
 In order to encrypt data between the Agent and NGINX, you need to create an x509 certificate with the Subject Alternative Name (SAN) extension for the NGINX host.
+
+**Note**: Download the Datadog certificate with one of the following commands:
+
+```shell
+sudo apt-get install ca-certificates # (Debian, Ubuntu)
+yum install ca-certificates # (CentOS, Red Hat)
+```
+
+The file might be located at `/etc/ssl/certs/ca-certificates.crt` for Debian, Ubuntu or `/etc/ssl/certs/ca-bundle.crt` for CentOS, Red Hat.
 
 ### Proxy forwarding with NGINX
 
@@ -1031,15 +1042,6 @@ stream {
 ```
 {{% /tab %}}
 {{< /tabs >}}
-
-**Note**: Download the certificate with one of the following commands:
-
-```shell
-sudo apt-get install ca-certificates # (Debian, Ubuntu)
-yum install ca-certificates # (CentOS, Red Hat)
-```
-
-The file might be located at `/etc/ssl/certs/ca-certificates.crt` for Debian, Ubuntu or `/etc/ssl/certs/ca-bundle.crt` for CentOS, Red Hat.
 
 **Note**: You can remove `proxy_ssl_verify on` if you are unable to get the certificates on the proxy host, but be aware that NGINX will not be able to verify Datadog's intake certificate in that case.
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -287,7 +287,7 @@ frontend network_devices_snmp_traps_frontend
     default_backend datadog-network-devices-snmp-traps
 
 # This declares the endpoint where your Agents connect for
-# sending Instrumentations Telemetry data (e.g. the value of "apm_config.telemetry.dd_url")
+# sending Instrumentation Telemetry data (e.g. the value of "apm_config.telemetry.dd_url")
 frontend instrumentation_telemetry_data_frontend
     bind *:3843
     mode tcp
@@ -537,7 +537,7 @@ frontend network_devices_snmp_traps_frontend
 
 
 # This declares the endpoint where your Agents connect for
-# sending Instrumentations Telemetry data (e.g. the value of "apm_config.telemetry.dd_url")
+# sending Instrumentation Telemetry data (e.g. the value of "apm_config.telemetry.dd_url")
 frontend instrumentation_telemetry_data_frontend
     bind *:3843 ssl crt <PATH_TO_PROXY_CERTIFICATE>
     mode tcp

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -411,6 +411,8 @@ backend datadog-appsec-events # deprecated
 {{% /tab %}}
 {{% tab "HTTPS" %}}
 
+This configuration adds SSL/TLS encryption on communication between the Agent and HAProxy. The variable `<PATH_TO_PROXY_CERTIFICATE_PEM>` should be replaced by the path to the proxy certificate bundle (*.pem).
+
 ```conf
 # Basic configuration
 global
@@ -453,7 +455,7 @@ resolvers my-dns
 # This declares the endpoint where your Agents connects for
 # sending metrics (for example, the value of "dd_url").
 frontend metrics-forwarder
-    bind *:3834 ssl crt <PATH_TO_PROXY_CERTIFICATE>
+    bind *:3834 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
     mode http
     option tcplog
     default_backend datadog-metrics
@@ -465,7 +467,7 @@ frontend metrics-forwarder
 # sending traces (for example, the value of "endpoint" in the APM
 # configuration section).
 frontend traces-forwarder
-    bind *:3835 ssl crt <PATH_TO_PROXY_CERTIFICATE>
+    bind *:3835 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
     mode tcp
     option tcplog
     default_backend datadog-traces
@@ -473,7 +475,7 @@ frontend traces-forwarder
 # This declares the endpoint where your Agents connects for
 # sending profiles (for example, the value of "apm_config.profiling_dd_url").
 frontend profiles-forwarder
-    bind *:3836 ssl crt <PATH_TO_PROXY_CERTIFICATE>
+    bind *:3836 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
     mode tcp
     option tcplog
     default_backend datadog-profiles
@@ -482,7 +484,7 @@ frontend profiles-forwarder
 # sending processes (for example, the value of "url" in the process
 # configuration section).
 frontend processes-forwarder
-    bind *:3837 ssl crt <PATH_TO_PROXY_CERTIFICATE>
+    bind *:3837 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
     mode tcp
     option tcplog
     default_backend datadog-processes
@@ -491,14 +493,14 @@ frontend processes-forwarder
 # sending Logs (e.g the value of "logs.config.logs_dd_url")
 # If sending logs with use_http: true
 frontend logs_http_frontend
-    bind *:3838 ssl crt <PATH_TO_PROXY_CERTIFICATE>
+    bind *:3838 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
     mode http
     option tcplog
     default_backend datadog-logs-http
 
 # If sending logs with use_tcp: true
 # frontend logs_frontend
-#    bind *:10514 ssl crt <PATH_TO_PROXY_CERTIFICATE>
+#    bind *:10514 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
 #    mode tcp
 #    option tcplog
 #    default_backend datadog-logs
@@ -506,7 +508,7 @@ frontend logs_http_frontend
 # This declares the endpoint where your Agents connects for
 # sending database monitoring metrics and activity (e.g the value of "database_monitoring.metrics.dd_url" and "database_monitoring.activity.dd_url")
 frontend database_monitoring_metrics_frontend
-    bind *:3839 ssl crt <PATH_TO_PROXY_CERTIFICATE>
+    bind *:3839 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
     mode http
     option tcplog
     default_backend datadog-database-monitoring-metrics
@@ -514,7 +516,7 @@ frontend database_monitoring_metrics_frontend
 # This declares the endpoint where your Agents connects for
 # sending database monitoring samples (e.g the value of "database_monitoring.samples.dd_url")
 frontend database_monitoring_samples_frontend
-    bind *:3840 ssl crt <PATH_TO_PROXY_CERTIFICATE>
+    bind *:3840 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
     mode http
     option tcplog
     default_backend datadog-database-monitoring-samples
@@ -522,7 +524,7 @@ frontend database_monitoring_samples_frontend
 # This declares the endpoint where your Agents connects for
 # sending Network Devices Monitoring metadata (e.g the value of "network_devices.metadata.dd_url")
 frontend network_devices_metadata_frontend
-    bind *:3841 ssl crt <PATH_TO_PROXY_CERTIFICATE>
+    bind *:3841 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
     mode http
     option tcplog
     default_backend datadog-network-devices-metadata
@@ -530,7 +532,7 @@ frontend network_devices_metadata_frontend
 # This declares the endpoint where your Agents connects for
 # sending Network Devices SNMP Traps data (e.g the value of "network_devices.snmp_traps.forwarder.dd_url")
 frontend network_devices_snmp_traps_frontend
-    bind *:3842 ssl crt <PATH_TO_PROXY_CERTIFICATE>
+    bind *:3842 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
     mode http
     option tcplog
     default_backend datadog-network-devices-snmp-traps
@@ -539,7 +541,7 @@ frontend network_devices_snmp_traps_frontend
 # This declares the endpoint where your Agents connect for
 # sending Instrumentation Telemetry data (e.g. the value of "apm_config.telemetry.dd_url")
 frontend instrumentation_telemetry_data_frontend
-    bind *:3843 ssl crt <PATH_TO_PROXY_CERTIFICATE>
+    bind *:3843 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
     mode tcp
     option tcplog
     default_backend datadog-instrumentations-telemetry
@@ -547,7 +549,7 @@ frontend instrumentation_telemetry_data_frontend
 # This declares the endpoint where your Agents connect for
 # sending appsec events (deprecated).
 frontend appsec-events-frontend
-    bind *:3844 ssl crt <PATH_TO_PROXY_CERTIFICATE>
+    bind *:3844 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
     mode tcp
     option tcplog
     default_backend datadog-appsec-events
@@ -685,7 +687,7 @@ This `dd_url` setting can be found in the `datadog.yaml` file.
 
 `dd_url: <SCHEME>://haproxy.example.com:3834`
 
-Replace `<SCHEME>` by `https` if you want your data to be encrypted between the Agent and HAProxy, or by `http` otherwise.
+Replace `<SCHEME>` by `https` if you previously chose the HAProxy `HTTPS` configuration, or by `http` otherwise.
 
 To send traces, profiles, processes, and logs through the proxy, setup the following in the `datadog.yaml` file:
 
@@ -917,6 +919,9 @@ stream {
 {{% /tab %}}
 {{% tab "HTTPS" %}}
 
+
+This configuration adds SSL/TLS encryption on communication between the Agent and NGINX. The variable `<PATH_TO_PROXY_CERTIFICATE>` should be replaced by the path to the proxy public certificate and `<PATH_TO_PROXY_CERTIFICATE_KEY>` by the path to the private key.
+
 ```conf
 user nginx;
 worker_processes auto;
@@ -1043,7 +1048,7 @@ This `dd_url` setting can be found in the `datadog.yaml` file.
 
 `dd_url: "<SCHEME>://nginx.example.com:3834"`
 
-Replace `<SCHEME>` by `https` if you want your data to be encrypted between the Agent and NGINX, or by `http` otherwise.
+Replace `<SCHEME>` by `https` if you previously chose the NGINX `HTTPS` configuration, or by `http` otherwise.
 
 To send traces, profiles, processes, and logs through the proxy, setup the following in the `datadog.yaml` file:
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -149,7 +149,7 @@ Do not forget to [restart the Agent][1] for the new settings to take effect.
 This is the best option if you do not have a web proxy readily available in your network, and you wish to proxy a large number of Agents. In some cases, a single HAProxy instance is sufficient to handle local Agent traffic in your network as each proxy can accommodate upwards connections of 1000 Agents. **Note**: This figure is a conservative estimate based on the performance of m3.xl instances specifically. Numerous network-related variables can influence load on proxies. As always, deploy under a watchful eye. See the [HAProxy documentation][2] for additional information.
 
 The communication between HAProxy and Datadog will always be encrypted and it is recommended to encrypt the communication between the Agent host and the HAProxy host if they are not part of the same local network.
-In order to encrypt data between the Agent and HAProxy, you will need to create a Subject Alternative Name (SAN) certificate for the HAProxy host. 
+In order to encrypt data between the Agent and HAProxy, you will need to create a Subject Alternative Name (SAN) certificate for the HAProxy host. This certificate should contain both the public certificate and private key. See this [HAProxy blog post][3] for more information.
 
 ### Proxy forwarding with HAProxy
 
@@ -796,7 +796,7 @@ To verify that everything is working properly, review the HAProxy statistics at 
 
 ## NGINX
 
-[NGINX][3] is a web server which can also be used as a reverse proxy, load balancer, mail proxy, and HTTP cache. You can also use NGINX as a proxy for your Datadog Agents:
+[NGINX][4] is a web server which can also be used as a reverse proxy, load balancer, mail proxy, and HTTP cache. You can also use NGINX as a proxy for your Datadog Agents:
 
 `agent ---> nginx ---> Datadog`
 
@@ -1147,6 +1147,8 @@ It is recommended to use an actual proxy (a web proxy or HAProxy) to forward you
 
 {{< partial name="whats-next/whats-next.html" >}}
 
+
 [1]: http://haproxy.1wt.eu
 [2]: http://www.haproxy.org/#perf
-[3]: https://www.nginx.com
+[3]: https://www.haproxy.com/blog/haproxy-ssl-termination/
+[4]: https://www.nginx.com


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

- Add guidelines on raw/encrypted communication between the Agent,  proxy and Datadog intake.
    - Add Datadog certificate verification on the proxy host.
    - Add docs on when and how to encrypt communication between the Agent and the proxy
- Fix some errors :
    - telemetry HAProxy frontend was missing after a merge
    - AppSec port was different on HAProxy and Nginx + missing in one `datadog.yaml` config
    - update the part about `skip_ssl_validation` (which was previously useless because HTTP was used between the Agent and the proxy)

### Motivation
<!-- What inspired you to submit this pull request?-->

Give better guidelines to customers

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/nicolas.guerguadj/aml-100-add-https-guideline-for-proxy-setup/agent/proxy/?tab=agentv6v7

### Additional Notes
<!-- Anything else we should know when reviewing?-->

- Did not test `network_devices` but as it is using the same component as `database_monitoring`, the behavior is the same
- There is still no guidelines on how to create certificates, will be addressed in a future PR

### To check

There was some modifications on this file before this PR that introduced some errors like missing frontend or inconsistencies with ports. I realized it and fixed them after all I added, so I might have missed some stuff : 

It would be nice if someone check after me that : 

- [ ]  `HTTP` configuration (the one by default before this PR) should only have : 
    - [ ] `ssl verify <PATH_TO_CERTIFICATES>` instead of `ssl verify none` for HAProxy
    - [ ] `proxy_ssl_verify on` added to all server for NGINX
- [ ]  `HTTPS` configuration should contains the `HTTP` config information and : 
    - [ ] `ssl crt <PATH_TO_PROXY_CERTIFICATE>` at the end on each `bind` line for HAProxy
    - [ ] `ssl` at the end on each `listen` line for NGINX
- [ ] There is no `HAProxy` reference in `NGINX` part and vice versa 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
