### PR TITLE
Documents that is_exact_match supports matching multiple strings

### DIFF
--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -164,7 +164,7 @@ The `is_exact_match` condition also supports matching multiple strings:
 {{#is_exact_match "host.name" "production" "staging"}}
   This displays if the host that triggered the alert is exactly
   named production or staging. @dev-team@company.com
-{{/is_match}}
+{{/is_exact_match}}
 
 The `is_exact_match` conditional variable also supports [`{{value}}` template variables](#template-variables):
 

--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -161,10 +161,12 @@ To notify your dev team if a triggering host has the name `production`, use the 
 
 The `is_exact_match` condition also supports matching multiple strings:
 
+```text
 {{#is_exact_match "host.name" "production" "staging"}}
   This displays if the host that triggered the alert is exactly
   named production or staging. @dev-team@company.com
 {{/is_exact_match}}
+```
 
 The `is_exact_match` conditional variable also supports [`{{value}}` template variables](#template-variables):
 

--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -159,6 +159,13 @@ To notify your dev team if a triggering host has the name `production`, use the 
 {{/is_exact_match}}
 ```
 
+The `is_exact_match` condition also supports matching multiple strings:
+
+{{#is_exact_match "host.name" "production" "staging"}}
+  This displays if the host that triggered the alert is exactly
+  named production or staging. @dev-team@company.com
+{{/is_match}}
+
 The `is_exact_match` conditional variable also supports [`{{value}}` template variables](#template-variables):
 
 ```text


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

It documents the fact that `is_exact_match` supports matching multiple strings, the same way it is supported for `is_match`.

### Motivation

https://github.com/DataDog/documentation/issues/14781

Since it wasn't clear from the documentation I had set up a dummy monitor to confirm it. Having it documented would have saved me that _hassle_.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes

I only confirmed it by testing it. It might be good to get it confirmed from the code as well.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
