### PR TITLE
Update number of days deleted views stay in the UI

### DIFF
--- a/content/en/logs/log_configuration/rehydrating.md
+++ b/content/en/logs/log_configuration/rehydrating.md
@@ -93,7 +93,7 @@ One hour later, the historical view is definitively deleted; until that time, th
 
 ### Viewing deleted historical views
 
-View deleted historical views for up to 90 days in the past using the `View` dropdown menu:
+View deleted historical views for up to 1 year in the past using the `View` dropdown menu:
 
 {{< img src="logs/archives/log_archives_deleted_rehydrations.png" alt="Deleting Historical Views" width="75%" >}}
 


### PR DESCRIPTION
Previous statement (90 days) was not correct, we can see deleted historical views for up to a year in the UI.