### PR TITLE
Write link to in-app tile for purchasing marketplace integrations in generated docs

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -614,8 +614,9 @@ class Integrations:
         2. add tabs if they exist
         3. inject metrics after ### Metrics header if metrics exists for file
         4. inject service checks after ### Service Checks if file exists
-        5. inject hugo front matter params at top of file
-        6. write out file to content/integrations with filename changed to integrationname.md
+        5. inject where to purchase integration if it's a marketplace integration
+        6. inject hugo front matter params at top of file
+        7. write out file to content/integrations with filename changed to integrationname.md
         :param file_name: path to a readme md file
         """
         no_integration_issue = True
@@ -677,7 +678,7 @@ class Integrations:
         regex_skip_sections_start = r"(```|\{\{< code-block |\{\{< site-region)"
 
         ## Formating all link as reference to avoid any corner cases
-        ## Replace image filenames in markdown for marketplace interations
+        ## Replace image filenames in markdown for marketplace iterations
         result = ''
         if not marketplace:
             try:
@@ -687,6 +688,11 @@ class Integrations:
         else:
             with open(file_name, 'r+') as f:
                 markdown_string = f.read()
+                # Add static copy with link to the in-app tile, link converters called later will ensure the `site` flag is respected
+                in_app_tile_link = f"https://app.datadoghq.com/marketplace/app/{manifest_json['integration_id']}"
+                purchase_copy = f"---\nThis application is made available through the Marketplace and is supported by a Datadog Technology Partner. [Click here]({in_app_tile_link}) to purchase this application."
+
+                markdown_string = f"{markdown_string}\n{purchase_copy}"
                 markdown_with_replaced_images = self.replace_image_src(markdown_string, basename(dirname(file_name)))
                 markdown_setup_removed = self.remove_markdown_section(markdown_with_replaced_images, '## Setup')
                 updated_markdown = self.remove_h3_markdown_section(markdown_setup_removed, '### Pricing')
@@ -776,11 +782,11 @@ class Integrations:
                     integration_version = matches.group(1)
 
         if not exist_already and no_integration_issue:
-            # lets only write out file.md if its going to be public
+            # let's only write out file.md if it's going to be public
             if manifest_json.get("is_public", False):
                 out_name = self.content_integrations_dir + new_file_name
 
-                # lets make relative app links to integrations tile absolute
+                # let's make relative app links to integrations tile absolute
                 regex = r"(?<!https://app.datadoghq.com)(/account/settings#integrations[^.)\s]*)"
                 regex_result = re.sub(regex, "https://app.datadoghq.com\\1", result, 0, re.MULTILINE)
                 if regex_result:

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -689,8 +689,8 @@ class Integrations:
             with open(file_name, 'r+') as f:
                 markdown_string = f.read()
                 # Add static copy with link to the in-app tile, link converters called later will ensure the `site` flag is respected
-                in_app_tile_link = f"https://app.datadoghq.com/marketplace/app/{manifest_json['integration_id']}"
-                purchase_copy = f"---\nThis application is made available through the Marketplace and is supported by a Datadog Technology Partner. [Click here]({in_app_tile_link}) to purchase this application."
+                purchase_copy = f"---\nThis application is made available through the Marketplace and is supported by a Datadog Technology Partner." \
+                                f" <a href=\"https://app.datadoghq.com/marketplace/app/{manifest_json['integration_id']}\" target=\"_blank\">Click Here</a> to purchase this application."
 
                 markdown_string = f"{markdown_string}\n{purchase_copy}"
                 markdown_with_replaced_images = self.replace_image_src(markdown_string, basename(dirname(file_name)))


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Hardcodes a sentence at the bottom of generated marketplace documentation to note that it was created by a partner, and where to go to make the purchase

I also updated some inline comments that my editor were complaining about 🙂 

### Motivation
<!-- What inspired you to submit this pull request?-->
This was previously expected to be placed in every marketplace README. However we had no validations around this which led to:
* Some integrations forgetting to include the sentence completely
* Some copy/paste issues where the link would be there, but point to a different tile

Additionally, we don't need this copy in the in-app tile, only in the documentation, so including it here directly is beneficial.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Some good examples to view are:
* rapdev_zoom - This will have the generated copy at the bottom 
* rapdev_sophos - This will have the generated copy at the bottom (Note the improper link in the first link thats accidentally pointing to `zoom`, and the second autogenerated link that points to the proper `sophos` tile
* oracle: This integrations-core integrations does not include the copy at the bottom


In terms of rollout the plan is:
* Get this PR reviewed/tested/approved
* Make and merge a PR that removes this sentence from all marketplace README's
* Then merge this PR

This rollout strategy ensures we don't have live documentation that includes this sentence twice

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
