### PR TITLE
Add the minimum required version to the .NET profiler documentation

### DIFF
--- a/content/en/tracing/profiler/enabling/dotnet.md
+++ b/content/en/tracing/profiler/enabling/dotnet.md
@@ -57,6 +57,8 @@ Supported languages
 
 If you are already using Datadog, upgrade your Agent to version [7.20.2][1]+ or [6.20.2][2]+. The profiler ships together with the tracer, so install it using the following steps, depending on your operating system.
 
+**Note:** The profiler ships with the tracer starting with version 2.8.0. If you're using an older version of the tracer, you need to upgrade first.
+
 {{< tabs >}}
 
 {{% tab "Linux" %}}


### PR DESCRIPTION
### What does this PR do?

Add the minimum required version to the .NET profiler documentation.

### Motivation

At least one customer tried to use the profiler with an older version and couldn't figure why it wasn't working.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
