### PR TITLE
Clarify exactly what "Limited Resource" means.

### DIFF
--- a/content/en/tracing/trace_pipeline/ingestion_controls.md
+++ b/content/en/tracing/trace_pipeline/ingestion_controls.md
@@ -66,7 +66,7 @@ Infrastructure
 : Hosts, containers, and functions on which the service is running.
 
 Service status
-: Shows `Limited Resource` when some spans are dropped due to the Datadog Agent reaching CPU or RAM limits, `Legacy Setup` when some spans are ingested through the legacy [App Analytics mechanism][6], and `OK` the rest of the time.
+: Shows `Limited Resource` when some spans are dropped due to the Datadog Agent reaching CPU or RAM limits set [in its configuration][12], `Legacy Setup` when some spans are ingested through the legacy [App Analytics mechanism][6], and `OK` the rest of the time.
 
 Filter the page by environment, configuration, and status to view services for which you need to take an action. To reduce the global ingestion volume, sort the table by the `Downstream Bytes/s` column to view services responsible for the largest share of your ingestion.
 
@@ -132,3 +132,4 @@ To specify that a specific percentage of a service's traffic should be sent, add
 [9]: /tracing/trace_pipeline/metrics
 [10]: /tracing/trace_pipeline/ingestion_mechanisms/
 [11]: https://app.datadoghq.com/dash/integration/30337/app-analytics-usage
+[12]: /tracing/troubleshooting/agent_rate_limits/#maximum-cpu-percentage

--- a/content/en/tracing/troubleshooting/agent_rate_limits.md
+++ b/content/en/tracing/troubleshooting/agent_rate_limits.md
@@ -5,7 +5,7 @@ aliases:
   - /tracing/troubleshooting/apm_rate_limits
 ---
 
-## Max events per second limit
+## Maximum events per second limit
 
 If you encounter the following error message in your Agent logs, your applications are emitting more than the default 200 trace events per second allowed by APM.
 
@@ -18,7 +18,7 @@ To increase the APM rate limit for the Agent, configure the `max_events_per_seco
 
 **Note**: Increasing the APM rate limit could result in increased costs for App Analytics.
 
-## Max connection limit
+## Maximum connection limit
 
 If you encounter the following error message in your Agent logs, the default APM connection limit of 2000 has been exceeded:
 
@@ -28,7 +28,7 @@ ERROR | (pkg/trace/logutil/throttled.go:38 in log) | http.Server: http: Accept e
 
 To increase the APM connection limit for the Agent, configure the `connection_limit` attribute within the Agent's configuration file (underneath the `apm_config:` section). For containerized deployments (for example, Docker or Kubernetes), use the `DD_APM_CONNECTION_LIMIT` environment variable.
 
-## Max memory limit
+## Maximum memory limit
 
 If you encounter the following error message in your Agent logs, it means the Agent has exceeded the max memory usage by 150%:
 
@@ -38,3 +38,13 @@ CRITICAL | (pkg/trace/osutil/file.go:39 in Exitf) | OOM
 ```
 
 To increase the max memory limit for the Agent, configure the `max_memory` attribute in the `apm_config` section of the Agent's configuration file. For containerized deployments (for example, Docker or Kubernetes), use the `DD_APM_MAX_MEMORY` environment variable.
+
+If you'd like your orchestrator (such as Kubernetes) to handle your memory limits, this limit can be disabled by setting it to `0` since Datadog Agent 7.23.0.
+
+## Maximum CPU percentage
+
+This setting defines the maximum CPU percentage that the APM agent should be using. In non-Kubernetes environments it defaults to 50, which is equivalent to 0.5 cores (100 = 1 core). After this limit is reached, payloads will be refused until the CPU usage goes below the limit again. This is reflected by the `datadog.trace_agent.receiver.ratelimit` which represents the percentage of payloads that are currently being dropped (a value of 1 meaning that no traces are being dropped). This may also be visible in the [Service Table View][1] as a `Limited Resource` warning.
+
+If you'd like to leave it up to your orchestrator (or an external service) to manage resource limitations for the Datadog Agent, we recommend disabling this by setting the environment variable `DD_APM_MAX_CPU_PERCENT` to `0` (supported since Datadog Agent 7.23.0).
+
+[1]: /tracing/trace_pipeline/ingestion_controls/#service-table-view

--- a/content/en/tracing/troubleshooting/agent_rate_limits.md
+++ b/content/en/tracing/troubleshooting/agent_rate_limits.md
@@ -45,6 +45,6 @@ If you'd like your orchestrator (such as Kubernetes) to handle your memory limit
 
 This setting defines the maximum CPU percentage that the APM agent should be using. In non-Kubernetes environments it defaults to 50, which is equivalent to 0.5 cores (100 = 1 core). After this limit is reached, payloads will be refused until the CPU usage goes below the limit again. This is reflected by the `datadog.trace_agent.receiver.ratelimit` which represents the percentage of payloads that are currently being dropped (a value of 1 meaning that no traces are being dropped). This may also be visible in the [Service Table View][1] as a `Limited Resource` warning.
 
-If you'd like to leave it up to your orchestrator (or an external service) to manage resource limitations for the Datadog Agent, we recommend disabling this by setting the environment variable `DD_APM_MAX_CPU_PERCENT` to `0` (supported since Datadog Agent 7.23.0).
+If you want your orchestrator (or an external service) to manage resource limitations for the Datadog Agent, Datadog recommends disabling this by setting the environment variable `DD_APM_MAX_CPU_PERCENT` to `0` (supported since Datadog Agent 7.23.0).
 
 [1]: /tracing/trace_pipeline/ingestion_controls/#service-table-view


### PR DESCRIPTION
Customers seeing "Limited Resource" as a warning while having plenty of memory and CPU available on their host get confused by this. This documentation clarifies the meaning of this warning and makes it clearer that this refers to internal limitations of the configuration rather than actual host resources.