### PR TITLE
update hugo version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "del": "4.1.1",
         "docsearch.js": "^2.6.3",
         "fancy-log": "^1.3.3",
-        "hugo-bin": "0.86.0",
+        "hugo-bin": "0.89.0",
         "jquery": "3.5.1",
         "js-cookie": "^2.2.1",
         "js-yaml": "^3.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4416,7 +4416,7 @@ __metadata:
     eslint-plugin-react-hooks: ^2.5.0
     eslint-plugin-standard: ^4.0.0
     fancy-log: ^1.3.3
-    hugo-bin: 0.86.0
+    hugo-bin: 0.89.0
     jest: ^25.3.0
     jquery: 3.5.1
     js-cookie: ^2.2.1
@@ -6300,9 +6300,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hugo-bin@npm:0.86.0":
-  version: 0.86.0
-  resolution: "hugo-bin@npm:0.86.0"
+"hugo-bin@npm:0.89.0":
+  version: 0.89.0
+  resolution: "hugo-bin@npm:0.89.0"
   dependencies:
     bin-wrapper: ^4.1.0
     picocolors: ^1.0.0
@@ -6310,7 +6310,7 @@ __metadata:
     rimraf: ^3.0.2
   bin:
     hugo: cli.js
-  checksum: 49d480ca9cde1154a5f74e4d21246e8fb831e277c7518392918c046c426d25113c3530f028c7cde3bc1fafc25d3e25d7fd8744ac3537449d59185a8738c6e521
+  checksum: 278ba5cc8cd77d80b5d8d98d9e517178955422a24e015888bbb0e3aa8689596b16373308c0e5239b0a9dbe1dc148996cefc8d9a30103005921d45e025ee94e0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

Updates the hugo version to 0.101.0

### Motivation

Staying up to date with the latest features

### Preview

QA as much as possible, looking for anything out of the ordinary
https://docs-staging.datadoghq.com/david.jones/hugo-latest/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
