### PR TITLE
RUM: remove mention of x-datadog-sampled

### DIFF
--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -183,9 +183,6 @@ Datadog uses the distributed tracing protocol and sets up the following HTTP hea
 `x-datadog-sampling-priority: 1`
 : To make sure that the Agent keeps the trace.
 
-`x-datadog-sampled: 1`
-: Generated from the Real User Monitoring SDK. Indicates this request is selected for sampling.
-
 **Note**: These HTTP headers are not CORS-safelisted, so you need to [configure Access-Control-Allow-Headers][16] on your server handling requests that the SDK is set up to monitor. The server must also accept [preflight requests][17] (OPTIONS requests), which are made by the SDK prior to every request.
 
 ## How are APM quotas affected?

--- a/content/fr/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/fr/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -147,9 +147,6 @@ Datadog utilise un protocole de tracing distribué et configure les en-têtes HT
 `x-datadog-sampling-priority: 1`
 : Permet de s'assurer que l'Agent conserve la trace.
 
-`x-datadog-sampled: 1`
-: Généré à partir du SDK RUM. Indique que cette requête est sélectionnée pour l'échantillonnage.
-
 **Remarque** : ces en-têtes HTTP ne sont pas ajoutés à la liste blanche du mécanisme CORS. Vous devez donc [configurer Access-Control-Allow-Headers][16] sur le serveur traitant les requêtes que le SDK surveille. Le serveur doit également accepter les [requêtes préliminaires][17] (requêtes OPTIONS), qui sont transmises par le SDK avant chaque requête.
 
 ## Cela a-t-il une incidence sur les quotas de l'APM ?

--- a/content/ja/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/ja/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -183,9 +183,6 @@ Real User Monitoring から生成されたトレースが、APM インデック�
 `x-datadog-sampling-priority: 1`
 : Agent がトレースを維持するようにします。
 
-`x-datadog-sampled: 1`
-Real User Monitoring SDK から生成されます。このリクエストがサンプリング用に選択されていることを示します。
-
 **注**: 上記 HTTP ヘッダーは CORS セーフリストに登録されていないため、SDK が監視するように設定されているリクエストを扱うサーバーで [Access-Control-Allow-Headers を構成][16]する必要があります。サーバーは、すべてのリクエストの前に SDK によって作られる[プレフライトリクエスト][17]も許可する必要があります (OPTIONS リクエスト)。
 
 ## APM クオータへの影響


### PR DESCRIPTION
This parameter is unused and deprecated since 3y+