### PR TITLE
[.NET Profiler] Update .net profiler documentation according new support of CentOS 7

### DIFF
--- a/content/en/tracing/profiler/enabling/dotnet.md
+++ b/content/en/tracing/profiler/enabling/dotnet.md
@@ -33,7 +33,7 @@ Supported operating systems for .NET Framework
 Windows Server starting from version 2012
 
 Supported operating systems for .NET Core and .NET 5+
-: Linux with glibc 2.17+ (ex: CentOS 7...) and musl-based (Alpine) <br/>
+: Linux with glibc 2.17+ (for example, CentOS 7+) and musl-based (Alpine) <br/>
 Windows 10<br/>
 Windows Server starting from version 2012
 
@@ -119,7 +119,8 @@ To install the .NET Profiler machine-wide:
 
 5. A minute or two after starting your application, your profiles appear on the [Datadog APM > Profiler page][1].
 
-{{< /tabs >}}
+[1]: https://app.datadoghq.com/profiling
+{{% /tab %}}
 
 {{% tab "Internet Information Services (IIS)" %}}
 3. Set needed environment variables to configure and enable Profiler.

--- a/content/en/tracing/profiler/enabling/dotnet.md
+++ b/content/en/tracing/profiler/enabling/dotnet.md
@@ -33,7 +33,7 @@ Supported operating systems for .NET Framework
 Windows Server starting from version 2012
 
 Supported operating systems for .NET Core and .NET 5+
-: Linux with glibc 2.18+ (for example CentOS 7 is not supported)<br/>
+: Linux with glibc 2.17+ (ex: CentOS 7...) and musl-based (Alpine) <br/>
 Windows 10<br/>
 Windows Server starting from version 2012
 
@@ -69,7 +69,7 @@ To install the .NET Profiler machine-wide:
    Debian or Ubuntu
    : `sudo dpkg -i ./datadog-dotnet-apm_<TRACER_VERSION>_amd64.deb && /opt/datadog/createLogPath.sh`
 
-   CentOS 8+ or Fedora
+   CentOS 7+ or Fedora
    : `sudo rpm -Uvh datadog-dotnet-apm<TRACER_VERSION>-1.x86_64.rpm && /opt/datadog/createLogPath.sh`
 
    Alpine or other musl-based distributions

--- a/content/en/tracing/profiler/enabling/dotnet.md
+++ b/content/en/tracing/profiler/enabling/dotnet.md
@@ -122,7 +122,8 @@ To install the .NET Profiler machine-wide:
 {{< /tabs >}}
 
 {{% tab "Internet Information Services (IIS)" %}}
-3. Set needed environment variables to configure and enable Profiler. To enable the Profiler for IIS applications, it is required to set the `DD_PROFILING_ENABLED`, `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` environment variables in the Registry under `HKLM\System\CurrentControlSet\Services\WAS` and `HKLM\System\CurrentControlSet\Services\W3SVC` nodes.
+3. Set needed environment variables to configure and enable Profiler.
+ To enable the Profiler for IIS applications, it is required to set the `DD_PROFILING_ENABLED` environment variable in the Registry under `HKLM\System\CurrentControlSet\Services\WAS` and `HKLM\System\CurrentControlSet\Services\W3SVC` nodes.
 
    **With the Registry Editor:**
 
@@ -168,7 +169,7 @@ To install the .NET Profiler machine-wide:
 {{% /tab %}}
 
 {{% tab "Windows services" %}}
-3. Set needed environment variables to configure and enable Profiler. To enable the Profiler for your service, it is required to set the `DD_PROFILING_ENABLED`, `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` environment variables in the Registry key associated to the service.
+3. Set needed environment variables to configure and enable Profiler. To enable the Profiler for your service, it is required to set the `DD_PROFILING_ENABLED` environment variable in the Registry key associated to the service. If the profiler is running alone (the tracer is deactivated), you can optionally add the `DD_SERVICE`, `DD_ENV` and `DD_VERSION` environment variables.
 
    **With the Registry Editor:**
 
@@ -230,7 +231,7 @@ To install the .NET Profiler machine-wide:
 {{% /tab %}}
 
 {{% tab "Windows Standalone applications" %}}
-3. Set needed environment variables to configure and enable Profiler for a non-service application, such as console, ASP.NET (Core), Windows Forms, or WPF. To enable the Profiler for Standalone applications, it is required to set the `DD_PROFILING_ENABLED`, `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` environment variables. The recommended approach is to create a batch file that sets these and starts the application, and run your application using the batch file.
+3. Set needed environment variables to configure and enable Profiler for a non-service application, such as console, ASP.NET (Core), Windows Forms, or WPF. To enable the Profiler for Standalone applications, it is required to set the `DD_PROFILING_ENABLED` environment variable. If the profiler is running alone (the tracer is deactivated), you can optionally set the `DD_SERVICE`, `DD_ENV` and `DD_VERSION` environment variables. The recommended approach is to create a batch file that sets these and starts the application, and run your application using the batch file.
 
    For .NET Core and .NET 5+:
    ```cmd


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adjust the documentation according to the new support of CentOS 7.
### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
