### PR TITLE
[DOCS-3794] Make front matter for guide indexes consistent

### DIFF
--- a/content/en/agent/guide/_index.md
+++ b/content/en/agent/guide/_index.md
@@ -2,6 +2,7 @@
 title: Agent Guides
 kind: guide
 private: true
+disable_toc: true
 ---
 
 {{< whatsnext desc="General guides:" >}}

--- a/content/en/continuous_integration/guides/_index.md
+++ b/content/en/continuous_integration/guides/_index.md
@@ -2,7 +2,7 @@
 title: CI Visibility Guides
 kind: guide
 private: true
-disable_sidebar: true
+disable_toc: true
 ---
 
 {{< whatsnext desc="CI Visibility Guides:" >}}

--- a/content/en/dashboards/guide/_index.md
+++ b/content/en/dashboards/guide/_index.md
@@ -2,6 +2,7 @@
 title: Graphing Guides
 kind: guide
 private: true
+disable_toc: true
 aliases:
     - /graphing/guide/
     - /faq/treemap-graph-visualization-can-i-use-this-elsewhere/

--- a/content/en/data_security/guide/_index.md
+++ b/content/en/data_security/guide/_index.md
@@ -2,6 +2,7 @@
 title: Security Guides
 kind: guide
 private: true
+disable_toc: true
 aliases:
     - /security/guide/
 ---

--- a/content/en/database_monitoring/guide/_index.md
+++ b/content/en/database_monitoring/guide/_index.md
@@ -2,6 +2,7 @@
 title: Database Monitoring Guides
 kind: guide
 private: true
+disable_toc: true
 ---
 
 {{< whatsnext desc="General guides:" >}}

--- a/content/en/developers/guide/_index.md
+++ b/content/en/developers/guide/_index.md
@@ -2,6 +2,7 @@
 title: Developer Guides
 kind: guide
 private: true
+disable_toc: true
 ---
 
 {{< whatsnext desc="General:" >}}

--- a/content/en/events/guides/_index.md
+++ b/content/en/events/guides/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Events Guides
 kind: documentation
+private: true
+disable_toc: true
 further_reading:
 - link: "/events/explorer/"
   tag: "Documentation"

--- a/content/en/integrations/guide/_index.md
+++ b/content/en/integrations/guide/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Integration Guides
 kind: guide
-disable_sidebar: true
+disable_toc: true
 private: true
 ---
 

--- a/content/en/logs/guide/_index.md
+++ b/content/en/logs/guide/_index.md
@@ -2,6 +2,7 @@
 title: Logs Guides
 kind: guide
 private: true
+disable_toc: true
 ---
 
 {{< whatsnext desc="Logging Without Limits™" >}}

--- a/content/en/metrics/guide/_index.md
+++ b/content/en/metrics/guide/_index.md
@@ -5,7 +5,7 @@ description: Index of Metrics Guides
 aliases:
     - /metrics/custom_metrics/guide/
 private: true
-disable_sidebar: true
+disable_toc: true
 ---
 
 {{< whatsnext desc="General guides:" >}}

--- a/content/en/monitors/guide/_index.md
+++ b/content/en/monitors/guide/_index.md
@@ -2,7 +2,7 @@
 title: Monitor Guides
 kind: guide
 private: true
-disable_sidebar: true
+disable_toc: true
 ---
 
 {{< whatsnext desc="General Guides:" >}}

--- a/content/en/network_monitoring/devices/guide/_index.md
+++ b/content/en/network_monitoring/devices/guide/_index.md
@@ -2,7 +2,7 @@
 title: NDM Guides
 kind: guide
 private: true
-disable_sidebar: true
+disable_toc: true
 aliases:
     - /network_performance_monitoring/devices/guide/
 further_reading:

--- a/content/en/network_monitoring/performance/guide/_index.md
+++ b/content/en/network_monitoring/performance/guide/_index.md
@@ -4,7 +4,7 @@ kind: guide
 aliases:
     - /network_performance_monitoring/guide/
 private: true
-disable_sidebar: true
+disable_toc: true
 ---
 
 {{< whatsnext desc="General Guides:" >}}

--- a/content/en/real_user_monitoring/guide/_index.md
+++ b/content/en/real_user_monitoring/guide/_index.md
@@ -2,6 +2,7 @@
 title: Real User Monitoring & Session Replay Guides
 kind: guide
 private: true
+disable_toc: true
 ---
 
 {{< whatsnext desc="General RUM:" >}}

--- a/content/en/security_platform/guide/_index.md
+++ b/content/en/security_platform/guide/_index.md
@@ -4,6 +4,7 @@ kind: guide
 aliases:
   - /security_monitoring/guide/
 private: true
+disable_toc: true
 ---
 
 {{< whatsnext desc="General Guides:" >}}

--- a/content/en/serverless/guide/_index.md
+++ b/content/en/serverless/guide/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Serverless Monitoring Guides
 kind: guide
+private: true
+disable_toc: true
 ---
 
 ## Monitor your serverless applications

--- a/content/en/synthetics/guide/_index.md
+++ b/content/en/synthetics/guide/_index.md
@@ -4,7 +4,7 @@ kind: guide
 aliases:
   - /synthetics/faq/uptime-check-internal-website/ 
 private: true
-disable_sidebar: true
+disable_toc: true
 ---
 
 {{< whatsnext desc="General Guides:" >}}

--- a/content/en/tracing/guide/_index.md
+++ b/content/en/tracing/guide/_index.md
@@ -2,6 +2,7 @@
 title: Tracing Guides
 kind: guide
 private: true
+disable_toc: true
 aliases:
 - /tracing/getting_further/
 - /tracing/guide/ecommerce_and_retail_use_cases/


### PR DESCRIPTION
### What does this PR do?

Update all front matter for guide indexes so that they have:
private: true
disable_toc: true

### Motivation

DOCS-3794

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
