### PR TITLE
Add region sections to format-links precommit

### DIFF
--- a/local/bin/py/build/actions/format_link.py
+++ b/local/bin/py/build/actions/format_link.py
@@ -71,7 +71,7 @@ def prepare_file(file):
                 else:
                     temp_section.append(line)            
     if state != 'main':
-        raise ValueError      
+        raise ValueError
 
     return [main_section] + sub_sections
 

--- a/local/bin/py/build/actions/format_link.py
+++ b/local/bin/py/build/actions/format_link.py
@@ -31,16 +31,30 @@ def prepare_file(file):
         for line in f:
             if state == 'main':
                 main_section.append(line)
-                if (re.search(r"{{< tabs >}}", line.strip()) or re.search(r"{{< programming-lang-wrapper", line.strip())):
+                if (
+                    re.search(r"{{< tabs >}}", line.strip()) or
+                    re.search(r"{{< programming-lang-wrapper", line.strip()) or
+                    re.search(r"{{< site-region", line.strip())
+                   ):
                     state = 'tabs'
             elif state == 'tabs':
                 main_section.append(line)
-                if (re.search(r"{{% tab ", line.strip()) or re.search(r"{{< programming-lang ", line.strip())):
+                if (
+                    re.search(r"{{% tab ", line.strip()) or
+                    re.search(r"{{< programming-lang ", line.strip())
+                   ):
                     state = 'tab'
-                if (re.search(r"{{< /tabs >}}", line.strip()) or re.search(r"{{< /programming-lang-wrapper >}}", line.strip())):
+                if (
+                    re.search(r"{{< /tabs >}}", line.strip()) or
+                    re.search(r"{{< /programming-lang-wrapper >}}", line.strip()) or
+                    re.search(r"{{< /site-region >}}", line.strip())
+                   ):
                     state = 'main'
             elif state == 'tab':
-                if (re.search(r"{{% /tab %}}", line.strip()) or re.search(r"{{< /programming-lang >}}", line.strip())):
+                if (
+                    re.search(r"{{% /tab %}}", line.strip()) or
+                    re.search(r"{{< /programming-lang >}}", line.strip())
+                   ):
                     state = 'tabs'
                     main_section.append(line)
                     sub_sections.append(temp_section)
@@ -326,12 +340,17 @@ def inline_section(file_prepared):
 
     end_section_pattern = r"\s*{{% /tab %}}.*"
     end_lang_section_pattern = r"\s*{{< /programming-lang >}}.*"
+    end_region_section_pattern = r"\s*{{< /site-region >}}.*"
 
     i = 1
 
     try:
         for line in file_prepared[0]:
-            if (re.match(end_section_pattern, line) or re.match(end_lang_section_pattern, line)):
+            if (
+                re.match(end_section_pattern, line) or
+                re.match(end_lang_section_pattern, line) or
+                re.match(end_region_section_pattern, line)
+               ):
                 final_text += file_prepared[i]
                 i += 1
             final_text.append(line)

--- a/local/bin/py/build/actions/format_link.py
+++ b/local/bin/py/build/actions/format_link.py
@@ -33,10 +33,20 @@ def prepare_file(file):
                 main_section.append(line)
                 if (
                     re.search(r"{{< tabs >}}", line.strip()) or
-                    re.search(r"{{< programming-lang-wrapper", line.strip()) or
-                    re.search(r"{{< site-region", line.strip())
+                    re.search(r"{{< programming-lang-wrapper", line.strip())
                    ):
                     state = 'tabs'
+                if re.search(r"{{< site-region", line.strip()):
+                    state = 'region'
+            elif state == 'region':
+                if re.search(r"{{< /site-region >}}", line.strip()):
+                    main_section.append(line)
+                    sub_sections.append(temp_section)
+                    temp_section = []
+                    state = 'main'
+                else:
+                    temp_section.append(line)
+
             elif state == 'tabs':
                 main_section.append(line)
                 if (
@@ -46,8 +56,7 @@ def prepare_file(file):
                     state = 'tab'
                 if (
                     re.search(r"{{< /tabs >}}", line.strip()) or
-                    re.search(r"{{< /programming-lang-wrapper >}}", line.strip()) or
-                    re.search(r"{{< /site-region >}}", line.strip())
+                    re.search(r"{{< /programming-lang-wrapper >}}", line.strip())
                    ):
                     state = 'main'
             elif state == 'tab':
@@ -60,10 +69,9 @@ def prepare_file(file):
                     sub_sections.append(temp_section)
                     temp_section = []
                 else:
-                    temp_section.append(line)
-
+                    temp_section.append(line)            
     if state != 'main':
-        raise ValueError
+        raise ValueError      
 
     return [main_section] + sub_sections
 

--- a/local/bin/py/build/actions/format_link.py
+++ b/local/bin/py/build/actions/format_link.py
@@ -31,10 +31,7 @@ def prepare_file(file):
         for line in f:
             if state == 'main':
                 main_section.append(line)
-                if (
-                    re.search(r"{{< tabs >}}", line.strip()) or
-                    re.search(r"{{< programming-lang-wrapper", line.strip())
-                   ):
+                if (re.search(r"{{< tabs >}}", line.strip()) or re.search(r"{{< programming-lang-wrapper", line.strip())):
                     state = 'tabs'
                 if re.search(r"{{< site-region", line.strip()):
                     state = 'region'
@@ -46,24 +43,14 @@ def prepare_file(file):
                     state = 'main'
                 else:
                     temp_section.append(line)
-
             elif state == 'tabs':
                 main_section.append(line)
-                if (
-                    re.search(r"{{% tab ", line.strip()) or
-                    re.search(r"{{< programming-lang ", line.strip())
-                   ):
+                if (re.search(r"{{% tab ", line.strip()) or re.search(r"{{< programming-lang ", line.strip())):
                     state = 'tab'
-                if (
-                    re.search(r"{{< /tabs >}}", line.strip()) or
-                    re.search(r"{{< /programming-lang-wrapper >}}", line.strip())
-                   ):
+                if (re.search(r"{{< /tabs >}}", line.strip()) or re.search(r"{{< /programming-lang-wrapper >}}", line.strip())):
                     state = 'main'
             elif state == 'tab':
-                if (
-                    re.search(r"{{% /tab %}}", line.strip()) or
-                    re.search(r"{{< /programming-lang >}}", line.strip())
-                   ):
+                if (re.search(r"{{% /tab %}}", line.strip()) or re.search(r"{{< /programming-lang >}}", line.strip())):
                     state = 'tabs'
                     main_section.append(line)
                     sub_sections.append(temp_section)


### PR DESCRIPTION
The precommit was moving links inside the `site-region` sections to the
end of the document, causing them to break. This alters that behavior
to mimic links that are in tabs or `programming-lang` sections.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
