### PR TITLE
[agent] disable service check

### DIFF
--- a/content/en/agent/troubleshooting/agent_check_status.md
+++ b/content/en/agent/troubleshooting/agent_check_status.md
@@ -18,6 +18,7 @@ If you are experiencing issues with a given Agent Check, use these commands for 
 - [Further Reading](#further-reading)
 
 **Note**: Replace `<CHECK_NAME>` in the examples below with any Agent check. For example: `activemq`, `ceph`, or `elastic`. Review an [integration's documentation][1] to confirm the Agent check name.
+
 **Note**: To disable a service check, rename `/conf.d/<CHECK_NAME>.d/conf.yaml` to something other than `.yaml`, `.yml` file extension, like `conf.yaml.disable`.
 
 ## Linux

--- a/content/en/agent/troubleshooting/agent_check_status.md
+++ b/content/en/agent/troubleshooting/agent_check_status.md
@@ -19,7 +19,7 @@ If you are experiencing issues with a given Agent Check, use these commands for 
 
 **Note**: Replace `<CHECK_NAME>` in the examples below with any Agent check. For example: `activemq`, `ceph`, or `elastic`. Review an [integration's documentation][1] to confirm the Agent check name.
 
-**Note**: To disable a service check, rename `/conf.d/<CHECK_NAME>.d/conf.yaml` to something other than `.yaml`, `.yml` file extension, like `conf.yaml.disable`.
+**Note**: To temporarily disable a service check while troubleshooting, rename `/conf.d/<CHECK_NAME>.d/conf.yaml` to something other than the `.yaml` or `.yml` file extension, such as `conf.yaml.disable`.
 
 ## Linux
 

--- a/content/en/agent/troubleshooting/agent_check_status.md
+++ b/content/en/agent/troubleshooting/agent_check_status.md
@@ -18,6 +18,7 @@ If you are experiencing issues with a given Agent Check, use these commands for 
 - [Further Reading](#further-reading)
 
 **Note**: Replace `<CHECK_NAME>` in the examples below with any Agent check. For example: `activemq`, `ceph`, or `elastic`. Review an [integration's documentation][1] to confirm the Agent check name.
+**Note**: To disable a service check, rename `/conf.d/<CHECK_NAME>.d/conf.yaml` to something other than `.yaml`, `.yml` file extension, like `conf.yaml.disable`.
 
 ## Linux
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Explain how to disable a service check.

### Motivation
<!-- What inspired you to submit this pull request?-->

I may want to temporarily disable check when troubleshooting. This was not in the documentation so I added it.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

How Agent get configuration files.
https://github.com/DataDog/datadog-agent/blob/edc2559d7167466ccf010d7f4a6bd42908ac6116/pkg/autodiscovery/providers/config_reader.go#L217-L278

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
