### PR TITLE
Fix minimum Windows version supported by Agent v5

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -182,7 +182,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [SUSE Enterprise Linux][7] | SUSE 11 SP4+           |
 | [Fedora][8]                | Fedora 26+             |
 | [MacOS][9]                 | macOS 10.10+           |
-| [Windows Server][10]       | Windows Server 2008r2+ |
+| [Windows Server][10]       | Windows Server 2008+   |
 | [Windows][10]              | Windows 7+             |
 
 **Notes**:


### PR DESCRIPTION

### What does this PR do?

The minimum version of Windows that Agent v5 supports is Windows 2008, not 2008r2, see https://app.datadoghq.com/account/settings?agent_version=5#agent/windows


<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
