### PR TITLE
Lambda Extension may require VPC Endpoint for Secrets Manager

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -84,14 +84,18 @@ However, to route traffic to Datadog's PrivateLink offering in `us-east-1` from 
     ```
 
     This configuration is required when sending logs to Datadog with AWS PrivateLink and the Datadog Agent, and is not required for the Lambda Extension. For more details, see [Agent log collection][3].
-12. [Restart your Agent][4] to send data to Datadog through AWS PrivateLink.
+    
+12. If your Lambda Extension loads the Datadog API Key from AWS Secrets Manager using the ARN specified by the environment variable `DD_API_KEY_SECRET_ARN`, you need to [create a VPC endpoint for Secrets Manager][4].
+
+13. [Restart your Agent][5] to send data to Datadog through AWS PrivateLink.
 
 
 
 [1]: /help/
 [2]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
 [3]: /agent/logs/?tab=tailexistingfiles#send-logs-over-https
-[4]: /agent/guide/agent-commands/#restart-the-agent
+[4]: https://docs.aws.amazon.com/secretsmanager/latest/userguide/vpc-endpoint-overview.html
+[5]: /agent/guide/agent-commands/#restart-the-agent
 {{% /tab %}}
 
 {{% tab "VPC peering" %}}
@@ -211,8 +215,10 @@ The VPCs with Private Hosted Zone (PHZ) attached need to have a couple of settin
     ```
 
     This configuration is required when sending logs to Datadog with AWS PrivateLink and the Datadog Agent, and is not required for the Lambda Extension. For more details, see [Agent log collection][8].
+    
+2. If your Lambda Extension loads the Datadog API Key from AWS Secrets Manager using the ARN specified by the environment variable `DD_API_KEY_SECRET_ARN`, you need to [create a VPC endpoint for Secrets Manager][9].
 
-2. [Restart the Agent][6].
+3. [Restart the Agent][6].
 
 
 [1]: /help/
@@ -223,6 +229,7 @@ The VPCs with Private Hosted Zone (PHZ) attached need to have a couple of settin
 [6]: /agent/guide/agent-commands/?tab=agentv6v7#restart-the-agent
 [7]: /agent/guide/agent-configuration-files/?tab=agentv6v7#agent-main-configuration-file
 [8]: https://docs.datadoghq.com/agent/logs/?tab=tailexistingfiles#send-logs-over-https
+[9]: https://docs.aws.amazon.com/secretsmanager/latest/userguide/vpc-endpoint-overview.html
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Lambda Extension requires the VPC Endpoint for Secrets Manager when using PrivateLink and loading Datadog API Key from Secretes Manager (recommended by Datadog).

### Motivation
Based on customer feedback.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
