### PR TITLE
WEB-2564 - set a default cloud logo for security rules when missing

### DIFF
--- a/layouts/partials/integrations-logo.html
+++ b/layouts/partials/integrations-logo.html
@@ -7,6 +7,9 @@ Description:
 Builds a string to the integration logo.
 :param basename: string of integration name without any variant or extension e.g "aws" or "amazon-ecs"
 :param variant: string of the variant e.g "avatar" or "small" or "large"
+:param fallback: string of the fallback method
+    "none" is the default and causes warning message and no data returned
+    "cloud" falls back to the cloud generic logo where possible from the string passed e.g aws_foobar returns aws generic logo
 :return: the string to the integration logo image or an empty string on failure
 
 ------------------
@@ -31,6 +34,7 @@ Both of these should return the same image.
 {{- $basename := (lower .basename) -}}
 {{- $variant := .variant | default "large" -}}
 {{- $extension := .extension | default ".svg" -}}
+{{- $fallback := .fallback | default "none" -}}
 {{- $img_url := $ctx.Site.Params.integrations_img_url -}}
 {{- $imagesJSON := getJSON "https://s3.amazonaws.com/origin-static-assets/websites-integrations/images.json" -}}
 {{- $integrationLogosList := index $imagesJSON "integrationLogosList" | default slice -}}
@@ -104,6 +108,21 @@ Both of these should return the same image.
   {{- end -}}
 {{- end -}}
 
+<!--{{/* if fallback settings */}}-->
+{{- if not $imageExists -}}
+  {{- if eq ($fallback | lower) "cloud" -}}
+    {{ warnf "fallback %q %q %q" $basename (or (hasPrefix $basename "gcp") (hasPrefix $basename "google")) (or (hasPrefix $basename "aws") (hasPrefix $basename "amazon")) }}
+    {{- if (or (hasPrefix $basename "gcp") (hasPrefix $basename "google")) -}}
+      {{- $basename = "google-cloud-platform" -}}
+      {{- $imageExists = true -}}
+    {{- else if (or (hasPrefix $basename "aws") (hasPrefix $basename "amazon")) -}}
+      {{- $basename = "amazon-web-services" -}}
+      {{- $imageExists = true -}}
+    {{- end -}}
+  {{- else -}}
+    <!-- Anything else we act like none -->
+  {{- end -}}
+{{- end -}}
 
 <!--{{/* Build the image path and return it or return empty string */}}-->
 {{- if $imageExists -}}

--- a/layouts/security_rules/list.html
+++ b/layouts/security_rules/list.html
@@ -44,10 +44,14 @@
                         {{ end }}
                     </div>
                     <div class="d-inline font-semibold ml-1">
-                        {{ if eq (len $v.Key) 3 }}
-                            {{ title $v.Key | title | upper }}
-                        {{ else }}
-                            {{ title $v.Key | humanize | title }}
+                        <!-- If first word/only word is 3 letters long e.g aws or gcp then lets capitalize -->
+                        {{ $words := (split (humanize $v.Key) " ") }}
+                        {{ range $index, $word := $words }}
+                          {{ if (and (eq $index 0) (eq (len $word) 3)) }}
+                            {{ $word | upper }}
+                          {{ else }}
+                            {{ $word | title }}
+                          {{ end }}
                         {{ end }}
                     </div>
                     <div class="js-group-header__arrow">></div>

--- a/layouts/security_rules/list.html
+++ b/layouts/security_rules/list.html
@@ -35,7 +35,7 @@
                     <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2 py-1">
                         {{ range last 1 $v.Pages }}
                             {{ $basename := .Params.integration_id | default .Params.source }}
-                            {{ $int_logo := partial "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "avatar") }}
+                            {{ $int_logo := partial "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "avatar" "fallback" "cloud") }}
                             {{ if $int_logo }}
                                 <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}" />
                             {{ else }}
@@ -60,7 +60,7 @@
                                 <!-- e.g gcp.project use source -->
                                 {{ $basename = .Params.source }}
                             {{ end }}
-                            {{ $int_logo := partial "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "avatar") }}
+                            {{ $int_logo := partial "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "avatar" "fallback" "cloud") }}
                             {{ if $int_logo }}
                                 <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}" />
                             {{ else }}


### PR DESCRIPTION
### What does this PR do?

- Updates the wording on security rule grouped sections so that aws or gcp appears capitalized.
- Sets up a fallback to generic cloud logos where possible

### Motivation

https://datadoghq.atlassian.net/browse/WEB-2564

### Preview

https://docs-staging.datadoghq.com/david.jones/rules-gcp/security_platform/default_rules/?q=gcp#all

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
