### PR TITLE
[monitors] Add `urlencode` helper docs.

### DIFF
--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -533,6 +533,16 @@ If `host.name` matches `<HOST_NAME>`, the template outputs:
 {{ .matched }} the host name
 ```
 
+### URL Encode
+
+If your alert message needs to include a piece of information that needs to be encoded for using it in a URL (for example: redirections), use the `{{ urlencode "<variable>"}}` syntax:
+
+**Example**: If your monitor message includes a URL to APM filtered by your `service` [tag variable](#attribute-and-tag-variables) that needs to be encoded for it:
+
+```
+https://app.datadoghq.com/apm/services/{{urlencode "service.name"}}
+```
+
 [1]: /monitors/create/configuration/#alert-grouping
 [2]: /monitors/create/types/log/
 [3]: /monitors/create/types/apm/?tab=analytics

--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -535,9 +535,9 @@ If `host.name` matches `<HOST_NAME>`, the template outputs:
 
 ### URL Encode
 
-If your alert message needs to include a piece of information that needs to be encoded for using it in a URL (for example: redirections), use the `{{ urlencode "<variable>"}}` syntax:
+If your alert message includes information that needs to be encoded in a URL (for example, for redirections), use the `{{ urlencode "<variable>"}}` syntax.
 
-**Example**: If your monitor message includes a URL to APM filtered by your `service` [tag variable](#attribute-and-tag-variables) that needs to be encoded for it:
+**Example**: If your monitor message includes a URL to the APM services page filtered to a specific service, use the `service` [tag variable](#attribute-and-tag-variables) add `{{ urlencode "<variable>"}}` syntax in the URL:
 
 ```
 https://app.datadoghq.com/apm/services/{{urlencode "service.name"}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds the explanation of the `urlencode` function helper for the monitor message.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
