### PR TITLE
isStaged switching to isShadowDeployed

### DIFF
--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -97,7 +97,7 @@ def security_rules(content, content_dir):
             if message_file_name.exists():
                 # delete file or skip if staged
                 # any() will return True when at least one of the elements is Truthy
-                if len(data.get('restrictedToOrgs', [])) > 0 or data.get('isStaged', False) \
+                if len(data.get('restrictedToOrgs', [])) > 0 or data.get('isShadowDeployed', False) \
                     or data.get('isDeleted', False) or not data.get('isEnabled', True) or data.get('isDeprecated', False):
                     if p.exists():
                         logger.info(f"removing file {p.name}")

--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -97,7 +97,8 @@ def security_rules(content, content_dir):
             if message_file_name.exists():
                 # delete file or skip if staged
                 # any() will return True when at least one of the elements is Truthy
-                if len(data.get('restrictedToOrgs', [])) > 0 or data.get('isShadowDeployed', False) \
+                # TODO: remove isStaged check after upstream removal
+                if len(data.get('restrictedToOrgs', [])) > 0 or data.get('isStaged', False) or data.get('isShadowDeployed', False) \
                     or data.get('isDeleted', False) or not data.get('isEnabled', True) or data.get('isDeprecated', False):
                     if p.exists():
                         logger.info(f"removing file {p.name}")


### PR DESCRIPTION
### What does this PR do?

Support skipping rules with both `isStaged` to `isShadowDeployed` flags until upstream switches completely to `isShadowDeployed`

### Motivation

https://github.com/DataDog/security-monitoring/pull/1589

### Preview 

https://docs-staging.datadoghq.com/david.jones/shadow-deploy/security_platform/default_rules#all

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
