### PR TITLE
rollback hugo bin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "del": "4.1.1",
         "docsearch.js": "^2.6.3",
         "fancy-log": "^1.3.3",
-        "hugo-bin": "0.89.0",
+        "hugo-bin": "0.86.0",
         "jquery": "3.5.1",
         "js-cookie": "^2.2.1",
         "js-yaml": "^3.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4416,7 +4416,7 @@ __metadata:
     eslint-plugin-react-hooks: ^2.5.0
     eslint-plugin-standard: ^4.0.0
     fancy-log: ^1.3.3
-    hugo-bin: 0.89.0
+    hugo-bin: 0.86.0
     jest: ^25.3.0
     jquery: 3.5.1
     js-cookie: ^2.2.1
@@ -6300,9 +6300,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hugo-bin@npm:0.89.0":
-  version: 0.89.0
-  resolution: "hugo-bin@npm:0.89.0"
+"hugo-bin@npm:0.86.0":
+  version: 0.86.0
+  resolution: "hugo-bin@npm:0.86.0"
   dependencies:
     bin-wrapper: ^4.1.0
     picocolors: ^1.0.0
@@ -6310,7 +6310,7 @@ __metadata:
     rimraf: ^3.0.2
   bin:
     hugo: cli.js
-  checksum: 278ba5cc8cd77d80b5d8d98d9e517178955422a24e015888bbb0e3aa8689596b16373308c0e5239b0a9dbe1dc148996cefc8d9a30103005921d45e025ee94e0b
+  checksum: 49d480ca9cde1154a5f74e4d21246e8fb831e277c7518392918c046c426d25113c3530f028c7cde3bc1fafc25d3e25d7fd8744ac3537449d59185a8738c6e521
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?
rollback a recent hugo version upgrade

### Motivation
it seems `jqmath-vanilla` (or something to do with it's implementation) was somehow broken by the latest version upgrade.

see these pages versus their live counterparts.   the jq math rendering should be working and there should not be a JS alert error popping up on page load.

- https://docs-staging.datadoghq.com/brian.deutsch/rollback-hugo-version/tracing/guide/span_and_trace_id_format/
- https://docs-staging.datadoghq.com/brian.deutsch/rollback-hugo-version/tracing/glossary/#execution-time
- https://docs-staging.datadoghq.com/brian.deutsch/rollback-hugo-version/monitors/service_level_objectives/burn_rate/

vs.

- https://docs.datadoghq.com/tracing/guide/span_and_trace_id_format/
- https://docs.datadoghq.com/tracing/glossary/#execution-time
- https://docs.datadoghq.com/monitors/service_level_objectives/burn_rate/

the rest of the site should still behave as it did previous to this hugo upgrade.

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
