### PR TITLE
Add the expected overhead for the .NET profiler

### DIFF
--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -265,6 +265,16 @@ Otherwise, turn on [debug mode][1] and [open a support ticket][2] with the debug
 - Application type (for example, Web application running in IIS).
 
 
+## High CPU usage when enabling the profiler
+
+The profiler has a fixed overhead. The exact value can vary but should be expected to be about:
+ -  200ms of CPU time per second on Linux (0.2 CPU)
+ -  20ms of CPU time per second on Windows (0.02 CPU)
+
+This fixed cost means that the relative overhead of the profiler can be significant in very small containers. For instance, if running in a Linux container with 0.4 CPU assigned, the fixed cost of 0.2 CPU means that the relative overhead will be of 50%. It is recommended to adjust the container limits accordingly.
+
+
+
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/
 {{< /programming-lang >}}

--- a/content/en/tracing/profiler/profiler_troubleshooting.md
+++ b/content/en/tracing/profiler/profiler_troubleshooting.md
@@ -271,7 +271,7 @@ The profiler has a fixed overhead. The exact value can vary but should be expect
  -  200ms of CPU time per second on Linux (0.2 CPU)
  -  20ms of CPU time per second on Windows (0.02 CPU)
 
-This fixed cost means that the relative overhead of the profiler can be significant in very small containers. For instance, if running in a Linux container with 0.4 CPU assigned, the fixed cost of 0.2 CPU means that the relative overhead will be of 50%. It is recommended to adjust the container limits accordingly.
+This fixed cost means that the relative overhead of the profiler can be significant in very small containers. For example, if you run the profiler in a Linux container with 0.4 CPU assigned, the fixed cost of 0.2 CPU means that the relative overhead is 50%. Adjust the container limits accordingly.
 
 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update the profiler troubleshooting page to indicate the expected CPU overhead for the .NET profiler.

### Motivation
<!-- What inspired you to submit this pull request?-->

Some customers had issues because they enabled the profiler in containers that weren't properly sized.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
