### PR TITLE
[PHP] DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED defaults to on

### DIFF
--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -111,8 +111,8 @@ Enable the Datadog profiler. Added in version `0.69.0`. See [Enabling the PHP Pr
 
 `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED`
 : **INI**: Not available<br>
-**Default**: `0`<br>
-Enable the experimental CPU profile type. Added in version `0.69.0`.
+**Default**: `1`<br>
+Enable the experimental CPU profile type. Added in version `0.69.0`. For version `0.76` and below it defaulted to `0`.
 
 `DD_PROFILING_LOG_LEVEL`
 : **INI**: Not available<br>


### PR DESCRIPTION
### What does this PR do?
Updates the default value of `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED` to reflect the upcoming v0.77.0 release.

### Motivation
Gotta keep the docs up-to-date :)

### Additional Notes
Shouldn't merge until dd-trace-php v0.77.0 is released in case the release process stalls or delayed due to issues found late in the process.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
