### PR TITLE
[ci-visibility] Add Instructions to set custom tags and metrics

### DIFF
--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -126,7 +126,7 @@ You can add custom tags to your tests by using the current active span:
   })
 ```
 
-To create filters or group bys for these tags, you need to create facets for them. For more information about custom instrumentation read the [NodeJS Custom Instrumentation][1] documentation.
+To create filters or `group by` fields for these tags, you must first create facets. For more information about custom instrumentation, see the [NodeJS Custom Instrumentation documentation][1].
 
 [1]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
 {{% /tab %}}
@@ -146,7 +146,7 @@ If you're using `yarn>=2` and a `.pnp.cjs` file, and you get the following error
  Error: Cannot find module 'dd-trace/ci/init'
 ```
 
-You can fix it by setting `NODE_OPTIONS` to the following:
+You can fix this by setting `NODE_OPTIONS` to the following:
 
 {{< code-block lang="bash" >}}
 NODE_OPTIONS="-r $(pwd)/.pnp.cjs -r dd-trace/ci/init" yarn test
@@ -166,7 +166,7 @@ You can add custom tags to your test by grabbing the current active span:
   });
 ```
 
-To create filters or group bys for these tags, you must create facets for them. For more information about custom instrumentation, read the [NodeJS Custom Instrumentation][1] documentation.
+To create filters or `group by` fields for these tags, you must first create facets. For more information about custom instrumentation, see the [NodeJS Custom Instrumentation documentation][1].
 
 [1]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
 {{% /tab %}}
@@ -268,7 +268,7 @@ it('renders a hello world', () => {
 })
 ```
 
-To create filters or group bys for these tags, you must create facets for them. For more information about custom instrumentation, read the [NodeJS Custom Instrumentation][1] documentation.
+To create filters or `group by` fields for these tags, you must first create facets. For more information about custom instrumentation, see the [NodeJS Custom Instrumentation documentation][1].
 
 ### Cypress - RUM integration
 

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -114,7 +114,7 @@ NODE_OPTIONS="-r $(pwd)/.pnp.cjs -r dd-trace/ci/init" yarn test
 
 ### Adding custom tags to tests
 
-You can add custom tags to your test by grabbing the current active span:
+You can add custom tags to your tests by using the current active span:
 
 ```javascript
   it('sum function can sum', () => {
@@ -126,13 +126,13 @@ You can add custom tags to your test by grabbing the current active span:
   })
 ```
 
-If you want to create filters or group bys for these tags you need to create facets for them. For more information about custom instrumentation you can read [NodeJS Custom Instrumentation][1].
+To create filters or group bys for these tags, you need to create facets for them. For more information about custom instrumentation read the [NodeJS Custom Instrumentation][1] documentation.
 
 [1]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
 {{% /tab %}}
 
 {{% tab "Cucumber" %}}
-Set `NODE_OPTIONS` environment variable to `-r dd-trace/ci/init`. Run your tests as you normally would, specifying the environment where the tests are run in the `DD_ENV` environment variable. For example, set `DD_ENV` to `local` when running tests on a developer workstation, or `ci` when running them on a CI provider:
+Set the `NODE_OPTIONS` environment variable to `-r dd-trace/ci/init`. Run your tests as you normally would, specifying the environment where the tests are run in the `DD_ENV` environment variable. For example, set `DD_ENV` to `local` when running tests on a developer workstation, or `ci` when running them on a CI provider:
 
 {{< code-block lang="bash" >}}
 NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app yarn test
@@ -166,7 +166,7 @@ You can add custom tags to your test by grabbing the current active span:
   });
 ```
 
-If you want to create filters or group bys for these tags you need to create facets for them. For more information about custom instrumentation you can read [NodeJS Custom Instrumentation][1].
+To create filters or group bys for these tags, you must create facets for them. For more information about custom instrumentation, read the [NodeJS Custom Instrumentation][1] documentation.
 
 [1]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
 {{% /tab %}}
@@ -268,7 +268,7 @@ it('renders a hello world', () => {
 })
 ```
 
-If you want to create filters or group bys for these tags you need to create facets for them. For more information about custom instrumentation you can read [NodeJS Custom Instrumentation][1].
+To create filters or group bys for these tags, you must create facets for them. For more information about custom instrumentation, read the [NodeJS Custom Instrumentation][1] documentation.
 
 ### Cypress - RUM integration
 

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -91,7 +91,7 @@ For more information, see the [JavaScript tracer installation docs][5].
 ## Instrument your tests
 
 {{< tabs >}}
-{{% tab "Jest/Mocha/Cucumber" %}}
+{{% tab "Jest/Mocha" %}}
 Set `NODE_OPTIONS` environment variable to `-r dd-trace/ci/init`. Run your tests as you normally would, specifying the environment where the tests are run in the `DD_ENV` environment variable. For example, set `DD_ENV` to `local` when running tests on a developer workstation, or `ci` when running them on a CI provider:
 
 {{< code-block lang="bash" >}}
@@ -111,6 +111,55 @@ You can fix it by setting `NODE_OPTIONS` to the following:
 {{< code-block lang="bash" >}}
 NODE_OPTIONS="-r $(pwd)/.pnp.cjs -r dd-trace/ci/init" yarn test
 {{< /code-block >}}
+
+### Add extra tags to your tests
+
+You can add custom tags and metrics to your test by grabbing the current active span:
+
+```javascript
+  it('sum function can sum', () => {
+    const testSpan = require('dd-trace').scope().active()
+    testSpan.setTag('team.owner', 'calculator')
+    testSpan.setTag('test.importance', 2)
+    // your test continues normally
+  })
+```
+
+{{% /tab %}}
+
+{{% tab "Cucumber" %}}
+Set `NODE_OPTIONS` environment variable to `-r dd-trace/ci/init`. Run your tests as you normally would, specifying the environment where the tests are run in the `DD_ENV` environment variable. For example, set `DD_ENV` to `local` when running tests on a developer workstation, or `ci` when running them on a CI provider:
+
+{{< code-block lang="bash" >}}
+NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app yarn test
+{{< /code-block >}}
+
+### Using Yarn >=2
+
+If you're using `yarn>=2` and a `.pnp.cjs` file, and you get the following error message when using `NODE_OPTIONS`:
+
+```text
+ Error: Cannot find module 'dd-trace/ci/init'
+```
+
+You can fix it by setting `NODE_OPTIONS` to the following:
+
+{{< code-block lang="bash" >}}
+NODE_OPTIONS="-r $(pwd)/.pnp.cjs -r dd-trace/ci/init" yarn test
+{{< /code-block >}}
+
+### Add extra tags to your tests
+
+You can add custom tags and metrics to your test by grabbing the current active span:
+
+```javascript
+  When('the function is called', function () {
+    const stepSpan = require('dd-trace').scope().active()
+    stepSpan.setTag('team.owner', 'calculator')
+    stepSpan.setTag('test.importance', 2)
+    // your test step continues normally
+  });
+```
 
 {{% /tab %}}
 
@@ -188,24 +237,30 @@ module.exports = defineConfig({
 {{< /code-block >}}
 
 
-#### Add extra tags to your Cypress test
+### Add extra tags to your test
 
 To add additional information to your tests, such as the team owner, use `cy.task('dd:addTags', { yourTags: 'here' })` in your test or hooks.
 
 For example:
 
-{{< code-block lang="javascript">}}
+```javascript
 beforeEach(() => {
-  cy.task('dd:addTags', { 'before.each': 'certain.information' })
+  cy.task('dd:addTags', {
+    'before.each':
+    'certain.information'
+  })
 })
 it('renders a hello world', () => {
-  cy.task('dd:addTags', { 'team.owner': 'ui' })
+  cy.task('dd:addTags', {
+    'team.owner': 'ui',
+    'test.importance': 3
+  })
   cy.get('.hello-world')
     .should('have.text', 'Hello World')
 })
-{{< /code-block >}}
+```
 
-#### Cypress - RUM integration
+### Cypress - RUM integration
 
 If the browser application being tested is instrumented using [RUM][5], your Cypress test results and their generated RUM browser sessions and session replays are automatically linked. Learn more in the [RUM integration][6] guide.
 

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -112,7 +112,7 @@ You can fix it by setting `NODE_OPTIONS` to the following:
 NODE_OPTIONS="-r $(pwd)/.pnp.cjs -r dd-trace/ci/init" yarn test
 {{< /code-block >}}
 
-### Add extra tags to your tests
+### Adding custom tags and metrics to testss
 
 You can add custom tags and metrics to your test by grabbing the current active span:
 
@@ -126,7 +126,7 @@ You can add custom tags and metrics to your test by grabbing the current active 
   })
 ```
 
-For more information about custom instrumentation you can read [NodeJS Custom Instrumentation][1].
+If you want to create filters or group bys for these tags you need to create facets for them. For more information about custom instrumentation you can read [NodeJS Custom Instrumentation][1].
 
 [1]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
 {{% /tab %}}
@@ -152,7 +152,7 @@ You can fix it by setting `NODE_OPTIONS` to the following:
 NODE_OPTIONS="-r $(pwd)/.pnp.cjs -r dd-trace/ci/init" yarn test
 {{< /code-block >}}
 
-### Add extra tags to your tests
+### Adding custom tags and metrics to tests
 
 You can add custom tags and metrics to your test by grabbing the current active span:
 
@@ -166,7 +166,7 @@ You can add custom tags and metrics to your test by grabbing the current active 
   });
 ```
 
-For more information about custom instrumentation you can read [NodeJS Custom Instrumentation][1].
+If you want to create filters or group bys for these tags you need to create facets for them. For more information about custom instrumentation you can read [NodeJS Custom Instrumentation][1].
 
 [1]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
 {{% /tab %}}
@@ -245,7 +245,7 @@ module.exports = defineConfig({
 {{< /code-block >}}
 
 
-### Add extra tags to your test
+### Adding custom tags and metrics to tests
 
 To add additional information to your tests, such as the team owner, use `cy.task('dd:addTags', { yourTags: 'here' })` in your test or hooks.
 
@@ -267,6 +267,8 @@ it('renders a hello world', () => {
     .should('have.text', 'Hello World')
 })
 ```
+
+If you want to create filters or group bys for these tags you need to create facets for them. For more information about custom instrumentation you can read [NodeJS Custom Instrumentation][1].
 
 ### Cypress - RUM integration
 

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -112,9 +112,9 @@ You can fix it by setting `NODE_OPTIONS` to the following:
 NODE_OPTIONS="-r $(pwd)/.pnp.cjs -r dd-trace/ci/init" yarn test
 {{< /code-block >}}
 
-### Adding custom tags and metrics to testss
+### Adding custom tags to tests
 
-You can add custom tags and metrics to your test by grabbing the current active span:
+You can add custom tags to your test by grabbing the current active span:
 
 ```javascript
   it('sum function can sum', () => {
@@ -152,9 +152,9 @@ You can fix it by setting `NODE_OPTIONS` to the following:
 NODE_OPTIONS="-r $(pwd)/.pnp.cjs -r dd-trace/ci/init" yarn test
 {{< /code-block >}}
 
-### Adding custom tags and metrics to tests
+### Adding custom tags to tests
 
-You can add custom tags and metrics to your test by grabbing the current active span:
+You can add custom tags to your test by grabbing the current active span:
 
 ```javascript
   When('the function is called', function () {
@@ -245,7 +245,7 @@ module.exports = defineConfig({
 {{< /code-block >}}
 
 
-### Adding custom tags and metrics to tests
+### Adding custom tags to tests
 
 To add additional information to your tests, such as the team owner, use `cy.task('dd:addTags', { yourTags: 'here' })` in your test or hooks.
 

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -125,6 +125,8 @@ You can add custom tags and metrics to your test by grabbing the current active 
   })
 ```
 
+For more information about custom instrumentation you can read [NodeJS Custom Instrumentation][7].
+
 {{% /tab %}}
 
 {{% tab "Cucumber" %}}
@@ -160,6 +162,8 @@ You can add custom tags and metrics to your test by grabbing the current active 
     // your test step continues normally
   });
 ```
+
+For more information about custom instrumentation you can read [NodeJS Custom Instrumentation][7].
 
 {{% /tab %}}
 

--- a/content/en/continuous_integration/setup_tests/javascript.md
+++ b/content/en/continuous_integration/setup_tests/javascript.md
@@ -121,12 +121,14 @@ You can add custom tags and metrics to your test by grabbing the current active 
     const testSpan = require('dd-trace').scope().active()
     testSpan.setTag('team.owner', 'calculator')
     testSpan.setTag('test.importance', 2)
-    // your test continues normally
+    // test continues normally
+    // ...
   })
 ```
 
-For more information about custom instrumentation you can read [NodeJS Custom Instrumentation][7].
+For more information about custom instrumentation you can read [NodeJS Custom Instrumentation][1].
 
+[1]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
 {{% /tab %}}
 
 {{% tab "Cucumber" %}}
@@ -159,12 +161,14 @@ You can add custom tags and metrics to your test by grabbing the current active 
     const stepSpan = require('dd-trace').scope().active()
     stepSpan.setTag('team.owner', 'calculator')
     stepSpan.setTag('test.importance', 2)
-    // your test step continues normally
+    // test continues normally
+    // ...
   });
 ```
 
-For more information about custom instrumentation you can read [NodeJS Custom Instrumentation][7].
+For more information about custom instrumentation you can read [NodeJS Custom Instrumentation][1].
 
+[1]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
 {{% /tab %}}
 
 {{% tab "Cypress" %}}


### PR DESCRIPTION
### What does this PR do?
Add section to javascript's test instrumentation (CI Visibility) about adding custom tags and metrics to test spans.

### Motivation
Allow users more flexibility on their tests.

### Links
* [`jest/mocha`](https://docs-staging.datadoghq.com/juan-fernandez/add-custom-instrumentation-instructions/continuous_integration/setup_tests/javascript/?tab=onpremisesciproviderdatadogagent#add-extra-tags-to-your-tests)
* [`cucumber`](https://docs-staging.datadoghq.com/juan-fernandez/add-custom-instrumentation-instructions/continuous_integration/setup_tests/javascript/?tab=cucumber#add-extra-tags-to-your-tests)
* [`cypress` (works slightly differently)](https://docs-staging.datadoghq.com/juan-fernandez/add-custom-instrumentation-instructions/continuous_integration/setup_tests/javascript/?tab=cypress#add-extra-tags-to-your-test)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
