### PR TITLE
Guide for Serverless Java instrumentation upgrade

### DIFF
--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -60,7 +60,7 @@ Datadog recommends using the [Datadog Lambda Extension][1] to submit custom metr
 1. If you are not interested in collecting logs from your Lambda function, set the environment variable `DD_SERVERLESS_LOGS_ENABLED` to `false`.
 1. Follow the sample code or instructions below to submit your custom metric. 
 
-{{< programming-lang-wrapper langs="python,nodeJS,go,ruby,other" >}}
+{{< programming-lang-wrapper langs="python,nodeJS,go,ruby,java,other" >}}
 {{< programming-lang lang="python" >}}
 
 ```python
@@ -128,6 +128,39 @@ def handler(event:, context:)
         )
     end
 end
+```
+
+{{< /programming-lang >}}
+{{< programming-lang lang="java" >}}
+
+```java
+package com.datadog.lambda.sample.java;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2ProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2ProxyResponseEvent;
+
+// import the statsd client builder
+import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
+import com.timgroup.statsd.StatsDClient;
+
+public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, APIGatewayV2ProxyResponseEvent> {
+
+    // instantiate the statsd client
+    private static final StatsDClient Statsd = new NonBlockingStatsDClientBuilder().hostname("localhost").build();
+
+    @Override
+    public APIGatewayV2ProxyResponseEvent handleRequest(APIGatewayV2ProxyRequestEvent request, Context context) {
+
+        // submit a distribution metric
+        Statsd.recordDistributionValue("my.custom.java.metric", 1, new String[]{"tag:value"});
+
+        APIGatewayV2ProxyResponseEvent response = new APIGatewayV2ProxyResponseEvent();
+        response.setStatusCode(200);
+        return response;
+    }
+}
 ```
 
 {{< /programming-lang >}}

--- a/content/en/serverless/guide/upgrade_java_instrumentation.md
+++ b/content/en/serverless/guide/upgrade_java_instrumentation.md
@@ -17,7 +17,7 @@ Datadog Lambda layers `dd-trace-java:5` and `Datadog-Extension:25` introduce the
 2. Remove `DDLambda` and the import statement from your function code.
 3. Set environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/datadog_wrapper`.
 4. Increment the `dd-trace-java` version to `{{< latest-lambda-layer-version layer="dd-trace-java" >}}` and `Datadog-Extension` to `{{< latest-lambda-layer-version layer="extension" >}}`.
-5. If you are submitting custom metrics using the `DDLambda.metric()` helper function, use the standard [DogStatsD clent for Java][4] and follow the [sample code][5] to submit a metric as a distribution. Note, you can [only use distribution in Lambda][6] and previously `DDLambda.metric()` submit metrics as distribution as well.
+5. If you are submitting custom metrics using the `DDLambda.metric()` helper function, use the standard [DogStatsD client for Java][4] and follow the [sample code][5] to submit a metric as a distribution. Note that [in Lambda, you can only use distributions][6].
     
 [1]: https://github.com/DataDog/datadog-lambda-java
 [2]: /serverless/installation/java/?tab=datadogcli

--- a/content/en/serverless/guide/upgrade_java_instrumentation.md
+++ b/content/en/serverless/guide/upgrade_java_instrumentation.md
@@ -9,16 +9,18 @@ Instructions to instrument Java Lambda functions were greatly simplified with th
 2. no code changes (such as the `DDLambda` wrapper) are required, except for custom instrumentation
 3. you can now set up Datadog using the [Datadog CI][2] and the [Datadog Serverless Plugin][3]
 
-Follow the instructions below to upgrade your instrumentation if you are currently using older versions of the previously mentioned Datadog Lambda layers.
+Follow the instructions below to upgrade your instrumentation if you are currently using older versions of the previously mentioned Datadog Lambda layers. If you are setting up Datadog for Java Lambda functions that were not instrumented previously, follow the [latest installation instructions][7] instead.
 
 1. Remove `datadog-lambda-java` from `build.gradle` or `pom.xml`, as it is no longer required
-2. Remove `DDLambda` and the import statement for `datadog-lambda-java` from your function code
+2. Remove `DDLambda` and the import statement from your function code
 3. Set environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/datadog_wrapper`
 4. Bump the `dd-trace-java` version to `{{< latest-lambda-layer-version layer="dd-trace-java" >}}` and `Datadog-Extension` to `{{< latest-lambda-layer-version layer="extension" >}}`
-5. Instead of using the `DDLambda.metric()` helper function, you need to submit custom metric using the Datadog standard [DogStatsD clent for Java][4] and the `distribution()` function. Note, you can [only use distribution in Lambda][5].
+5. If you are submitting custom metric using the `DDLambda.metric()` helper function, now you must use the standard [DogStatsD clent for Java][4] and follow the [sample code][5] to submit the metric as distribution. Note, you can [only use distribution in Lambda][6] and previously `DDLambda.metric()` submit metrics as distribution as well.
     
 [1]: https://github.com/DataDog/datadog-lambda-java
 [2]: /serverless/installation/java/?tab=datadogcli
 [3]: /serverless/installation/java/?tab=serverlessframework
 [4]: /developers/dogstatsd/?tab=hostagent&code-lang=java
-[5]: /serverless/custom_metrics#understanding-distribution-metrics
+[5]: /serverless/custom_metrics/?code-lang=java#with-the-datadog-lambda-extension
+[6]: /serverless/custom_metrics#understanding-distribution-metrics
+[7]: /serverless/installation/java/

--- a/content/en/serverless/guide/upgrade_java_instrumentation.md
+++ b/content/en/serverless/guide/upgrade_java_instrumentation.md
@@ -1,0 +1,24 @@
+---
+title: Upgrade Instrumentation for Java Lambda Functions
+kind: documentation
+---
+
+Instructions to instrument Java Lambda functions were greatly simplified with the releases of Datadog Lambda layers `dd-trace-java:5` and `Datadog-Extension:25`, specifically:
+
+1. the [datadog-lambda-java][1] library is deprecated and no longer required
+2. no code changes (such as the `DDLambda` wrapper) are required, except for custom instrumentation
+3. you can now set up Datadog using the [Datadog CI][2] and the [Datadog Serverless Plugin][3]
+
+Follow the instructions below to upgrade your instrumentation if you are currently using older versions of the previously mentioned Datadog Lambda layers.
+
+1. Remove `datadog-lambda-java` from `build.gradle` or `pom.xml`, as it is no longer required
+2. Remove `DDLambda` and the import statement for `datadog-lambda-java` from your function code
+3. Set environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/datadog_wrapper`
+4. Bump the `dd-trace-java` version to `{{< latest-lambda-layer-version layer="dd-trace-java" >}}` and `Datadog-Extension` to `{{< latest-lambda-layer-version layer="extension" >}}`
+5. Instead of using the `DDLambda.metric()` helper function, you need to submit custom metric using the Datadog standard [DogStatsD clent for Java][4] and the `distribution()` function. Note, you can [only use distribution in Lambda][5].
+    
+[1]: https://github.com/DataDog/datadog-lambda-java
+[2]: /serverless/installation/java/?tab=datadogcli
+[3]: /serverless/installation/java/?tab=serverlessframework
+[4]: /developers/dogstatsd/?tab=hostagent&code-lang=java
+[5]: /serverless/custom_metrics#understanding-distribution-metrics

--- a/content/en/serverless/guide/upgrade_java_instrumentation.md
+++ b/content/en/serverless/guide/upgrade_java_instrumentation.md
@@ -3,19 +3,21 @@ title: Upgrade Instrumentation for Java Lambda Functions
 kind: documentation
 ---
 
-Instructions to instrument Java Lambda functions were greatly simplified with the releases of Datadog Lambda layers `dd-trace-java:5` and `Datadog-Extension:25`, specifically:
+This document contains instructions for upgrading your Datadog for Java Lambda instrumentation. If you are setting up instrumentation for the first time, follow the [Java Lambda installation instructions][7] instead.
 
-1. the [datadog-lambda-java][1] library is deprecated and no longer required
-2. no code changes (such as the `DDLambda` wrapper) are required, except for custom instrumentation
-3. you can now set up Datadog using the [Datadog CI][2] and the [Datadog Serverless Plugin][3]
+Datadog Lambda layers `dd-trace-java:5` and `Datadog-Extension:25` introduce the following changes to the process of seetting up instrumentation on Java Lambda functions:
 
-Follow the instructions below to upgrade your instrumentation if you are currently using older versions of the previously mentioned Datadog Lambda layers. If you are setting up Datadog for Java Lambda functions that were not instrumented previously, follow the [latest installation instructions][7] instead.
+1. The [datadog-lambda-java][1] library is deprecated and not required.
+2. No code changes (such as the `DDLambda` wrapper) are required, except for custom instrumentation.
+3. You can set up Datadog using the [Datadog CI][2] and the [Datadog Serverless Plugin][3].
 
-1. Remove `datadog-lambda-java` from `build.gradle` or `pom.xml`, as it is no longer required
-2. Remove `DDLambda` and the import statement from your function code
-3. Set environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/datadog_wrapper`
-4. Bump the `dd-trace-java` version to `{{< latest-lambda-layer-version layer="dd-trace-java" >}}` and `Datadog-Extension` to `{{< latest-lambda-layer-version layer="extension" >}}`
-5. If you are submitting custom metric using the `DDLambda.metric()` helper function, now you must use the standard [DogStatsD clent for Java][4] and follow the [sample code][5] to submit the metric as distribution. Note, you can [only use distribution in Lambda][6] and previously `DDLambda.metric()` submit metrics as distribution as well.
+### Upgrade
+
+1. Remove `datadog-lambda-java` from `build.gradle` or `pom.xml`, as it is no longer required.
+2. Remove `DDLambda` and the import statement from your function code.
+3. Set environment variable `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/datadog_wrapper`.
+4. Increment the `dd-trace-java` version to `{{< latest-lambda-layer-version layer="dd-trace-java" >}}` and `Datadog-Extension` to `{{< latest-lambda-layer-version layer="extension" >}}`.
+5. If you are submitting custom metrics using the `DDLambda.metric()` helper function, use the standard [DogStatsD clent for Java][4] and follow the [sample code][5] to submit a metric as a distribution. Note, you can [only use distribution in Lambda][6] and previously `DDLambda.metric()` submit metrics as distribution as well.
     
 [1]: https://github.com/DataDog/datadog-lambda-java
 [2]: /serverless/installation/java/?tab=datadogcli

--- a/content/en/serverless/installation/dotnet.md
+++ b/content/en/serverless/installation/dotnet.md
@@ -42,11 +42,11 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
 
 4. Configure the Datadog site
 
-    Specify the [Datadog site][2] where the telemetry should be sent to. The default is `datadoghq.com`.
-
     ```sh
-    export DATADOG_SITE="<DD_SITE>" # such as datadoghq.com, datadoghq.eu or ddog-gov.com
+    export DATADOG_SITE="<DATADOG_SITE>"
     ```
+
+    Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
 
 5. Configure the Datadog API key
 
@@ -79,7 +79,6 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
     Additional parameters can be found in the [CLI documentation][3].
 
 [1]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html
-[2]: https://docs.datadoghq.com/getting_started/site/
 [3]: https://docs.datadoghq.com/serverless/serverless_integrations/cli
 {{% /tab %}}
 {{% tab "Serverless Framework" %}}
@@ -104,14 +103,13 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
     ```
 
     To fill in the placeholders:
-    - Replace `<DATADOG_SITE>` with your [Datadog site][3] to send the telemetry to.
+    - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use `apiKey` and set the Datadog API key in plaintext.
 
     For more information and additional settings, see the [plugin documentation][1].
 
 [1]: https://docs.datadoghq.com/serverless/serverless_integrations/plugin
 [2]: https://docs.datadoghq.com/serverless/libraries_integrations/extension
-[3]: https://docs.datadoghq.com/getting_started/site/
 [4]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
 {{% tab "Container image" %}}

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -21,7 +21,7 @@ aliases:
 
 <div class="alert alert-warning">If you previously set up your Lambda functions using the Datadog Forwarder, see <a href="https://docs.datadoghq.com/serverless/guide/datadog_forwarder_java">instrumenting using the Datadog Forwarder</a>.</div>
 
-<div class="alert alert-warning">If you are currently using the Datadog Lambda layers `dd-trace-java:4` (or older) and `Datadog-Extension:24` (or older), you need to follow the <a href="https://docs.datadoghq.com/serverless/guide/upgrade_java_instrumentation">special instructions to upgrade</a>.</div>
+<div class="alert alert-warning">If you are using the Datadog Lambda layers `dd-trace-java:4` (or older) and `Datadog-Extension:24` (or older), follow the <a href="https://docs.datadoghq.com/serverless/guide/upgrade_java_instrumentation">special instructions to upgrade</a>.</div>
 
 ## Installation
 

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -21,6 +21,8 @@ aliases:
 
 <div class="alert alert-warning">If you previously set up your Lambda functions using the Datadog Forwarder, see <a href="https://docs.datadoghq.com/serverless/guide/datadog_forwarder_java">instrumenting using the Datadog Forwarder</a>.</div>
 
+<div class="alert alert-warning">If you are currently using the Datadog Lambda layers `dd-trace-java:4` (or older) and `Datadog-Extension:24` (or older), you need to follow the <a href="https://docs.datadoghq.com/serverless/guide/upgrade_java_instrumentation">special instructions to upgrade</a>.</div>
+
 ## Installation
 
 Datadog offers many different ways to enable instrumentation for your serverless applications. Choose a method below that best suits your needs. Datadog generally recommends using the Datadog CLI.

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -48,11 +48,11 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
 
 4. Configure the Datadog site
 
-    Specify the [Datadog site][2] where the telemetry should be sent. The default is `datadoghq.com`.
-
     ```sh
-    export DATADOG_SITE="<DD_SITE>" # such as datadoghq.com, datadoghq.eu or ddog-gov.com
+    export DATADOG_SITE="<DATADOG_SITE>"
     ```
+
+    Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
 
 5. Configure your Datadog API key
 
@@ -85,7 +85,6 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
     Additional parameters can be found in the [CLI documentation][3].
 
 [1]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html
-[2]: https://docs.datadoghq.com/getting_started/site/
 [3]: https://docs.datadoghq.com/serverless/serverless_integrations/cli
 {{% /tab %}}
 {{% tab "Serverless Framework" %}}
@@ -110,14 +109,13 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
     ```
 
     To fill in the placeholders:
-    - Replace `<DATADOG_SITE>` with your [Datadog site][3] to send the telemetry to.
+    - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use `apiKey` and set the Datadog API key in plaintext.
 
     For more information and additional settings, see the [plugin documentation][1].
 
 [1]: https://docs.datadoghq.com/serverless/serverless_integrations/plugin
 [2]: https://docs.datadoghq.com/serverless/libraries_integrations/extension
-[3]: https://docs.datadoghq.com/getting_started/site/
 [4]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
 {{% tab "Container image" %}}

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -52,11 +52,11 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
 
 4. Configure the Datadog site
 
-    Specify the [Datadog site][2] where the telemetry should be sent to. The default is `datadoghq.com`.
-
     ```sh
-    export DATADOG_SITE="<DD_SITE>" # such as datadoghq.com, datadoghq.eu or ddog-gov.com
+    export DATADOG_SITE="<DATADOG_SITE>"
     ```
+
+    Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
 
 5. Configure the Datadog API key
 
@@ -90,7 +90,6 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
 
 
 [1]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html
-[2]: https://docs.datadoghq.com/getting_started/site/
 [3]: https://docs.datadoghq.com/serverless/serverless_integrations/cli
 {{% /tab %}}
 {{% tab "Serverless Framework" %}}
@@ -117,14 +116,13 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
     ```
 
     To fill in the placeholders:
-    - Replace `<DATADOG_SITE>` with your [Datadog site][3] to send the telemetry to. Possible values are `datadoghq.com`, `datadoghq.eu`, `us3.datadoghq.com`, `us5.datadoghq.com` and `ddog-gov.com`.
+    - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use `apiKey` and set the Datadog API key in plaintext.
 
     For more information and additional settings, see the [plugin documentation][1].
 
 [1]: https://docs.datadoghq.com/serverless/serverless_integrations/plugin
 [2]: https://docs.datadoghq.com/serverless/libraries_integrations/extension
-[3]: https://docs.datadoghq.com/getting_started/site/
 [4]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
 {{% tab "AWS SAM" %}}
@@ -161,7 +159,7 @@ The [Datadog CloudFormation macro][1] automatically transforms your SAM applicat
     ```
 
     To fill in the placeholders:
-    - Replace `<DATADOG_SITE>` with your [Datadog site][4] to send the telemetry to.
+    - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][5] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `apiKey` instead and set the Datadog API key in plaintext.
 
     More information and additional parameters can be found in the [macro documentation][1].
@@ -170,7 +168,6 @@ The [Datadog CloudFormation macro][1] automatically transforms your SAM applicat
 [1]: https://docs.datadoghq.com/serverless/serverless_integrations/macro
 [2]: https://docs.datadoghq.com/serverless/libraries_integrations/extension
 [3]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
-[4]: https://docs.datadoghq.com/getting_started/site/
 [5]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
 {{% tab "AWS CDK" %}}
@@ -206,13 +203,12 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
     ```
 
     To fill in the placeholders:
-    - Replace `<DATADOG_SITE>` with your [Datadog site][2] to send the telemetry to.
+    - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][3] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob).The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `apiKey` instead and set the Datadog API key in plaintext.
 
     More information and additional parameters can be found on the [Datadog CDK documentation][1].
 
 [1]: https://github.com/DataDog/datadog-cdk-constructs
-[2]: https://docs.datadoghq.com/getting_started/site/
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
 {{% tab "Container Image" %}}

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -47,11 +47,11 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
 
 4. Configure the Datadog site
 
-    Specify the [Datadog site][2] where the telemetry should be sent to. The default is `datadoghq.com`.
-
     ```sh
-    export DATADOG_SITE="<DD_SITE>" # such as datadoghq.com, datadoghq.eu or ddog-gov.com
+    export DATADOG_SITE="<DATADOG_SITE>"
     ```
+
+    Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
 
 5. Configure the Datadog API key
 
@@ -85,7 +85,6 @@ The Datadog CLI modifies existing Lambda functions' configurations to enable ins
 
 
 [1]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html
-[2]: https://docs.datadoghq.com/getting_started/site/
 [3]: https://docs.datadoghq.com/serverless/serverless_integrations/cli
 {{% /tab %}}
 {{% tab "Serverless Framework" %}}
@@ -110,14 +109,13 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
     ```
 
     To fill in the placeholders:
-    - Replace `<DATADOG_SITE>` with your [Datadog site][3] to send the telemetry to.
+    - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][4] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use `apiKey` and set the Datadog API key in plaintext.
 
     For more information and additional settings, see the [plugin documentation][1].
 
 [1]: https://docs.datadoghq.com/serverless/serverless_integrations/plugin
 [2]: https://docs.datadoghq.com/serverless/libraries_integrations/extension
-[3]: https://docs.datadoghq.com/getting_started/site/
 [4]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
 {{% tab "AWS SAM" %}}
@@ -154,7 +152,7 @@ The [Datadog CloudFormation macro][1] automatically transforms your SAM applicat
     ```
 
     To fill in the placeholders:
-    - Replace `<DATADOG_SITE>` with your [Datadog site][4] to send the telemetry to.
+    - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][5] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `apiKey` instead and set the Datadog API key in plaintext.
 
     More information and additional parameters can be found in the [macro documentation][1].
@@ -163,7 +161,6 @@ The [Datadog CloudFormation macro][1] automatically transforms your SAM applicat
 [1]: https://docs.datadoghq.com/serverless/serverless_integrations/macro
 [2]: https://docs.datadoghq.com/serverless/libraries_integrations/extension
 [3]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
-[4]: https://docs.datadoghq.com/getting_started/site/
 [5]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
 {{% tab "AWS CDK" %}}
@@ -199,13 +196,12 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
     ```
 
     To fill in the placeholders:
-    - Replace `<DATADOG_SITE>` with your [Datadog site][2] to send the telemetry to.
+    - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][3] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `apiKey` instead and set the Datadog API key in plaintext.
 
     More information and additional parameters can be found on the [Datadog CDK documentation][1].
 
 [1]: https://github.com/DataDog/datadog-cdk-constructs
-[2]: https://docs.datadoghq.com/getting_started/site/
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
 {{% tab "Container Image" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
1. Guide for upgrading serverless java instrumentation to the latest versions
2. Update all DD_SITE references to use the site parameter to show the correct value

### Motivation
Serverless java instrumentation was recently simplified, for existing users't we need a guide to summarize the steps to upgrade. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
