### PR TITLE
David.goffredo/fix nginx ingress controller sampling

### DIFF
--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -498,6 +498,8 @@ env:
 
 If no rules are specified, then sampling defaults to 100%.
 
+**Note**: The Kubernetes Nginx ingress controller uses [v1.2.1][11] of the `dd-opentracing-cpp` library).
+
 [1]: http://nginx.org/en/linux_packages.html#stable
 [2]: https://github.com/DataDog/dd-opentracing-cpp/blob/master/examples/nginx-tracing/Dockerfile
 [3]: https://github.com/opentracing-contrib/nginx-opentracing/releases/latest

--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -474,7 +474,7 @@ Sampling rules are specified via the `DD_TRACE_SAMPLING_RULES` environment
 variable. To define sampling rules in the Ingress Controller, two pieces of
 configuration must be modified.
 
-First, instruct Nginx to forward the environment variable to its worker processes. Add the following [main-snippet][13] to the `data` section of the Ingress Controller's `ConfigMap`:
+First, instruct Nginx to forward the environment variable to its worker processes. Add the following [main-snippet][12] to the `data` section of the Ingress Controller's `ConfigMap`:
 ```yaml
 data:
   main-snippet: "env DD_TRACE_SAMPLING_RULES;"
@@ -507,6 +507,7 @@ If no rules are specified, then sampling defaults to 100%.
 [9]: https://github.com/DataDog/dd-opentracing-cpp/blob/master/doc/sampling.md
 [10]: https://github.com/kubernetes/ingress-nginx
 [11]: https://github.com/DataDog/dd-opentracing-cpp/releases/tag/v1.2.1
+[12]: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#main-snippet
 {{% /tab %}}
 {{% tab "Istio" %}}
 
@@ -672,7 +673,6 @@ If using Kubernetes 1.18+, `appProtocol: tcp` can be added to the port specifica
 [10]: /getting_started/tagging/unified_service_tagging/?tab=kubernetes#configuration-1
 [11]: /tracing/setup/cpp/#environment-variables
 [12]: https://istio.io/docs/ops/configuration/traffic-management/protocol-selection/#manual-protocol-selection
-[13]: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#main-snippet
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -384,7 +384,7 @@ Complete examples:
 
 After completing this configuration, HTTP requests to Nginx will initiate and propagate Datadog traces, and will appear in the APM UI.
 
-#### Nginx Sampling
+### Nginx Sampling
 
 To control the volume of Nginx traces that are sent to Datadog, specify a sampling rate in the config file `dd-config.json` by setting the `sample_rate` parameter to a value between `0.0` (0%) and `1.0` (100%):
 
@@ -417,7 +417,7 @@ For example, to send 50% of the traces for the service named `nginx`, up to `50`
 
 Read more about sampling configuration options of the [dd-opentracing-cpp][8] library in the [respository documentation][9].
 
-#### Nginx and FastCGI
+### Nginx and FastCGI
 
 When the location is serving a FastCGI backend instead of HTTP, the `location` block should use `opentracing_fastcgi_propagate_context` instead of `opentracing_propagate_context`.
 
@@ -476,7 +476,7 @@ Sampling rules are specified via the `DD_TRACE_SAMPLING_RULES` environment
 variable. To define sampling rules in the Ingress Controller, two pieces of
 configuration must be modified.
 
-First, instruct Nginx to forward the environment variable to its worker processes. Add the following [main-snippet][12] to the `data` section of the Ingress Controller's `ConfigMap`:
+First, instruct Nginx to forward the environment variable to its worker processes. Add the following [main-snippet][11] to the `data` section of the Ingress Controller's `ConfigMap`:
 ```yaml
 data:
   main-snippet: "env DD_TRACE_SAMPLING_RULES;"
@@ -498,7 +498,7 @@ env:
 
 If no rules are specified, then sampling defaults to 100%.
 
-**Note**: The Kubernetes Nginx ingress controller uses [v1.2.1][11] of the `dd-opentracing-cpp` library).
+**Note**: The Kubernetes Nginx ingress controller uses [v1.2.1][12] of the `dd-opentracing-cpp` library).
 
 [1]: http://nginx.org/en/linux_packages.html#stable
 [2]: https://github.com/DataDog/dd-opentracing-cpp/blob/master/examples/nginx-tracing/Dockerfile
@@ -510,8 +510,8 @@ If no rules are specified, then sampling defaults to 100%.
 [8]: https://github.com/DataDog/dd-opentracing-cpp/
 [9]: https://github.com/DataDog/dd-opentracing-cpp/blob/master/doc/sampling.md
 [10]: https://github.com/kubernetes/ingress-nginx
-[11]: https://github.com/DataDog/dd-opentracing-cpp/releases/tag/v1.2.1
-[12]: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#main-snippet
+[11]: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#main-snippet
+[12]: https://github.com/DataDog/dd-opentracing-cpp/releases/tag/v1.2.1
 {{% /tab %}}
 {{% tab "Istio" %}}
 
@@ -523,18 +523,16 @@ Datadog monitors every aspect of your Istio environment, so you can:
 
 To learn more about monitoring your Istio environment with Datadog, [see the Istio blog][3].
 
-## Configuration
-
 Datadog APM is available for Istio v1.1.3+ on Kubernetes clusters.
 
-### Datadog Agent installation
+## Datadog Agent installation
 
 1. [Install the Agent][4]
 2. [Make sure APM is enabled for your Agent][5].
 3. Uncomment the `hostPort` setting so that Istio sidecars can connect to the Agent and submit traces.
 
 
-### Istio configuration and installation
+## Istio configuration and installation
 
 To enable Datadog APM, a [custom Istio installation][6] is required to set two extra options when installing Istio.
 
@@ -569,7 +567,7 @@ template:
 For [CronJobs][8], the `app` label should be added to the job template, as the generated name comes from the `Job` instead
 of the higher-level `CronJob`.
 
-### Istio Sampling
+## Istio Sampling
 
 To control the volume of Istio traces that are sent to Datadog, specify a sampling rate by setting the parameter `DD_TRACE_SAMPLING_RULES` to a value between `0.0` (0%) and `1.0` (100%). If no value is specified, 100% of traces starting from Istio are sent.
 
@@ -594,7 +592,7 @@ spec:
         apm.datadoghq.com/env: '{"DD_ENV": "prod", "DD_SERVICE": "my-service", "DD_VERSION": "v1.1", "DD_TRACE_SAMPLING_RULES": "[]"}'
 ```
 
-### Environment variables
+## Environment variables
 
 Environment variables for Istio sidecars can be set on a per-deployment basis using the `apm.datadoghq.com/env` annotation. This is unique for deployments employing Istio sidecars and is set in addition to the [labels for unified service tagging][10].
 ```yaml
@@ -627,7 +625,7 @@ The available [environment variables][11] depend on the version of the C++ trace
 | v1.1.3 | v0.4.2 |
 
 
-### Deployment and service
+## Deployment and service
 
 If the Agents on your cluster are running as a deployment and service instead of the default DaemonSet, then an additional option is required to specify the DNS address and port of the Agent.
 For a service named `datadog-agent` in the `default` namespace, that address would be `datadog-agent.default.svc.cluster.local:8126`.

--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -470,6 +470,8 @@ The above overrides the default `nginx-ingress-controller.ingress-nginx` service
 
 To control the volume of Ingress Controller traces that are sent to Datadog, specify a sampling rule that matches all traces. The `sample_rate` configured in the rule will determine the proportion of traces that are sampled.
 
+**Note**: If no rules are specified, 100% of the traces are sent to Datadog.
+
 Sampling rules are specified via the `DD_TRACE_SAMPLING_RULES` environment
 variable. To define sampling rules in the Ingress Controller, two pieces of
 configuration must be modified.

--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -472,32 +472,30 @@ tracing library, `dd-opentracing-cpp`.
 
 To control the volume of Ingress Controller traces that are sent to Datadog,
 specify a sampling rule that matches all traces. The `sample_rate` configured
-in the rule will determine the proportion of traces that are sampled. If no
+in the rule determines the proportion of traces that are sampled. If no
 rules are specified, then sampling defaults to 100%.
 
-Sampling rules are specified via the `DD_TRACE_SAMPLING_RULES` environment
-variable. To define sampling rules in the Ingress Controller, two pieces of
-configuration must be modified.
+Specify sampling rules by using the `DD_TRACE_SAMPLING_RULES` environment
+variable. To define sampling rules in the Ingress Controller:
 
-First, instruct Nginx to forward the environment variable to its worker processes. Add the following [main-snippet][11] to the `data` section of the Ingress Controller's `ConfigMap`:
-```yaml
-data:
-  main-snippet: "env DD_TRACE_SAMPLING_RULES;"
-```
+1. Instruct Nginx to forward the environment variable to its worker processes by adding the following [main-snippet][11] to the `data` section of the Ingress Controller's `ConfigMap`:
+   ```yaml
+   data:
+     main-snippet: "env DD_TRACE_SAMPLING_RULES;"
+   ```
 
-Second, specify a value for the environment variable in the `env` section of the Ingress Controller's `Deployment`.  For example, to keep 10% of traces originating from the Ingress Controller:
-```yaml
-env:
-- name: DD_TRACE_SAMPLING_RULES
-  value: '[{"sample_rate": 0.1}]'
-```
-
-To use the [Datadog Agent calculated sampling rates][7] (10 traces per second per Agent by default), specify an empty array of sampling rules:
-```yaml
-env:
-- name: DD_TRACE_SAMPLING_RULES
-  value: '[]'
-```
+2. Specify a value for the environment variable in the `env` section of the Ingress Controller's `Deployment`.  For example, to keep 10% of traces originating from the Ingress Controller:
+   ```yaml
+   env:
+   - name: DD_TRACE_SAMPLING_RULES
+     value: '[{"sample_rate": 0.1}]'
+   ```
+   To use the [Datadog Agent calculated sampling rates][7] (10 traces per second per Agent by default), specify an empty array of sampling rules:
+   ```yaml
+   env:
+   - name: DD_TRACE_SAMPLING_RULES
+     value: '[]'
+   ```
 
 [1]: http://nginx.org/en/linux_packages.html#stable
 [2]: https://github.com/DataDog/dd-opentracing-cpp/blob/master/examples/nginx-tracing/Dockerfile

--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -311,7 +311,7 @@ A workaround for this is to run Nginx from a Docker container. An example Docker
 The following plugins must be installed:
 
 - Nginx plugin for OpenTracing - [linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz][3] - installed in `/usr/lib/nginx/modules`
-- Datadog OpenTracing C++ Plugin - [linux-amd64-libdd_opentracing_plugin.so.gz][4] - installed somewhere accessible to Nginx, eg `/usr/local/lib`
+- Datadog OpenTracing C++ Plugin - [linux-amd64-libdd_opentracing_plugin.so.gz][4] - installed somewhere accessible to Nginx, for example `/usr/local/lib`
 
 Commands to download and install these modules:
 

--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -13,13 +13,13 @@ further_reading:
   text: "Envoy documentation"
 - link: "https://www.nginx.com/"
   tag: "Documentation"
-  text: "NGINX website"
+  text: "Nginx website"
 - link: "https://kubernetes.github.io/ingress-nginx/user-guide/third-party-addons/opentracing/"
   tag: "Documentation"
-  text: "NGINX Ingress Controller OpenTracing"
+  text: "Nginx Ingress Controller OpenTracing"
 - link: "https://github.com/opentracing-contrib/nginx-opentracing"
   tag: "Source Code"
-  text: "NGINX plugin for OpenTracing"
+  text: "Nginx plugin for OpenTracing"
 - link: "https://istio.io/"
   tag: "Documentation"
   text: "Istio website"
@@ -296,22 +296,22 @@ The available [environment variables][3] depend on the version of the C++ tracer
 [2]: /tracing/trace_pipeline/ingestion_mechanisms/#in-the-agent
 [3]: /tracing/setup/cpp/#environment-variables
 {{% /tab %}}
-{{% tab "NGINX" %}}
+{{% tab "Nginx" %}}
 
-Support for Datadog APM is available for NGINX using a combination of plugins and configurations.
-The instructions below use NGINX from the official [Linux repositories][1] and pre-built binaries for the plugins.
+Support for Datadog APM is available for Nginx using a combination of plugins and configurations.
+The instructions below use Nginx from the official [Linux repositories][1] and pre-built binaries for the plugins.
 
-## NGINX open source
+## Nginx open source
 
 ### Plugin installation
 
 **Note**: this plugin does not work on Linux distributions that use older versions of `libstdc++`. This includes RHEL/Centos 7 and AmazonLinux 1.
-A workaround for this is to run NGINX from a Docker container. An example Dockerfile is available [here][2].
+A workaround for this is to run Nginx from a Docker container. An example Dockerfile is available [here][2].
 
 The following plugins must be installed:
 
-- NGINX plugin for OpenTracing - [linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz][3] - installed in `/usr/lib/nginx/modules`
-- Datadog OpenTracing C++ Plugin - [linux-amd64-libdd_opentracing_plugin.so.gz][4] - installed somewhere accessible to NGINX, eg `/usr/local/lib`
+- Nginx plugin for OpenTracing - [linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz][3] - installed in `/usr/lib/nginx/modules`
+- Datadog OpenTracing C++ Plugin - [linux-amd64-libdd_opentracing_plugin.so.gz][4] - installed somewhere accessible to Nginx, eg `/usr/local/lib`
 
 Commands to download and install these modules:
 
@@ -325,7 +325,7 @@ get_latest_release() {
 NGINX_VERSION=1.17.3
 OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)"
 DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)"
-# Install NGINX plugin for OpenTracing
+# Install Nginx plugin for OpenTracing
 wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz
 tar zxf linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
 # Install Datadog Opentracing C++ Plugin
@@ -333,9 +333,9 @@ wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTR
 gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so
 ```
 
-### NGINX configuration
+### Nginx configuration
 
-The NGINX configuration must load the OpenTracing module.
+The Nginx configuration must load the OpenTracing module.
 
 ```nginx
 # Load OpenTracing module
@@ -353,7 +353,7 @@ The `http` block enables the OpenTracing module and loads the Datadog tracer:
     opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/nginx/dd-config.json;
 ```
 
-The `log_format with_trace_id` block is for correlating logs and traces. See the [example NGINX config][5] file for the complete format. The `$opentracing_context_x_datadog_trace_id` value captures the trace ID, and `$opentracing_context_x_datadog_parent_id` captures the span ID.
+The `log_format with_trace_id` block is for correlating logs and traces. See the [example Nginx config][5] file for the complete format. The `$opentracing_context_x_datadog_trace_id` value captures the trace ID, and `$opentracing_context_x_datadog_parent_id` captures the span ID.
 
 The `location` block within the server where tracing is desired should add the following:
 
@@ -374,19 +374,19 @@ A config file for the Datadog tracing implementation is also required:
 }
 ```
 
-The `service` value can be modified to a meaningful value for your usage of NGINX.
-The `agent_host` value may need to be changed if NGINX is running in a container or orchestrated environment.
+The `service` value can be modified to a meaningful value for your usage of Nginx.
+The `agent_host` value may need to be changed if Nginx is running in a container or orchestrated environment.
 
 Complete examples:
 
 * [nginx.conf][5]
 * [dd-config.json][6]
 
-After completing this configuration, HTTP requests to NGINX will initiate and propagate Datadog traces, and will appear in the APM UI.
+After completing this configuration, HTTP requests to Nginx will initiate and propagate Datadog traces, and will appear in the APM UI.
 
 #### Sampling
 
-To control the volume of traces starting from Nginx that are sent to Datadog, specify a sampling rate in the config file `dd-config.json` by setting the `sample_rate` parameter to a value between `0.0` (0%) and `1.0` (100%):
+To control the volume of Nginx traces that are sent to Datadog, specify a sampling rate in the config file `dd-config.json` by setting the `sample_rate` parameter to a value between `0.0` (0%) and `1.0` (100%):
 
 ```json
 {
@@ -417,13 +417,13 @@ For example, to send 50% of the traces for the service named `nginx`, up to `50`
 
 Read more about sampling configuration options of the [dd-opentracing-cpp][8] library in the [respository documentation][9].
 
-#### NGINX and FastCGI
+#### Nginx and FastCGI
 
 When the location is serving a FastCGI backend instead of HTTP, the `location` block should use `opentracing_fastcgi_propagate_context` instead of `opentracing_propagate_context`.
 
-## NGINX Ingress Controller for Kubernetes
+## Nginx Ingress Controller for Kubernetes
 
-The [Kubernetes ingress-nginx][10] controller versions 0.23.0+ include the NGINX plugin for OpenTracing.
+The [Kubernetes ingress-nginx][10] controller versions 0.23.0+ include the Nginx plugin for OpenTracing.
 
 To enable this plugin, create or edit a ConfigMap to set `enable-opentracing: "true"` and the `datadog-collector-host` to which traces should be sent.
 The name of the ConfigMap will be cited explicitly by the nginx-ingress controller container's command line argument, defaulting to `--configmap=$(POD_NAMESPACE)/nginx-configuration`.

--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -214,7 +214,7 @@ stats_config:
 
 ## Sampling
 
-To control the volume of traces starting from Envoy that are sent to Datadog, specify a sampling rate by setting the parameter `DD_TRACE_SAMPLING_RULES` to a value between `0.0` (0%) and `1.0` (100%). If no value is specified, 100% of traces starting from Envoy are sent.
+To control the volume of Envoy traces that are sent to Datadog, specify a sampling rate by setting the parameter `DD_TRACE_SAMPLING_RULES` to a value between `0.0` (0%) and `1.0` (100%). If no value is specified, 100% of traces starting from Envoy are sent.
 
 To use the [Datadog Agent calculated sampling rates][2] (10 traces per second per Agent) and ignore the default sampling rule set to 100%, set the parameter `DD_TRACE_SAMPLING_RULES` to an empty array:
 
@@ -468,7 +468,7 @@ The above overrides the default `nginx-ingress-controller.ingress-nginx` service
 
 ### Sampling
 
-To control the volume of traces starting from Nginx that are sent to Datadog, specify a sampling rate by setting the parameter `DD_TRACE_SAMPLING_RULES` to a value between `0.0` (0%) and `1.0` (100%). If no value is specified, 100% of traces starting from Nginx are sent. The Kubernetes Nginx ingress controller uses [v1.2.1][11] of the `dd-opentracing-cpp` library).
+To control the volume of Ingress Controller traces that are sent to Datadog, specify a sampling rate by setting the parameter `DD_TRACE_SAMPLING_RULES` to a value between `0.0` (0%) and `1.0` (100%). If no value is specified, 100% of traces starting from Nginx are sent. The Kubernetes Nginx ingress controller uses [v1.2.1][11] of the `dd-opentracing-cpp` library).
 
 For example, to keep 10% of the traces starting from the `ingress-nginx` service:
 
@@ -573,7 +573,7 @@ of the higher-level `CronJob`.
 
 ### Sampling
 
-To control the volume of traces starting from Istio that are sent to Datadog, specify a sampling rate by setting the parameter `DD_TRACE_SAMPLING_RULES` to a value between `0.0` (0%) and `1.0` (100%). If no value is specified, 100% of traces starting from Istio are sent.
+To control the volume of Istio traces that are sent to Datadog, specify a sampling rate by setting the parameter `DD_TRACE_SAMPLING_RULES` to a value between `0.0` (0%) and `1.0` (100%). If no value is specified, 100% of traces starting from Istio are sent.
 
 **Note**: These environment variables apply only to the subset of traces indicated by the `values.pilot.traceSampling` setting, hence the required `--set values.pilot.traceSampling=100.0` during Istio configuration.
 


### PR DESCRIPTION
### What does this PR do?
Correct inconsistencies in the "sampling" section of the getting started instructions for tracing the Nginx Ingress Controller for Kubernetes. See https://datadoghq.atlassian.net/browse/APMS-7568

### Motivation
The docs were inaccurate, as a customer learned.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
