### PR TITLE
hugo latest retry

### DIFF
--- a/assets/scripts/main-dd-js.js
+++ b/assets/scripts/main-dd-js.js
@@ -1,10 +1,11 @@
 import 'jquery';
 import 'bootstrap';
 
-
+import './jqmath-vanilla';
 import './datadog-docs';
 import './utms';
 
+import './components/search';
 import './components/copy-code';
 import './components/global-modals';
 // import './components/header';

--- a/assets/scripts/main-dd-js.js
+++ b/assets/scripts/main-dd-js.js
@@ -1,11 +1,9 @@
 import 'jquery';
 import 'bootstrap';
 
-import './jqmath-vanilla';
 import './datadog-docs';
 import './utms';
 
-import './components/search';
 import './components/copy-code';
 import './components/global-modals';
 // import './components/header';

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -7,6 +7,9 @@
     {{- $outputStyles = resources.Get $inputStyleFile | toCSS $options -}}
 {{- else -}}
     {{- $outputStyles = resources.Get $inputStyleFile | toCSS $options | minify | fingerprint -}}
+    {{ if ne (path.Ext $outputStyles.Permalink) ".css" }}
+        {{ errorf "ERROR CSS File Not Found! %q" .Path }}
+    {{ end }}
 {{- end -}}
 
-<link rel="stylesheet" href="{{- $outputStyles.Permalink -}}">
+<link rel="stylesheet" integrity="{{ $outputStyles.Data.Integrity }}" href="{{- $outputStyles.Permalink -}}">

--- a/layouts/partials/footer-scripts.html
+++ b/layouts/partials/footer-scripts.html
@@ -7,28 +7,12 @@ hugo defaults to environment development with hugo server
 {{- $sourcemap := cond $isProd "external" "inline" -}}
 {{- $inject := slice "scripts/injects/inject-jquery.js" -}}
 
-{{- if .HasShortcode "jqmath-vanilla" -}}
-  {{- $opts := dict "targetPath" "static/jqmath.js" "defines" $defines "inject" $inject "sourceMap" $sourcemap "minify" $isProd -}}
-  {{- $js := resources.Get "scripts/jqmath-vanilla.js" | js.Build $opts -}}
-  {{- $js = $js | fingerprint "sha512" -}}
-  <script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }}></script>
-{{- end -}}
-
 {{ $opts := dict "targetPath" "static/main-dd-js.js" "defines" $defines "inject" $inject "sourceMap" $sourcemap "minify" $isProd }}
 {{ $js := resources.Get "scripts/main-dd-js.js" | js.Build $opts }}
 {{ if $isProd }}
   {{ $js = $js | fingerprint "sha512" }}
 {{ end }}
 <script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }}></script>
-
-{{ if eq .File.BaseFileName "search" }}
-    {{ $opts := dict "targetPath" "static/search.js" "defines" $defines "inject" $inject "sourceMap" $sourcemap "minify" $isProd }}
-    {{ $js := resources.Get "scripts/components/search.js" | js.Build $opts }}
-    {{ if $isProd }}
-      {{ $js = $js | fingerprint "sha512" }}
-    {{ end }}
-    <script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }}></script>
-{{ end }}
 
 {{ if .Params.footer_scripts }}
     {{ range $k, $v := .Params.footer_scripts }}

--- a/layouts/partials/footer-scripts.html
+++ b/layouts/partials/footer-scripts.html
@@ -7,12 +7,28 @@ hugo defaults to environment development with hugo server
 {{- $sourcemap := cond $isProd "external" "inline" -}}
 {{- $inject := slice "scripts/injects/inject-jquery.js" -}}
 
+{{- if .HasShortcode "jqmath-vanilla" -}}
+  {{- $opts := dict "targetPath" "static/jqmath.js" "defines" $defines "sourceMap" $sourcemap "minify" $isProd -}}
+  {{- $js := resources.Get "scripts/jqmath-vanilla.js" | js.Build $opts -}}
+  {{- $js = $js | fingerprint "sha512" -}}
+  <script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }}></script>
+{{- end -}}
+
 {{ $opts := dict "targetPath" "static/main-dd-js.js" "defines" $defines "inject" $inject "sourceMap" $sourcemap "minify" $isProd }}
 {{ $js := resources.Get "scripts/main-dd-js.js" | js.Build $opts }}
 {{ if $isProd }}
   {{ $js = $js | fingerprint "sha512" }}
 {{ end }}
 <script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }}></script>
+
+{{ if eq .File.BaseFileName "search" }}
+    {{ $opts := dict "targetPath" "static/search.js" "defines" $defines "inject" $inject "sourceMap" $sourcemap "minify" $isProd }}
+    {{ $js := resources.Get "scripts/components/search.js" | js.Build $opts }}
+    {{ if $isProd }}
+      {{ $js = $js | fingerprint "sha512" }}
+    {{ end }}
+    <script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }}></script>
+{{ end }}
 
 {{ if .Params.footer_scripts }}
     {{ range $k, $v := .Params.footer_scripts }}

--- a/layouts/partials/footer-scripts.html
+++ b/layouts/partials/footer-scripts.html
@@ -7,6 +7,13 @@ hugo defaults to environment development with hugo server
 {{- $sourcemap := cond $isProd "external" "inline" -}}
 {{- $inject := slice "scripts/injects/inject-jquery.js" -}}
 
+{{- if .HasShortcode "jqmath-vanilla" -}}
+  {{- $opts := dict "targetPath" "static/jqmath.js" "defines" $defines "inject" $inject "sourceMap" $sourcemap "minify" $isProd -}}
+  {{- $js := resources.Get "scripts/jqmath-vanilla.js" | js.Build $opts -}}
+  {{- $js = $js | fingerprint "sha512" -}}
+  <script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }}></script>
+{{- end -}}
+
 {{ $opts := dict "targetPath" "static/main-dd-js.js" "defines" $defines "inject" $inject "sourceMap" $sourcemap "minify" $isProd }}
 {{ $js := resources.Get "scripts/main-dd-js.js" | js.Build $opts }}
 {{ if $isProd }}

--- a/layouts/partials/integrations-logo.html
+++ b/layouts/partials/integrations-logo.html
@@ -111,7 +111,6 @@ Both of these should return the same image.
 <!--{{/* if fallback settings */}}-->
 {{- if not $imageExists -}}
   {{- if eq ($fallback | lower) "cloud" -}}
-    {{ warnf "fallback %q %q %q" $basename (or (hasPrefix $basename "gcp") (hasPrefix $basename "google")) (or (hasPrefix $basename "aws") (hasPrefix $basename "amazon")) }}
     {{- if (or (hasPrefix $basename "gcp") (hasPrefix $basename "google")) -}}
       {{- $basename = "google-cloud-platform" -}}
       {{- $imageExists = true -}}

--- a/layouts/shortcodes/jqmath-vanilla.html
+++ b/layouts/shortcodes/jqmath-vanilla.html
@@ -1,2 +1,5 @@
-<!-- see footer-scripts  -->
+<script>
 
+  // Force page reload with script, see footer-scripts.html & hasScript in js
+
+</script>

--- a/layouts/shortcodes/jqmath-vanilla.html
+++ b/layouts/shortcodes/jqmath-vanilla.html
@@ -1,2 +1,2 @@
-{{- $jqmath := resources.Get "scripts/jqmath-vanilla.js" -}}
-<script>{{- $jqmath.Content | safeJS -}}</script>
+<!-- see footer-scripts  -->
+

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "del": "4.1.1",
         "docsearch.js": "^2.6.3",
         "fancy-log": "^1.3.3",
-        "hugo-bin": "0.86.0",
+        "hugo-bin": "0.89.0",
         "jquery": "3.5.1",
         "js-cookie": "^2.2.1",
         "js-yaml": "^3.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4416,7 +4416,7 @@ __metadata:
     eslint-plugin-react-hooks: ^2.5.0
     eslint-plugin-standard: ^4.0.0
     fancy-log: ^1.3.3
-    hugo-bin: 0.86.0
+    hugo-bin: 0.89.0
     jest: ^25.3.0
     jquery: 3.5.1
     js-cookie: ^2.2.1
@@ -6300,9 +6300,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hugo-bin@npm:0.86.0":
-  version: 0.86.0
-  resolution: "hugo-bin@npm:0.86.0"
+"hugo-bin@npm:0.89.0":
+  version: 0.89.0
+  resolution: "hugo-bin@npm:0.89.0"
   dependencies:
     bin-wrapper: ^4.1.0
     picocolors: ^1.0.0
@@ -6310,7 +6310,7 @@ __metadata:
     rimraf: ^3.0.2
   bin:
     hugo: cli.js
-  checksum: 49d480ca9cde1154a5f74e4d21246e8fb831e277c7518392918c046c426d25113c3530f028c7cde3bc1fafc25d3e25d7fd8744ac3537449d59185a8738c6e521
+  checksum: 278ba5cc8cd77d80b5d8d98d9e517178955422a24e015888bbb0e3aa8689596b16373308c0e5239b0a9dbe1dc148996cefc8d9a30103005921d45e025ee94e0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

We updated hugo in #14800 which we had to rollback due to `err_scanTokP_` alert popups that were appearing from jqmath.

This PR:
- updates hugo to the latest again 
- fixes the popup issues by loading the jqmath js file on the pages its needed instead of in-lining it on the page which hugo was disrupting somehow.
- removes a warnf i left from a previous task

### Motivation

To get us back to the latest hugo

### Preview

**Pages with jqmath to test**
https://docs-staging.datadoghq.com/david.jones/hugo-latest-retry/tracing/guide/span_and_trace_id_format/
https://docs-staging.datadoghq.com/david.jones/hugo-latest-retry/monitors/service_level_objectives/burn_rate/

(Also try starting on a non jqmath page and then navigating to one)

**Please check other random docs pages again**
https://docs-staging.datadoghq.com/david.jones/hugo-latest-retry/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
