### PR TITLE
Remove images links from Searching Profiles page

### DIFF
--- a/content/en/tracing/profiler/search_profiles.md
+++ b/content/en/tracing/profiler/search_profiles.md
@@ -68,8 +68,6 @@ In the **Profiles** tab, you can see all profile types available for a given lan
 {{< programming-lang-wrapper langs="java,python,go,ruby,nodejs,dotnet,php,ddprof" >}}
 {{< programming-lang lang="java" >}}
 
-{{< img src="tracing/profiling/profile.png" alt="A specific profile">}}
-
 Once enabled, the following profile types are collected:
 
 
@@ -193,8 +191,6 @@ Heap Live Size
 
 {{< /programming-lang >}}
 {{< programming-lang lang="dotnet" >}}
-
-{{< img src="tracing/profiling/profile_dotnet.png" alt="A .NET profile">}}
 
 Once enabled, the following profile type is collected:
 


### PR DESCRIPTION
### What does this PR do?
Removes the img links, but not the .png file because FR and JA still temporarily point to them.

### Motivation
Request from PM in slack
