### PR TITLE
Fix typo in Go profiler example

### DIFF
--- a/content/en/tracing/profiler/enabling/go.md
+++ b/content/en/tracing/profiler/enabling/go.md
@@ -51,7 +51,7 @@ To begin profiling applications:
         profiler.WithService("<SERVICE_NAME>"),
         profiler.WithEnv("<ENVIRONMENT>"),
         profiler.WithVersion("<APPLICATION_VERSION>"),
-        profiler.WithTags("<KEY1>:<VALUE1>,<KEY2>:<VALUE2>"),
+        profiler.WithTags("<KEY1>:<VALUE1>", "<KEY2>:<VALUE2>"),
         profiler.WithProfileTypes(
           profiler.CPUProfile,
           profiler.HeapProfile,

--- a/content/fr/tracing/profiler/getting_started.md
+++ b/content/fr/tracing/profiler/getting_started.md
@@ -173,7 +173,7 @@ Le profileur Datadog nécessite Go 1.12 ou une version ultérieure. Pour commen
         profiler.WithService("<SERVICE_NAME>"),
         profiler.WithEnv("<ENVIRONMENT>"),
         profiler.WithVersion("<APPLICATION_VERSION>"),
-        profiler.WithTags("<KEY1>:<VALUE1>,<KEY2>:<VALUE2>"),
+        profiler.WithTags("<KEY1>:<VALUE1>", "<KEY2>:<VALUE2>"),
     )
     if err != nil {
         log.Fatal(err)

--- a/content/ja/tracing/profiler/enabling.md
+++ b/content/ja/tracing/profiler/enabling.md
@@ -207,7 +207,7 @@ Datadog Profiler には Go 1.12 以降が必要です。アプリケーション
         profiler.WithService("<SERVICE_NAME>"),
         profiler.WithEnv("<ENVIRONMENT>"),
         profiler.WithVersion("<APPLICATION_VERSION>"),
-        profiler.WithTags("<KEY1>:<VALUE1>,<KEY2>:<VALUE2>"),
+        profiler.WithTags("<KEY1>:<VALUE1>", "<KEY2>:<VALUE2>"),
         profiler.WithProfileTypes(
           profiler.CPUProfile,
           profiler.HeapProfile,

--- a/content/ja/tracing/profiler/getting_started.md
+++ b/content/ja/tracing/profiler/getting_started.md
@@ -200,7 +200,7 @@ Datadog Profiler には Go 1.12 以降が必要です。アプリケーション
         profiler.WithService("<SERVICE_NAME>"),
         profiler.WithEnv("<ENVIRONMENT>"),
         profiler.WithVersion("<APPLICATION_VERSION>"),
-        profiler.WithTags("<KEY1>:<VALUE1>,<KEY2>:<VALUE2>"),
+        profiler.WithTags("<KEY1>:<VALUE1>", "<KEY2>:<VALUE2>"),
         profiler.WithProfileTypes(
           profiler.CPUProfile,
           profiler.HeapProfile,

--- a/content/ja/tracing/profiling/getting_started.md
+++ b/content/ja/tracing/profiling/getting_started.md
@@ -172,7 +172,7 @@ Datadog Profiler には Go 1.12 以降が必要です。アプリケーション
         profiler.WithService("<SERVICE_NAME>"),
         profiler.WithEnv("<ENVIRONMENT>"),
         profiler.WithVersion("<APPLICATION_VERSION>"),
-        profiler.WithTags("<KEY1>:<VALUE1>,<KEY2>:<VALUE2>"),
+        profiler.WithTags("<KEY1>:<VALUE1>", "<KEY2>:<VALUE2>"),
     )
     if err != nil {
         log.Fatal(err)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Corrects a typo in the Go continuous profiling example. Each tag passed to
profiler.WithTags should be a separate argument.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
