### PR TITLE
Correct range formula descriptions

### DIFF
--- a/content/en/monitors/guide/monitor-for-value-within-a-range.md
+++ b/content/en/monitors/guide/monitor-for-value-within-a-range.md
@@ -26,8 +26,8 @@ Mathematically, the difference between the metric and the center of the range (6
 
 A range is defined by `x > a > y` with `a` being the metric in question. 
 
-- To be notified if the value is outside the range, the monitor condition should be: `abs((x-y/2) - a) - (x-y)/2 > 0`.
-- To be notified if the value is inside the range, the monitor condition should be: `(x-y)/2 - abs((x-y/2) - a) > 0`.
+- To be notified if the value is outside the range, the monitor condition should be: `abs(x - (x-y)/2)) - a) - (x-y)/2 > 0`.
+- To be notified if the value is inside the range, the monitor condition should be: `(x-y)/2 - abs(x - (x-y)/2)) - a) > 0`.
 
 ## Troubleshooting
 

--- a/content/en/monitors/guide/monitor-for-value-within-a-range.md
+++ b/content/en/monitors/guide/monitor-for-value-within-a-range.md
@@ -26,8 +26,8 @@ Mathematically, the difference between the metric and the center of the range (6
 
 A range is defined by `x > a > y` with `a` being the metric in question. 
 
-- To be notified if the value is outside the range, the monitor condition should be: `abs(x - (x-y)/2)) - a) - (x-y)/2 > 0`.
-- To be notified if the value is inside the range, the monitor condition should be: `(x-y)/2 - abs(x - (x-y)/2)) - a) > 0`.
+- To be notified if the value is outside the range, the monitor condition should be: `abs(x - (x-y)/2 - a) - (x-y)/2 > 0`.
+- To be notified if the value is inside the range, the monitor condition should be: `(x-y)/2 - abs(x - (x-y)/2 - a) > 0`.
 
 ## Troubleshooting
 

--- a/content/en/monitors/guide/monitor-for-value-within-a-range.md
+++ b/content/en/monitors/guide/monitor-for-value-within-a-range.md
@@ -26,8 +26,8 @@ Mathematically, the difference between the metric and the center of the range (6
 
 A range is defined by `x > a > y` with `a` being the metric in question. 
 
-- To be notified if the value is inside the range, the monitor condition should be: `abs((x-y/2) - a) - (x-y)/2 > 0`.
-- To be notified if the value is outside the range, the monitor condition should be: `(x-y)/2 - abs((x-y/2) - a) > 0`.
+- To be notified if the value is outside the range, the monitor condition should be: `abs((x-y/2) - a) - (x-y)/2 > 0`.
+- To be notified if the value is inside the range, the monitor condition should be: `(x-y)/2 - abs((x-y/2) - a) > 0`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR corrects the appropriate formula for creating a monitor within a range of values in the documentation.

### Motivation
I created a monitor that was having the opposite effect of the intended behavior after following the documentation. The previous example in the same document had the correct formula described.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
