### PR TITLE
Correct WithTags option for Go profiling client library

### DIFF
--- a/content/en/profiler/enabling/go.md
+++ b/content/en/profiler/enabling/go.md
@@ -84,7 +84,7 @@ You can set profiler parameters in code with these functions:
 |  WithService     | String        | The Datadog [service][8] name, for example `my-web-app`.             |
 |  WithEnv         | String        | The Datadog [environment][9] name, for example, `production`.         |
 |  WithVersion     | String        | The version of your application.                                                                             |
-|  WithTags        | String        | The tags to apply to an uploaded profile. Must be a list of in the format `<KEY1>:<VALUE1>,<KEY2>:<VALUE2>`. |
+|  WithTags        | List of strings        | A list of tags to apply to an uploaded profile. Tags must be of the format `<KEY>:<VALUE>`. |
 
 Alternatively you can set profiler configuration using environment variables:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Corrects the Go profiler configuration documentation. For the Go profiling
client library API, tags are passed as a list of strings of the form
`"<key>:<value>"`, rather than a single comma-separated string of tags (as is the case for
the "DD_TAGS" environment variable).

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
