### PR TITLE
Document DD_RUM.addTiming second parameter

### DIFF
--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -138,7 +138,7 @@ Once the timing is sent, the timing is accessible as `@view.custom_timings.<timi
 
 **Note**: For single page applications, the `addTiming` API issues a timing relative to the start of the current RUM view. For example, if a user lands on your application (initial load), then goes on a different page after 5 seconds (route change) and finally triggers `addTiming` after 8 seconds, the timing is equal to `8-5 = 3` seconds.
 
-You can also provide your own timing as a second parameter. It should be a number of milliseconds relative to the start of the current RUM view or the UNIX epoch (timestamp). It is particularly useful when using an asynchronous setup. Example:
+You can also provide your own timing as a second parameter. It should be the number of milliseconds relative to the start of the current RUM view or the UNIX epoch (timestamp). It is particularly useful when using an asynchronous setup. Example:
 
 ```javascript
 document.addEventListener("scroll", function handler() {

--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -138,6 +138,22 @@ Once the timing is sent, the timing is accessible as `@view.custom_timings.<timi
 
 **Note**: For single page applications, the `addTiming` API issues a timing relative to the start of the current RUM view. For example, if a user lands on your application (initial load), then goes on a different page after 5 seconds (route change) and finally triggers `addTiming` after 8 seconds, the timing is equal to `8-5 = 3` seconds.
 
+You can also provide your own timing as a second parameter. It should be a number of milliseconds relative to the start of the current RUM view or the UNIX epoch (timestamp). It is particularly useful when using an asynchronous setup. Example:
+
+```javascript
+document.addEventListener("scroll", function handler() {
+    //Remove the event listener so that it only triggers once
+    document.removeEventListener("scroll", handler);
+
+    const timing = Date.now()
+    DD_RUM.onReady(function() {
+      DD_RUM.addTiming('first_scroll', timing);
+    });
+});
+
+```
+
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

`DD_RUM.addTiming` has a second parameter that the user can use to provide their own timing. This PR add documentation for that.

### Motivation

The documentation was missing.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
