### PR TITLE
Add docs about composites and downtimes behaviour

### DIFF
--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -146,15 +146,15 @@ A composite monitor and its individual monitors are independent of each other.
 
 **Downtime on composite monitor**
 
-Take a composite monitor that consists of two individual monitors with the condition `A \|\| B`. Creating a downtime on the composite monitor will surpress notifications from said composite only.
+Take a composite monitor that consists of two individual monitors with the condition `A \|\| B`. Creating a downtime on the composite monitor will surppress notifications from said composite only.
 
-In case monitor `A` or monitor `B` notify services or teams as well in their respective monitor configurations, the downtime on the composite alone will not mute any notifications caused by them. To achieve this, a separate downtime on the composite is needed.
+In case monitor `A` or monitor `B` notify services or teams as well in their respective monitor configurations, the downtime on the composite alone will not mute any notifications caused by them. To achieve this, one or more downtimes on the underlying monitors are needed.
 
 **Downtime on an individual monitor used in a composite monitor**
 
-Using the example above above a composite monitor that consists of two individual monitors with the condition `A \|\| B`. Creating a downtime on the individual monitor `A` will not mute the composite monitor.
+Using the example above a composite monitor that consists of two individual monitors with the condition `A \|\| B`. Creating a downtime on the individual monitor `A` will not mute the composite monitor.
 
-For example, a downtime mutes monitor `A`, specifically its group `env:staging`. While the individuak monitor `A` will be once the group `env:staging` triggers, the composite monitor will send an alert notifications.
+For example, a downtime mutes monitor `A`, specifically its group `env:staging`. While the individual monitor `A` will be once the group `env:staging` triggers, the composite monitor will send an alert notifications.
 
 ### Number of alerts
 

--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -148,13 +148,13 @@ A composite monitor and its individual monitors are independent of each other.
 
 Take a composite monitor that consists of two individual monitors with the condition `A \|\| B`. Creating a downtime on the composite monitor will surppress notifications from said composite only.
 
-In case monitor `A` or monitor `B` notify services or teams as well in their respective monitor configurations, the downtime on the composite alone will not mute any notifications caused by them. To achieve this, one or more downtimes on the underlying monitors are needed.
+In case monitor `A` or monitor `B` notify services or teams as well in their respective monitor configurations, the downtime on the composite alone does not mute any notifications caused by them. To achieve this, one or more downtimes on the underlying monitors are needed.
 
 **Downtime on an individual monitor used in a composite monitor**
 
-Using the example above a composite monitor that consists of two individual monitors with the condition `A \|\| B`. Creating a downtime on the individual monitor `A` will not mute the composite monitor.
+Creating a downtime on an individual monitor `A`, which is used within a composite monitor, does not mute the composite monitor.
 
-For example, a downtime mutes monitor `A`, specifically its group `env:staging`. While the individual monitor `A` will be once the group `env:staging` triggers, the composite monitor will send an alert notifications.
+For example, a downtime mutes monitor `A`, specifically its group `env:staging`. Once the group `env:staging` reaches an alert-worthy state, the notification coming from individual monitor is suppressed while the composite monitor sends an alert notification.
 
 ### Number of alerts
 

--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -150,7 +150,7 @@ Consider a composite monitor `C` that consists of two individual monitors with t
 
 If monitor `A` or monitor `B` notify services or teams in their respective monitor configurations, the downtime on the composite `C` does not mute any notifications caused by `A` or `B`. To mute notifications from `A` or `B`, set downtime on those monitors.
 
-**Downtime on an individual monitor used in a composite monitor**
+#### Downtime on an individual monitor used in a composite monitor
 
 Creating a downtime on an individual monitor `A`, which is used within a composite monitor, does not mute the composite monitor.
 

--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -140,6 +140,22 @@ Consider a composite monitor that uses two individual monitors: `A` and `B`. The
 
 **Note**: When the composite has `notify_no_data` to false, and the result of the evaluation of the sub-monitors should end up on a `No Data` status for the composite, the composite uses the last known state instead.
 
+### Composites and Downtimes
+
+A composite monitor and its individual monitors are independent of each other.
+
+**Downtime on composite monitor**
+
+Take a composite monitor that consists of two individual monitors with the condition `A \|\| B`. Creating a downtime on the composite monitor will surpress notifications from said composite only.
+
+In case monitor `A` or monitor `B` notify services or teams as well in their respective monitor configurations, the downtime on the composite alone will not mute any notifications caused by them. To achieve this, a separate downtime on the composite is needed.
+
+**Downtime on an individual monitor used in a composite monitor**
+
+Using the example above above a composite monitor that consists of two individual monitors with the condition `A \|\| B`. Creating a downtime on the individual monitor `A` will not mute the composite monitor.
+
+For example, a downtime mutes monitor `A`, specifically its group `env:staging`. While the individuak monitor `A` will be once the group `env:staging` triggers, the composite monitor will send an alert notifications.
+
 ### Number of alerts
 
 The number of alerts you receive depends on the individual monitor's alert type.
@@ -188,7 +204,7 @@ Setting [new_group_delay][4] is possible in composite monitors and if set and bi
     * monitor B: new_group_delay=60s
     * composite: `A&&B`
 
-    When a new group appears, immediately, the composite monitor has this new group in OK state. After `60s`, the new group has the state from B in the composite monitor. After `120s`, the new group has its worst status among A and B in the composite. 
+    When a new group appears, immediately, the composite monitor has this new group in OK state. After `60s`, the new group has the state from B in the composite monitor. After `120s`, the new group has its worst status among A and B in the composite.
 
 2. Composite with new group delay
 
@@ -197,7 +213,7 @@ Setting [new_group_delay][4] is possible in composite monitors and if set and bi
     * composite: new_group_delay=200s
     * composite: `A&&B`
 
-    When a new group appears, immediately, the composite monitor has this new group in OK state. After `200s`, the new group has its worst status among A and B in the composite. 
+    When a new group appears, immediately, the composite monitor has this new group in OK state. After `200s`, the new group has its worst status among A and B in the composite.
 
 
 ## Further Reading

--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -148,7 +148,7 @@ A composite monitor and its individual monitors are independent of each other.
 
 Consider a composite monitor `C` that consists of two individual monitors with the condition `A || B`. Creating a downtime on the composite monitor will suppress notifications from `C` only.
 
-In case monitor `A` or monitor `B` notify services or teams as well in their respective monitor configurations, the downtime on the composite alone does not mute any notifications caused by them. To achieve this, one or more downtimes on the underlying monitors are needed.
+If monitor `A` or monitor `B` notify services or teams in their respective monitor configurations, the downtime on the composite `C` does not mute any notifications caused by `A` or `B`. To mute notifications from `A` or `B`, set downtime on those monitors.
 
 **Downtime on an individual monitor used in a composite monitor**
 

--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -146,7 +146,7 @@ A composite monitor and its individual monitors are independent of each other.
 
 **Downtime on composite monitor**
 
-Take a composite monitor that consists of two individual monitors with the condition `A || B`. Creating a downtime on the composite monitor will surppress notifications from said composite only.
+Consider a composite monitor `C` that consists of two individual monitors with the condition `A || B`. Creating a downtime on the composite monitor will suppress notifications from `C` only.
 
 In case monitor `A` or monitor `B` notify services or teams as well in their respective monitor configurations, the downtime on the composite alone does not mute any notifications caused by them. To achieve this, one or more downtimes on the underlying monitors are needed.
 

--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -154,7 +154,7 @@ If monitor `A` or monitor `B` notify services or teams in their respective monit
 
 Creating a downtime on an individual monitor `A`, which is used within a composite monitor, does not mute the composite monitor.
 
-For example, a downtime mutes monitor `A`, specifically its group `env:staging`. Once the group `env:staging` reaches an alert-worthy state, the notification coming from individual monitor is suppressed while the composite monitor sends an alert notification.
+For example, a downtime mutes monitor `A`, specifically its group `env:staging`. Once the group `env:staging` reaches an alert-worthy state, the notification coming from the individual monitor is suppressed while the composite monitor sends an alert notification.
 
 ### Number of alerts
 

--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -144,7 +144,7 @@ Consider a composite monitor that uses two individual monitors: `A` and `B`. The
 
 A composite monitor and its individual monitors are independent of each other.
 
-**Downtime on composite monitor**
+#### Downtime on a composite monitor
 
 Consider a composite monitor `C` that consists of two individual monitors with the condition `A || B`. Creating a downtime on the composite monitor will suppress notifications from `C` only.
 

--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -146,7 +146,7 @@ A composite monitor and its individual monitors are independent of each other.
 
 **Downtime on composite monitor**
 
-Take a composite monitor that consists of two individual monitors with the condition `A \|\| B`. Creating a downtime on the composite monitor will surppress notifications from said composite only.
+Take a composite monitor that consists of two individual monitors with the condition `A || B`. Creating a downtime on the composite monitor will surppress notifications from said composite only.
 
 In case monitor `A` or monitor `B` notify services or teams as well in their respective monitor configurations, the downtime on the composite alone does not mute any notifications caused by them. To achieve this, one or more downtimes on the underlying monitors are needed.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a descriptions on how composites, child monitors, and downtimes all play together.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
