### PR TITLE
Update section on how monitor SLO status is calculated

### DIFF
--- a/content/en/monitors/service_level_objectives/monitor.md
+++ b/content/en/monitors/service_level_objectives/monitor.md
@@ -37,7 +37,7 @@ Under **Define the source**, select **Monitor Based**.
 
 In the search box, start typing the name of a monitor. A list of matching monitors appears. Click on a monitor name to add it to the source list. 
 
-If you’re only using a single multi-alert monitor in an SLO, you can optionally select “Calculate on selected groups” and pick up to 20 groups. Group selection is not supported for SLOs that contain multiple monitors. 
+If you’re only using a single multi-alert monitor in an SLO, you can optionally select "Calculate on selected groups" and pick up to 20 groups. Group selection is not supported for SLOs that contain multiple monitors. 
 
 
 ### Set your SLO targets
@@ -73,7 +73,7 @@ Select **Save & Exit** to save your new SLO.
 
 {{< img src="monitors/service_level_objectives/aggregate_slo.jpg" alt="SLO detail showing 99 percent green with 8 groups aggregated"  >}}
 
-Datadog calculates the overall SLO status as the uptime percentage across all monitors or monitor groups—unless specific groups have been selected, in which case the SLO status is calculated with only those groups. If no specific groups are selected, the UI displays the five groups with the worst statuses.
+Datadog calculates the overall SLO status as the uptime percentage across all monitors or monitor groups, unless specific groups have been selected. If specific groups have been selected, the SLO status is calculated with only those groups. If no specific groups are selected, the UI displays the five groups with the worst statuses.
 
 Monitor-based SLOs treat the `WARN` state as `OK`. The definition of an SLO requires a binary distinction between good and bad behavior. SLO calculations treat `WARN` as good behavior since `WARN` is not severe enough to indicate bad behavior.
 

--- a/content/en/monitors/service_level_objectives/monitor.md
+++ b/content/en/monitors/service_level_objectives/monitor.md
@@ -73,7 +73,7 @@ Select **Save & Exit** to save your new SLO.
 
 {{< img src="monitors/service_level_objectives/aggregate_slo.jpg" alt="SLO detail showing 99 percent green with 8 groups aggregated"  >}}
 
-Datadog calculates the overall SLO status as the uptime percentage across all monitors or monitor groups—unless specific groups have been selected, in which case the SLO status is calculated with only those groups. If no specific groups are selected, the UI displays the status of the five groups with the worst statuses.
+Datadog calculates the overall SLO status as the uptime percentage across all monitors or monitor groups—unless specific groups have been selected, in which case the SLO status is calculated with only those groups. If no specific groups are selected, the UI displays the five groups with the worst statuses.
 
 Monitor-based SLOs treat the `WARN` state as `OK`. The definition of an SLO requires a binary distinction between good and bad behavior. SLO calculations treat `WARN` as good behavior since `WARN` is not severe enough to indicate bad behavior.
 

--- a/content/en/monitors/service_level_objectives/monitor.md
+++ b/content/en/monitors/service_level_objectives/monitor.md
@@ -37,7 +37,7 @@ Under **Define the source**, select **Monitor Based**.
 
 In the search box, start typing the name of a monitor. A list of matching monitors appears. Click on a monitor name to add it to the source list. 
 
-If you’re only using a single multi-alert monitor in an SLO, you can optionally select “Calculate on selected groups” and pick up to 20 groups. By default, the SLO is calculated using five groups with the worst SLO statuses. Group selection is not supported for SLOs that contain multiple monitors. 
+If you’re only using a single multi-alert monitor in an SLO, you can optionally select “Calculate on selected groups” and pick up to 20 groups. Group selection is not supported for SLOs that contain multiple monitors. 
 
 
 ### Set your SLO targets
@@ -73,7 +73,7 @@ Select **Save & Exit** to save your new SLO.
 
 {{< img src="monitors/service_level_objectives/aggregate_slo.jpg" alt="SLO detail showing 99 percent green with 8 groups aggregated"  >}}
 
-Datadog calculates the overall status as the percentage of the time where **all** monitors or **all** the calculated groups in a single multi-alert monitor are NOT in the `ALERT` state. Datadog does not calculate the average of the aggregated monitors or the aggregated groups. 
+Datadog calculates the overall SLO status as the uptime percentage across all monitors or monitor groups—unless specific groups have been selected, in which case the SLO status is calculated with only those groups. If no specific groups are selected, the UI displays the status of the five groups with the worst statuses.
 
 Monitor-based SLOs treat the `WARN` state as `OK`. The definition of an SLO requires a binary distinction between good and bad behavior. SLO calculations treat `WARN` as good behavior since `WARN` is not severe enough to indicate bad behavior.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Clarify how the overall monitor-based SLO status is calculated. One of the sentences was inaccurate before. 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
https://docs-staging.datadoghq.com/kai/monitor-slos/monitors/service_level_objectives/monitor/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
