### PR TITLE
WEB-2580 - ensure new code examples are downloaded

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,6 +83,7 @@ build_preview:
   script:
     - post_dd_event "documentation deploy ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" "info"
     - touch Makefile.config
+    - make clean-examples
     - make dependencies
     - make config
     - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
@@ -223,6 +224,7 @@ build_live:
     - post_dd_event "documentation deploy ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" "info"
     - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_SHA:0:8}> sent to gitlab for production deployment. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}|details>" "#FFD700"
     - touch Makefile.config
+    - make clean-examples
     - make dependencies
     - yarn run prebuild
     - yarn run build:live


### PR DESCRIPTION
### What does this PR do?

Some code examples aren't showing on the api. This is due to recent makefile/gitlab-ci changes where we are no longer downloading the changes. 

This PR, makes sure we have a clean slate for examples so that they are pulled down fresh.

### Motivation

https://datadoghq.atlassian.net/browse/WEB-2580

### Preview

See python compared to production
https://docs-staging.datadoghq.com/david.jones/examples-fix/api/latest/incidents/#get-a-list-of-incidents

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
