### PR TITLE
Remove now-unnecessary custom Azure instructions

### DIFF
--- a/content/en/database_monitoring/setup_sql_server/azure.md
+++ b/content/en/database_monitoring/setup_sql_server/azure.md
@@ -54,36 +54,7 @@ Grant the Agent access to each additional Azure SQL Database on this server:
 CREATE USER datadog FOR LOGIN datadog;
 ```
 
-When configuring the Datadog Agent, specify one check instance for each application database located on a given single Azure SQL DB server. Do not include `master` and other [system databases][2]. The Datadog Agent must connect directly to each application database in Azure SQL DB because each database is running in an isolated compute environment. This also means that `database_autodiscovery` does not work for Azure SQL DB, so it should not be enabled.
-
-```yaml
-init_config:
-instances:
-  # database_1
-  - host: '<SERVER_NAME>.database.windows.net,1433'
-    database: '<DATABASE_1>'
-    reported_hostname: '<SERVER_NAME>.database.windows.net/<DATABASE_1>'
-    username: datadog
-    password: '<PASSWORD>'
-    azure:
-      deployment_type: 'sql_database'
-      name: '<SERVER_NAME>'
-
-  # database_2
-  - host: '<SERVER_NAME>.database.windows.net,1433'
-    database: '<DATABASE_2>'
-    reported_hostname: '<SERVER_NAME>.database.windows.net/<DATABASE_2>'
-    username: datadog
-    password: '<PASSWORD>'
-    azure:
-      deployment_type: 'sql_database'
-      name: '<SERVER_NAME>'
-```
-
-See [Install the Agent](#install-the-agent) for more detailed instructions on how to install and configure the Datadog Agent.
-
 [1]: https://docs.microsoft.com/en-us/azure/azure-sql/database/security-server-roles
-[2]: https://docs.microsoft.com/en-us/sql/relational-databases/databases/system-databases
 {{% /tab %}}
 
 {{% tab "Azure SQL Managed Instance" %}}

--- a/layouts/shortcodes/dbm-sqlserver-before-you-begin.md
+++ b/layouts/shortcodes/dbm-sqlserver-before-you-begin.md
@@ -1,5 +1,5 @@
 Supported Agent versions
-: 7.35.0+
+: 7.38.0+
 
 Performance impact
 : The default Agent configuration for Database Monitoring is conservative, but you can adjust settings such as the collection interval and query sampling rate to better suit your needs. For most workloads, the Agent represents less than one percent of query execution time on the database and less than one percent of CPU. <br/><br/>


### PR DESCRIPTION
### What does this PR do?

This reverts commit https://github.com/DataDog/documentation/commit/96356a4586148b2a1f76a8a34464111436fdf2b2.

Since https://github.com/DataDog/integrations-core/pull/12397 (released in 7.38.0) these custom Azure SQL Database configuration instructions are no longer neccessary.

### Motivation

Simplify documentation. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
