### PR TITLE
[WEB-2573] RBAC permissions page updates

### DIFF
--- a/content/en/account_management/rbac/permissions.md
+++ b/content/en/account_management/rbac/permissions.md
@@ -40,7 +40,6 @@ All users can read all data types. Admin and Standard users have write permissio
 In addition to the general permissions, you can define more granular permissions for specific assets or data types. Permissions can be either global or scoped to a subset of elements. Find below the details of these options and the impact they have on each available permission.
 
 {{% permissions %}}
-{{< permissions group="Logs" >}}
 
 ## Further reading
 

--- a/layouts/partials/rbac-permissions-table.html
+++ b/layouts/partials/rbac-permissions-table.html
@@ -12,49 +12,37 @@
   {{ $hide_scopable_column = false }}
 {{ end }}
 
-{{/* Logs permissions are rendered separate from the rest so they can appear on the page directly above the Log Configuration Access section.   This is meant to be a short-term solution until a decision is made on separating Logs permissions to a stand-alone page. */}}
-{{ if eq $permission_group "Logs" }}
-  <h2 id="{{ anchorize $permission_group }}">{{ $permission_group }}</h2>
-  <p>Find below the list of permissions for the log configuration assets and log data, along with the typical category of user you’d assign this permission to. See the recommendations on how to assign permissions to team members in the <a href="https://docs.datadoghq.com/logs/guide/logs-rbac/?tab=ui#overview">Logs RBAC guide</a>.</p>
-{{ end }}
-
-<table>
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Description</th>
-      <th {{ if $hide_scopable_column }}class="d-none"{{ end }}>Scopable</th>
-    </tr>
-  </thead>
-  <tbody>
-    {{- range $permissions_data -}}
-      {{- if in $scopable_permissions .attributes.name -}}
-          {{- $is_scopable = true -}}
-        {{- else -}}
-          {{- $is_scopable = false -}}
-        {{- end -}}
-
-      {{- if ne .attributes.name nil -}}
+{{ if ne $permissions_data nil }}
+  <table>
+    <thead>
       <tr>
-        <td>
-            {{- if eq $permission_group "Logs" -}}
-              <a href="/logs/guide/logs-rbac-permissions/#{{ .attributes.name }}">
-                <code>{{- .attributes.name -}}</code>
-              </a>
-            {{- else -}}
-              <code>{{- .attributes.name -}}</code>
-            {{- end -}}
-        </td>
-        <td>{{- .attributes.description -}}</td>
-        <td {{ if $hide_scopable_column }}class="d-none"{{ end }}>{{- $is_scopable -}}</td>
+        <th>Name</th>
+        <th>Description</th>
+        {{ if ne $hide_scopable_column true }}<th>Scopable</th>{{ end }}
       </tr>
-      {{- end -}}
-    {{ end }}
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      {{- range $permissions_data -}}
+        {{- if in $scopable_permissions .attributes.name -}}
+            {{- $is_scopable = true -}}
+          {{- else -}}
+            {{- $is_scopable = false -}}
+          {{- end -}}
 
-{{/* Harcoding the legacy logs section until deprecation */}}
-{{ if eq $permission_group "Logs" }}
+        {{- if ne .attributes.name nil -}}
+        <tr>
+          <td>
+            <code>{{- .attributes.name -}}</code>
+          </td>
+          <td>{{- .attributes.description -}}</td>
+          {{ if ne $hide_scopable_column true }}<td>{{- $is_scopable -}}</td>{{ end }}
+        </tr>
+        {{- end -}}
+      {{ end }}
+    </tbody>
+  </table>
+
+  {{ if eq $permission_group "Log Management" }}
   <p>Log Management RBAC also includes two legacy permissions, superseded by finer-grained and more extensive <code>logs_read_data</code> permission:</p>
 
   <table>
@@ -82,4 +70,5 @@
       </tr>
     </tbody>
   </table>
+  {{ end }}
 {{ end }}

--- a/layouts/shortcodes/permissions.html
+++ b/layouts/shortcodes/permissions.html
@@ -9,11 +9,17 @@
     {{ partial "rbac-permissions-table.html" (dict "data" $permissions_data "group" $single_permission_group) }}
   {{ else }}
     {{- range $group_name, $group_permissions_data := $permissions_data -}}
+      {{- $intro_text := print "Find below the list of permissions for the " (lower $group_name) " assets:" -}}
+
+      {{- if eq $group_name "Log Management" -}}
+        {{- $intro_text = "Find below the list of permissions for the log configuration assets and log data, along with the typical category of user you’d assign this permission to. See the recommendations on how to assign permissions to team members in the <a href='/logs/guide/logs-rbac'>Logs RBAC guide</a>." -}}
+      {{- end -}}
+
       {{- if ne $group_name "General" -}}
         <h2 id="{{ anchorize $group_name }}">
           {{- $group_name -}}
         </h2>
-        <p>Find below the list of permissions for the {{ lower $group_name }} assets:</p>
+        <p>{{ $intro_text | safeHTML }}</p>
         {{ partial "rbac-permissions-table.html" (dict "data" $group_permissions_data "group" $group_name) }}
       {{- end -}}
     {{- end -}}

--- a/layouts/shortcodes/permissions.html
+++ b/layouts/shortcodes/permissions.html
@@ -9,7 +9,7 @@
     {{ partial "rbac-permissions-table.html" (dict "data" $permissions_data "group" $single_permission_group) }}
   {{ else }}
     {{- range $group_name, $group_permissions_data := $permissions_data -}}
-      {{- if and (ne $group_name "General") (ne $group_name "Logs") -}}
+      {{- if ne $group_name "General" -}}
         <h2 id="{{ anchorize $group_name }}">
           {{- $group_name -}}
         </h2>

--- a/local/bin/py/build/pull_rbac.py
+++ b/local/bin/py/build/pull_rbac.py
@@ -49,4 +49,5 @@ def pull_rbac():
         with open('data/permissions.json', 'w+') as outfile:
             outfile.write(formatted_permissions_json)
 
+
 pull_rbac()


### PR DESCRIPTION
### What does this PR do?
- Removes hardcoded `Logs` section from RBAC permissions page.
- Moves legacy logs definitions under `Log Management` section.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2573

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/rbac-empty-table/account_management/rbac/permissions/

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
