### PR TITLE
Fix typo'd broken link in an APM guide

### DIFF
--- a/content/en/tracing/guide/trace_ingestion_volume_control.md
+++ b/content/en/tracing/guide/trace_ingestion_volume_control.md
@@ -130,7 +130,7 @@ Read more about ingestion reasons in the [Ingestion Mechanisms documentation][2]
 [3]: /tracing/metrics/metrics_namespace/
 [4]: /tracing/trace_pipeline/generate_metrics/
 [5]: /monitors/create/types/apm/?tab=analytics
-[6]: /tracing/trace_pipeline/ingestion_mechanisms//#head-based-sampling
+[6]: /tracing/trace_pipeline/ingestion_mechanisms/#head-based-sampling
 [7]: /tracing/trace_pipeline/metrics/
 [8]: /tracing/trace_pipeline/ingestion_mechanisms/#error-traces
 [9]: /tracing/trace_pipeline/ingestion_mechanisms/#rare-traces


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes an extra backslash that was causing a link to 404.

### Motivation
Noticed by a translator.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
