### PR TITLE
Fixes broken link to Ruby tracing source

### DIFF
--- a/content/en/tracing/trace_collection/library_config/ruby.md
+++ b/content/en/tracing/trace_collection/library_config/ruby.md
@@ -5,7 +5,7 @@ code_lang: ruby
 type: multi-code-lang
 code_lang_weight: 30
 further_reading:
-- link: "https://github.com/DataDog/dd-trace-rb/tree/v1"
+- link: "https://github.com/DataDog/dd-trace-rb/"
   tag: "GitHub"
   text: "Source code"
 ---


### PR DESCRIPTION

### What does this PR do?
Fixes a broken link on "Configuring the Ruby Tracing Library"

### Motivation
Hotjar comment

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
