### PR TITLE
Node: Tracer needs to be initialised before logger is imported

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/nodejs.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/nodejs.md
@@ -27,6 +27,7 @@ further_reading:
 Enable injection with the environment variable `DD_LOGS_INJECTION=true` or by configuring the tracer directly:
 
 ```javascript
+// This line must come before importing the logger.
 const tracer = require('dd-trace').init({
     logInjection: true
 });


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR add's a comment to the tracer initialisation code snippet mentioning the tracer needs to be initialised before the logger is imported.

### Motivation
[APMS-7662](https://datadoghq.atlassian.net/browse/APMS-7662)
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
