### PR TITLE
Add blog links to docs for Tuesday tasks

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/github.md
+++ b/content/en/continuous_integration/setup_pipelines/github.md
@@ -11,6 +11,9 @@ further_reading:
     - link: "/continuous_integration/setup_pipelines/custom_tags_and_metrics/"
       tag: "Documentation"
       text: "Extend Pipeline Visibility by adding custom tags and metrics"
+    - link: "https://www.datadoghq.com/blog/datadog-github-actions-ci-visibility/"
+      tag: "blog"
+      text: "Monitor your GitHub Actions workflows with Datadog CI Visibility"
 ---
 
 {{< site-region region="gov" >}}

--- a/content/en/infrastructure/livecontainers/_index.md
+++ b/content/en/infrastructure/livecontainers/_index.md
@@ -14,6 +14,9 @@ further_reading:
 - link: "/infrastructure/process/"
   tag: "Documentation"
   text: "Understand what is going on at any level of your system"
+- link: "https://www.datadoghq.com/blog/monitor-kubernetes-anomalies/"
+  tag: "Blog"
+  text: "Expedite infrastructure investigations with Kubernetes Anomalies"
 ---
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds two Datadog blog post links to the public docs.
- GitHub Actions in CI Visibility
- K8s anomalies in Live Containers

### Motivation
Docs team Tuesday tasks. Help direct users to the blog.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
