### PR TITLE
Add `post_runtime_duration` metric

### DIFF
--- a/content/en/serverless/enhanced_lambda_metrics/_index.md
+++ b/content/en/serverless/enhanced_lambda_metrics/_index.md
@@ -38,7 +38,10 @@ The following real-time enhanced Lambda metrics are available, and they are tagg
 : Measures the initialization time (second) of a function during a cold start.
 
 `aws.lambda.enhanced.runtime_duration`
-: Measures the elapsed millisecond from when the function code starts executing to when it returns the response back to the client, excluding the post-runtime duration added by Lambda extension executions.
+: Measures the elapsed milliseconds from when the function code starts executing to when it returns the response back to the client, excluding the post-runtime duration added by Lambda extension executions.
+
+`aws.lambda.enhanced.post_runtime_duration`
+: Measures the elapsed milliseconds from when the function code returns the response back to the client to when the function stops executing, representing the duration added by Lambda extension executions.
 
 `aws.lambda.enhanced.estimated_cost`  
 : Measures the total estimated cost of the function invocation (US dollars).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add description of the `aws.lambda.enhanced.post_runtime_duration` metric.

### Motivation
<!-- What inspired you to submit this pull request?-->
The Lambda Extension will now create the `aws.lambda.enhanced.post_runtime_duration` which is the time after the function returns the response to when the function finishes executing. We expect this metric to be released in the next version of the extension.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
