### PR TITLE
OTLP CONFIG vars take full endpoints not ports

### DIFF
--- a/content/en/tracing/trace_collection/open_standards/otlp_ingest_in_the_agent.md
+++ b/content/en/tracing/trace_collection/open_standards/otlp_ingest_in_the_agent.md
@@ -70,8 +70,8 @@ experimental:
 1. Follow the [Datadog Docker Agent setup][1]. 
   
 2. For the Datadog Agent container, set the following endpoint environment variables and expose the corresponding port: 
-   - For gPRC: `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT` and value `0.0.0.0:4317`
-   - For HTTP: `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT` and value `0.0.0.0:4318`
+   - For gPRC: `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT` and endpoint `0.0.0.0:4317`
+   - For HTTP: `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT` and endpoint `0.0.0.0:4318`
 
 [1]: /agent/docker/
 {{% /tab %}}

--- a/content/en/tracing/trace_collection/open_standards/otlp_ingest_in_the_agent.md
+++ b/content/en/tracing/trace_collection/open_standards/otlp_ingest_in_the_agent.md
@@ -70,8 +70,8 @@ experimental:
 1. Follow the [Datadog Docker Agent setup][1]. 
   
 2. For the Datadog Agent container, set the following endpoint environment variables and expose the corresponding port: 
-   - For gPRC: `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT` and endpoint `0.0.0.0:4317`
-   - For HTTP: `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT` and endpoint `0.0.0.0:4318`
+   - For gPRC: Set `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT` to `0.0.0.0:4317` and expose port `4317`
+   - For HTTP: Set `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT` to `0.0.0.0:4318` and expose port `4318`.
 
 [1]: /agent/docker/
 {{% /tab %}}

--- a/content/en/tracing/trace_collection/open_standards/otlp_ingest_in_the_agent.md
+++ b/content/en/tracing/trace_collection/open_standards/otlp_ingest_in_the_agent.md
@@ -70,7 +70,7 @@ experimental:
 1. Follow the [Datadog Docker Agent setup][1]. 
   
 2. For the Datadog Agent container, set the following endpoint environment variables and expose the corresponding port: 
-   - For gPRC: Set `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT` to `0.0.0.0:4317` and expose port `4317`
+   - For gPRC: Set `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT` to `0.0.0.0:4317` and expose port `4317`.
    - For HTTP: Set `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT` to `0.0.0.0:4318` and expose port `4318`.
 
 [1]: /agent/docker/

--- a/content/en/tracing/trace_collection/open_standards/otlp_ingest_in_the_agent.md
+++ b/content/en/tracing/trace_collection/open_standards/otlp_ingest_in_the_agent.md
@@ -70,8 +70,8 @@ experimental:
 1. Follow the [Datadog Docker Agent setup][1]. 
   
 2. For the Datadog Agent container, set the following endpoint environment variables and expose the corresponding port: 
-   - For gPRC: `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT` and port `4317`
-   - For HTTP: `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT` and port `4318`
+   - For gPRC: `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT` and value `0.0.0.0:4317`
+   - For HTTP: `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT` and value `0.0.0.0:4318`
 
 [1]: /agent/docker/
 {{% /tab %}}


### PR DESCRIPTION
Tested with the latest release candidate of the agent, note this brings this tab into alignment with the `host` tab

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
