### PR TITLE
Add documentation for Reference Table audit trail and change events

### DIFF
--- a/content/en/logs/guide/reference-tables.md
+++ b/content/en/logs/guide/reference-tables.md
@@ -80,7 +80,7 @@ This Reference Table can be used to add additional attributes to logs with the [
 
 ## Modify a Reference Table
 
-To modify an existing Reference Table with new data, select a table then click **Update Data +** in the top right corner.
+To modify an existing Reference Table with new data, select a table then click **Update Config** in the top right corner.
 The selected CSV is upserted into the table, meaning that:
 
 * All existing rows with the same primary key are updated
@@ -96,8 +96,27 @@ The table and all associated rows is deleted.
 
 If there is a Lookup Processor using a Reference Table for Log enrichment, then the enrichment stops. It may take up to 10 minutes for the enrichment to stop.
 
+## Monitoring Reference Table Activity
+
+Reference table activity can be monitored via [Audit Trail][2] or [Change Events][3]. To view the audit trail and change events for a specific reference table, select a table and click the cog dropdown in the top right next to **Update Config** (you will need org management permissions to view audit trail). 
+
+### Audit Trail
+
+Audit trail for reference tables is used for tracking user triggered actions. Audit trail events are sent when a user initially uploads or imports a csv file, or creates, modifies, or deletes a reference table. The `reference_table_file` Asset Type will show events for imports and/or uploads, and the `reference_table` Asset Type will show events for creation, modification, or deletion of a reference table. The purpose of the audit trail is to provide observability into the content of a reference table.
+
+### Change Events
+
+Change events for reference tables are used for tracking either automated or user triggered actions, and are sent when a cloud file is imported either via a user or automatic refresh. While events track user triggered actions as well, they are mainly used for tracking imports triggered when Reference Tables automatically pulls the corresponding file from your cloud storage when a change is detected. Events contain information for the success status, path, and table name of the import. If an error is encountered, information on the type of error is also provided.
+
+### Alerting
+
+To be alerted on errors encountered during imports, reference table change events can be tracked with [Event Monitors][4]. Reference table change events are sent from the `reference_tables` source. Monitors can be created from the Monitors tab, but a pre-filled monitor can be created by clicking on the cog dropdown in the top right next to **New Reference Table +**.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /logs/log_configuration/processors/#lookup-processor
+[2]: /account_management/audit_trail/
+[3]: /events/
+[4]: /monitors/create/types/event/

--- a/content/en/logs/guide/reference-tables.md
+++ b/content/en/logs/guide/reference-tables.md
@@ -98,15 +98,15 @@ If there is a Lookup Processor using a Reference Table for Log enrichment, then 
 
 ## Monitoring Reference Table Activity
 
-Reference table activity can be monitored via [Audit Trail][2] or [Change Events][3]. To view the audit trail and change events for a specific reference table, select a table and click the cog dropdown in the top right next to **Update Config** (you will need org management permissions to view audit trail). 
+Reference table activity can be monitored with [Audit Trail][2] or [Change Events][3]. To view the audit trail and change events for a specific reference table, select a table and click the cog dropdown in the top right next to **Update Config** (you will need org management permissions to view audit trail).
 
 ### Audit Trail
 
-Audit trail for reference tables is used for tracking user triggered actions. Audit trail events are sent when a user initially uploads or imports a csv file, or creates, modifies, or deletes a reference table. The `reference_table_file` Asset Type will show events for imports and/or uploads, and the `reference_table` Asset Type will show events for creation, modification, or deletion of a reference table. The purpose of the audit trail is to provide observability into the content of a reference table.
+Audit trail for reference tables is used for tracking user triggered actions. Audit trail events are sent when a user initially uploads or imports a csv file, or creates, modifies, or deletes a reference table. The `reference_table_file` Asset Type will show import/upload events, and the `reference_table` Asset Type will show reference table events. The purpose of the audit trail is to provide observability into the content of a reference table.
 
 ### Change Events
 
-Change events for reference tables are used for tracking either automated or user triggered actions, and are sent when a cloud file is imported either via a user or automatic refresh. While events track user triggered actions as well, they are mainly used for tracking imports triggered when Reference Tables automatically pulls the corresponding file from your cloud storage when a change is detected. Events contain information for the success status, path, and table name of the import. If an error is encountered, information on the type of error is also provided.
+Change events for reference tables are used for tracking either automated or user triggered actions. They are sent when a cloud file is imported either from a user or automatic refresh. While events track user triggered actions as well, they are mainly used for tracking imports triggered when Reference Tables automatically pull a new csv file. Events contain information for the success status, path, and table name of the import. If an error is encountered, information on the type of error is also provided.
 
 ### Alerting
 

--- a/content/en/logs/guide/reference-tables.md
+++ b/content/en/logs/guide/reference-tables.md
@@ -98,7 +98,7 @@ If there is a Lookup Processor using a Reference Table for Log enrichment, then 
 
 ## Monitor Reference Table Activity
 
-You can monitor reference table activity with [Audit Trail][2] or [Change Events][3]. To view the audit trail and change events for a specific reference table, select the table and click the Settings icon next to **Update Config**.  You need org management permissions to view the audit trail.
+You can monitor reference table activity with [Audit Trail][2] or [Change Events][3]. To view the audit trail and change events for a specific reference table, select the table and click the Settings icon next to **Update Config**. You need org management permissions to view the audit trail.
 
 ### Audit Trail
 

--- a/content/en/logs/guide/reference-tables.md
+++ b/content/en/logs/guide/reference-tables.md
@@ -80,7 +80,7 @@ This Reference Table can be used to add additional attributes to logs with the [
 
 ## Modify a Reference Table
 
-To modify an existing Reference Table with new data, select a table then click **Update Config** in the top right corner.
+To modify an existing Reference Table with new data, select a table and click **Update Config** on the top right corner.
 The selected CSV is upserted into the table, meaning that:
 
 * All existing rows with the same primary key are updated
@@ -96,21 +96,27 @@ The table and all associated rows is deleted.
 
 If there is a Lookup Processor using a Reference Table for Log enrichment, then the enrichment stops. It may take up to 10 minutes for the enrichment to stop.
 
-## Monitoring Reference Table Activity
+## Monitor Reference Table Activity
 
-Reference table activity can be monitored with [Audit Trail][2] or [Change Events][3]. To view the audit trail and change events for a specific reference table, select a table and click the cog dropdown in the top right next to **Update Config** (you will need org management permissions to view audit trail).
+You can monitor reference table activity with [Audit Trail][2] or [Change Events][3]. To view the audit trail and change events for a specific reference table, select the table and click the Settings icon next to **Update Config**.  You need org management permissions to view the audit trail.
 
 ### Audit Trail
 
-Audit trail for reference tables is used for tracking user triggered actions. Audit trail events are sent when a user initially uploads or imports a csv file, or creates, modifies, or deletes a reference table. The `reference_table_file` Asset Type will show import/upload events, and the `reference_table` Asset Type will show reference table events. The purpose of the audit trail is to provide observability into the content of a reference table.
+Use the audit trail for reference tables to track user-triggered actions. Audit trail events are sent when a user initially uploads or imports a CSV file, or when a user creates, modifies, or deletes a reference table. 
+
+The `reference_table_file` Asset Type displays import/upload events and the `reference_table` Asset Type displays reference table events. The audit trail provides observability into the content of a reference table.
 
 ### Change Events
 
-Change events for reference tables are used for tracking either automated or user triggered actions. They are sent when a cloud file is imported either from a user or automatic refresh. While events track user triggered actions as well, they are mainly used for tracking imports triggered when Reference Tables automatically pull a new csv file. Events contain information for the success status, path, and table name of the import. If an error is encountered, information on the type of error is also provided.
+Use change events for reference tables to track automated or user-triggered actions. They are sent when a cloud file is imported from a user or automatic refresh. While events can track user-triggered actions, they are mainly used to track triggered imports when a reference table automatically pulls a new CSV file. 
+
+Events contain information about the success status, path, and table name of the import. If an error occurs, information about the error type is provided.
 
 ### Alerting
 
-To be alerted on errors encountered during imports, reference table change events can be tracked with [Event Monitors][4]. Reference table change events are sent from the `reference_tables` source. Monitors can be created from the Monitors tab, but a pre-filled monitor can be created by clicking on the cog dropdown in the top right next to **New Reference Table +**.
+To be alerted on errors encountered during imports, use [Event Monitors][4] for reference table change events. Reference table change events are sent from the `reference_tables` source. 
+
+You can create monitors from the **Monitors** tab, or click on the Settings icon next to **New Reference Table +** to generate a pre-filled monitor.
 
 ## Further Reading
 


### PR DESCRIPTION
Add documentation for audit trail, change events, and setting up event monitor for reference tables

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
