### PR TITLE
[Serverless Java] correct jar location

### DIFF
--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -134,7 +134,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 
     ```dockerfile
     RUN yum -y install tar wget gzip
-    RUN wget -O /opt/dd-java-agent.jar https://dtdg.co/latest-java-tracer
+    RUN wget -O /opt/java/lib/dd-java-agent.jar https://dtdg.co/latest-java-tracer
     ```
 
 3. Set the required environment variables


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Correct the agent jar location.

### Motivation
Motivated by this PR: https://github.com/DataDog/documentation/pull/14724

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
