### PR TITLE
Adding a note about Array objects

### DIFF
--- a/content/en/logs/explorer/facets.md
+++ b/content/en/logs/explorer/facets.md
@@ -35,6 +35,8 @@ Facets also allow you to manipulate your logs in your [log monitors][4], log wid
 
 **Note**: You do not need facets to support [log processing][1], [livetail search][2], [archive][3] forwarding, rehydration, or [metric generation][4] from logs. You also do not need facets for routing logs through to [Pipelines][5] and [Indexes][6] with filters, or excluding or sampling logs from indexes with [exclusion filters][7]. 
 
+**Note**: You can't create facets for the attributes that are within the Array object.
+
 In all these contexts, autocomplete capabilities rely on existing facets, but any input matching incoming logs would work.
 
 [1]: /logs/log_configuration/processors

--- a/content/en/logs/explorer/facets.md
+++ b/content/en/logs/explorer/facets.md
@@ -35,8 +35,6 @@ Facets also allow you to manipulate your logs in your [log monitors][4], log wid
 
 **Note**: You do not need facets to support [log processing][1], [livetail search][2], [archive][3] forwarding, rehydration, or [metric generation][4] from logs. You also do not need facets for routing logs through to [Pipelines][5] and [Indexes][6] with filters, or excluding or sampling logs from indexes with [exclusion filters][7]. 
 
-**Note**: You can't create facets for the attributes that are within the Array object.
-
 In all these contexts, autocomplete capabilities rely on existing facets, but any input matching incoming logs would work.
 
 [1]: /logs/log_configuration/processors
@@ -201,6 +199,8 @@ The index facet is a specific facet that appears only if your organization has [
 
 As a matter of good practice, always consider using an existing facet rather than creating a new one (see the [alias facets](#alias-facets) section). Using a unique facet for information of a similar nature fosters cross-team collaboration.
 
+To create a facet on an array of JSON objects, first use a [grok parser][28] to extract the attribute and then create a facet for that attribute.
+
 **Note**: Once a facet is created, its content is populated **for all new logs** flowing in **either** index. For an optimal usage of the Log Management solution, Datadog recommends using at most 1000 facets.
 
 #### Log side panel
@@ -285,3 +285,4 @@ To delete a facet, follow these steps:
 [25]: /logs/log_configuration/attributes_naming_convention/#reserved-attributes
 [26]: /logs/log_configuration/attributes_naming_convention
 [27]: /logs/indexes/#indexes
+[28]: /logs/log_configuration/parsing/?tab=matchers#nested-json


### PR DESCRIPTION
This edit was suggested by a customer when I found out that facets can't be added to Array objects (after consultation with T2 in Logs OH). The workaround is to extract the attribute in Array object and then remap it. The extracted attribute will have the 'create facet' option.


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
