### PR TITLE
Add docs on composite a.status variable

### DIFF
--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -356,13 +356,21 @@ For check monitor variables (custom check and integration check), the variable `
 
 ### Composite monitor variables
 
-Composite monitors can access the value associated with the sub-monitors at the time the alert triggers.
+Composite monitors can access the value and status associated with the sub-monitors at the time the alert triggers.
 
 For example, if your composite monitor has sub-monitor `a`, you can include the value of `a` with:
 
 ```text
 {{ a.value }}
 ```
+
+To retriev the status of the sub-monitor `a` use:
+
+```text
+{{ a.status }}
+```
+
+Possible values for the status are: `ALERT`, `OK`, `WARN`, and `NO DATA`.
 
 Composite monitors also support tag variables in the same way as their underlying monitors. They follow the same format as other monitors, provided the underlying monitors are grouped by the same tag/facet.
 

--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -364,7 +364,7 @@ For example, if your composite monitor has sub-monitor `a`, you can include the 
 {{ a.value }}
 ```
 
-To retriev the status of the sub-monitor `a` use:
+To retrieve the status of the sub-monitor `a` use:
 
 ```text
 {{ a.status }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds documentation on the `status` variable of individual monitors within a composite.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
