### PR TITLE
docs(apm): add python configuration for trace sampling rules

### DIFF
--- a/content/en/tracing/trace_collection/library_config/python.md
+++ b/content/en/tracing/trace_collection/library_config/python.md
@@ -55,6 +55,10 @@ Propagation styles to use when extracting tracing headers. When multiple values 
 `DD_TRACE_SAMPLE_RATE`
 : Enable trace volume control
 
+`DD_TRACE_SAMPLING_RULES`
+**Default**: `[]` <br>
+A JSON array of objects. Each object must have a `"sample_rate"`. The `"name"` and `"service"` fields are optional. The `"sample_rate"` value must be between `0.0` and `1.0` (inclusive). Rules are applied in configured order to determine the trace's sample rate.
+
 `DD_TRACE_RATE_LIMIT`
 : Maximum number of spans to sample per-second, per-Python process. Defaults to `100` when `DD_TRACE_SAMPLE_RATE` is set. Otherwise, delegates rate limiting to the Datadog Agent.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add documentation for `DD_TRACE_SAMPLING_RULES` for Python tracing configuration in all languages

<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes

For translations, in addition to adding `DD_TRACE_SAMPLING_RULES` above for the Python configs, these `DD_TRACE_SAMPLE_RATE` and `DD_TRACE_RATE_LIMIT` are missing from the French and Japanese translations.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
