### PR TITLE
Rename monitor query aggregations

### DIFF
--- a/content/en/monitors/create/configuration.md
+++ b/content/en/monitors/create/configuration.md
@@ -53,8 +53,8 @@ The query returns a series of points, but a single value is needed to compare to
 | Option                  | Description                                            |
 |-------------------------|--------------------------------------------------------|
 | average         | The series is averaged to produce a single value that is checked against the threshold. It adds the `avg()` function to your monitor query. |
-| max | If any single value in the generated series crosses the threshold, then an alert is triggered. This option adds a function to your monitor query based on your selection: `max()` |
-| min  | If all points in the evaluation window for your query cross the threshold, then an alert is triggered. This option adds a function to your monitor query based on your selection: `min()` |
+| max | If any single value in the generated series crosses the threshold, then an alert is triggered. It adds the `max()` function to your monitor query. |
+| min  | If all points in the evaluation window for your query cross the threshold, then an alert is triggered. It adds the `min()` function to your monitor query. |
 | sum | If the summation of every point in the series crosses the threshold, then an alert is triggered. It adds the `sum()` function to your monitor query. |
 
 **Note**: There are different behaviors when utilizing `as_count()`. See [as_count() in Monitor Evaluations][1] for details.

--- a/content/en/monitors/create/configuration.md
+++ b/content/en/monitors/create/configuration.md
@@ -42,8 +42,8 @@ The alert conditions vary based on the [monitor type][1]. Configure monitors to 
 {{< tabs >}}
 {{% tab "Threshold alert" %}}
 
-* Trigger when the metric is `above`, `above or equal to`, `below`, or `below or equal to`
-* the threshold `on average`, `at least once`, `at all times`, or `in total`
+* Trigger when the `average`, `max`, `min`, or `sum` of the metric is
+* `above`, `above or equal to`, `below`, or `below or equal to` the threshold
 * during the last `5 minutes`, `15 minutes`, `1 hour`, etc. or `custom` to set a value between 1 minute and 48 hours (1 month for metric monitors)
 
 ### Aggregation method
@@ -53,9 +53,9 @@ The query returns a series of points, but a single value is needed to compare to
 | Option                  | Description                                            |
 |-------------------------|--------------------------------------------------------|
 | on&nbsp;average         | The series is averaged to produce a single value that is checked against the threshold. It adds the `avg()` function to your monitor query. |
-| at&nbsp;least&nbsp;once | If any single value in the generated series crosses the threshold, then an alert is triggered. This option adds a function to your monitor query based on your selection: `min()` for below or `max()` for above. |
-| at&nbsp;all&nbsp;times  | If all points in the evaluation window for your query cross the threshold, then an alert is triggered. This option adds a function to your monitor query based on your selection: `min()` for above or `max()` for below. |
-| in&nbsp;total           | If the summation of every point in the series crosses the threshold, then an alert is triggered. It adds the `sum()` function to your monitor query. |
+| max | If any single value in the generated series crosses the threshold, then an alert is triggered. This option adds a function to your monitor query based on your selection: `max()` |
+| min  | If all points in the evaluation window for your query cross the threshold, then an alert is triggered. This option adds a function to your monitor query based on your selection: `min()` |
+| sum | If the summation of every point in the series crosses the threshold, then an alert is triggered. It adds the `sum()` function to your monitor query. |
 
 **Note**: There are different behaviors when utilizing `as_count()`. See [as_count() in Monitor Evaluations][1] for details.
 

--- a/content/en/monitors/create/configuration.md
+++ b/content/en/monitors/create/configuration.md
@@ -52,7 +52,7 @@ The query returns a series of points, but a single value is needed to compare to
 
 | Option                  | Description                                            |
 |-------------------------|--------------------------------------------------------|
-| on&nbsp;average         | The series is averaged to produce a single value that is checked against the threshold. It adds the `avg()` function to your monitor query. |
+| average         | The series is averaged to produce a single value that is checked against the threshold. It adds the `avg()` function to your monitor query. |
 | max | If any single value in the generated series crosses the threshold, then an alert is triggered. This option adds a function to your monitor query based on your selection: `max()` |
 | min  | If all points in the evaluation window for your query cross the threshold, then an alert is triggered. This option adds a function to your monitor query based on your selection: `min()` |
 | sum | If the summation of every point in the series crosses the threshold, then an alert is triggered. It adds the `sum()` function to your monitor query. |

--- a/content/en/monitors/create/types/metric.md
+++ b/content/en/monitors/create/types/metric.md
@@ -108,7 +108,7 @@ The alert conditions vary slightly based on the chosen detection method.
 {{% tab "Threshold" %}}
 
 * Trigger when the metric is `above`, `above or equal to`, `below`, or `below or equal to`. If the value is between zero and one, a leading zero is required. For example, `0.3`.
-* the threshold `on average`, `at least once`, `at all times`, `in total`, or `percentile` (`percentile` is only offered on distribution metrics with percentiles enabled).
+* the threshold `average`, `max`, `min`, `sum`, or `percentile` (`percentile` is only offered on distribution metrics with percentiles enabled).
 
     _Note that if you've chosen a distribution metric with a percentile aggregator in Step 2: Define the Metric, a matching percentile threshold is automatically specified._
 

--- a/content/en/monitors/guide/reduce-alert-flapping.md
+++ b/content/en/monitors/guide/reduce-alert-flapping.md
@@ -15,7 +15,7 @@ Your individual Datadog alerts with groups [have notification][1] rollups on by 
 
 * Re-Evaluate the Alert Threshold Value
     * The easiest way to reduce flapping when the alert <-> ok or state changes are frequent could be to increase/decrease the threshold condition.
-* Use the 'At all times' threshold
+* Use the `min` threshold
     * This triggers the alert only when all data points for the metric in the timeframe violate the threshold
 
 * Reframe the query using Functions- rates, moving averages, or time-shift differentials


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
We renamed monitor query aggregations in the UI and this is the corresponding docs change. Here's a mapping of the new names:

`on average` -> `average`
`at least once` -> `max`
`at all times` -> `min`
`in total` -> `sum`

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
