### PR TITLE
clean examples on live & better branch selection

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -223,6 +223,7 @@ build_live:
     - post_dd_event "documentation deploy ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" "info"
     - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_SHA:0:8}> sent to gitlab for production deployment. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}|details>" "#FFD700"
     - touch Makefile.config
+    - make clean-examples
     - make dependencies
     - yarn run prebuild
     - yarn run build:live

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ examples/$(1):
 		git clone --depth 1 --branch $(TAG) https://github.com/DataDog/$(1).git examples/$(1); \
 	else \
 		echo "Cloning $(1) at $(BRANCH)"; \
-		git clone --depth 1 --branch $(BRANCH) https://github.com/DataDog/$(1).git examples/$(1); || git clone --depth 1 --branch $(TAG) https://github.com/DataDog/$(1).git examples/$(1); \
+		git clone --depth 1 --branch $(BRANCH) https://github.com/DataDog/$(1).git examples/$(1) || git clone --depth 1 --branch $(TAG) https://github.com/DataDog/$(1).git examples/$(1); \
 	fi
 
 .PHONY: examples/$(patsubst datadog-api-client-%,clean-%-examples,$(1)) examples/$(patsubst datadog-api-client-%,%,$(1))


### PR DESCRIPTION
### What does this PR do?

- Make sure we download examples fresh on live
- Improve the ref selection when cloning example client repos

master branches always use the version from sdk version
other branches attempt to use the current branch name in the client repo, if that associated branch doesn't exist it falls back to the sdk version

### Motivation

Api discussion

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes

https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/161950791

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
