### PR TITLE
update compatibility information for dd-trace-js 3.0 release

### DIFF
--- a/content/en/profiler/enabling/nodejs.md
+++ b/content/en/profiler/enabling/nodejs.md
@@ -22,7 +22,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 ## Requirements
 
-The Datadog Profiler requires at least Node.js 12, but Node.js 16 or higher is recommended. **If you use a version of Node.js earlier than 16, some applications see tail latency spikes every minute when starting the next profile.**
+The Datadog Profiler requires at least Node.js 14, but Node.js 16 or higher is recommended. **If you use a version of Node.js earlier than 16, some applications see tail latency spikes every minute when starting the next profile.**
 
 Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
 

--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -178,8 +178,7 @@ It supports the use of all PHP frameworks, and also the use no framework.
 
 The Datadog NodeJS library supports the following NodeJS versions:
 
-- NodeJS 13.10.0 and higher
-- NodeJS 12.17.0 and higher
+- NodeJS 14 and higher
 
 These are supported on the following architectures:
 

--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -50,7 +50,7 @@ For more information about Node.js release, see the [official Node.js documentat
 
 ### Operating system support
 
-The following operating systems are officially supported by dd-trace. Any operating system not listed is still likely to work, but with some features missing, for example ASM, profiling and runtime metrics. Generally speaking, operating systems that are actively maintained at the time of initial release for a major version are supported.
+The following operating systems are officially supported by `dd-trace`. Any operating system not listed is still likely to work, but with some features missing, for example ASM, profiling, and runtime metrics. Generally speaking, operating systems that are actively maintained at the time of initial release for a major version are supported.
 
 | dd-trace Version    | Operating System      | Architectures         | Minimum Versions                         |
 | ------------------- | --------------------- | --------------------- | ---------------------------------------- |

--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -48,6 +48,21 @@ For the best level of support, always run the latest LTS release of Node.js, and
 
 For more information about Node.js release, see the [official Node.js documentation][4].
 
+### Operating system support
+
+The following operating systems are officially supported by dd-trace. Any operating system not listed is still likely to work, but with some features missing, for example ASM, profiling and runtime metrics.
+
+| dd-trace Version    | Operating System      | Architectures         | Minimum Versions                         |
+| ------------------- | --------------------- | --------------------- | ---------------------------------------- |
+| 3.x                 | Linux (glibc)         | arm, arm64, x64       | CentOS 7, Debian 9, RHEL 7, Ubuntu 14.04 |
+|                     | Linux (musl)          | arm, arm64, x64       | Alpine 3.13                              |
+|                     | macOS                 | arm64, x64            | Catalina (10.15)                         |
+|                     | Windows               | ia32, x64             | Windows 8.1, Windows Server 2012         |
+| 2.x                 | Linux (glibc)         | arm, arm64, ia32, x64 | CentOS 7, Debian 9, RHEL 7, Ubuntu 14.04 |
+|                     | Linux (musl)          | arm, arm64, ia32, x64 | Alpine 3.10                              |
+|                     | macOS                 | arm64, x64            | Yosemite (10.10)                         |
+|                     | Windows               | ia32, x64             | Windows 8.1, Windows Server 2012         |
+
 ## Supported integrations
 
 APM provides out-of-the-box instrumentation for many popular frameworks and libraries by using a plugin system. To request support for a module that is not listed, contact our awesome [support team][3].

--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -50,7 +50,7 @@ For more information about Node.js release, see the [official Node.js documentat
 
 ### Operating system support
 
-The following operating systems are officially supported by dd-trace. Any operating system not listed is still likely to work, but with some features missing, for example ASM, profiling and runtime metrics.
+The following operating systems are officially supported by dd-trace. Any operating system not listed is still likely to work, but with some features missing, for example ASM, profiling and runtime metrics. Generally speaking, operating systems that are actively maintained at the time of initial release for a major version are supported.
 
 | dd-trace Version    | Operating System      | Architectures         | Minimum Versions                         |
 | ------------------- | --------------------- | --------------------- | ---------------------------------------- |

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -29,7 +29,7 @@ further_reading:
 ---
 ## Compatibility requirements
 
-The latest Node.js Tracer supports versions `>=12`. For a full list of Datadog’s Node.js version and framework support (including legacy and maintenance versions), see the [Compatibility Requirements][1] page.
+The latest Node.js Tracer supports versions `>=14`. For a full list of Datadog’s Node.js version and framework support (including legacy and maintenance versions), see the [Compatibility Requirements][1] page.
 
 ## Installation and getting started
 
@@ -104,18 +104,14 @@ Read [tracer settings][3] for a list of initialization options.
 
 After the Agent is installed, follow these steps to add the Datadog tracing library to your Node.js applications:
 
-1. Install the Datadog Tracing library using npm for Node.js 12+:
+1. Install the Datadog Tracing library using npm for Node.js 14+:
 
     ```sh
     npm install dd-trace --save
     ```
-    If you need to trace end-of-life Node.js versions 10 or 8, install version 0.x of `dd-trace` by running:
+    If you need to trace end-of-life Node.js version 12, install version 2.x of `dd-trace` by running:
     ```
-    npm install dd-trace@latest-node10
-    ```
-    or
-    ```
-    npm install dd-trace@latest-node8
+    npm install dd-trace@latest-node12
     ```
     For more information on our distribution tags and Node.js runtime version support, see the [Compatibility Requirements][1] page.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

Update compatibility information for dd-trace-js 3.0 release.

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update compatibility information for dd-trace-js 3.0 release. This includes dropping support for Node 12 and documenting our OS support policy.

### Motivation
<!-- What inspired you to submit this pull request?-->

Node 12 is end of life, and our OS support policy was never properly documented.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
