### PR TITLE
Revert "Add region sections to format-links precommit (#14818)"

### DIFF
--- a/local/bin/py/build/actions/format_link.py
+++ b/local/bin/py/build/actions/format_link.py
@@ -33,16 +33,6 @@ def prepare_file(file):
                 main_section.append(line)
                 if (re.search(r"{{< tabs >}}", line.strip()) or re.search(r"{{< programming-lang-wrapper", line.strip())):
                     state = 'tabs'
-                if re.search(r"{{< site-region", line.strip()):
-                    state = 'region'
-            elif state == 'region':
-                if re.search(r"{{< /site-region >}}", line.strip()):
-                    main_section.append(line)
-                    sub_sections.append(temp_section)
-                    temp_section = []
-                    state = 'main'
-                else:
-                    temp_section.append(line)
             elif state == 'tabs':
                 main_section.append(line)
                 if (re.search(r"{{% tab ", line.strip()) or re.search(r"{{< programming-lang ", line.strip())):
@@ -56,7 +46,8 @@ def prepare_file(file):
                     sub_sections.append(temp_section)
                     temp_section = []
                 else:
-                    temp_section.append(line)            
+                    temp_section.append(line)
+
     if state != 'main':
         raise ValueError
 
@@ -335,17 +326,12 @@ def inline_section(file_prepared):
 
     end_section_pattern = r"\s*{{% /tab %}}.*"
     end_lang_section_pattern = r"\s*{{< /programming-lang >}}.*"
-    end_region_section_pattern = r"\s*{{< /site-region >}}.*"
 
     i = 1
 
     try:
         for line in file_prepared[0]:
-            if (
-                re.match(end_section_pattern, line) or
-                re.match(end_lang_section_pattern, line) or
-                re.match(end_region_section_pattern, line)
-               ):
+            if (re.match(end_section_pattern, line) or re.match(end_lang_section_pattern, line)):
                 final_text += file_prepared[i]
                 i += 1
             final_text.append(line)


### PR DESCRIPTION
This change caused the build to fail on some integrations.

This reverts commit 291653b3362b777f85654f04d6c203284f2a3602.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
