### PR TITLE
Fix typo in documentation for frustration-signal filter

### DIFF
--- a/content/en/real_user_monitoring/frustration_signals/_index.md
+++ b/content/en/real_user_monitoring/frustration_signals/_index.md
@@ -67,7 +67,7 @@ Search through all the data collected by RUM in the [RUM Explorer][4] to surface
 Enter a facet in the search query to start your search. Available search fields include:
 
 Frustration Type
-: Find actions with frustration signals. For example, if you want to see any actions that had a rage click, add `action.frustration_type:rage_click` to the search query.
+: Find actions with frustration signals. For example, if you want to see any actions that had a rage click, add `action.frustration.type:rage_click` to the search query.
 
 Frustration Count
 : Find sessions and views where any frustration signal occurred. For example, if you want to find any user sessions or views with at least one frustration signal, add `session.frustration.count:>1` or `view.frustration.count:>1` to the search query.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixing a typo in the documentation that resulted in an unvalid filter for frustration-signals.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
