### PR TITLE
Update search config for profiler

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -155,7 +155,7 @@ index_algolia_preview:
   stage: post-deploy
   cache: []
   environment: "preview"
-  timeout: 1h 45m
+  timeout: 2h
   before_script:
     - "[ -f /usr/local/bin/helpers.sh ] && source /usr/local/bin/helpers.sh"  # source helpers
   script:
@@ -287,7 +287,7 @@ index_algolia:
   tags: ["runner:main"]
   stage: post-deploy
   environment: "live"
-  timeout: 1h 45m
+  timeout: 2h
   script:
     - |-
       echo APPLICATION_ID=$(get_secret 'ci.documentation.algolia_docsearch_application_id') > .env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,12 +153,12 @@ index_algolia_preview:
     entrypoint: [""] # force an empty entrypoint (see https://gitlab.com/gitlab-org/gitlab-runner/issues/2692)
   tags: ["runner:main"]
   stage: post-deploy
-  cache:
-    - *yarn_cache
+  cache: []
   environment: "preview"
-  timeout: 1h 30m
+  timeout: 1h 45m
+  before_script:
+    - "[ -f /usr/local/bin/helpers.sh ] && source /usr/local/bin/helpers.sh"  # source helpers
   script:
-    - yarn install --immutable
     - |-
         echo APPLICATION_ID=$(get_secret 'ci.documentation.algolia_preview_application_id') > .env
         echo API_KEY=$(get_secret 'ci.documentation.algolia_preview_api_key') >> .env

--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -26,7 +26,8 @@
                     "developers",
                     "account_management",
                     "synthetics",
-                    "database_monitoring"
+                    "database_monitoring",
+                    "profiler"
                 ]
             },
             "tags": ["faq"],
@@ -117,7 +118,8 @@
                     "tracing",
                     "serverless",
                     "watchdog",
-                    "database_monitoring"
+                    "database_monitoring",
+                    "profiler"
                 ]
             },
             "tags": ["docs"],

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -26,7 +26,8 @@
                     "developers",
                     "account_management",
                     "synthetics",
-                    "database_monitoring"
+                    "database_monitoring",
+                    "profiler"
                 ]
             },
             "tags": ["faq"],
@@ -117,7 +118,8 @@
                     "tracing",
                     "serverless",
                     "watchdog",
-                    "database_monitoring"
+                    "database_monitoring",
+                    "profiler"
                 ]
             },
             "tags": ["docs"],


### PR DESCRIPTION
### What does this PR do?

Since the reorg of the continuous profiler docs we aren't surfacing the same search results. 
This PR should fix this and also fixes the preview indexing job.

### Motivation

Slack

### Preview
https://docs-staging.datadoghq.com/david.jones/profiler-search/

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
