### PR TITLE
Configuring the Go Tracing Library Edit

### DIFF
--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -60,6 +60,10 @@ See all available options in the [configuration documentation][2].
 : **Default**: `localhost` <br>
 Override the default trace Agent host address for trace submission.
 
+`DD_TRACE_AGENT_PORT`
+: **Default**: `8126` <br>
+Override the default trace Agent port for Datadog trace submission.
+
 `DD_DOGSTATSD_PORT`
 : **Default**: `8125` <br>
 Override the default trace Agent port for DogStatsD metric submission.
@@ -70,7 +74,7 @@ A JSON array of objects. Each object must have a `"sample_rate"`. The `"name"` a
 For more information, see [Ingestion Mechanisms][3].<br>
 **Examples:**<br>
   - Set the sample rate to 20%: `'[{"sample_rate": 0.2}]'`
-  - Set the sample rate to 10% for services starting with 'a' and span name 'b' and set the sample rate to 20% for all other services: `'[{"service": "a.*", "name": "b", "sample_rate": 0.1}, {"sample_rate": 0.2}]'`
+  - Set the sample rate to 10% for services starting with 'a' and span name 'b' and set the sample rate to 20% for all other services: `'[{"service": "a.*", "name": "b", "sample_rate": 0.1}, {"sample_rate": 0.2}]'`.
 
 `DD_TRACE_SAMPLE_RATE`
 : Enable ingestion rate control.
@@ -80,7 +84,7 @@ For more information, see [Ingestion Mechanisms][3].<br>
 
 `DD_TAGS`
 : **Default**: [] <br>
-A list of default tags to be added to every span and profile. Tags can be separated by commas or spaces, for example: `layer:api,team:intake` or `layer:api team:intake`
+A list of default tags to be added to every span and profile. Tags can be separated by commas or spaces, for example: `layer:api,team:intake` or `layer:api team:intake`.
 
 `DD_TRACE_STARTUP_LOGS`
 : **Default**: `true` <br>
@@ -112,21 +116,18 @@ Distributed headers injection and extraction is controlled by
 configuring injection/extraction styles. Two styles are
 supported: `Datadog` and `B3`.
 
-Configure injection styles using the environment variable
-`DD_PROPAGATION_STYLE_INJECT=Datadog,B3`
+- Configure injection styles using the `DD_PROPAGATION_STYLE_INJECT=Datadog,B3` environment variable
+- Configure extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=Datadog,B3` environment variable
 
-Configure extraction styles using the environment variable
-`DD_PROPAGATION_STYLE_EXTRACT=Datadog,B3`
-
-The values of these environment variables are comma separated lists of
-header styles that are enabled for injection or extraction. By default only
+The values of these environment variables are comma-separated lists of
+header styles enabled for injection or extraction. By default, only
 the `Datadog` extraction style is enabled.
 
 If multiple extraction styles are enabled, extraction attempts are made
 in the order that those styles are specified. The first successfully
 extracted value is used.
 
-## Further Reading
+## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds a mention of the `DD_TRACE_AGENT_PORT` environment variable used by dd-trace-go. The current documentation mentions only the `DD_DOGSTATSD_PORT`, which only applied to dogstatsd metrics, not DD APM traces.

### Motivation
<!-- What inspired you to submit this pull request?-->

Ported over changes from https://github.com/DataDog/documentation/pull/14079. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Thanks @moskyb for your PR!

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
