### PR TITLE
[DOCS-3936] Fix propagation env var names

### DIFF
--- a/content/en/tracing/trace_collection/library_config/python.md
+++ b/content/en/tracing/trace_collection/library_config/python.md
@@ -38,13 +38,13 @@ It is recommended to use `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` to set `env`, 
 `DD_SERVICE`
 : The service name to be used for this application. The value is passed through when setting up middleware for web framework integrations like Pylons, Flask, or Django. For tracing without a web integration, it is recommended that you set the service name in code ([for example, see these Django docs][4]). Available in version 0.38+.
 
-`DD_PROPAGATION_STYLE_INJECT`
+`DD_TRACE_PROPAGATION_STYLE_INJECT`
 : **Default**: `Datadog`<br>
-Propagation styles to use when injecting tracing headers. For example, use `DD_PROPAGATION_STYLE_INJECT=Datadog,B3` to inject both Datadog and B3 format headers.
+Propagation styles to use when injecting tracing headers. For example, use `DD_TRACE_PROPAGATION_STYLE_INJECT=Datadog,B3` to inject both Datadog and B3 format headers.
 
-`DD_PROPAGATION_STYLE_EXTRACT`
-: **Default**: Value of `DD_PROPAGATION_STYLE_INJECT` (`Datadog`)<br>
-Propagation styles to use when extracting tracing headers. When multiple values are given, it uses the first header match found. The order of matching is static and unrelated to the order of values given. For example: `DD_PROPAGATION_STYLE_EXTRACT=B3,Datadog` produces the same behavior as `DD_PROPAGATION_STYLE_EXTRACT=Datadog,B3`.
+`DD_TRACE_PROPAGATION_STYLE_EXTRACT`
+: **Default**: Value of `DD_TRACE_PROPAGATION_STYLE_INJECT` (`Datadog`)<br>
+Propagation styles to use when extracting tracing headers. When multiple values are given, it uses the first header match found. The order of matching is static and unrelated to the order of values given. For example: `DD_TRACE_PROPAGATION_STYLE_EXTRACT=B3,Datadog` produces the same behavior as `DD_TRACE_PROPAGATION_STYLE_EXTRACT=Datadog,B3`.
 
 `DD_SERVICE_MAPPING`
 : Define service name mappings to allow renaming services in traces, for example: `postgres:postgresql,defaultdb:postgresql`. Available in version 0.47+.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fix env var names that were incorrect in our docs. This is what the tracer actually looks for: https://github.com/DataDog/dd-trace-py/blob/9061e297ed22d50e30b0c90d1c013f4b183927f3/ddtrace/settings/config.py#L188-L194

### Motivation
Raised by a customer in a support ticket

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
