### PR TITLE
Add API and app key header names to intro doc

### DIFF
--- a/content/en/api/latest/_index.md
+++ b/content/en/api/latest/_index.md
@@ -19,7 +19,7 @@ The Datadog API is an HTTP REST API. The API uses resource-oriented URLs to call
 
 ### Getting started
 
-Authenticate to the API with an [API key][1], and depending on the endpoint, an [Application key][2].
+Authenticate to the API with an [API key][1] using the header `DD-API-KEY`. For some endpoints, you also need an [Application key][2], which uses the header `DD-APPLICATION-KEY`.
 
 To try out the API [![Run in Postman][3]](https://god.gw.postman.com/run-collection/20651290-b051b74a-bbe6-433a-8670-7ec450e80199?action=collection%2Ffork&collection-url=entityId%3D20651290-b051b74a-bbe6-433a-8670-7ec450e80199%26entityType%3Dcollection%26workspaceId%3Dbf049f54-c695-4e91-b879-0cad1854bafa#?env%5BDatadog%20Authentication%5D=W3sia2V5IjoiYXBpX2tleSIsInZhbHVlIjoiIiwiZW5hYmxlZCI6dHJ1ZSwic2Vzc2lvblZhbHVlIjoiIiwic2Vzc2lvbkluZGV4IjowfSx7ImtleSI6ImFwcGxpY2F0aW9uX2tleSIsInZhbHVlIjoiIiwiZW5hYmxlZCI6dHJ1ZSwic2Vzc2lvblZhbHVlIjoiIiwic2Vzc2lvbkluZGV4IjoxfV0=)
 


### PR DESCRIPTION
Add the header names for the API and application keys to the API intro doc to save users some time looking for them.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
