### PR TITLE
Fix typo in example code

### DIFF
--- a/content/en/tracing/service_catalog/service_definition_api.md
+++ b/content/en/tracing/service_catalog/service_definition_api.md
@@ -82,7 +82,7 @@ You can generate this body data on the [Service Catalog Getting Started page][7]
 {{< code-block lang="json" filename="service.definition.json" collapsible="true" >}}
 {
   "schema-version": "v2",
-  "dd-version": "shopping-service"
+  "dd-service": "shopping-service"
 }
 {{< /code-block >}}
 


### PR DESCRIPTION
### What does this PR do?
The param for "name of a service" in the Service Definition API is "dd-service", not "dd-version". It's correct elsewhere on the page, so I think it's just a typo here =] This PR fixes the typo!

### Motivation
I was copying example code from the docs and it didn't work! Then, I realized the typo.

### Additional Notes
Thank you for the docs!

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
