### PR TITLE
Direct startup logs docs to debug tracer logs for file instructions

### DIFF
--- a/content/en/tracing/troubleshooting/tracer_startup_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_startup_logs.md
@@ -198,7 +198,11 @@ DATADOG TRACER DIAGNOSTIC - Agent Error: Network error trying to reach the agent
 
 The Python tracer logs configuration information as INFO-level. It logs diagnostics information, if found, as ERROR.
 
-If there is no logging configuration, only Diagnostics will be output to `Stderr`. To see tracer startup logs, either add a logger, or set `DD_TRACE_DEBUG=true` in your configuration and run your application with `ddtrace-run`. This adds a logger, and exposes both debug and startup tracer logs.
+If there is no logging configuration, only Diagnostics will be output to `Stderr`. 
+
+To see tracer startup logs, either add a logger, or set `DD_TRACE_DEBUG=true` in your configuration and run your application with `ddtrace-run`. This adds a logger, and exposes both debug and startup tracer logs.
+
+To see options for logging to a file with `DD_TRACE_LOG_FILE`, refer to [Tracer Debug Logs][1]
 
 **Configuration:**
 
@@ -213,6 +217,7 @@ The Python tracer prints a diagnostic line when the Agent cannot be reached.
 ```text
 DATADOG TRACER DIAGNOSTIC - Agent not reachable. Exception raised: [Errno 61] Connection refused
 ```
+[1]: /tracing/troubleshooting/tracer_debug_logs/?code-lang=python#enable-debug-mode
 
 {{< /programming-lang >}}
 {{< programming-lang lang="ruby" >}}

--- a/content/en/tracing/troubleshooting/tracer_startup_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_startup_logs.md
@@ -202,7 +202,7 @@ If there is no logging configuration, only Diagnostics will be output to `Stderr
 
 To see tracer startup logs, either add a logger, or set `DD_TRACE_DEBUG=true` in your configuration and run your application with `ddtrace-run`. This adds a logger, and exposes both debug and startup tracer logs.
 
-To see options for logging to a file with `DD_TRACE_LOG_FILE`, refer to [Tracer Debug Logs][1].
+To see options for logging to a file with `DD_TRACE_LOG_FILE`, read [Tracer Debug Logs][1].
 
 **Configuration:**
 

--- a/content/en/tracing/troubleshooting/tracer_startup_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_startup_logs.md
@@ -202,7 +202,7 @@ If there is no logging configuration, only Diagnostics will be output to `Stderr
 
 To see tracer startup logs, either add a logger, or set `DD_TRACE_DEBUG=true` in your configuration and run your application with `ddtrace-run`. This adds a logger, and exposes both debug and startup tracer logs.
 
-To see options for logging to a file with `DD_TRACE_LOG_FILE`, refer to [Tracer Debug Logs][1]
+To see options for logging to a file with `DD_TRACE_LOG_FILE`, refer to [Tracer Debug Logs][1].
 
 **Configuration:**
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Directs readers of the startup logs to refer to debug tracer log instructions when trying to figure out how to log to a file.

### Motivation
<!-- What inspired you to submit this pull request?-->

To avoid duplicating instructions, but to ensure https://docs.datadoghq.com/tracing/troubleshooting/tracer_debug_logs/?code-lang=python gets referenced.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Should be reviewed by someone from the Python APM team.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
