### PR TITLE
Update ingestion_mechanisms.md

### DIFF
--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -60,7 +60,7 @@ For more granular control, use tracing library sampling configuration options:
 - Set a **sampling rate to apply to specific root services**.
 - Set a **rate limit** on the number of ingested traces per second. The default rate limit is 100 traces per second per service instance (when using the Agent [default mechanism](#in-the-agent), the rate limiter is ignored).
 
-Sampling controls can only be set for root services
+Sampling controls can be set for only root services.
 
 **Note**: These rules are also head-based sampling controls. If the traffic for a service is higher than the configured maximum traces per second, then traces are dropped at the root. It does not create incomplete traces.
 

--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -57,8 +57,10 @@ All the spans from a trace sampled using the Datadog Agent [automatically comput
 
 For more granular control, use tracing library sampling configuration options:
 - Set a specific **sampling rate to apply to all root services** for the library, overriding the Agent's [default mechanism](#in-the-agent).
-- Set a **sampling rate to apply to specific root services** or for specific span operation names.
+- Set a **sampling rate to apply to specific root services**.
 - Set a **rate limit** on the number of ingested traces per second. The default rate limit is 100 traces per second per service instance (when using the Agent [default mechanism](#in-the-agent), the rate limiter is ignored).
+
+Only root service spans can receive sampling controls.
 
 **Note**: These rules are also head-based sampling controls. If the traffic for a service is higher than the configured maximum traces per second, then traces are dropped at the root. It does not create incomplete traces.
 

--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -60,7 +60,7 @@ For more granular control, use tracing library sampling configuration options:
 - Set a **sampling rate to apply to specific root services**.
 - Set a **rate limit** on the number of ingested traces per second. The default rate limit is 100 traces per second per service instance (when using the Agent [default mechanism](#in-the-agent), the rate limiter is ignored).
 
-Only root service spans can receive sampling controls.
+Sampling controls can only be set for root services
 
 **Note**: These rules are also head-based sampling controls. If the traffic for a service is higher than the configured maximum traces per second, then traces are dropped at the root. It does not create incomplete traces.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This PR clarifies that rule-based sampling can only apply to root spans, and can only target too spans.

### Motivation

There has been recurring cases of confusion around users enabling rule-based sampling targeting child spans in a trace. Such rules will never match, as rule samplers only target the root span.

### Preview
[docs-staging.datadoghq.com/marco.costa/root-span-sampling/tracing/trace_pipeline/ingestion_mechanisms](https://docs-staging.datadoghq.com/marco.costa/root-span-sampling/tracing/trace_pipeline/ingestion_mechanisms#in-tracing-libraries-user-defined-rules)

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
