### PR TITLE
API tab labels only say deprecated when x-deprecated flag set

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -83,7 +83,7 @@
               {{ $endpoint := partial "api/get-endpoint.html" (dict "lang" $.Page.Lang "operationids" $menuChild.Params.operationids "spec" $adat "generalRegions" $generalRegions ) }}
               {{ $endpointVisibility := partial "api/endpoint-visibility.html" (dict "versionCount" $versionCount "versionNum" $versionNum "menuChild" $menuChild "endpoint" $endpoint) }}
               <li class="nav-item">
-                <a class="nav-link mr-1 {{ if and ($endpointVisibility.isVisibleVersion) (gt (len $menuChild.Params.versions) 1) }}active{{ end }} {{ if and ($endpointVisibility.isVisibleVersion) (eq (len $menuChild.Params.versions) 1) }}disabled{{ end }}" {{- if and (eq (len $menuChild.Params.versions) 1) ($endpoint.action.deprecated | default false) -}}data-toggle="collapse"{{- else -}}data-toggle="tab"{{- end -}} href="#{{ (print $anchorStr "-" $versionNum) | anchorize }}">{{ $versionNum }} ({{ $endpointVisibility.label }})</a>
+                <a class="nav-link mr-1 {{ with $endpointVisibility.label }}{{ else }}px-3{{ end }} {{ if and ($endpointVisibility.isVisibleVersion) (gt (len $menuChild.Params.versions) 1) }}active{{ end }} {{ if and ($endpointVisibility.isVisibleVersion) (eq (len $menuChild.Params.versions) 1) }}disabled{{ end }}" {{- if and (eq (len $menuChild.Params.versions) 1) ($endpoint.action.deprecated | default false) -}}data-toggle="collapse"{{- else -}}data-toggle="tab"{{- end -}} href="#{{ (print $anchorStr "-" $versionNum) | anchorize }}">{{ $versionNum }} {{ with $endpointVisibility.label }}({{ . }}){{ end }}</a>
               </li>
             {{ end }}
           </ul>

--- a/layouts/partials/api/endpoint-visibility.html
+++ b/layouts/partials/api/endpoint-visibility.html
@@ -28,9 +28,10 @@
           <!-- if we are outputting v1 and we know v2 is stable we should collapse v1 -->
           {{- $s.SetInMap "output" "isVisibleVersion" false -}}
           <!-- if v1 and v2 are both stable, we should deprecate v1 -->
+          <!-- lets not output the word deprecated -->
           {{- $s.SetInMap "output" "labelPrefix" "~" -}}
           {{- $s.SetInMap "output" "labelSuffix" "~" -}}
-          {{- $s.SetInMap "output" "label" "deprecated" -}}
+          {{- $s.SetInMap "output" "label" "" -}}
         {{ end }}
     {{ else if eq $versionNum "v2" }}
         {{ if in $menuChild.Params.unstable "v2" }}


### PR DESCRIPTION
### What does this PR do?

It can be confusing when a v2 api endpoint goes GA as the docs will suddenly display the existing v1 tab as `v1 (deprecated)`. This kind of labeling can cause customers to believe the api they are using is soon to be disabled which isn't the case.

This PR keeps the deprecated label on endpoints using `x-deprecated` but anything else will just display the version.

### Motivation

API discussions

### Preview

https://docs-staging.datadoghq.com/david.jones/version-tablabel/api/latest/metrics/#submit-metrics

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
