### PR TITLE
WEB-2572 - security rules layout more reusable

### DIFF
--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -2,7 +2,7 @@ import { updateTOC, buildTOCMap } from './table-of-contents';
 import initCodeTabs from './codetabs';
 import { redirectToRegion } from '../region-redirects';
 import { initializeIntegrations } from './integrations';
-import { initializeSecurityRules } from './security-rules';
+import { initializeGroupedListings } from './grouped-item-listings';
 import {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName } from '../helpers/helpers';
 import configDocs from '../config/config-docs';
 import { redirectCodeLang, addCodeTabEventListeners, addCodeBlockVisibilityToggleEventListeners, activateCodeLangNav, toggleMultiCodeLangNav } from './code-languages'; // eslint-disable-line import/no-cycle
@@ -141,7 +141,7 @@ function loadPage(newUrl) {
                 wistiaVidId = wistiaVid.dataset.wistiaId;
             }
 
-            initializeSecurityRules();
+            initializeGroupedListings();
 
             // if newly requested TOC is NOT disabled
             if (newTOC && newTOC.querySelector('#TableOfContents') && currentTOC) {

--- a/assets/scripts/components/grouped-item-listings.js
+++ b/assets/scripts/components/grouped-item-listings.js
@@ -1,6 +1,6 @@
 import { stringToTitleCase } from '../helpers/string';
 
-export function initializeSecurityRules() {
+export function initializeGroupedListings() {
     const inputSearch = document.querySelector('[data-ref="search"]');
     const controls = document.querySelector('[data-ref="controls"]');
     const allGroupHeaders = Array.prototype.slice.call(document.getElementsByClassName('js-group-header') || []);

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -1,5 +1,5 @@
 import { initializeIntegrations } from './components/integrations';
-import { initializeSecurityRules } from './components/security-rules';
+import { initializeGroupedListings } from './components/grouped-item-listings';
 import { updateTOC, buildTOCMap, onScroll, closeMobileTOC } from './components/table-of-contents';
 import initCodeTabs from './components/codetabs';
 import configDocs from './config/config-docs';
@@ -82,8 +82,8 @@ $(document).ready(function () {
     buildTOCMap();
     onScroll();
 
-    if (document.body.classList.value.includes('security_platform')) {
-        initializeSecurityRules();
+    if (document.body.classList.value.includes('security_platform') || document.body.classList.value.includes('catalog')) {
+        initializeGroupedListings();
     }
 
     if (document.body.classList.value.includes('integrations')) {

--- a/layouts/partials/grouped-item-listings.html
+++ b/layouts/partials/grouped-item-listings.html
@@ -1,0 +1,69 @@
+{{- $ctx := .context -}}
+{{- $filters := .filters -}}
+{{- $listGroups := .listgroups }}
+
+{{ with $filters }}
+<div class="controls" data-ref="controls">
+  <a data-ref="filter" data-filter="all" href="#all" class="mb-1 mr-1 btn btn-sm-tag btn-outline-secondary sort-reset">{{- i18n "all" -}}</a>
+  {{- range $i, $filter := . -}}
+    {{- $clean_filter := replace $filter "/" "" | urlize -}}
+    <a data-ref="filter" data-filter="cat-{{- $clean_filter -}}" href="#cat-{{- $clean_filter -}}" class="mb-1 mr-1 btn btn-sm-tag btn-outline-secondary sort-time sort-{{- $clean_filter -}}">{{- $filter | upper -}}</a>
+  {{- end -}}
+</div>
+{{ end }}
+
+<div class="form-group clearfix">
+  <input type="input" data-ref="search" class="form-control rule-search mb-3" id="keywords" placeholder="Search here" aria-label="keywords"/>
+</div>
+
+<div class="list-group">
+  <div class="js-empty-results d-none font-semibold"></div>
+  {{ range $i, $v := $listGroups }}
+  <div class="js-group js-group-{{ $i }}">
+    <div class="js-group-header mb-1 active">
+      <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2 py-1">
+        {{ range last 1 $v.Pages }}
+          {{ $basename := .Params.integration_id | default .Params.source }}
+          {{ $int_logo := partial "integrations-logo.html" (dict "context" $ctx "basename" $basename "variant" "avatar" "fallback" "cloud") }}
+          {{ if $int_logo }}
+            <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}"/>
+          {{ else }}
+            <img height="17" src="{{ partial "img-resource.html" (dict "context" $ctx "src" (print "images/svg-icons/agent.svg")) }}?w=80&auto-enhance 2x" />
+          {{ end }}
+        {{ end }}
+      </div>
+      <div class="d-inline font-semibold ml-1">
+        <!-- If first word/only word is 3 letters long e.g aws or gcp then lets capitalize -->
+        {{ $words := (split (humanize $v.Key) " ") }}
+        {{ range $index, $word := $words }}
+          {{ if (and (eq $index 0) (eq (len $word) 3)) }}
+            {{ $word | upper }}
+          {{ else }}
+            {{ $word | title }}
+          {{ end }}
+        {{ end }}
+      </div>
+      <div class="js-group-header__arrow">></div>
+    </div>
+    <div class="group-{{ .Key }} mb-2 ml-4 d-none">
+      {{ range $v.Pages }}
+        <a class="mb-1 font-semibold mix js-single-rule {{ range $i, $e := .Params.rule_category }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" href="{{.Permalink}}" data-name="{{ lower .Title }} {{ .File.TranslationBaseName }}">
+          {{ $basename := .Params.integration_id | default .Params.source }}
+          {{ if in .Params.scope "." }}
+            <!-- e.g gcp.project use source -->
+            {{ $basename = .Params.source }}
+          {{ end }}
+          {{ $int_logo := partial "integrations-logo.html" (dict "context" $ctx "basename" $basename "variant" "avatar" "fallback" "cloud") }}
+          {{ if $int_logo }}
+            <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}"/>
+          {{ else }}
+            <img height="17" src="{{ partial "img-resource.html" (dict "context" $ctx "src" (print "images/svg-icons/agent.svg")) }}" alt="{{ $v.Key }}" />
+          {{ end }}
+          <span class="pl-1">{{ .Title }}</span><br/>
+        </a>
+      {{ end }}
+    </div>
+  </div>
+
+  {{ end }}
+</div>

--- a/layouts/security_rules/list.html
+++ b/layouts/security_rules/list.html
@@ -20,62 +20,6 @@
 
 {{ .Content }}
 <form id="rules">
-    <div class="controls" data-ref="controls">
-        <a data-ref="filter" data-filter="all" href="#all" class="mb-1 mr-1 btn btn-sm-tag btn-outline-secondary sort-reset">{{ i18n "all" }}</a>
-        {{ range $i, $e := (sort ($.Scratch.Get "filters")) }}<a data-ref="filter" data-filter="cat-{{ replace $e "/" "" | urlize }}" href="#cat-{{ replace $e "/" "" | urlize }}" class="mb-1 mr-1 btn btn-sm-tag btn-outline-secondary sort-time sort-{{ replace $e "/" "" | urlize }}">{{ $e | upper }}</a>{{ end }}
-    </div>
-    <div class="form-group clearfix">
-        <input type="input" data-ref="search" class="form-control rule-search mb-3" id="keywords" placeholder="Search here" aria-label="keywords" />
-    </div>
-    <div class="list-group">
-        <div class="js-empty-results d-none font-semibold"></div>
-        {{ range $i, $v := $list.GroupByParam "source" }}
-            <div class="js-group js-group-{{ $i }}">
-                <div class="js-group-header mb-1 active">
-                    <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2 py-1">
-                        {{ range last 1 $v.Pages }}
-                            {{ $basename := .Params.integration_id | default .Params.source }}
-                            {{ $int_logo := partial "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "avatar" "fallback" "cloud") }}
-                            {{ if $int_logo }}
-                                <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}" />
-                            {{ else }}
-                                <img height="17" src="{{ partial "img-resource.html" (dict "context" $dot "src" (print "images/svg-icons/agent.svg")) }}?w=80&auto-enhance 2x" />
-                            {{ end }}
-                        {{ end }}
-                    </div>
-                    <div class="d-inline font-semibold ml-1">
-                        <!-- If first word/only word is 3 letters long e.g aws or gcp then lets capitalize -->
-                        {{ $words := (split (humanize $v.Key) " ") }}
-                        {{ range $index, $word := $words }}
-                          {{ if (and (eq $index 0) (eq (len $word) 3)) }}
-                            {{ $word | upper }}
-                          {{ else }}
-                            {{ $word | title }}
-                          {{ end }}
-                        {{ end }}
-                    </div>
-                    <div class="js-group-header__arrow">></div>
-                </div>
-                <div class="group-{{ .Key }} mb-2 ml-4 d-none">
-                    {{ range $v.Pages }}
-                        <a class="mb-1 font-semibold mix js-single-rule {{ range $i, $e := .Params.rule_category }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" href="{{.Permalink}}" data-name="{{ lower .Title }} {{ .File.TranslationBaseName }}">
-                            {{ $basename := .Params.integration_id | default .Params.source }}
-                            {{ if in .Params.scope "." }}
-                                <!-- e.g gcp.project use source -->
-                                {{ $basename = .Params.source }}
-                            {{ end }}
-                            {{ $int_logo := partial "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "avatar" "fallback" "cloud") }}
-                            {{ if $int_logo }}
-                                <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}" />
-                            {{ else }}
-                                <img height="17" src="{{ partial "img-resource.html" (dict "context" $dot "src" (print "images/svg-icons/agent.svg")) }}" alt="{{ $v.Key }}" />
-                            {{ end }}
-                            <span class="pl-1">{{ .Title }}</span><br />
-                        </a>
-                    {{ end }}
-                </div>
-            </div>
-        {{ end }}
-    </div>
+    {{- partial "grouped-item-listings.html" ( dict "context" $dot "filters" (sort ($.Scratch.Get "filters")) "listgroups" ($list.GroupByParam "source") ) -}}
 </form>
 {{ end }}


### PR DESCRIPTION
### What does this PR do?

This PR makes the security rules layout more reusable:
- Renames the js and initialize
- Splits out the layout into its own partial

### Motivation

Initial step towards
https://datadoghq.atlassian.net/browse/WEB-2572

### Preview

Check that the ootb rules pages are working as expected still
https://docs-staging.datadoghq.com/david.jones/update-rules/security_platform/default_rules/#all

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
