### PR TITLE
Fix formatting in python library config

### DIFF
--- a/content/en/tracing/trace_collection/library_config/python.md
+++ b/content/en/tracing/trace_collection/library_config/python.md
@@ -56,7 +56,7 @@ Propagation styles to use when extracting tracing headers. When multiple values 
 : Enable trace volume control
 
 `DD_TRACE_SAMPLING_RULES`
-**Default**: `[]` <br>
+: **Default**: `[]`<br>
 A JSON array of objects. Each object must have a `"sample_rate"`. The `"name"` and `"service"` fields are optional. The `"sample_rate"` value must be between `0.0` and `1.0` (inclusive). Rules are applied in configured order to determine the trace's sample rate.
 
 `DD_TRACE_RATE_LIMIT`


### PR DESCRIPTION
Missing definition list directive.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
