### PR TITLE
[WA-44] Fix env var syntax in PowerShell commands

### DIFF
--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -55,7 +55,7 @@ To install the Agent with the command line:
 start /wait msiexec /qn /i datadog-agent-7-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>"
 ```
 
-**Powershell**
+**PowerShell**
 
 ```powershell
 Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>"'
@@ -88,7 +88,7 @@ Each configuration item is added as a property to the command line. The followin
 | `DDAGENTUSER_NAME`                          | String  | Override the default `ddagentuser` username used during Agent installation _(v6.11.0+)_. [Learn more about the Datadog Windows Agent User][3].                                                                                      |
 | `DDAGENTUSER_PASSWORD`                      | String  | Override the cryptographically secure password generated for the `ddagentuser` user during Agent installation _(v6.11.0+)_. Must be provided for installs on domain servers. [Learn more about the Datadog Windows Agent User][3].  |
 | `APPLICATIONDATADIRECTORY`                  | Path    | Override the directory to use for the configuration file directory tree. May only be provided on initial install; not valid for upgrades. Default: `C:\ProgramData\Datadog`. _(v6.11.0+)_                                           |
-| `PROJECTLOCATION`                           | Path    | Override the directory to use for the binary file directory tree. May only be provided on initial install; not valid for upgrades. Default: `%PROGRAMFILES%\Datadog\Datadog Agent`. _(v6.11.0+)_                                    |
+| `PROJECTLOCATION`                           | Path    | Override the directory to use for the binary file directory tree. May only be provided on initial install; not valid for upgrades. Default: `%ProgramFiles%\Datadog\Datadog Agent`. _(v6.11.0+)_                                    |
 | `ADDLOCAL`                                  | String  | Enable additional agent component. Setting to `"MainApplication,NPM"` causes the driver component for [Network Performance Monitoring][4] to be installed.                                                                          |
 | `EC2_USE_WINDOWS_PREFIX_DETECTION`          | Boolean | Use the EC2 instance id for Windows hosts on EC2. _(v7.28.0+)_                                                                                                                                                                      |
 
@@ -164,9 +164,9 @@ The execution of the Agent is controlled by the Windows Service Control Manager.
   - Command Prompt (`cmd.exe`)
 
     ```cmd
-    "%PROGRAMFILES%\Datadog\Datadog Agent\bin\agent.exe" status
-    "%PROGRAMFILES%\Datadog\Datadog Agent\bin\agent.exe" launch-gui
-    "%PROGRAMFILES%\Datadog\Datadog Agent\bin\agent.exe" flare
+    "%ProgramFiles%\Datadog\Datadog Agent\bin\agent.exe" status
+    "%ProgramFiles%\Datadog\Datadog Agent\bin\agent.exe" launch-gui
+    "%ProgramFiles%\Datadog\Datadog Agent\bin\agent.exe" flare
     ```
 
 {{% /tab %}}
@@ -180,7 +180,7 @@ Use the `start`, `stop`, and `restart` commands in the Datadog Agent Manager:
 
 {{< img src="agent/basic_agent_usage/windows/manager-snapshot.png" alt="Manager snapshot" style="width:75%;">}}
 
-You can also use Windows Powershell, where available:
+You can also use Windows PowerShell, where available:
 `[start|stop|restart]-service datadogagent`
 
 {{% /tab %}}
@@ -227,7 +227,7 @@ To receive more information about the Agent's state, start the Datadog Agent Man
 Then, open the status page by going to *Status* -> *General*.
 Get more information on running checks in *Status* -> *Collector* and *Checks* -> *Summary*.
 
-The status command is available for Powershell:
+The status command is available for PowerShell:
 
 ```powershell
 & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" status
@@ -236,7 +236,7 @@ The status command is available for Powershell:
 or cmd.exe:
 
 ```cmd
-"%PROGRAMFILES%\Datadog\Datadog Agent\bin\agent.exe" status
+"%ProgramFiles%\Datadog\Datadog Agent\bin\agent.exe" status
 ```
 
 {{% /tab %}}
@@ -251,7 +251,7 @@ Information about the Agent's state for Agent v5.2+ is available in the
 
 For the status of Agent v3.9.1 to v5.1, navigate to `http://localhost:17125/status`.
 
-The info command is available for Powershell:
+The info command is available for PowerShell:
 
 ```powershell
 & "$env:ProgramFiles\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python.exe" "$env:ProgramFiles\Datadog\Datadog Agent\agent\agent.py" info
@@ -260,10 +260,10 @@ The info command is available for Powershell:
 or cmd.exe:
 
 ```
-"%PROGRAMFILES%\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python.exe" "%PROGRAMFILES%\Datadog\Datadog Agent\agent\agent.py" info
+"%ProgramFiles%\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python.exe" "%ProgramFiles%\Datadog\Datadog Agent\agent\agent.py" info
 ```
 
-**Note**: For Agent versions <= 6.11 the path should be `%PROGRAMFILES%\Datadog\Datadog Agent\embedded\python.exe` instead.
+**Note**: For Agent versions <= 6.11 the path should be `%ProgramFiles%\Datadog\Datadog Agent\embedded\python.exe` instead.
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -308,7 +308,7 @@ Need help? Contact [Datadog support][1].
 
 * Press Submit.
 
-The flare command is available for Powershell:
+The flare command is available for PowerShell:
 
 ```powershell
 & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" flare <CASE_ID>
@@ -317,7 +317,7 @@ The flare command is available for Powershell:
 or cmd.exe:
 
 ```cmd
-"%PROGRAMFILES%\Datadog\Datadog Agent\bin\agent.exe" flare <CASE_ID>
+"%ProgramFiles%\Datadog\Datadog Agent\bin\agent.exe" flare <CASE_ID>
 ```
 
 {{< img src="agent/basic_agent_usage/windows/windows_flare_agent_6.png" alt="Windows flare with Agent 6" style="width:75%;">}}
@@ -340,16 +340,16 @@ To send Datadog support a copy of your Windows logs and configurations, do the f
 
 {{< img src="agent/faq/windows_flare.jpg" alt="Windows Flare" style="width:70%;">}}
 
-The flare command is available for Powershell:
+The flare command is available for PowerShell:
 
 ```powershell
-& "$env:ProgramFiles\Datadog\Datadog Agent\embedded\python.exe" "$env:Programfiles\Datadog\Datadog Agent\agent\agent.py" flare <CASE_ID>
+& "$env:ProgramFiles\Datadog\Datadog Agent\embedded\python.exe" "$env:ProgramFiles\Datadog\Datadog Agent\agent\agent.py" flare <CASE_ID>
 ```
 
 or cmd.exe:
 
 ```
-"%PROGRAMFILES%\Datadog\Datadog Agent\embedded\python.exe" "%PROGRAMFILES%\Datadog\Datadog Agent\agent\agent.py" flare <CASE_ID>
+"%ProgramFiles%\Datadog\Datadog Agent\embedded\python.exe" "%ProgramFiles%\Datadog\Datadog Agent\agent\agent.py" flare <CASE_ID>
 ```
 
 #### Flare fails to upload
@@ -364,10 +364,10 @@ For older Agent versions on Windows, you can find the location of this file by r
 **Step 1**:
 
 * Agent v5.12+:
-    `"%PROGRAMFILES%\Datadog\Datadog Agent\dist\shell.exe" since`
+    `"%ProgramFiles%\Datadog\Datadog Agent\dist\shell.exe" since`
 
 * Older Agent versions:
-    `"%PROGRAMFILES%\Datadog\Datadog Agent\files\shell.exe"`
+    `"%ProgramFiles%\Datadog\Datadog Agent\files\shell.exe"`
 
 **Step 2**:
 

--- a/content/en/agent/faq/agent_v6_changes.md
+++ b/content/en/agent/faq/agent_v6_changes.md
@@ -258,7 +258,7 @@ The major changes for Agent v6 on Windows are:
 
 * The Agent v5 Windows Agent Manager GUI was replaced with a browser-based, cross-platform manager. For details, see the [Datadog Agent Manager for Windows][1].
 * The main executable file is `agent.exe` (previously `ddagent.exe`).
-* Commands should be run with the command line `"%PROGRAMFILES%\datadog\datadog agent\embedded\agent.exe" <COMMAND>` from an **Administrator** command prompt.
+* Commands should be run with the command line `"%ProgramFiles%\datadog\datadog agent\embedded\agent.exe" <COMMAND>` from an **Administrator** command prompt.
 * The Windows service is started as "Automatic-Delayed". It is started automatically on boot, but after all other services. This results in a small delay in reporting metrics after a reboot.
 * The Windows GUI and Windows system tray icon are implemented separately. See the [Datadog Agent Manager for Windows][1] for more details.
 

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -108,7 +108,7 @@ Finally, restart the Datadog Agent service with `sudo systemctl restart datadog-
 
 ### Windows
 
-Save the following powershell code as `jndi_cleanup.ps1`.
+Save the following PowerShell code as `jndi_cleanup.ps1`.
 
 ```powershell
 Param(
@@ -152,10 +152,10 @@ $stream.Close()
 $stream.Dispose()
 ```
 
-Stop the Datadog Agent service before applying the patch:
+From an **elevated(run as Admin)** PowerShell, stop the Datadog Agent service before applying the patch:
 
 ```powershell
-"$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" stopservice
+& "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" stopservice
 ```
 
 Apply the patch to remove the JndiLogger.class from the jmxfetch.jar:
@@ -179,7 +179,7 @@ The C:\Program Files\Datadog\Datadog Agent\embedded\agent\dist\jmx\jmxfetch.jar 
 Finally, start the Datadog Agent service to apply the changes.
 
 ```powershell
-"$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" start-service
+& "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" start-service
 ```
 
 ### AIX

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -152,7 +152,7 @@ $stream.Close()
 $stream.Dispose()
 ```
 
-From an **elevated(run as Admin)** PowerShell, stop the Datadog Agent service before applying the patch:
+From an **elevated** (run as admin) PowerShell, stop the Datadog Agent service before applying the patch:
 
 ```powershell
 & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" stopservice

--- a/content/en/agent/guide/datadog-agent-manager-windows.md
+++ b/content/en/agent/guide/datadog-agent-manager-windows.md
@@ -30,7 +30,7 @@ The Datadog Agent Manager GUI is browser-based. The port the GUI runs on can be 
 | Chrome        | 60                           |                         |
 | Safari        | 8                            |                         |
 | IOS           | 12                           |  Mobile Safari          |
- 
+
 ### Start the Datadog Agent Manager
 
 After the Agent is [installed][1] on your Windows host, start the Datadog Agent Manager to manage the Agent graphically.
@@ -41,10 +41,9 @@ From the Windows start menu:
 * Right click on Datadog Agent Manager.
 * Choose `Run as Administrator`.
 
-From an elevated Powershell prompt:
-
+From an elevated PowerShell prompt:
 ```powershell
-& "%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe" launch-gui
+& "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" launch-gui
 ```
 
 The Datadog Agent Manager launches in your default web browser. The web address is `http://127.0.0.1:5002`.

--- a/content/en/agent/guide/integration-management.md
+++ b/content/en/agent/guide/integration-management.md
@@ -43,17 +43,19 @@ The syntax for this command is `datadog-agent integration install <INTEGRATION_P
 
 For example, to install version 3.6.0 of the vSphere integration, run:
 
-Linux:
-
+{{< tabs >}}
+{{% tab "Linux" %}}
 ```shell
 sudo -u dd-agent -- datadog-agent integration install datadog-vsphere==3.6.0
 ```
-
-Windows:
-
+{{% /tab %}}
+{{% tab "Windows PowerShell" %}}
+Run `powershell.exe` as **elevated(run as Admin)**
 ```powershell
-"%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe" integration install datadog-vsphere==3.6.0
+& "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" integration install datadog-vsphere==3.6.0
 ```
+{{% /tab %}}
+{{< /tabs >}}
 
 The command installs the Python package of the integration and copies the configuration files (`conf.yaml.example`, `conf.yaml.default`, `auto_conf.yaml`) to the `conf.d` directory, overwriting the existing ones. The same thing is done during a full Agent upgrade. If a failure occurs while copying of the files, the command exits with a failure, but the version of the integration you specified still gets installed.
 
@@ -73,17 +75,19 @@ To remove an integration, use the `datadog-agent integration remove` command. Th
 
 For example, to remove the vSphere integration, run:
 
-Linux:
-
+{{< tabs >}}
+{{% tab "Linux" %}}
 ```shell
 sudo -u dd-agent -- datadog-agent integration remove datadog-vsphere
 ```
-
-Windows:
-
+{{% /tab %}}
+{{% tab "Windows PowerShell" %}}
+Run `powershell.exe` as **elevated(run as Admin)**
 ```powershell
-"%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe" integration remove datadog-vsphere
+& "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" integration remove datadog-vsphere
 ```
+{{% /tab %}}
+{{< /tabs >}}
 
 Removing an integration does not remove the corresponding configuration folder in the `conf.d` directory.
 
@@ -93,33 +97,37 @@ To get information, such as the version, about an installed integration, use the
 
 For example, to show information on the vSphere integration, run:
 
-Linux:
-
+{{< tabs >}}
+{{% tab "Linux" %}}
 ```shell
 sudo -u dd-agent -- datadog-agent integration show datadog-vsphere
 ```
-
-Windows:
-
+{{% /tab %}}
+{{% tab "Windows PowerShell" %}}
+Run `powershell.exe` as **elevated(run as Admin)**
 ```powershell
-"%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe" integration show datadog-vsphere
+& "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" integration show datadog-vsphere
 ```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Freeze
 
 To list all the Python packages installed in the Agent's Python environment, use the `datadog-agent integration freeze` command. This lists all the Datadog integrations (packages starting with `datadog-`) and the Python dependencies required to run the integrations.
 
-Linux:
-
+{{< tabs >}}
+{{% tab "Linux" %}}
 ```text
 sudo -u dd-agent -- datadog-agent integration freeze
 ```
-
-Windows:
-
+{{% /tab %}}
+{{% tab "Windows PowerShell" %}}
+Run `powershell.exe` as **elevated(run as Admin)**
 ```powershell
-"%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe" integration freeze
+& "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" integration freeze
 ```
+{{% /tab %}}
+{{< /tabs >}}
 
 [1]: https://github.com/DataDog/integrations-core
 [2]: https://github.com/DataDog/integrations-core/blob/master/AGENT_INTEGRATIONS.md

--- a/content/en/agent/guide/integration-management.md
+++ b/content/en/agent/guide/integration-management.md
@@ -50,7 +50,7 @@ sudo -u dd-agent -- datadog-agent integration install datadog-vsphere==3.6.0
 ```
 {{% /tab %}}
 {{% tab "Windows PowerShell" %}}
-Run `powershell.exe` as **elevated(run as Admin)**
+Run `powershell.exe` as **elevated** (run as admin).
 ```powershell
 & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" integration install datadog-vsphere==3.6.0
 ```
@@ -82,7 +82,7 @@ sudo -u dd-agent -- datadog-agent integration remove datadog-vsphere
 ```
 {{% /tab %}}
 {{% tab "Windows PowerShell" %}}
-Run `powershell.exe` as **elevated(run as Admin)**
+Run `powershell.exe` as **elevated** (run as admin).
 ```powershell
 & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" integration remove datadog-vsphere
 ```
@@ -104,7 +104,7 @@ sudo -u dd-agent -- datadog-agent integration show datadog-vsphere
 ```
 {{% /tab %}}
 {{% tab "Windows PowerShell" %}}
-Run `powershell.exe` as **elevated(run as Admin)**
+Run `powershell.exe` as **elevated** (run as admin).
 ```powershell
 & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" integration show datadog-vsphere
 ```
@@ -122,7 +122,7 @@ sudo -u dd-agent -- datadog-agent integration freeze
 ```
 {{% /tab %}}
 {{% tab "Windows PowerShell" %}}
-Run `powershell.exe` as **elevated(run as Admin)**
+Run `powershell.exe` as **elevated** (run as admin).
 ```powershell
 & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" integration freeze
 ```

--- a/content/en/agent/guide/secrets-management.md
+++ b/content/en/agent/guide/secrets-management.md
@@ -385,10 +385,9 @@ Secrets handle decrypted:
 {{% /tab %}}
 {{% tab "Windows" %}}
 
-Example on Windows (from an Administrator Powershell):
-
+Example on Windows (from an Administrator PowerShell):
 ```powershell
-PS C:\> & '%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe' secret
+PS C:\> & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" secret
 === Checking executable rights ===
 Executable path: C:\path\to\you\executable.exe
 Check Rights: OK, the executable has the correct rights
@@ -496,12 +495,12 @@ To test your executable in the same conditions as the Agent, update the password
 To do so, follow those steps:
 
 1. Remove `ddagentuser` from the `Local Policies/User Rights Assignement/Deny Log on locally` list in the `Local Security Policy`.
-2. Set a new password for `ddagentuser` (since the one generated at install time is never saved anywhere). In Powershell, run:
+2. Set a new password for `ddagentuser` (since the one generated at install time is never saved anywhere). In PowerShell, run:
     ```powershell
     $user = [ADSI]"WinNT://./ddagentuser";
     $user.SetPassword("a_new_password")
     ```
-3. Update the password to be used by `DatadogAgent` service in the Service Control Manager. In Powershell, run:
+3. Update the password to be used by `DatadogAgent` service in the Service Control Manager. In PowerShell, run:
     ```powershell
     sc.exe config DatadogAgent password= "a_new_password"
     ```
@@ -544,7 +543,7 @@ When reading Secrets directly from Kubernetes you can double check your permissi
 kubectl auth can-i get secret/<SECRET_NAME> -n <SECRET_NAMESPACE> --as system:serviceaccount:<AGENT_NAMESPACE>:<AGENT_SERVICE_ACCOUNT>
 ```
 
-Consider the previous [Kubernetes Secrets example](#read-from-kubernetes-secret-example), where the Secret `Secret:database-secret` exists in the `Namespace: database`, and the Service Account `ServiceAccount:datadog-agent` exists in the `Namespace: default`. 
+Consider the previous [Kubernetes Secrets example](#read-from-kubernetes-secret-example), where the Secret `Secret:database-secret` exists in the `Namespace: database`, and the Service Account `ServiceAccount:datadog-agent` exists in the `Namespace: default`.
 
 In this case, use the following command:
 

--- a/content/en/agent/troubleshooting/agent_check_status.md
+++ b/content/en/agent/troubleshooting/agent_check_status.md
@@ -63,7 +63,7 @@ If your issue continues, [reach out to the Datadog support team][1] with a [flar
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
 
-Run the following script from an *elevated(run as Admin)* PowerShell command line, with the proper `<CHECK_NAME>`:
+Run the following script from an **elevated** (run as admin) PowerShell command line, with the proper `<CHECK_NAME>`:
 
 For Agent versions >= 6.12:
 
@@ -91,7 +91,7 @@ This outputs any metrics or events that the check returns.
 {{% /tab %}}
 {{% tab "Agent v>=5.12" %}}
 
-Run the following script from an *elevated(run as Admin)* PowerShell command line, with the proper `<CHECK_NAME>`:
+Run the following script from an **elevated** (run as admin) PowerShell command line, with the proper `<CHECK_NAME>`:
 
 `<INSTALL_DIR>/embedded/python.exe <INSTALL_DIR>agent/agent.py check <CHECK_NAME>`
 

--- a/content/en/agent/troubleshooting/agent_check_status.md
+++ b/content/en/agent/troubleshooting/agent_check_status.md
@@ -63,18 +63,17 @@ If your issue continues, [reach out to the Datadog support team][1] with a [flar
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
 
-Run the following script, with the proper `<CHECK_NAME>`:
+Run the following script from an *elevated(run as Admin)* PowerShell command line, with the proper `<CHECK_NAME>`:
 
 For Agent versions >= 6.12:
 
 ```powershell
-%PROGRAMFILES%\Datadog\Datadog Agent\bin\agent.exe check <CHECK_NAME>
+& "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" check <CHECK_NAME>
 ```
 
 For Agent versions <= 6.11:
-
 ```powershell
-%PROGRAMFILES%\Datadog\Datadog Agent\embedded\agent.exe check <CHECK_NAME>
+& "$env:ProgramFiles\Datadog\Datadog Agent\embedded\agent.exe" check <CHECK_NAME>
 ```
 
 {{% /tab %}}
@@ -92,14 +91,14 @@ This outputs any metrics or events that the check returns.
 {{% /tab %}}
 {{% tab "Agent v>=5.12" %}}
 
-Run the following script, with the proper `<CHECK_NAME>`:
+Run the following script from an *elevated(run as Admin)* PowerShell command line, with the proper `<CHECK_NAME>`:
 
 `<INSTALL_DIR>/embedded/python.exe <INSTALL_DIR>agent/agent.py check <CHECK_NAME>`
 
 For example, to run the disk check:
 
 ```powershell
-C:\Program' 'Files\Datadog\Datadog' 'Agent\embedded\python.exe C:\Program' 'Files\Datadog\Datadog' 'Agent\agent\agent.py check disk
+& "$env:ProgramFiles\Datadog\Datadog Agent\embedded\python.exe" "$env:ProgramFiles\Datadog\Datadog Agent\agent\agent.py" check disk
 ```
 
 {{% /tab %}}

--- a/content/en/developers/dogstatsd/datagram_shell.md
+++ b/content/en/developers/dogstatsd/datagram_shell.md
@@ -171,7 +171,7 @@ On Windows:
 PS C:\> .\send-statsd.ps1 "custom_metric:123|g|#shell"
 ```
 
-On any platform with Python (on Windows, the Agent's embedded Python interpreter can be used, which is located at `%PROGRAMFILES%\Datadog\Datadog Agent\embedded\python.exe` for Agent versions <= 6.11 and in `%PROGRAMFILES%\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python.exe` for Agent versions >= 6.12):
+On any platform with Python (on Windows, the Agent's embedded Python interpreter can be used, which is located at `%ProgramFiles%\Datadog\Datadog Agent\embedded\python.exe` for Agent versions <= 6.11 and in `%ProgramFiles%\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python.exe` for Agent versions >= 6.12):
 
 ### Python 2
 

--- a/content/en/developers/guide/custom-python-package.md
+++ b/content/en/developers/guide/custom-python-package.md
@@ -42,7 +42,7 @@ sudo /opt/datadog-agent/embedded/bin/pip install <PACKAGE_NAME>
 
 {{% tab "Windows" %}}
 
-Custom Python packages can be installed using the Agent's embedded Python using the following command in an **elevated(run as Admin)** PowerShell command line:
+Custom Python packages can be installed using the Agent's embedded Python using the following command in an **elevated** (run as admin) PowerShell command line:
 
 For Agent versions >= 6.12:
 

--- a/content/en/developers/guide/custom-python-package.md
+++ b/content/en/developers/guide/custom-python-package.md
@@ -42,24 +42,24 @@ sudo /opt/datadog-agent/embedded/bin/pip install <PACKAGE_NAME>
 
 {{% tab "Windows" %}}
 
-Custom Python packages can be installed using the Agent's embedded Python using the following command in PowerShell:
-
-For Agent versions <= 6.11:
-
-```powershell
-%PROGRAMFILES%\Datadog\"Datadog Agent"\embedded\python -m pip install <PACKAGE_NAME>
-```
+Custom Python packages can be installed using the Agent's embedded Python using the following command in an **elevated(run as Admin)** PowerShell command line:
 
 For Agent versions >= 6.12:
 
 ```powershell
-%PROGRAMFILES%\Datadog\"Datadog Agent"\embedded<PYTHON_MAJOR_VERSION>\python -m pip install <PACKAGE_NAME>
+& "$env:ProgramFiles\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python" -m pip install <PACKAGE_NAME>
+```
+
+For Agent versions <= 6.11:
+
+```powershell
+& "$env:ProgramFiles\Datadog\Datadog Agent\embedded\python" -m pip install <PACKAGE_NAME>
 ```
 
 Or the package can be added in the library zipped folder that can be found at
 
-```powershell
-%PROGRAMFILES%\Datadog\Datadog Agent\files
+```
+%ProgramFiles%\Datadog\Datadog Agent\files
 ```
 
 then [restart your Agent][1].

--- a/content/en/integrations/guide/running-jmx-commands-in-windows.md
+++ b/content/en/integrations/guide/running-jmx-commands-in-windows.md
@@ -10,7 +10,7 @@ If you are monitoring a JMX application with a Windows Agent, you can get access
 If java is in your path, from a command prompt you should be able to run:
 
 ```text
-java -Xms50m -Xmx200m -classpath "%PROGRAMFILES%\Datadog\Datadog Agent\files\jmxfetch\jmxfetch-0.7.0-jar-with-dependencies.jar" org.datadog.jmxfetch.App --check tomcat.yaml --conf_directory "C:\ProgramData\Datadog\conf.d" --log_level DEBUG --reporter console [collect, list_everything, list_collected_attributes, list_matching_attributes, list_not_matching_attributes, list_limited_attributes, help]
+java -Xms50m -Xmx200m -classpath "%ProgramFiles%\Datadog\Datadog Agent\files\jmxfetch\jmxfetch-0.7.0-jar-with-dependencies.jar" org.datadog.jmxfetch.App --check tomcat.yaml --conf_directory "C:\ProgramData\Datadog\conf.d" --log_level DEBUG --reporter console [collect, list_everything, list_collected_attributes, list_matching_attributes, list_not_matching_attributes, list_limited_attributes, help]
 ```
 
 Make sure that the JMXFetch version is the same as the one that ships with your version of the Agent.
@@ -18,7 +18,7 @@ Make sure that the JMXFetch version is the same as the one that ships with your 
 Here is a subset of the output from the list_matching_attributes command:
 
 ```text
-java -Xms50m -Xmx200m -classpath "%PROGRAMFILES%\Datadog\Datadog Agent\files\jmxfetch\jmxfe
+java -Xms50m -Xmx200m -classpath "%ProgramFiles%\Datadog\Datadog Agent\files\jmxfetch\jmxfe
 tch-0.7.0-jar-with-dependencies.jar" org.datadog.jmxfetch.App --check tomcat.yaml --conf_directory "C:\ProgramData\Datad
 og\conf.d" --log_level DEBUG --reporter console list_matching_attributes
 Log location is not set, not logging to file


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Fixes the environment variable syntax in PowerShell commands. `%ProgramFiles%` is for `cmd.exe`. `$env:ProgramFiles` is for `powershell.exe`.

Normalizes the case of the environment variables for consistency between pages and commands, for example `PROGRAMFILES` -> `ProgramFiles`. Though env vars are case insensitive on Windows the latter case matches what is reported by the `env` command in `cmd.exe` and `dir env:` in `powershell.exe`.

Normalizes "PowerShell" case (https://docs.microsoft.com/en-us/powershell/scripting/overview?view=powershell-7.2)

### Motivation
<!-- What inspired you to submit this pull request?-->

PowerShell throws an error if you try to use env vars like `%ProgramFiles%`. The proper syntax is `$env:ProgramFiles`.

xref [WA-44](https://datadoghq.atlassian.net/browse/WA-44)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

I think these commands should be updated in the other languages, too, but I can't read them to know for sure.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
