### PR TITLE
[Tracer][PHP] Add remark on appsec module being loaded even if not enabled

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/php.md
+++ b/content/en/tracing/trace_collection/dd_libraries/php.md
@@ -135,8 +135,6 @@ If the PHP CLI binary is built as NTS (non thread-safe), while Apache uses a ZTS
 </div>
 
 
-
-
 ## Automatic instrumentation
 
 Tracing is automatically enabled by default. Once the extension is installed, **ddtrace** traces your application and sends traces to the Agent.

--- a/content/en/tracing/trace_collection/dd_libraries/php.md
+++ b/content/en/tracing/trace_collection/dd_libraries/php.md
@@ -122,7 +122,7 @@ This command installs the extension to all the PHP binaries found in the host or
 
 Restart PHP (PHP-FPM or the Apache SAPI) and visit a tracing-enabled endpoint of your application. For traces, see the [APM Service List][5].
 
-Note that even when not specifying `--enable-appsec`, the appsec extension will be shortly loaded at startup, but not enabled by default. It will immediately be short-circuited out, causing negligible performance overhead. To disable the modules anyway, the best practice is to set `datadog.appsec.enabled=Off` in the `98-ddtrace.ini` file.
+Note that even when not specifying `--enable-appsec`, the appsec extension will be shortly loaded at startup, but not enabled by default. It will immediately be short-circuited out, causing negligible performance overhead.
 
 <div class="alert alert-info">
 <strong>Note:</strong>

--- a/content/en/tracing/trace_collection/dd_libraries/php.md
+++ b/content/en/tracing/trace_collection/dd_libraries/php.md
@@ -122,6 +122,8 @@ This command installs the extension to all the PHP binaries found in the host or
 
 Restart PHP (PHP-FPM or the Apache SAPI) and visit a tracing-enabled endpoint of your application. For traces, see the [APM Service List][5].
 
+Note that even when not specifying `--enable-appsec`, the appsec extension will be shortly loaded at startup, but not enabled by default. It will immediately be short-circuited out, causing negligible performance overhead. To disable the modules anyway, the best practice is to set `datadog.appsec.enabled=Off` in the `98-ddtrace.ini` file.
+
 <div class="alert alert-info">
 <strong>Note:</strong>
 It may take a few minutes before traces appear in the UI. If traces still do not appear after a few minutes, create a <a href="/tracing/troubleshooting/tracer_startup_logs?tab=php#php-info"><code>phpinfo()</code></a> page from the host machine and scroll down to the `ddtrace`. Failed diagnostic checks appear in this section to help identify any issues.
@@ -131,6 +133,8 @@ It may take a few minutes before traces appear in the UI. If traces still do not
 <strong>Apache ZTS:</strong>
 If the PHP CLI binary is built as NTS (non thread-safe), while Apache uses a ZTS (Zend thread-safe) version of PHP, you need to manually change the extension load for the ZTS binary. Run <code>/path/to/php-zts --ini</code> to find where Datadog's <code>.ini</code> file is located, then add the <code>-zts</code> suffix from the file name. For example, from <code>extension=ddtrace-20210902.so</code> to <code>extension=ddtrace-20210902-zts.so</code>.
 </div>
+
+
 
 
 ## Automatic instrumentation

--- a/content/en/tracing/trace_collection/dd_libraries/php.md
+++ b/content/en/tracing/trace_collection/dd_libraries/php.md
@@ -122,7 +122,7 @@ This command installs the extension to all the PHP binaries found in the host or
 
 Restart PHP (PHP-FPM or the Apache SAPI) and visit a tracing-enabled endpoint of your application. For traces, see the [APM Service List][5].
 
-Note that even when not specifying `--enable-appsec`, the appsec extension will be shortly loaded at startup, but not enabled by default. It will immediately be short-circuited out, causing negligible performance overhead.
+When you do not specify `--enable-appsec`, the AppSec extension loads shortly at startup, and is not enabled by default. It immediately short-circuits, causing negligible performance overhead.
 
 <div class="alert alert-info">
 <strong>Note:</strong>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Just add a remark on appsec module being loaded even if not enabled. 

### Motivation
<!-- What inspired you to submit this pull request?-->
This follows questions asked on #support-apm

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
