### PR TITLE
remove HTTPS from logs dual shipping urls

### DIFF
--- a/content/en/agent/guide/dual-shipping.md
+++ b/content/en/agent/guide/dual-shipping.md
@@ -24,17 +24,17 @@ You can add the YAML configuration to your `datadog.yaml` or launch the Agent wi
 In `datadog.yaml`:
 ```yaml
 additional_endpoints:
-  "mydomain.datadoghq.com":
+  "https://mydomain.datadoghq.com":
   - apikey2
   - apikey3
-  "mydomain.datadoghq.eu":
+  "https://mydomain.datadoghq.eu":
   - apikey4
 ```
 
 ### Environment variable configuration
 
 ```bash
-DD_ADDITIONAL_ENDPOINTS='{\"mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"mydomain.datadoghq.eu\": [\"apikey4\"]}'
+DD_ADDITIONAL_ENDPOINTS='{\"https://mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://mydomain.datadoghq.eu\": [\"apikey4\"]}'
 ```
 
 {{% /tab %}}
@@ -47,26 +47,26 @@ In `datadog.yaml`:
 apm_config:
   [...]
   additional_endpoints:
-    "mydomain.datadoghq.com":
+    "https://mydomain.datadoghq.com":
     - apikey2
     - apikey3
-    "mydomain.datadoghq.eu":
+    "https://mydomain.datadoghq.eu":
     - apikey4
 
   profiling_additional_endpoints:
-    "mydomain.datadoghq.com":
+    "https://mydomain.datadoghq.com":
     - apikey2
     - apikey3
-    "mydomain.datadoghq.eu":
+    "https://mydomain.datadoghq.eu":
     - apikey4
 ```
 
 ### Environment variable configuration
 
 ```bash
-DD_APM_ADDITIONAL_ENDPOINTS='{\"mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"mydomain.datadoghq.eu\": [\"apikey4\"]}'
+DD_APM_ADDITIONAL_ENDPOINTS='{\"https://mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://mydomain.datadoghq.eu\": [\"apikey4\"]}'
 
-DD_APM_PROFILING_ADDITIONAL_ENDPOINTS='{\"mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"mydomain.datadoghq.eu\": [\"apikey4\"]}'
+DD_APM_PROFILING_ADDITIONAL_ENDPOINTS='{\"https://mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://mydomain.datadoghq.eu\": [\"apikey4\"]}'
 ```
 
 {{% /tab %}}
@@ -79,17 +79,17 @@ In `datadog.yaml`:
 process_config:
   [...]
   additional_endpoints:
-    "mydomain.datadoghq.com":
+    "https://mydomain.datadoghq.com":
     - apikey2
     - apikey3
-    "mydomain.datadoghq.eu":
+    "https://mydomain.datadoghq.eu":
     - apikey4
 ```
 
 ### Environment variable configuration
 
 ```bash
-DD_PROCESS_ADDITIONAL_ENDPOINTS='{\"mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"mydomain.datadoghq.eu\": [\"apikey4\"]}'
+DD_PROCESS_ADDITIONAL_ENDPOINTS='{\"https://mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://mydomain.datadoghq.eu\": [\"apikey4\"]}'
 ```
 
 {{% /tab %}}
@@ -102,17 +102,17 @@ In `datadog.yaml`:
 orchestrator_explorer:
   [...]
   orchestrator_additional_endpoints:
-    "mydomain.datadoghq.com":
+    "https://mydomain.datadoghq.com":
     - apikey2
     - apikey3
-    "mydomain.datadoghq.eu":
+    "https://mydomain.datadoghq.eu":
     - apikey4
 ```
 
 ### Environment variable configuration
 
 ```bash
-DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_ADDITIONAL_ENDPOINTS='{\"mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"mydomain.datadoghq.eu\": [\"apikey4\"]}'
+DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_ADDITIONAL_ENDPOINTS='{\"https://mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://mydomain.datadoghq.eu\": [\"apikey4\"]}'
 ```
 
 {{% /tab %}}
@@ -127,17 +127,17 @@ In `datadog.yaml`:
 evp_proxy_config:
   [...]
   additional_endpoints:
-    "mydomain.datadoghq.com":
+    "https://mydomain.datadoghq.com":
     - apikey2
     - apikey3
-    "mydomain.datadoghq.eu":
+    "https://mydomain.datadoghq.eu":
     - apikey4
 ```
 
 ### Environment variable configuration
 
 ```bash
-DD_EVP_PROXY_CONFIG_ADDITIONAL_ENDPOINTS='{\"mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"mydomain.datadoghq.eu\": [\"apikey4\"]}'
+DD_EVP_PROXY_CONFIG_ADDITIONAL_ENDPOINTS='{\"https://mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://mydomain.datadoghq.eu\": [\"apikey4\"]}'
 ```
 
 {{% /tab %}}
@@ -320,10 +320,10 @@ and add the relevant settings to `customAgentConfig`.
   ## Note the `agents.useConfigMap` needs to be set to `true` for this parameter to be taken into account.
   customAgentConfig:
     additional_endpoints:
-      "mydomain.datadoghq.com":
+      "https://mydomain.datadoghq.com":
       - apikey2
       - apikey3
-      "mydomain.datadoghq.eu":
+      "https://mydomain.datadoghq.eu":
       - apikey4 
 
     logs_config:

--- a/content/en/agent/guide/dual-shipping.md
+++ b/content/en/agent/guide/dual-shipping.md
@@ -24,17 +24,17 @@ You can add the YAML configuration to your `datadog.yaml` or launch the Agent wi
 In `datadog.yaml`:
 ```yaml
 additional_endpoints:
-  "https://mydomain.datadoghq.com":
+  "mydomain.datadoghq.com":
   - apikey2
   - apikey3
-  "https://mydomain.datadoghq.eu":
+  "mydomain.datadoghq.eu":
   - apikey4
 ```
 
 ### Environment variable configuration
 
 ```bash
-DD_ADDITIONAL_ENDPOINTS='{\"https://mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://mydomain.datadoghq.eu\": [\"apikey4\"]}'
+DD_ADDITIONAL_ENDPOINTS='{\"mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"mydomain.datadoghq.eu\": [\"apikey4\"]}'
 ```
 
 {{% /tab %}}
@@ -47,26 +47,26 @@ In `datadog.yaml`:
 apm_config:
   [...]
   additional_endpoints:
-    "https://mydomain.datadoghq.com":
+    "mydomain.datadoghq.com":
     - apikey2
     - apikey3
-    "https://mydomain.datadoghq.eu":
+    "mydomain.datadoghq.eu":
     - apikey4
 
   profiling_additional_endpoints:
-    "https://mydomain.datadoghq.com":
+    "mydomain.datadoghq.com":
     - apikey2
     - apikey3
-    "https://mydomain.datadoghq.eu":
+    "mydomain.datadoghq.eu":
     - apikey4
 ```
 
 ### Environment variable configuration
 
 ```bash
-DD_APM_ADDITIONAL_ENDPOINTS='{\"https://mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://mydomain.datadoghq.eu\": [\"apikey4\"]}'
+DD_APM_ADDITIONAL_ENDPOINTS='{\"mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"mydomain.datadoghq.eu\": [\"apikey4\"]}'
 
-DD_APM_PROFILING_ADDITIONAL_ENDPOINTS='{\"https://mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://mydomain.datadoghq.eu\": [\"apikey4\"]}'
+DD_APM_PROFILING_ADDITIONAL_ENDPOINTS='{\"mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"mydomain.datadoghq.eu\": [\"apikey4\"]}'
 ```
 
 {{% /tab %}}
@@ -79,17 +79,17 @@ In `datadog.yaml`:
 process_config:
   [...]
   additional_endpoints:
-    "https://mydomain.datadoghq.com":
+    "mydomain.datadoghq.com":
     - apikey2
     - apikey3
-    "https://mydomain.datadoghq.eu":
+    "mydomain.datadoghq.eu":
     - apikey4
 ```
 
 ### Environment variable configuration
 
 ```bash
-DD_PROCESS_ADDITIONAL_ENDPOINTS='{\"https://mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://mydomain.datadoghq.eu\": [\"apikey4\"]}'
+DD_PROCESS_ADDITIONAL_ENDPOINTS='{\"mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"mydomain.datadoghq.eu\": [\"apikey4\"]}'
 ```
 
 {{% /tab %}}
@@ -102,17 +102,17 @@ In `datadog.yaml`:
 orchestrator_explorer:
   [...]
   orchestrator_additional_endpoints:
-    "https://mydomain.datadoghq.com":
+    "mydomain.datadoghq.com":
     - apikey2
     - apikey3
-    "https://mydomain.datadoghq.eu":
+    "mydomain.datadoghq.eu":
     - apikey4
 ```
 
 ### Environment variable configuration
 
 ```bash
-DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_ADDITIONAL_ENDPOINTS='{\"https://mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://mydomain.datadoghq.eu\": [\"apikey4\"]}'
+DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_ADDITIONAL_ENDPOINTS='{\"mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"mydomain.datadoghq.eu\": [\"apikey4\"]}'
 ```
 
 {{% /tab %}}
@@ -127,17 +127,17 @@ In `datadog.yaml`:
 evp_proxy_config:
   [...]
   additional_endpoints:
-    "https://mydomain.datadoghq.com":
+    "mydomain.datadoghq.com":
     - apikey2
     - apikey3
-    "https://mydomain.datadoghq.eu":
+    "mydomain.datadoghq.eu":
     - apikey4
 ```
 
 ### Environment variable configuration
 
 ```bash
-DD_EVP_PROXY_CONFIG_ADDITIONAL_ENDPOINTS='{\"https://mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://mydomain.datadoghq.eu\": [\"apikey4\"]}'
+DD_EVP_PROXY_CONFIG_ADDITIONAL_ENDPOINTS='{\"mydomain.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"mydomain.datadoghq.eu\": [\"apikey4\"]}'
 ```
 
 {{% /tab %}}
@@ -156,7 +156,7 @@ logs_config:
   use_http: true
   additional_endpoints:
   - api_key: "apiKey2"
-    Host: "https://mydomain.datadoghq.com"
+    Host: "mydomain.datadoghq.com"
     Port: 443
     is_reliable: true
 ```
@@ -165,7 +165,7 @@ logs_config:
 
 ```bash
 DD_LOGS_CONFIG_USE_HTTP=true
-DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS="[{\"api_key\": \"apiKey2\", \"Host\": \"https://mydomain.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
+DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS="[{\"api_key\": \"apiKey2\", \"Host\": \"mydomain.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
 ```
 
 {{% /tab %}}
@@ -180,21 +180,21 @@ database_monitoring:
     use_http: true
     additional_endpoints:
     - api_key: "apiKey2"
-      Host: "https://mydomain.datadoghq.com"
+      Host: "mydomain.datadoghq.com"
       Port: 443
       is_reliable: true
   activity:
     use_http: true
     additional_endpoints:
     - api_key: "apiKey2"
-      Host: "https://mydomain.datadoghq.com"
+      Host: "mydomain.datadoghq.com"
       Port: 443
       is_reliable: true
   metrics:
     use_http: true
     additional_endpoints:
     - api_key: "apiKey2"
-      Host: "https://mydomain.datadoghq.com"
+      Host: "mydomain.datadoghq.com"
       Port: 443
       is_reliable: true
 ```
@@ -203,11 +203,11 @@ database_monitoring:
 
 ```bash
 DD_DATABASE_MONITORING_SAMPLES_USE_HTTP=true
-DD_DATABASE_MONITORING_SAMPLES_ADDITIONAL_ENDPOINTS="[{\"api_key\": \"apiKey2\", \"Host\": \"https://mydomain.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
+DD_DATABASE_MONITORING_SAMPLES_ADDITIONAL_ENDPOINTS="[{\"api_key\": \"apiKey2\", \"Host\": \"mydomain.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
 DD_DATABASE_MONITORING_ACTIVITY_USE_HTTP=true
-DD_DATABASE_MONITORING_ACTIVITY_ADDITIONAL_ENDPOINTS="[{\"api_key\": \"apiKey2\", \"Host\": \"https://mydomain.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
+DD_DATABASE_MONITORING_ACTIVITY_ADDITIONAL_ENDPOINTS="[{\"api_key\": \"apiKey2\", \"Host\": \"mydomain.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
 DD_DATABASE_MONITORING_METRICS_USE_HTTP=true
-DD_DATABASE_MONITORING_METRICS_ADDITIONAL_ENDPOINTS="[{\"api_key\": \"apiKey2\", \"Host\": \"https://mydomain.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
+DD_DATABASE_MONITORING_METRICS_ADDITIONAL_ENDPOINTS="[{\"api_key\": \"apiKey2\", \"Host\": \"mydomain.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
 ```
 
 {{% /tab %}}
@@ -223,7 +223,7 @@ network_devices:
     use_http: true
     additional_endpoints:
     - api_key: "apiKey2"
-      Host: "https://mydomain.datadoghq.com"
+      Host: "mydomain.datadoghq.com"
       Port: 443
       is_reliable: true
   snmp_traps:
@@ -231,7 +231,7 @@ network_devices:
       use_http: true
       additional_endpoints:
       - api_key: "apiKey2"
-        Host: "https://mydomain.datadoghq.com"
+        Host: "mydomain.datadoghq.com"
         Port: 443
         is_reliable: true
 ```
@@ -240,7 +240,7 @@ network_devices:
 
 ```bash
 DD_NETWORK_DEVICES_METADATA_USE_HTTP=true
-DD_NETWORK_DEVICES_METADATA_ADDITIONAL_ENDPOINTS="[{\"api_key\": \"apiKey2\", \"Host\": \"https://mydomain.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
+DD_NETWORK_DEVICES_METADATA_ADDITIONAL_ENDPOINTS="[{\"api_key\": \"apiKey2\", \"Host\": \"mydomain.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
 ```
 
 {{% /tab %}}
@@ -255,7 +255,7 @@ In `datadog.yaml`:
     use_http: true
     additional_endpoints:
     - api_key: "apiKey2"
-      Host: "https://mydomain.datadoghq.com"
+      Host: "mydomain.datadoghq.com"
       Port: 443
       is_reliable: true
 ```
@@ -264,7 +264,7 @@ In `datadog.yaml`:
 
 ```bash
 DD_​​COMPLIANCE_CONFIG_ENDPOINTS_USE_HTTP=true
-DD_​​COMPLIANCE_CONFIG_ENDPOINTS_ADDITIONAL_ENDPOINTS="[{\"api_key\": \"apiKey2\", \"Host\": \"https://mydomain.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
+DD_​​COMPLIANCE_CONFIG_ENDPOINTS_ADDITIONAL_ENDPOINTS="[{\"api_key\": \"apiKey2\", \"Host\": \"mydomain.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
 ```
 
 {{% /tab %}}
@@ -279,7 +279,7 @@ runtime_security_config:
     use_http: true
     additional_endpoints:
     - api_key: "apiKey2"
-      Host: "https://mydomain.datadoghq.com"
+      Host: "mydomain.datadoghq.com"
       Port: 443
       is_reliable: true
 ```
@@ -288,7 +288,7 @@ runtime_security_config:
 
 ```bash
 DD_​​RUNTIME_SECURITY_CONFIG_ENDPOINTS_USE_HTTP=true
-DD_​​RUNTIME_SECURITY_CONFIG_ENDPOINTS_ADDITIONAL_ENDPOINTS="[{\"api_key\": \"apiKey2\", \"Host\": \"https://mydomain.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
+DD_​​RUNTIME_SECURITY_CONFIG_ENDPOINTS_ADDITIONAL_ENDPOINTS="[{\"api_key\": \"apiKey2\", \"Host\": \"mydomain.datadoghq.com\", \"Port\": 443, \"is_reliable\": true}]"
 ```
 
 {{% /tab %}}
@@ -320,17 +320,17 @@ and add the relevant settings to `customAgentConfig`.
   ## Note the `agents.useConfigMap` needs to be set to `true` for this parameter to be taken into account.
   customAgentConfig:
     additional_endpoints:
-      "https://mydomain.datadoghq.com":
+      "mydomain.datadoghq.com":
       - apikey2
       - apikey3
-      "https://mydomain.datadoghq.eu":
+      "mydomain.datadoghq.eu":
       - apikey4 
 
     logs_config:
       use_http: true
       additional_endpoints:
       - api_key: "apiKey2"
-        Host: "https://mydomain.datadoghq.com"
+        Host: "mydomain.datadoghq.com"
         Port: 443
         is_reliable: true
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update the recommended configuration. Logs agent doesn't support the `https://` prefix for additional endpoint URLs. 

### Motivation
<!-- What inspired you to submit this pull request?-->

Correctness

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
