### PR TITLE
[WEB-2626] Index top-level containers pages

### DIFF
--- a/local/etc/algolia/docs_datadoghq.json
+++ b/local/etc/algolia/docs_datadoghq.json
@@ -119,7 +119,8 @@
                     "serverless",
                     "watchdog",
                     "database_monitoring",
-                    "profiler"
+                    "profiler",
+                    "containers"
                 ]
             },
             "tags": ["docs"],

--- a/local/etc/algolia/docs_datadoghq_preview.json
+++ b/local/etc/algolia/docs_datadoghq_preview.json
@@ -119,7 +119,8 @@
                     "serverless",
                     "watchdog",
                     "database_monitoring",
-                    "profiler"
+                    "profiler",
+                    "containers"
                 ]
             },
             "tags": ["docs"],


### PR DESCRIPTION
### What does this PR do?
indexes `containers/` pages in Algolia.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2626

### Preview
- There should be 1 search result for the `containers/kubernetes/data_collected` page: https://docs-staging.datadoghq.com/brian.deutsch/containers-indexing/search/?s=kubernetes.liveness_probe.success.total

- Searching for `kubernetes` from either the search page or home/left-side nav dropdowns should surface some results from `containers/` pages.   Same for `amazon ecs`, `cluster agent`, etc.

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
