### PR TITLE
Update sample manifests for 7.38.2

### DIFF
--- a/static/resources/yaml/datadog-agent-aks.yaml
+++ b/static/resources/yaml/datadog-agent-aks.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.33.6"
+    chart: "datadog-2.37.4"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -191,6 +191,17 @@ rules:
       - get
       - watch
   - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+    verbs: ["get", "list", "watch", "update", "create"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
+    verbs: ["get"]
+  - apiGroups:
       - policy
     resources:
       - podsecuritypolicies
@@ -223,6 +234,34 @@ subjects:
     name: datadog-cluster-agent
     namespace: default
 ---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: Role
+metadata:
+  labels: {}
+  name: datadog-cluster-agent-main
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "update", "create"]
+---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: RoleBinding
+metadata:
+  labels: {}
+  name: "datadog-cluster-agent-main"
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: datadog-cluster-agent-main
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: default
+---
 # Source: datadog/templates/agent-services.yaml
 apiVersion: v1
 kind: Service
@@ -238,6 +277,24 @@ spec:
     - port: 5005
       name: agentport
       protocol: TCP
+---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-cluster-agent-admission-controller
+  namespace: default
+  labels:
+    app: "datadog"
+    chart: "datadog-2.37.4"
+    release: "datadog"
+    heritage: "Helm"
+spec:
+  selector:
+    app: datadog-cluster-agent
+  ports:
+    - port: 443
+      targetPort: 8000
 ---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
@@ -262,7 +319,7 @@ spec:
         runAsUser: 0
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -370,7 +427,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -438,9 +495,9 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
-          command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]
           resources: {}
           env:
             # Needs to be removed when Agent N-2 is built with Golang 1.17
@@ -507,7 +564,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -517,7 +574,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -624,7 +681,7 @@ spec:
       serviceAccountName: datadog-cluster-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:1.19.0"
+          image: "gcr.io/datadoghq/cluster-agent:1.22.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -643,6 +700,14 @@ spec:
                   name: "datadog"
                   key: api-key
                   optional: true
+            - name: DD_ADMISSION_CONTROLLER_ENABLED
+              value: "true"
+            - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
+              value: "false"
+            - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
+              value: datadog-cluster-agent-admission-controller
+            - name: DD_ADMISSION_CONTROLLER_FAILURE_POLICY
+              value: "Ignore"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.33.6"
+    chart: "datadog-2.37.4"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -83,11 +83,16 @@ data:
       enabled: false
     runtime_security_config:
       enabled: true
+      fim_enabled: false
       socket: /var/run/sysprobe/runtime-security.sock
       policies:
         dir: /etc/datadog-agent/runtime-security.d
       syscall_monitor:
         enabled: false
+      network:
+        enabled: false
+      activity_dump:
+        traced_cgroups_count: 0
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -190,6 +195,7 @@ data:
             "newfstatat",
             "open",
             "openat",
+            "openat2",
             "pause",
             "perf_event_open",
             "pipe",
@@ -445,6 +451,17 @@ rules:
       - get
       - watch
   - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+    verbs: ["get", "list", "watch", "update", "create"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
+    verbs: ["get"]
+  - apiGroups:
       - ""
     resources:
       - serviceaccounts
@@ -505,6 +522,34 @@ subjects:
     name: datadog-cluster-agent
     namespace: default
 ---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: Role
+metadata:
+  labels: {}
+  name: datadog-cluster-agent-main
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "update", "create"]
+---
+# Source: datadog/templates/cluster-agent-rbac.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: RoleBinding
+metadata:
+  labels: {}
+  name: "datadog-cluster-agent-main"
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: datadog-cluster-agent-main
+subjects:
+  - kind: ServiceAccount
+    name: datadog-cluster-agent
+    namespace: default
+---
 # Source: datadog/templates/agent-services.yaml
 apiVersion: v1
 kind: Service
@@ -520,6 +565,24 @@ spec:
     - port: 5005
       name: agentport
       protocol: TCP
+---
+# Source: datadog/templates/agent-services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: datadog-cluster-agent-admission-controller
+  namespace: default
+  labels:
+    app: "datadog"
+    chart: "datadog-2.37.4"
+    release: "datadog"
+    heritage: "Helm"
+spec:
+  selector:
+    app: datadog-cluster-agent
+  ports:
+    - port: 443
+      targetPort: 8000
 ---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
@@ -547,7 +610,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -671,7 +734,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -737,9 +800,9 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
-          command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]
           resources: {}
           env:
             # Needs to be removed when Agent N-2 is built with Golang 1.17
@@ -812,7 +875,7 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -882,7 +945,7 @@ spec:
               mountPropagation: None
               readOnly: true
         - name: security-agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -927,8 +990,6 @@ spec:
               value: "/etc/datadog-agent/runtime-security.d"
             - name: DD_RUNTIME_SECURITY_CONFIG_SOCKET
               value: /var/run/sysprobe/runtime-security.sock
-            - name: DD_RUNTIME_SECURITY_CONFIG_SYSCALL_MONITOR_ENABLED
-              value: "false"
             - name: DD_DOGSTATSD_SOCKET
               value: "/var/run/datadog/dsd.socket"
           volumeMounts:
@@ -969,7 +1030,7 @@ spec:
               subPath: system-probe.yaml
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -979,7 +1040,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -1017,7 +1078,7 @@ spec:
               value: "yes"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json
@@ -1143,7 +1204,7 @@ spec:
       serviceAccountName: datadog-cluster-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:1.19.0"
+          image: "gcr.io/datadoghq/cluster-agent:1.22.0"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -1162,6 +1223,14 @@ spec:
                   name: "datadog"
                   key: api-key
                   optional: true
+            - name: DD_ADMISSION_CONTROLLER_ENABLED
+              value: "true"
+            - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
+              value: "false"
+            - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
+              value: datadog-cluster-agent-admission-controller
+            - name: DD_ADMISSION_CONTROLLER_FAILURE_POLICY
+              value: "Ignore"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -49,7 +49,7 @@ spec:
         runAsUser: 0
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -145,7 +145,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -205,7 +205,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -215,7 +215,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -49,7 +49,7 @@ spec:
         runAsUser: 0
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -160,7 +160,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -220,7 +220,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -230,7 +230,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -49,7 +49,7 @@ spec:
         runAsUser: 0
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -161,7 +161,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -171,7 +171,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -60,11 +60,16 @@ data:
       enabled: false
     runtime_security_config:
       enabled: false
+      fim_enabled: false
       socket: /var/run/sysprobe/runtime-security.sock
       policies:
         dir: /etc/datadog-agent/runtime-security.d
       syscall_monitor:
         enabled: false
+      network:
+        enabled: false
+      activity_dump:
+        traced_cgroups_count: 0
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -167,6 +172,7 @@ data:
             "newfstatat",
             "open",
             "openat",
+            "openat2",
             "pause",
             "perf_event_open",
             "pipe",
@@ -305,7 +311,7 @@ spec:
         runAsUser: 0
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -407,9 +413,9 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
-          command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
+          command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]
           resources: {}
           env:
             # Needs to be removed when Agent N-2 is built with Golang 1.17
@@ -473,7 +479,7 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -544,7 +550,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -554,7 +560,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -594,7 +600,7 @@ spec:
               value: "true"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -49,7 +49,7 @@ spec:
         runAsUser: 0
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -146,7 +146,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -156,7 +156,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/static/resources/yaml/datadog-agent-windows-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-windows-all-features.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -130,7 +130,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -178,9 +178,9 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
-          command: ["process-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
+          command: ["process-agent", "-foreground", "--cfgpath=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
           env:
             # Needs to be removed when Agent N-2 is built with Golang 1.17
@@ -220,7 +220,7 @@ spec:
               mountPath: \\.\pipe\containerd-containerd
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -234,7 +234,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:

--- a/static/resources/yaml/datadog-agent-windows-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -122,7 +122,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -171,7 +171,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -185,7 +185,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:

--- a/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -130,7 +130,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -179,7 +179,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -193,7 +193,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:

--- a/static/resources/yaml/datadog-agent-windows-logs.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -131,7 +131,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -145,7 +145,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:

--- a/static/resources/yaml/datadog-agent-windows-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -123,7 +123,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -137,7 +137,7 @@ spec:
               mountPath: C:/Temp/install_info
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.35.2"
+          image: "gcr.io/datadoghq/agent:7.38.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update sample manifests to go from Agent `7.35.2` -> `7.38.2`, Helm `2.33.6` -> `2.37.4`.
### Motivation
<!-- What inspired you to submit this pull request?-->
Keep up to date

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
https://docs-staging.datadoghq.com/jack.davenport/k8s-daemonset-7.38/containers/kubernetes/installation?tab=daemonset

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
