### PR TITLE
add event API details and troubleshooting

### DIFF
--- a/content/en/logs/guide/sending-events-and-logs-to-datadog-with-amazon-eventbridge-api-destinations.md
+++ b/content/en/logs/guide/sending-events-and-logs-to-datadog-with-amazon-eventbridge-api-destinations.md
@@ -18,6 +18,7 @@ Before you begin, you need a [Datadog account][2], with [an API key][3], and you
 1. Follow the steps in the [Amazon Create an API destination docs][5] to add Datadog as an API destination.
     - Use API key authorization, with `DD-API-KEY` as your key name and your [Datadog API key][3] as the value.
     - For your destination endpoint, use `https://http-intake.logs.datadoghq.com/v1/input` for logs or `https://api.datadoghq.com/api/v1/events` for events, and set `POST` as the HTTP method. For more information about the differences between logs and events, see the [logs section][6], and the [events section][7] of the [Categories of Data docs page][8].
+    - If you are utilizing the events endpoint, you will need to include a `title` and `text` as `body.field` parameters in the API Destination connection. These are required values to `POST` to the events endpoint, see [Post an event API documentation][13]
 2. Once you've set up the destination, you can now follow the Amazon instructions to [create an EventBridge rule][9], where you set Datadog as your destination.
 3. Once you've set up the rule with Datadog as the destination, trigger an event by posting an event to EventBridge. For more information about pushing events to EventBridge from Datadog, see the [EventBridge integration docs][1]. For example, to trigger a test event by [uploading the objects to an S3 bucket][10] in your account, use this AWS CloudShell command:
 
@@ -26,6 +27,13 @@ Before you begin, you need a [Datadog account][2], with [an API key][3], and you
     aws s3 cp testfile.txt s3://YOUR_BUCKET_NAME
     ```
 4. Once events and logs are sending, after about five minutes, the data is available in the Datadog [logs console][11] or [events explorer][12], depending on which endpoint you are sending them to.
+
+## Troubleshooting
+
+To view the response of the API endpoints you can setup AWS SQS for more details regarding the payloads sent to Datadog. 
+1. Create a new queue in AWS SQS.
+2. In the target section for your EventBridge rule, expand the additional details section. 
+3. Select the AWS SQS created.
 
 ## Further Reading
 
@@ -44,3 +52,4 @@ Before you begin, you need a [Datadog account][2], with [an API key][3], and you
 [10]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html
 [11]: https://app.datadoghq.com/logs
 [12]: https://app.datadoghq.com/event/explorer
+[13]: https://docs.datadoghq.com/api/latest/events/#post-an-event


### PR DESCRIPTION
This document does not highlight the Datadog requirement to specify a title and text in the body the Event API call. Without these parameters, Events will not be posted to Datadog. Similarly since there is no guide on finding out why errors might be happening I also included a small section to self-guide users on basic troubleshooting.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
