### PR TITLE
[agent] Update supported macOS versions

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -146,7 +146,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [SUSE Enterprise Linux][7] with SysVinit | SUSE 11 SP4 in Agent 6.16.0/7.16.0 - 6.33.0/7.33.0        |
 | [OpenSUSE][7] with systemd               | OpenSUSE 15+ in Agent 6.33.0+/7.33.0+                     |
 | [Fedora][8]                              | Fedora 26+                                                |
-| [macOS][9]                               | macOS 10.12+                                              |
+| [macOS][9]                               | macOS 10.12+ in Agent < 6.35.0/7.35.0, macOS 10.13+ in Agent < 7.39.0, macOS 10.14+ in Agent 7.39.0+ |
 | [Windows Server][10]                     | Windows Server 2008 R2+ (including Server Core)           |
 | [Windows][10]                            | Windows 7+                                                |
 | [Windows Azure Stack HCI OS][10]         | All Versions                                              |
@@ -181,7 +181,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [Kubernetes][6]            | Version 1.3 to 1.8     |
 | [SUSE Enterprise Linux][7] | SUSE 11 SP4+           |
 | [Fedora][8]                | Fedora 26+             |
-| [MacOS][9]                 | macOS 10.10+           |
+| [macOS][9]                 | macOS 10.10+           |
 | [Windows Server][10]       | Windows Server 2008+   |
 | [Windows][10]              | Windows 7+             |
 

--- a/content/en/agent/basic_agent_usage/osx.md
+++ b/content/en/agent/basic_agent_usage/osx.md
@@ -23,7 +23,14 @@ This page outlines the basic features of the Datadog Agent for macOS. If you hav
 
 By default, the Agent is installed in a sandbox located at `/opt/datadog-agent`. You can move this folder anywhere; however, this documentation assumes a default installation location.
 
-**Note**: macOS 10.12 and above are supported by the Agent v6, macOS 10.10 and above by the Agent v5.
+## Supported macOS versions
+
+| macOS version       | Supported Agent versions                                            |
+|---------------------|---------------------------------------------------------------------|
+| macOS 10.10 & 10.11 | Agent v5                                                            |
+| macOS 10.12         | Agent v5, Agent v6 until v6.34.0, Agent v7 until v7.34.0            |
+| macOS 10.13         | Agent v5, Agent v6 until v6.38.2, Agent v7 until v7.38.2            |
+| macOS 10.14+        | Agent v5, Agent v6, Agent v7                                        |
 
 ## Commands
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates documentation about the macOS Agent, detailing which versions of the Agent support which version.

### Motivation
<!-- What inspired you to submit this pull request?-->

Better documentation on supported versions of the macOS Agent.

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

[Basic Agent usage page](https://docs-staging.datadoghq.com/kylian.serrania/update-macos-agent-versions/agent/basic_agent_usage/?tab=agentv6v7)
[macOS page](https://docs-staging.datadoghq.com/kylian.serrania/update-macos-agent-versions/agent/basic_agent_usage/osx/?tab=agentv6v7)

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
