### PR TITLE
Update RUM SDK proxy configuration guide

### DIFF
--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -74,9 +74,9 @@ To successfully proxy request to Datadog:
 2. Forward the request to the URL set in the `ddforward` query parameter using the POST method.
 4. The request body must remain unchanged.
 
-**IMPORTANT**: Ensure the `ddforward` attribute points to a valid RUM endpoint for your [Datadog Site](https://docs.datadoghq.com/getting_started/site/). Failing to do so may expose your systems to SSRF/XSS attacks. The list of valid intake URL patterns per sites are:
+**IMPORTANT**: Ensure the `ddforward` attribute points to a valid RUM endpoint for your [Datadog Site][2]. Failing to do so may expose your systems to SSRF/XSS attacks. The list of valid intake URL patterns per sites are:
 
-| Site    | Valid RUM URL Pattern                          | Site Parameter (SDK [initialization parameter](https://docs.datadoghq.com/real_user_monitoring/browser/#initialization-parameters))| 
+| Site    | Valid RUM URL Pattern                          | Site Parameter (SDK [initialization parameter][1])| 
 |---------|------------------------------------------------|---------------------|
 | US1     | `https://*.browser-intake-datadoghq.com/*`     | `datadoghq.com`     |
 | US3     | `https://*.browser-intake-us3-datadoghq.com/*` | `us3.datadoghq.com` |
@@ -89,3 +89,4 @@ To successfully proxy request to Datadog:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /real_user_monitoring/browser/#initialization-parameters
+[2]: /getting_started/site/

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -64,7 +64,7 @@ window.DD_RUM &&
 {{% /tab %}}
 {{< /tabs >}}
 
-## Proxy setup
+## Proxy Setup
 
 When your proxy receives data from the RUM Browser SDK, it must be forwarded to Datadog. The RUM Browser SDK adds the `ddforward` query parameter to all POST requests to your proxy. This query parameter contains the URL where all data must be forwarded to.
 
@@ -72,8 +72,17 @@ To successfully proxy request to Datadog:
 
 1. Add a `X-Forwarded-For` header containing the request client IP address for accurate geoIP.
 2. Forward the request to the URL set in the `ddforward` query parameter using the POST method.
+4. The request body must remain unchanged.
 
-**Note:** The request body must remain unchanged.
+**IMPORTANT**: Please ensure the `ddforward` attribute points to a valid RUM endpoint for your [Datadog Site](https://docs.datadoghq.com/getting_started/site/). Failing to do so may expose your systems to SSRF/XSS attacks. The list of valid intake URL patterns per sites are:
+
+| Site    | Valid RUM URL Pattern                          | Site Parameter (SDK [initialization parameter](https://docs.datadoghq.com/real_user_monitoring/browser/#initialization-parameters))| 
+|---------|------------------------------------------------|---------------------|
+| US1     | `https://*.browser-intake-datadoghq.com/*`     | `datadoghq.com`     |
+| US3     | `https://*.browser-intake-us3-datadoghq.com/*` | `us3.datadoghq.com` |
+| US5     | `https://*.browser-intake-us5-datadoghq.com/*` | `us5.datadoghq.com` |
+| EU1     | `https://*.browser-intake-datadoghq.eu/*`      | `datadoghq.eu`      |
+| US1-FED | `https://*.browser-intake-ddog-gov.com/*`      | `ddog-gov.com`      |
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -76,7 +76,7 @@ To successfully proxy request to Datadog:
 
 **IMPORTANT**: Ensure the `ddforward` attribute points to a valid RUM endpoint for your [Datadog site][2]. Failing to do so may expose your systems to SSRF/XSS attacks. The list of valid intake URL patterns per sites are:
 
-| Site    | Valid RUM URL Pattern                          | Site Parameter (SDK [initialization parameter][1])| 
+| Site    | Valid RUM URL Pattern                          | Site Parameter (SDK [initialization parameter][3])| 
 |---------|------------------------------------------------|---------------------|
 | US1     | `https://*.browser-intake-datadoghq.com/*`     | `datadoghq.com`     |
 | US3     | `https://*.browser-intake-us3-datadoghq.com/*` | `us3.datadoghq.com` |
@@ -90,3 +90,4 @@ To successfully proxy request to Datadog:
 
 [1]: /real_user_monitoring/browser/#initialization-parameters
 [2]: /getting_started/site/
+[3]: /real_user_monitoring/browser/#initialization-parameters

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -64,7 +64,7 @@ window.DD_RUM &&
 {{% /tab %}}
 {{< /tabs >}}
 
-## Proxy Setup
+## Proxy setup
 
 When your proxy receives data from the RUM Browser SDK, it must be forwarded to Datadog. The RUM Browser SDK adds the `ddforward` query parameter to all POST requests to your proxy. This query parameter contains the URL where all data must be forwarded to.
 
@@ -74,7 +74,7 @@ To successfully proxy request to Datadog:
 2. Forward the request to the URL set in the `ddforward` query parameter using the POST method.
 4. The request body must remain unchanged.
 
-**IMPORTANT**: Please ensure the `ddforward` attribute points to a valid RUM endpoint for your [Datadog Site](https://docs.datadoghq.com/getting_started/site/). Failing to do so may expose your systems to SSRF/XSS attacks. The list of valid intake URL patterns per sites are:
+**IMPORTANT**: Ensure the `ddforward` attribute points to a valid RUM endpoint for your [Datadog Site](https://docs.datadoghq.com/getting_started/site/). Failing to do so may expose your systems to SSRF/XSS attacks. The list of valid intake URL patterns per sites are:
 
 | Site    | Valid RUM URL Pattern                          | Site Parameter (SDK [initialization parameter](https://docs.datadoghq.com/real_user_monitoring/browser/#initialization-parameters))| 
 |---------|------------------------------------------------|---------------------|

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -74,7 +74,7 @@ To successfully proxy request to Datadog:
 2. Forward the request to the URL set in the `ddforward` query parameter using the POST method.
 4. The request body must remain unchanged.
 
-**IMPORTANT**: Ensure the `ddforward` attribute points to a valid RUM endpoint for your [Datadog Site][2]. Failing to do so may expose your systems to SSRF/XSS attacks. The list of valid intake URL patterns per sites are:
+**IMPORTANT**: Ensure the `ddforward` attribute points to a valid RUM endpoint for your [Datadog site][2]. Failing to do so may expose your systems to SSRF/XSS attacks. The list of valid intake URL patterns per sites are:
 
 | Site    | Valid RUM URL Pattern                          | Site Parameter (SDK [initialization parameter][1])| 
 |---------|------------------------------------------------|---------------------|


### PR DESCRIPTION
### What does this PR do?

This PR updates the RUM SDK proxy configuration guide to clearly warn the reader about the security risk of not validating the `ddforward` attrbute.

### Motivation
Not ensuring the ddforward parameter points to a valid Datadog RUM URL can lead to SSRF/XSS attacks.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
- The list of URL patterns was taken from the [SDK source code](https://github.com/DataDog/browser-sdk/blob/e88668449d898b549e3168c79e96cf744c9e1324/developer-extension/src/background/intakeUrlPatterns.ts), omitting URLs used in older versions of the SDK.
- Formatting (i.e: writing **important**) was inspired from the [AWS Integration Billing](https://docs.datadoghq.com/account_management/billing/aws/#overview) page.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
