### PR TITLE
add graphql-core integration to docs

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -113,6 +113,7 @@ The `ddtrace` library includes support for the following libraries:
 | [Mako][56]        | >= 0.1.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mako        |
 | [Requests][57]    | >= 2.08           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#requests    |
 | [urllib3][58]     | >= 1.22           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#urllib3     |
+| [graphql-core][59]| >= 2.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#graphql |
 
 ## Further Reading
 
@@ -177,3 +178,4 @@ The `ddtrace` library includes support for the following libraries:
 [56]: https://www.makotemplates.org
 [57]: https://requests.readthedocs.io/en/master/
 [58]: https://urllib3.readthedocs.io/en/stable/
+[59]: https://graphql-core-3.readthedocs.io/en/latest/intro.html


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Documents graphql integration in the python tracer. The graphql-core integration was introduced in the ddtrace v1.4.0.

### Motivation

Sync corp docs with dd-trace-py in-app docs.

<!-- ### Preview -->


### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
