### PR TITLE
RUM proxy configuration: add intake url for previous sdk version

### DIFF
--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -74,11 +74,11 @@ To successfully proxy request to Datadog:
 2. Forward the request to the URL set in the `ddforward` query parameter using the POST method.
 4. The request body must remain unchanged.
 
-**IMPORTANT**: Ensure the `ddforward` attribute points to a valid RUM endpoint for your [Datadog site][2]. Failing to do so may expose your systems to SSRF/XSS attacks. The list of valid intake URL patterns per sites are:
+**IMPORTANT**: Ensure the `ddforward` attribute points to a valid Datadog endpoint for your [Datadog site][2]. Failing to do so may expose your systems to SSRF/XSS attacks. The list of valid intake URL patterns per sites are:
 
 For latest SDK version:
 
-| Site    | Valid RUM URL Pattern                          | Site Parameter (SDK [initialization parameter][3])|
+| Site    | Valid intake URL Pattern                       | Site Parameter (SDK [initialization parameter][3])|
 |---------|------------------------------------------------|---------------------|
 | US1     | `https://*.browser-intake-datadoghq.com/*`     | `datadoghq.com`     |
 | US3     | `https://*.browser-intake-us3-datadoghq.com/*` | `us3.datadoghq.com` |
@@ -88,12 +88,12 @@ For latest SDK version:
 
 Before SDK v4:
 
-| Site    | Valid RUM URL Pattern                 | Site Parameter (SDK [initialization parameter][3])|
-|---------|---------------------------------------|---------------------|
-| US1     | `https://*.logs.datadoghq.com/*`      | `datadoghq.com`     |
-| US3     | `https://*.logs.us3-datadoghq.com/*`  | `us3.datadoghq.com` |
-| EU1     | `https://*.logs.datadoghq.eu/*`       | `datadoghq.eu`      |
-| US1-FED | `https://*.logs.ddog-gov.com/*`       | `ddog-gov.com`      |
+| Site    | Valid intake URL Pattern             | Site Parameter (SDK [initialization parameter][3])|
+|---------|--------------------------------------|---------------------|
+| US1     | `https://*.logs.datadoghq.com/*`     | `datadoghq.com`     |
+| US3     | `https://*.logs.us3-datadoghq.com/*` | `us3.datadoghq.com` |
+| EU1     | `https://*.logs.datadoghq.eu/*`      | `datadoghq.eu`      |
+| US1-FED | `https://*.logs.ddog-gov.com/*`      | `ddog-gov.com`      |
 
 
 

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -76,7 +76,8 @@ To successfully proxy request to Datadog:
 
 **IMPORTANT**: Ensure the `ddforward` attribute points to a valid Datadog endpoint for your [Datadog site][2]. Failing to do so may expose your systems to SSRF/XSS attacks. The list of valid intake URL patterns per sites are:
 
-For latest SDK version:
+{{< tabs >}}
+{{% tab "latest version" %}}
 
 | Site    | Valid intake URL Pattern                       | Site Parameter (SDK [initialization parameter][3])|
 |---------|------------------------------------------------|---------------------|
@@ -86,7 +87,8 @@ For latest SDK version:
 | EU1     | `https://*.browser-intake-datadoghq.eu/*`      | `datadoghq.eu`      |
 | US1-FED | `https://*.browser-intake-ddog-gov.com/*`      | `ddog-gov.com`      |
 
-Before SDK v4:
+{{% /tab %}}
+{{% tab "before v4" %}}
 
 | Site    | Valid intake URL Pattern             | Site Parameter (SDK [initialization parameter][3])|
 |---------|--------------------------------------|---------------------|
@@ -95,7 +97,8 @@ Before SDK v4:
 | EU1     | `https://*.logs.datadoghq.eu/*`      | `datadoghq.eu`      |
 | US1-FED | `https://*.logs.ddog-gov.com/*`      | `ddog-gov.com`      |
 
-
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -76,13 +76,26 @@ To successfully proxy request to Datadog:
 
 **IMPORTANT**: Ensure the `ddforward` attribute points to a valid RUM endpoint for your [Datadog site][2]. Failing to do so may expose your systems to SSRF/XSS attacks. The list of valid intake URL patterns per sites are:
 
-| Site    | Valid RUM URL Pattern                          | Site Parameter (SDK [initialization parameter][3])| 
+For latest SDK version:
+
+| Site    | Valid RUM URL Pattern                          | Site Parameter (SDK [initialization parameter][3])|
 |---------|------------------------------------------------|---------------------|
 | US1     | `https://*.browser-intake-datadoghq.com/*`     | `datadoghq.com`     |
 | US3     | `https://*.browser-intake-us3-datadoghq.com/*` | `us3.datadoghq.com` |
 | US5     | `https://*.browser-intake-us5-datadoghq.com/*` | `us5.datadoghq.com` |
 | EU1     | `https://*.browser-intake-datadoghq.eu/*`      | `datadoghq.eu`      |
 | US1-FED | `https://*.browser-intake-ddog-gov.com/*`      | `ddog-gov.com`      |
+
+Before SDK v4:
+
+| Site    | Valid RUM URL Pattern                 | Site Parameter (SDK [initialization parameter][3])|
+|---------|---------------------------------------|---------------------|
+| US1     | `https://*.logs.datadoghq.com/*`      | `datadoghq.com`     |
+| US3     | `https://*.logs.us3-datadoghq.com/*`  | `us3.datadoghq.com` |
+| EU1     | `https://*.logs.datadoghq.eu/*`       | `datadoghq.eu`      |
+| US1-FED | `https://*.logs.ddog-gov.com/*`       | `ddog-gov.com`      |
+
+
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -74,10 +74,12 @@ To successfully proxy request to Datadog:
 2. Forward the request to the URL set in the `ddforward` query parameter using the POST method.
 4. The request body must remain unchanged.
 
-**IMPORTANT**: Ensure the `ddforward` attribute points to a valid Datadog endpoint for your [Datadog site][2]. Failing to do so may expose your systems to SSRF/XSS attacks. The list of valid intake URL patterns per sites are:
+Ensure the `ddforward` attribute points to a valid Datadog endpoint for your [Datadog site][2]. Failure to do so may expose your systems to SSRF/XSS attacks. 
+
+The site parameter is an SDK [initialization parameter][3]. Valid intake URL patterns for each site are listed below:
 
 {{< tabs >}}
-{{% tab "latest version" %}}
+{{% tab "Latest version" %}}
 
 | Site    | Valid intake URL Pattern                       | Site Parameter      |
 |---------|------------------------------------------------|---------------------|
@@ -88,7 +90,7 @@ To successfully proxy request to Datadog:
 | US1-FED | `https://*.browser-intake-ddog-gov.com/*`      | `ddog-gov.com`      |
 
 {{% /tab %}}
-{{% tab "before v4" %}}
+{{% tab "Before `v4`" %}}
 
 | Site    | Valid intake URL Pattern             | Site Parameter      |
 |---------|--------------------------------------|---------------------|
@@ -100,7 +102,6 @@ To successfully proxy request to Datadog:
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note:** Site parameter is an SDK [initialization parameter][3].
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -79,7 +79,7 @@ To successfully proxy request to Datadog:
 {{< tabs >}}
 {{% tab "latest version" %}}
 
-| Site    | Valid intake URL Pattern                       | Site Parameter (SDK [initialization parameter][3])|
+| Site    | Valid intake URL Pattern                       | Site Parameter      |
 |---------|------------------------------------------------|---------------------|
 | US1     | `https://*.browser-intake-datadoghq.com/*`     | `datadoghq.com`     |
 | US3     | `https://*.browser-intake-us3-datadoghq.com/*` | `us3.datadoghq.com` |
@@ -90,7 +90,7 @@ To successfully proxy request to Datadog:
 {{% /tab %}}
 {{% tab "before v4" %}}
 
-| Site    | Valid intake URL Pattern             | Site Parameter (SDK [initialization parameter][3])|
+| Site    | Valid intake URL Pattern             | Site Parameter      |
 |---------|--------------------------------------|---------------------|
 | US1     | `https://*.logs.datadoghq.com/*`     | `datadoghq.com`     |
 | US3     | `https://*.logs.us3-datadoghq.com/*` | `us3.datadoghq.com` |
@@ -99,6 +99,8 @@ To successfully proxy request to Datadog:
 
 {{% /tab %}}
 {{< /tabs >}}
+
+**Note:** Site parameter is an SDK [initialization parameter][3].
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

List intake url patterns for sdk version < v4

### Motivation

Follow up of #15074 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
