### PR TITLE
[DOCS-3983] getSpan is now apart of TraceAPI

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -172,7 +172,7 @@ function readInt32 (buffer, offset) {
 
 const tracingFormat = function () {
   return winston.format(info => {
-    const span = opentelemetry.getSpan(opentelemetry.context.active());
+    const span = opentelemetry.trace.getSpan(opentelemetry.context.active());
     if (span) {
       const context = span.context();
       const traceIdEnd = context.traceId.slice(context.traceId.length / 2)


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
As of at least @opentelemetry/api@1.1.0, `opentelemetry.getSpan` needs to be `opentelemetry.trace.getSpan`. Looks like the changed happened here: https://github.com/open-telemetry/opentelemetry-js-api/commit/e1745d19b9bdfd1af7d805a6b2c32a5a5dbf4d15

### Motivation
Working on an custom OTEL integration and a subtle hiccup trying to figure out where the `getSpan` comes from. Minor change but can be a little frustrating to new comers.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
