### PR TITLE
[DOCS-3986] Correct datadog agent configuration path

### DIFF
--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -266,7 +266,7 @@ If you are _not_ correlating logs and traces, you can remove the MDC placeholder
 
 ## Configure the Datadog Agent
 
-Create a file `java.d/conf.yaml` in the Agent’s `conf.d/` directory with the following content:
+Create a file `java.d/conf.yaml` in the Agent's `conf.d/` directory with the following content:
 
 ```yaml
 #Log section

--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -266,7 +266,7 @@ If you are _not_ correlating logs and traces, you can remove the MDC placeholder
 
 ## Configure the Datadog Agent
 
-Create a file `java.yaml` in the Agent's `conf.d/` directory with the following content:
+Create a file `java.d/conf.yaml` in the Agent’s `conf.d/` directory with the following content:
 
 ```yaml
 #Log section


### PR DESCRIPTION
### What does this PR do?
The documentation and the Getting Started guide of the web-ui differ.
The information from the web-ui is the correct one and the one from the docs is incorrect (or maybe obsolete).
Therefore I have changed the documentation so that it is consistent again

### Motivation
I tried to configure a datadog agent to send logs to Datadog. 
This has not worked because the configuration path from the documentation was wrong:
> Create a file java.yaml in the Agent’s conf.d/ directory with the following content:

[Configure the Datadog Agent](https://docs.datadoghq.com/logs/log_collection/java/?tab=logback#configure-the-datadog-agent)
<br />
Afterwards I tried the path described in the Web-UI and it worked successfully with:
> Create a file java.d/conf.yaml in the Agent’s conf.d/ directory with the following content:

[Web-UI](https://app.datadoghq.eu/logs/onboarding/server)
<br />

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
