### PR TITLE
Fix audit trail viz to list

### DIFF
--- a/content/en/account_management/audit_trail/_index.md
+++ b/content/en/account_management/audit_trail/_index.md
@@ -90,7 +90,7 @@ To create a monitor on a type of audit trail event or by specificTrail attribute
 Give more visual context to your audit trail events with dashboards. To create an audit dashboard:
 
 1. Create a [New Dashboard][6] in Datadog.
-2. Select your visualization. You can visualize an Audit event as [top lists][7], [timeseries][8], and [log streams][9].
+2. Select your visualization. You can visualize an Audit event as [top lists][7], [timeseries][8], and [lists][9].
 3. [Graph your data][10]: Under edit, select *Audit Events* as the data source, and create a query. Audit events are filtered by count and can be grouped by different facets. Select a facet and limit.
 {{< img src="account_management/audit_logs/audit_graphing.png" alt="Set Audit Trail as a data source to graph your data" style="width:100%;">}}
 4. Set your display preferences and give your graph a title. Click the *Save* button to create the dashboard.
@@ -113,6 +113,6 @@ Datadog Audit Trail comes with an [out-of-the-box dashboard][11] that shows vari
 [6]: /dashboards/
 [7]: /dashboards/widgets/top_list/
 [8]: /dashboards/widgets/timeseries/
-[9]: /dashboards/widgets/log_stream/
+[9]: /dashboards/widgets/lists/
 [10]: /dashboards/querying/#choose-the-metric-to-graph/
 [11]: https://app.datadoghq.com/dash/integration/30691/datadog-audit-trail-overview?from_ts=1652452436351&to_ts=1655130836351&live=true

--- a/content/en/account_management/audit_trail/_index.md
+++ b/content/en/account_management/audit_trail/_index.md
@@ -113,6 +113,6 @@ Datadog Audit Trail comes with an [out-of-the-box dashboard][11] that shows vari
 [6]: /dashboards/
 [7]: /dashboards/widgets/top_list/
 [8]: /dashboards/widgets/timeseries/
-[9]: /dashboards/widgets/lists/
+[9]: /dashboards/widgets/list/
 [10]: /dashboards/querying/#choose-the-metric-to-graph/
 [11]: https://app.datadoghq.com/dash/integration/30691/datadog-audit-trail-overview?from_ts=1652452436351&to_ts=1655130836351&live=true

--- a/content/en/account_management/audit_trail/_index.md
+++ b/content/en/account_management/audit_trail/_index.md
@@ -90,7 +90,7 @@ To create a monitor on a type of audit trail event or by specificTrail attribute
 Give more visual context to your audit trail events with dashboards. To create an audit dashboard:
 
 1. Create a [New Dashboard][6] in Datadog.
-2. Select your visualization. You can visualize an Audit event as [top lists][7], [timeseries][8], and [lists][9].
+2. Select your visualization. You can visualize Audit events as [top lists][7], [timeseries][8], and [lists][9].
 3. [Graph your data][10]: Under edit, select *Audit Events* as the data source, and create a query. Audit events are filtered by count and can be grouped by different facets. Select a facet and limit.
 {{< img src="account_management/audit_logs/audit_graphing.png" alt="Set Audit Trail as a data source to graph your data" style="width:100%;">}}
 4. Set your display preferences and give your graph a title. Click the *Save* button to create the dashboard.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes the visualization from log stream, which does not support Audit Trail events, to the list.

### Motivation
a support case https://datadoghq.atlassian.net/browse/LOGSS-6077
Approved by one of our Log PMs

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
