### PR TITLE
Add alias to frontmatter

### DIFF
--- a/content/en/dashboards/scheduled_reports.md
+++ b/content/en/dashboards/scheduled_reports.md
@@ -13,6 +13,8 @@ further_reading:
   - link: "https://learn.datadoghq.com/courses/building-better-dashboards"
     tag: "Learning Center"
     text: "Building Better Dashboards"
+aliases:
+    - /dashboards/reporting
 ---
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add an alias to the frontmatter of the new scheduled reports documentation to redirect users using the old URL

### Motivation
Mentioned in Slack

### Preview
https://docs-staging.datadoghq.com/bryce/add-reporting-alias/dashboards/

<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
