### PR TITLE
[ci-visibility] Add Instructions to set custom tags in dotnet

### DIFF
--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -149,6 +149,22 @@ The following list shows the default values for key configuration settings:
 
 All other [Datadog Tracer configuration][5] options can also be used.
 
+### Adding custom tags to tests
+
+You can add custom tags to your tests by using the current active span:
+
+```csharp
+// inside your test
+var scope = Tracer.Instance.ActiveScope; // from Datadog.Trace;
+if (scope != null) {
+    scope.Span.SetTag("test_owner", "my_team");
+}
+// test continues normally
+// ...
+```
+
+To create filters or `group by` fields for these tags, you must first create facets. For more information about adding tags, see the [Adding Tags][8] section of the .NET custom instrumentation documentation.
+
 ### Collecting Git metadata
 
 Datadog uses Git information for visualizing your test results and grouping them by repository, branch, and commit. Git metadata is automatically collected by the test instrumentation from CI provider environment variables and the local `.git` folder in the project path, if available.
@@ -226,3 +242,4 @@ For more information about how to add spans and tags for custom instrumentation,
 [5]: /tracing/trace_collection/dd_libraries/dotnet-core/?tab=windows#configuration
 [6]: https://www.nuget.org/packages/Datadog.Trace
 [7]: /tracing/trace_collection/custom_instrumentation/dotnet/
+[8]: /tracing/trace_collection/custom_instrumentation/dotnet?tab=locally#adding-tags


### PR DESCRIPTION
### What does this PR do?

Add section to dotnet's test instrumentation (CI Visibility) about adding custom tags to test spans.

Same as we did for javascript here: https://github.com/DataDog/documentation/pull/14866

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
