### PR TITLE
Trace Agent metrics: fix spans metric descriptions

### DIFF
--- a/content/en/tracing/troubleshooting/agent_apm_metrics.md
+++ b/content/en/tracing/troubleshooting/agent_apm_metrics.md
@@ -88,15 +88,15 @@ Number of payloads rejected by the receiver because of the sampling.
 
 `datadog.trace_agent.receiver.spans_dropped`
 : **Type**: Count<br>
-Total bytes of payloads dropped by the Agent.
+Number of spans dropped by the Agent.
 
 `datadog.trace_agent.receiver.spans_filtered`
 : **Type**: Count<br>
-Total bytes of payloads filtered by the Agent
+Number of spans filtered by the Agent.
 
 `datadog.trace_agent.receiver.spans_received`
 : **Type**: Count<br>
-Total bytes of payloads received by the Agent.
+Total number of spans received by the Agent.
 
 `datadog.trace_agent.receiver.tcp_connections`
 : **Type**: Count<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Fix the description of the following Trace Agent metrics
- `datadog.trace_agent.receiver.spans_dropped`
- `datadog.trace_agent.receiver.spans_filtered`
- `datadog.trace_agent.receiver.spans_received`

### Motivation
<!-- What inspired you to submit this pull request?-->

The descriptions were inaccurate.
The metric descriptions in the Agent code are here 
https://github.com/DataDog/datadog-agent/blob/773dd33dca5887425b90085a8809e289db118ae0/pkg/trace/info/stats.go#L362-L367

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
