### PR TITLE
[CIAPP] Add instructions to correlate pipelines executed in Jenkins workers with infrastructure metrics.

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -142,6 +142,25 @@ Re/Initialize Datadog-Plugin Agent Http Client
 TRACE -> http://<HOST>:<TRACE_PORT>/v0.3/traces
 {{< /code-block >}}
 
+### Infrastructure metric correlation
+
+If you are using Jenkins workers, you can corralate pipelines with the infrastructure that is running them. For this feature to work:
+
+1. Install the [Datadog Agent][1] in every Jenkins worker.
+2. Set and export a new environment variable called `DD_CI_HOSTNAME` in every Jenkins worker with the worker hostname. 
+    1. It must be the same hostname that the Datadog Agent is reporting in the infrastructure metrics for that worker.
+    2. You can use either fixed values or another environment variables as valid values.
+
+```bash
+# Using fixed value
+export DD_CI_HOSTNAME=my-hostname
+
+# Using other environment variable
+export DD_CI_HOSTNAME=$HOSTNAME
+```
+
+Notice this is only required for Jenkins workers. For the Jenkins controller, the infrastructure metric correlation does not required additional actions.
+
 ## Enable job log collection
 
 This is an optional step that enables the collection of job logs. It involves two steps: enabling the job collection port on the Datadog Agent, and enabling job collection on the Datadog Plugin.

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -20,8 +20,7 @@ further_reading:
 ## Compatibility
 
 Supported Jenkins versions:
-* For 3.x versions of the plugin: Jenkins >= 2.164.1
-* For 4.x versions of the plugin: Jenkins >= 2.303.3
+* Jenkins >= 2.346.1
 
 ## Prerequisite
 
@@ -160,6 +159,8 @@ export DD_CI_HOSTNAME=$HOSTNAME
 ```
 
 Notice this is only required for Jenkins workers. For the Jenkins controller, the infrastructure metric correlation does not required additional actions.
+
+**Note**: Infrastructure metric correlation is supported since Jenkins Plugin v5.0.0+
 
 ## Enable job log collection
 

--- a/content/en/continuous_integration/setup_pipelines/jenkins.md
+++ b/content/en/continuous_integration/setup_pipelines/jenkins.md
@@ -147,8 +147,8 @@ If you are using Jenkins workers, you can corralate pipelines with the infrastru
 
 1. Install the [Datadog Agent][1] in every Jenkins worker.
 2. Set and export a new environment variable called `DD_CI_HOSTNAME` in every Jenkins worker with the worker hostname. 
-    1. It must be the same hostname that the Datadog Agent is reporting in the infrastructure metrics for that worker.
-    2. You can use either fixed values or another environment variables as valid values.
+  * It must be the same hostname that the Datadog Agent is reporting in the infrastructure metrics for that worker.
+  * You can use fixed values or other environment variables as valid values.
 
 ```bash
 # Using fixed value
@@ -158,7 +158,7 @@ export DD_CI_HOSTNAME=my-hostname
 export DD_CI_HOSTNAME=$HOSTNAME
 ```
 
-Notice this is only required for Jenkins workers. For the Jenkins controller, the infrastructure metric correlation does not required additional actions.
+This is only required for Jenkins workers. For the Jenkins controller, the infrastructure metric correlation does not require additional actions.
 
 **Note**: Infrastructure metric correlation is supported since Jenkins Plugin v5.0.0+
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR adds the instructions to correlate pipelines executed in Jenkins workers with infrastructure metrics for CI Visibility.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
