### PR TITLE
Use permalink for join_standard_tags integration

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -186,7 +186,7 @@ containers:
 [1]: /agent/cluster_agent/admission_controller/
 [2]: https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#capabilities-of-the-downward-api
 [3]: /agent/kubernetes/data_collected/#kube-state-metrics
-[4]: https://github.com/DataDog/integrations-core/blob/42ecba8180fdce32c2e6739e8db006da2941c29d/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example#L63
+[4]: https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example#L63
 [5]: /tracing/send_traces/
 [6]: /integrations/statsd/
 {{% /tab %}}

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -186,7 +186,7 @@ containers:
 [1]: /agent/cluster_agent/admission_controller/
 [2]: https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#capabilities-of-the-downward-api
 [3]: /agent/kubernetes/data_collected/#kube-state-metrics
-[4]: https://github.com/DataDog/integrations-core/blob/master/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example#L70
+[4]: https://github.com/DataDog/integrations-core/blob/42ecba8180fdce32c2e6739e8db006da2941c29d/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example#L63
 [5]: /tracing/send_traces/
 [6]: /integrations/statsd/
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
URL is pointing to the wrong key (should be `join_standard_tags`).
![Screen Shot 2022-08-30 at 9 37 51 AM](https://user-images.githubusercontent.com/9448877/187451790-ccfaf3ad-c3e9-41a0-98c1-534fb27d99fe.png)


### Motivation
<!-- What inspired you to submit this pull request?-->
Incorrect documentation
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
