### PR TITLE
Update increase-number-of-log-files-tailed.md

### DIFF
--- a/content/en/logs/guide/increase-number-of-log-files-tailed.md
+++ b/content/en/logs/guide/increase-number-of-log-files-tailed.md
@@ -15,7 +15,7 @@ further_reading:
   text: "How to investigate a log parsing issue?"
 ---
 
-By default the Agent can tail up to 500 log files. This limit is set to avoid performances issue when wildcards are set on huge directories.
+By default the Agent can tail up to 200 log files on Windows and MacOS, and 500 log files on other operating systems. This limit is set to avoid performances issue when wildcards are set on huge directories.
 
 To increase this limit, set the value of `open_files_limit` in the Agent's configuration file (`/etc/datadog-agent/datadog.yaml`) in the `logs_config` section:
 

--- a/content/en/logs/guide/increase-number-of-log-files-tailed.md
+++ b/content/en/logs/guide/increase-number-of-log-files-tailed.md
@@ -15,13 +15,13 @@ further_reading:
   text: "How to investigate a log parsing issue?"
 ---
 
-By default the Agent can tail up to 100 log files. This limit is set to avoid performances issue when wildcards are set on huge directories.
+By default the Agent can tail up to 500 log files. This limit is set to avoid performances issue when wildcards are set on huge directories.
 
 To increase this limit, set the value of `open_files_limit` in the Agent's configuration file (`/etc/datadog-agent/datadog.yaml`) in the `logs_config` section:
 
 ```yaml
 logs_config:
-  open_files_limit: 100
+  open_files_limit: 500
 ```
 
 For containerized environments you can set the `DD_LOGS_CONFIG_OPEN_FILES_LIMIT` environment variable.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
The default # of log files tailed by the Agent is now 500 for Linux-based hosts (see PR here - https://github.com/DataDog/datadog-agent/commit/1aec92f38bc07381ca3f37bd104541a0f88b03b3) . Updating documentation to reflect the new default limit. 
I haven't checked this page for the other supported language sites, but assuming it may need to be changed there as well to reflect the new default limit.

### Motivation
<!-- What inspired you to submit this pull request?-->
See above PR.
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
