### PR TITLE
Drop a now obsolete comment about PHP not supporting UDS

### DIFF
--- a/content/en/containers/kubernetes/apm.md
+++ b/content/en/containers/kubernetes/apm.md
@@ -229,8 +229,6 @@ After configuring your Datadog Agent to collect traces and giving your applicati
 
 Refer to the [language-specific APM instrumentation docs][2] for more examples.
 
-**Note:** The PHP tracer does not support sending traces over Unix Domain Socket (UDS). For updates on UDS for PHP, contact support.
-
 
 ## Agent environment variables
 


### PR DESCRIPTION
### What does this PR do?

PHP has support for UDS by now, a customer was confused by this obsolete comment. Removed it.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
