### PR TITLE
Handle secure redis URLs

### DIFF
--- a/content/en/agent/guide/heroku-ruby.md
+++ b/content/en/agent/guide/heroku-ruby.md
@@ -297,7 +297,7 @@ Instead of manually updating the configuration, you can set up your Redis integr
 
 # Update the Redis configuration from above using the Heroku application environment variable
 if [ -n "$REDIS_URL" ]; then
-  REDISREGEX='redis://([^:]*):([^@]+)@([^:]+):([^/]+)$'
+  REDISREGEX='rediss?://([^:]*):([^@]+)@([^:]+):([^/]+)$'
   if [[ $REDIS_URL =~ $REDISREGEX ]]; then
     sed -i "s/<YOUR_REDIS_HOST>/${BASH_REMATCH[3]}/" "$DD_CONF_DIR/conf.d/redisdb.d/conf.yaml"
     sed -i "s/<YOUR_REDIS_PASSWORD>/${BASH_REMATCH[2]}/" "$DD_CONF_DIR/conf.d/redisdb.d/conf.yaml"


### PR DESCRIPTION
### What does this PR do?

Improves the `prerun.sh` sample code for configuring Redis in Heroku to account for secure URLs.

### Motivation

I got an error as follows after following the steps in the setup documentation;

```
2022-08-31 13:18:12 UTC | CORE | ERROR | (pkg/collector/worker/check_logger.go:69 in Error) | check:redisdb | Error running check: [{"message": "invalid literal for int() with base 10: '<YOUR_REDIS_PORT>'", "traceback": "Traceback (most recent call last):
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/base.py\", line 1120, in run
    self.check(instance)
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/redisdb/redisdb.py\", line 552, in check
    self._check_db()
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/redisdb/redisdb.py\", line 203, in _check_db
    info = conn.info()
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python2.7/site-packages/redis/client.py\", line 1304, in info
    return self.execute_command('INFO')
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python2.7/site-packages/redis/client.py\", line 898, in execute_command
    conn = self.connection or pool.get_connection(command_name, **options)
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python2.7/site-packages/redis/connection.py\", line 1187, in get_connection
    connection = self.make_connection()
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python2.7/site-packages/redis/connection.py\", line 1227, in make_connection
    return self.connection_class(**self.connection_kwargs)
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python2.7/site-packages/redis/connection.py\", line 509, in __init__
    self.port = int(port)
ValueError: invalid literal for int() with base 10: '<YOUR_REDIS_PORT>'
"}]
```

My `REDIS_URL` variable was configured as a secure redis url - `rediss://...`. Updating my `prerun.sh` config to include the optional additional `s` in the regex resolved the error.

### Additional Notes

None

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
