### PR TITLE
(DOCS) Update casing on Agents

### DIFF
--- a/data/api/v2/translate_actions.json
+++ b/data/api/v2/translate_actions.json
@@ -487,7 +487,7 @@
     "request_description": ""
   },
   "DownloadCloudWorkloadPolicyFile": {
-    "description": "The download endpoint generates a Cloud Workload Security policy file from your currently active\nCloud Workload Security rules, and downloads them as a .policy file. This file can then be deployed to\nyour agents to update the policy running in your environment.",
+    "description": "The download endpoint generates a Cloud Workload Security policy file from your currently active\nCloud Workload Security rules, and downloads them as a .policy file. This file can then be deployed to\nyour Agents to update the policy running in your environment.",
     "summary": "Get the latest Cloud Workload Security policy"
   },
   "ListCloudWorkloadSecurityAgentRules": {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Corrects the casing of `agents` to `Agents`

### Motivation
A question raised by a translator uncertain if this line is referencing the Datadog Agent.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
