### PR TITLE
Fix broken links on SLO Alerts pages

### DIFF
--- a/content/en/monitors/service_level_objectives/burn_rate.md
+++ b/content/en/monitors/service_level_objectives/burn_rate.md
@@ -160,3 +160,4 @@ resource "datadog_monitor" "metric-based-slo" {
 [3]: https://sre.google/workbook/alerting-on-slos/
 [4]: https://app.datadoghq.com/slo
 [5]: /api/v1/monitors/#create-a-monitor
+[6]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor

--- a/content/en/monitors/service_level_objectives/error_budget.md
+++ b/content/en/monitors/service_level_objectives/error_budget.md
@@ -60,4 +60,4 @@ resource "datadog_monitor" "metric-based-slo" {
 [3]: https://app.datadoghq.com/slo
 [4]: /monitors/notify/
 [5]: /api/v1/monitors/#create-a-monitor
-[6]: https://www.terraform.io/docs/providers/datadog/r/monitor.html
+[6]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes a link 

### Motivation
<!-- What inspired you to submit this pull request?-->
Link to the [datadog_monitor Terraform resource](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) was broken on the SLO alerts pages

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
https://docs-staging.datadoghq.com/kai/slo_alert_tf/monitors/service_level_objectives/error_budget/#api-and-terraform
https://docs-staging.datadoghq.com/kai/slo_alert_tf/monitors/service_level_objectives/burn_rate/#api-and-terraform

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
