### PR TITLE
Fix incorrect policy in the document and add note

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -81,7 +81,7 @@ Alternatively, customize this CloudFormation template and install it from the AW
 3. Check the `Subscriptions` column in the [log groups index page][1] to confirm that the new Kinesis stream is now subscribed to your log groups.
 
 If you want to push logs directly to the delivery stream without going through a Kinesis data stream, you can subscribe the CloudWatch log groups directly to the Kinesis Firehose Destination by adding the Kinesis Firehose ARN in the `destination-arn` parameter of the subscription filter, as shown in [the AWS Subscription Filters documentation][4] (step 12).
-  * **Note**: As logs that are sent to a receiving service through a subscription filter are base64 encoded and compressed with the gzip format. So you need to do transformation with lambda within a Kinesis Firehose delivery stream.
+  * **Note**: As logs that are sent to a receiving service through a subscription filter are base64 encoded and compressed with the gzip format. So you need to do transformation with lambda within a Kinesis Firehose delivery stream to be able to see logs content in Datadog.
 
 ## Search for AWS Kinesis logs in Datadog
 

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -63,7 +63,7 @@ Alternatively, customize this CloudFormation template and install it from the AW
   * **Note**: If you have more than two sources you want to subscribe to, you can subscribe to the new Kinesis stream after completing this setup.
 2. Subscribe your new Kinesis stream to the CloudWatch log groups you want to ingest into Datadog. Refer to [this CloudWatch Logs documentation section][2] (step 3 to 6) to:  
    - Use the `aws iam create-role` command to create the IAM role that gives CloudWatch Logs permission to put logs data into the Kinesis stream.
-   - Create a permissions policy allowing the `firehose:PutRecord` `firehose:PutRecordBatch`, `kinesis:PutRecord`, and `kinesis:PutRecordBatch` actions.
+   - Create a permissions policy allowing the `firehose:PutRecord` `firehose:PutRecordBatch`, `kinesis:PutRecord`, and `kinesis:PutRecords` actions.
    - Attach the permissions policy to your newly created IAM role using the `aws iam put-role-policy` command.
    - Use the `aws logs put-subscription-filter` command to subscribe your Kinesis stream to each CloudWatch log group you want to ingest into Datadog.  
 
@@ -81,6 +81,7 @@ Alternatively, customize this CloudFormation template and install it from the AW
 3. Check the `Subscriptions` column in the [log groups index page][1] to confirm that the new Kinesis stream is now subscribed to your log groups.
 
 If you want to push logs directly to the delivery stream without going through a Kinesis data stream, you can subscribe the CloudWatch log groups directly to the Kinesis Firehose Destination by adding the Kinesis Firehose ARN in the `destination-arn` parameter of the subscription filter, as shown in [the AWS Subscription Filters documentation][4] (step 12).
+  * **Note**: As logs that are sent to a receiving service through a subscription filter are base64 encoded and compressed with the gzip format. So you need to do transformation with lambda within a Kinesis Firehose delivery stream.
 
 ## Search for AWS Kinesis logs in Datadog
 

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -81,7 +81,6 @@ Alternatively, customize this CloudFormation template and install it from the AW
 3. Check the `Subscriptions` column in the [log groups index page][1] to confirm that the new Kinesis stream is now subscribed to your log groups.
 
 If you want to push logs directly to the delivery stream without going through a Kinesis data stream, you can subscribe the CloudWatch log groups directly to the Kinesis Firehose Destination by adding the Kinesis Firehose ARN in the `destination-arn` parameter of the subscription filter, as shown in [the AWS Subscription Filters documentation][4] (step 12).
-  * **Note**: As logs that are sent to a receiving service through a subscription filter are base64 encoded and compressed with the gzip format. So you need to do transformation with lambda within a Kinesis Firehose delivery stream to be able to see logs content in Datadog.
 
 ## Search for AWS Kinesis logs in Datadog
 


### PR DESCRIPTION
### What does this PR do?
- Fix the incorrect policy in the document `kinesis:PutRecordBatch` to `kinesis:PutRecords`. `kinesis:PutRecordBatch` does not exist.
- ~~Add note for pushing logs directly to Kinesis Firehose delivery stream. Reference: [AWS doc](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html).~~ (removed)

### Motivation
- See those problem when try to implement CloudWatch logs subscription myself


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
