### PR TITLE
Update .NET version required for UDS

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/dd_libraries/dotnet-core.md
@@ -93,7 +93,7 @@ For containerized, serverless, and cloud environments:
     - The `/var/run/datadog/apm.socket` Unix domain socket by default.
     - If the socket does not exist, then traces are sent to `localhost:8126`.
     - If a different socket, host, or port is required, use the `DD_TRACE_AGENT_URL` environment variable: `DD_TRACE_AGENT_URL=http://custom-hostname:1234` or `DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket`
-    - Using Unix Domain Sockets for trace transport is only supported on .NET Core 3.1 and greater.
+    - Using Unix Domain Sockets for trace transport is only supported on .NET Core 3.1 and later.
 
 For more information on how to configure these settings, see [Configuration](#configuration).
 

--- a/content/en/tracing/trace_collection/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/dd_libraries/dotnet-core.md
@@ -93,6 +93,7 @@ For containerized, serverless, and cloud environments:
     - The `/var/run/datadog/apm.socket` Unix domain socket by default.
     - If the socket does not exist, then traces are sent to `localhost:8126`.
     - If a different socket, host, or port is required, use the `DD_TRACE_AGENT_URL` environment variable: `DD_TRACE_AGENT_URL=http://custom-hostname:1234` or `DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket`
+    - Using Unix Domain Sockets for trace transport is only supported on .NET Core 3.1 and greater.
 
 For more information on how to configure these settings, see [Configuration](#configuration).
 


### PR DESCRIPTION
Adding an additional comment/note under step 3 for Configure the Datadog Agent for APM. The notes addresses the required version of .NET in order for UDS to work, which was discovered in debug logs from ticket (https://datadog.zendesk.com/agent/tickets/888404)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds an additional note for the .NET tracer configuration for UDS

### Motivation
A customer was setting up .NET tracer for UDS, but was using .NET 2.1. The discrete error in their debug logs showed that .NET 3.1 or higher is required so APM T2 and I thought it would be useful to call this out on our public-facing documentation.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Related ticket: https://datadog.zendesk.com/agent/tickets/888404

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
