### PR TITLE
content/en/tracing/trace_collection/open_standards: warn about gateway deploys

### DIFF
--- a/content/en/tracing/trace_collection/open_standards/otel_collector_datadog_exporter.md
+++ b/content/en/tracing/trace_collection/open_standards/otel_collector_datadog_exporter.md
@@ -200,6 +200,10 @@ To learn more about configuring your application, read the [Application Configur
 
 For Gateway deployments: 
 
+<div class="alert alert-warning">
+Datadog is incompatible with Gateway deployments which do not have a Collector agent deployed running on each application host. Such a set up will result in a broken product exprience.
+</div>
+
 1. Set up each [OpenTelemetry Collector agent][18], just like in the [DaemonSet deployment](#daemonset-deployment). 
 
 2. Change the DaemonSet to include an [OTLP exporter][19] instead of the Datadog Exporter [currently in place][20]:


### PR DESCRIPTION
This change ensures to underline the fact that Datadog is only compatible with [Gateway deployments](https://opentelemetry.io/docs/collector/deployment/#gateway) where an agent is deployed on each application host, by adding a warning that looks like this:

<img width="858" alt="Screenshot 2022-09-05 at 15 43 51" src="https://user-images.githubusercontent.com/6686356/188452382-07eda640-d2e5-4d5a-8efc-161be299e2ba.png">
