### PR TITLE
(DOCS-3944) Update monitor limit note

### DIFF
--- a/content/en/monitors/create/types/apm.md
+++ b/content/en/monitors/create/types/apm.md
@@ -73,7 +73,7 @@ For detailed instructions on the advanced alert options (no data, evaluation del
 {{% /tab %}}
 {{% tab "Trace Analytics" %}}
 
-<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 Trace Analytics monitors per account. <a href="/help/">Contact Support</a> to lift this limit for your account.</div>
+<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 Trace Analytics monitors per account. If you are encountering this limit, consider using <a href="/monitors/create/configuration/?tab=thresholdalert#alert-grouping">multi-alerts</a>, or <a href="/help/">Contact Support</a>.</div>
 
 ### Define the search query
 

--- a/content/en/monitors/create/types/log.md
+++ b/content/en/monitors/create/types/log.md
@@ -23,7 +23,7 @@ Once [log management is enabled][1] for your organization, you can create a logs
 
 To create a [logs monitor][2] in Datadog, use the main navigation: *Monitors --> New Monitor --> Logs*.
 
-<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 Event monitors per account. If you are encountering this limit, consider using <a href="/monitors/create/configuration/?tab=thresholdalert#alert-grouping">multi-alerts</a>, or <a href="/help/">Contact Support</a>.</div>
+<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 Log monitors per account. If you are encountering this limit, consider using <a href="/monitors/create/configuration/?tab=thresholdalert#alert-grouping">multi-alerts</a>, or <a href="/help/">Contact Support</a>.</div>
 
 ### Define the search query
 

--- a/content/en/monitors/create/types/log.md
+++ b/content/en/monitors/create/types/log.md
@@ -23,7 +23,7 @@ Once [log management is enabled][1] for your organization, you can create a logs
 
 To create a [logs monitor][2] in Datadog, use the main navigation: *Monitors --> New Monitor --> Logs*.
 
-<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 Log monitors per account. <a href="/help/">Contact Support</a> to lift this limit for your account.</div>
+<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 Event monitors per account. If you are encountering this limit, consider using <a href="/monitors/create/configuration/?tab=thresholdalert#alert-grouping">multi-alerts</a>, or <a href="/help/">Contact Support</a>.</div>
 
 ### Define the search query
 

--- a/content/en/monitors/create/types/real_user_monitoring.md
+++ b/content/en/monitors/create/types/real_user_monitoring.md
@@ -20,13 +20,13 @@ further_reading:
 
 ## Overview
 
-Once [Real User Monitoring is enabled][1] for your organization, you can create a RUM monitor to alert you when a specific RUM event type exceeds a predefined threshold over a given period of time.
+Once [Real User Monitoring (RUM) is enabled][1] for your organization, you can create a RUM monitor to alert you when a specific RUM event type exceeds a predefined threshold over a given period of time.
 
 ## Create a RUM monitor
 
-To create a Real User Monitoring monitor in Datadog, first navigate to [**Monitors** > **New Monitor** > **Real User Monitoring**][2].
+To create a RUM monitor in Datadog, first navigate to [**Monitors** > **New Monitor** > **Real User Monitoring**][2].
 
-<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1,000 RUM monitors per account. <a href="/help/">Contact Support</a> to lift this limit for your account.</div>
+<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 RUM monitors per account. If you are encountering this limit, consider using <a href="/monitors/create/configuration/?tab=thresholdalert#alert-grouping">multi-alerts</a>, or <a href="/help/">Contact Support</a>.</div>
 
 ### Define the search query
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the warning notes on event-based monitors that mention the default limit of 1000 monitors per account. This is to achieve consistency with the recently updated event monitor documentation:
https://github.com/DataDog/documentation/pull/15145

### Motivation
DOCS-3944

### Previews
[APM monitors](https://docs-staging.datadoghq.com/bryce/update-monitor-limit-notes/monitors/create/types/apm/?tab=traceanalytics)
[Log monitors](https://docs-staging.datadoghq.com/bryce/update-monitor-limit-notes/monitors/create/types/log/#monitor-creation)
[RUM monitors](https://docs-staging.datadoghq.com/bryce/update-monitor-limit-notes/monitors/create/types/real_user_monitoring/#create-a-rum-monitor)

<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
