### PR TITLE
(DOCS-3795) Remove outdated tagging note

### DIFF
--- a/content/en/getting_started/tagging/_index.md
+++ b/content/en/getting_started/tagging/_index.md
@@ -56,7 +56,7 @@ Below are Datadog's tagging requirements:
     Other special characters are converted to underscores.
 
 2. Tags can be **up to 200 characters** long and support Unicode (which includes most character sets, including languages such as Japanese).
-3. Tags are converted to lowercase. Therefore, `CamelCase` tags are not recommended. Authentication (crawler) based integrations convert camel case tags to underscores, for example `TestTag` --> `test_tag`. **Note**: `host` and `device` tags are excluded from this conversion.
+3. Tags are converted to lowercase. Therefore, `CamelCase` tags are not recommended. Authentication (crawler) based integrations convert camel case tags to underscores, for example `TestTag` --> `test_tag`.
 4. A tag can be in the format `value` or `<KEY>:<VALUE>`. Commonly used tag keys are `env`, `instance`, and `name`. The key always precedes the first colon of the global tag definition, for example:
 
     | Tag                | Key           | Value          |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Remove an outdated note about certain tags being excluded from lower-casing when sent to Datadog. Details about how these tags can be excluded from lower-casing have been moved to the API docs:
https://docs.datadoghq.com/api/latest/metrics/#submit-metrics

### Motivation
DOCS-3795

### Preview
https://docs-staging.datadoghq.com/bryce/update-tag-note/getting_started/tagging/#define-tags

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
