### PR TITLE
Remove `delete_if` from Ruby example of post-processing spans

### DIFF
--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -267,14 +267,14 @@ Some of the language-specific tracers have an option to modify spans before they
 
 {{< programming-lang lang="ruby" >}}
 
-The Ruby tracer has a post-processing pipeline that deletes traces that meet certain criteria. More information and examples can be found in [Post-processing traces][1].
+The Ruby tracer has a post-processing pipeline that removes traces that meet certain criteria. More information and examples can be found in [Post-processing traces][1].
 
-For example, if the resource name is `Api::HealthchecksController#index`, use the `trace.delete_if` method to delete traces that contain the resource name. This filter can also be used to match on other metadata available for the [span object][2].
+For example, if the resource name is `Api::HealthchecksController#index`, use the `Datadog::Tracing::Pipeline::SpanFilter` class to removes traces that contain the resource name. This filter can also be used to match on other metadata available for the [span object][2].
 
 ```
-Datadog::Tracing.before_flush do |trace|
-  trace.delete_if { |span| span.resource =~ /Api::HealthchecksController#index/ }
-end
+Datadog::Tracing.before_flush(
+   Datadog::Tracing::Pipeline::SpanFilter.new { |span| span.resource =~ /Api::HealthchecksController#index/ }
+)
 ```
 
 [1]: /tracing/trace_collection/custom_instrumentation/ruby/?tab=activespan#post-processing-traces

--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -269,7 +269,7 @@ Some of the language-specific tracers have an option to modify spans before they
 
 The Ruby tracer has a post-processing pipeline that removes traces that meet certain criteria. More information and examples can be found in [Post-processing traces][1].
 
-For example, if the resource name is `Api::HealthchecksController#index`, use the `Datadog::Tracing::Pipeline::SpanFilter` class to removes traces that contain the resource name. This filter can also be used to match on other metadata available for the [span object][2].
+For example, if the resource name is `Api::HealthchecksController#index`, use the `Datadog::Tracing::Pipeline::SpanFilter` class to remove traces that contain the resource name. This filter can also be used to match on other metadata available for the [span object][2].
 
 ```
 Datadog::Tracing.before_flush(


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This corrects the misleading/invalid documentation for filtering spans.

### Motivation
When I attempted to use `delete_if` in my code I got a NoMethodError: 

```
#<NoMethodError: undefined method `delete_if' for #<Datadog::Tracing::TraceSegment:0x000000012056f560>>
```

From looking at the Post processing traces section in the Ruby Custom Instrumentation doc (https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/ruby/?tab=activespan#filtering), I found that the correct way to do this was with a Span Filter.


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
