### PR TITLE
APM:Recommend Ruby environment variables only for sampling rates

### DIFF
--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -101,23 +101,13 @@ Read more about sampling controls in the [Python tracing library documentation][
 [1]: /tracing/trace_collection/dd_libraries/python
 {{% /tab %}}
 {{% tab "Ruby" %}}
-For Ruby applications, set a global sampling rate in the library using the `DD_TRACE_SAMPLE_RATE` environment variable.
+For Ruby applications, set a global sampling rate for the library using the `DD_TRACE_SAMPLE_RATE` environment variable. Set by-service sampling rates with the `DD_TRACE_SAMPLING_RULES` environment variable.
 
-You can also configure sampling rates by service. For instance, to send 20% of the traces for the service named `my-service`:
+For example, to send 50% of the traces for the service named `my-service` and 10% of the rest of the traces:
 
-```ruby
-require 'ddtrace'
-
-Datadog.configure do |c|
-  c.tracing.sampler = Datadog::Tracing::Sampling::PrioritySampler.new(
-    post_sampler: Datadog::Tracing::Sampling::RuleSampler.new(
-      [
-        # Sample all 'my-service' traces at 20.00%:
-        Datadog::Tracing::Sampling::SimpleRule.new(service: 'my-service', sample_rate: 0.2000)
-      ]
-    )
-  )
-end
+```
+@env DD_TRACE_SAMPLE_RATE=0.1
+@env DD_TRACE_SAMPLING_RULES=[{"service": `my-service`, "sample_rate": 0.5}]
 ```
 
 Configure a rate limit by setting the environment variable `DD_TRACE_RATE_LIMIT` to a number of traces per second per service instance. If no `DD_TRACE_RATE_LIMIT` value is set, a limit of 100 traces per second is applied.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This PR removes the code snippet instructions for Sampling Rate settings for the Ruby language: environment variables are recommended instead. They are simple and accomplish the same goal.

### Motivation
<!-- What inspired you to submit this pull request?-->

The previous language documented a more verbose and error prone approach to sampling configuration.

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/marcotc/sampling-docs/tracing/trace_pipeline/ingestion_mechanisms/?tab=ruby

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
