### PR TITLE
Make RUM & Session Replay Docs Searchable 

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -559,7 +559,6 @@
         front_matters:
           title: Android Trace Collection
           kind: documentation
-          beta: true
           aliases:
             - /tracing/setup_overview/setup/android
             - /tracing/setup/android
@@ -585,7 +584,6 @@
         front_matters:
           title: RUM iOS and tvOS Monitoring
           kind: documentation
-          beta: true
           description: "Collect RUM data from your iOS projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/_index.md"]
           further_reading:
@@ -626,7 +624,6 @@
         front_matters:
           title: iOS Trace Collection
           kind: documentation
-          beta: true
           aliases:
             - /tracing/setup_overview/setup/ios/
             - /tracing/setup/ios/
@@ -650,7 +647,6 @@
         front_matters:
           title: Mobile Vitals
           kind: documentation
-          beta: true
           description: "Collect RUM data from your iOS projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_mobile_vitals.md"]
           further_reading:
@@ -671,7 +667,6 @@
         front_matters:
           title: iOS Crash Reporting and Error Tracking
           kind: documentation
-          beta: true
           description: "Set up Error Tracking for your iOS projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/crash_reporting.md"]
           aliases:
@@ -719,7 +714,6 @@
         front_matters:
           title: React Native Monitoring
           kind: documentation
-          beta: true
           description: "Collect RUM data from your React Native projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/README.md"]
           further_reading:
@@ -766,7 +760,6 @@
         front_matters:
           title: Mobile Vitals
           kind: documentation
-          beta: true
           description: "Collect RUM data from your React Native projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/docs/rum_mobile_vitals.md"]
           further_reading:
@@ -789,7 +782,6 @@
         front_matters:
           title: Expo
           kind: documentation
-          beta: true
           description: "Monitor your React Native projects using Expo and Expo Go with Datadog."
           dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/docs/expo_development.md"]
           further_reading:
@@ -809,7 +801,6 @@
         front_matters:
           title: Expo Crash Reporting and Error Tracking
           kind: documentation
-          beta: true
           description: "Capture Expo crash reports in Datadog."
           dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/docs/expo_crash_reporting.md"]
           further_reading:
@@ -835,7 +826,6 @@
         front_matters:
           title: React Native Crash Reporting and Error Tracking
           kind: documentation
-          beta: true
           description: "Set up Error Tracking for your React Native projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/docs/crash_reporting.md"]
           further_reading:
@@ -857,7 +847,6 @@
         front_matters:
           title: Flutter Monitoring
           kind: documentation
-          beta: true
           description: "Collect RUM data from your Flutter projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/README.md"]
           further_reading:
@@ -880,7 +869,6 @@
         front_matters:
           title: Flutter Log Collection
           kind: documentation
-          beta: true
           description: "Collect Logs data from your Flutter projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/log_collection.md"]
           further_reading:
@@ -900,7 +888,6 @@
         front_matters:
           title: Setup
           kind: documentation
-          beta: true
           description: "Setup Flutter Monitoring for RUM & Session Replay or Log Management."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/common_setup.md"]
           further_reading:
@@ -923,7 +910,6 @@
         front_matters:
           title: RUM Flutter Advanced Configuration
           kind: documentation
-          beta: true
           description: "Learn how to configure Flutter Monitoring."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/advanced_configuration.md"]
           further_reading:
@@ -943,7 +929,6 @@
         front_matters:
           title: RUM Flutter Data Collected
           kind: documentation
-          beta: true
           description: "Learn about the data collected by Flutter Monitoring."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/data_collected.md"]
           further_reading:
@@ -963,7 +948,6 @@
         front_matters:
           title: Mobile Vitals
           kind: documentation
-          beta: true
           description: "Learn about mobile vitals collected by Flutter Monitoring."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/mobile_vitals.md"]
           further_reading:
@@ -986,7 +970,6 @@
         front_matters:
           title: Troubleshooting
           kind: documentation
-          beta: true
           description: "Learn how to troubleshoot issues with Flutter Monitoring."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/troubleshooting.md"]
           further_reading:
@@ -1006,7 +989,6 @@
         front_matters:
           title: Flutter Crash Reporting and Error Tracking
           kind: documentation
-          beta: true
           description: "Learn how to track Flutter errors with Error Tracking."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/error_tracking.md"]
           further_reading:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -562,7 +562,6 @@
         front_matters:
           title: Android Trace Collection
           kind: documentation
-          beta: true
           aliases:
             - /tracing/setup_overview/setup/android
             - /tracing/setup/android
@@ -588,7 +587,6 @@
         front_matters:
           title: RUM iOS and tvOS Monitoring
           kind: documentation
-          beta: true
           description: "Collect RUM data from your iOS projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/_index.md"]
           further_reading:
@@ -629,7 +627,6 @@
         front_matters:
           title: iOS Trace Collection
           kind: documentation
-          beta: true
           aliases:
             - /tracing/setup_overview/setup/ios/
             - /tracing/setup/ios/
@@ -653,7 +650,6 @@
         front_matters:
           title: Mobile Vitals
           kind: documentation
-          beta: true
           description: "Collect RUM data from your iOS projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_mobile_vitals.md"]
           further_reading:
@@ -674,7 +670,6 @@
         front_matters:
           title: iOS Crash Reporting and Error Tracking
           kind: documentation
-          beta: true
           description: "Set up Error Tracking for your iOS projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_collection/crash_reporting.md"]
           aliases:
@@ -722,7 +717,6 @@
         front_matters:
           title: React Native Monitoring
           kind: documentation
-          beta: true
           description: "Collect RUM data from your React Native projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/README.md"]
           further_reading:
@@ -745,7 +739,6 @@
         front_matters:
           title: React Native Integrated Libraries
           kind: faq
-          beta: true
           description: "Collect RUM data from your React Native projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/docs/rum_integrations.md"]
           further_reading:
@@ -768,7 +761,6 @@
         front_matters:
           title: Mobile Vitals
           kind: documentation
-          beta: true
           description: "Collect RUM data from your React Native projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/docs/rum_mobile_vitals.md"]
           further_reading:
@@ -791,7 +783,6 @@
         front_matters:
           title: Expo
           kind: documentation
-          beta: true
           description: "Monitor your React Native projects using Expo and Expo Go with Datadog."
           dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/docs/expo_development.md"]
           further_reading:
@@ -812,7 +803,6 @@
           dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/docs/expo_crash_reporting.md"]
           title: Expo Crash Reporting and Error Tracking
           kind: documentation
-          beta: true
           description: Capture Expo crash reports in Datadog.
           further_reading:
           - link: 'https://www.datadoghq.com/blog/debug-android-crashes/'
@@ -837,7 +827,6 @@
         front_matters:
           title: React Native Crash Reporting and Error Tracking
           kind: documentation
-          beta: true
           description: Set up Error Tracking for your React Native projects.
           dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/docs/crash_reporting.md"]
           further_reading:
@@ -860,7 +849,6 @@
         front_matters:
           title: Flutter Monitoring
           kind: documentation
-          beta: true
           description: "Collect RUM data from your Flutter projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/rum_collection.md"]
           further_reading:
@@ -883,7 +871,6 @@
         front_matters:
           title: Flutter Log Collection
           kind: documentation
-          beta: true
           description: "Collect Logs data from your Flutter projects."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/log_collection.md"]
           further_reading:
@@ -903,7 +890,6 @@
         front_matters:
           title: Setup
           kind: documentation
-          beta: true
           description: "Setup Flutter Monitoring for RUM & Session Replay or Log Management."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/common_setup.md"]
           further_reading:
@@ -926,7 +912,6 @@
         front_matters:
           title: RUM Flutter Advanced Configuration
           kind: documentation
-          beta: true
           description: "Learn how to configure Flutter Monitoring."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/advanced_configuration.md"]
           further_reading:
@@ -946,7 +931,6 @@
         front_matters:
           title: RUM Flutter Data Collected
           kind: documentation
-          beta: true
           description: "Learn about the data collected by Flutter Monitoring."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/data_collected.md"]
           further_reading:
@@ -966,7 +950,6 @@
         front_matters:
           title: Mobile Vitals
           kind: documentation
-          beta: true
           description: "Learn about mobile vitals collected by Flutter Monitoring."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/mobile_vitals.md"]
           further_reading:
@@ -989,7 +972,6 @@
         front_matters:
           title: Troubleshooting
           kind: documentation
-          beta: true
           description: "Learn how to troubleshoot issues with Flutter Monitoring."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/troubleshooting.md"]
           further_reading:
@@ -1009,7 +991,6 @@
         front_matters:
           title: Flutter Crash Reporting and Error Tracking
           kind: documentation
-          beta: true
           description: "Learn how to track Flutter errors with Error Tracking."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/error_tracking.md"]
           further_reading:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

These doc pages were previously marked as `beta: true`, they are generally available now, so these pages should be indexed by Google Search.

### Motivation
<!-- What inspired you to submit this pull request?-->

Discussion with @louiszawadzki!

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
