### PR TITLE
Add id to integrations card

### DIFF
--- a/layouts/shortcodes/integrations.html
+++ b/layouts/shortcodes/integrations.html
@@ -110,9 +110,7 @@
                             <p class="font-primary font-weight-bold text-uppercase text-center">Marketplace</p>
                         </div>
                     {{ end }}
-                    <div class="card-content">
-
-
+                    <div id="{{ $v.name }}" class="card-content">
                       <a href="{{ $v.redirect | absLangURL }}" aria-label="{{ $v.public_title }} datadog integration docs link">
                         <picture class="mx-auto my-auto">
                           {{ $img := (replace $v.int_logo "_large" "_avatar") }}


### PR DESCRIPTION
### What does this PR do?
This is to fix the yaml data file dependency on Corp, allowing Integration tiles to be referenced again by DG landing pages

### Motivation
Integration partial no longer loading proper data because this id value is missing

### Preview
https://docs-staging.datadoghq.com/nsollecito/integrations-id/integrations/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
