### PR TITLE
Add PHP to endpoint profiling

### DIFF
--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -187,7 +187,7 @@ Endpoint profiling is enabled by default when you turn on profiling for your [PH
 <p></p>
 
 [1]: /profiler/enabling/php
-[2]: https://pypi.org/project/ddtrace/
+[2]: https://github.com/DataDog/dd-trace-php
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 

--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -149,7 +149,7 @@ Click the **Span/Trace/Full profile** selector to define the scope of the data:
 
 ### Prerequisites
 
-{{< programming-lang-wrapper langs="python,go,php,ruby" >}}
+{{< programming-lang-wrapper langs="python,go,ruby,php" >}}
 {{< programming-lang lang="python" >}}
 
 Endpoint profiling is enabled by default when you turn on profiling for your [Python][1] service. It requires `dd-trace-py` version 0.54.0 or greater.
@@ -174,19 +174,19 @@ Endpoint profiling is disabled by default when you turn on profiling for your [G
 [7]: https://go-review.googlesource.com/c/go/+/369741/
 [8]: https://go-review.googlesource.com/c/go/+/369983/
 {{< /programming-lang >}}
-{{< programming-lang lang="php" >}}
-
-Endpoint profiling is enabled by default when you turn on profiling for your [PHP][1] service. It requires ddtrace version 0.79.0 or greater. To disable it, set the environment variable `DD_PROFILING_ENDPOINT_COLLECTION_ENABLED` to `0`, `no`, `off`, or `false`.
-<p></p>
-
-[1]: /profiler/enabling/php
-{{< /programming-lang >}}
 {{< programming-lang lang="ruby" >}}
 
 Endpoint profiling is enabled by default when you turn on profiling for your [Ruby][1] service. It requires `dd-trace-rb` version 0.54.0 or greater.
 <p></p>
 
 [1]: /profiler/enabling/ruby
+{{< /programming-lang >}}
+{{< programming-lang lang="php" >}}
+
+Endpoint profiling is enabled by default when you turn on profiling for your [PHP][1] service. It requires ddtrace version 0.79.0 or greater. To disable it, set the environment variable `DD_PROFILING_ENDPOINT_COLLECTION_ENABLED` to `0`, `no`, `off`, or `false`.
+<p></p>
+
+[1]: /profiler/enabling/php
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 

--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -183,10 +183,11 @@ Endpoint profiling is enabled by default when you turn on profiling for your [Ru
 {{< /programming-lang >}}
 {{< programming-lang lang="php" >}}
 
-Endpoint profiling is enabled by default when you turn on profiling for your [PHP][1] service. It requires ddtrace version 0.79.0 or greater. To disable it, set the environment variable `DD_PROFILING_ENDPOINT_COLLECTION_ENABLED` to `0`, `no`, `off`, or `false`.
+Endpoint profiling is enabled by default when you turn on profiling for your [PHP][1] service. It requires [`ddtrace`][2] v0.79.0+. To disable endpoint profiling, set the environment variable `DD_PROFILING_ENDPOINT_COLLECTION_ENABLED` to `0`, `no`, `off`, or `false`.
 <p></p>
 
 [1]: /profiler/enabling/php
+[2]: https://pypi.org/project/ddtrace/
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 

--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -149,7 +149,7 @@ Click the **Span/Trace/Full profile** selector to define the scope of the data:
 
 ### Prerequisites
 
-{{< programming-lang-wrapper langs="python,go,ruby" >}}
+{{< programming-lang-wrapper langs="python,go,php,ruby" >}}
 {{< programming-lang lang="python" >}}
 
 Endpoint profiling is enabled by default when you turn on profiling for your [Python][1] service. It requires `dd-trace-py` version 0.54.0 or greater.
@@ -173,6 +173,13 @@ Endpoint profiling is disabled by default when you turn on profiling for your [G
 [6]: https://github.com/golang/go/issues/48577
 [7]: https://go-review.googlesource.com/c/go/+/369741/
 [8]: https://go-review.googlesource.com/c/go/+/369983/
+{{< /programming-lang >}}
+{{< programming-lang lang="php" >}}
+
+Endpoint profiling is enabled by default when you turn on profiling for your [PHP][1] service. It requires ddtrace version 0.79.0 or greater. To disable it, set the environment variable `DD_PROFILING_ENDPOINT_COLLECTION_ENABLED` to `0`, `no`, `off`, or `false`.
+<p></p>
+
+[1]: /profiler/enabling/php
 {{< /programming-lang >}}
 {{< programming-lang lang="ruby" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds PHP information to the section on endpoint profiling.

### Motivation
<!-- What inspired you to submit this pull request?-->
I added this feature and it ships in v0.79.0 of the PHP tracer, which is in draft at this time.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Is there an order we ought to be putting these languages in? Order by general APM usage? Alphabetical? Order they were added?

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
