### PR TITLE
[kubernetes/distributions] Update note about OOM kill and TCP queue length on GKE

### DIFF
--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -171,7 +171,9 @@ Depending on the operation mode of your cluster, the Datadog Agent needs to be c
 
 Since Agent 7.26, no specific configuration is required for GKE (whether you run `Docker` or `containerd`).
 
-**Note**: When using COS (Container Optimized OS), the eBPF-based `OOM Kill` and `TCP Queue Length` checks are not supported due to missing Kernel headers.
+**Note**: When using COS (Container Optimized OS), the eBPF-based `OOM Kill` and `TCP Queue Length` checks are supported starting from the version 3.0.1 of the helm chart. There are two settings that need to be set:
+- `datadog.systemProbe.enableDefaultKernelHeadersPaths` to `false`.
+- `datadog.systemProbe.enableKernelHeaderDownload` to `true`.
 
 ### Autopilot
 

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -171,7 +171,7 @@ Depending on the operation mode of your cluster, the Datadog Agent needs to be c
 
 Since Agent 7.26, no specific configuration is required for GKE (whether you run `Docker` or `containerd`).
 
-**Note**: When using COS (Container Optimized OS), the eBPF-based `OOM Kill` and `TCP Queue Length` checks are supported starting from the version 3.0.1 of the helm chart. There are two settings that need to be set:
+**Note**: When using COS (Container Optimized OS), the eBPF-based `OOM Kill` and `TCP Queue Length` checks are supported starting from the version 3.0.1 of the Helm chart. To enable these checks, configure the following settings:
 - `datadog.systemProbe.enableDefaultKernelHeadersPaths` to `false`.
 - `datadog.systemProbe.enableKernelHeaderDownload` to `true`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Updates the note about the OOM kill and TCP queue length checks on GKE because they're working now.


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
