### PR TITLE
Fixes V2 annotations to have an actual working example

### DIFF
--- a/content/en/containers/kubernetes/prometheus.md
+++ b/content/en/containers/kubernetes/prometheus.md
@@ -142,15 +142,16 @@ For a full list of available parameters for instances, including `namespace` and
             ad.datadoghq.com/prometheus-example.checks: |
               {
                 "openmetrics": {
-                  "init_config": {},
                   "instances": [
-                   "openmetrics_endpoint": "http://%%host%%:%%port%%/metrics",
-                   "namespace": "documentation_example_kubernetes",
-                   "metrics": [
-                     {"promhttp_metric_handler_requests": "handler.requests"},
-                      {"promhttp_metric_handler_requests_in_flight": "handler.requests.in_flight"},
-                      "go_memory.*"
-                    ]
+                    {
+                      "openmetrics_endpoint": "http://%%host%%:%%port%%/metrics",
+                      "namespace": "documentation_example_kubernetes",
+                      "metrics": [
+                          {"promhttp_metric_handler_requests": "handler.requests"},
+                          {"promhttp_metric_handler_requests_in_flight": "handler.requests.in_flight"},
+                          "go_memory.*"
+                        ]
+                    }
                   ]
                 }
               }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* Adds curly brackets `{}` around the instance to have a valid JSON and thus have the check working
* Removes `init_config` from the annotations as it doesn't add anything and is not necessary
* Lines up the items in `metrics`

### Motivation
<!-- What inspired you to submit this pull request?-->
* Testing the example in my sandbox resulted in a failure, thus it misleads customers
* To Q/A, run a local cluster, deploy with the updated annotations and the Agent, ensure an `openmetrics` gets correctly scheduled

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
