### PR TITLE
Correct default for DD_DOGSTATSD_PORT

### DIFF
--- a/content/en/tracing/trace_collection/library_config/python.md
+++ b/content/en/tracing/trace_collection/library_config/python.md
@@ -92,7 +92,7 @@ Override the port that the default tracer submit traces to.
 Override the address of the trace Agent host that the default tracer attempts to submit DogStatsD metrics to. Use `DD_AGENT_HOST` to override `DD_DOGSTATSD_HOST`.
 
 `DD_DOGSTATSD_PORT`
-: **Default**: `8126`<br>
+: **Default**: `8125`<br>
 Override the port that the default tracer submits DogStatsD metrics to.
 
 `DD_LOGS_INJECTION`


### PR DESCRIPTION
Fix the default port according to source: https://github.com/DataDog/dd-trace-py/blob/685b0b46e21517b4dfd06a70e41ddb8e5a0d7253/ddtrace/internal/agent.py#L16

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
