### PR TITLE
[SCI] Update SCI repo url doc

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -60,7 +60,7 @@ If you are running your app in containers, Datadog can extract source code infor
 docker build . \
   -t my-application \
   --label org.opencontainers.image.revision=$(git rev-parse HEAD) \
-  --label org.opencontainers.image.source=https://git-provider.example/me/my-repo
+  --label org.opencontainers.image.source=git-provider.example/me/my-repo
 ```
 
 [1]: https://github.com/opencontainers/image-spec/blob/859973e32ccae7b7fc76b40b762c9fff6e912f9e/annotations.md#pre-defined-annotation-keys
@@ -70,7 +70,7 @@ docker build . \
 If you use Kubernetes, tag your deployed pod with a pod annotation using [Datadog's Tag Autodiscovery][1]:
 
 ```
-ad.datadoghq.com/tags: '{"git.commit.sha": "<FULL_GIT_COMMIT_SHA>", "git.repository_url": "<REPOSITORY_URL>"}'
+ad.datadoghq.com/tags: '{"git.commit.sha": "<FULL_GIT_COMMIT_SHA>", "git.repository_url": "git-provider.example/me/my-repo"}'
 ```
 
 The git commit SHA and repository URL are added to your telemetry.
@@ -84,7 +84,7 @@ For non-containerized or unsupported environments, manually tag your traces, spa
 To tag your traces, spans, and profiles with `git.commit.sha` and `git.repository_url`, configure the tracer with the `DD_TAGS` environment variable:
 
 ```
-export DD_TAGS="git.commit.sha:<GIT_COMMIT_SHA> git.repository_url:<REPOSITORY_URL>"
+export DD_TAGS="git.commit.sha:<FULL_GIT_COMMIT_SHA> git.repository_url:git-provider.example/me/my-repo"
 ./my-application start
 ```
 


### PR DESCRIPTION
Small update to the Source Code Integration page that removes the scheme in the repository URL example. Also adds more consistency between the `Tag your telemetry` tabs.