### PR TITLE
DOCS-4056 Adds CodePush Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ content/en/real_user_monitoring/ios/mobile_vitals.md
 content/en/real_user_monitoring/ios/*
 content/en/real_user_monitoring/reactnative/_index.md
 content/en/real_user_monitoring/reactnative/integrated_libraries.md
+content/en/real_user_monitoring/reactnative/codepush.md
 content/en/real_user_monitoring/reactnative/mobile_vitals.md
 content/en/real_user_monitoring/reactnative/expo.md
 content/en/real_user_monitoring/error_tracking/reactnative.md

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2946,6 +2946,11 @@ main:
     parent: rum_reactnative
     identifier: rum_reactnative_expo
     weight: 402
+  - name: CodePush
+    url: real_user_monitoring/reactnative/codepush/
+    parent: rum_reactnative
+    identifier: rum_reactnative_codepush
+    weight: 403
   - name: Flutter Monitoring
     url: real_user_monitoring/flutter/
     parent: rum

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -807,14 +807,14 @@
               tag: "Documentation"
               text: "Learn how to explore your RUM data"
     - action: pull-and-push-file
-      branch: develop
+      branch: main
       globs:
       - 'docs/codepush.md'
       options:
         dest_path: '/real_user_monitoring/reactnative/'
         file_name: 'codepush.md'
         front_matters:
-          dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/develop/docs/codepush.md"]
+          dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/docs/codepush.md"]
           title: CodePush
           kind: documentation
           description: 'Learn how to use a client-side React Native module to interact with Appcenter Codepush and Datadog.'

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -807,6 +807,25 @@
               tag: "Documentation"
               text: "Learn how to explore your RUM data"
     - action: pull-and-push-file
+      branch: develop
+      globs:
+      - 'docs/codepush.md'
+      options:
+        dest_path: '/real_user_monitoring/reactnative/'
+        file_name: 'codepush.md'
+        front_matters:
+          dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/develop/docs/codepush.md"]
+          title: CodePush
+          kind: documentation
+          description: 'Learn how to use a client-side React Native module to interact with Appcenter Codepush and Datadog.'
+          further_reading:
+            - link: 'https://github.com/DataDog/dd-sdk-reactnative'
+              tag: 'GitHub'
+              text: 'dd-sdk-reactnative Source code'
+            - link: 'real_user_monitoring/reactnative/'
+              tag: 'Documentation'
+              text: "Learn about React Native Monitoring"
+    - action: pull-and-push-file
       branch: main
       globs:
       - 'docs/expo_crash_reporting.md'

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -809,14 +809,14 @@
               text: "Learn how to explore your RUM data"
 
     - action: pull-and-push-file
-      branch: develop
+      branch: main
       globs:
       - 'docs/codepush.md'
       options:
         dest_path: '/real_user_monitoring/reactnative/'
         file_name: 'codepush.md'
         front_matters:
-          dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/develop/docs/codepush.md"]
+          dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/main/docs/codepush.md"]
           title: CodePush
           kind: documentation
           description: 'Learn how to use a client-side React Native module to interact with Appcenter Codepush and Datadog.'

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -807,6 +807,27 @@
             - link: "real_user_monitoring/explorer/"
               tag: "Documentation"
               text: "Learn how to explore your RUM data"
+
+    - action: pull-and-push-file
+      branch: develop
+      globs:
+      - 'docs/codepush.md'
+      options:
+        dest_path: '/real_user_monitoring/reactnative/'
+        file_name: 'codepush.md'
+        front_matters:
+          dependencies: ["https://github.com/DataDog/dd-sdk-reactnative/blob/develop/docs/codepush.md"]
+          title: CodePush
+          kind: documentation
+          description: 'Learn how to use a client-side React Native module to interact with Appcenter Codepush and Datadog.'
+          further_reading:
+            - link: 'https://github.com/DataDog/dd-sdk-reactnative'
+              tag: 'GitHub'
+              text: 'dd-sdk-reactnative Source code'
+            - link: 'real_user_monitoring/reactnative/'
+              tag: 'Documentation'
+              text: "Learn about React Native Monitoring"
+
     - action: pull-and-push-file
       branch: main
       globs:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Single sources a doc page for Appcenter Codepush into the React Native Monitoring docs.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-4056

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/alai97/reactnative-codepush-doc-update/real_user_monitoring/reactnative/codepush

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Remember to update the `pull_config.yaml` file back to `main` before merging!

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
