### PR TITLE
Remove iam_access_analyzer.md from .gitignore exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ content/en/integrations/guide/amazon_cloudformation.md
 !content/en/integrations/adobe_experience_manager.md
 !content/en/integrations/pivotal_platform.md
 !content/en/integrations/alcide.md
-!content/en/integrations/iam_access_analyzer.md
 !content/en/integrations/kubernetes_audit_logs.md
 !content/en/integrations/apigee.md
 !content/en/integrations/snyk.md


### PR DESCRIPTION
This integration lives in integrations-core, so it looks like we can remove it from the gitignore exclusions list. It keeps showing up in local builds.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
