### PR TITLE
adding Agent FAQ link to top level Agent docs page

### DIFF
--- a/content/en/agent/_index.md
+++ b/content/en/agent/_index.md
@@ -66,6 +66,7 @@ Datadog Agent release numbering follows <a href="https://semver.org/">SemVer</a>
   {{< nextlink href="/agent/guide">}}<u>Guides</u>: These are in-depth, step-by-step tutorials for using the Agent.{{< /nextlink >}}
   {{< nextlink href="/agent/security">}}<u>Security</u>: Information on the main security capabilities and features available to customers to ensure their environment is secure.{{< /nextlink >}}
   {{< nextlink href="/integrations/observability_pipelines/integrate_vector_with_datadog">}}<u>Integrate Vector with Datadog</u>: Configure the Datadog Agent to send data to Vector, a tool for building observability pipelines.{{< /nextlink >}}
+  {{< nextlink href="/agent/faq">}}<u>Agent FAQ</u>: Frequently Asked Questions about the Datadog Agent.{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ## Further Reading


### PR DESCRIPTION
adding Agent FAQ link to top level Agent docs page. Also requesting that this page be made searchable so that it can be more easily found.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Makes the Agent FAQ page easily findable from the top level Agent docs

### Motivation
This FAQ page is very useful, but hard to find. Making it easier to find will be beneficial to everyone coming to the page. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
