### PR TITLE
Update Monolog Message Format

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -43,7 +43,7 @@ For instance, you would append those two attributes to your logs with:
   <?php
   $context = \DDTrace\current_context();
   $append = sprintf(
-      ' [dd.trace_id=%d dd.span_id=%d]',
+      ' [dd.trace_id=%s dd.span_id=%s]',
       $context['trace_id'],
       $context['span_id']
   );
@@ -58,7 +58,7 @@ If the logger implements the [**monolog/monolog** library][4], use `Logger::push
   $logger->pushProcessor(function ($record) {
       $context = \DDTrace\current_context();
       $record['message'] .= sprintf(
-          ' [dd.trace_id=%d dd.span_id=%d]',
+          ' [dd.trace_id=%s dd.span_id=%s]',
           $context['trace_id'],
           $context['span_id']
       );


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
```php
sprintf(
      ' [dd.trace_id=%d dd.span_id=%d]',
      $context['trace_id'],
      $context['span_id']
);
```
- By using this `%d` specifier, the `$context['trace_id']` will be considered as an integer.
- In case the `trace_id` is greater than `9223372036854775807` (the max value), it always return `9223372036854775807` in the output message
- The result is the Log can't be connected with the APM Trace, because actual `trace_id` is different than `9223372036854775807`
<img width="1520" alt="image" src="https://user-images.githubusercontent.com/9279315/191331907-03315aad-1a7b-4b0b-b47c-edcefeda5289.png">

### Motivation
- I had an issue when connecting the log and APM Trace in some cases, and found out that there are duplicated trace_id appeared with the id `9223372036854775807`.
- Hope this PR can help.


<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
