### PR TITLE
Add verification meta tag into our Docs and remove invalid values in Sitemap

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,31 +1,29 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}"
-    data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0"
-    class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner announcement{{ end }}">
+<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0" class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner announcement{{ end }}">
 
 <head>
-    {{ partial "header-scripts.html" . }}
+        {{ partial "header-scripts.html" . }}
 
-    <meta name='zd-site-verification' content='scvnk4hxijj6or52029kqx' />
+        <meta name='zd-site-verification' content='scvnk4hxijj6or52029kqx' />
+        
+        <meta charset="utf-8">
+        {{ partial "prefetch.html" . }}
+        {{ partial "preload.html" . }}
+        <title>{{ if isset .Params "integration_title" }}{{ .Params.integration_title }}{{ else }}{{ .Title }}{{ end }}
+        </title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
+        {{- partial "canonical.html" . -}}
+        {{- partial "noindex.html" . -}}
+        {{- partial "hreflang.html" . -}}
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
 
-    <meta charset="utf-8">
-    {{ partial "prefetch.html" . }}
-    {{ partial "preload.html" . }}
-    <title>{{ if isset .Params "integration_title" }}{{ .Params.integration_title }}{{ else }}{{ .Title }}{{ end }}
-    </title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
-    {{- partial "canonical.html" . -}}
-    {{- partial "noindex.html" . -}}
-    {{- partial "hreflang.html" . -}}
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
+        {{ partialCached "css.html" . }}
 
-    {{ partialCached "css.html" . }}
-
-    {{- if ne $.Params.disable_opengraph_meta_tags true -}}
-    {{- partial "meta.html" . -}}
-    {{- end -}}
+        {{- if ne $.Params.disable_opengraph_meta_tags true -}}
+        {{- partial "meta.html" . -}}
+        {{- end -}}
 </head>
 
 {{ $dot := . }}
@@ -33,13 +31,13 @@
 <!-- get lang specific data file -->
 {{ $.Scratch.Set "data" "" }}
 {{ if ne $dot.Page.Lang "en"}}
-{{ if (fileExists (print "data/partials/home." $dot.Page.Lang ".yaml")) }}
-{{ $.Scratch.Set "data" (index $dot.Page.Site.Data.partials (print "home." $dot.Page.Lang)) }}
+    {{ if (fileExists (print "data/partials/home." $dot.Page.Lang ".yaml")) }}
+      {{ $.Scratch.Set "data" (index $dot.Page.Site.Data.partials (print "home." $dot.Page.Lang)) }}
+    {{ else }}
+      {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.home }}
+    {{ end }}
 {{ else }}
-{{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.home }}
-{{ end }}
-{{ else }}
-{{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.home }}
+    {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.home }}
 {{ end }}
 {{ $datafile := ($.Scratch.Get "data") }}
 
@@ -47,10 +45,7 @@
 
 {{- $bodyClass := $.Scratch.Get "bodyClass" -}}
 {{- $customClass := $.Params.customclass -}}
-
-<body class="{{ .Site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type " /" "-"
-    }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }} {{ $customClass }} {{ if .Site.Params.announcement_banner
-    }}announcement{{ end }}">
+<body class="{{ .Site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }} {{ $customClass }} {{ if .Site.Params.announcement_banner }}announcement{{ end }}">
 
 
     {{ partial "header/header.html" . }}
@@ -60,66 +55,62 @@
     <main class="container pb-2">
 
         <section class="row guides justify-content-center">
-            {{ range $i, $guide := $datafile.guides }}
-            <div class=" guide-col d-flex flex-column">
-                <div class="inner-content">
-                    <div class="guide-no">{{ add $i 1}}.</div>
-                    <h5 class="text-black text-uppercase pt-0 mt-0">{{ $guide.title}} </h5>
+                {{ range $i, $guide := $datafile.guides }}
+                    <div class=" guide-col d-flex flex-column">
+                            <div class="inner-content">
+                            <div class="guide-no">{{ add $i 1}}.</div>
+                        <h5 class="text-black text-uppercase pt-0 mt-0">{{ $guide.title}} </h5>
 
-                    <p class="small">{{ $guide.desc }}</p>
-                    <div class="mt-auto">
-                        <a class="smaller font-semibold text-primary" href="{{ $guide.link | absLangURL }}">{{
-                            $guide.link_text }} ></a>
+                            <p class="small">{{ $guide.desc }}</p>
+                            <div class="mt-auto">
+                                    <a class="smaller font-semibold text-primary" href="{{ $guide.link | absLangURL }}">{{ $guide.link_text }} ></a>
+                            </div>
+                        </div>
+
+
                     </div>
-                </div>
 
+                    {{ if ne $i 2 }}
+                    <div class="px-0 mx-0 right-arrow-container d-none d-md-flex">
+                        <svg class="right-arrow" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 100 100" preserveAspectRatio="none">
+                            <path d="M0,0 L100,50 L0,100" />
+                        </svg>
+                    </div>
 
-            </div>
+                    <svg class="d-block d-md-none down-arrow" xmlns="http://www.w3.org/2000/svg" version="1.1"  viewBox="0 0 100 100" preserveAspectRatio="none">
+                        <path d="M0 0 L50 100 L100 0" />
+                    </svg>
 
-            {{ if ne $i 2 }}
-            <div class="px-0 mx-0 right-arrow-container d-none d-md-flex">
-                <svg class="right-arrow" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 100 100"
-                    preserveAspectRatio="none">
-                    <path d="M0,0 L100,50 L0,100" />
-                </svg>
-            </div>
-
-            <svg class="d-block d-md-none down-arrow" xmlns="http://www.w3.org/2000/svg" version="1.1"
-                viewBox="0 0 100 100" preserveAspectRatio="none">
-                <path d="M0 0 L50 100 L100 0" />
-            </svg>
-
-            {{ end }}
-            {{ end }}
+                    {{ end }}
+                {{ end }}
         </section>
         {{ range $i, $nav_section := $datafile.nav_sections }}
 
-        <section class="row nav-tiles mb-2">
+            <section class="row nav-tiles mb-2">
 
-            {{ range $i, $tile := $nav_section }}
+                    {{ range $i, $tile := $nav_section }}
 
-            {{ range $i, $section := $tile }}
-            {{ if $section.name}}
-            <div class="col-12">
-                <h3 class="text-center mb-2">{{ $section.name }}</h3>
-            </div>
-            {{ end }}
+                        {{ range $i, $section := $tile }}
+                            {{ if $section.name}}
+                                <div class="col-12">
+                                    <h3 class="text-center mb-2">{{ $section.name }}</h3>
+                                </div>
+                            {{ end }}
 
-            {{ range $i, $navtile := $section.navtiles }}
-            <div class="col-12 col-md-6 col-lg-4 col-xl-3 nav-tile d-flex mb-2 mb-md-3">
-                <a class="d-flex flex-column align-items-center w-100 small font-semibold"
-                    href="{{ $navtile.link | absLangURL }}">
-                    {{ partial "icon" (dict "name" $navtile.icon "size" "18px" "color" "transparent" )}}
-                    {{ $navtile.title }}
-                    <span class="font-regular text-center smaller">{{ $navtile.desc }}</span>
-                </a>
+                            {{ range $i, $navtile := $section.navtiles }}
+                                <div class="col-12 col-md-6 col-lg-4 col-xl-3 nav-tile d-flex mb-2 mb-md-3">
+                                        <a class="d-flex flex-column align-items-center w-100 small font-semibold" href="{{ $navtile.link | absLangURL }}">
+                                                {{ partial "icon" (dict "name" $navtile.icon "size" "18px" "color" "transparent" )}}
+                                                {{ $navtile.title }}
+                                                <span class="font-regular text-center smaller">{{ $navtile.desc }}</span>
+                                        </a>
 
-            </div>
-            {{ end }}
+                                </div>
+                            {{ end }}
 
-            {{ end }}
-            {{ end }}
-        </section>
+                        {{ end }}
+                    {{ end }}
+            </section>
 
         {{ end }}
 
@@ -134,5 +125,4 @@
     {{ partial "preview_banner/preview_banner" . }}
 
 </body>
-
 </html>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,29 +1,31 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}" data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0" class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner announcement{{ end }}">
+<html lang="{{ .Site.Language.Lang }}" data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}"
+    data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0"
+    class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner announcement{{ end }}">
 
 <head>
-        {{ partial "header-scripts.html" . }}
+    {{ partial "header-scripts.html" . }}
 
-        <meta name='zd-site-verification' content='jlboaqzlshkylxm3xj9s9' />      
-  
-        <meta charset="utf-8">
-        {{ partial "prefetch.html" . }}
-        {{ partial "preload.html" . }}
-        <title>{{ if isset .Params "integration_title" }}{{ .Params.integration_title }}{{ else }}{{ .Title }}{{ end }}
-        </title>
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
-        {{- partial "canonical.html" . -}}
-        {{- partial "noindex.html" . -}}
-        {{- partial "hreflang.html" . -}}
-        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
+    <meta name='zd-site-verification' content='scvnk4hxijj6or52029kqx' />
 
-        {{ partialCached "css.html" . }}
+    <meta charset="utf-8">
+    {{ partial "prefetch.html" . }}
+    {{ partial "preload.html" . }}
+    <title>{{ if isset .Params "integration_title" }}{{ .Params.integration_title }}{{ else }}{{ .Title }}{{ end }}
+    </title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    {{ if .Params.external_redirect }} {{ partial "meta-http-equiv.html" . }} {{ end }}
+    {{- partial "canonical.html" . -}}
+    {{- partial "noindex.html" . -}}
+    {{- partial "hreflang.html" . -}}
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <link rel="icon" type="image/png" href="https://docs.datadoghq.com/favicon.ico">
 
-        {{- if ne $.Params.disable_opengraph_meta_tags true -}}
-        {{- partial "meta.html" . -}}
-        {{- end -}}
+    {{ partialCached "css.html" . }}
+
+    {{- if ne $.Params.disable_opengraph_meta_tags true -}}
+    {{- partial "meta.html" . -}}
+    {{- end -}}
 </head>
 
 {{ $dot := . }}
@@ -31,13 +33,13 @@
 <!-- get lang specific data file -->
 {{ $.Scratch.Set "data" "" }}
 {{ if ne $dot.Page.Lang "en"}}
-    {{ if (fileExists (print "data/partials/home." $dot.Page.Lang ".yaml")) }}
-      {{ $.Scratch.Set "data" (index $dot.Page.Site.Data.partials (print "home." $dot.Page.Lang)) }}
-    {{ else }}
-      {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.home }}
-    {{ end }}
+{{ if (fileExists (print "data/partials/home." $dot.Page.Lang ".yaml")) }}
+{{ $.Scratch.Set "data" (index $dot.Page.Site.Data.partials (print "home." $dot.Page.Lang)) }}
 {{ else }}
-    {{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.home }}
+{{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.home }}
+{{ end }}
+{{ else }}
+{{ $.Scratch.Set "data" $dot.Page.Site.Data.partials.home }}
 {{ end }}
 {{ $datafile := ($.Scratch.Get "data") }}
 
@@ -45,7 +47,10 @@
 
 {{- $bodyClass := $.Scratch.Get "bodyClass" -}}
 {{- $customClass := $.Params.customclass -}}
-<body class="{{ .Site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }} {{ $customClass }} {{ if .Site.Params.announcement_banner }}announcement{{ end }}">
+
+<body class="{{ .Site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type " /" "-"
+    }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }} {{ $customClass }} {{ if .Site.Params.announcement_banner
+    }}announcement{{ end }}">
 
 
     {{ partial "header/header.html" . }}
@@ -55,62 +60,66 @@
     <main class="container pb-2">
 
         <section class="row guides justify-content-center">
-                {{ range $i, $guide := $datafile.guides }}
-                    <div class=" guide-col d-flex flex-column">
-                            <div class="inner-content">
-                            <div class="guide-no">{{ add $i 1}}.</div>
-                        <h5 class="text-black text-uppercase pt-0 mt-0">{{ $guide.title}} </h5>
+            {{ range $i, $guide := $datafile.guides }}
+            <div class=" guide-col d-flex flex-column">
+                <div class="inner-content">
+                    <div class="guide-no">{{ add $i 1}}.</div>
+                    <h5 class="text-black text-uppercase pt-0 mt-0">{{ $guide.title}} </h5>
 
-                            <p class="small">{{ $guide.desc }}</p>
-                            <div class="mt-auto">
-                                    <a class="smaller font-semibold text-primary" href="{{ $guide.link | absLangURL }}">{{ $guide.link_text }} ></a>
-                            </div>
-                        </div>
-
-
+                    <p class="small">{{ $guide.desc }}</p>
+                    <div class="mt-auto">
+                        <a class="smaller font-semibold text-primary" href="{{ $guide.link | absLangURL }}">{{
+                            $guide.link_text }} ></a>
                     </div>
+                </div>
 
-                    {{ if ne $i 2 }}
-                    <div class="px-0 mx-0 right-arrow-container d-none d-md-flex">
-                        <svg class="right-arrow" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 100 100" preserveAspectRatio="none">
-                            <path d="M0,0 L100,50 L0,100" />
-                        </svg>
-                    </div>
 
-                    <svg class="d-block d-md-none down-arrow" xmlns="http://www.w3.org/2000/svg" version="1.1"  viewBox="0 0 100 100" preserveAspectRatio="none">
-                        <path d="M0 0 L50 100 L100 0" />
-                    </svg>
+            </div>
 
-                    {{ end }}
-                {{ end }}
+            {{ if ne $i 2 }}
+            <div class="px-0 mx-0 right-arrow-container d-none d-md-flex">
+                <svg class="right-arrow" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 100 100"
+                    preserveAspectRatio="none">
+                    <path d="M0,0 L100,50 L0,100" />
+                </svg>
+            </div>
+
+            <svg class="d-block d-md-none down-arrow" xmlns="http://www.w3.org/2000/svg" version="1.1"
+                viewBox="0 0 100 100" preserveAspectRatio="none">
+                <path d="M0 0 L50 100 L100 0" />
+            </svg>
+
+            {{ end }}
+            {{ end }}
         </section>
         {{ range $i, $nav_section := $datafile.nav_sections }}
 
-            <section class="row nav-tiles mb-2">
+        <section class="row nav-tiles mb-2">
 
-                    {{ range $i, $tile := $nav_section }}
+            {{ range $i, $tile := $nav_section }}
 
-                        {{ range $i, $section := $tile }}
-                            {{ if $section.name}}
-                                <div class="col-12">
-                                    <h3 class="text-center mb-2">{{ $section.name }}</h3>
-                                </div>
-                            {{ end }}
+            {{ range $i, $section := $tile }}
+            {{ if $section.name}}
+            <div class="col-12">
+                <h3 class="text-center mb-2">{{ $section.name }}</h3>
+            </div>
+            {{ end }}
 
-                            {{ range $i, $navtile := $section.navtiles }}
-                                <div class="col-12 col-md-6 col-lg-4 col-xl-3 nav-tile d-flex mb-2 mb-md-3">
-                                        <a class="d-flex flex-column align-items-center w-100 small font-semibold" href="{{ $navtile.link | absLangURL }}">
-                                                {{ partial "icon" (dict "name" $navtile.icon "size" "18px" "color" "transparent" )}}
-                                                {{ $navtile.title }}
-                                                <span class="font-regular text-center smaller">{{ $navtile.desc }}</span>
-                                        </a>
+            {{ range $i, $navtile := $section.navtiles }}
+            <div class="col-12 col-md-6 col-lg-4 col-xl-3 nav-tile d-flex mb-2 mb-md-3">
+                <a class="d-flex flex-column align-items-center w-100 small font-semibold"
+                    href="{{ $navtile.link | absLangURL }}">
+                    {{ partial "icon" (dict "name" $navtile.icon "size" "18px" "color" "transparent" )}}
+                    {{ $navtile.title }}
+                    <span class="font-regular text-center smaller">{{ $navtile.desc }}</span>
+                </a>
 
-                                </div>
-                            {{ end }}
+            </div>
+            {{ end }}
 
-                        {{ end }}
-                    {{ end }}
-            </section>
+            {{ end }}
+            {{ end }}
+        </section>
 
         {{ end }}
 
@@ -125,4 +134,5 @@
     {{ partial "preview_banner/preview_banner" . }}
 
 </body>
+
 </html>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,6 +4,8 @@
 <head>
         {{ partial "header-scripts.html" . }}
 
+        <meta name='zd-site-verification' content='jlboaqzlshkylxm3xj9s9' />      
+  
         <meta charset="utf-8">
         {{ partial "prefetch.html" . }}
         {{ partial "preload.html" . }}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -2,7 +2,7 @@
   {{ $allowed := (slice "fr" "ja" ) }}
   {{ range where (where .Data.Pages "Params.beta" "!=" true) ".Params.is_public" "!=" false }}
     {{ $page := . }}
-    {{ if (and (not .Params.private) (not .Params.placeholder)) }}
+    {{ if (and (not .Params.private) (not .Params.placeholder) (.Permalink)) }}
 	  <url>
 	    <loc>{{ .Permalink }}</loc>
       {{ if not .Lastmod.IsZero }}


### PR DESCRIPTION
### What does this PR do?
This PR is to add a verification meta tag within the `<head>` tag on the Documentation homepage to allow Zendesk to verify our domain for their [search crawler](https://support.zendesk.com/hc/en-us/articles/4593564000410). 

Additionally, this PR also adds an additional check to remove `url` tags with empty `loc` in our sitemap.xml. As per the [Sitemap protocol](https://www.sitemaps.org/protocol.html), `loc` must contain a URL string, otherwise it's considered as an invalid value. Please see screenshot below for example:

<img width="1047" alt="image" src="https://user-images.githubusercontent.com/13922058/195005589-d9ae2b0c-a740-4883-b881-b349aa4e857a.png">

Due to this Sitemap XML issue, it's also preventing Zendesk from detecting our page indices and thus cannot crawl our documentation.

### Motivation
I am part of the Technical Solutions team and I need this added in relation to this Support Ops Jira card: https://datadoghq.atlassian.net/browse/SOT-731. Feel free to take a look for more context.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
