### PR TITLE
usage metering consolidate

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -64,9 +64,6 @@
 {{ range (where .Sites.First.Menus.api ".Name" "==" $ParamTitleEn) }}
   {{ range $menuChild := sort .Children ".Params.order" "asc" }}
 
-    {{/* if hasPrefix ($menuChild.Name | lower) "get hourly usage for" */}}
-    {{/* else */}}
-
     {{ $anchorStr := $menuChild.Name }}
     {{ $versionCount := (len $menuChild.Params.versions) }}
     <div class="row">
@@ -204,7 +201,6 @@
             <hr class="mt-0 mb-2" style="border-top: 2px solid#DADADA"/>
         </div>
     </div>
-    {{/* end */}}
 
   {{ end }}
 {{ end }}

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -64,6 +64,9 @@
 {{ range (where .Sites.First.Menus.api ".Name" "==" $ParamTitleEn) }}
   {{ range $menuChild := sort .Children ".Params.order" "asc" }}
 
+    {{/* if hasPrefix ($menuChild.Name | lower) "get hourly usage for" */}}
+    {{/* else */}}
+
     {{ $anchorStr := $menuChild.Name }}
     {{ $versionCount := (len $menuChild.Params.versions) }}
     <div class="row">
@@ -77,13 +80,22 @@
       {{ if gt (len $menuChild.Params.versions) 0 }}
       <div class="col-12 col-md-6">
           <ul class="nav nav-tabs response-toggle border-none justify-content-md-end">
+
+            {{ $isHourlyUsage := (eq ( .Name | lower ) "get hourly usage by product family") }}
+
+            {{ if $isHourlyUsage }}
+              <li class="nav-item">
+                <a class="nav-link mr-1" data-toggle="tab" href="#get-hourly-usage-by-product-family-v1">v1</a>
+              </li>
+            {{ end }}
+
             {{ range $versionIndex, $versionNum := $menuChild.Params.versions }}
               {{ $adat := (index (index $dot.Site.Data.api $versionNum) "full_spec_deref") }}
               {{ $generalRegions := partial "api/regions.html" (dict "servers" $adat.servers) }}
               {{ $endpoint := partial "api/get-endpoint.html" (dict "lang" $.Page.Lang "operationids" $menuChild.Params.operationids "spec" $adat "generalRegions" $generalRegions ) }}
               {{ $endpointVisibility := partial "api/endpoint-visibility.html" (dict "versionCount" $versionCount "versionNum" $versionNum "menuChild" $menuChild "endpoint" $endpoint) }}
               <li class="nav-item">
-                <a class="nav-link mr-1 {{ with $endpointVisibility.label }}{{ else }}px-3{{ end }} {{ if and ($endpointVisibility.isVisibleVersion) (gt (len $menuChild.Params.versions) 1) }}active{{ end }} {{ if and ($endpointVisibility.isVisibleVersion) (eq (len $menuChild.Params.versions) 1) }}disabled{{ end }}" {{- if and (eq (len $menuChild.Params.versions) 1) ($endpoint.action.deprecated | default false) -}}data-toggle="collapse"{{- else -}}data-toggle="tab"{{- end -}} href="#{{ (print $anchorStr "-" $versionNum) | anchorize }}">{{ $versionNum }} {{ with $endpointVisibility.label }}({{ . }}){{ end }}</a>
+                <a class="nav-link mr-1 {{ with $endpointVisibility.label }}{{ else }}px-3{{ end }} {{ if or (and ($endpointVisibility.isVisibleVersion) (gt (len $menuChild.Params.versions) 1)) $isHourlyUsage }}active{{ end }} {{ if and ($endpointVisibility.isVisibleVersion) (eq (len $menuChild.Params.versions) 1) (not $isHourlyUsage) }}disabled{{ end }}" {{- if and (eq (len $menuChild.Params.versions) 1) ($endpoint.action.deprecated | default false) -}}data-toggle="collapse"{{- else -}}data-toggle="tab"{{- end -}} href="#{{ (print $anchorStr "-" $versionNum) | anchorize }}">{{ $versionNum }} {{ with $endpointVisibility.label }}({{ . }}){{ end }}</a>
               </li>
             {{ end }}
           </ul>
@@ -92,6 +104,12 @@
     </div>
 
     <div class="tab-content">
+
+
+    <div id="get-hourly-usage-by-product-family-v1" class="collapse" role="tabpanel">
+      {{ partial "api/usage-menu" (dict "dot" $dot "ParamTitleEn" $ParamTitleEn) }}
+    </div>
+
     <!-- If we have multiple endpoints for a version output them next to each other -->
     {{ range $versionIndex, $versionNum := .Params.versions }}
       {{ $adat := (index (index $dot.Site.Data.api $versionNum) "full_spec_deref") }}
@@ -186,6 +204,7 @@
             <hr class="mt-0 mb-2" style="border-top: 2px solid#DADADA"/>
         </div>
     </div>
+    {{/* end */}}
 
   {{ end }}
 {{ end }}

--- a/layouts/partials/api/usage-menu.html
+++ b/layouts/partials/api/usage-menu.html
@@ -1,0 +1,16 @@
+{{ $dot := .dot }}
+{{ $ParamTitleEn := .ParamTitleEn }}
+<ul>
+{{ range (where $dot.Sites.First.Menus.api ".Name" "==" $ParamTitleEn) }}
+  {{ range $menuChild := sort .Children ".Params.order" "asc" }}
+    {{ $anchorStr := $menuChild.Name }}
+
+    {{ if hasPrefix ($menuChild.Name | lower) "get hourly usage for" }}
+      {{ range $versionIndex, $versionNum := $menuChild.Params.versions }}
+        <li><a href="#{{ (print $anchorStr) | anchorize }}">{{ $menuChild.Name }}</a></li>
+      {{ end }}
+    {{ end }}
+
+  {{ end }}
+{{ end }}
+</ul>

--- a/layouts/partials/nav/left-nav-api.html
+++ b/layouts/partials/nav/left-nav-api.html
@@ -34,12 +34,39 @@
             <ul class="nav">
                 {{ range sort .Children ".Params.order" "asc"  }}
                     {{ $menuChild := . }}
+                    {{ if hasPrefix (.Name | lower) "get hourly usage for" }}
+                      <!--<li style="color:red">{{ .Name }}</li>-->
+                    {{ else }}
                     <li class="row nav-item {{ if $currentPage.IsMenuCurrent $apiMenu . }}active{{ end }}">
                         <a class="col nav-link d-inline-block" href="{{ if hasPrefix .URL "#" }}#{{ .Name | anchorize }}{{ else }}{{ (strings.TrimLeft "/" .URL) | absLangURL }}{{ end }}" data-target="#{{.Identifier}}">
                           <span class="d-inline-block">{{ .Name }}</span>
                         </a>
+
+                        {{- with .Params.versions -}}
+                          {{ $versionCount := (len .) }}
+
+                          <span class="col-auto text-right pr-3 d-inline-block">
+                          {{- range $i, $version := . -}}
+                            {{ if $i }}, {{ end }}
+                            {{ $endpointVisibility := partial "api/endpoint-visibility.html" (dict "versionCount" $versionCount "versionNum" $version "menuChild" $menuChild) }}
+                            <a class="d-inline-block text-purple font-bold px-0 mx-0" data-version="{{- $version -}}" href="#{{- $menuChild.Name | anchorize -}}">
+                              <!-- * - beta , ~x~ - deprecated -->
+                              {{- $endpointVisibility.labelPrefix -}}{{- $version -}}{{- $endpointVisibility.labelSuffix -}}
+                            </a>
+                          {{- end -}}
+                          </span>
+
+                        {{- end -}}
                     </li>
+                    {{ end }}
                 {{ end }}
+
+                <!-- manual get hourly usage -->
+                <!--<li class="row nav-item {{ if $currentPage.IsMenuCurrent $apiMenu . }}active{{ end }}">
+                    <a class="col nav-link d-inline-block" href="#{{ "Get hourly usage" | anchorize }}" data-target="#{{.Identifier}}">
+                      <span class="d-inline-block">Get hourly usage by product family (v1)</span>
+                    </a>
+                </li>-->
             </ul>
         </li>
     {{ else }}

--- a/layouts/partials/nav/left-nav-api.html
+++ b/layouts/partials/nav/left-nav-api.html
@@ -35,38 +35,14 @@
                 {{ range sort .Children ".Params.order" "asc"  }}
                     {{ $menuChild := . }}
                     {{ if hasPrefix (.Name | lower) "get hourly usage for" }}
-                      <!--<li style="color:red">{{ .Name }}</li>-->
                     {{ else }}
                     <li class="row nav-item {{ if $currentPage.IsMenuCurrent $apiMenu . }}active{{ end }}">
                         <a class="col nav-link d-inline-block" href="{{ if hasPrefix .URL "#" }}#{{ .Name | anchorize }}{{ else }}{{ (strings.TrimLeft "/" .URL) | absLangURL }}{{ end }}" data-target="#{{.Identifier}}">
                           <span class="d-inline-block">{{ .Name }}</span>
                         </a>
-
-                        {{- with .Params.versions -}}
-                          {{ $versionCount := (len .) }}
-
-                          <span class="col-auto text-right pr-3 d-inline-block">
-                          {{- range $i, $version := . -}}
-                            {{ if $i }}, {{ end }}
-                            {{ $endpointVisibility := partial "api/endpoint-visibility.html" (dict "versionCount" $versionCount "versionNum" $version "menuChild" $menuChild) }}
-                            <a class="d-inline-block text-purple font-bold px-0 mx-0" data-version="{{- $version -}}" href="#{{- $menuChild.Name | anchorize -}}">
-                              <!-- * - beta , ~x~ - deprecated -->
-                              {{- $endpointVisibility.labelPrefix -}}{{- $version -}}{{- $endpointVisibility.labelSuffix -}}
-                            </a>
-                          {{- end -}}
-                          </span>
-
-                        {{- end -}}
                     </li>
                     {{ end }}
                 {{ end }}
-
-                <!-- manual get hourly usage -->
-                <!--<li class="row nav-item {{ if $currentPage.IsMenuCurrent $apiMenu . }}active{{ end }}">
-                    <a class="col nav-link d-inline-block" href="#{{ "Get hourly usage" | anchorize }}" data-target="#{{.Identifier}}">
-                      <span class="d-inline-block">Get hourly usage by product family (v1)</span>
-                    </a>
-                </li>-->
             </ul>
         </li>
     {{ else }}


### PR DESCRIPTION
### What does this PR do?

This PR:
- Removes from the usage metering api nav endpoints by specific products e.g `Get hourly usage for lambda`
- Adds links to these specific endpoints under a v1 tab in `get hourly usage by product family`

### Motivation

API discussions

### Preview

View the v1 and v2 tabs for `get hourly usage by product family`
https://docs-staging.datadoghq.com/david.jones/metric-usage-migrate/api/latest/usage-metering/#get-hourly-usage-by-product-family

Check other endpoints in other places operate as normal.

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
