### PR TITLE
indent cleanup

### DIFF
--- a/local/bin/py/build/actions/pull_and_push_file.py
+++ b/local/bin/py/build/actions/pull_and_push_file.py
@@ -49,6 +49,8 @@ def pull_and_push_file(content, content_dir):
 
     if output_content:
         file_content = file_content.replace("{{%", "{{<").replace("%}}", ">}}")
+        # remove space or tab before shortcode
+        file_content = re.sub(r"[\t ]+{{<", '{{<', file_content, 0, re.MULTILINE)
         destination_path = content["options"]["dest_path"].lstrip('/')
         dest_path_dir = pathlib.Path(content_dir) / pathlib.Path(destination_path)
         dest_path_dir.mkdir(parents=True, exist_ok=True)

--- a/local/bin/py/build/actions/pull_and_push_folder.py
+++ b/local/bin/py/build/actions/pull_and_push_folder.py
@@ -71,6 +71,8 @@ def pull_and_push_folder(content, content_dir):
             )
             file_content = TEMPLATE.format(front_matter=front_matter, content=txt.strip())
             file_content = file_content.replace("{{%", "{{<").replace("%}}", ">}}")
+            # remove space or tab before shortcode
+            file_content = re.sub(r"[\t ]+{{<", '{{<', file_content, 0, re.MULTILINE)
 
             # Replacing the master README.md by _index.md to follow Hugo logic
             if file_name.endswith("README.md"):


### PR DESCRIPTION
### What does this PR do?

Some shortcodes that are in files in external repos have indentation issues.
This PR cleans spaces or tabs before a shortcode during import to avoid broken pages.

### Motivation

This came to light while testing shortcode usage swap.

### Preview 

https://docs-staging.datadoghq.com/david.jones/cleanup-indent/logs/log_collection/ios/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
