### PR TITLE
Add configuration options based on region

### DIFF
--- a/content/en/integrations/syslog_ng.md
+++ b/content/en/integrations/syslog_ng.md
@@ -96,7 +96,7 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
     - Change the definition of the destination to the following:
 
         ```conf
-        destination d_datadog { tcp("intake.logs.datadoghq.com" port(10516)     tls(peer-verify(required-trusted)) template(DatadogFormat)); };
+        destination d_datadog { tcp({{< region-param key="web_integrations_endpoint" >}} port({{< region-param key="tcp_endpoint_port_ssl" >}})     tls(peer-verify(required-trusted)) template(DatadogFormat)); };
         ```
 
     More information about the TLS parameters and possibilities are available in the [syslog-ng Open Source Edition Administration Guide][1].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add region shortcode for logs tcp intake and shortcode for port

### Motivation
https://datadog.zendesk.com/agent/tickets/906530
- Customer could not see logs as they were sending it to the wrong site and port based on the configuration.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
