### PR TITLE
AWS integrations page unrendered markdown quick fix

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -812,6 +812,9 @@ class Integrations:
                 # Remove % delimiters which can cause Hugo's to break with nested shortcodes.
                 result = result.replace("{{%", "{{<").replace("%}}", ">}}")
 
+                # Preserve % delimiters for markdown shortcodes.
+                result = result.replace("{{< aws-permissions >}}", "{{% aws-permissions %}}")
+
                 with open(out_name, "w", ) as out:
                     out.write(result)
 


### PR DESCRIPTION
### What does this PR do?
Make sure integrations content containing markdown shortcode `aws-permissions` is not converted to use `< >` delimiter yet.

This is a quick fix, we will need a better long-term solution ensuring markdown shortcodes are handled properly when pulling content into the docs build.

### Motivation
Slack: https://dd.slack.com/archives/C0DESMBQU/p1663847183212829

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/aws-integration-fix/integrations/amazon_web_services/#manual

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
