### PR TITLE
Remove unnecessary 'agent_spec' from kubectl apply comamand

### DIFF
--- a/content/en/getting_started/containers/datadog_operator.md
+++ b/content/en/getting_started/containers/datadog_operator.md
@@ -91,7 +91,7 @@ Datadog fully supports using a DaemonSet to deploy the Agent, but manual DaemonS
 
 4. Deploy the Datadog Agent:
   ```bash
-  kubectl apply -f agent_spec=/path/to/your/datadog-agent.yaml
+  kubectl apply -f /path/to/your/datadog-agent.yaml
   ```
 
 ## Validation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines]

### What does this PR do?
Fixes invalid syntax for the `kubectl apply` command in the operator instructions. 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
