### PR TITLE
added path example for windows users

### DIFF
--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -63,6 +63,8 @@ logs:
     source: "<SOURCE>"
 ```
 
+If you are using Windows use `path: "<DRIVE_LETTER>:\\<PATH_LOG_FILE>\\<LOG_FILE_NAME>.log"` for the path. Also verify that the `ddagentuser` has all the read/write access to the log file.
+
 [1]: /agent/guide/agent-configuration-files/
 {{% /tab %}}
 

--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -63,7 +63,7 @@ logs:
     source: "<SOURCE>"
 ```
 
-If you are using Windows use `path: "<DRIVE_LETTER>:\\<PATH_LOG_FILE>\\<LOG_FILE_NAME>.log"` for the path. Also verify that the `ddagentuser` has all the read/write access to the log file.
+On Windows, use the path `"<DRIVE_LETTER>:\\<PATH_LOG_FILE>\\<LOG_FILE_NAME>.log"`, and verify that the user `ddagentuser` has read and write access to the log file.
 
 [1]: /agent/guide/agent-configuration-files/
 {{% /tab %}}


### PR DESCRIPTION
In the docs current state, it isn't clear how a Windows user would tail a custom log file. This gets tricky since the syntax is not clear considering even if they knew to use the Windows file path, they have to use two slashes and also verify the ddagentuser has the proper permissions to access the file.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds an example path for Windows user for tailing custom log files. 

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadog.zendesk.com/agent/tickets/942473
I recently worked with my peer on this ticket here. I found no documentation for tailing custom logs on Windows. After some sandboxing I found that the proper way to configure the log file was with double backslashes. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Once I figured out the backslash issue, I still struggled with the permissions. So I included that as well! 


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
