### PR TITLE
Provide explicit example of the env variable value

### DIFF
--- a/content/en/containers/kubernetes/log.md
+++ b/content/en/containers/kubernetes/log.md
@@ -579,6 +579,7 @@ For Agent v6.12+, short lived container logs (stopped or crashed) are automatica
 If you are missing tags on Kubernetes logs, this may be because the Agent's internal tagger does not yet have the related container or pod tags when logs are sent. To make the Log Agent wait a few seconds for the tagger to be ready, you can use the environment variable `DD_LOGS_CONFIG_TAGGER_WARMUP_DURATION` to set how many seconds to wait. The default value is 0.
 
 ```yaml
+# This is the number of seconds that the log agent waits for the internal tagger to add the related container/pod tags to the logs before the logs are sent.
 # For example, to have the Log Agent wait 5 seconds (Note the value is an integer):
 tagger_warmup_duration: 5
 ```

--- a/content/en/containers/kubernetes/log.md
+++ b/content/en/containers/kubernetes/log.md
@@ -578,6 +578,11 @@ For Agent v6.12+, short lived container logs (stopped or crashed) are automatica
 
 If you are missing tags on Kubernetes logs, this may be because the Agent's internal tagger does not yet have the related container or pod tags when logs are sent. To make the Log Agent wait a few seconds for the tagger to be ready, you can use the environment variable `DD_LOGS_CONFIG_TAGGER_WARMUP_DURATION` to set how many seconds to wait. The default value is 0.
 
+```yaml
+# For example, to have the Log Agent wait 5 seconds (Note the value is an integer):
+tagger_warmup_duration: 5
+```
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Provide an example of the environment variable and the expected value type

### Motivation
https://datadog.zendesk.com/agent/tickets/859823
- Customer on this ticket used an unsupported value type for this variable (ex. '5s'), which disrupted their logging configuration. They requested that the value type be listed in the documentation.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
- There was a PR for a config change which the customer referenced https://github.com/DataDog/datadog-agent/pull/12583

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
