### PR TITLE
Update documentation to reflect 7.41.0 changing the default collectio…

### DIFF
--- a/content/en/database_monitoring/setup_postgres/troubleshooting.md
+++ b/content/en/database_monitoring/setup_postgres/troubleshooting.md
@@ -182,7 +182,9 @@ If a client is using the Postgres [extended query protocol][9] or prepared state
 | Node     | [node-postgres][17]       | Uses the extended query protocol and cannot be disabled. To enable the Datadog Agent to collect execution plans, use [pg-format][18] to format SQL Queries before passing them to [node-postgres][17].                                                                                                                                                                                 |
 
 #### Query is in a database ignored by the Agent instance config
-The query is in a database ignored by the Agent instance config `ignore_databases`. Default databases such as the `rdsadmin` and the `azure_maintenance` databases are ignored in the `ignore_databases` setting. Prior to Agent 7.41.0, the `postgres` database is also ignored. Queries in these databases do not have samples or explain plans. Check the the value of this setting in your instance config and the default values in the [example config file][19].
+The query is in a database ignored by the Agent instance config `ignore_databases`. Default databases such as the `rdsadmin` and the `azure_maintenance` databases are ignored in the `ignore_databases` setting. Queries in these databases do not have samples or explain plans. Check the the value of this setting in your instance config and the default values in the [example config file][19].
+
+_Prior to Agent 7.41.0, the `postgres` database also ignored by default._
 
 #### Query cannot be explained
 Some queries such as BEGIN, COMMIT, SHOW, USE, and ALTER queries cannot yield a valid explain plan from the database. Only SELECT, UPDATE, INSERT, DELETE, and REPLACE queries have support for explain plans.

--- a/content/en/database_monitoring/setup_postgres/troubleshooting.md
+++ b/content/en/database_monitoring/setup_postgres/troubleshooting.md
@@ -182,7 +182,7 @@ If a client is using the Postgres [extended query protocol][9] or prepared state
 | Node     | [node-postgres][17]       | Uses the extended query protocol and cannot be disabled. To enable the Datadog Agent to collect execution plans, use [pg-format][18] to format SQL Queries before passing them to [node-postgres][17].                                                                                                                                                                                 |
 
 #### Query is in a database ignored by the Agent instance config
-The query is in a database ignored by the Agent instance config `ignore_databases`. Default databases such as the `postgres` database are ignored in the `ignore_databases` setting. Queries in these databases do not have samples or explain plans. Check the the value of this setting in your instance config and the default values in the [example config file][19].
+The query is in a database ignored by the Agent instance config `ignore_databases`. Default databases such as the `rdsadmin` and the `azure_maintenance` databases are ignored in the `ignore_databases` setting. Prior to Agent 7.41.0, the `postgres` database is also ignored. Queries in these databases do not have samples or explain plans. Check the the value of this setting in your instance config and the default values in the [example config file][19].
 
 #### Query cannot be explained
 Some queries such as BEGIN, COMMIT, SHOW, USE, and ALTER queries cannot yield a valid explain plan from the database. Only SELECT, UPDATE, INSERT, DELETE, and REPLACE queries have support for explain plans.

--- a/content/en/database_monitoring/setup_postgres/troubleshooting.md
+++ b/content/en/database_monitoring/setup_postgres/troubleshooting.md
@@ -184,7 +184,7 @@ If a client is using the Postgres [extended query protocol][9] or prepared state
 #### Query is in a database ignored by the Agent instance config
 The query is in a database ignored by the Agent instance config `ignore_databases`. Default databases such as the `rdsadmin` and the `azure_maintenance` databases are ignored in the `ignore_databases` setting. Queries in these databases do not have samples or explain plans. Check the the value of this setting in your instance config and the default values in the [example config file][19].
 
-_Prior to Agent 7.41.0, the `postgres` database also ignored by default._
+**Note:** The `postgres` database is also ignored by default in Agent versions <7.41.0.
 
 #### Query cannot be explained
 Some queries such as BEGIN, COMMIT, SHOW, USE, and ALTER queries cannot yield a valid explain plan from the database. Only SELECT, UPDATE, INSERT, DELETE, and REPLACE queries have support for explain plans.


### PR DESCRIPTION
…n for the postgres database

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This updates a troubleshooting entry for postgres to note that we updated the [default collection configuration in agent 7.41.0](https://github.com/DataDog/integrations-core/pull/12999) (not released yet). 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

https://docs-staging.datadoghq.com/alex.normand/update-postgres-doc-mentionning-ignore-databases/database_monitoring/setup_postgres/troubleshooting

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
