### PR TITLE
Add Java tracer compatibility matrix and new download links

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -25,7 +25,7 @@ The Java Tracer supports automatic instrumentation of the following Oracle JDK a
 
 | JVM versions | Operating Systems                                                             | Support level             | Tracer version |
 | -------------| ----------------------------------------------------------------------------- | ------------------------- | -------------- |
-| 18 to 19     | Windows (x86, x86-64)<br>Linux (x86, x86-, arm64)<br>Mac (x86, x86-64, arm64) | [Beta](#support-beta)     | latest         |
+| 18 to 19     | Windows (x86, x86-64)<br>Linux (x86, x86-, arm64)<br>Mac (x86, x86-64, arm64) | [Beta](#support-beta)     | Latest         |
 | 7 to 17      | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)             | [GA](#support-ga)         | latest         |
 | 7 to 17      | Linux (arm64)<br>Mac (arm64)                                                  | [Beta](#support-beta)     | latest         |
 

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -36,7 +36,7 @@ Datadog does not officially support any early-access versions of Java.
 | **Level**                                              | **Support provided**                                                                                                                       |
 |--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
 | <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact customer support for special requests.][6]                                                                    |
-| <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features, bug & security fixes provided on a best-effort basis. |
+| <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features and bug and security fixes are provided on a best-effort basis. |
 | <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                 |
 | <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                           |
 | <span id="support-eol">End-of-life (EOL)</span>        |  No support.                                                                                                                               |

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -19,7 +19,28 @@ further_reading:
 
 The Java Datadog Trace library is open source - view the [GitHub repository][1] for more information.
 
-Datadog officially supports the Java JRE 1.7 and higher of both Oracle JDK and OpenJDK. Datadog does not officially support any early-access versions of Java.
+### Supported JVM runtimes
+
+The Java Tracer supports automatic instrumentation of the following Oracle JDK and OpenJDK JVM runtimes.
+
+| JVM versions | Operating Systems                                                 | Support level         | Tracer version |
+| -------------| ----------------------------------------------------------------- | --------------------- | -------------- |
+| 7 to 17      | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64) | [GA](#support-ga)     | latest         |
+| 7 to 17      | Linux (arm64)<br>Mac (arm64)                                      | [Beta](#support-beta) | latest         |
+
+Datadog does not officially support any early-access versions of Java.
+
+### Levels of support
+
+| **Level**                                              | **Support provided**                                                                                                                       |
+|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact customer support for special requests.][6]                                                                    |
+| <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features, bug & security fixes provided on a best-effort basis. |
+| <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                 |
+| <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                           |
+| <span id="support-eol">End-of-life (EOL)</span>        |  No support.                                                                                                                               |
+
+## Integrations
 
 Beta integrations are disabled by default but can be enabled individually:
 
@@ -222,3 +243,4 @@ Running the Java tracer in Bitbucket is not supported.
 [3]: http://bytebuddy.net
 [4]: /tracing/manual_instrumentation/java
 [5]: https://github.com/DataDog/documentation#outside-contributors
+[6]: https://www.datadoghq.com/support/

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -35,7 +35,7 @@ Datadog does not officially support any early-access versions of Java.
 
 | **Level**                                              | **Support provided**                                                                                                                       |
 |--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact customer support for special requests.][6]                                                                    |
+| <span id="support-unsupported">Unsupported</span>      |  No implementation. Contact [Datadog support][6] for special requests.                                                                   |
 | <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features and bug and security fixes are provided on a best-effort basis. |
 | <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                 |
 | <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                           |

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -21,7 +21,7 @@ The Java Datadog Trace library is open source - view the [GitHub repository][1] 
 
 ### Supported JVM runtimes
 
-The Java Tracer supports automatic instrumentation of the following Oracle JDK and OpenJDK JVM runtimes.
+The Java Tracer supports automatic instrumentation for the following Oracle JDK and OpenJDK JVM runtimes.
 
 | JVM versions | Operating Systems                                                             | Support level             | Tracer version |
 | -------------| ----------------------------------------------------------------------------- | ------------------------- | -------------- |

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -23,10 +23,11 @@ The Java Datadog Trace library is open source - view the [GitHub repository][1] 
 
 The Java Tracer supports automatic instrumentation of the following Oracle JDK and OpenJDK JVM runtimes.
 
-| JVM versions | Operating Systems                                                 | Support level         | Tracer version |
-| -------------| ----------------------------------------------------------------- | --------------------- | -------------- |
-| 7 to 17      | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64) | [GA](#support-ga)     | latest         |
-| 7 to 17      | Linux (arm64)<br>Mac (arm64)                                      | [Beta](#support-beta) | latest         |
+| JVM versions | Operating Systems                                                             | Support level             | Tracer version |
+| -------------| ----------------------------------------------------------------------------- | ------------------------- | -------------- |
+| 18 to 19     | Windows (x86, x86-64)<br>Linux (x86, x86-, arm64)<br>Mac (x86, x86-64, arm64) | [Beta](#support-beta)     | latest         |
+| 7 to 17      | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)             | [GA](#support-ga)         | latest         |
+| 7 to 17      | Linux (arm64)<br>Mac (arm64)                                                  | [Beta](#support-beta)     | latest         |
 
 Datadog does not officially support any early-access versions of Java.
 

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -27,7 +27,7 @@ The Java Tracer supports automatic instrumentation for the following Oracle JDK 
 | -------------| ----------------------------------------------------------------------------- | ------------------------- | -------------- |
 | 18 to 19     | Windows (x86, x86-64)<br>Linux (x86, x86-, arm64)<br>Mac (x86, x86-64, arm64) | [Beta](#support-beta)     | Latest         |
 | 7 to 17      | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)             | [GA](#support-ga)         | Latest         |
-| 7 to 17      | Linux (arm64)<br>Mac (arm64)                                                  | [Beta](#support-beta)     | latest         |
+| 7 to 17      | Linux (arm64)<br>Mac (arm64)                                                  | [Beta](#support-beta)     | Latest         |
 
 Datadog does not officially support any early-access versions of Java.
 

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -37,7 +37,7 @@ Datadog does not officially support any early-access versions of Java.
 |--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
 | <span id="support-unsupported">Unsupported</span>      |  No implementation. Contact [Datadog support][6] for special requests.                                                                   |
 | <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features and bug and security fixes are provided on a best-effort basis. |
-| <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                 |
+| <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features and bug and security fixes.                                                 |
 | <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug and security fixes only.                           |
 | <span id="support-eol">End-of-life (EOL)</span>        |  No support.                                                                                                                               |
 

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -38,7 +38,7 @@ Datadog does not officially support any early-access versions of Java.
 | <span id="support-unsupported">Unsupported</span>      |  No implementation. Contact [Datadog support][6] for special requests.                                                                   |
 | <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features and bug and security fixes are provided on a best-effort basis. |
 | <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                 |
-| <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                           |
+| <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug and security fixes only.                           |
 | <span id="support-eol">End-of-life (EOL)</span>        |  No support.                                                                                                                               |
 
 ## Integrations

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -26,7 +26,7 @@ The Java Tracer supports automatic instrumentation of the following Oracle JDK a
 | JVM versions | Operating Systems                                                             | Support level             | Tracer version |
 | -------------| ----------------------------------------------------------------------------- | ------------------------- | -------------- |
 | 18 to 19     | Windows (x86, x86-64)<br>Linux (x86, x86-, arm64)<br>Mac (x86, x86-64, arm64) | [Beta](#support-beta)     | Latest         |
-| 7 to 17      | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)             | [GA](#support-ga)         | latest         |
+| 7 to 17      | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)             | [GA](#support-ga)         | Latest         |
 | 7 to 17      | Linux (arm64)<br>Mac (arm64)                                                  | [Beta](#support-beta)     | latest         |
 
 Datadog does not officially support any early-access versions of Java.

--- a/content/en/tracing/trace_collection/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/dd_libraries/java.md
@@ -114,7 +114,7 @@ After the agent is installed, to begin tracing your applications:
    
    **Note:** To download a specific major version, use the `https://dtdg.co/java-tracer-vX` link instead, where `vX` is the desired vesion
    (`https://dtdg.co/java-tracer-v0` for latest version 0 for example).
-   Alternatively, visit Datadog's [Maven repository][3] for any specific version.
+   Alternatively, see Datadog's [Maven repository][3] for any specific version.
 
 2. To run your app from an IDE, Maven or Gradle application script, or `java -jar` command, with the Continuous Profiler, deployment tracking, and logs injection (if you are sending logs to Datadog), add the `-javaagent` JVM argument and the following configuration options, as applicable:
 

--- a/content/en/tracing/trace_collection/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/dd_libraries/java.md
@@ -113,7 +113,7 @@ After the agent is installed, to begin tracing your applications:
    ```
    
    **Note:** To download a specific major version, use the `https://dtdg.co/java-tracer-vX` link instead, where `vX` is the desired vesion
-   (`https://dtdg.co/java-tracer-v0` for latest version 0 for example).
+   For example, use `https://dtdg.co/java-tracer-v0` for the latest version 0.
    Alternatively, see Datadog's [Maven repository][3] for any specific version.
 
 2. To run your app from an IDE, Maven or Gradle application script, or `java -jar` command, with the Continuous Profiler, deployment tracking, and logs injection (if you are sending logs to Datadog), add the `-javaagent` JVM argument and the following configuration options, as applicable:

--- a/content/en/tracing/trace_collection/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/dd_libraries/java.md
@@ -111,7 +111,10 @@ After the agent is installed, to begin tracing your applications:
    ```shell
    wget -O dd-java-agent.jar https://dtdg.co/latest-java-tracer
    ```
-   To access a specific tracer version, visit Datadog's [Maven repository][3].
+   
+   **Note:** To download a specific major version, use the `https://dtdg.co/java-tracer-vX` link instead, where `vX` is the desired vesion
+   (`https://dtdg.co/java-tracer-v0` for latest version 0 for example).
+   Alternatively, visit Datadog's [Maven repository][3] for any specific version.
 
 2. To run your app from an IDE, Maven or Gradle application script, or `java -jar` command, with the Continuous Profiler, deployment tracking, and logs injection (if you are sending logs to Datadog), add the `-javaagent` JVM argument and the following configuration options, as applicable:
 

--- a/content/en/tracing/trace_collection/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/dd_libraries/java.md
@@ -112,7 +112,7 @@ After the agent is installed, to begin tracing your applications:
    wget -O dd-java-agent.jar https://dtdg.co/latest-java-tracer
    ```
    
-   **Note:** To download a specific major version, use the `https://dtdg.co/java-tracer-vX` link instead, where `vX` is the desired vesion
+   **Note:** To download a specific major version, use the `https://dtdg.co/java-tracer-vX` link instead, where `vX` is the desired version.
    For example, use `https://dtdg.co/java-tracer-v0` for the latest version 0.
    Alternatively, see Datadog's [Maven repository][3] for any specific version.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR describes the JVM compatibility for Java tracer.
Additionally, it introduces the new download link for major versions.

### Motivation
<!-- What inspired you to submit this pull request?-->
We need to define clear statement about supported JVM for the current and coming versions of the Java tracer.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

@bantonsson Can you review the content to check it matches what you expected?
Compared to the original document, I added mentions to Oracle JDK and OpenJDK, and also the non-support rule for early access builds.

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
