### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/approved_status.yml
+++ b/.github/workflows/approved_status.yml
@@ -10,6 +10,9 @@ on:
       - submitted
       - dismissed
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   send_status:
     runs-on: ubuntu-latest

--- a/.github/workflows/bump_versions.yml
+++ b/.github/workflows/bump_versions.yml
@@ -3,8 +3,13 @@ on:
     # At 08:00 on every day-of-week from Monday through Friday.
     - cron: '0 8 * * 1-5'
 
+permissions: {}
 jobs:
   sdk-versions:
+    permissions:
+      contents: write # for git push
+      pull-requests: write # to create pull request
+
     runs-on: ubuntu-latest
     steps:
       - id: set-versions


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.