### PR TITLE
[ci visibility] Add link to Jenkins instructions in custom tags and metrics

### DIFF
--- a/content/en/continuous_integration/setup_pipelines/custom_tags_and_metrics.md
+++ b/content/en/continuous_integration/setup_pipelines/custom_tags_and_metrics.md
@@ -26,7 +26,7 @@ Custom tags and metrics work with the following CI providers:
 - CircleCI
 - GitLab (SaaS or self-hosted >= 14.1)
 - GitHub.com (SaaS) **Note:** For GitHub, tags and metrics can only be added to the pipeline span.
-- Jenkins **Note:** For Jenkins, you need to follow [these instructions][5].
+- Jenkins **Note:** For Jenkins, follow [these instructions][5] to set up custom tags in your pipelines.
 
 ## Installing the Datadog CI CLI
 

--- a/content/en/continuous_integration/setup_pipelines/custom_tags_and_metrics.md
+++ b/content/en/continuous_integration/setup_pipelines/custom_tags_and_metrics.md
@@ -26,6 +26,7 @@ Custom tags and metrics work with the following CI providers:
 - CircleCI
 - GitLab (SaaS or self-hosted >= 14.1)
 - GitHub.com (SaaS) **Note:** For GitHub, tags and metrics can only be added to the pipeline span.
+- Jenkins **Note:** For Jenkins, you need to follow [these instructions][5].
 
 ## Installing the Datadog CI CLI
 
@@ -134,3 +135,4 @@ and then click the **create measure** option.
 [2]: https://github.com/datadog/datadog-ci#standalone-binary-beta
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 [4]: https://app.datadoghq.com/ci/pipeline-executions
+[5]: /continuous_integration/setup_pipelines/jenkins/?tab=usingui#setting-custom-tags-for-your-pipelines


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR adds `Jenkins` as a supported provider in the `Custom tags and metrics` section with a link to its specific instructions.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
