### PR TITLE
call-out of OpenTelemetry sampling effect on APM metrics accuracy

### DIFF
--- a/content/en/tracing/guide/trace_ingestion_volume_control.md
+++ b/content/en/tracing/guide/trace_ingestion_volume_control.md
@@ -22,7 +22,7 @@ With the ingestion control page, you have full visibility and complete control o
 
 If you decide to reduce the ingestion volume for certain services, the **request, error, and latency [metrics][3]** (known as RED metrics, for Requests, Errors, and Duration) remain 100% accurate, as they are being calculated based on 100% of the application's traffic, regardless of any sampling configuration. These metrics are included when purchasing Datadog APM. In order to make sure you have full visibility into your application's traffic, you can use these metrics to spot potential errors on a service or a resource, by creating dashboards, monitors, and SLOs.
 
-**Note**: If your applications and services are instrumented with OpenTelemetry libraries and you set up some sampling at the SDK level and/or at the collector level, APM metrics are based on the **sampled** set of data.
+**Note**: If your applications and services are instrumented with OpenTelemetry libraries and you set up sampling at the SDK level and/or at the collector level, APM metrics are based on the **sampled** set of data.
 
 Trace data is very repetitive, which means trace samples to investigate any issues are still available with ingestion sampling. For high throughput services, there's usually no need for you to collect every single request - an important enough problem should always show symptoms in multiple traces. Ingestion controls helps you to have the visibility that you need to troubleshoot problems while remaining within budget.
 
@@ -76,7 +76,7 @@ The **Configuration** column tells you whether or not your services are configur
 
 To reduce the ingestion volume at the Agent level, configure `DD_APM_MAX_TPS` (set to `10` by default) to reduce the share of head-based sampling volume. Read more about the [default sampling mechanism][6].
 
-**Note**: this configuration option only takes effect when using **Datadog tracing libraries**. If data is collected with the OTLP Ingest in the Agent from applications instrumented with OpenTelemetry, modifying `DD_APM_MAX_TPS` will not change sampling rates applied in tracing libraries.
+**Note**: This configuration option only goes into effect when using **Datadog tracing libraries**. If the OTLP Ingest in the Agent collects data from applications instrumented with OpenTelemetry, modifying `DD_APM_MAX_TPS` does not change sampling rates that are applied in tracing libraries.
 
 Additionally, to reduce the volume of [error][8] and [rare][9] traces:
 - Configure `DD_APM_ERROR_TPS` to reduce the share of error sampling.
@@ -94,14 +94,14 @@ Click the **Manage Ingestion Rate** button to configure a sampling rate for the 
 
 **Note:** The application needs to be redeployed in order to apply the configuration changes. Datadog recommends applying the changes by setting [environment variables][10].
 
-### Trace Sampling with OpenTelemetry
+### Trace sampling with OpenTelemetry
 
-If your applications and services are instrumented with OpenTelemetry libraries and you're using the OpenTelemetry collector, you are able to use OpenTelemetry sampling capabilities:
+If your applications and services are instrumented with OpenTelemetry libraries and you're using the OpenTelemetry collector, you can use the following OpenTelemetry sampling capabilities:
 
-- [TraceIdRatioBased][11] and [ParentBased][12] are 2 built-in samplers that allow you to implement deterministic head-based sampling based on the trace_id at the **sdk** level.
-- The [Tail Sampling Processor][13] and [Probabilistic Sampling Processor][14] allow you to sample traces based on a set of rules at the **collector** level
+- [TraceIdRatioBased][11] and [ParentBased][12] are 2 built-in samplers that allow you to implement deterministic head-based sampling based on the trace_id at the **SDK** level.
+- The [Tail Sampling Processor][13] and [Probabilistic Sampling Processor][14] allow you to sample traces based on a set of rules at the **collector** level.
 
-Using either of the two options will result in sampled [APM Metrics](#effects-of-reducing-trace-ingestion-volume).
+Using either of the two options results in sampled [APM Metrics](#effects-of-reducing-trace-ingestion-volume).
 
 ## Ingestion reasons glossary
 

--- a/content/en/tracing/guide/trace_ingestion_volume_control.md
+++ b/content/en/tracing/guide/trace_ingestion_volume_control.md
@@ -94,6 +94,15 @@ Click the **Manage Ingestion Rate** button to configure a sampling rate for the 
 
 **Note:** The application needs to be redeployed in order to apply the configuration changes. Datadog recommends applying the changes by setting [environment variables][10].
 
+### Trace Sampling with OpenTelemetry
+
+If your applications and services are instrumented with OpenTelemetry libraries and you're using the OpenTelemetry collector, you are able to use OpenTelemetry sampling capabilities:
+
+- [TraceIdRatioBased][11] and [ParentBased][12] are 2 built-in samplers that allow you to implement deterministic head-based sampling based on the trace_id at the **sdk** level.
+- The [Tail Sampling Processor][13] and [Probabilistic Sampling Processor][14] allow you to sample traces based on a set of rules at the **collector** level
+
+Using either of the two options will result in sampled [APM Metrics](#effects-of-reducing-trace-ingestion-volume).
+
 ## Ingestion reasons glossary
 
 _Know which ingestion mechanisms are responsible for most of the ingestion volume_
@@ -115,7 +124,7 @@ Several other ingestion reasons are surfaced in the Ingestion Control page and a
 | `error`            | [Agent](#globally-configure-the-ingestion-sampling-rate-at-the-agent-level)             | Sampling of errors uncaught by the head-based sampling.             | 10 traces per second per Agent (null, if rules are defined) |
 | `rare`            | [Agent](#globally-configure-the-ingestion-sampling-rate-at-the-agent-level)             |  Sampling of rare traces (catching all combinations of a set of span tags).        | 5 traces per second per Agent (null, if rules are defined) |
 | `manual`             | In-code         | In-code decision override to keep/drop a span and its children.    | null |
-| `analytics`          | Agent and Tracing Libraries | [Deprecated ingestion mechanism][11] that samples single spans without the full trace.   | null                 |
+| `analytics`          | Agent and Tracing Libraries | [Deprecated ingestion mechanism][15] that samples single spans without the full trace.   | null                 |
 
 Additionally, other products can be responsible for sampled span volume:
 
@@ -139,4 +148,8 @@ Read more about ingestion reasons in the [Ingestion Mechanisms documentation][2]
 [8]: /tracing/trace_pipeline/ingestion_mechanisms/#error-traces
 [9]: /tracing/trace_pipeline/ingestion_mechanisms/#rare-traces
 [10]: /tracing/trace_pipeline/ingestion_mechanisms//?tab=environmentvariables#in-tracing-libraries-user-defined-rules
-[11]: /tracing/legacy_app_analytics
+[11]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#traceidratiobased
+[12]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#parentbased
+[13]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/tailsamplingprocessor/README.md
+[14]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/probabilisticsamplerprocessor/README.md
+[15]: /tracing/legacy_app_analytics

--- a/content/en/tracing/guide/trace_ingestion_volume_control.md
+++ b/content/en/tracing/guide/trace_ingestion_volume_control.md
@@ -22,7 +22,7 @@ With the ingestion control page, you have full visibility and complete control o
 
 If you decide to reduce the ingestion volume for certain services, the **request, error, and latency [metrics][3]** (known as RED metrics, for Requests, Errors, and Duration) remain 100% accurate, as they are being calculated based on 100% of the application's traffic, regardless of any sampling configuration. These metrics are included when purchasing Datadog APM. In order to make sure you have full visibility into your application's traffic, you can use these metrics to spot potential errors on a service or a resource, by creating dashboards, monitors, and SLOs.
 
-**Note**: If your applications and services are instrumented with OpenTelemetry libraries and you set up some sampling at the sdk level and/or at the collector level, APM metrics are based on the **sampled** set of data.
+**Note**: If your applications and services are instrumented with OpenTelemetry libraries and you set up some sampling at the SDK level and/or at the collector level, APM metrics are based on the **sampled** set of data.
 
 Trace data is very repetitive, which means trace samples to investigate any issues are still available with ingestion sampling. For high throughput services, there's usually no need for you to collect every single request - an important enough problem should always show symptoms in multiple traces. Ingestion controls helps you to have the visibility that you need to troubleshoot problems while remaining within budget.
 

--- a/content/en/tracing/guide/trace_ingestion_volume_control.md
+++ b/content/en/tracing/guide/trace_ingestion_volume_control.md
@@ -22,6 +22,8 @@ With the ingestion control page, you have full visibility and complete control o
 
 If you decide to reduce the ingestion volume for certain services, the **request, error, and latency [metrics][3]** (known as RED metrics, for Requests, Errors, and Duration) remain 100% accurate, as they are being calculated based on 100% of the application's traffic, regardless of any sampling configuration. These metrics are included when purchasing Datadog APM. In order to make sure you have full visibility into your application's traffic, you can use these metrics to spot potential errors on a service or a resource, by creating dashboards, monitors, and SLOs.
 
+**Note**: If your applications and services are instrumented with OpenTelemetry libraries and you set up some sampling at the sdk level and/or at the collector level, APM metrics are based on the **sampled** set of data.
+
 Trace data is very repetitive, which means trace samples to investigate any issues are still available with ingestion sampling. For high throughput services, there's usually no need for you to collect every single request - an important enough problem should always show symptoms in multiple traces. Ingestion controls helps you to have the visibility that you need to troubleshoot problems while remaining within budget.
 
 #### Metrics from spans
@@ -73,6 +75,8 @@ If the service has a high Downstream Bytes/s rate and a high sampling rate (disp
 The **Configuration** column tells you whether or not your services are configured with sampling rules. If the top services are labelled with `AUTOMATIC` configuration, changing the **Agent configuration** will reduce the volume globally accross services.
 
 To reduce the ingestion volume at the Agent level, configure `DD_APM_MAX_TPS` (set to `10` by default) to reduce the share of head-based sampling volume. Read more about the [default sampling mechanism][6].
+
+**Note**: this configuration option only takes effect when using **Datadog tracing libraries**. If data is collected with the OTLP Ingest in the Agent from applications instrumented with OpenTelemetry, modifying `DD_APM_MAX_TPS` will not change sampling rates applied in tracing libraries.
 
 Additionally, to reduce the volume of [error][8] and [rare][9] traces:
 - Configure `DD_APM_ERROR_TPS` to reduce the share of error sampling.

--- a/content/en/tracing/metrics/metrics_namespace.md
+++ b/content/en/tracing/metrics/metrics_namespace.md
@@ -28,7 +28,9 @@ Tracing application metrics are collected after you [enable trace collection and
 
 {{< img src="tracing/apm_lifecycle/trace_metrics.png" style="width:70%; background:none; border:none; box-shadow:none;" alt="Trace Metrics" >}}
 
-These metrics capture **request** counts, **error** counts, and **latency** measures. They are calculated based on 100% of the application's traffic, regardless of any [trace ingestion sampling][2] configuration. Ensure you have full visibility into your application's traffic by using these metrics to spot potential errors on a service or a resource, and by creating dashboards, monitors, and SLOs. 
+These metrics capture **request** counts, **error** counts, and **latency** measures. They are calculated based on 100% of the application's traffic, regardless of any [trace ingestion sampling][2] configuration. Ensure you have full visibility into your application's traffic by using these metrics to spot potential errors on a service or a resource, and by creating dashboards, monitors, and SLOs.
+
+**Note**: If your applications and services are instrumented with OpenTelemetry libraries and you set up some sampling at the sdk level and/or at the collector level, APM metrics are calculated based on the sampled set of data.
 
 Trace metrics are generated for service entry spans and certain operations depending on integration language. For example, the Django integration produces trace metrics from spans that represent various operations (1 root span for the Django request, 1 for each middleware, and 1 for the view).
 

--- a/content/en/tracing/metrics/metrics_namespace.md
+++ b/content/en/tracing/metrics/metrics_namespace.md
@@ -30,7 +30,7 @@ Tracing application metrics are collected after you [enable trace collection and
 
 These metrics capture **request** counts, **error** counts, and **latency** measures. They are calculated based on 100% of the application's traffic, regardless of any [trace ingestion sampling][2] configuration. Ensure you have full visibility into your application's traffic by using these metrics to spot potential errors on a service or a resource, and by creating dashboards, monitors, and SLOs.
 
-**Note**: If your applications and services are instrumented with OpenTelemetry libraries and you set up some sampling at the sdk level and/or at the collector level, APM metrics are calculated based on the sampled set of data.
+**Note**: If your applications and services are instrumented with OpenTelemetry libraries and you set up some sampling at the SDK level and/or at the collector level, APM metrics are calculated based on the sampled set of data.
 
 Trace metrics are generated for service entry spans and certain operations depending on integration language. For example, the Django integration produces trace metrics from spans that represent various operations (1 root span for the Django request, 1 for each middleware, and 1 for the view).
 

--- a/content/en/tracing/metrics/metrics_namespace.md
+++ b/content/en/tracing/metrics/metrics_namespace.md
@@ -28,9 +28,9 @@ Tracing application metrics are collected after you [enable trace collection and
 
 {{< img src="tracing/apm_lifecycle/trace_metrics.png" style="width:70%; background:none; border:none; box-shadow:none;" alt="Trace Metrics" >}}
 
-These metrics capture **request** counts, **error** counts, and **latency** measures. They are calculated based on 100% of the application's traffic, regardless of any [trace ingestion sampling][2] configuration. Ensure you have full visibility into your application's traffic by using these metrics to spot potential errors on a service or a resource, and by creating dashboards, monitors, and SLOs.
+These metrics capture request counts, error counts, and latency measures. They are calculated based on 100% of the application's traffic, regardless of any [trace ingestion sampling][2] configuration. Ensure that you have full visibility into your application's traffic by using these metrics to spot potential errors on a service or a resource, and by creating dashboards, monitors, and SLOs.
 
-**Note**: If your applications and services are instrumented with OpenTelemetry libraries and you set up some sampling at the SDK level and/or at the collector level, APM metrics are calculated based on the sampled set of data.
+**Note**: If your applications and services are instrumented with OpenTelemetry libraries and you set up sampling at the SDK level and/or at the collector level, APM metrics are calculated based on the sampled set of data.
 
 Trace metrics are generated for service entry spans and certain operations depending on integration language. For example, the Django integration produces trace metrics from spans that represent various operations (1 root span for the Django request, 1 for each middleware, and 1 for the view).
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
When setting up some trace sampling with OpenTelemetry (sdk / collector level), APM metrics are affected. Adding a note about this behaviour in the ingestion volume control guide and in the APM metrics docs

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
