### PR TITLE
Update public documentation for Windows container support

### DIFF
--- a/content/en/containers/docker/_index.md
+++ b/content/en/containers/docker/_index.md
@@ -94,7 +94,7 @@ docker run -d --cgroupns host --pid host --name dd-agent -v /var/run/docker.sock
 {{% /tab %}}
 {{% tab "Windows" %}}
 
-The Datadog Agent is supported in Windows Server 2019 (LTSC) and version 1909 (SAC).
+The Datadog Agent is supported in Windows Server 2019 (LTSC) and Windows Server 2022 (LTSC).
 
 ```shell
 docker run -d --name dd-agent -e DD_API_KEY=<API_KEY> -v \\.\pipe\docker_engine:\\.\pipe\docker_engine gcr.io/datadoghq/agent


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR updates the documentation with the supported Windows versions for containers.

### Motivation
We are ending support for EOLd Windows container versions 1909, 2004 and 20H2 with 7.39.x as the last supported Windows Agent version for these versions. Therefore, the documentation needs to be updated with the new supported versions.
xref [WA-86](https://datadoghq.atlassian.net/browse/WA-86)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
