### PR TITLE
Rename Datadog.Monitoring.Distrib into Datadog.Trace.Bundle

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/dd_libraries/dotnet-core.md
@@ -186,9 +186,9 @@ To install the .NET Tracer machine-wide:
 
 To install the .NET Tracer per-application:
 
-1. Add the `Datadog.Monitoring.Distribution` [NuGet package][1] to your application.
+1. Add the `Datadog.Trace.Bundle` [NuGet package][1] to your application.
 
-[1]: https://www.nuget.org/packages/Datadog.Monitoring.Distribution
+[1]: https://www.nuget.org/packages/Datadog.Trace.Bundle
 {{% /tab %}}
 
 {{< /tabs >}}
@@ -247,37 +247,11 @@ For information about the different methods for setting environment variables, s
 
 {{% tab "NuGet" %}}
 
-1. Set the following required environment variables for automatic instrumentation to attach to your application:
+Follow the instructions in the package readme, also available in [`dd-trace-dotnet` repository][1].
+Docker examples are also available in the [repository][2].
 
-   ```
-   CORECLR_ENABLE_PROFILING=1
-   CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-   CORECLR_PROFILER_PATH=<System-dependent path>
-   DD_DOTNET_TRACER_HOME=<APP_DIRECTORY>/datadog
-   ```
-
-   The value for the `<APP_DIRECTORY>` placeholder is the path to the directory containing the application's `.dll` files. The value for the `CORECLR_PROFILER_PATH` environment variable varies based on the system where the application is running:
-
-   Operating System and Process Architecture | CORECLR_PROFILER_PATH Value
-   ------------------------------------------|----------------------------
-   Alpine Linux x64 | `<APP_DIRECTORY>/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so`
-   Linux x64        | `<APP_DIRECTORY>/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so`
-   Linux ARM64      | `<APP_DIRECTORY>/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so`
-   Windows x64      | `<APP_DIRECTORY>\datadog\win-x64\Datadog.Trace.ClrProfiler.Native.dll`
-   Windows x86      | `<APP_DIRECTORY>\datadog\win-x86\Datadog.Trace.ClrProfiler.Native.dll`
-
-2. For Docker images running on Linux, configure the image to run the `createLogPath.sh` script:
-
-   ```
-   RUN /<APP_DIRECTORY>/datadog/createLogPath.sh
-   ```
-
-   Docker examples are available in the [`dd-trace-dotnet` repository][1].
-
-3. For standalone applications, manually restart the application.
-
-
-[1]: https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples/NugetDeployment
+[1]: https://github.com/DataDog/dd-trace-dotnet/tree/master/docs.Datadog.Trace.Bundle/README.md
+[2]: https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples/NugetDeployment
 {{% /tab %}}
 
 {{< /tabs >}}

--- a/content/en/tracing/trace_collection/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/dd_libraries/dotnet-core.md
@@ -250,7 +250,7 @@ For information about the different methods for setting environment variables, s
 Follow the instructions in the package readme, also available in [`dd-trace-dotnet` repository][1].
 Docker examples are also available in the [repository][2].
 
-[1]: https://github.com/DataDog/dd-trace-dotnet/tree/master/docs.Datadog.Trace.Bundle/README.md
+[1]: https://github.com/DataDog/dd-trace-dotnet/tree/master/docs/Datadog.Trace.Bundle/README.md
 [2]: https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples/NugetDeployment
 {{% /tab %}}
 

--- a/content/en/tracing/trace_collection/dd_libraries/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/dd_libraries/dotnet-framework.md
@@ -159,9 +159,10 @@ To install the .NET Tracer machine-wide:
 
 To install the .NET Tracer per-application:
 
-1. Add the `Datadog.Monitoring.Distribution` [NuGet package][1] to your application.
+1. Add the `Datadog.Trace.Bundle` [NuGet package][1] to your application.
 
-[1]: https://www.nuget.org/packages/Datadog.Monitoring.Distribution
+
+[1]: https://www.nuget.org/packages/Datadog.Trace.Bundle
 {{% /tab %}}
 
 {{< /tabs >}}
@@ -205,25 +206,13 @@ For information about the different methods for setting environment variables, s
 
 {{% tab "NuGet" %}}
 
-1. Set the following required environment variables for automatic instrumentation to attach to your application:
-
-   ```
-   COR_ENABLE_PROFILING=1
-   COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-   COR_PROFILER_PATH=<System-dependent path>
-   DD_DOTNET_TRACER_HOME=<APP_DIRECTORY>/datadog
-   ```
-
-   The value for the `<APP_DIRECTORY>` placeholder is the path to the directory containing the application's `.dll` files. The value for the `COR_PROFILER_PATH` environment variable varies based on the system where the application is running:
-
-   Operating System and Process Architecture | COR_PROFILER_PATH Value
-   ------------------------------------------|----------------------------
-   Windows x64      | `<APP_DIRECTORY>\datadog\win-x64\Datadog.Trace.ClrProfiler.Native.dll`
-   Windows x86      | `<APP_DIRECTORY>\datadog\win-x86\Datadog.Trace.ClrProfiler.Native.dll`
-
-2. For standalone applications, manually restart the application.
+Follow the instructions in the package readme, also available in [`dd-trace-dotnet` repository][1].
+Docker examples are also available in the [repository][2].
 
 
+
+[1]: https://github.com/DataDog/dd-trace-dotnet/tree/master/docs.Datadog.Trace.Bundle/README.md
+[2]: https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples/NugetDeployment
 {{% /tab %}}
 
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Rename Datadog.Monitoring.Distrib into Datadog.Trace.Bundle. It simplifies the documentation as we make it leave in our repo or on the package documentation itself. cf https://github.com/DataDog/dd-trace-dotnet/pull/3263

### Motivation
This setup is now GA.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
