### PR TITLE
[WEB-2737] Allow full docs build when running in Docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ DD_API_KEY ?= false
 DD_APP_KEY ?= false
 DATADOG_API_KEY ?= $(DD_API_KEY)
 DATADOG_APP_KEY ?= $(DD_APP_KEY)
+FULL_BUILD ?= false
 CONFIGURATION_FILE ?= "./local/bin/py/build/configurations/pull_config_preview.yaml"
 
 help:
@@ -74,6 +75,7 @@ start-no-pre-build: node_modules  ## Build and run docs excluding external conte
 start-docker: clean  ## Build and run docs including external content via docker
 	@export REPO_PATH=$(PWD) && \
 	export GITHUB_TOKEN=$(GITHUB_TOKEN) && \
+	export FULL_BUILD=$(FULL_BUILD) && \
 	docker-compose -f ./docker-compose-docs.yml pull && docker-compose -p docs-local -f ./docker-compose-docs.yml up
 
 stop-docker: ## Stop the running docker container.

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -4,4 +4,5 @@
 GITHUB_TOKEN := ${github_personal_token}
 DATADOG_API_KEY := false
 DATADOG_APP_KEY := false
+FULL_BUILD := false
 CONFIGURATION_FILE := "./local/bin/py/build/configurations/pull_config_preview.yaml"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Prerequsites:
 1. Go to project root
 2. Make a copy of `Makefile.config.example` called `Makefile.config`
 3. Enter value for `GITHUB_TOKEN`
-4. Set `DOCKER` to true
+4. Set `FULL_BUILD` to true to build the full documentation with all extra content
 5. Run `make start-docker`
 
 To stop the app, hit Ctrl-C or run `make stop-docker`


### PR DESCRIPTION
### What does this PR do?
Reintroduces `FULL_BUILD` parameter to `Makefile.config` to build the full docs with Docker.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2737

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/docker-full-build/   (nothing should be affected in preview)

testing locally: 
in `Makefile.config` add `FULL_BUILD := true` and follow instructions in readme to start Docker.   this should build the full docs including all external content.   change `FULL_BUILD := false` or remove the parameter.   the lightweight docs should run without the prebuild content.

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
