### PR TITLE
Clarify classification of metrics submitted via DogStatsD or Agent

### DIFF
--- a/content/en/account_management/billing/custom_metrics.md
+++ b/content/en/account_management/billing/custom_metrics.md
@@ -7,7 +7,7 @@ aliases:
 
 If a metric is not submitted from one of the [more than {{< translate key="integration_count" >}} Datadog integrations][1] it's considered a [custom metric][2]<sup>[(1)](#standard-integrations)</sup>.
 
-**A custom metric is uniquely identified by a combination of a metric name and tag values (including the host tag)**.
+**A custom metric is uniquely identified by a combination of a metric name and tag values (including the host tag)**. In general, any metric you send using [DogStatsD][25] or through a [custom Agent Check][26] is a custom metric.
 
 Your monthly billable count for custom metrics (reflected on the Usage page) is calculated by taking the total of all distinct custom metrics for each hour in a given month, and dividing it by the number of hours in the month to compute a monthly average value.
 
@@ -340,3 +340,5 @@ For billing questions, contact your [Customer Success][10] Manager.
 [22]: /integrations/sqlserver/
 [23]: /integrations/amazon_web_services/
 [24]: /help/
+[25]: /metrics/custom_metrics/dogstatsd_metrics_submission/
+[26]: /metrics/custom_metrics/agent_metrics_submission/


### PR DESCRIPTION
### What does this PR do?

Adds guidance for the treatment of metrics as Custom Metrics when using DogStatsD or Agent Checks.

This language appears in /metrics/custom_metrics/ but is separately useful in the context of billing.

### Motivation

I encountered conflicting information when researching this topic--this language from the Custom Metrics page helped me clarify categorization of Custom Metrics. For example, the Node.js StatsD client (`npm/hot-shots`) appears in the list of "more than 500 integrations" but ultimately produces Custom Metrics via DogStatsD.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

I avoided reorganizing the links in this document to avoid a large diff.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
