### PR TITLE
Fixed left nav scrolls to top - [WEB-2516]

### DIFF
--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -196,6 +196,7 @@ function getPathElement(event = null) {
     if (sideNavPathElement) {
         sideNavPathElement.classList.add('active');
         hasParentLi(sideNavPathElement);
+        scrollActiveNavItemToTop()
     }
 
     if (mobileNavPathElement) {
@@ -416,3 +417,23 @@ window.addEventListener(
     false
 );
 
+
+
+function scrollActiveNavItemToTop(){
+    // Scroll the open top level left nav item into view below Docs search input
+    if (document.querySelector('.sidenav:not(.sidenav-api)')) {
+        const headerHeight = $('body .main-nav').height();
+        const padding = 200;
+
+        // set max height of side nav
+        document.querySelector('.sidenav-nav').style.maxHeight = document.documentElement.clientHeight - headerHeight - padding
+    
+        const leftSideNav = document.querySelector('.sidenav:not(.sidenav-api) .sidenav-nav');
+        const sideNavActiveMenuItem = leftSideNav.querySelector('li.open');
+
+        if (sideNavActiveMenuItem) {
+            const distanceToTop = sideNavActiveMenuItem.offsetTop;
+            leftSideNav.scrollTop = distanceToTop - 100;
+        }
+    }
+}

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -424,13 +424,11 @@ function scrollActiveNavItemToTop(){
     if (document.querySelector('.sidenav:not(.sidenav-api)')) {
         const headerHeight = document.querySelector('body .main-nav').style.height;
         const padding = 200;
+        const maxHeight = document.documentElement.clientHeight - headerHeight - padding
 
-        // set max height of side nav. vanilla js here doesnt enable you to set the max height
-        $('.sidenav-nav').css(
-            'maxHeight',
-            document.documentElement.clientHeight - headerHeight - padding
-        );
-    
+        // set max height of side nav.
+        document.querySelector('.sidenav-nav').style.maxHeight = `${maxHeight}px`
+
         const leftSideNav = document.querySelector('.sidenav:not(.sidenav-api) .sidenav-nav');
         const sideNavActiveMenuItem = leftSideNav.querySelector('li.open');
 

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -422,11 +422,14 @@ window.addEventListener(
 function scrollActiveNavItemToTop(){
     // Scroll the open top level left nav item into view below Docs search input
     if (document.querySelector('.sidenav:not(.sidenav-api)')) {
-        const headerHeight = $('body .main-nav').height();
+        const headerHeight = document.querySelector('body .main-nav').style.height;
         const padding = 200;
 
-        // set max height of side nav
-        document.querySelector('.sidenav-nav').style.maxHeight = document.documentElement.clientHeight - headerHeight - padding
+        // set max height of side nav. vanilla js here doesnt enable you to set the max height
+        $('.sidenav-nav').css(
+            'maxHeight',
+            document.documentElement.clientHeight - headerHeight - padding
+        );
     
         const leftSideNav = document.querySelector('.sidenav:not(.sidenav-api) .sidenav-nav');
         const sideNavActiveMenuItem = leftSideNav.querySelector('li.open');


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

fixes the scroll to top functionality on the left nav. A top-level nav item should come into view when opened.

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-2516

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/stefon.simmons/fix-scroll-left-to-selected-pg/getting_started/agent/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
