### PR TITLE
Replace DD_DOGSTATSD_DISABLE with DD_USE_DOGSTATSD

### DIFF
--- a/content/en/containers/docker/_index.md
+++ b/content/en/containers/docker/_index.md
@@ -184,7 +184,7 @@ Send custom metrics with [the StatsD protocol][20]:
 | `DD_DOGSTATSD_SOCKET`            | Path to the unix socket to listen to. Must be in a `rw` mounted volume.                                                                                    |
 | `DD_DOGSTATSD_ORIGIN_DETECTION`  | Enable container detection and tagging for unix socket metrics.                                                                                            |
 | `DD_DOGSTATSD_TAGS`              | Additional tags to append to all metrics, events, and service checks received by this DogStatsD server, for example: `"env:golden group:retrievers"`. |
-| `DD_USE_DOGSTATSD`           | Enable/disable sending custom metrics from the dogstatsd library.                                                                                                |
+| `DD_USE_DOGSTATSD`           | Enable or disable sending custom metrics from the DogStatsD library.                                                                                                |
 Learn more about [DogStatsD over Unix Domain Sockets][21].
 
 ### Tagging

--- a/content/en/containers/docker/_index.md
+++ b/content/en/containers/docker/_index.md
@@ -184,7 +184,7 @@ Send custom metrics with [the StatsD protocol][20]:
 | `DD_DOGSTATSD_SOCKET`            | Path to the unix socket to listen to. Must be in a `rw` mounted volume.                                                                                    |
 | `DD_DOGSTATSD_ORIGIN_DETECTION`  | Enable container detection and tagging for unix socket metrics.                                                                                            |
 | `DD_DOGSTATSD_TAGS`              | Additional tags to append to all metrics, events, and service checks received by this DogStatsD server, for example: `"env:golden group:retrievers"`. |
-| `DD_DOGSTATSD_DISABLE`           | Disables sending custom metrics from the dogstatsd library.                                                                                                |
+| `DD_USE_DOGSTATSD`           | Enable/disable sending custom metrics from the dogstatsd library.                                                                                                |
 Learn more about [DogStatsD over Unix Domain Sockets][21].
 
 ### Tagging


### PR DESCRIPTION
The document lists the environment variable DD_DOGSTATSD_DISABLE to disable sending custom StatsD metrics. The customer had used this variable, but they got this error - "Unknown environment variable: DD_DOGSTATSD_DISABLE".

After discussing with engineering, I was advised to use DD_USE_DOGSTATSD instead. This must be set to false to disable the custom metrics. The customer tried this and it worked fine.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Replace the environment variable DD_DOGSTATSD_DISABLE in the document with DD_USE_DOGSTATSD

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
