### PR TITLE
Fixed Spacing and alignment issues in code samples

### DIFF
--- a/content/en/network_monitoring/devices/guide/migrating-to-snmp-core-check.md
+++ b/content/en/network_monitoring/devices/guide/migrating-to-snmp-core-check.md
@@ -126,7 +126,7 @@ SNMP no longer supports only listing OIDs by their human-readable name. You can 
 {{< code-block lang="yaml" filename="scalar_symbols.yaml" >}}
 metrics:
   - MIB: HOST-RESOURCES-MIB
-  symbol: hrSystemUptime
+    symbol: hrSystemUptime
 {{< /code-block >}}
 
 **With Agent 7.27.0:**
@@ -134,9 +134,9 @@ metrics:
 {{< code-block lang="yaml" filename="scalar_symbols_7_27.yaml" >}}
 metrics:
   - MIB: HOST-RESOURCES-MIB
-  symbol:
-    OID: 1.3.6.1.2.1.25.1.1.0
-    name: hrSystemUptime
+    symbol:
+      OID: 1.3.6.1.2.1.25.1.1.0
+      name: hrSystemUptime
 {{< /code-block >}}
 
 #### Table symbols
@@ -146,14 +146,14 @@ metrics:
 {{< code-block lang="yaml" filename="table_symbols.yaml" >}}
 
 metrics:
-  -MIB: HOST-RESOURCES-MIB
-  table: hrStorageTable
-  symbols:
-    - hrStorageAllocationUnits
-    - hrStoageSize
-  metrics_tags:
-    - tag: storagedec
-      column: hrStorageDescr
+  - MIB: HOST-RESOURCES-MIB
+    table: hrStorageTable
+    symbols:
+      - hrStorageAllocationUnits
+      - hrStoageSize
+    metrics_tags:
+      - tag: storagedec
+        column: hrStorageDescr
 
 {{< /code-block >}}
 
@@ -162,20 +162,20 @@ metrics:
 
 {{< code-block lang="yaml" filename="table_symbols_7_27.yaml" >}}
 metrics:
-  -MIB: HOST-RESOURCES-MIB
-  table:
-    OID: 1.3.6.1.2.1.25.2.3
-    name: hrStorageTable
-  symbols:
-    - OID: 1.3.6.1.2.1.25.2.3.1.4
-      name: hrStorageAllocationUnits
-    - OID: 1.3.6.1.2.1.25.2.3.1.5
-      name: hrStoageSize
-  metrics_tags:
-    - tag: storagedec
-      column:
-        OID: 1.3.6.1.2.1.25.2.3.1.3
-        name: hrStorageDescr
+  - MIB: HOST-RESOURCES-MIB
+    table:
+      OID: 1.3.6.1.2.1.25.2.3
+      name: hrStorageTable
+    symbols:
+      - OID: 1.3.6.1.2.1.25.2.3.1.4
+        name: hrStorageAllocationUnits
+      - OID: 1.3.6.1.2.1.25.2.3.1.5
+        name: hrStoageSize
+    metrics_tags:
+      - tag: storagedec
+        column:
+          OID: 1.3.6.1.2.1.25.2.3.1.3
+          name: hrStorageDescr
 {{< /code-block >}}
 
 


### PR DESCRIPTION
Code spacing was off and made a customers config fail. It was: 
metrics:
  -MIB: HOST-RESOURCES-MIB
  symbol:

It is now:
metrics:
  - MIB: HOST-RESOURCES-MIB symbol:

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the public documentation

### Motivation
Errors customer was running into:
https://a.cl.ly/xQuxj5db

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Check the alignment of the last code block, I wasn't sure about it but it still looks off to me

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
