### PR TITLE
Add blog link to Further Reading section

### DIFF
--- a/content/en/developers/_index.md
+++ b/content/en/developers/_index.md
@@ -11,6 +11,9 @@ further_reading:
 - link: "https://datadoghq.dev/integrations-core/guidelines/dashboards/#best-practices"
   tag: "Best Practices"
   text: "Create great integration dashboards"
+- link: "https://www.datadoghq.com/blog/engineering/druids-the-design-system-that-powers-datadog/"
+  tag: "Blog"
+  text: "DRUIDS, the design system that powers Datadog"
 ---
 
 ## Overview

--- a/content/en/getting_started/application/_index.md
+++ b/content/en/getting_started/application/_index.md
@@ -11,7 +11,9 @@ further_reading:
   - link: 'https://www.datadoghq.com/blog/datadog-quick-nav-menu/'
     tag: 'Blog'
     text: 'Introducing the Datadog quick nav menu'
-
+  - link: 'https://www.datadoghq.com/blog/engineering/druids-the-design-system-that-powers-datadog/'
+    tag: 'Blog'
+    text: 'DRUIDS, the design system that powers Datadog'
 ---
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a link to the DRUIDS blog post to the Datadog Developer docs as well as the `Getting Started with Datadog` page. 

As a side note, I'm not totally convinced that `Getting Started with Datadog` is a good place for this link, so I'm open to feedback in that regard.

### Motivation
Spread awareness of the new Datadog blog post.

### Preview
Developer doc:
https://docs-staging.datadoghq.com/bryce/add-druids-blog-link-to-further-reading-section/developers/#further-reading

Getting Started with Datadog:
https://docs-staging.datadoghq.com/bryce/add-druids-blog-link-to-further-reading-section/getting_started/application/#further-reading

<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
