### PR TITLE
Add blog link to Further Reading section

### DIFF
--- a/content/en/serverless/_index.md
+++ b/content/en/serverless/_index.md
@@ -14,16 +14,16 @@ further_reading:
   text: "Check out the latest Serverless releases! (App login required)."
 - link: "https://www.datadoghq.com/state-of-serverless"
   tag: "Blog"
-  text: "The State of Serverless"
+  text: "The state of Serverless"
 - link: "/serverless/installation/"
   tag: "Documentation"
-  text: "Installing Serverless Monitoring"
+  text: "Installing Serverless monitoring"
 - link: '/serverless/configuration/'
   tag: 'Documentation'
-  text: 'Configure Serverless Monitoring'
+  text: 'Configure Serverless monitoring'
 - link: "/integrations/amazon_lambda/"
   tag: "Documentation"
-  text: "AWS Lambda Integration"
+  text: "AWS Lambda integration"
 - link: "https://www.datadoghq.com/blog/monitoring-lambda-containers/"
   tag: "Blog"
   text: "Monitor AWS Lambda functions deployed using container images"
@@ -39,6 +39,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/aws-lambda-functions-ephemeral-storage-monitoring/"
   tag: "Blog"
   text: "Monitor your AWS Lambda functions' ephemeral storage usage"
+- link: "https://www.datadoghq.com/blog/azure-container-apps/"
+  tag: "Blog"
+  text: "Monitor Azure Container Apps with Datadog"
 ---
 
 {{< vimeo 543362476 >}}

--- a/content/en/serverless/_index.md
+++ b/content/en/serverless/_index.md
@@ -14,7 +14,7 @@ further_reading:
   text: "Check out the latest Serverless releases! (App login required)."
 - link: "https://www.datadoghq.com/state-of-serverless"
   tag: "Blog"
-  text: "The state of Serverless"
+  text: "The State of Serverless"
 - link: "/serverless/installation/"
   tag: "Documentation"
   text: "Installing Serverless monitoring"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a link to the [Monitor Azure Container Apps with Datadog](https://www.datadoghq.com/blog/azure-container-apps/) blog post to the Further Reading section

### Motivation
Spread knowledge of Datadog's ability to monitor Azure Container Apps

### Preview
https://docs-staging.datadoghq.com/bryce/add-blog-link-to-further-reading/serverless#further-reading

### Additional Notes
This is also being added to the Azure docs in the following PR:
https://github.com/DataDog/dogweb/pull/84817
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
