### PR TITLE
Cloud Run edits

### DIFF
--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -6,10 +6,6 @@ kind: documentation
 ## Overview
 Google Cloud Run is is a fully managed serverless platform for deploying and scaling container-based applications. 
 
-## Quickstart
-
-To deploy Datadog serverless monitoring on a pre-built Cloud Run demo application, see [Getting Started with Serverless Monitoring (Cloud Run)][1].
-
 ## Build your Container
 
 2. Add Datadog instrumentation to your existing service.


### PR DESCRIPTION
Updated instructions based on a couple recent customer questions to state what they need to accomplish with the Dockerfile changes instead of setting expectation that it will always be copy and paste. Broke into two sections: 1. Build your Container, 2. Deploy to Cloud Run have a clearer split point where customers may begin using their own CI/CD and secrets tooling instead of the basic GCP ones.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
