### PR TITLE
Recommend using localhost on host installs for OTLP ingest

### DIFF
--- a/content/en/tracing/trace_collection/open_standards/otlp_ingest_in_the_agent.md
+++ b/content/en/tracing/trace_collection/open_standards/otlp_ingest_in_the_agent.md
@@ -50,9 +50,7 @@ Alternatively, configure the endpoints by providing the port through the environ
 - For gRPC (`localhost:4317`): `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT` 
 - For HTTP (`localhost:4318`): `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT`
 
-These must be passed to both the core Agent and trace Agent processes.
-
-If running in a containerized environment, use `0.0.0.0` instead of `localhost` to ensure visibility.
+These must be passed to both the core Agent and trace Agent processes. If running in a containerized environment, use `0.0.0.0` instead of `localhost` to ensure the server is available on non-local interfaces.
 
 Configure either gRPC or HTTP for this feature. Here is [an example application that shows configuration for both][1].
 

--- a/content/en/tracing/trace_collection/open_standards/otlp_ingest_in_the_agent.md
+++ b/content/en/tracing/trace_collection/open_standards/otlp_ingest_in_the_agent.md
@@ -33,6 +33,7 @@ otlp_config:
   receiver:
     protocols:
       grpc:
+        endpoint: localhost:4317
 ```
 For HTTP, default port 4318:
 
@@ -41,14 +42,17 @@ otlp_config:
   receiver:
     protocols:
       http:
+        endpoint: localhost:4318
 ```
 
 Alternatively, configure the endpoints by providing the port through the environment variables:
 
-- For gRPC (`0.0.0.0:4317`): `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT` 
-- For HTTP (`0.0.0.0:4318`): `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT`
+- For gRPC (`localhost:4317`): `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT` 
+- For HTTP (`localhost:4318`): `DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT`
 
-These must be passed to both the core Agent and trace Agent if they are running in separate containers.
+These must be passed to both the core Agent and trace Agent processes.
+
+If running in a containerized environment, use `0.0.0.0` instead of `localhost` to ensure visibility.
 
 Configure either gRPC or HTTP for this feature. Here is [an example application that shows configuration for both][1].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Changes recommendations for OTLP ingest endpoint on local installs to recommend using `localhost`.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

Follow recommendations proposed over at open-telemetry/opentelemetry-collector/issues/6151.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
