### PR TITLE
Add explicit callout for community integration version

### DIFF
--- a/content/en/agent/guide/use-community-integrations.md
+++ b/content/en/agent/guide/use-community-integrations.md
@@ -34,7 +34,7 @@ For Agent v7.21+ / v6.21+:
     ```
     datadog-agent integration install -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
     ```
-
+   The version for the integration can be found in the respective changelog on the integration's Github repository 
 2. Configure your integration similar to core [integrations][1].
 3. [Restart the Agent][2].
 


### PR DESCRIPTION
I've found that customers often don't know how to find a community integrations version number to use in the installation command. I've added a line to explicitly note that the version can be found in the integations changelog to clarify this.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Explicitly call out where to find a community integration version number, which is needed when installing it

### Motivation
<!-- What inspired you to submit this pull request?-->
This is a common question from customers using community integrations

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
