### PR TITLE
Missing a "]"

### DIFF
--- a/content/en/network_monitoring/devices/data.md
+++ b/content/en/network_monitoring/devices/data.md
@@ -21,3 +21,4 @@ Network Device Monitoring does not include any events.
 {{< get-service-checks-from-git "snmp" >}}
 
 [1]: http://oidref.com
+ 


### PR DESCRIPTION
[F5 BIG-IP The number of bytes sent per second by a given virtual server. should be [F5 BIG-IP] The number of bytes sent per second by a given virtual server. for the snmp.ltmVirtualServStatClientBytesOut metric

Link to page: https://docs.datadoghq.com/network_monitoring/devices/data/#metrics

screenshot of punction: https://a.cl.ly/04uWEobn


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
