### PR TITLE
more detail in the C++ tracing error tagging section

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/cpp.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/cpp.md
@@ -83,9 +83,8 @@ span->SetTag("error.type", "errno");
 Adding any of the `error.msg`, `error.stack`, or `error.type` tags sets
 `error` to the value `true`.
 
-To unset an error on a span, set the "error" tag to a false value. This also has
-removing any previously set `error.msg`, `error.stack`, or
-`error.type` tags.
+To unset an error on a span, set the `error` tag to value `false`, which removes
+any previously set `error.msg`, `error.stack`, or `error.type` tags.
 
 ```cpp
 // Clear any error information associated with this span.

--- a/content/en/tracing/trace_collection/custom_instrumentation/cpp.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/cpp.md
@@ -55,23 +55,23 @@ To set tags across all your spans, set the `DD_TAGS` environment variable as a l
 ### Set errors on a span
 
 To associate a span with an error, set one or more error-related tags on the
-span. For example,
+span. For example:
 
 ```cpp
 span->SetTag(opentracing::ext::error, true);
 ```
 
-Or, equivalently,
+Or, alternatively:
 
 ```cpp
 span->SetTag("error", true);
 ```
 
 Add more specific information about the error by setting any combination of the
-"error.msg", "error.stack", or "error.type" tags. See [Error Tracking][12] for
+`error.msg`, `error.stack`, or `error.type` tags. See [Error Tracking][12] for
 more information about error tags.
 
-For example,
+An example of adding a combination of error tags:
 
 ```cpp
 // Associate this span with the "bad file descriptor" error from the standard
@@ -81,11 +81,11 @@ span->SetTag("error.type", "errno");
 ```
 
 Setting any of "error.msg", "error.stack", or "error.type" has the effect of
-setting "error" to a true value.
+`error` to the value `true`.
 
 To unset an error on a span, set the "error" tag to a false value. This also has
-the effect of removing any previously set "error.msg", "error.stack", or
-"error.type" tags.
+removing any previously set `error.msg`, `error.stack`, or
+`error.type` tags.
 
 ```cpp
 // Clear any error information associated with this span.
@@ -202,4 +202,4 @@ Traces can be excluded based on their resource name, to remove synthetic traffic
 [9]: https://github.com/opentracing/opentracing-cpp/blob/master/include/opentracing/propagation.h
 [10]: https://github.com/openzipkin/b3-propagation
 [11]: /tracing/security
-[12]: https://docs.datadoghq.com/tracing/error_tracking/
+[12]: /tracing/error_tracking/

--- a/content/en/tracing/trace_collection/custom_instrumentation/cpp.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/cpp.md
@@ -54,13 +54,43 @@ To set tags across all your spans, set the `DD_TAGS` environment variable as a l
 
 ### Set errors on a span
 
-To customize an error associated with one of your spans, use the below:
+To associate a span with an error, set one or more error-related tags on the
+span. For example,
 
 ```cpp
 span->SetTag(opentracing::ext::error, true);
 ```
 
-Error metadata may be set as additional tags on the same span as well.
+Or, equivalently,
+
+```cpp
+span->SetTag("error", true);
+```
+
+Add more specific information about the error by setting any combination of the
+"error.msg", "error.stack", or "error.type" tags. See [Error Tracking][12] for
+more information about error tags.
+
+For example,
+
+```cpp
+// Associate this span with the "bad file descriptor" error from the standard
+// library.
+span->SetTag("error.msg", "[EBADF] invalid file");
+span->SetTag("error.type", "errno");
+```
+
+Setting any of "error.msg", "error.stack", or "error.type" has the effect of
+setting "error" to a true value.
+
+To unset an error on a span, set the "error" tag to a false value. This also has
+the effect of removing any previously set "error.msg", "error.stack", or
+"error.type" tags.
+
+```cpp
+// Clear any error information associated with this span.
+span->SetTag("error", false);
+```
 
 ## Adding spans
 
@@ -172,3 +202,4 @@ Traces can be excluded based on their resource name, to remove synthetic traffic
 [9]: https://github.com/opentracing/opentracing-cpp/blob/master/include/opentracing/propagation.h
 [10]: https://github.com/openzipkin/b3-propagation
 [11]: /tracing/security
+[12]: https://docs.datadoghq.com/tracing/error_tracking/

--- a/content/en/tracing/trace_collection/custom_instrumentation/cpp.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/cpp.md
@@ -80,7 +80,7 @@ span->SetTag("error.msg", "[EBADF] invalid file");
 span->SetTag("error.type", "errno");
 ```
 
-Setting any of "error.msg", "error.stack", or "error.type" has the effect of
+Adding any of the `error.msg`, `error.stack`, or `error.type` tags sets
 `error` to the value `true`.
 
 To unset an error on a span, set the "error" tag to a false value. This also has


### PR DESCRIPTION
### What does this PR do?
The C++ tracer was recently [updated][1] with changes that affect how `error.*` tags are handled. This is the corresponding documentation update.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.

[1]: https://github.com/DataDog/dd-opentracing-cpp/pull/244