### PR TITLE
[WEB-2718] Exclude files from Transifex syncing

### DIFF
--- a/translate.yaml
+++ b/translate.yaml
@@ -21,6 +21,15 @@ ignores:
   - "**/*.ja.yaml"
   - "**/*.ja.json"
   - "**/ja.json"
+  - "content/en/api/latest/service-level-objective-corrections/*.md"
+  - "content/en/integrations/observability_pipelines/guide/*.md"
+  - "content/en/real_user_monitoring/connect_rum_and_traces/*.md"
+  - "content/en/security_platform/application_security/**/*.md"
+  - "content/en/security_platform/security_signal_management/*.md"
+  - "content/en/tracing/dynamic_instrumentation/**/*.md"
+  - "content/en/tracing/other_telemetry/**/*.md"
+  - "content/en/tracing/setup_overview/**/*.md"
+  - "content/en/tracing/trace_collection/**/*.md"
 
 # These files will be uploaded to Transifex for translation when syncing.
 sources:


### PR DESCRIPTION
### What does this PR do?
Temporarily exclude some file paths from being included in the Transifex-Github sync.  We will re-enable these after running some data cleanup scripts in Transifex.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2718

### Preview
n/a

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
