### PR TITLE
Add Workflows Authentication page

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1284,7 +1284,7 @@ main:
     identifier: workflows
     parent: platform_heading
     weight: 140000
-  - name: Set up Workflows
+  - name: Authentication
     url: workflows/setup/
     parent: workflows
     identifier: workflows_setup

--- a/content/en/workflows/setup.md
+++ b/content/en/workflows/setup.md
@@ -1,9 +1,82 @@
 ---
-title: Set up Workflows
+title: Authentication
 kind: documentation
 disable_toc: false
 further_reading:
-- link: "logs/processing/pipelines"
+- link: "/integrations/"
   tag: "Documentation"
-  text: "Log processing pipelines"
+  text: "Learn about integrations"
 ---
+
+<div class="alert alert-warning">Workflows are in public beta. If you have any feedback or questions, contact <a href="/help">Datadog support</a>.</div>
+
+Because workflow actions connect with external software systems, you may need to authenticate your Datadog account to the corresponding integration or integrations. A workflow can run successfully only if every workflow action that requires authentication can verify the identity of your Datadog account.
+
+Integration actions can be authenticated in two ways:
+- Credentials and permissions configured in the integration tile
+- Custom connection credentials
+
+## Integration tile credentials
+
+Credentials and account authentication that you set up in Datadog integration tiles automatically propagate to the corresponding actions in Workflows. Configure the integration tiles by following instructions in [Datadog Integrations][1].
+
+## Custom connection credentials
+
+You can create custom credentials within Workflows. These custom connection credentials are only available for use within the Workflows product.
+
+### Create custom connection
+
+1. In the left navigation, go to **Integrations** -> **Workflows** to access the [Workflows list][2].
+1. Click **Connections** in the upper right.
+1. Select **New Connection**. A dialog box appears.
+1. Choose an integration schema. The **Custom** option allows you to authenticate using a token or username/password combination. The other options use authentication schemas associated with the integration.
+1. Fill in the remaining information required by the integration schema.
+1. Click **Create** to save your custom connection.
+
+### Restrict connection use
+
+You can set permissions on each connection to limit modifications or restrict their use. The granular permissions include **Editor** and **Resolver**.
+
+1. Navigate to the [Workflows list][2].
+1. Click **Connections** in the upper right. A list of connections appears.
+1. Hover over the connection on which you would like to set granular permissions. Edit, permissions, and delete icons appear on the right.
+1. Click the lock (permissions) icon.
+1. Select **Restrict Access**.
+1. Select a role from the dropdown. Click **Add**. The role you selected populates into the bottom of the dialog box.
+1. Next to the role name, select your desired permission from the dropdown.
+1. Click **Save**.
+
+### Edit connection
+
+1. Navigate to the [Workflows list][2].
+1. Click **Connections** in the upper right. A list of connections appears.
+1. Hover over the connection you would like to edit. Edit, permissions, and delete icons appear on the right.
+1. Click the pencil (edit) icon. A dialog box appears.
+1. Update the fields you would like to change.
+1. Click **Save**.
+
+### Delete connection
+
+1. Navigate to the [Workflows list][2].
+1. Click **Connections** in the upper right. A list of connections appears.
+1. Hover over the connection you would like to delete. Edit, permissions, and delete icons appear on the right.
+1. Click the trash can (delete) icon. "Are you sure?" text appears.
+1. Select **Delete**.
+
+## Add credentials to an action
+
+Whether you configured credentials in the integration tile or created a custom connection, Workflows makes your credentials available for each workflow action. To add credentials to an action, follow the steps below:
+
+1. Navigate to the [Workflows list][2].
+1. Select the workflow containing the action to which you need to add a credential. The workflow builder appears.
+1. In the workflow visualization, click the action to which you need to add a credential.
+1. The right side panel populates with the action details.
+1. Under the **Configure** tab, look for the **Authentication** dropdown. Choose your desired credential from the dropdown. Or, click **Add New** to create a new credential.
+1. Click **Save**.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /integrations/
+[2]: https://app.datadoghq.com/workflow

--- a/content/en/workflows/setup.md
+++ b/content/en/workflows/setup.md
@@ -39,8 +39,8 @@ You can set permissions on each connection to limit modifications or restrict th
 
 1. Navigate to the [Workflows list][2].
 1. Click **Connections** in the upper right. A list of connections appears.
-1. Hover over the connection on which you would like to set granular permissions. Edit, permissions, and delete icons appear on the right.
-1. Click the lock (permissions) icon.
+1. Hover over the connection on which you would like to set granular permissions. **Edit**, **Permissions**, and **Delete** icons appear on the right.
+1. Click the padlock (**Permissions**) icon.
 1. Select **Restrict Access**.
 1. Select a role from the dropdown. Click **Add**. The role you selected populates into the bottom of the dialog box.
 1. Next to the role name, select your desired permission from the dropdown.
@@ -50,8 +50,8 @@ You can set permissions on each connection to limit modifications or restrict th
 
 1. Navigate to the [Workflows list][2].
 1. Click **Connections** in the upper right. A list of connections appears.
-1. Hover over the connection you would like to edit. Edit, permissions, and delete icons appear on the right.
-1. Click the pencil (edit) icon. A dialog box appears.
+1. Hover over the connection you would like to edit. **Edit**, **Permissions**, and **Delete** icons appear on the right.
+1. Click the pencil (**Edit**) icon. A dialog box appears.
 1. Update the fields you would like to change.
 1. Click **Save**.
 
@@ -59,8 +59,8 @@ You can set permissions on each connection to limit modifications or restrict th
 
 1. Navigate to the [Workflows list][2].
 1. Click **Connections** in the upper right. A list of connections appears.
-1. Hover over the connection you would like to delete. Edit, permissions, and delete icons appear on the right.
-1. Click the trash can (delete) icon. "Are you sure?" text appears.
+1. Hover over the connection you would like to delete. **Edit**, **Permissions**, and **Delete** icons appear on the right.
+1. Click the trash can (**Delete**) icon. "Are you sure?" text appears.
 1. Select **Delete**.
 
 ## Add credentials to an action

--- a/content/en/workflows/setup.md
+++ b/content/en/workflows/setup.md
@@ -6,49 +6,72 @@ further_reading:
 - link: "/integrations/"
   tag: "Documentation"
   text: "Learn about integrations"
+- link: "/workflows/actions_catalog"
+  tag: "Documentation"
+  text: "See the list of workflow actions"
 ---
 
-<div class="alert alert-warning">Workflows are in public beta. If you have any feedback or questions, contact <a href="/help">Datadog support</a>.</div>
+{{< beta-callout url="https://forms.gle/VEjerYVQ2QJhauZ57" >}}
+  Workflows are in public beta. If you have any feedback or questions, contact <a href="/help">Datadog support</a>.
+{{< /beta-callout >}}
 
-Because workflow actions connect with external software systems, you may need to authenticate your Datadog account to the corresponding integration or integrations. A workflow can run successfully only if every workflow action that requires authentication can verify the identity of your Datadog account.
+Because workflow [actions][1] connect with external software systems, you may need to authenticate your Datadog account to the corresponding integration or integrations. A workflow can run successfully only if every workflow action that requires authentication can verify the identity of your Datadog account.
 
-Integration actions can be authenticated in two ways:
+Workflow actions can be authenticated in two ways:
 - Credentials and permissions configured in the integration tile
 - Custom connection credentials
 
 ## Integration tile credentials
 
-Credentials and account authentication that you set up in Datadog integration tiles automatically propagate to the corresponding actions in Workflows. Configure the integration tiles by following instructions in [Datadog Integrations][1].
+Credentials and account authentication that you set up in Datadog integration tiles automatically propagate to the corresponding actions in Workflows. Configure the integration tiles by following instructions in [Datadog Integrations][2].
 
 ## Custom connection credentials
 
-You can create custom credentials within Workflows. These custom connection credentials are only available for use within the Workflows product.
+You can create custom credentials within Workflows. These custom connection credentials are only available for use within the Workflows product. 
+
+Using custom connection credentials allow you to authenticate a workflow action using one of the following options:
+- Token based authentication
+- A username and password combination
+
+Use custom connections to authenticate [generic actions][3] or any action for which the integration tile does not offer authentication.
 
 ### Create custom connection
 
-1. In the left navigation, go to **Integrations** -> **Workflows** to access the [Workflows list][2].
+1. In the left navigation, go to **Integrations** -> **Workflows** to access the [Workflows list][3].
 1. Click **Connections** in the upper right.
 1. Select **New Connection**. A dialog box appears.
 1. Choose an integration schema. The **Custom** option allows you to authenticate using a token or username/password combination. The other options use authentication schemas associated with the integration.
 1. Fill in the remaining information required by the integration schema.
 1. Click **Create** to save your custom connection.
 
+## Working with connections
+
 ### Restrict connection use
 
-You can set permissions on each connection to limit modifications or restrict their use. The granular permissions include **Editor** and **Resolver**.
+You can set permissions on each connection to limit modifications or restrict their use. The granular permissions include **Viewer**, **Resolver**, and **Editor**.
 
-1. Navigate to the [Workflows list][2].
+Viewer
+: Can view
+
+Resolver
+: Can resolve and view
+
+Editor
+: Can edit, resolve, and view
+
+1. Navigate to the [Workflows list][3].
 1. Click **Connections** in the upper right. A list of connections appears.
 1. Hover over the connection on which you would like to set granular permissions. **Edit**, **Permissions**, and **Delete** icons appear on the right.
 1. Click the padlock (**Permissions**) icon.
 1. Select **Restrict Access**.
 1. Select a role from the dropdown. Click **Add**. The role you selected populates into the bottom of the dialog box.
 1. Next to the role name, select your desired permission from the dropdown.
+1. If you would like to remove access from a role, click the trash can icon to the right of the role name.
 1. Click **Save**.
 
 ### Edit connection
 
-1. Navigate to the [Workflows list][2].
+1. Navigate to the [Workflows list][3].
 1. Click **Connections** in the upper right. A list of connections appears.
 1. Hover over the connection you would like to edit. **Edit**, **Permissions**, and **Delete** icons appear on the right.
 1. Click the pencil (**Edit**) icon. A dialog box appears.
@@ -57,17 +80,17 @@ You can set permissions on each connection to limit modifications or restrict th
 
 ### Delete connection
 
-1. Navigate to the [Workflows list][2].
+1. Navigate to the [Workflows list][3].
 1. Click **Connections** in the upper right. A list of connections appears.
 1. Hover over the connection you would like to delete. **Edit**, **Permissions**, and **Delete** icons appear on the right.
 1. Click the trash can (**Delete**) icon. "Are you sure?" text appears.
 1. Select **Delete**.
 
-## Add credentials to an action
+### Add credentials to an action
 
 Whether you configured credentials in the integration tile or created a custom connection, Workflows makes your credentials available for each workflow action. To add credentials to an action, follow the steps below:
 
-1. Navigate to the [Workflows list][2].
+1. Navigate to the [Workflows list][3].
 1. Select the workflow containing the action to which you need to add a credential. The workflow builder appears.
 1. In the workflow visualization, click the action to which you need to add a credential.
 1. The right side panel populates with the action details.
@@ -78,5 +101,6 @@ Whether you configured credentials in the integration tile or created a custom c
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /integrations/
-[2]: https://app.datadoghq.com/workflow
+[1]: /workflows/actions_catalog/
+[2]: /integrations/
+[3]: https://app.datadoghq.com/workflow


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a page to the Workflows product documentation about Authentication. Originally, this section was called Setup, but I realized that it only has to do with authentication, so I renamed it.

### Motivation
This section corresponds to the following outline, agreed upon by the Documentation team and Sarjeel:

Setup/Prerequisites
1. Explain that workflows use integration configurations
2. Manage Workflow Integrations via Workflow Connections
    a. (P1) Create New Connection 
    b. (P1) Restrict Workflow Connection Usage
    c. (P2) Edit Workflow Connection
    d. (P3) Delete Workflow Connection


<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
