### PR TITLE
Add note on Synthetics no data

### DIFF
--- a/content/en/monitors/service_level_objectives/monitor.md
+++ b/content/en/monitors/service_level_objectives/monitor.md
@@ -110,9 +110,10 @@ Muting a monitor does not affect the SLO calculation.
 To exclude time periods from an SLO calculation, use the [SLO status corrections][5] feature.
 
 ### Missing data
-When you create a monitor, you choose whether it sends an alert when data is missing. This configuration affects how a monitor-based SLO calculation interprets missing data.
+When you create a metric monitor or service check, you choose whether it sends an alert when data is missing. This configuration affects how a monitor-based SLO calculation interprets missing data. For monitors configured to ignore missing data, time periods with missing data are treated as OK (uptime) by the SLO. For monitors configured to alert on missing data, time periods with missing data are treated as ALERT (downtime) by the SLO.
 
-For monitors configured to ignore missing data, time periods with missing data are treated as OK by the SLO. For monitors configured to alert on missing data, time periods with missing data are treated as ALERT by the SLO.
+If you pause a Synthetic test, the SLO removes the time period with missing data from its calculation. In the UI, these time periods are marked light gray on the SLO status bar. 
+
 
 ## Underlying monitor and SLO histories
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add a sentence explaining how SLOs treat Synthetic no data periods, following the release of the new unified no data monitor settings

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
https://docs-staging.datadoghq.com/kai/synthetic-slo-no-data/monitors/service_level_objectives/monitor/#missing-data

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
