### PR TITLE
Clarification on supported monitors for "Group Retention Time"

### DIFF
--- a/content/en/monitors/create/configuration.md
+++ b/content/en/monitors/create/configuration.md
@@ -199,7 +199,7 @@ Some use cases to define a group retention time include:
 - When you would like to drop the group immediately or shortly after data stops reporting
 - When you would like to keep the group in the status for as long as you usually take for troubleshooting
 
-**Note**: This option is only available for multi-alert monitors and works with the [`On missing data`][5] option mentioned above.
+**Note**: This option is only available for multi-alert monitors and will only work with monitors that support the [`On missing data`][5] option mentioned above (APM Trace Analytics, Audit Logs, CI Pipelines, Error Tracking, Events, Logs, and RUM monitors).
 
 #### New group delay
 

--- a/content/en/monitors/create/configuration.md
+++ b/content/en/monitors/create/configuration.md
@@ -199,7 +199,7 @@ Some use cases to define a group retention time include:
 - When you would like to drop the group immediately or shortly after data stops reporting
 - When you would like to keep the group in the status for as long as you usually take for troubleshooting
 
-**Note**: This option is only available for multi-alert monitors and will only work with monitors that support the [`On missing data`][5] option mentioned above (APM Trace Analytics, Audit Logs, CI Pipelines, Error Tracking, Events, Logs, and RUM monitors).
+**Note**: The group retention time option requires a multi-alert monitor that supports the [`On missing data`][5] option. These monitor types are APM Trace Analytics, Audit Logs, CI Pipelines, Error Tracking, Events, Logs, and RUM monitors.
 
 #### New group delay
 


### PR DESCRIPTION
### What does this PR do?
Clarify further that the "Group Retention Time" only works with multi-alert monitors THAT ARE ALSO monitors that support the "On missing data" feature (APM Trace Analytics, Audit Logs, CI Pipelines, Error Tracking, Events, Logs, and RUM monitors).

### Motivation
https://docs.datadoghq.com/monitors/create/configuration/?tab=othermonitortypes#group-retention-time

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->



---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
