### PR TITLE
go: Update Go version required in Code Hotspots documentation

### DIFF
--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -163,7 +163,7 @@ Endpoint profiling is disabled by default when you turn on profiling for your [G
 - You are using [dd-trace-go][2] version 1.35.0 or later.
 - [`DD_PROFILING_ENDPOINT_COLLECTION_ENABLED=true`][3] is set in your environment, or the [`tracer.WithProfilerEndpoints(true)`][3] option is passed to [`tracer.Start()`][4]. This option is enabled by default in [dd-trace-go][2] versions 1.37.0+.
 
-**Warning:** Go 1.17 and below has several bugs (see [GH-35057][5], [GH-48577][6], [CL-369741][7], [CL-369983][8]) that can reduce the accuracy of this feature, especially when using a lot of CGO. They are scheduled to be fixed in the 1.18 release.
+**Note:** This feature works best with Go version 1.18 or newer. Go 1.17 and below has several bugs (see [GH-35057][5], [GH-48577][6], [CL-369741][7], [CL-369983][8]) that can reduce the accuracy of this feature, especially when using a lot of CGO.
 
 [1]: /profiler/enabling/go
 [2]: https://github.com/DataDog/dd-trace-go/releases

--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -74,7 +74,7 @@ To enable Code Hotspots identification for Go, [turn on profiling for your servi
 - [`profiler.CPUDuration(60*time.Second)`][5] and [`profiler.WithPeriod(60*time.Second)`][6] are passed to [`profiler.Start()`][7] to capture hotspot information for 100% of all spans. These values are set by default in [dd-trace-go][2] versions 1.37.0+.
 
 
-**Warning:** Go 1.17 and below has several bugs (see [GH-35057][8], [GH-48577][9], [CL-369741][10], [CL-369983][11]) that can reduce the accuracy of this feature, especially when using a lot of CGO. They are scheduled to be fixed in the 1.18 release.
+**Note:** This features works best with Go version 1.18 or newer. Go 1.17 and below has several bugs (see [GH-35057][8], [GH-48577][9], [CL-369741][10], [CL-369983][11]) that can reduce the accuracy of this feature, especially when using a lot of CGO.
 
 [1]: /profiler/enabling/go
 [2]: https://github.com/DataDog/dd-trace-go/releases

--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -74,7 +74,7 @@ To enable Code Hotspots identification for Go, [turn on profiling for your servi
 - [`profiler.CPUDuration(60*time.Second)`][5] and [`profiler.WithPeriod(60*time.Second)`][6] are passed to [`profiler.Start()`][7] to capture hotspot information for 100% of all spans. These values are set by default in [dd-trace-go][2] versions 1.37.0+.
 
 
-**Note:** This features works best with Go version 1.18 or newer. Go 1.17 and below has several bugs (see [GH-35057][8], [GH-48577][9], [CL-369741][10], [CL-369983][11]) that can reduce the accuracy of this feature, especially when using a lot of CGO.
+**Note:** This feature works best with Go version 1.18 or newer. Go 1.17 and below has several bugs (see [GH-35057][8], [GH-48577][9], [CL-369741][10], [CL-369983][11]) that can reduce the accuracy of this feature, especially when using a lot of CGO.
 
 [1]: /profiler/enabling/go
 [2]: https://github.com/DataDog/dd-trace-go/releases

--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -74,7 +74,7 @@ To enable Code Hotspots identification for Go, [turn on profiling for your servi
 - [`profiler.CPUDuration(60*time.Second)`][5] and [`profiler.WithPeriod(60*time.Second)`][6] are passed to [`profiler.Start()`][7] to capture hotspot information for 100% of all spans. These values are set by default in [dd-trace-go][2] versions 1.37.0+.
 
 
-**Note:** This feature works best with Go version 1.18 or newer. Go 1.17 and below has several bugs (see [GH-35057][8], [GH-48577][9], [CL-369741][10], [CL-369983][11]) that can reduce the accuracy of this feature, especially when using a lot of CGO.
+**Note:** This feature works best with Go version 1.18 or newer. Go 1.17 and below have several bugs (see [GH-35057][8], [GH-48577][9], [CL-369741][10], and [CL-369983][11]) that can reduce the accuracy of this feature, especially when using a lot of CGO.
 
 [1]: /profiler/enabling/go
 [2]: https://github.com/DataDog/dd-trace-go/releases
@@ -163,7 +163,7 @@ Endpoint profiling is disabled by default when you turn on profiling for your [G
 - You are using [dd-trace-go][2] version 1.35.0 or later.
 - [`DD_PROFILING_ENDPOINT_COLLECTION_ENABLED=true`][3] is set in your environment, or the [`tracer.WithProfilerEndpoints(true)`][3] option is passed to [`tracer.Start()`][4]. This option is enabled by default in [dd-trace-go][2] versions 1.37.0+.
 
-**Note:** This feature works best with Go version 1.18 or newer. Go 1.17 and below has several bugs (see [GH-35057][5], [GH-48577][6], [CL-369741][7], [CL-369983][8]) that can reduce the accuracy of this feature, especially when using a lot of CGO.
+**Note:** This feature works best with Go version 1.18 or newer. Go 1.17 and below have several bugs (see [GH-35057][5], [GH-48577][6], [CL-369741][7], and [CL-369983][8]) that can reduce the accuracy of this feature, especially when using a lot of CGO.
 
 [1]: /profiler/enabling/go
 [2]: https://github.com/DataDog/dd-trace-go/releases


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates a warning in the Go Code Hotspots documentation. This warning called out several bugs that
could affect the accuracy of Code Hotspots. These bugs have been fixed for the past few Go
releases.

### Motivation
<!-- What inspired you to submit this pull request?-->

The warning is no longer necessary, though it's still worth noting that the feature works
best with more recent Go versions.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
