### PR TITLE
[CWS] Add requirement and troubleshooting sections for CWS network

### DIFF
--- a/content/en/security_platform/cloud_security_management/troubleshooting.md
+++ b/content/en/security_platform/cloud_security_management/troubleshooting.md
@@ -42,28 +42,28 @@ You can now see events coming from the `runtime-security-agent` in the Log Explo
 
 {{< img src="security_platform/cws/self_test_logs.png" alt="Self test events in the Log Explorer" style="width:90%;">}}
 
-## Compatibility with custom Kubernetes Network Plugins
+## Compatibility with custom Kubernetes network plugins
 
-The network based detections of Cloud Workload Security rely on the Traffic Control sub-system of the Linux Kernel. This sub-system is known to introduce race conditions if multiple vendors try to insert, replace or delete filters on the "clsact" ingress qdisc. Follow the checklist below to ensure that Cloud Workload Security is properly configured:
+The network based detections of Cloud Workload Security rely on the traffic control sub-system of the Linux kernel. This sub-system is known to introduce race conditions if multiple vendors try to insert, replace, or delete filters on the "clsact" ingress qdisc. Follow the checklist below to ensure that Cloud Workload Security is properly configured:
 
-* Check with your vendor if they leverage eBPF Traffic Control classifiers. If not, you can ignore this paragraph.
-* Check with your vendor if they return TC_ACT_OK or TC_ACT_UNSPEC after granting access to a network packet. If the answer is TC_ACT_UNSPEC, you can ignore this paragraph.
-* Check with your vendor on which priority they attach their eBPF classifiers:
-  * If they use priority 1, CWS network detections will not work inside your containers.
+* Check if your vendor leverages eBPF traffic control classifiers. If they do not, you can ignore this paragraph.
+* Check if your vendor returns TC_ACT_OK or TC_ACT_UNSPEC after granting access to a network packet. If they return TC_ACT_UNSPEC, you can ignore this paragraph.
+* Check which priority your vendor attaches their eBPF classifiers to:
+  * If they use priority 1, CWS network detections do not work inside your containers.
   * If they use priority 2 to 10, make sure to configure `runtime_security_config.network.classifier_priority` to a number strictly below the priority chosen by your vendor.
   * If they use priority 11 or higher, you can ignore this paragraph.
 
 For example, there is a known race with Cilium 1.9 and lower with the Datadog Agent (version 7.36 to 7.39.1, 7.39.2 excluded) that may happen when a new pod is started. The race can lead to loss of connectivity inside the pod, depending on how Cilium is configured.
 
-Ultimately, if the Datadog Agent or your third party vendors cannot be configured to prevent the issue from happening, you'll want to disable the network based detections of Cloud Workload Security by:
+Ultimately, if the Datadog Agent or your third party vendors cannot be configured to prevent the issue from happening, you should want to disable the network based detections of Cloud Workload Security by following the steps below:
 
-* Adding the following parameter to your `system-probe.yaml` configuration file on host based installations:
+* Add the following parameter to your `system-probe.yaml` configuration file on host based installations:
 ```yaml
 runtime_security_config:
   network:
     enabled: false
 ```
-* Adding the following values if you're using the public Helm Chart to deploy the Datadog Agent:
+* Add the following values if you're using the public Helm Chart to deploy the Datadog Agent:
 ```yaml
 datadog:
   securityAgent:
@@ -71,7 +71,7 @@ datadog:
       network:
         enabled: false
 ```
-* Adding the following environment variable if you're deploying the Datadog Agent container manually:
+* Add the following environment variable if you're deploying the Datadog Agent container manually:
 ```bash
 DD_RUNTIME_SECURITY_CONFIG_NETWORK_ENABLED=false
 ```

--- a/content/en/security_platform/cloud_security_management/troubleshooting.md
+++ b/content/en/security_platform/cloud_security_management/troubleshooting.md
@@ -55,7 +55,7 @@ The network based detections of Cloud Workload Security rely on the traffic cont
 
 For example, there is a known race with Cilium 1.9 and lower with the Datadog Agent (version 7.36 to 7.39.1, 7.39.2 excluded) that may happen when a new pod is started. The race can lead to loss of connectivity inside the pod, depending on how Cilium is configured.
 
-Ultimately, if the Datadog Agent or your third party vendors cannot be configured to prevent the issue from happening, you should want to disable the network based detections of Cloud Workload Security by following the steps below:
+Ultimately, if the Datadog Agent or your third party vendors cannot be configured to prevent the issue from happening, you should disable the network based detections of Cloud Workload Security by following the steps below:
 
 * Add the following parameter to your `system-probe.yaml` configuration file on host based installations:
 ```yaml

--- a/content/en/security_platform/cloud_security_management/troubleshooting.md
+++ b/content/en/security_platform/cloud_security_management/troubleshooting.md
@@ -42,4 +42,38 @@ You can now see events coming from the `runtime-security-agent` in the Log Explo
 
 {{< img src="security_platform/cws/self_test_logs.png" alt="Self test events in the Log Explorer" style="width:90%;">}}
 
+## Compatibility with custom Kubernetes Network Plugins
+
+The network based detections of Cloud Workload Security rely on the Traffic Control sub-system of the Linux Kernel. This sub-system is known to introduce race conditions if multiple vendors try to insert, replace or delete filters on the "clsact" ingress qdisc. Follow the checklist below to ensure that Cloud Workload Security is properly configured:
+
+* Check with your vendor if they leverage eBPF Traffic Control classifiers. If not, you can ignore this paragraph.
+* Check with your vendor if they return TC_ACT_OK or TC_ACT_UNSPEC after granting access to a network packet. If the answer is TC_ACT_UNSPEC, you can ignore this paragraph.
+* Check with your vendor on which priority they attach their eBPF classifiers:
+  * If they use priority 1, CWS network detections will not work inside your containers.
+  * If they use priority 2 to 10, make sure to configure `runtime_security_config.network.classifier_priority` to a number strictly below the priority chosen by your vendor.
+  * If they use priority 11 or higher, you can ignore this paragraph.
+
+For example, there is a known race with Cilium 1.9 and lower with the Datadog Agent (version 7.36 to 7.39.1, 7.39.2 excluded) that may happen when a new pod is started. The race can lead to loss of connectivity inside the pod, depending on how Cilium is configured.
+
+Ultimately, if the Datadog Agent or your third party vendors cannot be configured to prevent the issue from happening, you'll want to disable the network based detections of Cloud Workload Security by:
+
+* Adding the following parameter to your `system-probe.yaml` configuration file on host based installations:
+```yaml
+runtime_security_config:
+  network:
+    enabled: false
+```
+* Adding the following values if you're using the public Helm Chart to deploy the Datadog Agent:
+```yaml
+datadog:
+  securityAgent:
+    runtime:
+      network:
+        enabled: false
+```
+* Adding the following environment variable if you're deploying the Datadog Agent container manually:
+```bash
+DD_RUNTIME_SECURITY_CONFIG_NETWORK_ENABLED=false
+```
+
 [1]: /agent/troubleshooting/send_a_flare/?tab=agentv6v7

--- a/content/en/security_platform/cloud_workload_security/getting_started.md
+++ b/content/en/security_platform/cloud_workload_security/getting_started.md
@@ -42,7 +42,7 @@ There are three types of monitoring that the Datadog Agent uses for Cloud Worklo
   * SUSE 15+
   * CentOS/RHEL 7.6+
   * Custom kernel builds are not supported.
-* For compatibility with a custom Kubernetes Network Plugin like Cilium or Calico, please refer to the [Troubleshooting page][3].
+* For compatibility with a custom Kubernetes network plugin like Cilium or Calico, please see the [Troubleshooting page][3].
 
 ## Installation
 

--- a/content/en/security_platform/cloud_workload_security/getting_started.md
+++ b/content/en/security_platform/cloud_workload_security/getting_started.md
@@ -42,6 +42,7 @@ There are three types of monitoring that the Datadog Agent uses for Cloud Worklo
   * SUSE 15+
   * CentOS/RHEL 7.6+
   * Custom kernel builds are not supported.
+* For compatibility with a custom Kubernetes Network Plugin like Cilium or Calico, please refer to the [Troubleshooting page][3].
 
 ## Installation
 
@@ -60,7 +61,7 @@ There are three types of monitoring that the Datadog Agent uses for Cloud Worklo
       securityAgent:
         runtime:
           enabled: true
-          
+
     # Add this to enable the collection of CWS network events, only for Datadog Agent version 7.36
           network:
             enabled: true
@@ -72,6 +73,7 @@ There are three types of monitoring that the Datadog Agent uses for Cloud Worklo
 
 [1]: https://app.datadoghq.com/account/settings#agent/kubernetes
 [2]: https://docs.datadoghq.com/integrations/kubernetes_audit_logs/
+[3]: /security_platform/cloud_workload_security/troubleshooting#compatibility_with_custom_kubernetes_network_plugins
 {{% /tab %}}
 
 {{% tab "Docker" %}}
@@ -120,7 +122,7 @@ By default Runtime Security is disabled. To enable it, both the datadog.yaml and
 
 echo "runtime_security_config.enabled: true" >> /etc/datadog-agent/security-agent.yaml
 echo "runtime_security_config.enabled: true" >> /etc/datadog-agent/system-probe.yaml
-  
+
 # For [Datadog Agent][1] version 7.36 only, to enable the collection of CWS network events
 echo "runtime_security_config.network.enabled: true" >> /etc/datadog-agent/system-probe.yaml
 
@@ -140,10 +142,10 @@ For a package-based deployment, the Datadog package has to be deployed: run `yum
 
 echo "runtime_security_config.enabled: true" >> /etc/datadog-agent/security-agent.yaml
 echo "runtime_security_config.enabled: true" >> /etc/datadog-agent/system-probe.yaml
-  
+
 # For [Datadog Agent][1] version 7.36 only, to enable the collection of CWS network events
 echo "runtime_security_config.network.enabled: true" >> /etc/datadog-agent/system-probe.yaml
-  
+
 systemctl restart datadog-agent
 
 {{< /code-block >}}

--- a/content/en/security_platform/cloud_workload_security/getting_started.md
+++ b/content/en/security_platform/cloud_workload_security/getting_started.md
@@ -73,7 +73,7 @@ There are three types of monitoring that the Datadog Agent uses for Cloud Worklo
 
 [1]: https://app.datadoghq.com/account/settings#agent/kubernetes
 [2]: https://docs.datadoghq.com/integrations/kubernetes_audit_logs/
-[3]: /security_platform/cloud_workload_security/troubleshooting#compatibility_with_custom_kubernetes_network_plugins
+[3]: /security_platform/cloud_security_management/troubleshooting
 {{% /tab %}}
 
 {{% tab "Docker" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This PR adds a paragraph in the troubleshooting guide for CWS to help configure CWS Network when a custom Kubernetes Network plugin is in use.

### Motivation

There is a known race with Cilium 1.9 and lower that customers need to be made aware of. More generally speaking, this race may happen with any third party tool that rely on the Traffic Control of the Linux kernel.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
