### PR TITLE
Fix Broken slf4j link

### DIFF
--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -25,7 +25,7 @@ To enable debug mode for the Datadog Java Tracer, set the flag `-Ddd.trace.debug
 ```
 
 
-[1]: https://www.slf4j.org/api/org/slf4j/impl/SimpleLogger.html
+[1]: https://www.slf4j.org/api/org/slf4j/simple/SimpleLogger.html
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python" >}}


### PR DESCRIPTION
### What does this PR do?
Fix Broken link:
Change: https://www.slf4j.org/api/org/slf4j/impl/SimpleLogger.html
To: https://www.slf4j.org/api/org/slf4j/simple/SimpleLogger.html

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
