### PR TITLE
Change guide title

### DIFF
--- a/content/en/continuous_integration/guides/_index.md
+++ b/content/en/continuous_integration/guides/_index.md
@@ -10,5 +10,5 @@ disable_toc: true
     {{< nextlink href="/continuous_integration/guides/test_configurations" >}}Test Configurations{{< /nextlink >}}
     {{< nextlink href="/continuous_integration/guides/rum_integration" >}}Instrumenting your browser tests with RUM{{< /nextlink >}}
     {{< nextlink href="/continuous_integration/guides/rum_swift_integration" >}}Instrumenting your Swift tests with RUM{{< /nextlink >}}
-    {{< nextlink href="/continuous_integration/guides/pull_request_comments" >}}Test summary pull request comments{{< /nextlink >}}
+    {{< nextlink href="/continuous_integration/guides/pull_request_comments" >}}Enabling Test Summaries in GitHub Pull Request Comments{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/continuous_integration/guides/pull_request_comments.md
+++ b/content/en/continuous_integration/guides/pull_request_comments.md
@@ -1,5 +1,5 @@
 ---
-title: Enabling Test Summaries in GitHub Pull Requests
+title: Enabling Test Summaries in GitHub Pull Request Comments
 kind: guide
 ---
 


### PR DESCRIPTION
### What does this PR do?
Change guide title for GitHub pull request comment integration

### Motivation
The titles didn't align on the two pages affected

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
