### PR TITLE
dan.chiniara/remove downtime sentence about manual cancels

### DIFF
--- a/content/en/monitors/notify/downtimes.md
+++ b/content/en/monitors/notify/downtimes.md
@@ -177,7 +177,7 @@ Monitors trigger events when they change between possible states: `ALERT`, `WARN
 
 ### Expiration
 
-If a monitor is in an alert-worthy state (`ALERT`, `WARNING`, or `NO DATA`) when a downtime expires, the monitor triggers a new notification. This applies to monitors that change state during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`), and to monitors that already have an alert-worthy state when downtime begins. If a downtime is manually canceled, notifications are not sent, even if the monitor has entered an alert-worthy state.
+If a monitor is in an alert-worthy state (`ALERT`, `WARNING`, or `NO DATA`) when a downtime expires, the monitor triggers a new notification. This applies to monitors that change state during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`), and to monitors that already have an alert-worthy state when downtime begins.
 
 **Example 1:** If a monitor is in an alert state *before* downtime starts and *continues* for the duration of downtime:
 1. During downtime, notifications for this alert are suppressed.


### PR DESCRIPTION
Adding the information that when downtimes are manually canceled, no notifications are sent.

### What does this PR do?
Remove the sentence "If a downtime is manually canceled, notifications will not be sent, even if the monitor has entered an alert-worthy state" after it was added in https://github.com/DataDog/documentation/pull/14694.

### Motivation
Downtimes had a bug and were behaving in an unexpected way. We didn't catch this in the first escalation.

escalation with bug fix: https://datadoghq.atlassian.net/browse/MNTS-89107
initial escalation: https://datadoghq.atlassian.net/browse/MNTS-88918

### Preview -->
[link](https://docs-staging.datadoghq.com/dan.chiniara/remove-downtime-sentence-about-manual-cancels/monitors/notify/downtimes/?tab=bymonitorname#expiration) | [screenshot](https://a.cl.ly/4gueevBw)

![screenshot](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/4gueevBw/38759456-a66f-4c51-a6c9-fba2d5156092.jpg?source=viewer&v=8bebb5dab3bc057b3f6be9d54a346259)