### PR TITLE
Update list of CI env vars to be passed to containers

### DIFF
--- a/content/en/continuous_integration/setup_tests/containers.md
+++ b/content/en/continuous_integration/setup_tests/containers.md
@@ -47,7 +47,7 @@ Additionally, you need to pass in the environment variables required to configur
 - `BUILD_REQUESTEDFORID`
 - `BUILD_REQUESTEDFOREMAIL`
 - `SYSTEM_TEAMFOUNDATIONSERVERURI`
-- `SYSTEM_TEAMPROJECT`
+- `SYSTEM_TEAMPROJECTID`
 - `SYSTEM_JOBID`
 - `SYSTEM_TASKINSTANCEID`
 - `SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI`
@@ -174,6 +174,7 @@ Additionally, you need to pass in the environment variables required to configur
 - `JOB_NAME`
 - `JOB_URL`
 - `GIT_URL`
+- `GIT_URL_1`
 - `GIT_COMMIT`
 - `GIT_BRANCH`
 
@@ -239,6 +240,7 @@ Additionally, you need to pass in the environment variables required to configur
 - `GIT_CLONE_COMMIT_AUTHOR_NAME`
 - `GIT_CLONE_COMMIT_AUTHOR_EMAIL`
 - `GIT_CLONE_COMMIT_COMMITER_NAME`
+- `GIT_CLONE_COMMIT_COMMITER_EMAIL`
 
 [Full list of build environment variables provided by Bitrise][1]
 


### PR DESCRIPTION
### What does this PR do?
Follow-up to #15222

### Motivation

Match the env vars that our tracers read in the code [1].
    
[1] https://github.com/DataDog/dd-trace-py/blob/master/ddtrace/ext/ci.py

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
