### PR TITLE
Update CI Visibility Java/Gradle code example

### DIFF
--- a/content/en/continuous_integration/setup_tests/java.md
+++ b/content/en/continuous_integration/setup_tests/java.md
@@ -178,8 +178,12 @@ Configure the `test` Gradle task by adding to the `jvmArgs` attribute the `-java
 
 {{< code-block lang="groovy" filename="build.gradle" >}}
 test {
-  if(project.hasProperty("dd-civisibility")) {
-    jvmArgs = ["-javaagent:${configurations.ddTracerAgent.asPath}", "-Ddd.service=my-java-app", "-Ddd.civisibility.enabled=true"]
+  if (project.hasProperty("dd-civisibility")) {
+    jvmArgs += List.of(
+            "-javaagent:" + configurations.ddTracerAgent.asPath,
+            "-Ddd.service=my-java-app",
+            "-Ddd.civisibility.enabled=true"
+        )
   }
 }
 {{< /code-block >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The example provided is destructive to existing JVM args fed prior to this gradle script being evaluated. For example, if a root project script adds `--enable-preview` (arbitrary flag example) to the JVM args, the current Gradle example script will overwrite it with the user not realizing it until their CI tests run and behave aberrantly.


### Motivation
My CI tests broke when I was using Java 17 experimental features using the aforementioned JVM flag, but I didn't figure that out until later.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
This is super easy to test and it worked really well for me, but beware that the Gradle script I provided is only checked against Groovy Gradle 7+. I am unaware of what language or Gradle version your documentation targets.

**I encourage you to not believe me**, run this yourselves to check my math. 😄 

---

### Reviewer checklist
- [x] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
