### PR TITLE
Add required quotes in port variable

### DIFF
--- a/layouts/shortcodes/dbm-sqlserver-agent-setup-kubernetes.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-setup-kubernetes.md
@@ -61,7 +61,7 @@ metadata:
         {
           "dbm": true,
           "host": "<HOSTNAME>",
-          "port": <SQL_PORT>,
+          "port": "<SQL_PORT>",
           "username": "datadog",
           "password": "<PASSWORD>",
           "connector": "odbc",


### PR DESCRIPTION
Agent is unable to connect to SQL Server on AWS RDS when set up with k8s annotations because the python driver cannot concatenate the port int value to str.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds quotes in port variable value in k8s annotations.

### Motivation
Agent is unable to connect to SQL Server on AWS RDS when set up with k8s annotations because the python driver cannot concatenate the port int value to str. See error below as taken from agent logs:

```
[
  {
    "message": "can only concatenate str (not \"int\") to str",
    "traceback": "Traceback (most recent call last):\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py\", line 1116, in run\n    self.check(instance)\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sqlserver/sqlserver.py\", line 624, in check\n    self.load_static_information()\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sqlserver/sqlserver.py\", line 236, in load_static_information\n    with self.connection.open_managed_default_connection():\n  File \"/opt/datadog-agent/embedded/lib/python3.8/contextlib.py\", line 113, in __enter__\n    return next(self.gen)\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sqlserver/connection.py\", line 276, in open_managed_default_connection\n    with self._open_managed_db_connections(self.DEFAULT_DB_KEY, key_prefix=key_prefix):\n  File \"/opt/datadog-agent/embedded/lib/python3.8/contextlib.py\", line 113, in __enter__\n    return next(self.gen)\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sqlserver/connection.py\", line 281, in _open_managed_db_connections\n    self.open_db_connections(db_key, db_name, key_prefix=key_prefix)\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sqlserver/connection.py\", line 294, in open_db_connections\n    conn_key = self._conn_key(db_key, db_name, key_prefix)\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sqlserver/connection.py\", line 495, in _conn_key\n    dsn, host, username, password, database, driver = self._get_access_info(db_key, db_name)\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sqlserver/connection.py\", line 447, in _get_access_info\n    host = self._get_host_with_port()\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sqlserver/connection.py\", line 491, in _get_host_with_port\n    return split_host + \",\" + port\nTypeError: can only concatenate str (not \"int\") to str\n"
  }
]

```
It's probably better to amend the driver to be able to correctly concatenate the port int value, but as is the docs are misleading. This PR adds quotes only in the k8s annotations sections, it's not tested if they are needed in the alternative configurations.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
