### PR TITLE
[ci-visibility] Add instructions for enabling Intelligent Test Runner in dotnet

### DIFF
--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -236,7 +236,7 @@ For more information about how to add spans and tags for custom instrumentation,
 
 Read more about Intelligent Test Runner here.
 
-To enable Intelligent Test Runner the following environment variables need to be set:
+To enable Intelligent Test Runner you need to be sure the version of the `dd-trace` tool is >= 2.16.0 (execute `dd-trace --version` to get the version of the tool) and the following environment variables are set:
 
 `DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required)
 : Enables or disables Agentless mode.<br/>

--- a/content/en/continuous_integration/setup_tests/dotnet.md
+++ b/content/en/continuous_integration/setup_tests/dotnet.md
@@ -230,6 +230,64 @@ To use the custom instrumentation in your .NET application:
 
 For more information about how to add spans and tags for custom instrumentation, see the [.NET Custom Instrumentation documentation][8].
 
+## Intelligent Test Runner
+
+<div class="alert alert-warning">Intelligent Test Runner is currently in closed beta.</div>
+
+Read more about Intelligent Test Runner here.
+
+To enable Intelligent Test Runner the following environment variables need to be set:
+
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required)
+: Enables or disables Agentless mode.<br/>
+**Default**: `false`
+
+`DD_API_KEY` (Required)
+: The [Datadog API key][9] used to upload the test results.<br/>
+**Default**: `(empty)`
+
+`DD_APPLICATION_KEY` (Required)
+: The [Datadog Application key][10] used to query the tests to be skipped.<br/>
+**Default**: `(empty)`
+
+`DD_SITE` (Required)
+: The [Datadog site][11] to upload results to.<br/>
+**Default**: `datadoghq.com`<br/>
+**Selected site**: {{< region-param key="dd_site" code="true" >}}
+
+`DD_CIVISIBILITY_ITR_ENABLED=true` (Required)
+: Flag to enable intelligent test runner. <br/>
+**Default**: `false`
+
+After setting these environment variables, run your tests as you normally do:
+
+{{< tabs >}}
+
+{{% tab "dotnet test" %}}
+
+By using <a href="https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test">dotnet test</a>
+
+{{< code-block lang="bash" >}}
+dd-trace ci run --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
+{{< /code-block >}}
+
+{{% /tab %}}
+
+{{% tab "VSTest.Console" %}}
+
+By using <a href="https://docs.microsoft.com/en-us/visualstudio/test/vstest-console-options">VSTest.Console.exe</a>
+
+{{< code-block lang="bash" >}}
+dd-trace ci run --dd-service=my-dotnet-app --dd-env=ci -- VSTest.Console.exe {test_assembly}.dll
+{{< /code-block >}}
+
+{{% /tab %}}
+
+{{< /tabs >}}
+
+### UI activation
+In addition to the environment variables above, the Intelligent Test Runner needs to be activated in [Test Service Settings][12].
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -243,3 +301,7 @@ For more information about how to add spans and tags for custom instrumentation,
 [6]: /tracing/trace_collection/custom_instrumentation/dotnet?tab=locally#adding-tags
 [7]: https://www.nuget.org/packages/Datadog.Trace
 [8]: /tracing/trace_collection/custom_instrumentation/dotnet/
+[9]: https://app.datadoghq.com/organization-settings/api-keys
+[10]: https://app.datadoghq.com/organization-settings/application-keys
+[11]: /getting_started/site/
+[12]: https://app.datadoghq.com/ci/settings/test-service


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds the new Intelligent Test Runner section of the documentation for .NET.

### Motivation
<!-- What inspired you to submit this pull request?-->
CI Visibility is introducing a new feature in private beta, this PR adds the documentation to enable the feature in .NET

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
https://docs-staging.datadoghq.com/tony/itr-docs-dotnet/continuous_integration/setup_tests/dotnet

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
