### PR TITLE
add support to hide button

### DIFF
--- a/layouts/shortcodes/beta-callout.html
+++ b/layouts/shortcodes/beta-callout.html
@@ -1,15 +1,18 @@
+{{- $btn_hidden := (.Get "btn_hidden") | default "false" -}}
 <div class="card beta-callout-card mb-4">
 
     <div class="card-body d-flex flex-column">
         <h5 class="card-title text-black mt-0 mb-1">Join the Beta!</h5>
         <p class="card-text">{{.Inner}}</p>
-        <a href="{{.Get `url`}}" 
-            target="_blank" 
-            class="{{.Get `custom_class`}} btn btn-outline-primary pb-1 align-self-end d-flex flex-column justify-content-center" 
-            {{with .Get `d_toggle`}}data-toggle="{{.}}"{{end}} 
+        {{- if not (eq $btn_hidden "true") -}}
+        <a href="{{.Get `url`}}"
+            target="_blank"
+            class="{{.Get `custom_class`}} btn btn-outline-primary pb-1 align-self-end d-flex flex-column justify-content-center"
+            {{with .Get `d_toggle`}}data-toggle="{{.}}"{{end}}
             {{with .Get `d_target`}}data-target="{{.}}"{{end}}
         >
             Request Access
         </a>
+        {{- end -}}
     </div>
 </div>


### PR DESCRIPTION
### What does this PR do?

Updates the beta callout shortcode to support hiding the button

### Motivation

Slack

### Preview

Check current beta callouts still show button
https://docs-staging.datadoghq.com/david.jones/beta-callout-hidebtn/tracing/dynamic_instrumentation/

### Additional Notes

Usage to hide just add `btn_hidden="true"`
```
{{< beta-callout url="https://www.datadoghq.com/live-debugger-request/" d-toggle="modal" d_target="#signupModal" custom_class="sign-up-trigger" btn_hidden="true">}}
  Dynamic Instrumentation is in private beta. Fill out this form if you would like to
  access it.
{{< /beta-callout >}}
```

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
