### PR TITLE
WEB-2783 Frontmatter param `is_beta` no longer adds noindex meta tags on Docs pages

### DIFF
--- a/content/en/account_management/billing/rum_units.md
+++ b/content/en/account_management/billing/rum_units.md
@@ -2,6 +2,7 @@
 title: RUM Billing Details
 kind: documentation
 beta: true
+private: true
 ---
 
 <div class="alert alert-warning">

--- a/content/en/glossary/_index.md
+++ b/content/en/glossary/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Glossary
 is_beta: true
+private: true
 cascade:
     disable_toc: true
 scrollspy:

--- a/content/en/logs/log_configuration/online_archives.md
+++ b/content/en/logs/log_configuration/online_archives.md
@@ -3,6 +3,7 @@ title: Online Archives
 kind: documentation
 description: Cost effective live query capabilities over long term retention of Logs
 is_beta: true
+private: true
 further_reading:
 - link: "/logs/log_configuration/indexes/#indexes-filters"
   tag: "Documentation"

--- a/content/en/real_user_monitoring/error_tracking/explorer.md
+++ b/content/en/real_user_monitoring/error_tracking/explorer.md
@@ -2,6 +2,7 @@
 title: RUM Error Tracking Explorer
 kind: documentation
 beta: true
+private: true
 ---
 
 {{< img src="real_user_monitoring/error_tracking/explorer.png" alt="Error Tracking Explorer"  >}}

--- a/content/en/real_user_monitoring/guide/send-rum-custom-actions.md
+++ b/content/en/real_user_monitoring/guide/send-rum-custom-actions.md
@@ -2,6 +2,7 @@
 title: Send RUM Custom Actions
 kind: guide
 beta: true
+private: true
 description: Learn how to send custom actions to extend your collection of user interactions.
 aliases:
 - /real_user_monitoring/guide/send-custom-user-actions/

--- a/content/en/tracing/error_tracking/explorer.md
+++ b/content/en/tracing/error_tracking/explorer.md
@@ -1,7 +1,6 @@
 ---
 title: Error Tracking Explorer
 kind: documentation
-beta: false
 ---
 
 {{< img src="tracing/error_tracking/error_tracking_explore_inspect.png" alt="Error Tracking Explorer"  >}}

--- a/layouts/partials/noindex.html
+++ b/layouts/partials/noindex.html
@@ -1,5 +1,3 @@
-{{ $is_beta := or (eq .Params.beta true) (eq .Params.is_beta true) }}
-
-{{ if (or (eq $is_beta true) (eq .Params.private true) (eq .Params.is_public false) (eq .Params.placeholder true) (eq .Site.Params.environment "preview") (eq .Params.noindex true) ) }}
+{{ if (or (eq .Params.private true) (eq .Params.is_public false) (eq .Params.placeholder true) (eq .Site.Params.environment "preview") (eq .Params.noindex true) ) }}
 <meta name="robots" content="noindex, nofollow">
 {{ end }}


### PR DESCRIPTION
### What does this PR do?
Removes condition where `is_beta` excludes content from being searchable and indexed by crawlers

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2783

### Preview
https://docs-staging.datadoghq.com/nsollecito/web-2783/

### Additional Notes
No visible changes. Check for a doc with is_beta and confirm there is no longer a `noindex, no follow` meta tag

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
