### PR TITLE
Template variables 48 hours

### DIFF
--- a/content/en/dashboards/faq/historical-data.md
+++ b/content/en/dashboards/faq/historical-data.md
@@ -16,7 +16,7 @@ If you stop reporting data to Datadog, after a certain period of time metrics, t
 |--------------------------------------|----------|
 | Hosts                                | 2 hours  |
 | Metrics                              | 24 hours |
-| Tags in template variable drop-downs | 30 days  |
+| Tags in template variable drop-downs | 48 hours |
 | Tags in other drop-downs             | 12 hours |
 | APM `env` tags                       | 60 days  |
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Tags in Template Variables are only guaranteed for 48 hours.  We have supported 7 days in the past but we are phasing that out, but we never supported 30 days.

### Motivation
Customer referenced the 30 days.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ x] Review any mentions of "Contact Datadog support" for internal support documentation.
