### PR TITLE
add mariadb in the list of nodejs apm supported integrations

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -106,6 +106,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 | [elasticsearch][30]    | `>=10`   | Fully supported | Supports `@elastic/elasticsearch` versions `>=5` |
 | [ioredis][31]          | `>=2`    | Fully supported |                                                  |
 | [knex][32]             | `>=0.8`  | Fully supported | This integration is only for context propagation |
+| [mariadb][63]          | `>=3`    | Fully supported |                                                  |
 | [memcached][33]        | `>=2.2`  | Fully supported |                                                  |
 | [mongodb-core][34]     | `>=2`    | Fully supported | Supports Mongoose                                |
 | [mysql][35]            | `>=2`    | Fully supported |                                                  |
@@ -227,3 +228,4 @@ For additional information or to discuss [leave a comment on this github issue][
 [60]: https://nodejs.org/api/async_hooks.html
 [61]: https://www.meteor.com/
 [62]: https://github.com/DataDog/dd-trace-js/issues/1229
+[63]: https://github.com/mariadb-corporation/mariadb-connector-nodejs


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add `mariadb` in the list of Node.js APM supported integrations.

### Motivation
<!-- What inspired you to submit this pull request?-->

Support for `mariadb` was recently added to dd-trace.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
