### PR TITLE
go: document adding C functoin calls to CPU profiles

### DIFF
--- a/content/en/profiler/enabling/go.md
+++ b/content/en/profiler/enabling/go.md
@@ -95,6 +95,12 @@ Alternatively you can set profiler configuration using environment variables:
 | `DD_VERSION`                                     | String        | The [version][8] of your service. |
 | `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`.   |
 
+### Showing C function calls in CPU profiles
+
+Go's CPU profiler only shows detailed information for Go code by default. If your program calls into C code, time spent running C code will be reflected in the profile, but the call stacks will only show Go function calls.
+
+You can optionally use a library such as [ianlancetalylor/cgosymbolizer][10] to add detailed C function call information to CPU profiles. Note that this library is considered experimental. At Datadog, it has been used in production with few issues. However, the library has been known to occasionally cause crashes and deadlocks. This can happen for programs which use C++ exceptions, or which use libraries such as `tcmalloc` which have their own profiling interfaces.
+
 ## Not sure what to do next?
 
 The [Getting Started with Profiler][9] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
@@ -112,3 +118,4 @@ The [Getting Started with Profiler][9] guide takes a sample service with a perfo
 [7]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#ProfileType
 [8]: /getting_started/tagging/unified_service_tagging
 [9]: /getting_started/profiler/
+[10]: https://pkg.go.dev/ianlancetaylor/cgosymbolizer


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Documents how to add C function call information to Go's CPU profiles.

### Motivation
<!-- What inspired you to submit this pull request?-->

Go's CPU profiles lack detailed information on time spent running C
code. There is an optional extension interface to add more detail, and
one of the Go maintainers has released a library which implements some
of this interface. It is experimental and has some known issues, but
it's still mostly usable. We should let our users know it exists, since
they might wonder why they don't see C code in their profiles if they
expect to.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
