### PR TITLE
dan.chiniara/specify metric monitor for alert value widget

### DIFF
--- a/content/en/dashboards/widgets/alert_value.md
+++ b/content/en/dashboards/widgets/alert_value.md
@@ -1,7 +1,7 @@
 ---
 title: Alert Value Widget
 kind: documentation
-description: "Graph the current value of a metric in any monitor defined on your system."
+description: "Graph the current value of a metric in any metric monitor defined on your system."
 aliases:
     - /graphing/widgets/alert_value/
 further_reading:
@@ -10,7 +10,7 @@ further_reading:
   text: "Building Dashboards using JSON"
 ---
 
-Alert values are query values showing the current value of the metric in any monitor defined on your system:
+Alert values are query values showing the current value of the metric in any metric monitor defined on your system:
 
 {{< img src="dashboards/widgets/alert_value/alert_value.png" alt="Alert Value" >}}
 
@@ -19,7 +19,7 @@ Alert values are query values showing the current value of the metric in any mon
 
 ### Configuration
 
-1. Choose a previously created monitor to graph.
+1. Choose a previously created metric monitor to graph.
 2. Select the formatting to display:
     * raw value
     * 0/1/2/3 decimals


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
specifying metric monitor as the input for the alert value widget

### Motivation
https://datadoghq.atlassian.net/browse/MNTS-89208

### Preview 

https://docs-staging.datadoghq.com/dan.chiniara/specify_metric_monitor_for_alert_value_widget/dashboards/widgets/alert_value/#pagetitle
