### PR TITLE
DOCS-4200 Per Service sampling rule name is case sensitive

### DIFF
--- a/content/en/tracing/trace_pipeline/ingestion_controls.md
+++ b/content/en/tracing/trace_pipeline/ingestion_controls.md
@@ -136,7 +136,7 @@ To specify a specific percentage of a service's traffic to be sent, add an envir
 1. Select the service you want to change the ingested span percent for.
 2. Choose the service language.
 3. Choose the desired ingestion percentage.
-4. Apply the appropriate configuration generated from these choices to the indicated service and redeploy the service.
+4. Apply the appropriate configuration generated from these choices to the indicated service and redeploy the service. **Note**: The service name value is case sensitive. It should match the case of your service name.
 5. Confirm on the Ingestion Control Page that your new percentage has been applied by looking at the Traffic Breakdown column, which surfaces the sampling rate applied. The ingestion reason for the service is shown as `ingestion_reason:rule`.
 
 

--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -80,6 +80,8 @@ java -Ddd.trace.sampling.service.rules=my-service:0.2 -javaagent:dd-java-agent.j
 export DD_TRACE_SAMPLING_SERVICE_RULES=my-service:0.2
 ```
 
+The service name value is case sensitive and must match the case of the actual service name.
+
 Configure a rate limit by setting the environment variable `DD_TRACE_RATE_LIMIT` to a number of traces per second per service instance. If no `DD_TRACE_RATE_LIMIT` value is set, a limit of 100 traces per second is applied.
 
 Read more about sampling controls in the [Java tracing library documentation][1].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Specify that service name case must match for per-service sampling rules

### Motivation
DOCS-4200

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
