### PR TITLE
Give APM Admission Controller docs its own page

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1550,16 +1550,21 @@ main:
     parent: tracing_trace_collection
     identifier: tracing_serverless
     weight: 106
+  - name: Admission Controller Injection
+    url: tracing/trace_collection/admission_controller/
+    parent: tracing_trace_collection
+    identifier: tracing_admission_controller
+    weight: 107
   - name: Tracing Proxies
     url: tracing/trace_collection/proxy_setup/
     parent: tracing_trace_collection
     identifier: tracing_proxies
-    weight: 107
+    weight: 108
   - name: Span Tags Semantics
     url: tracing/trace_collection/tracing_naming_convention
     parent: tracing_trace_collection
     identifier: tracing_naming_convention
-    weight: 108
+    weight: 109
   - name: APM Metrics Collection
     url: tracing/metrics/
     parent: tracing

--- a/content/en/containers/cluster_agent/admission_controller.md
+++ b/content/en/containers/cluster_agent/admission_controller.md
@@ -130,60 +130,8 @@ Finally, run the following commands:
 
 
 ### APM
-You can configure the Cluster Agent (version 7.39 and higher) to inject APM tracing libraries automatically.
+You can configure the Cluster Agent (version 7.39 and higher) to inject APM tracing libraries automatically. Read [APM Tracing Setup with Admission Controller][3] for more information
 
-After you install the Cluster Agent, do one of the following:
-- Add the label `admission.datadoghq.com/enabled: "true"` to your pod.
-- Configure the Cluster Agent admission controller by setting `mutateUnlabelled` (or `DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED`, depending on your configuration method) to `true`.
-
-To opt-in your container for library injection, use Pod annotations inside your application's YAML file to specify language tracers and versions.
-
-
-The annotations are a `key: value` pair in the following format:
-
-```yaml
-datadoghq.com/<language>-lib.version: <lib-version>
-```
-
-Adding a this annotation results in the injection of the tracer library for that language and version into the containerized application.
-Valid `<language>` values are:
-- `java`
-- `js`
-
-For example to inject the latest Java tracer:
-
-```yaml
-annotations:
-    admission.datadoghq.com/java-lib.version: "latest"
-```
-
-**Note**: Use caution specifying `latest` as major library releases can introduce breaking changes.
-
-Although it's an uncommon scenario, you can add multiple `<language>-lib.version` annotations to inject multiple language tracers into one container.
-
-For example to inject the latest Java tracer and Node tracer v3.0.0:
-```yaml
-annotations:
-    admission.datadoghq.com/java-lib.version: "latest"
-    admission.datadoghq.com/js-lib.version: "3.0.0"
-```
-
-Adding a `mutateUnlabelled: true` annotation causes the cluster agent to attempt to intercept every unlabelled pod.
-
-To prevent pods from receiving environment variables, add the label `admission.datadoghq.com/enabled: "false"`. This works even if you set `mutateUnlabelled: true`.
-
-If `mutateUnlabelled` is set to `false`, the pod label must be set to `admission.datadoghq.com/enabled: "true"`.
-
-Possible options:
-
-| mutateUnlabelled | Pod label                               | Injection |
-|------------------|-----------------------------------------|-----------|
-| `true`           | No label                                | Yes       |
-| `true`           | `admission.datadoghq.com/enabled=true`  | Yes       |
-| `true`           | `admission.datadoghq.com/enabled=false` | No        |
-| `false`          | No label                                | No        |
-| `false`          | `admission.datadoghq.com/enabled=true`  | Yes       |
-| `false`          | `admission.datadoghq.com/enabled=false` | No        |
 
 ### DogStatsD
 
@@ -218,8 +166,8 @@ Possible options:
 
 - The admission controller needs to be deployed and configured before the creation of new application pods. It cannot update pods that already exist.
 - To disable the admission controller injection feature, use the Cluster Agent configuration: `DD_ADMISSION_CONTROLLER_INJECT_CONFIG_ENABLED=false`
-- By using the Datadog admission controller, users can skip configuring the application pods using downward API ([step 2 in Kubernetes Trace Collection setup][3]).
-- In a Google Kubernetes Engine (GKE) Private Cluster, you need to [add a Firewall Rule for the control plane][4]. The webhook handling incoming connections receives the request on port `443` and directs it to a service implemented on port `8000`. By default, in the Network for the cluster there should be a Firewall Rule named like `gke-<CLUSTER_NAME>-master`. The "Source filters" of the rule match the "Control plane address range" of the cluster. Edit this Firewall Rule to allow ingress to the TCP port `8000`.
+- By using the Datadog admission controller, users can skip configuring the application pods using downward API ([step 2 in Kubernetes Trace Collection setup][4]).
+- In a Google Kubernetes Engine (GKE) Private Cluster, you need to [add a Firewall Rule for the control plane][5]. The webhook handling incoming connections receives the request on port `443` and directs it to a service implemented on port `8000`. By default, in the Network for the cluster there should be a Firewall Rule named like `gke-<CLUSTER_NAME>-master`. The "Source filters" of the rule match the "Control plane address range" of the cluster. Edit this Firewall Rule to allow ingress to the TCP port `8000`.
 
 
 ## Further Reading
@@ -228,5 +176,6 @@ Possible options:
 
 [1]: https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers/
 [2]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml
-[3]: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#setup
-[4]: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
+[3]: /tracing/trace_collection/admission_controller/
+[4]: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#setup
+[5]: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules

--- a/content/en/tracing/trace_collection/admission_controller.md
+++ b/content/en/tracing/trace_collection/admission_controller.md
@@ -9,7 +9,8 @@ is_beta: true
   Tracing library injection using Admission Controller is in beta. 
 {{< /beta-callout >}} 
 
-For your Kubernetes applications that send traces to Datadog by the Cluster Agent (version 7.39 and higher), you can configure the Admission Controller to inject APM Java and JavaScript tracing libraries automatically.
+For your Kubernetes applications that send traces to Datadog by the Cluster Agent (version 7.39 and higher), you can configure the Admission Controller to inject APM Java and JavaScript tracing libraries automatically. By automating the injection of tracer libraries via the admission controller, application images do not need to change, thus removing a time-costly step and helping you tap into the value of APM quicker than ever before.
+
 
 After you [install the Cluster Agent][1], do one of the following:
 - Add the label `admission.datadoghq.com/enabled: "true"` to your pod.

--- a/content/en/tracing/trace_collection/admission_controller.md
+++ b/content/en/tracing/trace_collection/admission_controller.md
@@ -1,0 +1,68 @@
+---
+title: Injecting Libraries Using Admission Controller
+kind: documentation
+description: "Inject tracing libraries into applications using Cluster Agent and Admission Controller"
+is_beta: true
+---
+
+{{< beta-callout url="#" btn_hidden="true">}}
+  Tracing library injection using Admission Controller is in private beta. 
+{{< /beta-callout >}} 
+
+For your containerized applications that send traces to Datadog by the Cluster Agent, you can configure the Cluster Agent (version 7.39 and higher) to inject APM Java and JavaScript tracing libraries automatically.
+
+After you [install the Cluster Agent][1], do one of the following:
+- Add the label `admission.datadoghq.com/enabled: "true"` to your pod.
+- Configure the Cluster Agent admission controller by setting `mutateUnlabelled` (or `DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED`, depending on your configuration method) to `true`.
+
+To opt-in your container for library injection, use Pod annotations inside your application's YAML file to specify language tracers and versions.
+
+
+The annotations are a `key: value` pair in the following format:
+
+```yaml
+datadoghq.com/<language>-lib.version: <lib-version>
+```
+
+Adding a this annotation results in the injection of the tracer library for that language and version into the containerized application.
+Valid `<language>` values are:
+- `java`
+- `js`
+
+For example to inject the latest Java tracer:
+
+```yaml
+annotations:
+    admission.datadoghq.com/java-lib.version: "latest"
+```
+
+**Note**: Use caution specifying `latest` as major library releases can introduce breaking changes.
+
+Although it's an uncommon scenario, you can add multiple `<language>-lib.version` annotations to inject multiple language tracers into one container.
+
+For example to inject the latest Java tracer and Node tracer v3.0.0:
+```yaml
+annotations:
+    admission.datadoghq.com/java-lib.version: "latest"
+    admission.datadoghq.com/js-lib.version: "3.0.0"
+```
+
+Adding a `mutateUnlabelled: true` annotation causes the cluster agent to attempt to intercept every unlabelled pod.
+
+To prevent pods from receiving environment variables, add the label `admission.datadoghq.com/enabled: "false"`. This works even if you set `mutateUnlabelled: true`.
+
+If `mutateUnlabelled` is set to `false`, the pod label must be set to `admission.datadoghq.com/enabled: "true"`.
+
+Possible options:
+
+| mutateUnlabelled | Pod label                               | Injection |
+|------------------|-----------------------------------------|-----------|
+| `true`           | No label                                | Yes       |
+| `true`           | `admission.datadoghq.com/enabled=true`  | Yes       |
+| `true`           | `admission.datadoghq.com/enabled=false` | No        |
+| `false`          | No label                                | No        |
+| `false`          | `admission.datadoghq.com/enabled=true`  | Yes       |
+| `false`          | `admission.datadoghq.com/enabled=false` | No        |
+
+
+[1]: /containers/cluster_agent/admission_controller/

--- a/content/en/tracing/trace_collection/admission_controller.md
+++ b/content/en/tracing/trace_collection/admission_controller.md
@@ -23,10 +23,10 @@ To opt-in your container for library injection, use Pod annotations inside your 
 The annotations are a `key: value` pair in the following format:
 
 ```yaml
-datadoghq.com/<language>-lib.version: <lib-version>
+    admission.datadoghq.com/<language>-lib.version: <lib-version>
 ```
 
-Adding a this annotation results in the injection of the tracer library for that language and version into the containerized application.
+Adding this annotation results in the injection of the tracer library for that language and version into the containerized application.
 Valid `<language>` values are:
 - `java`
 - `js`

--- a/content/en/tracing/trace_collection/admission_controller.md
+++ b/content/en/tracing/trace_collection/admission_controller.md
@@ -9,7 +9,7 @@ is_beta: true
   Tracing library injection using Admission Controller is in beta. 
 {{< /beta-callout >}} 
 
-For your Kubernetes applications that send traces to Datadog by the Cluster Agent (version 7.39 and higher), you can configure the Admission Controller to inject APM Java and JavaScript tracing libraries automatically. By automating the injection of tracer libraries via the admission controller, application images do not need to change, thus removing a time-costly step and helping you tap into the value of APM quicker than ever before.
+For your Kubernetes applications that send traces to Datadog by the Cluster Agent (version 7.39 and higher), you can configure the Admission Controller to inject APM Java and JavaScript tracing libraries automatically. By automating the injection of tracer libraries through the admission controller, you don't have to change your application images, helping you get up and running with APM quickly.
 
 
 After you [install the Cluster Agent][1], do one of the following:

--- a/content/en/tracing/trace_collection/admission_controller.md
+++ b/content/en/tracing/trace_collection/admission_controller.md
@@ -6,14 +6,16 @@ is_beta: true
 ---
 
 {{< beta-callout url="#" btn_hidden="true">}}
-  Tracing library injection using Admission Controller is in private beta. 
+  Tracing library injection using Admission Controller is in beta. 
 {{< /beta-callout >}} 
 
-For your containerized applications that send traces to Datadog by the Cluster Agent, you can configure the Cluster Agent (version 7.39 and higher) to inject APM Java and JavaScript tracing libraries automatically.
+For your Kubernetes applications that send traces to Datadog by the Cluster Agent (version 7.39 and higher), you can configure the Admission Controller to inject APM Java and JavaScript tracing libraries automatically.
 
 After you [install the Cluster Agent][1], do one of the following:
 - Add the label `admission.datadoghq.com/enabled: "true"` to your pod.
 - Configure the Cluster Agent admission controller by setting `mutateUnlabelled` (or `DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED`, depending on your configuration method) to `true`.
+
+Read [Admission Controller][2] for more information about configuring the Admission Controller.
 
 To opt-in your container for library injection, use Pod annotations inside your application's YAML file to specify language tracers and versions.
 
@@ -65,4 +67,5 @@ Possible options:
 | `false`          | `admission.datadoghq.com/enabled=false` | No        |
 
 
-[1]: /containers/cluster_agent/admission_controller/
+[1]: /containers/cluster_agent/
+[2]: /containers/cluster_agent/admission_controller/

--- a/content/en/tracing/trace_collection/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/dd_libraries/java.md
@@ -104,6 +104,8 @@ For other environments, please refer to the [Integrations][5] documentation for 
 
 ### Instrument Your Application
 
+<div class="alert alert-info">If you are collecting traces from a Kubernetes application, as an alternative to the following instructions, you can inject the tracing library into your application using the Cluster Agent Admission Controller. Read <a href="/tracing/trace_collection/admission_controller">Injecting Libraries Using Admission Controller</a> for instructions.</div>
+
 After the agent is installed, to begin tracing your applications:
 
 1. Download `dd-java-agent.jar` that contains the latest Agent class files:

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -102,6 +102,8 @@ Read [tracer settings][3] for a list of initialization options.
 
 ### Instrument your application
 
+<div class="alert alert-info">If you are collecting traces from a Kubernetes application, as an alternative to the following instructions, you can inject the tracing library into your application using the Cluster Agent Admission Controller. Read <a href="/tracing/trace_collection/admission_controller">Injecting Libraries Using Admission Controller</a> for instructions.</div>
+
 After the Agent is installed, follow these steps to add the Datadog tracing library to your Node.js applications:
 
 1. Install the Datadog Tracing library using npm for Node.js 14+:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Moves instructions for injecting tracing libraries into kubernetes applications to its own page in /tracing

### Motivation
DOCS-4220, conversation with PM

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes

No real new content, just moving it around and linking it up.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
