### PR TITLE
[DOCS-4226][apm] add page on APM quantization

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1863,6 +1863,11 @@ main:
     identifier: tracing_troubleshooting_dotnet_diagnostic_tool
     parent: tracing_troubleshooting
     weight: 1209
+  - name: APM Quantization
+    url: tracing/troubleshooting/quantization
+    identifier: tracing_troubleshooting_quantization
+    parent: tracing_troubleshooting
+    weight: 1210
   - name: Continuous Profiler
     url: profiler/
     pre: profiling-1

--- a/content/en/tracing/troubleshooting/quantization.md
+++ b/content/en/tracing/troubleshooting/quantization.md
@@ -15,7 +15,7 @@ further_reading:
 
 ## Overview
 
-During ingestion, Datadog applies _quantization_ to APM data such as random globally unique IDs (GUIDs), numeric IDs, and query parameter values in span or resource names. The resulting normalization cuts down on name pollution that results from these random patterns by grouping those spans and resources together because they are, for analysis purposes, the same.
+During ingestion, Datadog applies _quantization_ to APM data such as random globally unique IDs (GUIDs), numeric IDs, and query parameter values in [span][1] or [resource][2] names. The resulting normalization cuts down on name pollution that results from these random patterns by grouping those spans and resources together because they are, for analysis purposes, the same.
 
 Certain patterns in resource or span names are replaced with the following static strings:
 - GUIDs: `{guid}`
@@ -25,7 +25,7 @@ Certain patterns in resource or span names are replaced with the following stati
 These replacements affect:
 - trace metrics,
 - the resource name tag on those metrics, and
-- all the resource and span names for ingested spans.
+- all the resource and span for all ingested spans.
 
 ### Quantization examples
 
@@ -48,7 +48,7 @@ To search for these spans in trace search, the query is `resource_name:"SELECT ?
 
 ### In-code instrumentation
 
-If your application runs in an agentless setup or if you prefer to make instrumentation changes more directly in your code, see [the tracer documentation of your application's runtime][1] for information on how to create custom configuration for span names and resource names.
+If your application runs in an agentless setup or if you prefer to make instrumentation changes more directly in your code, see [the tracer documentation of your application's runtime][3] for information on how to create custom configuration for span names and resource names.
 
 ### Agent configuration
 
@@ -77,4 +77,6 @@ export DD_APM_REPLACE_TAGS = '[{"name": "span.name", "pattern": "get_id_[0-9]+",
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/trace_collection/custom_instrumentation/
+[1]: /tracing/glossary/#spans
+[2]: /tracing/glossary/#resources
+[3]: /tracing/trace_collection/custom_instrumentation/

--- a/content/en/tracing/troubleshooting/quantization.md
+++ b/content/en/tracing/troubleshooting/quantization.md
@@ -23,9 +23,9 @@ Certain patterns in resource or span names are replaced with the following stati
 - Query parameter values: `{val}`
 
 These replacements affect:
-- trace metrics,
+- trace metric names,
 - the resource name tag on those metrics, and
-- all the resource and span for all ingested spans.
+- the resource and span names for all ingested spans.
 
 ### Quantization examples
 

--- a/content/en/tracing/troubleshooting/quantization.md
+++ b/content/en/tracing/troubleshooting/quantization.md
@@ -1,0 +1,66 @@
+---
+title: APM Quantization
+kind: Documentation
+aliases:
+  - /tracing/troubleshooting/quantization
+---
+
+## What is APM quantization?
+
+Datadog applies quantization to APM data during ingestion to prevent random IDs, IP addresses, or query parameter values in span or resource names from unnecessarily categorized as separate resources.
+
+## How does quantization affect Resource and Span Names?
+Certain patterns in resource or span names will be replaced with static strings:
+- GUIDs: `{guid}`
+- Numeric IDs (6+ digit numbers, surrounded by delimiters or found at the end of a string): `{num}`
+- Query parameter values: `{val}`
+
+These replacements affect trace metrics, the resource name tag on those metrics, and all the resource and span names for ingested spans.
+
+### Quanization examples
+
+If a _span name_ is `find_user_2461685a_80c9_4d9e_85e9_a3b0e9e3ea84`, then it will be renamed to `find_user_{guid}` and the resulting trace metrics will be:
+- `trace.find_user_dd_guid`
+- `trace.find_user_dd_guid.hits`
+- `trace.find_user_dd_guid.errors`
+- `trace.find_user_dd_guid.duration`
+- `trace.find_user_dd_guid.apdex` (if apdex is configured for the service)
+
+To search for relevant spans in trace search, the query would be `operation_name:"find_user_{guid}"`.
+
+If a _resource name_ is `SELECT ? FROM TABLE temp_128390123`, then it will be renamed to `SELECT ? FROM TABLE temp_{num}` and its metric-normalized tag will become `resource_name:select_from_table_temp_num`.
+To search for relevant spans in trace search, the query would be `resource_name:"SELECT ? FROM TABLE temp_{num}"`.
+
+## How can I change my instrumentation to avoid quantization?
+
+**NOTE**: Any change to span and resource names upstream in the APM instrumentation or the agent will produce new metrics and tags.
+If you are using queries on quantized data then these queries will need to be updated to work with the new names.
+
+### In code
+
+Your application may run in an agentless setup or perhaps you would prefer to make instrumentation changes more directly in your code.
+Either way, see [the tracer documentation of your application's runtime][1] for more information on how to create custom configuration for span names and resource names.
+
+### With the trace agent
+
+You can use the `replace_tags` configuration to set up your own replacement strings through Go-compliant regex:
+
+```
+apm_config:
+  replace_tags:
+    # Replace tailing numeric IDs in span names with "x".
+    - name: "span.name"
+      pattern: "get_id_[0-9]+"
+      repl: "get_id_x"
+    # Replace numeric IDs in resource paths.
+    - name: "resource.name"
+      pattern: "/users/[0-9]+/"
+      repl: "/users/{user_id}/"
+```
+
+Or you can use the `DD_APM_REPLACE_TAGS` environment variable that has a JSON string as its value:
+```
+export DD_APM_REPLACE_TAGS = '[{"name": "span.name", "pattern": "get_id_[0-9]+", "repl": "get_id_x"}, {...}, …]'
+```
+
+[1]: /tracing/trace_collection/custom_instrumentation/

--- a/content/en/tracing/troubleshooting/quantization.md
+++ b/content/en/tracing/troubleshooting/quantization.md
@@ -19,7 +19,7 @@ During ingestion, Datadog applies _quantization_ to APM data such as random glob
 
 Certain patterns in resource or span names are replaced with the following static strings:
 - GUIDs: `{guid}`
-- Numeric IDs (6+ digit numbers, surrounded by delimiters or found at the end of a string): `{num}`
+- Numeric IDs (6+ digit numbers surrounded by non-alphanumeric characters or found at the end of a string): `{num}`
 - Query parameter values: `{val}`
 
 These replacements affect:
@@ -30,11 +30,11 @@ These replacements affect:
 ### Quantization examples
 
 For example, if a _span name_ is `find_user_2461685a_80c9_4d9e_85e9_a3b0e9e3ea84`, it is renamed to `find_user_{guid}` and the resulting trace metrics are:
-- `trace.find_user_dd_guid`
-- `trace.find_user_dd_guid.hits`
-- `trace.find_user_dd_guid.errors`
-- `trace.find_user_dd_guid.duration`
-- `trace.find_user_dd_guid.apdex` (if Apdex is configured for the service)
+- `trace.find_user_guid`
+- `trace.find_user_guid.hits`
+- `trace.find_user_guid.errors`
+- `trace.find_user_guid.duration`
+- `trace.find_user_guid.apdex` (if Apdex is configured for the service)
 
 To search for these spans in trace search, the query is `operation_name:"find_user_{guid}"`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a page to explain APM quantization: what it is, why it happens, and how to use quantized data.

### Motivation
To provide documentation on the APM quantization feature.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
