### PR TITLE
remove reference to deprecated `force_tls_12` configuration parameter and replace it by the new parameter `min_tls_version`

### DIFF
--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -33,7 +33,7 @@ On Debian and Ubuntu, the `datadog-agent` package has a soft dependency on the `
 
 ## Information security
 
-The Datadog Agent submits data to Datadog over a TLS-encrypted TCP connection by default. As of version 6, the Agent can be configured to enforce a minimum TLS version when connecting to Datadog. If you require the use of strong cryptography, for example, to meet PCI requirements, you should use Agent v6/7 and set the `min_tls_version: 'tlsv1.2'` setting in the Agent's configuration file.
+The Datadog Agent submits data to Datadog over a TLS-encrypted TCP connection by default. As of version 6, the Agent can be configured to enforce a minimum TLS version when connecting to Datadog. If you require the use of strong cryptography, for example, to meet PCI requirements, you should use Agent v6/7 and set the `min_tls_version: 'tlsv1.2'` setting, or `force_tls_12: true` for Agent < 6.39.0/7.39.0, in the Agent's configuration file.
 
 ## Networking and proxying
 

--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -33,7 +33,7 @@ On Debian and Ubuntu, the `datadog-agent` package has a soft dependency on the `
 
 ## Information security
 
-The Datadog Agent submits data to Datadog over a TLS-encrypted TCP connection by default. As of version 6, the Agent can be configured to enforce a minimum TLS version when connecting to Datadog. If you require the use of strong cryptography, for example, to meet PCI requirements, you should use Agent v6 and set the `min_tls_version: 'tlsv1.2'` setting in the Agent's configuration file.
+The Datadog Agent submits data to Datadog over a TLS-encrypted TCP connection by default. As of version 6, the Agent can be configured to enforce a minimum TLS version when connecting to Datadog. If you require the use of strong cryptography, for example, to meet PCI requirements, you should use Agent v6/7 and set the `min_tls_version: 'tlsv1.2'` setting in the Agent's configuration file.
 
 ## Networking and proxying
 
@@ -45,11 +45,11 @@ The Datadog Agent generates local logs in order to support [Agent troubleshootin
 
 ## Local HTTPS server
 
-Agent v6 exposes a local HTTPS API to ease communication between a running Agent and Agent tools (for example, the `datadog-agent` commands). The API server can only be accessed from the local network interface (`localhost/127.0.0.1`), and authentication is enforced through a token that's only readable by the user that the Agent runs as. Communication to the local HTTPS API is encrypted in transport to protect from eavesdropping on `localhost`.
+Agent v6/7 exposes a local HTTPS API to ease communication between a running Agent and Agent tools (for example, the `datadog-agent` commands). The API server can only be accessed from the local network interface (`localhost/127.0.0.1`), and authentication is enforced through a token that's only readable by the user that the Agent runs as. Communication to the local HTTPS API is encrypted in transport to protect from eavesdropping on `localhost`.
 
 ## Agent GUI
 
-Agent v6 comes bundled with a Graphical User Interface (GUI) by default, which launches in your default web browser. The GUI is launched only if the user launching it has the correct user permissions, including the ability to open the Agent's configuration file. The GUI can only be accessed from the local network interface (`localhost/127.0.0.1`). Finally, the user's cookies must be enabled, as the GUI generates and saves a token used for authenticating all communications with the GUI server as well as protecting against Cross-Site Request Forgery (CSRF) attacks. The GUI can also be disabled altogether if needed.
+Agent v6/7 comes bundled with a Graphical User Interface (GUI) by default, which launches in your default web browser. The GUI is launched only if the user launching it has the correct user permissions, including the ability to open the Agent's configuration file. The GUI can only be accessed from the local network interface (`localhost/127.0.0.1`). Finally, the user's cookies must be enabled, as the GUI generates and saves a token used for authenticating all communications with the GUI server as well as protecting against Cross-Site Request Forgery (CSRF) attacks. The GUI can also be disabled altogether if needed.
 
 ## Agent security scans
 

--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -33,7 +33,7 @@ On Debian and Ubuntu, the `datadog-agent` package has a soft dependency on the `
 
 ## Information security
 
-The Datadog Agent submits data to Datadog over a TLS-encrypted TCP connection by default. As of version 6, the Agent can be configured to enforce TLS 1.2 when connecting to Datadog. If you require the use of strong cryptography, for example, to meet PCI requirements, you should use Agent v6 and set the `force_tls_12: true` setting in the Agent's configuration file.
+The Datadog Agent submits data to Datadog over a TLS-encrypted TCP connection by default. As of version 6, the Agent can be configured to enforce a minimum TLS version when connecting to Datadog. If you require the use of strong cryptography, for example, to meet PCI requirements, you should use Agent v6 and set the `min_tls_version: 'tlsv1.2'` setting in the Agent's configuration file.
 
 ## Networking and proxying
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

It replaces a reference to the configuration parameter `force_tls_12` by `min_tls_version`

### Motivation

`force_tls_12` is depreciated since 7.39 and will be remove (probably, [see here](https://github.com/DataDog/datadog-agent/pull/13867)) in 7.41. The new parameter that should be used is `min_tls_version`

 ### Preview 
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/nicolas.guerguadj/replace-reference-to-force-tls-12-by-min-tls-version/data_security/agent/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
