### PR TITLE
[WEB-2770] Updates OOTB default security rules Cloud SIEM categories

### DIFF
--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -144,9 +144,9 @@ def security_rules(content, content_dir):
                         # new categorization
                         if any(sub_path in relative_path for sub_path in ['security-monitoring', 'cloud-siem']):
                             if 'signal-correlation/production' in relative_path:
-                                page_data['rule_category'].append('Cloud SIEM (Correlated)')
+                                page_data['rule_category'].append('Cloud SIEM (Signal Correlation)')
                             else:
-                                page_data['rule_category'].append('Cloud SIEM (Logs)')
+                                page_data['rule_category'].append('Cloud SIEM (Log Detection)')
 
                         if 'posture-management' in relative_path:
                             if 'cloud-configuration' in relative_path:

--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -143,7 +143,10 @@ def security_rules(content, content_dir):
 
                         # new categorization
                         if any(sub_path in relative_path for sub_path in ['security-monitoring', 'cloud-siem']):
-                            page_data['rule_category'].append('Cloud SIEM')
+                            if 'signal-correlation/production' in relative_path:
+                                page_data['rule_category'].append('Cloud SIEM (Correlated)')
+                            else:
+                                page_data['rule_category'].append('Cloud SIEM (Logs)')
 
                         if 'posture-management' in relative_path:
                             if 'cloud-configuration' in relative_path:


### PR DESCRIPTION
### What does this PR do?
Updates OOTB default security rules so Cloud SIEM is broken out into two categories, Log Detection and Signal Correlation.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2770

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/ootb-correlated/security_platform/default_rules/

- Cloud SIEM should be separated into two categories, `Cloud SIEM (Log Detection)` and `Cloud SIEM (Signal Correlation)`
- Detail pages under any `Cloud SIEM` category should be unaffected i.e. https://docs-staging.datadoghq.com/brian.deutsch/ootb-correlated/security_platform/default_rules/aws-signal-correlation-login-assumed-role/
- No errors are present

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
