### PR TITLE
sqlserver: add note about sql server browser service

### DIFF
--- a/layouts/shortcodes/dbm-sqlserver-agent-setup-windows.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-setup-windows.md
@@ -18,6 +18,8 @@ instances:
 
 To use [Windows Authentication][10], set `connection_string: "Trusted_Connection=yes"` and omit the `username` and `password` fields.
 
+The agent supports [SQL Server Browser Service][11] in versions 7.41+. To enable SSBS, provide a port of `0` in the host string: `<HOSTNAME>,0`.
+
 Use the `service` and `env` tags to link your database telemetry to other telemetry through a common tagging scheme. See [Unified Service Tagging][5] on how these tags are used throughout Datadog.
 
 ### Supported Drivers
@@ -57,3 +59,4 @@ Once all Agent configuration is complete, [restart the Datadog Agent][6].
 [8]: https://app.datadoghq.com/databases
 [9]: https://docs.microsoft.com/en-us/sql/ado/microsoft-activex-data-objects-ado
 [10]: https://docs.microsoft.com/en-us/sql/relational-databases/security/choose-an-authentication-mode
+[11]: https://learn.microsoft.com/en-us/sql/tools/configuration-manager/sql-server-browser-service


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Starting in agent version 7.41, we will support SQL Server Browser Service. This change adds a note about how to configure SQL Server for Windows to enable SSBS. 

Note: this is prepped but won't get merged until mid-Nov, when we are closer to Agent 7.41 release. 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
