### PR TITLE
[downtimes] Advertise automuting in Downtimes page

### DIFF
--- a/content/en/monitors/notify/downtimes.md
+++ b/content/en/monitors/notify/downtimes.md
@@ -193,6 +193,14 @@ If a monitor is in an alert-worthy state (`ALERT`, `WARNING`, or `NO DATA`) when
 
 All alerted states are included on the [weekly monitor report][7] even if the monitor is in a downtime.
 
+## AUTOMUTING
+
+Datadog can proactively mute monitors related to the manual shutdown of certain cloud workloads. Following scenarios are supported:
+
+- Auto-muting for manual shutdown of AWS EC2 instances and instance termination by AWS autoscaling based on host statuses from the CloudWatch API, more information [here][8].
+- Auto-muting for manual shutdown of Google Compute Engine (GCE) instances and instance termination triggered by GCE autoscaling based on host statuses from the GCE API, more information [here][9].
+- Auto-muting for shutdown or termination of Azure VMs, whether the shutdown was triggered manually or by Azure autoscaling, based on health statuses available through the Azure Resource Health API, more information [here][10].
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -204,3 +212,6 @@ All alerted states are included on the [weekly monitor report][7] even if the mo
 [5]: /events/explorer
 [6]: /api/v1/downtimes/#cancel-a-downtime
 [7]: /account_management/#preferences
+[8]: /integrations/amazon_ec2/#ec2-automuting
+[10]: /integrations/google_compute_engine/#gce-automuting
+[9]: /integrations/azure_vm/#automuting-monitors


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds information on what automutes are and links to relevant docs within the Downtimes page.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
https://docs.datadoghq.com/monitors/notify/downtimes/?tab=bymonitorname#automuting

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
