### PR TITLE
Corrected Linux/Windows section in process.md

### DIFF
--- a/content/en/infrastructure/process.md
+++ b/content/en/infrastructure/process.md
@@ -45,6 +45,7 @@ Once the Datadog Agent is installed, enable Live Processes collection by editing
 
 ```yaml
 process_config:
+  process_collection:
     enabled: true
 ```
 


### PR DESCRIPTION
The command suggested to enable Live Process collection by editing the Agent main configuration file is deprecated according to the config file in GitHub (https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml), I updated the command to match this config file.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Change one deprecated command with its updated version, according to the official config file found on GitHub.

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer feedback about misalignment between documentation and GitHub config file.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Reach out to me on slack if needed.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
