### PR TITLE
Remove Debug Workflows page, update left nav

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1325,11 +1325,6 @@ main:
     parent: workflows_actions_catalog
     identifier: workflows_generic_actions
     weight: 101
-  - name: Debug Workflows
-    url: workflows/debug/
-    parent: workflows
-    identifier: workflows_debug
-    weight: 5
   - name: Service Accounts
     url: workflows/service_accounts/
     parent: workflows

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1300,15 +1300,15 @@ main:
     identifier: workflows
     parent: platform_heading
     weight: 140000
-  - name: Authentication
-    url: workflows/setup/
-    parent: workflows
-    identifier: workflows_setup
-    weight: 1
   - name: Build Workflows
     url: workflows/build/
     parent: workflows
     identifier: workflows_build
+    weight: 1
+  - name: Authentication
+    url: workflows/setup/
+    parent: workflows
+    identifier: workflows_setup
     weight: 2
   - name: Trigger Workflows
     url: workflows/trigger/

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1329,7 +1329,7 @@ main:
     url: workflows/service_accounts/
     parent: workflows
     identifier: workflows_service_accounts
-    weight: 6
+    weight: 5
   - name: APM
     url: tracing/
     pre: apm

--- a/content/en/workflows/debug.md
+++ b/content/en/workflows/debug.md
@@ -1,9 +1,0 @@
----
-title: Debug Workflows
-kind: documentation
-disable_toc: false
-further_reading:
-- link: "logs/processing/pipelines"
-  tag: "Documentation"
-  text: "Log processing pipelines"
----


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Remove the Debug workflows left nav menu item and the markdown page.
- Move Authentication to below Build in the left nav.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
