### PR TITLE
Add Squid Proxy instructions

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -31,7 +31,7 @@ A few options are available to send traffic to Datadog over SSL/TLS for hosts th
 
 [Squid][2] is a forward proxy for the web supporting HTTP, HTTPS, FTP, and more. It runs on most available operating systems, including Windows, and is licensed under the GNU GPL. Squid is easy to configure and widely used for proxying traffic in a variety of different situations. 
 
-This is the best option if you do not have a web proxy readily available in your network and you wish to proxy a large number of Agents. 
+This is a simple, straightforward option if you do not already have a running web proxy in your network.
 
 #### Proxy forwarding with Squid
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -176,7 +176,7 @@ Restart Squid so that your configurations can be applied.
 sudo systemctl start squid
 ```
 
-If Squid is already running, restart Squid.
+If Squid is already running, restart Squid instead with the following command:
 
 ```bash
 sudo systemctl restart squid

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -146,7 +146,7 @@ This is the best option if you do not have a web proxy readily available in your
 
 Squid should be installed on a host that has connectivity to Datadog. Use your operating system's package manager, or install the software directly from [Squid's project page][2].
 
-Most of these settings will be configured within Squid's configuration file, usually located at `/etc/squid/squid.conf` on Linux or `C:\squid\etc\squid.conf` in Windows. 
+Most of the settings below are configured within Squid's configuration file, usually located at `/etc/squid/squid.conf` on Linux or `C:\squid\etc\squid.conf` in Windows. 
 
 ##### Configure Squid to only send traffic to Datadog
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -191,7 +191,7 @@ Assuming you've [already configured Squid as a system service][9], you can run t
 net start squid
 ```
 
-If Squid is already running, restart Squid.
+If Squid is already running, restart Squid instead with the following commands:
 
 ```bash
 net stop squid

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -27,105 +27,9 @@ A few options are available to send traffic to Datadog over SSL/TLS for hosts th
 
 ## Web proxy
 
-### Squid
+### Configuring web proxies
 
-[Squid][2] is a forward proxy for the web supporting HTTP, HTTPS, FTP, and more. It runs on most available operating systems, including Windows, and is licensed under the GNU GPL. Squid is easy to configure and widely used for proxying traffic in a variety of different situations. 
-
-This is a simple, straightforward option if you do not already have a running web proxy in your network.
-
-#### Proxy forwarding with Squid
-
-##### Squid configuration
-
-Squid should be installed on a host that has connectivity to Datadog. Use your operating system's package manager, or install the software directly from [Squid's project page][2].
-
-Most of the settings below are configured within Squid's configuration file, usually located at `/etc/squid/squid.conf` on Linux or `C:\squid\etc\squid.conf` in Windows. 
-
-###### Configure Squid to only send traffic to Datadog
-
-Edit your `squid.conf` file so Squid is able to accept local traffic and forward it to the necessary Datadog intakes.
-
-An example config file is shared below, some of these ACLs (Access Lists) may already be defined:
-
-```conf
-http_port 0.0.0.0:3128
-
-acl local src 127.0.0.1/32
-
-acl Datadog dstdomain .{{< region-param key="dd_site" >}}
-
-http_access allow Datadog
-http_access allow local manager
-```
-
-###### Start Squid
-
-Restart Squid so that your configurations can be applied. If you're configuring Squid on Windows, you will first need [to configure Squid as a system service][9].
-
-{{< tabs >}}
-{{% tab "Linux" %}}
-
-```bash
-sudo systemctl start squid
-```
-
-If Squid is already running, restart Squid instead with the following command:
-
-```bash
-sudo systemctl restart squid
-```
-
-{{% /tab %}}
-{{% tab "Windows" %}}
-
-Assuming Squid is configured as a system service, you can run the following:
-
-```bash
-net start squid
-```
-
-If Squid is already running, restart Squid instead with the following commands:
-
-```bash
-net stop squid
-net start squid
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-##### Datadog Agent configuration
-
-**Agent v6 & v7**
-
-Modify the Agent's configuration file (`datadog.yaml`) to include the following.
-
-```yaml
-proxy:
-  http: http://127.0.0.1:3128
-  https: http://127.0.0.1:3128
-```
-
-After saving these changes, [restart the Agent][1].
-
-Verify that everything is working by checking your [Infrastructure Overview][6].
-
-**Agent v5**
-
-Modify the Agent's configuration file (`datadog.conf`) to include the following.
-
-```conf
-proxy_host: 127.0.0.1
-proxy_port: 3128
-```
-
-After saving these changes, [restart the Agent][1].
-
-Verify that everything is working by checking your [Infrastructure Overview][6].
-
-### Other web proxies
-
-Other traditional web proxies are supported natively by the Agent. If you need to connect to the Internet through a proxy, edit your Agent configuration file.
+Traditional web proxies are supported natively by the Agent. If you need to connect to the Internet through a proxy, edit your Agent configuration file.
 
 **Agent v6 & v7**
 
@@ -231,6 +135,100 @@ proxy_password: my_password
 ```
 
 Do not forget to [restart the Agent][1] for the new settings to take effect.
+
+### Configuring Squid to proxy agent traffic
+
+[Squid][2] is a forward proxy for the web supporting HTTP, HTTPS, FTP, and more. It runs on most available operating systems, including Windows, and is licensed under the GNU GPL license. Squid is easy to configure and widely used for proxying traffic in a variety of deployment scenarios. 
+
+This is a simple, straightforward option if you do not already have a running web proxy in your network.
+
+#### Proxy forwarding with Squid
+
+##### Squid configuration
+
+###### Configure Squid to only send traffic to Datadog
+
+Squid should be installed on a host that has connectivity to both your internal agents and Datadog. Use your operating system's package manager, or install the software directly from [Squid's project page][2].
+
+Most options are configured within Squid's configuration file, usually located at `/etc/squid/squid.conf` on Linux or `C:\squid\etc\squid.conf` in Windows. 
+
+Edit your `squid.conf` configuration file so that Squid is able to accept local traffic and forward it to the necessary Datadog intakes:
+
+```conf
+http_port 0.0.0.0:3128
+
+acl local src 127.0.0.1/32
+
+acl Datadog dstdomain .{{< region-param key="dd_site" >}}
+
+http_access allow Datadog
+http_access allow local manager
+```
+
+###### Start Squid
+
+Start (or restart) Squid so that your new configurations can be applied. Note that if you're configuring Squid on Windows, you will first need [to configure Squid as a system service][9].
+
+{{< tabs >}}
+{{% tab "Linux" %}}
+
+```bash
+sudo systemctl start squid
+```
+
+If Squid is already running, restart Squid instead with the following command:
+
+```bash
+sudo systemctl restart squid
+```
+
+{{% /tab %}}
+{{% tab "Windows" %}}
+
+Assuming Squid is configured as a system service, you can run the following in an Administrator command prompt:
+
+```bash
+net start squid
+```
+
+If Squid is already running, restart Squid instead with the following commands:
+
+```bash
+net stop squid
+net start squid
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+##### Datadog Agent configuration
+
+**Agent v6 & v7**
+
+Modify the Agent's configuration file (`datadog.yaml`) to include the following.
+
+```yaml
+proxy:
+  http: http://127.0.0.1:3128
+  https: http://127.0.0.1:3128
+```
+
+After saving these changes, [restart the Agent][1].
+
+Verify that Datadog is able to receive the data from your Agent(s) by checking your [Infrastructure Overview][6].
+
+**Agent v5**
+
+Modify the Agent's configuration file (`datadog.conf`) to include the following.
+
+```conf
+proxy_host: 127.0.0.1
+proxy_port: 3128
+```
+
+After saving these changes, [restart the Agent][1].
+
+Verify that Datadog is able to receive the data from your Agent(s) by checking your [Infrastructure Overview][6].
 
 ## HAProxy
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -167,7 +167,7 @@ http_access allow local manager
 
 ##### Start Squid
 
-Now that Squid has been correctly configured, restart Squid so that your configurations can be applied.  
+Restart Squid so that your configurations can be applied.  
 
 {{< tabs >}}
 {{% tab "Linux" %}}

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -167,7 +167,7 @@ http_access allow local manager
 
 ##### Start Squid
 
-Restart Squid so that your configurations can be applied.  
+Restart Squid so that your configurations can be applied. If you're configuring Squid on Windows, you will first need [to configure Squid as a system service][9]
 
 {{< tabs >}}
 {{% tab "Linux" %}}
@@ -185,7 +185,7 @@ sudo systemctl restart squid
 {{% /tab %}}
 {{% tab "Windows" %}}
 
-Assuming you've [already configured Squid as a system service][9], you can run the following.
+Assuming Squid is configured as a system service, you can run the following:
 
 ```bash
 net start squid

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -148,43 +148,21 @@ Squid should be installed on a host that has connectivity to Datadog. Use your o
 
 Most of these settings will be configured within Squid's configuration file, usually located at `/etc/squid/squid.conf` on Linux or `C:\squid\etc\squid.conf` in Windows. 
 
-##### Define Access Lists (ACLs) for local IP address ranges
+##### Configure Squid to only send traffic to Datadog
 
 First, you will want to be sure that Squid is configured to accept traffic from the correct internal IP address ranges where your agents are running. Many of these Access Lists (ACLs) may already be defined.
 
-Ensure that your `squid.conf` file contains the following. The IP ranges listed below may be different for your environment depending on your network.
+Ensure that your `squid.conf` file contains the following settings. The IP ranges listed below may be different for your environment depending on your network.
 
 ```conf
-# Example rule allowing access from local networks
-# Adapt this list to your (internal) IP networks from which 
-# you would like to send agent traffic
-acl localnet src 0.0.0.1-0.255.255.255  # RFC 1122 "this" network (LAN)
-acl localnet src 10.0.0.0/8             # RFC 1918 local private network (LAN)
-acl localnet src 100.64.0.0/10          # RFC 6598 shared address space (CGN)
-acl localnet src 169.254.0.0/16         # RFC 3927 link-local (directly plugged) machines
-acl localnet src 172.16.0.0/12          # RFC 1918 local private network (LAN)
-acl localnet src 192.168.0.0/16         # RFC 1918 local private network (LAN)
-acl localnet src fc00::/7               # RFC 4193 local private network range
-acl localnet src fe80::/10              # RFC 4291 link-local (directly plugged) machines
-```
+http_port 0.0.0.0:3128
 
-##### Allow local traffic from the defined ACLs
+acl local src 127.0.0.1/32
 
-Now that your ACLs are correctly configured, modify `squid.conf` to allow HTTP traffic from the ACLs listed above.
+acl Datadog dstdomain .{{< region-param key="dd_site" >}}
 
-```conf
-# Example rule allowing access from local networks
-http_access allow localnet
-http_access allow localhost
-```
-
-##### Ensure Squid is listening on the correct port
-
-Squid should be listening on port `3128`, but you should check `squid.conf` to verify this. 
-
-```conf
-# Squid port
-http_port 3128
+http_access allow Datadog
+http_access allow local manager
 ```
 
 ##### Start Squid

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -152,7 +152,7 @@ Most of the settings below are configured within Squid's configuration file, usu
 
 First, configure Squid to accept traffic from the correct internal IP address ranges where your Agents are running. Many of these ACLs may already be defined.
 
-Ensure that your `squid.conf` file contains the following settings. The IP ranges listed below may be different for your environment depending on your network.
+Edit your `squid.conf` file so Squid is able to accept local traffic and forward it to the necessary Datadog intakes. An example config file is shared below:
 
 ```conf
 http_port 0.0.0.0:3128

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -27,7 +27,7 @@ A few options are available to send traffic to Datadog over SSL/TLS for hosts th
 
 ## Web proxy
 
-### Configuring a web proxy to proxy agent traffic
+For specific information regarding Squid, see the [Squid](#squid) section of this page.
 
 Traditional web proxies are supported natively by the Agent. If you need to connect to the Internet through a proxy, edit your Agent configuration file.
 
@@ -136,19 +136,17 @@ proxy_password: my_password
 
 Do not forget to [restart the Agent][1] for the new settings to take effect.
 
-### Configuring Squid to proxy agent traffic
+### Squid
 
-[Squid][2] is a forward proxy for the web supporting HTTP, HTTPS, FTP, and more. It runs on most available operating systems, including Windows, and is licensed under the GNU GPL license. Squid is easy to configure and widely used for proxying traffic in a variety of deployment scenarios. 
-
-This is a simple, straightforward option if you do not already have a running web proxy in your network.
+[Squid][2] is a forward proxy for the web supporting HTTP, HTTPS, FTP, and more. It runs on most available operating systems, including Windows, and is licensed under the GNU GPL license. Squid is a straightforward option if you do not already have a running web proxy in your network.
 
 #### Proxy forwarding with Squid
 
 ##### Configure Squid to only send traffic to Datadog
 
-Squid should be installed on a host that has connectivity to both your internal agents and Datadog. Use your operating system's package manager, or install the software directly from [Squid's project page][2].
+Install Squid on a host that has connectivity to both your internal Agents and Datadog. Use your operating system's package manager, or install the software directly from [Squid's project page][2].
 
-Most options are configured within Squid's configuration file, usually located at `/etc/squid/squid.conf` on Linux or `C:\squid\etc\squid.conf` in Windows. 
+To configure Squid, edit the configuration file. This file is usually located at `/etc/squid/squid.conf` on Linux or `C:\squid\etc\squid.conf` in Windows. 
 
 Edit your `squid.conf` configuration file so that Squid is able to accept local traffic and forward it to the necessary Datadog intakes:
 
@@ -165,7 +163,7 @@ http_access allow local manager
 
 ##### Start Squid
 
-Start (or restart) Squid so that your new configurations can be applied. Note that if you're configuring Squid on Windows, you will first need [to configure Squid as a system service][9].
+Start (or restart) Squid so that your new configurations can be applied. 
 
 {{< tabs >}}
 {{% tab "Linux" %}}
@@ -183,7 +181,7 @@ sudo systemctl restart squid
 {{% /tab %}}
 {{% tab "Windows" %}}
 
-Assuming Squid is configured as a system service, you can run the following in an Administrator command prompt:
+If you are configuring Squid on Windows, you must first [configure Squid as a system service][1]. You can then run the following in an Administrator command prompt:
 
 ```bash
 net start squid
@@ -196,6 +194,7 @@ net stop squid
 net start squid
 ```
 
+[1]: https://wiki.squid-cache.org/KnowledgeBase/Windows
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -203,7 +202,7 @@ net start squid
 
 **Agent v6 & v7**
 
-Modify the Agent's configuration file (`datadog.yaml`) to include the following.
+Modify the Agent's configuration file (`datadog.yaml`) to include the following:
 
 ```yaml
 proxy:
@@ -217,7 +216,7 @@ Verify that Datadog is able to receive the data from your Agent(s) by checking y
 
 **Agent v5**
 
-Modify the Agent's configuration file (`datadog.conf`) to include the following.
+Modify the Agent's configuration file (`datadog.conf`) to include the following:
 
 ```conf
 proxy_host: 127.0.0.1
@@ -1234,4 +1233,3 @@ It is recommended to use an actual proxy (a web proxy or HAProxy) to forward you
 [6]: https://app.datadoghq.com/infrastructure
 [7]: https://www.nginx.com
 [8]: /agent/logs/proxy
-[9]: https://wiki.squid-cache.org/KnowledgeBase/Windows

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -144,9 +144,7 @@ This is a simple, straightforward option if you do not already have a running we
 
 #### Proxy forwarding with Squid
 
-##### Squid configuration
-
-###### Configure Squid to only send traffic to Datadog
+##### Configure Squid to only send traffic to Datadog
 
 Squid should be installed on a host that has connectivity to both your internal agents and Datadog. Use your operating system's package manager, or install the software directly from [Squid's project page][2].
 
@@ -165,7 +163,7 @@ http_access allow Datadog
 http_access allow local manager
 ```
 
-###### Start Squid
+##### Start Squid
 
 Start (or restart) Squid so that your new configurations can be applied. Note that if you're configuring Squid on Windows, you will first need [to configure Squid as a system service][9].
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -167,7 +167,7 @@ http_access allow local manager
 
 ##### Start Squid
 
-Restart Squid so that your configurations can be applied. If you're configuring Squid on Windows, you will first need [to configure Squid as a system service][9]
+Restart Squid so that your configurations can be applied. If you're configuring Squid on Windows, you will first need [to configure Squid as a system service][9].
 
 {{< tabs >}}
 {{% tab "Linux" %}}

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -221,7 +221,7 @@ net start squid
 ```
 
 {{% /tab %}}
-{{ < /tabs >}}
+{{< /tabs >}}
 
 #### Datadog Agent configuration
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -150,9 +150,9 @@ Most of the settings below are configured within Squid's configuration file, usu
 
 ##### Configure Squid to only send traffic to Datadog
 
-First, configure Squid to accept traffic from the correct internal IP address ranges where your Agents are running. Many of these ACLs may already be defined.
+Edit your `squid.conf` file so Squid is able to accept local traffic and forward it to the necessary Datadog intakes.
 
-Edit your `squid.conf` file so Squid is able to accept local traffic and forward it to the necessary Datadog intakes. An example config file is shared below:
+An example config file is shared below, some of these ACLs (Access Lists) may already be defined:
 
 ```conf
 http_port 0.0.0.0:3128

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -27,7 +27,105 @@ A few options are available to send traffic to Datadog over SSL/TLS for hosts th
 
 ## Web proxy
 
-Traditional web proxies are supported natively by the Agent. If you need to connect to the Internet through a proxy, edit your Agent configuration file.
+### Squid
+
+[Squid][2] is a forward proxy for the web supporting HTTP, HTTPS, FTP, and more. It runs on most available operating systems, including Windows, and is licensed under the GNU GPL. Squid is easy to configure and widely used for proxying traffic in a variety of different situations. 
+
+This is the best option if you do not have a web proxy readily available in your network and you wish to proxy a large number of Agents. 
+
+#### Proxy forwarding with Squid
+
+##### Squid configuration
+
+Squid should be installed on a host that has connectivity to Datadog. Use your operating system's package manager, or install the software directly from [Squid's project page][2].
+
+Most of the settings below are configured within Squid's configuration file, usually located at `/etc/squid/squid.conf` on Linux or `C:\squid\etc\squid.conf` in Windows. 
+
+###### Configure Squid to only send traffic to Datadog
+
+Edit your `squid.conf` file so Squid is able to accept local traffic and forward it to the necessary Datadog intakes.
+
+An example config file is shared below, some of these ACLs (Access Lists) may already be defined:
+
+```conf
+http_port 0.0.0.0:3128
+
+acl local src 127.0.0.1/32
+
+acl Datadog dstdomain .{{< region-param key="dd_site" >}}
+
+http_access allow Datadog
+http_access allow local manager
+```
+
+###### Start Squid
+
+Restart Squid so that your configurations can be applied. If you're configuring Squid on Windows, you will first need [to configure Squid as a system service][9].
+
+{{< tabs >}}
+{{% tab "Linux" %}}
+
+```bash
+sudo systemctl start squid
+```
+
+If Squid is already running, restart Squid instead with the following command:
+
+```bash
+sudo systemctl restart squid
+```
+
+{{% /tab %}}
+{{% tab "Windows" %}}
+
+Assuming Squid is configured as a system service, you can run the following:
+
+```bash
+net start squid
+```
+
+If Squid is already running, restart Squid instead with the following commands:
+
+```bash
+net stop squid
+net start squid
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+##### Datadog Agent configuration
+
+**Agent v6 & v7**
+
+Modify the Agent's configuration file (`datadog.yaml`) to include the following.
+
+```yaml
+proxy:
+  http: http://127.0.0.1:3128
+  https: http://127.0.0.1:3128
+```
+
+After saving these changes, [restart the Agent][1].
+
+Verify that everything is working by checking your [Infrastructure Overview][6].
+
+**Agent v5**
+
+Modify the Agent's configuration file (`datadog.conf`) to include the following.
+
+```conf
+proxy_host: 127.0.0.1
+proxy_port: 3128
+```
+
+After saving these changes, [restart the Agent][1].
+
+Verify that everything is working by checking your [Infrastructure Overview][6].
+
+### Other web proxies
+
+Other traditional web proxies are supported natively by the Agent. If you need to connect to the Internet through a proxy, edit your Agent configuration file.
 
 **Agent v6 & v7**
 
@@ -133,102 +231,6 @@ proxy_password: my_password
 ```
 
 Do not forget to [restart the Agent][1] for the new settings to take effect.
-
-## Squid
-
-[Squid][2] is a caching proxy for the web supporting HTTP, HTTPS, FTP, and more. It runs on most available operating systems, including Windows, and is licensed under the GNU GPL. Squid is easy to configure and widely used for proxying traffic in a variety of different situations. 
-
-This is the best option if you do not have a web proxy readily available in your network and you wish to proxy a large number of Agents. 
-
-### Proxy forwarding with Squid
-
-#### Squid configuration
-
-Squid should be installed on a host that has connectivity to Datadog. Use your operating system's package manager, or install the software directly from [Squid's project page][2].
-
-Most of the settings below are configured within Squid's configuration file, usually located at `/etc/squid/squid.conf` on Linux or `C:\squid\etc\squid.conf` in Windows. 
-
-##### Configure Squid to only send traffic to Datadog
-
-Edit your `squid.conf` file so Squid is able to accept local traffic and forward it to the necessary Datadog intakes.
-
-An example config file is shared below, some of these ACLs (Access Lists) may already be defined:
-
-```conf
-http_port 0.0.0.0:3128
-
-acl local src 127.0.0.1/32
-
-acl Datadog dstdomain .{{< region-param key="dd_site" >}}
-
-http_access allow Datadog
-http_access allow local manager
-```
-
-##### Start Squid
-
-Restart Squid so that your configurations can be applied. If you're configuring Squid on Windows, you will first need [to configure Squid as a system service][9].
-
-{{< tabs >}}
-{{% tab "Linux" %}}
-
-```bash
-sudo systemctl start squid
-```
-
-If Squid is already running, restart Squid instead with the following command:
-
-```bash
-sudo systemctl restart squid
-```
-
-{{% /tab %}}
-{{% tab "Windows" %}}
-
-Assuming Squid is configured as a system service, you can run the following:
-
-```bash
-net start squid
-```
-
-If Squid is already running, restart Squid instead with the following commands:
-
-```bash
-net stop squid
-net start squid
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-#### Datadog Agent configuration
-
-**Agent v6 & v7**
-
-Modify the Agent's configuration file (`datadog.yaml`) to include the following.
-
-```yaml
-proxy:
-  http: http://127.0.0.1:3128
-  https: http://127.0.0.1:3128
-```
-
-After saving these changes, [restart the Agent][1].
-
-Verify that everything is working by checking your [Infrastructure Overview][6].
-
-**Agent v5**
-
-Modify the Agent's configuration file (`datadog.conf`) to include the following.
-
-```conf
-proxy_host: 127.0.0.1
-proxy_port: 3128
-```
-
-After saving these changes, [restart the Agent][1].
-
-Verify that everything is working by checking your [Infrastructure Overview][6].
 
 ## HAProxy
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -27,7 +27,7 @@ A few options are available to send traffic to Datadog over SSL/TLS for hosts th
 
 ## Web proxy
 
-### Configuring web proxies
+### Configuring a web proxy to proxy agent traffic
 
 Traditional web proxies are supported natively by the Agent. If you need to connect to the Internet through a proxy, edit your Agent configuration file.
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -150,7 +150,7 @@ Most of the settings below are configured within Squid's configuration file, usu
 
 ##### Configure Squid to only send traffic to Datadog
 
-First, you will want to be sure that Squid is configured to accept traffic from the correct internal IP address ranges where your agents are running. Many of these Access Lists (ACLs) may already be defined.
+First, configure Squid to accept traffic from the correct internal IP address ranges where your Agents are running. Many of these ACLs may already be defined.
 
 Ensure that your `squid.conf` file contains the following settings. The IP ranges listed below may be different for your environment depending on your network.
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -136,7 +136,7 @@ Do not forget to [restart the Agent][1] for the new settings to take effect.
 
 ## Squid
 
-[Squid][2] is a caching proxy for the Web supporting HTTP, HTTPS, FTP, and more. It runs on most available operating systems, including Windows and is licensed under the GNU GPL. Squid is easy to configure and widely used for proxying traffic in a variety of different situations. 
+[Squid][2] is a caching proxy for the web supporting HTTP, HTTPS, FTP, and more. It runs on most available operating systems, including Windows, and is licensed under the GNU GPL. Squid is easy to configure and widely used for proxying traffic in a variety of different situations. 
 
 This is the best option if you do not have a web proxy readily available in your network and you wish to proxy a large number of Agents. 
 

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -144,7 +144,7 @@ This is the best option if you do not have a web proxy readily available in your
 
 #### Squid configuration
 
-Squid should be installed on a host that has connectivity to Datadog. Use your operating system's package manager or install the software directly from [Squid's project page][2].
+Squid should be installed on a host that has connectivity to Datadog. Use your operating system's package manager, or install the software directly from [Squid's project page][2].
 
 Most of these settings will be configured within Squid's configuration file, usually located at `/etc/squid/squid.conf` on Linux or `C:\squid\etc\squid.conf` in Windows. 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds Squid Proxy configuration steps to this documentation page. 

### Motivation
Squid is typically easier to configure than Nginx/HAproxy as a means for proxying agent traffic but is not mentioned explicitly in our documentation. The steps included here were transcribed from some internal guides we have on the subject. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
