### PR TITLE
Wrong API docs link update

### DIFF
--- a/content/en/getting_started/api/_index.md
+++ b/content/en/getting_started/api/_index.md
@@ -111,5 +111,5 @@ This tab is an alternative to viewing the `param1:value1&param2:value2` structur
 [4]: https://identity.getpostman.com/login
 [5]: https://www.postman.com/downloads/
 [6]: https://learning.postman.com/docs/postman/variables-and-environments/variables/#environments-in-postman
-[7]: /api/v1/organizations/
+[7]: /api/latest/#api-reference
 [8]: /api/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR updates a link that pointed towards the wrong API docs (https://docs.datadoghq.com/api/latest/organizations/ instead of the API reference https://docs.datadoghq.com/api/latest/#api-reference)

### Motivation
Flagged by a customer.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
