### PR TITLE
Bump mod version for new product dropdown updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.3.60 // indirect
+require github.com/DataDog/websites-modules v1.3.61 // indirect
 
 // replace github.com/DataDog/websites-modules => /Users/carlos.santos/GitHub/websites-modules

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/DataDog/websites-modules v1.3.60 h1:u1kMzHnzTNakSELrv9sz5WH2D732pn3dtIH/BggW3mo=
-github.com/DataDog/websites-modules v1.3.60/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.3.61 h1:IDjUqmbSp+AxozNxfLJp0168Bhi5/rJfs5WZNKaK8Mc=
+github.com/DataDog/websites-modules v1.3.61/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- get new product dropdown updates from websites-modules

### Motivation
- update product dropdown menu

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
https://docs-staging.datadoghq.com/carlos/bump-mod-version/

- [ ] check product dropdown for new products against live corpsite 

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
