### PR TITLE
Bump algolia indexing timeout to 2h 30m due to new workflows pages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -155,7 +155,7 @@ index_algolia_preview:
   stage: post-deploy
   cache: []
   environment: "preview"
-  timeout: 2h
+  timeout: 2h 30m
   before_script:
     - "[ -f /usr/local/bin/helpers.sh ] && source /usr/local/bin/helpers.sh"  # source helpers
   script:
@@ -287,7 +287,7 @@ index_algolia:
   tags: ["runner:main"]
   stage: post-deploy
   environment: "live"
-  timeout: 2h
+  timeout: 2h 30m
   script:
     - |-
       echo APPLICATION_ID=$(get_secret 'ci.documentation.algolia_docsearch_application_id') > .env


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Increases the timeout on Algolia indexing by half an hour to 2 hours and 30 minutes. Modeled after the commit from the last bump: https://github.com/DataDog/documentation/commit/96ee7dea49d1dfa38046b7bdc3efd822c141a93f.

### Motivation
The Algolia indexing job timed out Tuesday night, presumably because of the large number of new Workflow files. Over Slack, Brian from the Websites team says they usually bump it by 30 each time.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
