### PR TITLE
fix build-container-agent.md

### DIFF
--- a/content/en/agent/guide/build-container-agent.md
+++ b/content/en/agent/guide/build-container-agent.md
@@ -11,10 +11,10 @@ Follow the instructions below to build the Datadog Docker Agent image for a give
     git clone https://github.com/DataDog/datadog-agent.git
     ```
 
-2. Go into the `datadog-agent/Dockerfile/agent/` folder:
+2. Go into the `datadog-agent/Dockerfiles/agent/` folder:
 
     ```shell
-    cd datadog-agent/Dockerfile/agent/
+    cd datadog-agent/Dockerfiles/agent/
     ```
 
 3. Switch to the Agent version branch you want to build the Agent from:

--- a/content/fr/agent/guide/build-container-agent.md
+++ b/content/fr/agent/guide/build-container-agent.md
@@ -11,10 +11,10 @@ Suivez les instructions ci-dessous pour créer l'image Docker de l'Agent Datadog
     git clone https://github.com/DataDog/datadog-agent.git
     ```
 
-2. Accédez au dossier `datadog-agent/Dockerfile/agent/` :
+2. Accédez au dossier `datadog-agent/Dockerfiles/agent/` :
 
     ```shell
-    cd datadog-agent/Dockerfile/agent/
+    cd datadog-agent/Dockerfiles/agent/
     ```
 
 3. Sélectionnez la branche correspondant à la version de l'Agent Datadog qui vous intéresse :

--- a/content/ja/agent/guide/build-container-agent.md
+++ b/content/ja/agent/guide/build-container-agent.md
@@ -11,10 +11,10 @@ Datadog Docker Agent を特定の `<AGENT_VERSION>` でビルドするには、�
     git clone https://github.com/DataDog/datadog-agent.git
     ```
 
-2. `datadog-agent/Dockerfile/agent/` フォルダに移動します。
+2. `datadog-agent/Dockerfiles/agent/` フォルダに移動します。
 
     ```shell
-    cd datadog-agent/Dockerfile/agent/
+    cd datadog-agent/Dockerfiles/agent/
     ```
 
 3. ビルドする Agent のバージョンのブランチに切り替えます。

--- a/content/kr/agent/guide/build-container-agent.md
+++ b/content/kr/agent/guide/build-container-agent.md
@@ -11,10 +11,10 @@ title: Datadog Agent 이미지 빌드
     git clone https://github.com/DataDog/datadog-agent.git
     ```
 
-2. `datadog-agent/Dockerfile/agent/` 폴더로 이동하세요.
+2. `datadog-agent/Dockerfiles/agent/` 폴더로 이동하세요.
 
     ```shell
-    cd datadog-agent/Dockerfile/agent/
+    cd datadog-agent/Dockerfiles/agent/
     ```
 
 3. 빌드하고자 하는 Agent 버전의 브랜치로 전환합니다.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Fix errors in build-container-agent documentation
`datadog-agent/Dockerfile/agent/` -> `datadog-agent/Dockerfiles/agent/`

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
