### PR TITLE
Bring tabs back to proxy doc

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -29,7 +29,8 @@ A few options are available to send traffic to Datadog over SSL/TLS for hosts th
 
 Traditional web proxies are supported natively by the Agent. If you need to connect to the Internet through a proxy, edit your Agent configuration file.
 
-**Agent v6 & v7**
+{{< tabs >}}
+{{% tab "Agent v6 & v7" %}}
 
 Set different proxy servers for `https` and `http` requests in your Agent `datadog.yaml` configuration file. The Agent uses `https` to send data to Datadog, but integrations might use `http` to gather metrics. No matter the proxied requests, you can activate SSL on your proxy server. Below are some configuration examples for your `datadog.yaml` file.
 
@@ -116,7 +117,8 @@ The Agent uses the following values in order of precedence:
 2. `HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY` environment variables
 3. Values inside `datadog.yaml`
 
-**Agent v5**
+{{% /tab %}}
+{{% tab "Agent v5" %}}
 
 <div class="alert alert-warning">
 The <code>&ltHOST&gt;:&ltPORT&gt;</code> used to proxy metrics can NOT be used to proxy logs. See the <a href="/agent/logs/proxy">Proxy for Logs</a> page.
@@ -134,20 +136,22 @@ proxy_password: my_password
 
 Do not forget to [restart the Agent][1] for the new settings to take effect.
 
-
+[1]: /agent/guide/agent-commands/
+{{% /tab %}}
+{{< /tabs >}}
 
 ## HAProxy
 
-[HAProxy][2] is a free, fast, and reliable solution offering proxying for TCP and HTTP applications. While HAProxy is usually used as a load balancer to distribute incoming requests to pool servers, you can also use it to proxy Agent traffic to Datadog from hosts that have no outside connectivity:
+[HAProxy][1] is a free, fast, and reliable solution offering proxying for TCP and HTTP applications. While HAProxy is usually used as a load balancer to distribute incoming requests to pool servers, you can also use it to proxy Agent traffic to Datadog from hosts that have no outside connectivity:
 
 `agent ---> haproxy ---> Datadog`
 
 This is the best option if you do not have a web proxy readily available in your network and you wish to proxy a large number of Agents. In some cases, a single HAProxy instance is sufficient to handle local Agent traffic in your network, because each proxy can accommodate upwards of 1000 Agents. 
 
-**Note**: This figure is a conservative estimate based on the performance of `m3.xl` instances specifically. Numerous network-related and host-related variables can influence throughput of HAProxy, so you should keep an eye on your proxy deployment both before and after putting it into service. See the [HAProxy documentation][3] for additional information.
+**Note**: This figure is a conservative estimate based on the performance of `m3.xl` instances specifically. Numerous network-related and host-related variables can influence throughput of HAProxy, so you should keep an eye on your proxy deployment both before and after putting it into service. See the [HAProxy documentation][2] for additional information.
 
 The communication between HAProxy and Datadog is always encrypted with TLS. The communication between the Agent host and the HAProxy host is not encrypted by default, because the proxy and the Agent are assumed to be on the same host. However, it is recommended that you secure this communication with TLS encryption if the HAproxy host and Agent host are not located on the same isolated local network.
-To encrypt data between the Agent and HAProxy, you need to create an x509 certificate with the Subject Alternative Name (SAN) extension for the HAProxy host. This certificate bundle (*.pem) should contain both the public certificate and private key. See this [HAProxy blog post][4] for more information.
+To encrypt data between the Agent and HAProxy, you need to create an x509 certificate with the Subject Alternative Name (SAN) extension for the HAProxy host. This certificate bundle (*.pem) should contain both the public certificate and private key. See this [HAProxy blog post][3] for more information.
 
 
 **Note**: Download the Datadog certificate with one of the following commands:
@@ -167,7 +171,8 @@ HAProxy should be installed on a host that has connectivity to Datadog. You can 
 
 **Note**: It is recommended to use the `HTTPS` configuration file if the Agent and HAProxy are not part of the same isolated local network.
 
-##### HTTP
+{{< tabs >}}
+{{% tab "HTTP" %}}
 
 ```conf
 # Basic configuration
@@ -415,7 +420,8 @@ backend datadog-appsec-events # deprecated
     # server mothership appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 ```
 
-##### HTTPS
+{{% /tab %}}
+{{% tab "HTTPS" %}}
 
 This configuration adds SSL/TLS encryption on communication between the Agent and HAProxy. Replace the variable `<PATH_TO_PROXY_CERTIFICATE_PEM>` with the path to the proxy certificate bundle (*.pem).
 
@@ -666,6 +672,10 @@ backend datadog-appsec-events # deprecated
     # server mothership appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 ```
 
+{{% /tab %}}
+{{< /tabs >}}
+
+
 **Note**: You can use `verify none` instead of `verify required ca-file <PATH_TO_CERTIFICATES>` if you are unable to get the certificates on the proxy host, but be aware that HAProxy will not be able to verify Datadog's intake certificate in that case.
 
 HAProxy 1.8 and newer allow DNS service discovery to detect server changes and automatically apply them to your configuration.
@@ -673,7 +683,8 @@ If you are using older version of HAProxy, you have to reload or restart HAProxy
 
 #### Datadog Agent configuration
 
-**Agent v6 & v7**
+{{< tabs >}}
+{{% tab "Agent v6 & v7" %}}
 
 Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy, for example: `haproxy.example.com`.
 This `dd_url` setting can be found in the `datadog.yaml` file.
@@ -738,9 +749,12 @@ skip_ssl_validation: true
 
 Finally [restart the Agent][1].
 
-To verify that everything is working properly, review the HAProxy statistics at `http://haproxy.example.com:3833` as well as the [Infrastructure Overview][5].
+To verify that everything is working properly, review the HAProxy statistics at `http://haproxy.example.com:3833` as well as the [Infrastructure Overview][2].
 
-**Agent v5**
+[1]: /agent/guide/agent-commands/#restart-the-agent
+[2]: https://app.datadoghq.com/infrastructure
+{{% /tab %}}
+{{% tab "Agent v5" %}}
 
 Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy, for example: `haproxy.example.com`.
 This `dd_url` setting can be found in the `datadog.conf` file.
@@ -779,11 +793,16 @@ skip_ssl_validation: yes
 
 Finally [restart the Agent][1].
 
-To verify that everything is working properly, review the HAProxy statistics at `http://haproxy.example.com:3833` as well as the [Infrastructure Overview][5].
+To verify that everything is working properly, review the HAProxy statistics at `http://haproxy.example.com:3833` as well as the [Infrastructure Overview][2].
+
+[1]: /agent/guide/agent-commands/#restart-the-agent
+[2]: https://app.datadoghq.com/infrastructure
+{{% /tab %}}
+{{< /tabs >}}
 
 ## NGINX
 
-[NGINX][6] is a web server which can also be used as a reverse proxy, load balancer, mail proxy, and HTTP cache. You can also use NGINX as a proxy for your Datadog Agents:
+[NGINX][4] is a web server which can also be used as a reverse proxy, load balancer, mail proxy, and HTTP cache. You can also use NGINX as a proxy for your Datadog Agents:
 
 `agent ---> nginx ---> Datadog`
 
@@ -807,7 +826,8 @@ NGINX should be installed on a host that has connectivity to Datadog. You can us
 
 **Note**: It is recommended to use the `HTTPS` configuration file if the Agent and NGINX are not part of the same isolated local network.
 
-##### HTTP
+{{< tabs >}}
+{{% tab "HTTP" %}}
 
 ```conf
 user nginx;
@@ -909,7 +929,8 @@ stream {
 }
 ```
 
-##### HTTPS
+{{% /tab %}}
+{{% tab "HTTPS" %}}
 
 
 This configuration adds SSL/TLS encryption on communication between the Agent and NGINX. Replace `<PATH_TO_PROXY_CERTIFICATE>` with the path to the proxy public certificate and `<PATH_TO_PROXY_CERTIFICATE_KEY>` with the path to the private key.
@@ -1019,6 +1040,8 @@ stream {
     }
 }
 ```
+{{% /tab %}}
+{{< /tabs >}}
 
 **Note**: You can remove `proxy_ssl_verify on` if you are unable to get the certificates on the proxy host, but be aware that NGINX will not be able to verify Datadog's intake certificate in that case.
 
@@ -1086,7 +1109,7 @@ With this option set to `true`, the Agent skips the certificate validation step 
 skip_ssl_validation: true
 ```
 
-When sending logs over TCP, see [TCP Proxy for Logs][7].
+When sending logs over TCP, see [TCP Proxy for Logs][5].
 
 ## Datadog Agent
 
@@ -1134,10 +1157,8 @@ It is recommended to use an actual proxy (a web proxy or HAProxy) to forward you
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: /agent/guide/agent-commands/
-[2]: http://haproxy.1wt.eu
-[3]: http://www.haproxy.org/#perf
-[4]: https://www.haproxy.com/blog/haproxy-ssl-termination/
-[5]: https://app.datadoghq.com/infrastructure
-[6]: https://www.nginx.com
-[7]: /agent/logs/proxy
+[1]: http://haproxy.1wt.eu
+[2]: http://www.haproxy.org/#perf
+[3]: https://www.haproxy.com/blog/haproxy-ssl-termination/
+[4]: https://www.nginx.com
+[5]: /agent/logs/proxy

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -172,9 +172,9 @@ HAProxy should be installed on a host that has connectivity to Datadog. You can 
 **Note**: It is recommended to use the `HTTPS` configuration file if the Agent and HAProxy are not part of the same isolated local network.
 
 {{< tabs >}}
-{{< tab "HTTP" >}}
+{{% tab "HTTP" %}}
 
-```conf
+<pre><code>
 # Basic configuration
 global
     log 127.0.0.1 local0
@@ -201,7 +201,7 @@ listen stats
     stats uri /
 
 # This section is to reload DNS Records
-# Replace <DNS_SERVER_IP> and <DNS_SECONDARY_SERVER_IP> with your DNS Server IP addresses.
+# Replace &lt;DNS_SERVER_IP&gt; and <DNS_SECONDARY_SERVER_IP> with your DNS Server IP addresses.
 # For HAProxy 1.8 and newer
 resolvers my-dns
     nameserver dns1 <DNS_SERVER_IP>:53
@@ -418,9 +418,9 @@ backend datadog-appsec-events # deprecated
     server-template mothership 5 appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
     # server mothership appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
-```
+</pre></code>
 
-{{< /tab >}}
+{{% /tab %}}
 {{< tab "HTTPS" >}}
 
 This configuration adds SSL/TLS encryption on communication between the Agent and HAProxy. Replace the variable `<PATH_TO_PROXY_CERTIFICATE_PEM>` with the path to the proxy certificate bundle (*.pem).
@@ -753,7 +753,7 @@ To verify that everything is working properly, review the HAProxy statistics at 
 
 [1]: /agent/guide/agent-commands/#restart-the-agent
 [2]: https://app.datadoghq.com/infrastructure
-{{< /tab >}}
+{{% /tab %}}
 {{< tab "Agent v5" >}}
 
 Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy, for example: `haproxy.example.com`.

--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -30,7 +30,7 @@ A few options are available to send traffic to Datadog over SSL/TLS for hosts th
 Traditional web proxies are supported natively by the Agent. If you need to connect to the Internet through a proxy, edit your Agent configuration file.
 
 {{< tabs >}}
-{{% tab "Agent v6 & v7" %}}
+{{< tab "Agent v6 & v7" >}}
 
 Set different proxy servers for `https` and `http` requests in your Agent `datadog.yaml` configuration file. The Agent uses `https` to send data to Datadog, but integrations might use `http` to gather metrics. No matter the proxied requests, you can activate SSL on your proxy server. Below are some configuration examples for your `datadog.yaml` file.
 
@@ -117,8 +117,8 @@ The Agent uses the following values in order of precedence:
 2. `HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY` environment variables
 3. Values inside `datadog.yaml`
 
-{{% /tab %}}
-{{% tab "Agent v5" %}}
+{{< /tab >}}
+{{< tab "Agent v5" >}}
 
 <div class="alert alert-warning">
 The <code>&ltHOST&gt;:&ltPORT&gt;</code> used to proxy metrics can NOT be used to proxy logs. See the <a href="/agent/logs/proxy">Proxy for Logs</a> page.
@@ -137,7 +137,7 @@ proxy_password: my_password
 Do not forget to [restart the Agent][1] for the new settings to take effect.
 
 [1]: /agent/guide/agent-commands/
-{{% /tab %}}
+{{< /tab >}}
 {{< /tabs >}}
 
 ## HAProxy
@@ -172,7 +172,7 @@ HAProxy should be installed on a host that has connectivity to Datadog. You can 
 **Note**: It is recommended to use the `HTTPS` configuration file if the Agent and HAProxy are not part of the same isolated local network.
 
 {{< tabs >}}
-{{% tab "HTTP" %}}
+{{< tab "HTTP" >}}
 
 ```conf
 # Basic configuration
@@ -420,8 +420,8 @@ backend datadog-appsec-events # deprecated
     # server mothership appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 ```
 
-{{% /tab %}}
-{{% tab "HTTPS" %}}
+{{< /tab >}}
+{{< tab "HTTPS" >}}
 
 This configuration adds SSL/TLS encryption on communication between the Agent and HAProxy. Replace the variable `<PATH_TO_PROXY_CERTIFICATE_PEM>` with the path to the proxy certificate bundle (*.pem).
 
@@ -672,7 +672,7 @@ backend datadog-appsec-events # deprecated
     # server mothership appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 ```
 
-{{% /tab %}}
+{{< /tab >}}
 {{< /tabs >}}
 
 
@@ -684,7 +684,7 @@ If you are using older version of HAProxy, you have to reload or restart HAProxy
 #### Datadog Agent configuration
 
 {{< tabs >}}
-{{% tab "Agent v6 & v7" %}}
+{{< tab "Agent v6 & v7" >}}
 
 Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy, for example: `haproxy.example.com`.
 This `dd_url` setting can be found in the `datadog.yaml` file.
@@ -753,8 +753,8 @@ To verify that everything is working properly, review the HAProxy statistics at 
 
 [1]: /agent/guide/agent-commands/#restart-the-agent
 [2]: https://app.datadoghq.com/infrastructure
-{{% /tab %}}
-{{% tab "Agent v5" %}}
+{{< /tab >}}
+{{< tab "Agent v5" >}}
 
 Edit each Agent to point to HAProxy by setting its `dd_url` to the address of HAProxy, for example: `haproxy.example.com`.
 This `dd_url` setting can be found in the `datadog.conf` file.
@@ -797,7 +797,7 @@ To verify that everything is working properly, review the HAProxy statistics at 
 
 [1]: /agent/guide/agent-commands/#restart-the-agent
 [2]: https://app.datadoghq.com/infrastructure
-{{% /tab %}}
+{{< /tab >}}
 {{< /tabs >}}
 
 ## NGINX
@@ -827,7 +827,7 @@ NGINX should be installed on a host that has connectivity to Datadog. You can us
 **Note**: It is recommended to use the `HTTPS` configuration file if the Agent and NGINX are not part of the same isolated local network.
 
 {{< tabs >}}
-{{% tab "HTTP" %}}
+{{< tab "HTTP" >}}
 
 ```conf
 user nginx;
@@ -929,8 +929,8 @@ stream {
 }
 ```
 
-{{% /tab %}}
-{{% tab "HTTPS" %}}
+{{< /tab >}}
+{{< tab "HTTPS" >}}
 
 
 This configuration adds SSL/TLS encryption on communication between the Agent and NGINX. Replace `<PATH_TO_PROXY_CERTIFICATE>` with the path to the proxy public certificate and `<PATH_TO_PROXY_CERTIFICATE_KEY>` with the path to the private key.
@@ -1040,7 +1040,7 @@ stream {
     }
 }
 ```
-{{% /tab %}}
+{{< /tab >}}
 {{< /tabs >}}
 
 **Note**: You can remove `proxy_ssl_verify on` if you are unable to get the certificates on the proxy host, but be aware that NGINX will not be able to verify Datadog's intake certificate in that case.
@@ -1114,12 +1114,12 @@ When sending logs over TCP, see [TCP Proxy for Logs][5].
 ## Datadog Agent
 
 {{< tabs >}}
-{{% tab "Agent v6 & v7" %}}
+{{< tab "Agent v6 & v7" >}}
 
 **This feature is only available for Agent v5**.
 
-{{% /tab %}}
-{{% tab "Agent v5" %}}
+{{< /tab >}}
+{{< tab "Agent v5" >}}
 
 It is recommended to use an actual proxy (a web proxy or HAProxy) to forward your traffic to Datadog, however if those options aren't available to you, it is possible to configure an instance of **Agent v5** to serve as a proxy.
 
@@ -1149,7 +1149,7 @@ It is recommended to use an actual proxy (a web proxy or HAProxy) to forward you
 
 
 [1]: https://app.datadoghq.com/infrastructure#overview
-{{% /tab %}}
+{{< /tab >}}
 {{< /tabs >}}
 
 ## Further Reading


### PR DESCRIPTION
The proxy doc is hard to use without tabs, but there are currently issues with the tabbing on this page. We think the issue is related to the `dd_site` parameter. When we use the old `{{%` style tabs, the `dd_site` parameter breaks and appears as raw HTML. When we use the newer style `{{<` tabs, the tabs break completely. 

See [WEB-2802](https://datadoghq.atlassian.net/browse/WEB-2802)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
