### PR TITLE
[DOCS-4231] Add note about HIPAA-enabled accounts

### DIFF
--- a/content/en/security_platform/notifications/variables.md
+++ b/content/en/security_platform/notifications/variables.md
@@ -76,6 +76,10 @@ The result is displayed in the ISO 8601 format: `yyyy-MM-dd HH:mm:ss±HH:mm`, fo
 
 ## Attribute variables
 
+<div class="alert alert-warning">
+HIPAA-enabled Datadog organizations have access to only <a href="#template-variables">template variables</a> for security notifications. Attribute variables are not supported.
+</div>
+
 Use attribute variables to customize signal notifications with specific information about the triggered signal. 
 
 To see a signal’s list of event attributes, click **JSON** at the bottom of the **Overview** tab in the signal’s side panel. Use the following syntax to add these event attributes in your rule notifications: `{{@attribute}}`. To access inner keys of the event attributes, use JSON dot notation, for example, `{{@attribute.inner_key}})`.


### PR DESCRIPTION
### What does this PR do?

Adds note about HIPAA-enabled accounts having access to only template variables.

### Motivation

DOCS-4231

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
