### PR TITLE
WEB-2855 - curl generate api example content encoding

### DIFF
--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -159,15 +159,15 @@
   {{- range split $exampleDefinition.description "\n" }}
 # {{ . }}
   {{- end }}
-{{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body) }}
+{{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
                   {{- end -}}
               {{- else -}}
-{{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body) }}
+{{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
               {{- end -}}
           {{- end -}}
       {{- end -}}
   {{- else -}}
-{{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body) }}
+{{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
   {{- end -}}
   </code>
   {{/* Do not change indent of html above as it will change the indentation of the curl code block */}}
@@ -215,15 +215,15 @@
 {{- range split $exampleDefinition.description "\n" }}
 # {{ . }}
 {{- end }}
-{{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint) }}
+{{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
                 {{- end -}}
             {{- else -}}
-{{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint) }}
+{{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
             {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- else -}}
-{{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint) }}
+{{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
 {{- end -}}
 </code>
 {{/* Do not change indent of html above as it will change the indentation of the curl code block */}}

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -155,11 +155,7 @@
                             {{- $exampleValue = $exampleValue | jsonify (dict "indent" "  ") -}}
                         {{- end -}}
                       {{- end -}}
-## {{ default $exampleId $exampleDefinition.summary }}
-  {{- range split $exampleDefinition.description "\n" }}
-# {{ . }}
-  {{- end }}
-{{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
+{{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleId" $exampleId "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
                   {{- end -}}
               {{- else -}}
 {{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
@@ -211,11 +207,7 @@
                           {{- $exampleValue = $exampleValue | jsonify (dict "indent" "  ") -}}
                       {{- end -}}
                     {{- end -}}
-## {{ default $exampleId $exampleDefinition.summary }}
-{{- range split $exampleDefinition.description "\n" }}
-# {{ . }}
-{{- end }}
-{{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
+{{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleId" $exampleId "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
                 {{- end -}}
             {{- else -}}
 {{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}

--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -98,13 +98,21 @@
 <span class="o">-H</span> <span class="s1">"{{ $securitySchemes.appKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.appKeyAuth "x-env-name" -}} }</span>"</span>
 {{- end -}}
 
-{{- /* Render binary data (usually compressed) @<(echo "Uncompressed data" | gzip) */ -}}
+{{- /* Render binary data (usually compressed) */ -}}
 {{- if gt (len $contentEncoding) 0 -}}
+{{- if eq $contentEncoding "gzip" -}}
 &nbsp;\
-<span class="o">--data-binary</span> <span class="n">@<</span><span class="o">({{ $contentEncoding }} <<</span> <span class="n">EOF</span>
+<span class="o">--data-binary</span> <span class="n">@<</span><span class="o">(gzip <<</span> <span class="n">EOF</span>
 <span class="s1">{{ $body | default .exampleValue | default (.dollarScratch.Get "jsonRequestBody") }}</span>
 <span class="n">EOF</span>
 <span class="n">)</span>
+{{- else if eq $contentEncoding "deflate" -}}
+&nbsp;\
+<span class="o">--data-binary</span> <span class="n">@<</span><span class="o">(echo $(cat <<</span> <span class="n">EOF</span>
+<span class="s1">{{ $body | default .exampleValue | default (.dollarScratch.Get "jsonRequestBody") }}</span>
+<span class="n">EOF</span>
+<span class="n">) | gzip --no-name | tail --bytes=+11 | head --bytes=-8)</span>
+{{- end -}}
 {{ else if (or ($body) ($endpoint.action.requestBody)) }}
 {{- /* Render requestBody example JSON "-d @- << EOF ... EOF" */ -}}
 &nbsp;\

--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -157,5 +157,5 @@
 {{- end -}}
 <br/>
 {{- else -}}
-<span class="c1">See one of the other client libraries for examples of deflate compression.</span><br/><br/>
+<span class="c1">See one of the other client libraries for an example of sending deflate-compressed logs.</span><br/><br/>
 {{- end -}}

--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -26,14 +26,14 @@
   {{- end -}}
 {{- end -}}
 
-{{- if ne $contentEncoding "deflate" -}}
-
 {{- with $exampleDefinition -}}
 ## {{ default $exampleId .summary }}
 {{- range split .description "\n" }}
 # {{ . }}
 {{- end }}
+<br/>
 {{- end -}}
+{{- if ne $contentEncoding "deflate" -}}
 
 {{- with $parameters.pathParams -}}
     <span class="c1"># Path parameters</span><br/>
@@ -157,5 +157,5 @@
 {{- end -}}
 <br/>
 {{- else -}}
-See one of the other client libraries for examples of deflate compression.<br/>
+See one of the other client libraries for examples of deflate compression.<br/><br/>
 {{- end -}}

--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -36,7 +36,37 @@
     {{- end -}}
 {{- end -}}
 
-<span class="c1"># Curl command</span>
+{{/* Determine contentencoding */}}
+{{- with $parameters.headerParams -}}
+  {{- range . -}}
+    {{- if eq .name "Content-Encoding" -}}
+      {{- $def := "" -}}
+      {{- range $enumVal := .schema.enum -}}
+        {{- if in $title $enumVal -}}{{- $def = $enumVal -}}{{- end -}}
+      {{- end -}}
+      {{- if gt (len $def) 0 -}}
+        {{- $contentEncoding = $def -}}
+      {{- else if (or (and (isset .schema "example") (.required | default false)) (in $title "compression") ) -}}
+        {{- $contentEncoding = (.example | default .schema.example) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+<span class="c1"># Curl command</span><br/>
+{{- if gt (len $contentEncoding) 0 -}}
+{{- if eq $contentEncoding "gzip" -}}
+<span class="o">echo $(cat <<</span> <span class="n">EOF</span>
+<span class="s1">{{ $body | default .exampleValue | default (.dollarScratch.Get "jsonRequestBody") }}</span>
+<span class="n">EOF</span>
+<span class="n">) | gzip | </span>
+{{- else if eq $contentEncoding "deflate" -}}
+<span class="o">echo $(cat <<</span> <span class="n">EOF</span>
+<span class="s1">{{ $body | default .exampleValue | default (.dollarScratch.Get "jsonRequestBody") }}</span>
+<span class="n">EOF</span>
+<span class="n">) | gzip --no-name | tail --bytes=+11 | head --bytes=-8 | </span>
+{{- end -}}
+{{- end -}}
 <span class="n">curl</span> <span class="o">-X</span> <span class="s1">{{ $endpoint.actionType | upper }}</span> {{ range $region, $url := $endpoint.regions }}{{ if ne $region "local" }}<span class="kn d-none" data-region="{{ $region }}">"{{ $url }}</span>{{ else }}<span class="kn">"{{ $url }}</span>{{ end }}{{ end }}<span class="kn">{{ replace $endpoint.pathKey "{" "${" }}</span>
 {{- range $qi, $q := where $parameters.queryStrings ".required" true -}}
       <span class="kn">{{ cond (gt $qi 0) "&" "?" }}</span><span class="kn">{{ $q.name }}</span><span class="kn">=</span><span class="kn">${ {{- $q.name -}} }</span>
@@ -66,15 +96,6 @@
 {{- with $parameters.headerParams -}}
 {{- range . -}}
 {{- if eq .name "Content-Encoding" -}}
-  {{- $def := "" -}}
-  {{- range $enumVal := .schema.enum -}}
-    {{- if in $title $enumVal -}}{{- $def = $enumVal -}}{{- end -}}
-  {{- end -}}
-  {{- if gt (len $def) 0 -}}
-    {{- $contentEncoding = $def -}}
-  {{- else if (or (and (isset .schema "example") (.required | default false)) (in $title "compression") ) -}}
-    {{- $contentEncoding = (.example | default .schema.example) -}}
-  {{- end -}}
   {{- if $contentEncoding -}}
 &nbsp;\
 <span class="o">-H</span> <span class="s1">"{{ .name }}: {{ $contentEncoding }}"</span>
@@ -111,16 +132,10 @@
 {{- if gt (len $contentEncoding) 0 -}}
 {{- if eq $contentEncoding "gzip" -}}
 &nbsp;\
-<span class="o">--data-binary</span> <span class="n">@<</span><span class="o">(gzip <<</span> <span class="n">EOF</span>
-<span class="s1">{{ $body | default .exampleValue | default (.dollarScratch.Get "jsonRequestBody") }}</span>
-<span class="n">EOF</span>
-<span class="n">)</span>
+<span class="o">--data-binary</span> <span class="n">@-</span>
 {{- else if eq $contentEncoding "deflate" -}}
 &nbsp;\
-<span class="o">--data-binary</span> <span class="n">@<</span><span class="o">(echo $(cat <<</span> <span class="n">EOF</span>
-<span class="s1">{{ $body | default .exampleValue | default (.dollarScratch.Get "jsonRequestBody") }}</span>
-<span class="n">EOF</span>
-<span class="n">) | gzip --no-name | tail --bytes=+11 | head --bytes=-8)</span>
+<span class="o">--data-binary</span> <span class="n">@-</span>
 {{- end -}}
 {{ else if (or ($body) ($endpoint.action.requestBody)) }}
 {{- /* Render requestBody example JSON "-d @- << EOF ... EOF" */ -}}

--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -5,6 +5,7 @@
 {{- $count := 0 -}}
 {{- $body := .body -}}
 {{- $title := .title -}}
+{{- $contentEncoding := "" -}}
 
 {{- with $parameters.pathParams -}}
     <span class="c1"># Path parameters</span><br/>
@@ -69,6 +70,7 @@
 {{- if in $title $enumVal -}}{{- $def = $enumVal -}}{{- end -}}
 {{- end -}}
 {{- if or (isset .schema "example") (gt (len $def) 0) -}}
+{{- $contentEncoding = (.example | default (.schema.example | default $def)) -}}
 &nbsp;\
 <span class="o">-H</span> <span class="s1">"{{ .name }}: {{ .example | default (.schema.example | default $def ) }}"</span>
 {{- end -}}
@@ -96,8 +98,15 @@
 <span class="o">-H</span> <span class="s1">"{{ $securitySchemes.appKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.appKeyAuth "x-env-name" -}} }</span>"</span>
 {{- end -}}
 
+{{- /* Render binary data (usually compressed) @<(echo "Uncompressed data" | gzip) */ -}}
+{{- if gt (len $contentEncoding) 0 -}}
+&nbsp;\
+<span class="o">--data-binary</span> <span class="n">@<</span><span class="o">({{ $contentEncoding }} <<</span> <span class="n">EOF</span>
+<span class="s1">{{ $body | default .exampleValue | default (.dollarScratch.Get "jsonRequestBody") }}</span>
+<span class="n">EOF</span>
+<span class="n">)</span>
+{{ else if (or ($body) ($endpoint.action.requestBody)) }}
 {{- /* Render requestBody example JSON "-d @- << EOF ... EOF" */ -}}
-{{- if (or ($body) ($endpoint.action.requestBody)) -}}
 &nbsp;\
 <span class="o">-d</span> <span class="n">@-</span> <span class="o"><<</span> <span class="n">EOF</span>
 <span class="s1">{{ .exampleValue | default $body | default (.dollarScratch.Get "jsonRequestBody") }}</span>

--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -65,14 +65,23 @@
 <span class="o">-H</span> <span class="s1">"Content-Type: {{ default "application/json" .contentType }}"</span>
 {{- with $parameters.headerParams -}}
 {{- range . -}}
-{{- $def := "" -}}
-{{- range $enumVal := .schema.enum -}}
-{{- if in $title $enumVal -}}{{- $def = $enumVal -}}{{- end -}}
-{{- end -}}
-{{- if or (isset .schema "example") (gt (len $def) 0) -}}
-{{- $contentEncoding = (.example | default (.schema.example | default $def)) -}}
+{{- if eq .name "Content-Encoding" -}}
+  {{- $def := "" -}}
+  {{- range $enumVal := .schema.enum -}}
+    {{- if in $title $enumVal -}}{{- $def = $enumVal -}}{{- end -}}
+  {{- end -}}
+  {{- if gt (len $def) 0 -}}
+    {{- $contentEncoding = $def -}}
+  {{- else if (or (and (isset .schema "example") (.required | default false)) (in $title "compression") ) -}}
+    {{- $contentEncoding = (.example | default .schema.example) -}}
+  {{- end -}}
+  {{- if $contentEncoding -}}
 &nbsp;\
-<span class="o">-H</span> <span class="s1">"{{ .name }}: {{ .example | default (.schema.example | default $def ) }}"</span>
+<span class="o">-H</span> <span class="s1">"{{ .name }}: {{ $contentEncoding }}"</span>
+  {{- end -}}
+{{- else -}}
+&nbsp;\
+<span class="o">-H</span> <span class="s1">"{{ .name }}: {{ .example | default .schema.example }}"</span>
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -6,6 +6,34 @@
 {{- $body := .body -}}
 {{- $title := .title -}}
 {{- $contentEncoding := "" -}}
+{{- $exampleDefinition := .exampleDefinition -}}
+{{- $exampleId := .exampleId -}}
+
+{{/* Determine contentencoding */}}
+{{- with $parameters.headerParams -}}
+  {{- range . -}}
+    {{- if eq .name "Content-Encoding" -}}
+      {{- $def := "" -}}
+      {{- range $enumVal := .schema.enum -}}
+        {{- if in $title $enumVal -}}{{- $def = $enumVal -}}{{- end -}}
+      {{- end -}}
+      {{- if gt (len $def) 0 -}}
+        {{- $contentEncoding = $def -}}
+      {{- else if (or (and (isset .schema "example") (.required | default false)) (in $title "compression") ) -}}
+        {{- $contentEncoding = (.example | default .schema.example) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if ne $contentEncoding "deflate" -}}
+
+{{- with $exampleDefinition -}}
+## {{ default $exampleId .summary }}
+{{- range split .description "\n" }}
+# {{ . }}
+{{- end }}
+{{- end -}}
 
 {{- with $parameters.pathParams -}}
     <span class="c1"># Path parameters</span><br/>
@@ -34,23 +62,6 @@
             <span class="kn">export</span> <span class="n">{{ $name }}</span><span class="o">=</span><span class="s1">"{{ $example }}"</span><br/>
         {{- end -}}
     {{- end -}}
-{{- end -}}
-
-{{/* Determine contentencoding */}}
-{{- with $parameters.headerParams -}}
-  {{- range . -}}
-    {{- if eq .name "Content-Encoding" -}}
-      {{- $def := "" -}}
-      {{- range $enumVal := .schema.enum -}}
-        {{- if in $title $enumVal -}}{{- $def = $enumVal -}}{{- end -}}
-      {{- end -}}
-      {{- if gt (len $def) 0 -}}
-        {{- $contentEncoding = $def -}}
-      {{- else if (or (and (isset .schema "example") (.required | default false)) (in $title "compression") ) -}}
-        {{- $contentEncoding = (.example | default .schema.example) -}}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
 {{- end -}}
 
 <span class="c1"># Curl command</span><br/>
@@ -145,3 +156,6 @@
 <span class="n">EOF</span>
 {{- end -}}
 <br/>
+{{- else -}}
+See one of the other client libraries for examples of deflate compression.<br/>
+{{- end -}}

--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -4,6 +4,7 @@
 {{- $parameters := partial "api/arguments-data.html" (dict "endpoint" $endpoint) -}}
 {{- $count := 0 -}}
 {{- $body := .body -}}
+{{- $title := .title -}}
 
 {{- with $parameters.pathParams -}}
     <span class="c1"># Path parameters</span><br/>
@@ -61,6 +62,18 @@
 {{- else -}}
 &nbsp;\
 <span class="o">-H</span> <span class="s1">"Content-Type: {{ default "application/json" .contentType }}"</span>
+{{- with $parameters.headerParams -}}
+{{- range . -}}
+{{- $def := "" -}}
+{{- range $enumVal := .schema.enum -}}
+{{- if in $title $enumVal -}}{{- $def = $enumVal -}}{{- end -}}
+{{- end -}}
+{{- if or (isset .schema "example") (gt (len $def) 0) -}}
+&nbsp;\
+<span class="o">-H</span> <span class="s1">"{{ .name }}: {{ .example | default (.schema.example | default $def ) }}"</span>
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -157,5 +157,5 @@
 {{- end -}}
 <br/>
 {{- else -}}
-See one of the other client libraries for examples of deflate compression.<br/><br/>
+<span class="c1">See one of the other client libraries for examples of deflate compression.</span><br/><br/>
 {{- end -}}


### PR DESCRIPTION
### What does this PR do?

Updates the generated curl examples to use the header params provided too.

We will try and use the schema.example for the header value. Note that because we try and sync the curl generated examples accordion tab with a python,ruby etc. the title might not match the intention of the example exactly. In this case i've checked for the compression content-encoding in the accordion title to determine what compression to show to help avoid this.

### Motivation

slack / https://datadoghq.atlassian.net/browse/DOCS-3960

### Preview

https://docs-staging.datadoghq.com/david.jones/content-encoding/api/latest/logs/?code-lang=curl#send-logs
https://docs-staging.datadoghq.com/david.jones/content-encoding/api/latest/metrics/?code-lang=curl#submit-metrics

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
