### PR TITLE
[agent] Describe Arm v8 architecture OS support

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -133,7 +133,7 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 {{< tabs >}}
 {{% tab "Agent v6 & v7" %}}
 
-| Platform                                 | Supported versions                                        |
+| Platform (64-bit x86)                    | Supported versions                                        |
 |------------------------------------------|-----------------------------------------------------------|
 | [Amazon Linux][1]                        | Amazon Linux 2                                            |
 | [Debian][2] with systemd                 | Debian 7 (wheezy)+ in Agent < 6.36.0/7.36.0, Debian 8 (jessie)+ in Agent 6.36.0+/7.36.0+ |
@@ -151,8 +151,19 @@ When the Agent is running, use the `datadog-agent launch-gui` command to open th
 | [Windows][10]                            | Windows 7+                                                |
 | [Windows Azure Stack HCI OS][10]         | All Versions                                              |
 
+| Platform (64-bit Arm v8)                 | Supported versions                                        |
+|------------------------------------------|-----------------------------------------------------------|
+| [Amazon Linux][1]                        | Amazon Linux 2                                            |
+| [Debian][2] with systemd                 | Debian 9 (stretch)+                                       |
+| [Ubuntu][3]                              | Ubuntu 16.04+                                             |
+| [RedHat/CentOS/AlmaLinux/Rocky][4]       | RedHat/CentOS 8+, AlmaLinux/Rocky 8+ in Agent 6.33.0+/7.33.0+ |
+| [Docker][5]                              | Version 1.12+                                             |
+| [Kubernetes][6]                          | Version 1.3+                                              |
+| [Fedora][8]                              | Fedora 27+                                                |
+| [macOS][9]                               | macOS 11.0+                                               |
+
+
 **Notes**: 
-- 64-bit x86 packages are available for all platforms on the list. Arm v8 packages are available for all platforms except Windows and MacOS.
 - [Source][11] install may work on operating systems not listed here and is supported on a best effort basis.
 - Datadog Agent v6+ supports Windows Server 2008 R2 with the most recent Windows updates installed. There is also a [known issue with clock drift and Go][12] that affects Windows Server 2008 R2.
 

--- a/content/en/agent/basic_agent_usage/centos.md
+++ b/content/en/agent/basic_agent_usage/centos.md
@@ -22,7 +22,7 @@ This page outlines the basic features of the Datadog Agent for CentOS. To instal
 
 Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
 
-**Note**: CentOS 6 and above are supported.
+**Note**: CentOS 6 and above are supported on the 64-bit x86 architecture. CentOS 8 and above are supported on the 64-bit Arm v8 architecture.
 
 ## Commands
 

--- a/content/en/agent/basic_agent_usage/deb.md
+++ b/content/en/agent/basic_agent_usage/deb.md
@@ -24,7 +24,9 @@ This page outlines the basic features of the Datadog Agent for Debian. If you ha
 
 Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
 
-**Note**: Debian 7 (wheezy) and above is supported in Agent < 6.36.0/7.36.0. Debian 8 (jessie) and above is supported in Agent >= 6.36.0/7.36.0. SysVinit is supported in Agent v6.6.0+.
+**Notes**:
+- On the 64-bit x86 architecture, Debian 7 (wheezy) and above are supported in Agent < 6.36.0/7.36.0. Debian 8 (jessie) and above are supported in Agent >= 6.36.0/7.36.0. SysVinit is supported in Agent v6.6.0+.
+- On the 64-bit Arm v8 architecture, Debian 9 (stretch) and above are supported.
 
 ## Commands
 

--- a/content/en/agent/basic_agent_usage/fedora.md
+++ b/content/en/agent/basic_agent_usage/fedora.md
@@ -22,7 +22,7 @@ This page outlines the basic features of the Datadog Agent for Fedora. If you ha
 
 Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
 
-**Note**: Fedora 26 and above are supported.
+**Note**: Fedora 26 and above are supported on the 64-bit x86 architecture. Fedora 27 and above are supported on the 64-bit Arm v8 architecture.
 
 ## Commands
 

--- a/content/en/agent/basic_agent_usage/redhat.md
+++ b/content/en/agent/basic_agent_usage/redhat.md
@@ -22,7 +22,9 @@ This page outlines the basic features of the Datadog Agent for Red Hat. If you h
 
 Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
 
-**Note**: RedHat/CentOS 6 and above are supported. Since Agent 6.33.0/7.33.0, AlmaLinux/Rocky 8 and above are supported. 
+**Notes**:
+- On the 64-bit x86 architecture, RedHat/CentOS 6 and above are supported. Since Agent 6.33.0/7.33.0, AlmaLinux/Rocky 8 and above are supported.
+- On the 64-bit Arm v8 architecture, RedHat/CentOS 8 and above are supported. Since Agent 6.33.0/7.33.0, AlmaLinux/Rocky 8 and above are supported.
 
 ## Commands
 

--- a/content/en/agent/basic_agent_usage/ubuntu.md
+++ b/content/en/agent/basic_agent_usage/ubuntu.md
@@ -22,7 +22,7 @@ This page outlines the basic features of the Datadog Agent for Ubuntu. If you ha
 
 Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
 
-**Note**: Ubuntu 14.04 and above are supported.
+**Note**: Ubuntu 14.04 and above are supported on the 64-bit x86 architecture. Ubuntu 16.04 and above are supported on the 64-bit Arm v8 architecture.
 
 ## Commands
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates the Agent install pages to specify the OS requirements for Arm v8 hosts.

### Motivation
<!-- What inspired you to submit this pull request?-->

Our OS support is different on Arm v8.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Should the x86 / Arm v8 split in the `Basic Agent Usage` page be displayed in a different way (eg. two different tabs)?
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
