### PR TITLE
Update NetFlow Monitoring beta docs

### DIFF
--- a/content/en/network_monitoring/devices/netflow.md
+++ b/content/en/network_monitoring/devices/netflow.md
@@ -8,7 +8,7 @@ further_reading:
   text: "Using Profiles with Network Device Monitoring"
 ---
 
-<div class="alert alert-warning">NetFlow Monitoring for Datadog Network Device Monitoring is in private beta.</div>
+<div class="alert alert-warning">NetFlow Monitoring for Datadog Network Device Monitoring is in public beta.</div>
 
 ## Overview
 
@@ -16,9 +16,9 @@ Use NetFlow Monitoring in Datadog to visualize and monitor your flow records fro
 
 ## Installation
 
-To use NetFlow Monitoring with Network Device Monitoring, ensure you are using the [Agent][1] version 7.40 or newer.
+To use NetFlow Monitoring with Network Device Monitoring, ensure you are using the [Agent][1] version 7.39 or newer.
 
-**Note:** Configuring [metric collection from Network Device Monitoring][2] is not a requirement for sending NetFlow data, although it is recommended.
+**Note:** Configuring [metric collection from Network Device Monitoring][2] is not a requirement for sending NetFlow data, although it is strongly recommended.
 
 ## Configuration
 
@@ -31,7 +31,7 @@ network_devices:
   netflow:
     enabled: true
     listeners:
-      - flow_type: netflow9   # choices: netflow5, netflow9, ipfix, sflow
+      - flow_type: netflow9   # choices: netflow5, netflow9, ipfix, sflow5
         port: 2055            # devices must send traffic to this port
       - flow_type: netflow5
         port: 2056


### PR DESCRIPTION
Small changes to netflow docs to list as private beta, and make a few tweaks to the Agent configuration recommendations

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates the docs to list NetFlow monitoring as a public beta, instead of private, and change the Agent version required to 7.39, instead of 7.40.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
