### PR TITLE
Update Security filters PATCH API

### DIFF
--- a/content/en/security_platform/cloud_siem/guide/how-to-setup-security-filters-using-cloud-siem-api.md
+++ b/content/en/security_platform/cloud_siem/guide/how-to-setup-security-filters-using-cloud-siem-api.md
@@ -67,7 +67,7 @@ curl -L -X GET 'https://api.{{< region-param key="dd_site" code="true" >}}/api/v
 
 In this example, the filter's `id` is `"l6l-rmx-mqx"`. You can then modify it to add an exclusion, for example exclude all the logs tagged with `env:staging`.
 
-**Note**: `version` indicates the current version of the filter you want to update.
+**Note**: `version` indicates the current version of the filter you want to update. This field is optional. If it is not provided, the latest version will be updated.
 
 **API call:**
 


### PR DESCRIPTION
Make the `version` field optional

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
It informs users that the `version` field is now optional. It also describes the behaviour of the API when this field is not provided.

### Motivation
Backend was modified to allow users to not provide this field. It makes updates easier since users do not have to track the current version in use.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
