### PR TITLE
Tracing http client ip documentation update

### DIFF
--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -227,6 +227,10 @@ Support for query strings is not available for Flask.
 
 {{< /programming-lang-wrapper >}}
 
+## Configuring a client IP header
+
+ASM automatically attempts to resolve `http.client_ip` from a number of well known headers, such as `X-Forwarded-For`. If you use a custom header for this field, or want to bypass the resolution algorithm, set the `DD_TRACE_CLIENT_IP_HEADER` environment variable and the library looks only in the specified header for the client IP.
+
 ## Add user information to traces
 
 Instrument your services with the standardized user tags to track authenticated user activity, whether you're tracking application performance or application security.

--- a/content/en/security_platform/application_security/setup_and_configure.md
+++ b/content/en/security_platform/application_security/setup_and_configure.md
@@ -229,7 +229,7 @@ Support for query strings is not available for Flask.
 
 ## Configuring a client IP header
 
-ASM automatically attempts to resolve `http.client_ip` from a number of well known headers, such as `X-Forwarded-For`. If you use a custom header for this field, or want to bypass the resolution algorithm, set the `DD_TRACE_CLIENT_IP_HEADER` environment variable and the library looks only in the specified header for the client IP.
+ASM automatically attempts to resolve `http.client_ip` from several well-known headers, such as `X-Forwarded-For`. If you use a custom header for this field, or want to bypass the resolution algorithm, set the `DD_TRACE_CLIENT_IP_HEADER` environment variable and the library only checks the specified header for the client IP.
 
 ## Add user information to traces
 

--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -7,7 +7,7 @@ aliases:
     - /tracing/security
     - /tracing/guide/security
     - /tracing/guide/agent_obfuscation
-    - /tracing/guide/agent-obfuscation
+    - /tracing/guide/agent-obfuscationDD
     - /tracing/custom_instrumentation/agent_customization
     - /tracing/faq/if-i-instrument-a-database-with-datadog-apm-will-there-be-sensitive-database-data-sent-to-datadog
     - /tracing/setup_overview/configure_data_security/
@@ -177,12 +177,6 @@ apm_config:
 ## HTTP data collected
 
 Datadog is standardizing the tags collected for web spans across the supported tracing libraries. Check your library's release notes to see if it has implemented collecting these tags. For fully standardized libraries, see [Span Tags Semantics][3].
-
-### Configuring a client IP header
-
-Datadog automatically attempts to resolve `http.client_ip` from a number of well known headers, such as `X-Forwarded-For`. If you use a custom header for this field, or want to bypass the resolution algorithm, set the `DD_TRACE_CLIENT_IP_HEADER` environment variable and the library looks only in the specified header for the client IP.
-
-If you do not wish to collect the client IP value, set the `DD_TRACE_CLIENT_IP_HEADER_DISABLED` environment variable to `true`. It is `false` by default.
 
 ### Redacting the query in the URL
 

--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -7,7 +7,7 @@ aliases:
     - /tracing/security
     - /tracing/guide/security
     - /tracing/guide/agent_obfuscation
-    - /tracing/guide/agent-obfuscationDD
+    - /tracing/guide/agent-obfuscation
     - /tracing/custom_instrumentation/agent_customization
     - /tracing/faq/if-i-instrument-a-database-with-datadog-apm-will-there-be-sensitive-database-data-sent-to-datadog
     - /tracing/setup_overview/configure_data_security/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR moves the existing documentation of this feature into the ASM setup and configure page.

### Motivation
Following up on a SEV-1 incident, it has been decided to report the APM span tag `http.client_ip` only with ASM.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes

How do you deal with existing translations?

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
