### PR TITLE
Remove client_ip_header_disabled from php documentation

### DIFF
--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -275,11 +275,6 @@ A comma-separated list of query parameters to be collected as part of the URL. S
 **Default**: `*`<br>
 A comma-separated list of query parameters to be collected as part of the resource URI. Set to empty to prevent collecting any parameters, or `*` to collect all parameters. Added in version `0.74.0`.
 
-`DD_TRACE_CLIENT_IP_HEADER_DISABLED`
-: **INI**: `datadog.trace.client_ip_header_disabled`<br>
-**Default**: `0`<br>
-Disable client IP collection from relevant IP headers. Added in version `0.76.0`.
-
 `DD_TRACE_CLIENT_IP_HEADER`
 : **INI**: `datadog.trace.client_ip_header`<br>
 **Default**: `null`<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Client IP is considered PII and therefore there has to be a valid reason for it to be collected. The new strategy for collecting it
is: Tracer wont collect client IP and instead ASM will do always.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
