### PR TITLE
[CI Visibility] Junit upload instructions to upload when tests fail

### DIFF
--- a/content/en/continuous_integration/tests/junit_upload.md
+++ b/content/en/continuous_integration/tests/junit_upload.md
@@ -168,7 +168,7 @@ if [ $tests_exit_code -ne 0 ]; then exit $tests_exit_code; fi
 
 {{< /tabs >}}
 
-**Note:** Reports larger than 250 MiB may not be processed completely resulting in missing tests or logs. For the best experience ensure that the reports are under 250 MiB.
+**Note:** Reports larger than 250 MiB may not be processed completely, resulting in missing tests or logs. For the best experience ensure that the reports are under 250 MiB.
 
 ## Configuration settings
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Expands instruction for CI Visibility with junit upload with guidelines to run the upload command even when the tests fail.
Guidelines provided for Github Actions, Gitlab, Jenkins and a generic Bash script.

### Motivation
<!-- What inspired you to submit this pull request?-->

We often get support tickets with "I'm missing some failed tests" where the answer is the upload command is not running.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
