### PR TITLE
Add default value to source_type_name parameter

### DIFF
--- a/content/en/events/guides/dogstatsd.md
+++ b/content/en/events/guides/dogstatsd.md
@@ -32,7 +32,7 @@ event(<title>, <message>, <alert_type>, <aggregation_key>, <source_type_name>, <
 | `<message>`          | String          | Yes      | The text body of the event                                                                 |
 | `<alert_type>`       | String          | No       | `error`, `warning`, `success`, or `info` (defaults to `info`)                              |
 | `<aggregation_key>`  | String          | No       | A key to use for aggregating events                                                        |
-| `<source_type_name>` | String          | No       | The source type name                                                                       |
+| `<source_type_name>` | String          | No       | The source type name (defaults to `my_apps`)                                               |
 | `<date_happened>`    | Integer         | No       | The epoch timestamp for the event (defaults to the current time from the DogStatsD server) |
 | `<priority>`         | String          | No       | Specifies the priority of the event (`normal` or `low`)                                    |
 | `<tags>`             | List of strings | No       | A list of tags associated with this event                                                  |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds the default value to the `source_type_name` parameter

### Motivation
DOCS-3734

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
