### PR TITLE
Adds depreciation of hpa tag to horizontalpodautoscaler when migrating

### DIFF
--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -103,6 +103,7 @@ Here is the mapping between deprecated tags and the official tags that have repl
 | cronjob               | kube_cronjob                |
 | daemonset             | kube_daemon_set             |
 | deployment            | kube_deployment             |
+| hpa                   | horizontalpodautoscaler     |
 | image                 | image_name                  |
 | job                   | kube_job                    |
 | job_name              | kube_job                    |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* Adds an entry to the tag migration table to showcase the behaviour of the Core check vs its legacy version : the `hpa` tag (legacy) is now `horizontalpodautoscaler` (core)

### Motivation
<!-- What inspired you to submit this pull request?-->
* Customer reaching out about this undocumented change
* Can be replicated using an old chart version like `2.36.1` (legacy) and newer chart version like `3.1.0` (core) and see the transition : 
<img width="2381" alt="Image 2022-10-26 at 11 29 05 AM" src="https://user-images.githubusercontent.com/97530782/197991161-d37c039d-ded7-471b-9f76-b8a6811561b5.png">


<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
