### PR TITLE
[Source Code Integration] Mention non-support of tag extraction for AWS fargate

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -51,7 +51,8 @@ To link data to a specific commit, tag your telemetry with `git.commit.sha` and 
 {{% tab "Docker Runtime" %}}
 
 <div class="alert alert-warning">
-This approach requires Docker, or containerd >= 1.5.6. For other container setups, see the "Other" section.
+This approach requires Docker, or containerd >= 1.5.6. It doesn't support containers running on AWS Fargate.
+For other container setups, see the "Other" section.
 </div>
 
 If you are running your app in containers, Datadog can extract source code information directly from your images' Docker labels. During build time, follow the [Open Containers standard][1] to add the git commit SHA and repository URL as Docker labels:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

The method described in the first tab to automatically extract tags from container labels is not supported for containers running on AWS Fargate. This updates the message box to mention it.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
