### PR TITLE
[aws-ints] modifying external_id docs

### DIFF
--- a/content/en/integrations/guide/aws-manual-setup.md
+++ b/content/en/integrations/guide/aws-manual-setup.md
@@ -14,7 +14,7 @@ further_reading:
   text: "Send AWS service logs with the Datadog Kinesis Firehose destination"
 - link: "https://docs.datadoghq.com/integrations/guide/aws-integration-troubleshooting/"
   tag: "Guide"
-  text: "Troubleshooting the AWS integration" 
+  text: "Troubleshooting the AWS integration"
 - link: "https://docs.datadoghq.com/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose/"
   tag: "Guide"
   text: "AWS CloudWatch metric streams with Kinesis Data Firehose"
@@ -56,14 +56,14 @@ To set up the AWS integration manually, create an IAM policy and IAM role in you
 ### Generate an external ID
 
 1. In the [AWS integration configuration page][1], click **Add AWS Account**, and then select **Manually**.
-2. Select `Role Delegation` for the access type and copy the `AWS External ID`. For more information about the external ID, read the [IAM User Guide][2].  
-  **Note: Do not close the integration tile or the Datadog site**, as this causes the external ID value to reset.
+2. Select `Role Delegation` for the access type and copy the `AWS External ID`. For more information about the external ID, read the [IAM User Guide][2].
+  **Note:** The External ID below will be available and not regenerate for 48 hours unless explicitly changed by a user or another AWS account is added to Datadog during this period. You can come back to this page within that time period after the Datadog IAM role is created in AWS to complete the process of adding this account without the External ID changing.
 
 ### AWS IAM policy for Datadog
-Create an IAM policy for the Datadog role in your AWS account with the [necessary permissions](#aws-integration-iam-policy) to take advantage of every AWS integration offered by Datadog. As other components are added to an integration, these permissions may change. 
+Create an IAM policy for the Datadog role in your AWS account with the [necessary permissions](#aws-integration-iam-policy) to take advantage of every AWS integration offered by Datadog. As other components are added to an integration, these permissions may change.
 
 3. Create a new policy in the AWS [IAM Console][3].
-4. Select the **JSON** tab. Paste the [permission policies](#aws-integration-iam-policy) in the textbox. 
+4. Select the **JSON** tab. Paste the [permission policies](#aws-integration-iam-policy) in the textbox.
 5. Click **Next: Tags** and **Next: Review**.
 6. Name the policy `DatadogIntegrationPolicy` or one of your own choosing, and provide an apt description.
 7. Click **Create policy**.
@@ -74,20 +74,20 @@ Create an IAM role for Datadog to use the permissions defined in the IAM policy.
 8. Create a new role in the AWS [IAM Console][4].
 9. Select **AWS account** for the trusted entity type, and **Another AWS account**.
 10. Enter `464622532012` as the `Account ID`. This is Datadog's account ID, and grants Datadog access to your AWS data.
-11. Select **Require external ID** and enter the external ID copied in the [Generate an external ID](#generate-an-external-id) section. 
+11. Select **Require external ID** and enter the external ID copied in the [Generate an external ID](#generate-an-external-id) section.
 Ensure to leave `Require MFA` disabled. For more details, see the [How to use an external ID when granting access to your AWS resources to a third party][2] AWS documentation.
 12. Click **Next**.
-13. If you've already created the policy, search for it on this page and select it. Otherwise, click **Create Policy**, which opens in a new window, and follow the instructions from the previous section. 
+13. If you've already created the policy, search for it on this page and select it. Otherwise, click **Create Policy**, which opens in a new window, and follow the instructions from the previous section.
 14. Optionally, attach the <a href="https://console.aws.amazon.com/iam/home#policies/arn:aws:iam::aws:policy/SecurityAudit" target="_blank">AWS SecurityAudit Policy</a> to the role to use Datadog's [Cloud Security Posture Management product][5] (CSPM).
 15. Click **Next**.
-16. Give the role a name such as `DatadogIntegrationRole`, as well as an apt description. 
+16. Give the role a name such as `DatadogIntegrationRole`, as well as an apt description.
 17. Click **Create Role**.
 
 ### Complete the setup in Datadog
 
 18. Return to the AWS integration configuration page for manually adding an account in Datadog that you had open in another tab. Click the checkbox to confirm the Datadog IAM role was added to the AWS account.
 19. Enter the account ID **without dashes**, for example: `123456789012`. Your Account ID can be found in the ARN of the role created for Datadog.
-20. Enter the name of the role created in the previous section, and click **Save**.  
+20. Enter the name of the role created in the previous section, and click **Save**.
   **Note:** The role name you enter in the integration tile is case sensitive and must exactly match the role name in AWS.
 21. If there is a [Datadog is not authorized to perform sts:AssumeRole][6] error, follow the troubleshooting steps recommended in the UI, or read the [troubleshooting guide][6].
 22. Wait up to 10 minutes for data to start being collected, and then view the out-of-the-box <a href="https://app.datadoghq.com/screen/integration/7/aws-overview" target="_blank">AWS Overview Dashboard</a> to see metrics sent by your AWS services and infrastructure.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This pr changes our documentation on how to handle external_ids when generating a new AWS Account Integration. We want to indicate that the generated external_ids last for 48 hours, allowing users to send them to internal teams for account creation.

### Motivation
Customer confusion over the process of creating new accounts.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
