### PR TITLE
Corrects typo with haproxy connect timeout

### DIFF
--- a/content/en/agent/logs/proxy.md
+++ b/content/en/agent/logs/proxy.md
@@ -108,7 +108,7 @@ defaults
     option  redispatch
     timeout client 5s
     timeout server 5s
-    timeout connect 5
+    timeout connect 5s
 # This declares a view into HAProxy statistics, on port 3833
 # You do not need credentials to view this page and you can
 # turn it off once you are done with setup.


### PR DESCRIPTION
### What does this PR do?
The example haproxy config has a typo which sets the `connect` timeout to 5 (unitless, I suspect milliseconds). It should be set to 5s for consistency with the other timeouts.

### Motivation
Connections sent will fail with code `sC`.
Extracted from haproxy [docs](https://www.haproxy.com/documentation/hapee/1-8r1/onepage/#8.2.2):
```
s : the server-side timeout expired while waiting for the server to
            send or receive data.
C : the proxy was waiting for the CONNECTION to establish on the
            server. The server might at most have noticed a connection attempt.
```

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
