### PR TITLE
Adds a script to toggle the commit hook

### DIFF
--- a/local/bin/sh/nohooks.sh
+++ b/local/bin/sh/nohooks.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+mkdir -p ~/.nohooks
+hooks=`git config --get core.hooksPath`
+if [[ $hooks == *nohooks* ]]; then
+    git config --global core.hooksPath /usr/local/dd/global_hooks/
+    echo "Hooks enabled"
+    echo "Hooks directory set to $(git config --get core.hooksPath)"
+else
+    git config --global core.hooksPath ~/.nohooks
+    echo "Hooks disabled"
+    echo "Hooks directory set to $(git config --get core.hooksPath)"
+fi


### PR DESCRIPTION
Adds a small script that writers can use to toggle pre-commit hooks on and off. 

To test:
1. Check out this branch
2. Follow the instructions in [Docs4Docs](https://datadoghq.atlassian.net/wiki/spaces/docs4docs/pages/1896808601/Troubleshooting+Local+Doc+Build#Disable-pre-commit-hooks)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
