### PR TITLE
Change documentation for Continuous Testing

### DIFF
--- a/content/en/continuous_testing/cicd_integrations/configuration.md
+++ b/content/en/continuous_testing/cicd_integrations/configuration.md
@@ -123,6 +123,7 @@ For example:
         "locations": ["aws:us-west-1"],
         "retry": { "count": 2, "interval": 300 },
         "executionRule": "blocking",
+        "startUrlSubstitutionRegex": "s/(https://www.)(.*)/$1extra-$2/",
         "startUrl": "{{URL}}?static_hash={{STATIC_HASH}}",
         "variables": { "titleVariable": "new value" },
         "pollingTimeout": 180000
@@ -223,6 +224,10 @@ Execution rule of the test that defines the CLI behavior in case of a failing te
 : **Type**: string<br>
 New start URL to provide to the HTTP or browser test.
 
+`startUrlSubstitutionRegex`
+: **Type**: string<br>
+Regex to modify the start URL of the test (browser and HTTP tests only), whether it was given by the original test or by the configuration override startUrl. If the URL contains variables, this regex will be applied after the interpolation of the variables.
+
 `variables`
 : **Type**: object<br>
 Variables to replace in the test. This object should contain the name of the variable to replace as keys and the new value of the variable as values.
@@ -250,6 +255,7 @@ The duration in milliseconds after which `datadog-ci` stops polling for test res
                 "locations": ["aws:us-west-1"],
                 "retry": { "count": 2, "interval": 300 },
                 "executionRule": "skipped",
+                "startUrlSubstitutionRegex": "s/(https://www.)(.*)/$1extra-$2/",
                 "startUrl": "{{URL}}?static_hash={{STATIC_HASH}}",
                 "variables": { "titleVariable": "new value" },
                 "pollingTimeout": 180000
@@ -268,63 +274,11 @@ Use the drop-down menu next to **CI Execution** to define the execution rule for
 
 The execution rule associated with the test is the most restrictive one in the configuration file. The options range from most to least restrictive: `skipped`, `non_blocking`, and `blocking`. For example, if your test is configured as `skipped` in the UI but `blocking` in the configuration file, it is `skipped` when your test runs.
 
-#### Starting URL
+#### Customizing your Continuous Testing test start URL
 
-`URL`
-: Test's original starting URL <br>
-**Example**: `https://www.example.org:81/path/to/something?abc=123#target`
+You can override the starting URL for your tests through the `startURL` configuration option. For example, your test starting URL is `shopist.io`, but you want to test your staging environment at `staging.shopist.io`, you would pass the option as `starURL: "staging.shopist.io"`.
 
-`DOMAIN`
-: Test's domain name<br>
-**Example**: `example.org`
-
-`HASH`
-: Test's hash<br>
-**Example**: `#target`
-
-`HOST`
-: Test's host<br>
-**Example**: `www.example.org:81`
-
-`HOSTNAME`
-: Test's hostname<br>
-**Example**: `www.example.org`
-
-`ORIGIN`
-: Test's origin<br>
-**Example**: `https://www.example.org:81`
-
-`PARAMS`
-: Test's query parameters<br>
-**Example**: `?abc=123`
-
-`PATHNAME`
-: Test's URl path<br>
-**Example**: `/path/to/something`
-
-`PORT`
-: Test's host port<br>
-**Example**: `81`
-
-`PROTOCOL`
-: Test's protocol<br>
-**Example**: `https:`
-
-`SUBDOMAIN`
-: Test's sub domain<br>
-**Example**: `www`
-
-Whether you use Synthetic tests to control your CI/CD deployments in production or staging, you can run Synthetic tests against a generated staging URL instead of in production by setting local environment variables in your test's starting URL. 
-
-To trigger an existing Synthetics test on a staging endpoint instead of in production, set the `$SUBDOMAIN` environment variable to `staging-example` and the `$PORT` environment variable to a port used for staging. Your Synthetic tests run against the generated staging URL instead of running in production. 
-
-For example, you can write `https://app.datadoghq.com/synthetics/details/abc-123-zyx?live=1h#test-results` as:
-
-* `{{PROTOCOL}}//{{SUBDOMAIN}}.{{DOMAIN}}:{{PORT}}{{PATHNAME}}{{PARAMS}}{{HASH}}`
-* `{{PROTOCOL}}//{{HOST}}{{PATHNAME}}{{PARAMS}}{{HASH}}`
-* `{{URL}}`
-
-**Note:** If you have environment variables with names corresponding to one of the reserved variables above, your environment variables are ignored and replaced with the corresponding component parsed from your test's `startUrl`. 
+If you want to customize this start URL further (or only part of the URL), you can use the `startUrlSubstitutionRegex` configuration option. The format is `s/your_regex/your_substitution/modifiers` and follow Javascript regex syntax. For example, s/(https://www.)(.*)/$1extra-$2/ to transform https://www.example.com into https://www.extra-example.com
 
 ### Run tests
 


### PR DESCRIPTION
Remove reference to environment variables and add documentation for `startUrlSubstitutionRegex`

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
