### PR TITLE
[DOCS-4333][CI Visibility] Add doc for junit upload detailing XPath tags feature

### DIFF
--- a/content/en/continuous_integration/tests/junit_upload.md
+++ b/content/en/continuous_integration/tests/junit_upload.md
@@ -345,7 +345,7 @@ XPath syntax is used for familiarity but only a limited subset of expressions ar
 : The XML attribute from the parent `<testsuite attribute-name="value">` of the current `<testcase>`.
 
 `/testcase/..//property[@name='property-name']`
-: The `value` attribute from the `<property name="property-name" value="value">` inside the parent `<testsuite>` of current `<testcase>`.
+: The `value` attribute from the `<property name="property-name" value="value">` inside the parent `<testsuite>` of the current `<testcase>`.
 
 `/testcase//property[@name='property-name']`
 : The `value` attribute from the `<property name="property-name" value="value">` inside the current `<testcase>`.

--- a/content/en/continuous_integration/tests/junit_upload.md
+++ b/content/en/continuous_integration/tests/junit_upload.md
@@ -335,7 +335,7 @@ In addition to the `--tags` CLI parameter and the `DD_TAGS` environment variable
 
 The parameter provided must have the format `key=expression`, where `key` is the name of the custom tag to be added and `expression` is a valid [XPath][10] expression within the ones supported.
 
-XPath syntax is used for familiarity but only a limited subset of expressions are supported:
+While XPath syntax is used for familiarity, only the following expressions are supported:
 
 
 `/testcase/@attribute-name`

--- a/content/en/continuous_integration/tests/junit_upload.md
+++ b/content/en/continuous_integration/tests/junit_upload.md
@@ -196,7 +196,7 @@ This is the full list of options available when using the `datadog-ci junit uplo
 See [Providing metadata with XPath expressions][9] for more details on the supported expressions.<br/>
 **Default**: (none)<br/>
 **Example**: `test.suite=/testcase/@classname`<br/>
-**Note**: Tags specified using `--xpath-tag` and with --tags or `DD_TAGS` environment variable are merged. xpath-tag gets the highest precedence, as the value is usually different for each test.
+**Note**: Tags specified using `--xpath-tag` and with `--tags` or `DD_TAGS` environment variable are merged. xpath-tag gets the highest precedence, as the value is usually different for each test.
 
 `--logs` **(beta)**
 : Enable forwarding content from the XML reports as [Logs][6]. The content inside `<system-out>`, `<system-err>`, and `<failure>` is collected as logs. Logs from elements inside a `<testcase>` are automatically connected to the test.<br/>
@@ -355,7 +355,7 @@ Examples:
 {{< tabs >}}
 
 {{% tab "Test suite from @classname" %}}
-By default the `test.suite` tag of the tests is read from `<testsuite name="suite name">`. However some plugins might report a better value in `<testcase classname="TestSuite">`.
+By default, the `test.suite` tag of the tests is read from `<testsuite name="suite name">`. However, some plugins might report a better value in `<testcase classname="TestSuite">`.
 
 To change `test.suite` tags from `value 1`, `value 2` to `SomeTestSuiteClass`, `OtherTestSuiteClass`:
 
@@ -379,7 +379,7 @@ datadog-ci junit upload --service service_name \
 {{% /tab %}}
 
 {{% tab "Tag from attribute" %}}
-To add `custom_tag` to each test with values `value 1`, `value 2`.
+To add `custom_tag` to each test with values `value 1`, `value 2`:
 
 {{< code-block lang="xml" >}}
 <?xml version="1.0" encoding="UTF-8"?>
@@ -399,7 +399,7 @@ datadog-ci junit upload --service service_name \
 {{% /tab %}}
 
 {{% tab "Tag from testsuite property" %}}
-To add `custom_tag` to each test with values `value 1`, `value 2`.
+To add `custom_tag` to each test with values `value 1`, `value 2`:
 
 {{< code-block lang="xml" >}}
 <?xml version="1.0" encoding="UTF-8"?>
@@ -424,7 +424,7 @@ datadog-ci junit upload --service service_name \
   --xpath-tag custom_tag=/testcase/..//property[@name=\'prop\'] ./junit.xml
 {{< /code-block >}}
 
-**Note:** the escaping of quotes with `\'`. The quotes are required and bash removes them if not escaped.
+**Note:** The name must be in quotes. Bash requires quotes to be escaped using a backslash, for example `[@name='prop']` must be entered as `[@name=\'prop\'].
 {{% /tab %}}
 
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
New section explaining new feature for custom tags with XPath syntax in junit upload command from CI Visibility.

### Motivation
<!-- What inspired you to submit this pull request?-->
We need to explain a new feature

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
