### PR TITLE
Fix `sendDistributionMetricWithDate` param order

### DIFF
--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -264,9 +264,9 @@ async function myHandler(event, context) {
     sendDistributionMetricWithDate(
         'coffee_house.order_value', // Metric name
         12.45,                      // Metric value
-        'product:latte',            // First tag
-        'order:online'              // Second tag
         new Date(Date.now()),       // date
+        'product:latte',            // First tag
+        'order:online',             // Second tag
     );
 }
 ```


### PR DESCRIPTION
The third param is the metric date, not the last one: https://github.com/DataDog/datadog-lambda-js/blob/38453fd6375cd70f7b8f26fae2134bb7a248ddfc/src/index.ts#L185