### PR TITLE
Remove the service account guidance for Observability Pipelines

### DIFF
--- a/content/en/observability_pipelines/setup.md
+++ b/content/en/observability_pipelines/setup.md
@@ -123,7 +123,6 @@ See [Vector Configurations][22] for more examples on setting up the three main V
 
 Connect your Vector configuration to Observability Pipelines by doing the following:
 
-- In Datadog, [create a service account][23], if you don’t already have one. A service account is required to generate the application keys necessary to connect Vector to Observability Pipelines. 
 - Go to [Observability Pipelines][24].
 - Click **Create Configuration**, and follow the in-app instructions to set up the configuration.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This is no longer needed for setting up OP, and has caused some confusion with customers. Let's remove it.

### Motivation
See above.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
