### PR TITLE
agent/proxy.md: remove the appsecevt configuration

### DIFF
--- a/content/en/agent/proxy.md
+++ b/content/en/agent/proxy.md
@@ -393,14 +393,6 @@ frontend instrumentation_telemetry_data_frontend
     default_backend datadog-instrumentations-telemetry
 
 # This declares the endpoint where your Agents connects for
-# sending appsec events (deprecated).
-frontend appsec-events-frontend
-    bind *:3844
-    mode tcp
-    option tcplog
-    default_backend datadog-appsec-events
-
-# This declares the endpoint where your Agents connects for
 # sending Network Devices Monitoring NetFlow flows (for example, the value of "network_devices.netflow.dd_url")
 frontend network_devices_netflow_frontend
     bind *:3845
@@ -504,14 +496,6 @@ backend datadog-instrumentations-telemetry
     server-template mothership 5 instrumentation-telemetry-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
     # server mothership instrumentation-telemetry-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
-
-backend datadog-appsec-events # deprecated
-    balance roundrobin
-    mode tcp
-    # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
-    # Uncomment the following configuration for older HAProxy versions
-    # server mothership appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-network-devices-netflow
     balance roundrobin
@@ -660,14 +644,6 @@ frontend instrumentation_telemetry_data_frontend
     default_backend datadog-instrumentations-telemetry
 
 # This declares the endpoint where your Agents connect for
-# sending appsec events (deprecated).
-frontend appsec-events-frontend
-    bind *:3844 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
-    mode tcp
-    option tcplog
-    default_backend datadog-appsec-events
-
-# This declares the endpoint where your Agents connect for
 # sending Network Devices Monitoring NetFlow flows (for example, the value of "network_devices.netflow.dd_url")
 frontend network_devices_netflow_frontend
     bind *:3845 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
@@ -772,14 +748,6 @@ backend datadog-instrumentations-telemetry
     # Uncomment the following configuration for older HAProxy versions
     # server mothership instrumentation-telemetry-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
-backend datadog-appsec-events # deprecated
-    balance roundrobin
-    mode tcp
-    # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
-    # Uncomment the following configuration for older HAProxy versions
-    # server mothership appsecevts-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
-
 backend datadog-network-devices-netflow
     balance roundrobin
     mode http
@@ -852,9 +820,6 @@ network_devices:
             logs_dd_url: haproxy.example.com:3845
             # Comment the line below to use encryption between the Agent and HAProxy
             logs_no_ssl: true
-
-appsec_config (deprecated):
-    appsec_dd_url: haproxy.example.com:3844
 ```
 
 When using encryption between the Agent and HAProxy, if the Agent does not have access to the proxy certificate, is unable to validate it, or the validation is not needed, you can edit the `datadog.yaml` Agent configuration file and set `skip_ssl_validation` to `true`.
@@ -1029,12 +994,6 @@ stream {
         proxy_pass instrumentation-telemetry-intake.{{< region-param key="dd_site" >}}:443;
     }
     server {
-        listen 3844; #listen for appsec events (deprecated)
-        proxy_ssl_verify on;
-        proxy_ssl on;
-        proxy_pass appsecevts-intake.{{< region-param key="dd_site" >}}:443;
-    }
-    server {
         listen 3845; #listen for network devices netflow
         proxy_ssl_verify on;
         proxy_ssl on;
@@ -1146,12 +1105,6 @@ stream {
         proxy_pass instrumentation-telemetry-intake.{{< region-param key="dd_site" >}}:443;
     }
     server {
-        listen 3844 ssl; #listen for appsec events (deprecated)
-        proxy_ssl_verify on;
-        proxy_ssl on;
-        proxy_pass appsecevts-intake.{{< region-param key="dd_site" >}}:443;
-    }
-    server {
         listen 3845 ssl; #listen for network devices netflow
         proxy_ssl_verify on;
         proxy_ssl on;
@@ -1218,9 +1171,6 @@ network_devices:
             logs_dd_url: nginx.example.com:3845
             # Comment the line below to use encryption between the Agent and NGINX
             logs_no_ssl: true
-
-appsec_config (deprecated):
-    appsec_dd_url: haproxy.example.com:3844
 
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Remove all references to the old appsecevt intake.

### Motivation
<!-- What inspired you to submit this pull request?-->
This backend intake API is no longer available and its documentation can be removed.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
