### PR TITLE
Removes ignored files from translation config

### DIFF
--- a/translate.yaml
+++ b/translate.yaml
@@ -22,15 +22,6 @@ ignores:
   - "**/*.ja.yaml"
   - "**/*.ja.json"
   - "**/ja.json"
-  - "content/en/api/latest/service-level-objective-corrections/*.md"
-  - "content/en/integrations/observability_pipelines/guide/*.md"
-  - "content/en/real_user_monitoring/connect_rum_and_traces/*.md"
-  - "content/en/security_platform/application_security/**/*.md"
-  - "content/en/security_platform/security_signal_management/*.md"
-  - "content/en/tracing/dynamic_instrumentation/**/*.md"
-  - "content/en/tracing/other_telemetry/**/*.md"
-  - "content/en/tracing/setup_overview/**/*.md"
-  - "content/en/tracing/trace_collection/**/*.md"
 
 # These files will be uploaded to Transifex for translation when syncing.
 sources:


### PR DESCRIPTION
### What does this PR do?
Removes some file path glob patterns that were previously being excluded from translation syncing.

### Motivation
We had excluded these files from translation syncing to prepare for updates/data migration in Transifex.   The original PR was #15453.  

### Preview
n/a this shouldn't affect the site.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
