### PR TITLE
Update advanced_log_collection.md

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -368,7 +368,7 @@ logs:
    log_processing_rules:
       - type: multi_line
         name: new_log_start_with_date
-        pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+        pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])\s
 ```
 
 {{% /tab %}}
@@ -385,7 +385,7 @@ In a Docker environment, use the label `com.datadoghq.ad.logs` on your container
         "log_processing_rules": [{
           "type": "multi_line",
           "name": "log_start_with_date",
-          "pattern" : "\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])"
+          "pattern" : "\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])\\s"
         }]
       }]
 ```
@@ -414,7 +414,7 @@ spec:
             "log_processing_rules": [{
               "type": "multi_line",
               "name": "log_start_with_date",
-              "pattern" : "\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])"
+              "pattern" : "\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])\\s"
             }]
           }]
       labels:


### PR DESCRIPTION
current

<img width="591" alt="image" src="https://user-images.githubusercontent.com/38891791/199034598-b5a1d04b-7e65-4bbd-9c1f-10b18ba8a234.png">

better rule
<img width="622" alt="image" src="https://user-images.githubusercontent.com/38891791/199034844-88b3b7ee-aa25-4aaa-b824-b02fe4d6facb.png">

### What does this PR do?
the current paterrns doesn't actually match the full date.

### Motivation
it was inaccurate

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
