### PR TITLE
Move link to work around rendering problem

### DIFF
--- a/content/en/containers/docker/_index.md
+++ b/content/en/containers/docker/_index.md
@@ -49,6 +49,8 @@ The CLI commands on this page are for the Docker runtime. Replace `docker` with 
 
 If you haven’t installed the Docker Agent, follow the [in-app installation instructions][8] or see below. For [supported versions][9], see the Agent documentation. Use the one-step install command. Replace `<YOUR_DATADOG_API_KEY>` with your [Datadog API key][10].
 
+**Note**: For Docker Compose, see [Compose and the Datadog Agent][11].
+
 {{< tabs >}}
 {{% tab "Standard" %}}
 
@@ -124,11 +126,10 @@ docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: For Docker Compose, see [Compose and the Datadog Agent][11].
-
 ## Integrations
 
 Once the Agent is up and running, use [Datadog's Autodiscovery feature][12] to collect metrics and logs automatically from your application containers.
+
 
 ## Environment variables
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Moves a paragraph with a link that wasn't working. I suspect the tabs processing is causing the link to render incorrectly. Will open a WEB ticket to track.

### Motivation
report in documentation channel.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
