### PR TITLE
Update service_definition_api.md - tags should be an array

### DIFF
--- a/content/en/tracing/service_catalog/service_definition_api.md
+++ b/content/en/tracing/service_catalog/service_definition_api.md
@@ -108,7 +108,7 @@ You can generate this body data on the [Service Catalog Getting Started page][7]
                     "contacts": [],
                     "docs": [],
                     "repos": [],
-                    "tags": null,
+                    "tags": [],
                     "integrations": {},
                     "team": "",
                     "extensions": {}


### PR DESCRIPTION
### What does this PR do?
Make example compliant with our rules + match the in app example

### Motivation
error message "expected array, but got null" when using this example

<!-- ### Preview -->


### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
