### PR TITLE
Add Topology Map and remove Service Map widget

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -716,24 +716,24 @@ main:
     url: dashboards/widgets/slo/
     parent: dashboards_widgets
     weight: 30
-  - name: Service Map
-    url: dashboards/widgets/service_map/
-    parent: dashboards_widgets
-    weight: 31
   - name: Service Summary
     url: dashboards/widgets/service_summary/
     parent: dashboards_widgets
-    weight: 32
+    weight: 31
   - name: Table
     url: dashboards/widgets/table/
     parent: dashboards_widgets
-    weight: 33
+    weight: 32
   - name: Timeseries
     url: dashboards/widgets/timeseries/
     parent: dashboards_widgets
-    weight: 34
+    weight: 33
   - name: Top List
     url: dashboards/widgets/top_list/
+    parent: dashboards_widgets
+    weight: 34
+  - name: Topology Map
+    url: dashboards/widgets/topology_map/
     parent: dashboards_widgets
     weight: 35
   - name: Querying

--- a/content/en/dashboards/widgets/_index.md
+++ b/content/en/dashboards/widgets/_index.md
@@ -34,6 +34,7 @@ Widgets are building blocks for your dashboards. They are categorized into three
     {{< nextlink href="/dashboards/widgets/treemap" >}}Treemap{{< /nextlink >}}
     {{< nextlink href="/dashboards/widgets/timeseries" >}}Timeseries{{< /nextlink >}}
     {{< nextlink href="/dashboards/widgets/top_list" >}}Top List{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/topology_map" >}}Topology Map{{< /nextlink >}}
 {{< /whatsnext >}}
 
 {{< whatsnext desc="Summary widgets to display Synthetic Monitoring information: ">}}
@@ -43,7 +44,6 @@ Widgets are building blocks for your dashboards. They are categorized into three
     {{< nextlink href="/dashboards/widgets/monitor_summary" >}}Monitor Summary{{< /nextlink >}}
     {{< nextlink href="/dashboards/widgets/slo" >}}Service Level Objective (SLO) Summary{{< /nextlink >}}
     {{< nextlink href="/dashboards/widgets/slo_list" >}}Service Level Objective (SLO) List{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/service_map" >}}Service Map{{< /nextlink >}}
     {{< nextlink href="/dashboards/widgets/service_summary" >}}Service Summary{{< /nextlink >}}
 {{< /whatsnext >}}
 

--- a/content/en/dashboards/widgets/topology_map.md
+++ b/content/en/dashboards/widgets/topology_map.md
@@ -1,0 +1,42 @@
+---
+title: Topology Map Widget
+kind: documentation
+description: "Displays a map of a service to all of the services that call it, and all of the services that it calls."
+widget_type: "topologymap"
+aliases:
+    - /graphing/widgets/topology_map/
+further_reading:
+- link: "/dashboards/graphing_json/"
+  tag: "Documentation"
+  text: "Building Dashboards using JSON"
+- link: "/tracing/services/services_map/"
+  tag: "Documentation"
+  text: "Service Map"
+---
+
+The Topology Map widget displays a visualization of data sources and their relationships to help understand how data flows through your architecture. 
+
+## Setup
+
+### Configuration
+
+1. Choose the data to graph:
+    * Service Map: The node in the center of the widget represents the mapped service. Services that call the mapped service are shown with arrows from the caller to the service. To learn more about the Service Map, reference the [Service Map feature of APM][1].
+
+2. Enter a title for your graph.
+
+## API
+
+This widget can be used with the **Dashboards API**. See the [Dashboards API documentation][2] for additional reference.
+
+The dedicated [widget JSON schema definition][3] for the service map widget is:
+
+{{< dashboards-widgets-api >}}
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /tracing/services/services_map/
+[2]: /api/v1/dashboards/
+[3]: /dashboards/graphing_json/widget_json/

--- a/content/en/dashboards/widgets/topology_map.md
+++ b/content/en/dashboards/widgets/topology_map.md
@@ -4,7 +4,7 @@ kind: documentation
 description: "Displays a map of a service to all of the services that call it, and all of the services that it calls."
 widget_type: "topologymap"
 aliases:
-    - /graphing/widgets/topology_map/
+    - /dashboards/widgets/service_map
 further_reading:
 - link: "/dashboards/graphing_json/"
   tag: "Documentation"

--- a/content/en/dashboards/widgets/topology_map.md
+++ b/content/en/dashboards/widgets/topology_map.md
@@ -2,7 +2,7 @@
 title: Topology Map Widget
 kind: documentation
 description: "Displays a map of a service to all of the services that call it, and all of the services that it calls."
-widget_type: "topologymap"
+widget_type: "topology_map"
 aliases:
     - /dashboards/widgets/service_map
 further_reading:
@@ -38,5 +38,5 @@ The dedicated [widget JSON schema definition][3] for the service map widget is:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing/services/services_map/
-[2]: /api/v1/dashboards/
+[2]: /api/latest/dashboards/
 [3]: /dashboards/graphing_json/widget_json/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Add topology map to menus.en.yaml file
- Remove the Service Map widget from the menu and the index list
- Add information about the widget in the Topology Map page

### Motivation
[DOCS-4081](https://datadoghq.atlassian.net/browse/DOCS-4081)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Will remove the Service Map page in a separate [PR](https://github.com/DataDog/documentation/pull/15769)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
