### PR TITLE
Fixed broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Avoid using passive voice in favor of active voice. If you think your sentence i
 
 ### Inclusive language
 
-Use inclusive language unless you are referencing third-party technologies such as Redis' master/slave nodes. The Datadog docs follow the inclusive language best practices described in the [Terminology, Power and Inclusive Language](https://tools.ietf.org/id/draft-knodel-terminology-02.html) document from the Center for Democracy & Technology.
+Use inclusive language unless you are referencing third-party technologies such as Redis' master/slave nodes. The Datadog docs follow the inclusive language best practices described in the [Terminology, Power and Inclusive Language](https://datatracker.ietf.org/doc/draft-knodel-terminology) document from the Center for Democracy & Technology.
 - **Recommended**: "Primary/secondary, disallowlist/allowlist"
 - **Not recommended**: "Master/slave, blacklist/whitelist"
 


### PR DESCRIPTION
It appears the IETF's Terminology, Power, and Inclusive Language page has moved.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes a broken link.

### Motivation
See something, fix something.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
