### PR TITLE
[DOCS-4331] Add dbm guide for setting up dbm/apm linking

### DIFF
--- a/content/en/database_monitoring/guide/apm-linking.md
+++ b/content/en/database_monitoring/guide/apm-linking.md
@@ -56,6 +56,7 @@ sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithSQLCommentInjection(tra
 3. Via code on sql.Open
 ```go
 sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithServiceName("my-db-service"))
+
 db, err := sqltrace.Open("postgres", "postgres://pqgotest:password@localhost/pqgotest?sslmode=disable", sqltrace.WithSQLCommentInjection(tracer.SQLInjectionModeFull))
 if err != nil {
 	log.Fatal(err)
@@ -65,13 +66,13 @@ if err != nil {
 Full example:
 ```go
 import (
-    "database/sql"
-   "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-   sqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
+	"database/sql"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	sqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
 )
 
 func main() {
-    // The first step is to set the dbm propagation mode when registering the driver. Note that this can also
+	// The first step is to set the dbm propagation mode when registering the driver. Note that this can also
 	// be done on sqltrace.Open for more granular control over the feature.
 	sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithDBMPropagation(tracer.DBMPropagationModeFull))
 

--- a/content/en/database_monitoring/guide/apm-linking.md
+++ b/content/en/database_monitoring/guide/apm-linking.md
@@ -1,0 +1,89 @@
+---
+title: Linking Database Monitoring with APM
+kind: guide
+private: true
+---
+
+This guide assumes that you have configured [Datadog Monitoring](database_monitoring/#getting-started) and are using [APM](/tracing/).
+
+## Before you begin
+
+Supported configurations
+: dd-trace-go >= 1.42.0 (db accessed via the `database/sql` or `github.com/jmoiron/sqlx` packages)
+
+Supported databases
+: mysql or postgres
+
+Supported Agent versions
+: 7.36.1+
+
+Data Privacy
+: Enabling sql comment propagation results in potentially confidential data (service names) being stored in the databases which can then be accessed by other 3rd parties that have been granted access to the database.
+
+## Setup
+
+{{< tabs >}}
+{{% tab "Go" %}}
+
+Update your app dependencies to include dd-trace-go@v1.42.0 or greater
+```
+go get gopkg.in/DataDog/dd-trace-go.v1@v1.42.0
+```
+
+Update your code to import the `contrib/database/sql` package
+```go
+import (
+   "database/sql"
+   "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+   sqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
+)
+```
+
+Enable the dbm propagation feature using one of the 3 methods:
+1. Env variable: 
+DD_TRACE_SQL_COMMENT_INJECTION_MODE=full
+
+2. Via code during the driver registration
+```go
+sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithSQLCommentInjection(tracer.SQLInjectionModeFull), sqltrace.WithServiceName("my-db-service"))
+```
+
+3. Via code on sql.Open
+```go
+sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithServiceName("my-db-service"))
+db, err := sqltrace.Open("postgres", "postgres://pqgotest:password@localhost/pqgotest?sslmode=disable", sqltrace.WithSQLCommentInjection(tracer.SQLInjectionModeFull))
+if err != nil {
+	log.Fatal(err)
+}
+```
+
+Full example:
+```go
+import (
+    "database/sql"
+   "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+   sqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
+)
+
+func main() {
+    // The first step is to set the dbm propagation mode when registering the driver. Note that this can also
+	// be done on sqltrace.Open for more granular control over the feature.
+	sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithDBMPropagation(tracer.DBMPropagationModeFull))
+
+	// Followed by a call to Open.
+	db, err := sqltrace.Open("postgres", "postgres://pqgotest:password@localhost/pqgotest?sslmode=disable")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Then, we continue using the database/sql package as we normally would, with tracing.
+	rows, err := db.Query("SELECT name FROM users WHERE age=?", 27)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+}
+```
+{{% /tab %}}
+
+

--- a/content/en/database_monitoring/guide/apm-linking.md
+++ b/content/en/database_monitoring/guide/apm-linking.md
@@ -14,7 +14,7 @@ This guide assumes that you have configured [Datadog Monitoring](/database_monit
 ## Before you begin
 
 Supported tracers
-: dd-trace-go >= 1.42.0 (support for `database/sql` and `github.com/jmoiron/sqlx` packages)
+: [dd-trace-go](https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1) >= 1.42.0 (support for [database/sql](https://pkg.go.dev/database/sql) and [sqlx](https://pkg.go.dev/github.com/jmoiron/sqlx) packages)
 
 Supported databases
 : postgres, mysql

--- a/content/en/database_monitoring/guide/apm-linking.md
+++ b/content/en/database_monitoring/guide/apm-linking.md
@@ -1,14 +1,19 @@
 ---
 title: Linking Database Monitoring with APM
 kind: guide
+beta: true
 private: true
 ---
 
-This guide assumes that you have configured [Datadog Monitoring](database_monitoring/#getting-started) and are using [APM](/tracing/).
+<div class="alert alert-warning">
+The features discussed on this page are in private beta. Contact your Customer Success Manager to learn more about it.
+</div>
+
+This guide assumes that you have configured [Datadog Monitoring](/database_monitoring/#getting-started) and are using [APM](/tracing/).
 
 ## Before you begin
 
-Supported configurations
+Supported tracers
 : dd-trace-go >= 1.42.0 (db accessed via the `database/sql` or `github.com/jmoiron/sqlx` packages)
 
 Supported databases
@@ -17,7 +22,7 @@ Supported databases
 Supported Agent versions
 : 7.36.1+
 
-Data Privacy
+Data privacy
 : Enabling sql comment propagation results in potentially confidential data (service names) being stored in the databases which can then be accessed by other 3rd parties that have been granted access to the database.
 
 ## Setup

--- a/content/en/database_monitoring/guide/apm-linking.md
+++ b/content/en/database_monitoring/guide/apm-linking.md
@@ -14,10 +14,10 @@ This guide assumes that you have configured [Datadog Monitoring](/database_monit
 ## Before you begin
 
 Supported tracers
-: dd-trace-go >= 1.42.0 (db accessed via the `database/sql` or `github.com/jmoiron/sqlx` packages)
+: dd-trace-go >= 1.42.0 (support for `database/sql` and `github.com/jmoiron/sqlx` packages)
 
 Supported databases
-: mysql or postgres
+: postgres, mysql
 
 Supported Agent versions
 : 7.36.1+

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -1,5 +1,5 @@
 ---
-title: Linking Database Monitoring with APM
+title: Connecting DBM and APM
 kind: guide
 beta: true
 private: true

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -9,12 +9,12 @@ private: true
 The features discussed on this page are in private beta. Contact your Customer Success Manager to learn more about it.
 </div>
 
-This guide assumes that you have configured [Datadog Monitoring](/database_monitoring/#getting-started) and are using [APM](/tracing/).
+This guide assumes that you have configured [Datadog Monitoring][1] and are using [APM][2].
 
 ## Before you begin
 
 Supported tracers
-: [dd-trace-go](https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1) >= 1.42.0 (support for [database/sql](https://pkg.go.dev/database/sql) and [sqlx](https://pkg.go.dev/github.com/jmoiron/sqlx) packages)
+: [dd-trace-go][3] >= 1.42.0 (support for [database/sql][4] and [sqlx][5] packages)
 
 Supported databases
 : postgres, mysql
@@ -92,4 +92,8 @@ func main() {
 ```
 {{% /tab %}}
 
-
+[1]: /database_monitoring/#getting-started
+[2]: /tracing/
+[3]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1
+[4]: https://pkg.go.dev/database/sql
+[5]: https://pkg.go.dev/github.com/jmoiron/sqlx

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -30,7 +30,7 @@ Data privacy
 {{< tabs >}}
 {{% tab "Go" %}}
 
-Update your app dependencies to include dd-trace-go@v1.42.0 or greater
+Update your app dependencies to include [dd-trace-go@v1.42.0][3] or greater
 ```
 go get gopkg.in/DataDog/dd-trace-go.v1@v1.42.0
 ```
@@ -46,14 +46,14 @@ import (
 
 Enable the dbm propagation feature using one of the 3 methods:
 1. Env variable: 
-DD_TRACE_SQL_COMMENT_INJECTION_MODE=full
+`DD_TRACE_SQL_COMMENT_INJECTION_MODE=full`
 
 2. Via code during the driver registration
 ```go
 sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithSQLCommentInjection(tracer.SQLInjectionModeFull), sqltrace.WithServiceName("my-db-service"))
 ```
 
-3. Via code on sql.Open
+3. Via code on `sqltrace.Open`
 ```go
 sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithServiceName("my-db-service"))
 
@@ -91,6 +91,7 @@ func main() {
 }
 ```
 {{% /tab %}}
+{{< /tabs >}}
 
 
 [1]: /database_monitoring/#getting-started

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -92,6 +92,7 @@ func main() {
 ```
 {{% /tab %}}
 
+
 [1]: /database_monitoring/#getting-started
 [2]: /tracing/
 [3]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -30,7 +30,7 @@ Data privacy
 {{< tabs >}}
 {{% tab "Go" %}}
 
-Update your app dependencies to include [dd-trace-go@v1.42.0][3] or greater
+Update your app dependencies to include [dd-trace-go@v1.42.0][3] or greater:
 ```
 go get gopkg.in/DataDog/dd-trace-go.v1@v1.42.0
 ```

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -46,7 +46,7 @@ import (
 
 Enable the database monitoring propagation feature using one of the following methods:
 1. Env variable: 
-`DD_TRACE_SQL_COMMENT_INJECTION_MODE=full`
+   `DD_TRACE_SQL_COMMENT_INJECTION_MODE=full`
 
 2. Using code during the driver registration:
 ```go

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -23,7 +23,7 @@ Supported Agent versions
 : 7.36.1+
 
 Data privacy
-: Enabling sql comment propagation results in potentially confidential data (service names) being stored in the databases which can then be accessed by other 3rd parties that have been granted access to the database.
+: Enabling SQL comment propagation results in potentially confidential data (service names) being stored in the databases which can then be accessed by other third-parties that have been granted access to the database.
 
 ## Setup
 

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -54,14 +54,14 @@ sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithSQLCommentInjection(tra
 ```
 
 3. Using code on `sqltrace.Open`:
-```go
-sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithServiceName("my-db-service"))
-
-db, err := sqltrace.Open("postgres", "postgres://pqgotest:password@localhost/pqgotest?sslmode=disable", sqltrace.WithSQLCommentInjection(tracer.SQLInjectionModeFull))
-if err != nil {
-	log.Fatal(err)
-}
-```
+   ```go
+   sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithServiceName("my-db-service"))
+   
+   db, err := sqltrace.Open("postgres", "postgres://pqgotest:password@localhost/pqgotest?sslmode=disable", sqltrace.WithSQLCommentInjection(tracer.SQLInjectionModeFull))
+   if err != nil {
+	   log.Fatal(err)
+   }
+   ```
 
 Full example:
 ```go

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -49,9 +49,9 @@ Enable the database monitoring propagation feature using one of the following me
    `DD_TRACE_SQL_COMMENT_INJECTION_MODE=full`
 
 2. Using code during the driver registration:
-```go
-sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithSQLCommentInjection(tracer.SQLInjectionModeFull), sqltrace.WithServiceName("my-db-service"))
-```
+   ```go
+   sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithSQLCommentInjection(tracer.SQLInjectionModeFull), sqltrace.WithServiceName("my-db-service"))
+   ```
 
 3. Using code on `sqltrace.Open`:
    ```go

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -6,7 +6,7 @@ private: true
 ---
 
 <div class="alert alert-warning">
-The features discussed on this page are in private beta. Contact your Customer Success Manager to learn more about it.
+The features described on this page are in beta. Contact your Customer Success Manager to learn more about them.
 </div>
 
 This guide assumes that you have configured [Datadog Monitoring][1] and are using [APM][2].

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -48,7 +48,7 @@ Enable the dbm propagation feature using one of the 3 methods:
 1. Env variable: 
 `DD_TRACE_SQL_COMMENT_INJECTION_MODE=full`
 
-2. Via code during the driver registration
+2. Using code during the driver registration:
 ```go
 sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithSQLCommentInjection(tracer.SQLInjectionModeFull), sqltrace.WithServiceName("my-db-service"))
 ```

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -35,7 +35,7 @@ Update your app dependencies to include [dd-trace-go@v1.42.0][3] or greater
 go get gopkg.in/DataDog/dd-trace-go.v1@v1.42.0
 ```
 
-Update your code to import the `contrib/database/sql` package
+Update your code to import the `contrib/database/sql` package:
 ```go
 import (
    "database/sql"

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -30,7 +30,7 @@ Data privacy
 {{< tabs >}}
 {{% tab "Go" %}}
 
-Update your app dependencies to include [dd-trace-go@v1.42.0][3] or greater:
+Update your app dependencies to include [dd-trace-go@v1.42.0][1] or greater:
 ```
 go get gopkg.in/DataDog/dd-trace-go.v1@v1.42.0
 ```
@@ -90,6 +90,9 @@ func main() {
 	defer rows.Close()
 }
 ```
+
+[1]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1
+
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -53,7 +53,7 @@ Enable the dbm propagation feature using one of the 3 methods:
 sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithSQLCommentInjection(tracer.SQLInjectionModeFull), sqltrace.WithServiceName("my-db-service"))
 ```
 
-3. Via code on `sqltrace.Open`
+3. Using code on `sqltrace.Open`:
 ```go
 sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithServiceName("my-db-service"))
 

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -44,7 +44,7 @@ import (
 )
 ```
 
-Enable the dbm propagation feature using one of the 3 methods:
+Enable the database monitoring propagation feature using one of the following methods:
 1. Env variable: 
 `DD_TRACE_SQL_COMMENT_INJECTION_MODE=full`
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This adds a new database monitoring guide describing how to enable dbm propagation in tracers to use dbm/apm linking features. 

Note that this page is meant to be hidden for the time being as this is still in beta. This first version of the page is filling in the technical details for the first supported tracer language (Go). @iFallUpHill will follow-up soon to add some content to describe the product and features. 

### Motivation
We'd like to have the docs publicly accessible for when we get customers to trial apm/dbm linking features. 

### Preview

https://docs-staging.datadoghq.com/alex.normand/dbm-1695/database_monitoring/guide/connect_dbm_and_apm

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
