### PR TITLE
Added link for clarity on Composite monitor variables

### DIFF
--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -81,7 +81,7 @@ For detailed instructions on the advanced alert options (auto resolve, etc.), se
 
 ### Notifications
 
-For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][3] page.
+For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][3] page and the [Variables][5] page.
 
 ### API
 
@@ -224,3 +224,4 @@ Setting [new_group_delay][4] is possible in composite monitors and if set and bi
 [2]: /monitors/create/configuration/#advanced-alert-conditions
 [3]: /monitors/notify/
 [4]: /monitors/create/configuration/?tab=thresholdalert#new-group-delay
+[5]: /monitors/notify/variables/?tab=is_alert#composite-monitor-variables

--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -81,7 +81,7 @@ For detailed instructions on the advanced alert options (auto resolve, etc.), se
 
 ### Notifications
 
-For instructions on using template variables from a composite monitor's constituent monitors in your notifications, see [composite monitor variables][5].  For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][3] page.
+For instructions on using template variables from a composite monitor's constituent monitors in your notifications, see [composite monitor variables][5]. For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][3] page.
 
 ### API
 

--- a/content/en/monitors/create/types/composite.md
+++ b/content/en/monitors/create/types/composite.md
@@ -81,7 +81,7 @@ For detailed instructions on the advanced alert options (auto resolve, etc.), se
 
 ### Notifications
 
-For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][3] page and the [Variables][5] page.
+For instructions on using template variables from a composite monitor's constituent monitors in your notifications, see [composite monitor variables][5].  For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][3] page.
 
 ### API
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a link in the Composite monitors to the Composite monitor variables so users can have clarity on what notification and variable options are available.

### Motivation
[DOCS-1695](https://datadoghq.atlassian.net/browse/DOCS-1695)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
