### PR TITLE
[DOCS-4332] Use real simple quotes instead of mac os quote

### DIFF
--- a/content/fr/security_platform/application_security/troubleshooting.md
+++ b/content/fr/security_platform/application_security/troubleshooting.md
@@ -305,15 +305,15 @@ Pour commencer à diagnostiquer les problèmes concernant l'extension ASM de Dat
 Il se trouve généralement dans `/etc/php/<version>/xxx/conf.d/98-ddtrace.ini`. Toutefois, l'emplacement précis du fichier `ini` peut varier en fonction de votre installation. Consultez le début de la sortie de `phpinfo()` pour identifier le répertoire à partir duquel les éventuels fichiers `.ini` sont analysés. Définissez les options de configuration suivantes dans le fichier `.ini` :
 
 ```php
-datadog.appsec.log_level=‘debug’
-datadog.appsec.helper_extra_args=‘--log_level=debug’
-datadog.appsec.helper_log_file=‘/tmp/helper.log’
+datadog.appsec.log_level='debug'
+datadog.appsec.helper_extra_args='--log_level=debug'
+datadog.appsec.helper_log_file='/tmp/helper.log'
 ```
 
 L'extension enregistre les logs dans le fichier de log `php_error` par défaut. Si le fichier ne contient aucun log, ajoutez ce qui suit au fichier `.ini` :
 
 ```php
-datadog.appsec.log_file=’tmp/extension.log’
+datadog.appsec.log_file='tmp/extension.log'
 ```
 
 ### Installation ne trouvant pas PHP


### PR DESCRIPTION
Copy / Paste to config will trigger errors on php-fpm daemon

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
