### PR TITLE
WEB-2808 | Update hugo version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "del": "4.1.1",
         "docsearch.js": "^2.6.3",
         "fancy-log": "^1.3.3",
-        "hugo-bin": "0.89.0",
+        "hugo-bin": "0.93.0",
         "jquery": "3.5.1",
         "js-cookie": "^2.2.1",
         "js-yaml": "^3.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4426,7 +4426,7 @@ __metadata:
     eslint-plugin-react-hooks: ^2.5.0
     eslint-plugin-standard: ^4.0.0
     fancy-log: ^1.3.3
-    hugo-bin: 0.89.0
+    hugo-bin: 0.93.0
     jest: ^25.3.0
     jquery: 3.5.1
     js-cookie: ^2.2.1
@@ -6310,9 +6310,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hugo-bin@npm:0.89.0":
-  version: 0.89.0
-  resolution: "hugo-bin@npm:0.89.0"
+"hugo-bin@npm:0.93.0":
+  version: 0.93.0
+  resolution: "hugo-bin@npm:0.93.0"
   dependencies:
     bin-wrapper: ^4.1.0
     picocolors: ^1.0.0
@@ -6320,7 +6320,7 @@ __metadata:
     rimraf: ^3.0.2
   bin:
     hugo: cli.js
-  checksum: 278ba5cc8cd77d80b5d8d98d9e517178955422a24e015888bbb0e3aa8689596b16373308c0e5239b0a9dbe1dc148996cefc8d9a30103005921d45e025ee94e0b
+  checksum: 6feec9ba2164762e8c33fd70f3715cb9081dd860cbc3d0739e48f9d88b47a344f824711238ab1a4ef6a7927f580ccf8e69b42ddfe2ed4b75242cde8e51506124
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update the hugo version to `0.105.0`
### Motivation
<!-- What inspired you to submit this pull request?-->
Keeping up with hugo version bumps to avoid deprecation
### Preview
https://docs-staging.datadoghq.com/devin.ford/upgrade_hugo_version/
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Try to check as many templates as you can think of to make sure there is no wonkiness 
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](https://docs-staging.datadoghq.com/devin.ford/upgrade_hugo_version/) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
