### PR TITLE
DBM-1700: Include AO config 

### DIFF
--- a/content/en/database_monitoring/setup_sql_server/azure.md
+++ b/content/en/database_monitoring/setup_sql_server/azure.md
@@ -373,6 +373,7 @@ metadata:
           "connector": "odbc",
           "driver": "FreeTDS",
           "include_ao_metrics": true,  # Optional: For AlwaysOn users
+          "tags": ["service:<CUSTOM_SERVICE>", "env:<CUSTOM_ENV>"],  # Optional
           "azure": {
             "deployment_type": "<DEPLOYMENT_TYPE>",
             "name": "<YOUR_INSTANCE_NAME>"

--- a/content/en/database_monitoring/setup_sql_server/azure.md
+++ b/content/en/database_monitoring/setup_sql_server/azure.md
@@ -119,8 +119,6 @@ For [SQL Server on Windows Azure VM][1] follow the [Setting Up Database Monitori
 
 Since Azure does not grant direct host access, the Datadog Agent must be installed on a separate host where it is able to talk to the SQL Server host. There are several options for installing and running the Agent.
 
-**For AlwaysOn users**, the Agent must be installed on a separate server and connected to the cluster through the listener endpoint, as information about Availability Group (AG) secondary replicas is collected from the primary replica. Additionally, installing the Agent in this way helps keep it up and running in the event of a failover.
-
 {{< tabs >}}
 {{% tab "Windows Host" %}}
 To start collecting SQL Server telemetry, first [install the Datadog Agent][1].
@@ -136,7 +134,6 @@ instances:
     password: '<PASSWORD>'
     connector: adodbapi
     adoprovider: MSOLEDBSQL
-    include_ao_metrics: true  # Optional: For AlwaysOn users
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
@@ -210,7 +207,6 @@ instances:
     password: '<PASSWORD>'
     connector: odbc
     driver: '<Driver from the `odbcinst.ini` file>'
-    include_ao_metrics: true  # Optional: For AlwaysOn users
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
@@ -262,7 +258,6 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "driver": "FreeTDS",
     "username": "datadog",
     "password": "<PASSWORD>",
-    "include_ao_metrics": true,  # Optional: For AlwaysOn users
     "tags": [
       "service:<CUSTOM_SERVICE>"
       "env:<CUSTOM_ENV>"
@@ -340,7 +335,6 @@ instances:
     password: '<PASSWORD>'
     connector: "odbc"
     driver: "FreeTDS"
-    include_ao_metrics: true  # Optional: For AlwaysOn users
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
@@ -372,7 +366,6 @@ metadata:
           "password": "<PASSWORD>",
           "connector": "odbc",
           "driver": "FreeTDS",
-          "include_ao_metrics": true,  # Optional: For AlwaysOn users
           "tags": ["service:<CUSTOM_SERVICE>", "env:<CUSTOM_ENV>"],  # Optional
           "azure": {
             "deployment_type": "<DEPLOYMENT_TYPE>",

--- a/content/en/database_monitoring/setup_sql_server/azure.md
+++ b/content/en/database_monitoring/setup_sql_server/azure.md
@@ -25,8 +25,6 @@ Do the following steps to enable Database Monitoring with your database:
 2. [Install the Agent](#install-the-agent)
 3. [Install the Azure integration](#install-the-azure-integration)
 
-**For AlwaysOn users**, the Agent must be installed on a separate server and connected to the cluster through the listener endpoint, as information about Availability Group (AG) secondary replicas is collected from the primary replica. Additionally, installing the Agent in this way helps keep it up and running in the event of a failover.
-
 ## Before you begin
 
 Supported SQL Server versions
@@ -121,6 +119,8 @@ For [SQL Server on Windows Azure VM][1] follow the [Setting Up Database Monitori
 
 Since Azure does not grant direct host access, the Datadog Agent must be installed on a separate host where it is able to talk to the SQL Server host. There are several options for installing and running the Agent.
 
+**For AlwaysOn users**, the Agent must be installed on a separate server and connected to the cluster through the listener endpoint, as information about Availability Group (AG) secondary replicas is collected from the primary replica. Additionally, installing the Agent in this way helps keep it up and running in the event of a failover.
+
 {{< tabs >}}
 {{% tab "Windows Host" %}}
 To start collecting SQL Server telemetry, first [install the Datadog Agent][1].
@@ -136,7 +136,8 @@ instances:
     password: '<PASSWORD>'
     connector: adodbapi
     adoprovider: MSOLEDBSQL
-    tags:  # optional
+    include_ao_metrics: true  # Optional: For AlwaysOn users
+    tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
     # After adding your project and instance, configure the Datadog Azure integration to pull additional cloud data such as CPU, Memory, etc.
@@ -209,10 +210,10 @@ instances:
     password: '<PASSWORD>'
     connector: odbc
     driver: '<Driver from the `odbcinst.ini` file>'
-    tags:  # optional
+    include_ao_metrics: true  # Optional: For AlwaysOn users
+    tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
-
     # After adding your project and instance, configure the Datadog Azure integration to pull additional cloud data such as CPU, Memory, etc.
     azure:
       deployment_type: '<DEPLOYMENT_TYPE>'
@@ -261,6 +262,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "driver": "FreeTDS",
     "username": "datadog",
     "password": "<PASSWORD>",
+    "include_ao_metrics": true,  # Optional: For AlwaysOn users
     "tags": [
       "service:<CUSTOM_SERVICE>"
       "env:<CUSTOM_ENV>"
@@ -314,6 +316,10 @@ instances:
     password: '<PASSWORD>'
     connector: 'odbc'
     driver: 'FreeTDS'
+    include_ao_metrics: true  # Optional: For AlwaysOn users
+    tags:  # Optional
+      - 'service:<CUSTOM_SERVICE>'
+      - 'env:<CUSTOM_ENV>'
     azure:
       deployment_type: '<DEPLOYMENT_TYPE>'
       name: '<YOUR_INSTANCE_NAME>' \
@@ -334,6 +340,10 @@ instances:
     password: '<PASSWORD>'
     connector: "odbc"
     driver: "FreeTDS"
+    include_ao_metrics: true  # Optional: For AlwaysOn users
+    tags:  # Optional
+      - 'service:<CUSTOM_SERVICE>'
+      - 'env:<CUSTOM_ENV>'
     # After adding your project and instance, configure the Datadog Azure integration to pull additional cloud data such as CPU, Memory, etc.
     azure:
       deployment_type: '<DEPLOYMENT_TYPE>'
@@ -362,6 +372,7 @@ metadata:
           "password": "<PASSWORD>",
           "connector": "odbc",
           "driver": "FreeTDS",
+          "include_ao_metrics": true,  # Optional: For AlwaysOn users
           "azure": {
             "deployment_type": "<DEPLOYMENT_TYPE>",
             "name": "<YOUR_INSTANCE_NAME>"

--- a/content/en/database_monitoring/setup_sql_server/gcsql.md
+++ b/content/en/database_monitoring/setup_sql_server/gcsql.md
@@ -22,8 +22,6 @@ Complete the following steps to enable Database Monitoring with your database:
 2. [Install the Agent](#install-the-agent)
 3. [Install the Cloud SQL integration](#install-the-cloud-sql-integration)
 
-**For AlwaysOn users**, the Agent must be installed on a separate server and connected to the cluster through the listener endpoint, as information about Availability Group (AG) secondary replicas is collected from the primary replica. Additionally, installing the Agent in this way helps keep it up and running in the event of a failover.
-
 ## Before you begin
 
 Supported SQL Server versions
@@ -57,6 +55,8 @@ This is required because Google Cloud SQL does not permit granting `CONNECT ANY 
 
 GCP does not grant direct host access, meaning the Datadog Agent must be installed on a separate host where it is able to talk to the SQL Server host. There are several options for installing and running the Agent.
 
+**For AlwaysOn users**, the Agent must be installed on a separate server and connected to the cluster through the listener endpoint, as information about Availability Group (AG) secondary replicas is collected from the primary replica. Additionally, installing the Agent in this way helps keep it up and running in the event of a failover.
+
 {{< tabs >}}
 {{% tab "Windows Host" %}}
 To start collecting SQL Server telemetry, first [install the Datadog Agent][1].
@@ -72,7 +72,8 @@ instances:
     password: '<PASSWORD>'
     connector: adodbapi
     provider: MSOLEDBSQL
-    tags:  # optional
+    include_ao_metrics: true  # Optional: For AlwaysOn users
+    tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
     # After adding your project and instance, configure the Datadog GCP integration to pull additional cloud data such as CPU, Memory, etc.
@@ -145,10 +146,10 @@ instances:
     password: '<PASSWORD>'
     connector: odbc
     driver: '<Driver from the `odbcinst.ini` file>'
-    tags:  # optional
+    include_ao_metrics: true  # Optional: For AlwaysOn users
+    tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
-
     # After adding your project and instance, configure the Datadog GCP integration to pull additional cloud data such as CPU, Memory, etc.
     gcp:
       project_id: '<PROJECT_ID>'
@@ -198,6 +199,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "driver": "FreeTDS",
     "username": "datadog",
     "password": "<PASSWORD>",
+    "include_ao_metrics": true,  # Optional: For AlwaysOn users
     "tags": [
       "service:<CUSTOM_SERVICE>"
       "env:<CUSTOM_ENV>"
@@ -251,6 +253,10 @@ instances:
     password: '<PASSWORD>'
     connector: 'odbc'
     driver: 'FreeTDS'
+    include_ao_metrics: true  # Optional: For AlwaysOn users
+    tags:  # Optional
+      - 'service:<CUSTOM_SERVICE>'
+      - 'env:<CUSTOM_ENV>'
     gcp:
       project_id: '<PROJECT_ID>'
       instance_id: '<INSTANCE_ID>' \
@@ -272,6 +278,10 @@ instances:
     password: '<PASSWORD>'
     connector: "odbc"
     driver: "FreeTDS"
+    include_ao_metrics: true  # Optional: For AlwaysOn users
+    tags:  # Optional
+      - 'service:<CUSTOM_SERVICE>'
+      - 'env:<CUSTOM_ENV>'
     # After adding your project and instance, configure the Datadog GCP integration to pull additional cloud data such as CPU, Memory, etc.
     gcp:
       project_id: '<PROJECT_ID>'
@@ -301,6 +311,8 @@ metadata:
           "password": "<PASSWORD>",
           "connector": "odbc",
           "driver": "FreeTDS",
+          "include_ao_metrics": true,  # Optional: For AlwaysOn users
+          "tags": ["service:<CUSTOM_SERVICE>", "env:<CUSTOM_ENV>"],  # Optional,
           "gcp": {
             "project_id": "<PROJECT_ID>",
             "instance_id": "<INSTANCE_ID>"

--- a/content/en/database_monitoring/setup_sql_server/gcsql.md
+++ b/content/en/database_monitoring/setup_sql_server/gcsql.md
@@ -55,8 +55,6 @@ This is required because Google Cloud SQL does not permit granting `CONNECT ANY 
 
 GCP does not grant direct host access, meaning the Datadog Agent must be installed on a separate host where it is able to talk to the SQL Server host. There are several options for installing and running the Agent.
 
-**For AlwaysOn users**, the Agent must be installed on a separate server and connected to the cluster through the listener endpoint, as information about Availability Group (AG) secondary replicas is collected from the primary replica. Additionally, installing the Agent in this way helps keep it up and running in the event of a failover.
-
 {{< tabs >}}
 {{% tab "Windows Host" %}}
 To start collecting SQL Server telemetry, first [install the Datadog Agent][1].
@@ -145,7 +143,6 @@ instances:
     password: '<PASSWORD>'
     connector: odbc
     driver: '<Driver from the `odbcinst.ini` file>'
-    include_ao_metrics: true  # Optional: For AlwaysOn users
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
@@ -198,7 +195,6 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "driver": "FreeTDS",
     "username": "datadog",
     "password": "<PASSWORD>",
-    "include_ao_metrics": true,  # Optional: For AlwaysOn users
     "tags": [
       "service:<CUSTOM_SERVICE>"
       "env:<CUSTOM_ENV>"

--- a/content/en/database_monitoring/setup_sql_server/gcsql.md
+++ b/content/en/database_monitoring/setup_sql_server/gcsql.md
@@ -312,7 +312,7 @@ metadata:
           "connector": "odbc",
           "driver": "FreeTDS",
           "include_ao_metrics": true,  # Optional: For AlwaysOn users
-          "tags": ["service:<CUSTOM_SERVICE>", "env:<CUSTOM_ENV>"],  # Optional,
+          "tags": ["service:<CUSTOM_SERVICE>", "env:<CUSTOM_ENV>"],  # Optional
           "gcp": {
             "project_id": "<PROJECT_ID>",
             "instance_id": "<INSTANCE_ID>"

--- a/content/en/database_monitoring/setup_sql_server/gcsql.md
+++ b/content/en/database_monitoring/setup_sql_server/gcsql.md
@@ -72,7 +72,6 @@ instances:
     password: '<PASSWORD>'
     connector: adodbapi
     provider: MSOLEDBSQL
-    include_ao_metrics: true  # Optional: For AlwaysOn users
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
@@ -253,7 +252,6 @@ instances:
     password: '<PASSWORD>'
     connector: 'odbc'
     driver: 'FreeTDS'
-    include_ao_metrics: true  # Optional: For AlwaysOn users
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
@@ -278,7 +276,6 @@ instances:
     password: '<PASSWORD>'
     connector: "odbc"
     driver: "FreeTDS"
-    include_ao_metrics: true  # Optional: For AlwaysOn users
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
@@ -311,7 +308,6 @@ metadata:
           "password": "<PASSWORD>",
           "connector": "odbc",
           "driver": "FreeTDS",
-          "include_ao_metrics": true,  # Optional: For AlwaysOn users
           "tags": ["service:<CUSTOM_SERVICE>", "env:<CUSTOM_ENV>"],  # Optional
           "gcp": {
             "project_id": "<PROJECT_ID>",

--- a/content/en/database_monitoring/setup_sql_server/rds.md
+++ b/content/en/database_monitoring/setup_sql_server/rds.md
@@ -25,8 +25,6 @@ Do the following steps to enable Database Monitoring with your database:
 2. [Install the Agent](#install-the-agent)
 3. [Install the RDS integration](#install-the-rds-integration)
 
-**For AlwaysOn users**, the Agent must be installed on a separate server and connected to the cluster through the listener endpoint, as information about Availability Group (AG) secondary replicas is collected from the primary replica. Additionally, installing the Agent in this way helps keep it up and running in the event of a failover.
-
 ## Before you begin
 
 Supported SQL Server versions
@@ -66,6 +64,8 @@ This is required because RDS does not permit granting `CONNECT ANY DATABASE`. Th
 ## Install the Agent
 
 Since AWS does not grant direct host access, the Datadog Agent must be installed on a separate host where it is able to talk to the SQL Server host. There are several options for installing and running the Agent.
+
+**For AlwaysOn users**, the Agent must be installed on a separate server and connected to the cluster through the listener endpoint, as information about Availability Group (AG) secondary replicas is collected from the primary replica. Additionally, installing the Agent in this way helps keep it up and running in the event of a failover.
 
 {{< tabs >}}
 {{% tab "Windows Host" %}}

--- a/layouts/shortcodes/dbm-sqlserver-agent-setup-docker.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-setup-docker.md
@@ -20,6 +20,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "driver": "FreeTDS",
     "username": "datadog",
     "password": "<PASSWORD>",
+    "include_ao_metrics": true,  # Optional: For AlwaysOn users
     "tags": [
       "service:<CUSTOM_SERVICE>"
       "env:<CUSTOM_ENV>"

--- a/layouts/shortcodes/dbm-sqlserver-agent-setup-kubernetes.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-setup-kubernetes.md
@@ -22,7 +22,11 @@ instances:
     username: datadog
     password: '<PASSWORD>'
     connector: 'odbc'
-    driver: 'FreeTDS'\
+    driver: 'FreeTDS'
+    include_ao_metrics: true  # Optional: For AlwaysOn users
+    tags:  # Optional
+      - 'service:<CUSTOM_SERVICE>'
+      - 'env:<CUSTOM_ENV>'\
   datadog/datadog"
 ```
 
@@ -39,8 +43,12 @@ instances:
     port: <SQL_PORT>
     username: datadog
     password: '<PASSWORD>'
-    connector: "odbc"
-    driver: "FreeTDS"
+    connector: 'odbc'
+    driver: 'FreeTDS'
+    include_ao_metrics: true  # Optional: For AlwaysOn users
+    tags:  # Optional
+      - 'service:<CUSTOM_SERVICE>'
+      - 'env:<CUSTOM_ENV>
 ```
 
 ### Configure with Kubernetes service annotations
@@ -65,7 +73,9 @@ metadata:
           "username": "datadog",
           "password": "<PASSWORD>",
           "connector": "odbc",
-          "driver": "FreeTDS"
+          "driver": "FreeTDS",
+          "include_ao_metrics": true,  # Optional: For AlwaysOn users
+          "tags": ["service:<CUSTOM_SERVICE>", "env:<CUSTOM_ENV>"],  # Optional
         }
       ]
 spec:

--- a/layouts/shortcodes/dbm-sqlserver-agent-setup-kubernetes.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-setup-kubernetes.md
@@ -75,7 +75,7 @@ metadata:
           "connector": "odbc",
           "driver": "FreeTDS",
           "include_ao_metrics": true,  # Optional: For AlwaysOn users
-          "tags": ["service:<CUSTOM_SERVICE>", "env:<CUSTOM_ENV>"],  # Optional
+          "tags": ["service:<CUSTOM_SERVICE>", "env:<CUSTOM_ENV>"]  # Optional
         }
       ]
 spec:

--- a/layouts/shortcodes/dbm-sqlserver-agent-setup-linux.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-setup-linux.md
@@ -15,7 +15,8 @@ instances:
     password: '<PASSWORD>'
     connector: odbc
     driver: '<Driver from the `odbcinst.ini` file>'
-    tags:  # optional
+    include_ao_metrics: true  # Optional: For AlwaysOn users
+    tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
 ```

--- a/layouts/shortcodes/dbm-sqlserver-agent-setup-windows.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-setup-windows.md
@@ -11,7 +11,8 @@ instances:
     password: '<PASSWORD>'
     connector: adodbapi
     adoprovider: MSOLEDBSQL
-    tags:  # optional
+    include_ao_metrics: true  # Optional: For AlwaysOn users
+    tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updates the docs to include instructions for enabling AlwaysOn metrics. Note, Azure & GCP sections will not include it because those providers don't have an AO offering, only RDS.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
