### PR TITLE
Fixes broken front-end search components

### DIFF
--- a/assets/scripts/components/algolia.js
+++ b/assets/scripts/components/algolia.js
@@ -2,7 +2,11 @@ import docsearch from 'docsearch.js';
 import configDocs from '../config/config-docs';
 
 const { env } = document.documentElement.dataset;
-const lang = document.documentElement.lang || 'en';
+let lang = document.documentElement.lang || 'en';
+
+if (lang.toLowerCase() === 'en-us') {
+    lang = 'en'
+}
 
 // Set baseUrl based on environment
 let baseUrl = window.location.origin;

--- a/assets/scripts/components/search.js
+++ b/assets/scripts/components/search.js
@@ -15,7 +15,8 @@ const initializeAlgoliaIndex = () => {
 }
 
 const getSiteLang = () => {
-    return document.querySelector('html').lang;
+    const lang = document.querySelector('html').lang || 'en'
+    return lang.toLowerCase() === 'en-us' ? 'en' : lang
 }
 
 const getTitle = (hit) => {
@@ -404,12 +405,16 @@ const handleSearch = () => {
         const index = initializeAlgoliaIndex();
         const query = getQueryParameterByName('s', window.location.href);
 
+        console.log(index)
+        console.log(query)
+
         index.search(decodeURIComponent(query), {
             hitsPerPage: 200,
             attributesToRetrieve: ['*'],
             filters: `language:${getSiteLang()}`
         })
         .then(({ hits }) => {
+            console.log(hits)
             renderResults(query, hits);
         })
         .catch(() => {

--- a/assets/scripts/components/search.js
+++ b/assets/scripts/components/search.js
@@ -405,16 +405,12 @@ const handleSearch = () => {
         const index = initializeAlgoliaIndex();
         const query = getQueryParameterByName('s', window.location.href);
 
-        console.log(index)
-        console.log(query)
-
         index.search(decodeURIComponent(query), {
             hitsPerPage: 200,
             attributesToRetrieve: ['*'],
             filters: `language:${getSiteLang()}`
         })
         .then(({ hits }) => {
-            console.log(hits)
             renderResults(query, hits);
         })
         .catch(() => {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "@datadog/browser-logs": "^4.19.1",
         "@datadog/browser-rum": "^4.19.1",
         "a11y": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/a11y-v1.0.1.tgz",
-        "algoliasearch": "4.11.0",
+        "algoliasearch": "4.14.2",
         "bootstrap": "4.3.1",
         "del": "4.1.1",
         "docsearch.js": "^2.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,135 +5,135 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@algolia/cache-browser-local-storage@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@algolia/cache-browser-local-storage@npm:4.11.0"
+"@algolia/cache-browser-local-storage@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/cache-browser-local-storage@npm:4.14.2"
   dependencies:
-    "@algolia/cache-common": 4.11.0
-  checksum: bf06711107209b2ea7824bab80c4df60ffaf82af1a9648b417b123dea7588c9e348d1eded194dfbc693fbeaf9d3c51b78ea0300804f1383994711e58dce6b829
+    "@algolia/cache-common": 4.14.2
+  checksum: e7d5f43ff01df5f21a2b5304b5d8f8ae25f2c6093e83e79556cb78ae07f342111ba77eba633b837b5b74a17293ea6a208acb1ade71782baafa9c2da7d58ee45c
   languageName: node
   linkType: hard
 
-"@algolia/cache-common@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@algolia/cache-common@npm:4.11.0"
-  checksum: d69a0f4e1b3baeebd0cea77568ac4911f2053536be14ca7676e8c4b9d4022f9122f78ba2f24405e308af45eff8a9a1e1c17b53079bfddc5131dd94f4d6bd3064
+"@algolia/cache-common@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/cache-common@npm:4.14.2"
+  checksum: 4fd04c714aee19f6eaaac4ae7e00e914a44473af9a84cf3c4260e436c6ea20f5590e05e9006d963372d84ce57268776811fcb929d79e0415b59d74779bd31ee7
   languageName: node
   linkType: hard
 
-"@algolia/cache-in-memory@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@algolia/cache-in-memory@npm:4.11.0"
+"@algolia/cache-in-memory@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/cache-in-memory@npm:4.14.2"
   dependencies:
-    "@algolia/cache-common": 4.11.0
-  checksum: 59f788eb5590de26db97147c5a601b326071599a2b04dbaf0a636875dfc462aed86348b5d1405958a28a6b0d2a9145e848e1614b1f8d18cb886da61b996367b2
+    "@algolia/cache-common": 4.14.2
+  checksum: d6981f812a368a38db21e52c98ec81a5c0eda5d896377f7bdcc04a0be1673ac9e184836d7973065fab84dc947a63fe959586468fc14b9a87e32f916959df6222
   languageName: node
   linkType: hard
 
-"@algolia/client-account@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@algolia/client-account@npm:4.11.0"
+"@algolia/client-account@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/client-account@npm:4.14.2"
   dependencies:
-    "@algolia/client-common": 4.11.0
-    "@algolia/client-search": 4.11.0
-    "@algolia/transporter": 4.11.0
-  checksum: a35833bfedaf3d3588588c635167c6c1293b91597940d4ef897ca83203da3b9bf33990165b4bf486f663356799277076a5f31364e97397e93c666898a0985842
+    "@algolia/client-common": 4.14.2
+    "@algolia/client-search": 4.14.2
+    "@algolia/transporter": 4.14.2
+  checksum: 2e9eed5a4b8434775af87899bda8140d51eb2dd0cf08fc49370a4dc9541c220db9b241976dad14ae5d07a25f7ddafd9759a2eb462788f21a20f14e04968f98a4
   languageName: node
   linkType: hard
 
-"@algolia/client-analytics@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@algolia/client-analytics@npm:4.11.0"
+"@algolia/client-analytics@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/client-analytics@npm:4.14.2"
   dependencies:
-    "@algolia/client-common": 4.11.0
-    "@algolia/client-search": 4.11.0
-    "@algolia/requester-common": 4.11.0
-    "@algolia/transporter": 4.11.0
-  checksum: d85ccf8f51061df30336e71a85bb197e0469a5688b89ae29b28314b7af95bc6f7b7fb890895ff79d4b6a610b5bed2ce655826f893359b6e6d2056994fff017a0
+    "@algolia/client-common": 4.14.2
+    "@algolia/client-search": 4.14.2
+    "@algolia/requester-common": 4.14.2
+    "@algolia/transporter": 4.14.2
+  checksum: 61874e026c9d08dd628da443b5b34d1a3bb707a0283e727d94ee6d61057631039c5cf6303e6234cc6fbe84ff71c2758f952b664277715ca5761819aec73e7aad
   languageName: node
   linkType: hard
 
-"@algolia/client-common@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@algolia/client-common@npm:4.11.0"
+"@algolia/client-common@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/client-common@npm:4.14.2"
   dependencies:
-    "@algolia/requester-common": 4.11.0
-    "@algolia/transporter": 4.11.0
-  checksum: 791fda2cc2c8d86012b72c5e1d22bdd7a89f37a497f176e875105b55297112ac41f735e53b1980aac35b13d908b791d4de7c017a5b74e73358c46b9f728f03b3
+    "@algolia/requester-common": 4.14.2
+    "@algolia/transporter": 4.14.2
+  checksum: da2be279ac51e1b43c02c6d2bbf0d9cc8b1cb3250ad10a803fca609bcfb8164a8adc21281b599fd8aa322c04deea77d2f07adcae1a363952559472e781e26c71
   languageName: node
   linkType: hard
 
-"@algolia/client-personalization@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@algolia/client-personalization@npm:4.11.0"
+"@algolia/client-personalization@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/client-personalization@npm:4.14.2"
   dependencies:
-    "@algolia/client-common": 4.11.0
-    "@algolia/requester-common": 4.11.0
-    "@algolia/transporter": 4.11.0
-  checksum: fd9230b375f2e4635f6f5c18fd1272ab0dd83267bd644431501544679e677b9b98dfd4e42e9a735ba961f25468741f90ae8eb8a7a4458c17bff057d704e7d06c
+    "@algolia/client-common": 4.14.2
+    "@algolia/requester-common": 4.14.2
+    "@algolia/transporter": 4.14.2
+  checksum: 0dd25c84a40fe9853d14fadc3c8893e84bee370b5a3eb6730afe816afe1f92b970096d2dfb68073f606fa074fdeb66c3a73811d9a9a9774af5311f34d939fd72
   languageName: node
   linkType: hard
 
-"@algolia/client-search@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@algolia/client-search@npm:4.11.0"
+"@algolia/client-search@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/client-search@npm:4.14.2"
   dependencies:
-    "@algolia/client-common": 4.11.0
-    "@algolia/requester-common": 4.11.0
-    "@algolia/transporter": 4.11.0
-  checksum: 3e6c518a43ba9f327a338d428ba709bb78100faf107888f4500743f802e7ad384f1e7b8647f6d68e4bcca389ffb19e7f29b0d0d8af15a45df7b0eaa21da3740c
+    "@algolia/client-common": 4.14.2
+    "@algolia/requester-common": 4.14.2
+    "@algolia/transporter": 4.14.2
+  checksum: 2695bc9e8c98badb601b915dbb075dd92996af350b0e4915a7a3b7825bd45f20815534debcfcb51bb7f682ba5d09f3c41918edb36e0a7f7bb154d3b205825f65
   languageName: node
   linkType: hard
 
-"@algolia/logger-common@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@algolia/logger-common@npm:4.11.0"
-  checksum: 1b081abbf80e36bb4e43e4b30a09e31443a1b79f71096226a647f5fa2e653876f0f4215951435c7151a63b6a0537e69cfc158f573583128b2bbf148452055f8e
+"@algolia/logger-common@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/logger-common@npm:4.14.2"
+  checksum: a4000a98831d64c8d826ccece9f5f3a77bc000d93d74a7c6b51f186d3dfd96c0bb00934f70c69da8f3c4dfb9f30ce55ab59aca9ba79c3cc3e924597838a94429
   languageName: node
   linkType: hard
 
-"@algolia/logger-console@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@algolia/logger-console@npm:4.11.0"
+"@algolia/logger-console@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/logger-console@npm:4.14.2"
   dependencies:
-    "@algolia/logger-common": 4.11.0
-  checksum: 974a65e5b98c999840fbc2313d62f5ca1b466960f5641e4d407c406359d214b557a4ca619dc49247ee1fe7b23de1d32bc181048c6c7f3ee9a4fe36ceeee91932
+    "@algolia/logger-common": 4.14.2
+  checksum: 96c6209c7ef72cbc170b180f5b84c6523a5b6f4dea978c982577d2417eb19eb9c9ea3bc73089ced692a05bec141d66fd6d5401458d0aa162dbcace5017dbd127
   languageName: node
   linkType: hard
 
-"@algolia/requester-browser-xhr@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@algolia/requester-browser-xhr@npm:4.11.0"
+"@algolia/requester-browser-xhr@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/requester-browser-xhr@npm:4.14.2"
   dependencies:
-    "@algolia/requester-common": 4.11.0
-  checksum: 8e0f0a848a5df4a41415a74955c14dd9f42d8e8e1da7f5db05efbeec4f9b7e7cca1ce638624a80eed985c8cfdf59a13933821e7efc2b5b363dde5a77008370e1
+    "@algolia/requester-common": 4.14.2
+  checksum: 7d8666e21cd0d15dc2e25f6917464c2f98cf73e0d2fced94cc6a3c4e97a990b8b93d9531bbf6f3b1ff2342b9ce9760d1dcb64dbbf61a5f2c31fe4f42541deef2
   languageName: node
   linkType: hard
 
-"@algolia/requester-common@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@algolia/requester-common@npm:4.11.0"
-  checksum: d503d488c582cc126cb35076a28671aba7fcb8658f5a69995f1fd2f22bb4cc1b63de6e255791306c142877503830ab17fd7cacde6e9430c8b0b1da2e5f32ed38
+"@algolia/requester-common@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/requester-common@npm:4.14.2"
+  checksum: 7de4148a55db56fe2bf18c1359cccbc2f41031fe2bfbc945d75f143b854638c51e7ec2ef9c6dc69b38d5edb87cd096ce5d7087680da32825562db79026ea39cc
   languageName: node
   linkType: hard
 
-"@algolia/requester-node-http@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@algolia/requester-node-http@npm:4.11.0"
+"@algolia/requester-node-http@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/requester-node-http@npm:4.14.2"
   dependencies:
-    "@algolia/requester-common": 4.11.0
-  checksum: 148a2053aab568fcc8f1df2478afad20cc9a7a326a1c17ee437058a35b4904a3a606fd9b12ff22a1b6b9086350b1437f6edbb7ed9e7995f4bbaf2470263ea002
+    "@algolia/requester-common": 4.14.2
+  checksum: 5f5fe8b040f73bd95c6bdb5b97396e078b629b2b4cd93fea671d545be375c79501c65296c34824f0ff8368b5b51edc7a6ad9e694b04223c1416dcda869c6f566
   languageName: node
   linkType: hard
 
-"@algolia/transporter@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@algolia/transporter@npm:4.11.0"
+"@algolia/transporter@npm:4.14.2":
+  version: 4.14.2
+  resolution: "@algolia/transporter@npm:4.14.2"
   dependencies:
-    "@algolia/cache-common": 4.11.0
-    "@algolia/logger-common": 4.11.0
-    "@algolia/requester-common": 4.11.0
-  checksum: 650eee6c5ac7792baf7b10b63afd006ca51e62b6827a0b09b5b45d2b7af9dcf5d68dd9cdb2ffec25febe3a9e5549df0460a32f775b8efa24162b01df2b16e884
+    "@algolia/cache-common": 4.14.2
+    "@algolia/logger-common": 4.14.2
+    "@algolia/requester-common": 4.14.2
+  checksum: 72c72013f3edb4d4484e7a43fb3c2555646ab04f422249514ed0309e20f41f5563f4c4dcf5623ca64c293624ecc74f87acaf2d9820e8c829cb5de067bdfe0257
   languageName: node
   linkType: hard
 
@@ -2401,25 +2401,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"algoliasearch@npm:4.11.0":
-  version: 4.11.0
-  resolution: "algoliasearch@npm:4.11.0"
+"algoliasearch@npm:4.14.2":
+  version: 4.14.2
+  resolution: "algoliasearch@npm:4.14.2"
   dependencies:
-    "@algolia/cache-browser-local-storage": 4.11.0
-    "@algolia/cache-common": 4.11.0
-    "@algolia/cache-in-memory": 4.11.0
-    "@algolia/client-account": 4.11.0
-    "@algolia/client-analytics": 4.11.0
-    "@algolia/client-common": 4.11.0
-    "@algolia/client-personalization": 4.11.0
-    "@algolia/client-search": 4.11.0
-    "@algolia/logger-common": 4.11.0
-    "@algolia/logger-console": 4.11.0
-    "@algolia/requester-browser-xhr": 4.11.0
-    "@algolia/requester-common": 4.11.0
-    "@algolia/requester-node-http": 4.11.0
-    "@algolia/transporter": 4.11.0
-  checksum: 016f5812fcd892df962ebc4b3788443352618ea882698a15c5f0c3c6f4bb72c50754156cb960e21fa8dcfe7234f96cb4d07605b3ea930a59de9b683f16fe33bc
+    "@algolia/cache-browser-local-storage": 4.14.2
+    "@algolia/cache-common": 4.14.2
+    "@algolia/cache-in-memory": 4.14.2
+    "@algolia/client-account": 4.14.2
+    "@algolia/client-analytics": 4.14.2
+    "@algolia/client-common": 4.14.2
+    "@algolia/client-personalization": 4.14.2
+    "@algolia/client-search": 4.14.2
+    "@algolia/logger-common": 4.14.2
+    "@algolia/logger-console": 4.14.2
+    "@algolia/requester-browser-xhr": 4.14.2
+    "@algolia/requester-common": 4.14.2
+    "@algolia/requester-node-http": 4.14.2
+    "@algolia/transporter": 4.14.2
+  checksum: 4365a0d0f066f3ad6798e4dd0d7487cba1cf4546dac27e66cb84865f91955d6537dc5bad4e71d4bf22a68c0b721b1e6f20109203566ca1a252fe2713d713c0fd
   languageName: node
   linkType: hard
 
@@ -4409,7 +4409,7 @@ __metadata:
     "@datadog/datadog-ci": ^1.2.0
     a11y: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/a11y-v1.0.1.tgz"
     acorn: ^7.1.1
-    algoliasearch: 4.11.0
+    algoliasearch: 4.14.2
     bootstrap: 4.3.1
     cross-env: ^5.2.0
     del: 4.1.1


### PR DESCRIPTION
### What does this PR do?
Fixes broken front end search components which broke due to the `lang` html attribute changing from `en` to `en-US`.

### Motivation
Search results always empty for english users

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/broken-search

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
