### PR TITLE
Updates site language logic for algolia environments

### DIFF
--- a/assets/scripts/components/algolia.js
+++ b/assets/scripts/components/algolia.js
@@ -2,10 +2,11 @@ import docsearch from 'docsearch.js';
 import configDocs from '../config/config-docs';
 
 const { env } = document.documentElement.dataset;
-let lang = document.documentElement.lang || 'en';
+let lang = document.documentElement.lang.toLowerCase() || 'en-us';
 
-if (lang.toLowerCase() === 'en-us') {
-    lang = 'en'
+// Todo: Remove this after the staging algolia index has been updated.
+if (env !== 'live') {
+    lang = lang === 'en-us' ? 'en' : lang
 }
 
 // Set baseUrl based on environment

--- a/assets/scripts/components/search.js
+++ b/assets/scripts/components/search.js
@@ -15,8 +15,14 @@ const initializeAlgoliaIndex = () => {
 }
 
 const getSiteLang = () => {
-    const lang = document.querySelector('html').lang || 'en'
-    return lang.toLowerCase() === 'en-us' ? 'en' : lang
+    const siteEnv = document.querySelector('html').dataset.env
+    const lang = document.querySelector('html').lang.toLowerCase() || 'en-us'
+
+    if (siteEnv === 'live') {
+        return lang
+    }
+
+    return lang === 'en-us' ? 'en' : lang
 }
 
 const getTitle = (hit) => {


### PR DESCRIPTION
### What does this PR do?
Fixes frontend search.   Previously we used `en` as the english language facet when querying.   The previous change told our frontend search to look for that, however after the algolia indexing job finished it had scraped the html `lang` attribute and updated all records to match `en-us`.

The staging index will need to be updated so all indexes use `en-us`

### Motivation
Broken search.

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/broken-search-2

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
