### PR TITLE
Fixes log collection with custom tags on K8s

### DIFF
--- a/content/en/containers/kubernetes/log.md
+++ b/content/en/containers/kubernetes/log.md
@@ -398,7 +398,7 @@ You can customize logs collection per integration within `confd`. This method mo
 {{< tabs >}}
 {{% tab "Kubernetes" %}}
 
-The following pod annotation defines the integration template for `redis` containers with a custom `password` parameter and tags all its logs with the correct `source` and `service` attributes, including custom tags.
+The following pod annotation defines the integration template for `redis` containers with a custom `password` parameter and tags all its logs with the correct `source` and `service` attributes, including custom tags :
 
 ```yaml
 apiVersion: v1
@@ -406,7 +406,7 @@ kind: Pod
 metadata:
   name: redis
   annotations:
-    ad.datadoghq.com/redis.logs: '[{"source":"redis","service":"redis","tags":"env:prod"}]'
+    ad.datadoghq.com/redis.logs: '[{"source": "redis","service": "redis","tags": ["env:prod"]}]'
   labels:
     name: redis
 spec:
@@ -420,7 +420,7 @@ spec:
 {{% /tab %}}
 {{% tab "ConfigMap" %}}
 
-The following ConfigMap defines the integration template for `redis` containers with the `source` and `service` attributes for collecting logs:
+The following ConfigMap defines the integration template for `redis` containers with the `source` and `service` attributes for collecting logs and tags all its logs with the correct `source` and `service` attributes, including custom tags :
 
 ```yaml
 kind: ConfigMap
@@ -434,9 +434,10 @@ data:
       - redis
       - redis-test
     logs:
-      source: redis
-      service: redis
-      tags: env:prod
+      - source: redis
+        service: redis
+        tags:
+          - env:prod
 ```
 
 In the manifest, define the `volumeMounts` and `volumes`:
@@ -466,7 +467,7 @@ The following etcd commands create a Redis integration template with a custom `p
 
 ```conf
 etcdctl mkdir /datadog/check_configs/redis
-etcdctl set /datadog/check_configs/redis/logs '[{"source": "redis", "service": "redis", "tags": "env:prod"}]'
+etcdctl set /datadog/check_configs/redis/logs '[{"source": "redis", "service": "redis", "tags": ["env:prod"]}]'
 ```
 
 Notice that each of the three values is a list. Autodiscovery assembles list items into the integration configurations based on shared list indexes. In this case, it composes the first (and only) check configuration from `check_names[0]`, `init_configs[0]` and `instances[0]`.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->


### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* Slightly alters https://github.com/DataDog/documentation/pull/15600 to use the correct syntax to collect logs with custom tags
* Modifies `tags` entry to be a proper list (`.yaml`) or an array (JSON annotations) to ensure the Agent understands the syntax

### Motivation
<!-- What inspired you to submit this pull request?-->
* Following a call with a customer, I found out the documentation was recently updated with a slight syntax typo, which causes the annotations to be ignored, and thus logs not to be collected

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
