### PR TITLE
Updates algolia preview logic

### DIFF
--- a/assets/scripts/components/algolia.js
+++ b/assets/scripts/components/algolia.js
@@ -2,12 +2,7 @@ import docsearch from 'docsearch.js';
 import configDocs from '../config/config-docs';
 
 const { env } = document.documentElement.dataset;
-let lang = document.documentElement.lang.toLowerCase() || 'en-us';
-
-// Todo: Remove this after the staging algolia index has been updated.
-if (env !== 'live') {
-    lang = lang === 'en-us' ? 'en' : lang
-}
+const lang = document.documentElement.lang.toLowerCase() || 'en-us';
 
 // Set baseUrl based on environment
 let baseUrl = window.location.origin;

--- a/assets/scripts/components/search.js
+++ b/assets/scripts/components/search.js
@@ -15,14 +15,7 @@ const initializeAlgoliaIndex = () => {
 }
 
 const getSiteLang = () => {
-    const siteEnv = document.querySelector('html').dataset.env
-    const lang = document.querySelector('html').lang.toLowerCase() || 'en-us'
-
-    if (siteEnv === 'live') {
-        return lang
-    }
-
-    return lang === 'en-us' ? 'en' : lang
+    return document.querySelector('html').lang.toLowerCase() || 'en-us'
 }
 
 const getTitle = (hit) => {


### PR DESCRIPTION
### What does this PR do?
Following up on #15803, this updates the front-end search for preview sites to look for `en-us` as the language identifier for english when querying Algolia.   At this time the approach should be consistent for both preview and live environments.

### Motivation
Preview and live environments inconsistent in how they handle querying Algolia on the front end.

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/algolia-preview-update

searching should work correctly from the homepage/sidenav as well as search page itself.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
