### PR TITLE
[WEB-2831] Ignore api v1 and v2 directories from translation pipeline

### DIFF
--- a/translate.yaml
+++ b/translate.yaml
@@ -14,6 +14,8 @@ ignores:
   - "content/en/security_monitoring/default_rules/*.md"
   - "content/en/integrations/rapdev_services.md"
   - "content/en/workflows/actions_catalog/*.md"
+  - "content/en/api/v1/**/*.md"
+  - "content/en/api/v2/**/*.md"
   - "**/*.fr.md"
   - "**/*.fr.yaml"
   - "**/*.fr.json"


### PR DESCRIPTION
### What does this PR do?
Ignores `api/v1` and `api/v2` content from the translation pipeline.   These pages are currently in Transifex, but they don't reflect any content that exists on the site (the live content is all under `api/latest`, these pages are headless ), and only the document title is ever sent to Transifex.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2831

### Preview
n/a, translation config change only

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
