### PR TITLE
Fix default sampling rate for Android & iOS SDKs

### DIFF
--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -99,7 +99,7 @@ Use frontend data from RUM, as well as backend, infrastructure, and log informat
 
     By default, all subdomains of listed hosts are traced. For instance, if you add `example.com`, you also enable the tracing for `api.example.com` and `foo.example.com`.
 
-3.  _(Optional)_ Configure the `traceSamplingRate` parameter to keep a defined percentage of the backend traces. If not set, 100% of the traces coming from application requests are sent to Datadog. To keep 20% of backend traces:
+3.  _(Optional)_ Configure the `traceSamplingRate` parameter to keep a defined percentage of the backend traces. If not set, 20% of the traces coming from application requests are sent to Datadog. To keep 100% of backend traces:
 
 ```java
     val okHttpClient = OkHttpClient.Builder()
@@ -146,15 +146,15 @@ Use frontend data from RUM, as well as backend, infrastructure, and log informat
 
    Trace ID injection works when you are providing a `URLRequest` to the `URLSession`. Distributed tracing does not work when you are using a `URL` object.
 
-5. _(Optional)_ Set the `tracingSamplingRate` initialization parameter to keep a defined percentage of the backend traces. If not set, 100% of the traces coming from application requests are sent to Datadog.
+5. _(Optional)_ Set the `tracingSamplingRate` initialization parameter to keep a defined percentage of the backend traces. If not set, 20% of the traces coming from application requests are sent to Datadog.
 
-     To keep 20% of backend traces:
+     To keep 100% of backend traces:
     ```swift
     Datadog.initialize(
         appContext: .init(),
         configuration: Datadog.Configuration
             .builderUsing(rumApplicationID: "<rum_app_id>", clientToken: "<client_token>", environment: "<env_name>")
-            .set(tracingSamplingRate: 20)
+            .set(tracingSamplingRate: 100)
             .build()
     )
     ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Mobile SDKs are currently setting the tracing sampling rate default value to 20%, not 100% as is stated.  Also changed the examples to show how to configure to 100%.

### Motivation
Incorrect information. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
