### PR TITLE
fixed links right before headers not being clickable [WEB-2828]

### DIFF
--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -376,6 +376,7 @@ h5 {
         h3,
         h4,
         h5 {
+            pointer-events: none;
             &:before {
                 margin-top: -110px;
                 height: 110px;
@@ -551,7 +552,7 @@ h5 {
     & > ul {
         list-style-type: none;
         padding-top: 6px;
-        
+
         li {
             padding-bottom: 6px;
 

--- a/content/en/containers/docker/_index.md
+++ b/content/en/containers/docker/_index.md
@@ -49,8 +49,6 @@ The CLI commands on this page are for the Docker runtime. Replace `docker` with 
 
 If you haven’t installed the Docker Agent, follow the [in-app installation instructions][8] or see below. For [supported versions][9], see the Agent documentation. Use the one-step install command. Replace `<YOUR_DATADOG_API_KEY>` with your [Datadog API key][10].
 
-**Note**: For Docker Compose, see [Compose and the Datadog Agent][11].
-
 {{< tabs >}}
 {{% tab "Standard" %}}
 
@@ -125,6 +123,8 @@ docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v
 
 {{% /tab %}}
 {{< /tabs >}}
+
+**Note**: For Docker Compose, see [Compose and the Datadog Agent][11].
 
 ## Integrations
 


### PR DESCRIPTION
### What does this PR do?

Links that were placed right before a header in the body content were not clickable. This is because of the margin/padding hack that allows headers visited via hashes to their ID to show up below the sticky navbar, which extends the height of the header over the top of content that comes right before it.

The solution was to make the header pass through click events so as not to block the links. This works without breaking the links in the headers themselves.

### Motivation

Fix for reported issue in https://datadoghq.atlassian.net/browse/WEB-2828

### Preview

I've moved the link in question from [this previous preview branch](https://docs-staging.datadoghq.com/jorie/DOCS-4241/containers/docker/?tab=standard#setup) back to that location so you can see that it's working. The link in question is the one in the paragraph right before the Integrations header.

https://docs-staging.datadoghq.com/fitzage/link-before-header-fix/containers/docker/?tab=standard#setup

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
