### PR TITLE
Adding note to OAuth docs

### DIFF
--- a/content/en/developers/authorization/oauth2_in_datadog.md
+++ b/content/en/developers/authorization/oauth2_in_datadog.md
@@ -60,6 +60,8 @@ When kicking off authorization from a third-party location—anywhere outside of
 
 To ensure that users are authorizing in the correct site, always direct them to the US1 Datadog site (`app.datadoghq.com`), and from there, they can select their region. Once the authorization flow is complete, ensure that all followup API calls use the correct site that is returned as a query parameter with the `redirect_uri` (See Step 5 in [Implement the OAuth protocol](#Implement-the-oauth-protocol)).
 
+When users initiate authorization from within the Datadog integration tile, they are required to have corresponding permissions for all requested scopes. If authorization is initiated from somewhere other than the integration tile, users without all of the required permissions may complete authorization (but will be prompted to re-authorize with proper permissions when returning to the integration tile). To avoid this, users should be routed from third-party platforms to the Datadog tile to begin authorization. 
+
 ## Authorization code grant flow with PKCE
 
 While the OAuth2 protocol supports several grant flows, the [authorization code grant flow][8] [with PKCE](#authorization-code-grant-flow-with-pkce) is the recommended grant type for long-running applications where a user grants explicit consent once and client credentials can be securely stored. 

--- a/content/en/developers/authorization/oauth2_in_datadog.md
+++ b/content/en/developers/authorization/oauth2_in_datadog.md
@@ -60,7 +60,7 @@ When kicking off authorization from a third-party location—anywhere outside of
 
 To ensure that users are authorizing in the correct site, always direct them to the US1 Datadog site (`app.datadoghq.com`), and from there, they can select their region. Once the authorization flow is complete, ensure that all followup API calls use the correct site that is returned as a query parameter with the `redirect_uri` (See Step 5 in [Implement the OAuth protocol](#Implement-the-oauth-protocol)).
 
-When users initiate authorization from within the Datadog integration tile, they are required to have corresponding permissions for all requested scopes. If authorization is initiated from somewhere other than the integration tile, users without all of the required permissions may complete authorization (but will be prompted to re-authorize with proper permissions when returning to the integration tile). To avoid this, users should be routed from third-party platforms to the Datadog tile to begin authorization. 
+When users initiate authorization from the Datadog integration tile, they are required to have corresponding permissions for all requested scopes. If authorization is initiated from somewhere other than the integration tile, users without all of the required permissions may complete authorization (but are prompted to re-authorize with proper permissions when returning to the integration tile). To avoid this, users should be routed from third-party platforms to the Datadog integration tile to begin authorization. 
 
 ## Authorization code grant flow with PKCE
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updating the OAuth docs to include a note about authorizing from outside of the Datadog integration tile. 

### Motivation
<!-- What inspired you to submit this pull request?-->
A partner ran into this issue.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
