### PR TITLE
Mention configurable Temporality of OTEL with direct Datadog Agent integration

### DIFF
--- a/content/en/metrics/open_telemetry/otlp_metric_types.md
+++ b/content/en/metrics/open_telemetry/otlp_metric_types.md
@@ -32,6 +32,8 @@ A single OTLP metric may be mapped to several Datadog metrics with a suffix indi
 
 **Note**: OpenTelemetry provides metric API instruments (`Gauge`, `Counter`, `UpDownCounter`, `Histogram`, and so on), whose measurements can be exported as OTLP metrics (Sum, Gauge, Histogram). Other sources for OTLP metrics are possible. Applications and libraries may provide customization into the OTLP metrics they produce. Read the documentation of your OpenTelemetry SDK or OTLP-producing application to understand the OTLP metrics produced and how to customize them.
 
+**Note**: OpenTelemetry protocol supports two different ways of representing metrics in time - [Cumulative and Delta temporality](https://opentelemetry.io/docs/reference/specification/metrics/data-model/#temporality). Detailed behavior of different metric types affected by temporality configuration is described below. We **recommend setting the temporality preference** of the OTEL implementation to **DELTA** as CUMULATIVE configuration may discard some data points during application (or collector) startup.  
+
 ## Metric types
 
 ### Mapping

--- a/content/en/metrics/open_telemetry/otlp_metric_types.md
+++ b/content/en/metrics/open_telemetry/otlp_metric_types.md
@@ -32,7 +32,7 @@ A single OTLP metric may be mapped to several Datadog metrics with a suffix indi
 
 **Note**: OpenTelemetry provides metric API instruments (`Gauge`, `Counter`, `UpDownCounter`, `Histogram`, and so on), whose measurements can be exported as OTLP metrics (Sum, Gauge, Histogram). Other sources for OTLP metrics are possible. Applications and libraries may provide customization into the OTLP metrics they produce. Read the documentation of your OpenTelemetry SDK or OTLP-producing application to understand the OTLP metrics produced and how to customize them.
 
-**Note**: OpenTelemetry protocol supports two different ways of representing metrics in time - [Cumulative and Delta temporality](https://opentelemetry.io/docs/reference/specification/metrics/data-model/#temporality). Detailed behavior of different metric types affected by temporality configuration is described below. We **recommend setting the temporality preference** of the OTEL implementation to **DELTA** as CUMULATIVE configuration may discard some data points during application (or collector) startup.  
+**Note**: OpenTelemetry protocol supports two ways of representing metrics in time: [Cumulative and Delta temporality][2], affecting the metrics described below. Set the temporality preference of the OTel implementation to **DELTA**, because setting it to CUMULATIVE may discard some data points during application (or collector) startup.  
 
 ## Metric types
 
@@ -216,3 +216,4 @@ Suppose you are submitting a legacy OTLP Summary metric, `request.response_time.
 
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#resource-detection-processor
+[2]: https://opentelemetry.io/docs/reference/specification/metrics/data-model/#temporality


### PR DESCRIPTION
The default behavior of most OTEL SDK implementations is CUMULATIVE temporality. This is very unexpected in comparison with default Datadog implementation as the first reported datapoints of some Metric types are "discarded". The OTLP standard allows to configure the temporality to DELTA which works optimally with Datadog yet it's not mentioned in the documentation

### Additional Notes
<!-- Anything else we should know when reviewing?-->
We got stuck on this for a few days to find out that it's just OTEL configuration. I'm not sure if this is the best place to mention it but I'd love to see it in the Datadog documentation.
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
