### PR TITLE
Update Jenkins infra metrics correlation instructions for K8s

### DIFF
--- a/content/en/continuous_integration/pipelines/jenkins.md
+++ b/content/en/continuous_integration/pipelines/jenkins.md
@@ -160,6 +160,8 @@ export DD_CI_HOSTNAME=my-hostname
 export DD_CI_HOSTNAME=$HOSTNAME
 ```
 
+If you are using Kubernetes to manage your Jenkins instances, add the `DD_CI_HOSTNAME` environment variable to the [pod that executes the Jenkins job][9]. The value of this environment variable will depend on what you are using in your Datadog Agent daemonset when reporting the infrastructure metrics.
+
 This is only required for Jenkins workers. For the Jenkins controller, the infrastructure metric correlation does not require additional actions.
 
 **Note**: Infrastructure metric correlation is supported since Jenkins Plugin v5.0.0+
@@ -616,3 +618,4 @@ Failed to reinitialize Datadog-Plugin Tracer, Cannot enable traces collection vi
 [6]: /agent/guide/agent-commands/?tab=agentv6v7#restart-the-agent
 [7]: https://app.datadoghq.com/ci/pipelines
 [8]: https://app.datadoghq.com/ci/pipeline-executions
+[9]: https://plugins.jenkins.io/kubernetes/#plugin-content-pod-template


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR updates the Jenkins infra metrics correlation instructions for CI Visibility if the user uses K8s to run the Jenkins instances.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
