### PR TITLE
[CI Visibility] Adapt CI monitors documentation for GA

### DIFF
--- a/content/en/monitors/create/types/ci.md
+++ b/content/en/monitors/create/types/ci.md
@@ -141,11 +141,12 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 
 #### Notifications behavior when there is no data
 
-A monitor that uses an event count for its evaluation query after the specified period with no data will evaluate to 0, potentially resolving immediately.
+A monitor that uses an event count for its evaluation query will resolve after the specified evaluation period with no data, triggering a notification. For example, a monitor configured to alert on the number of pipeline errors with an evaluation window of five minutes will automatically resolve after five minutes without any pipeline executions.
 
-In this case Datadog recommends using a formula like `(number of failures)/(number of all events)`, because if `(number of all events) = 0`, the division `x/0` cannot be evaluated and the monitor will keep the last known state.
+As an alternative, Datadog recommends using rate formulas. For example, instead of using a monitor on the number of pipeline failures (count), use a monitor on the rate of pipeline failures (formula), such as `(number of pipeline failures)/(number of all pipeline executions)`. In this case, when there's no data, the denominator `(number of all pipeline executions)` will be `0`, making the division `x/0` impossible to evaluate. The monitor will keep the previous known state instead of evaluating it to `0`.
 
-For example, use a monitor on pipeline error rate rather than on pipeline error count.
+This way, if the monitor triggers because there's a burst of pipeline failures that makes the error rate go above the monitor threshold, it will not clear until the error rate goes below the threshold, which can be at any time afterwards.
+
 
 ## Further Reading
 

--- a/content/en/monitors/create/types/ci.md
+++ b/content/en/monitors/create/types/ci.md
@@ -141,19 +141,11 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 
 #### Notifications behavior when there is no data
 
-A monitor that uses an event count for its evaluation query will resolve after the specified evaluation period with no data, triggering a notification. For example, a monitor on pipeline error count with an evaluation window of five minutes will automatically resolve after five minutes without any data.
+A monitor that uses an event count for its evaluation query after the specified  period with no data will evaluate to 0, potentially resolving immediately.
 
-As CI pipeline data is usually sparse and can have relatively long periods with no data, this can result in monitor recovery notifications that might not be desired.
+In this case Datadog recommends using a formula like `(number of failures)/(number of all events)`, because if `(number of all events) = 0`, the division `x/0` cannot be evaluated and the monitor will keep the last known state.
 
-In these cases, Datadog recommends configuring the monitor notification to trigger only for alerts by wrapping the full message with the `{{#is_alert}}` and `{{/is_alert}}` directives.
-
-```text
-{{#is_alert}}
-This notification will only be sent for monitor alerts!
-{{/is_alert}}
-```
-
-**Note**: A monitor that uses a formula for its evaluation query will keep the last state (for example, **Alert**) if there is no data by default.
+For example, use a monitor on pipeline error rate rather than on pipeline error count.
 
 ## Further Reading
 

--- a/content/en/monitors/create/types/ci.md
+++ b/content/en/monitors/create/types/ci.md
@@ -103,8 +103,6 @@ The following example is a test error rate monitor using a formula that calculat
 
 {{< img src="monitors/monitor_types/ci_tests/define-the-search-query-fnf.png" alt="Monitor being defined with steps a, b, and c, where steps a and b are queries and step c calculates the rate from them." style="width:80%;" >}}
 
-<div class="alert alert-info"><strong>Note</strong>: A maximum of two queries can be used to build the evaluation formula per monitor.</div>
-
 #### Using CODEOWNERS for notifications
 
 You can send the notification to different teams using the `CODEOWNERS` information available in the test event.

--- a/content/en/monitors/create/types/ci.md
+++ b/content/en/monitors/create/types/ci.md
@@ -20,9 +20,6 @@ further_reading:
 <div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-<div class="alert alert-info">CI monitors are in alpha.
-</div>
-
 ## Overview
 
 Once [CI Visibility is enabled][1] for your organization, you can create a CI Pipeline or CI Test monitor.
@@ -110,7 +107,7 @@ The following example is a test error rate monitor using a formula that calculat
 
 #### Using CODEOWNERS for notifications
 
-You can send the notification to different teams using the `CODEOWNERS` information available in the test event. 
+You can send the notification to different teams using the `CODEOWNERS` information available in the test event.
 
 The example below configures the notification with the following logic:
 * If the test code owner is `MyOrg/my-team`, then send the notification to the `my-team-channel` Slack channel.
@@ -146,7 +143,7 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 
 #### Notifications behavior when there is no data
 
-A monitor that uses an event count, or a formula for its evaluation query will resolve after the specified evaluation period with no data, triggering a notification. For example, a monitor using a formula to alert on pipeline error rate with an evaluation window of five minutes will automatically resolve after five minutes without any data.
+A monitor that uses an event count for its evaluation query will resolve after the specified evaluation period with no data, triggering a notification. For example, a monitor on pipeline error count with an evaluation window of five minutes will automatically resolve after five minutes without any data.
 
 As CI pipeline data is usually sparse and can have relatively long periods with no data, this can result in monitor recovery notifications that might not be desired.
 
@@ -157,6 +154,8 @@ In these cases, Datadog recommends configuring the monitor notification to trigg
 This notification will only be sent for monitor alerts!
 {{/is_alert}}
 ```
+
+**Note**: A monitor that uses a formula for its evaluation query will keep the last state (e.g. Alert) if there is no data.
 
 ## Further Reading
 

--- a/content/en/monitors/create/types/ci.md
+++ b/content/en/monitors/create/types/ci.md
@@ -153,7 +153,7 @@ This notification will only be sent for monitor alerts!
 {{/is_alert}}
 ```
 
-**Note**: A monitor that uses a formula for its evaluation query will keep the last state (e.g. Alert) if there is no data by default.
+**Note**: A monitor that uses a formula for its evaluation query will keep the last state (for example, **Alert**) if there is no data by default.
 
 ## Further Reading
 

--- a/content/en/monitors/create/types/ci.md
+++ b/content/en/monitors/create/types/ci.md
@@ -141,7 +141,7 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 
 #### Notifications behavior when there is no data
 
-A monitor that uses an event count for its evaluation query after the specified  period with no data will evaluate to 0, potentially resolving immediately.
+A monitor that uses an event count for its evaluation query after the specified period with no data will evaluate to 0, potentially resolving immediately.
 
 In this case Datadog recommends using a formula like `(number of failures)/(number of all events)`, because if `(number of all events) = 0`, the division `x/0` cannot be evaluated and the monitor will keep the last known state.
 

--- a/content/en/monitors/create/types/ci.md
+++ b/content/en/monitors/create/types/ci.md
@@ -155,7 +155,7 @@ This notification will only be sent for monitor alerts!
 {{/is_alert}}
 ```
 
-**Note**: A monitor that uses a formula for its evaluation query will keep the last state (e.g. Alert) if there is no data.
+**Note**: A monitor that uses a formula for its evaluation query will keep the last state (e.g. Alert) if there is no data by default.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

We're releasing CI monitors to GA, in this PR removing `Alpha` section, and updating the notification section up to date.

JIRA issue: https://datadoghq.atlassian.net/browse/CIAPP-5265

### Motivation
<!-- What inspired you to submit this pull request?-->
CI monitors GA.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
