### PR TITLE
[CI Visibility] Changing note on GH comments for GHA triggered by pull_request* events

### DIFF
--- a/content/en/continuous_integration/guides/pull_request_comments.md
+++ b/content/en/continuous_integration/guides/pull_request_comments.md
@@ -10,7 +10,9 @@ kind: guide
 Datadog integrates with GitHub to show test result summaries and error messages for failed tests in pull request comments.
 
 ### Compatibility
-This integration is only available for test services hosted on `github.com`. It is also unavailable for workflows running on `pull_request` triggers.
+This integration is only available for test services hosted on `github.com`.
+
+<div class="alert alert-info"><strong>Note</strong>: The integration is not currently available for GitHub Actions when triggered by the <code>pull_request*</code> event. </div>
 
 {{< img src="ci/github_comments_light.png" alt="Datadog GitHub pull request comment preview" style="width:100%;">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Changing note on GH comments for GHA triggered by `pull_request*` events

### Motivation
<!-- What inspired you to submit this pull request?-->
Clarifying the current state of Github Coments

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
