### PR TITLE
[CIAPP-5225] Add information about flaky facets in Test Runs page.

### DIFF
--- a/content/en/continuous_integration/guides/flaky_test_management.md
+++ b/content/en/continuous_integration/guides/flaky_test_management.md
@@ -40,15 +40,13 @@ These are tests that exhibit flaky behavior and didn’t previously exist in the
 ### Test Runs page
 
 1. Navigate to the [Test Runs][1] page.
-2. In the facets list on the left sidebar, in the **Test** section, expand the **New Flaky** facet and check `true`.
+2. In the facets list on the left sidebar, expand the **New Flaky** facet in the **Test** section, and check `true`.
 All test runs that exhibited flakiness behavior for the first time as per the definition above are displayed.
 
 ### Branches page
 
 1. On the [Tests][2] page, select the **Branches** view.
-
 2. Filter the table to see branches, services, or commits of interest to you.
-
 3. Look at the **New Flaky** column to see the number of new flaky tests introduced by the latest commit as per the definition above.
 
 #### Ignore new flaky tests detected by mistake
@@ -66,16 +64,14 @@ Known flaky failed tests are tests that have flaky behavior on the current or de
 ### Test Runs page
 
 1. Navigate to the [Test Runs][1] page.
-2. In the facets list on the left sidebar, in the **Test** section, expand the **Known Flaky** facet and check `true`.
+2. In the facets list on the left sidebar, expand the **Known Flaky** facet in the **Test** section, and check `true`.
 Failed test runs that were known to be flaky as per the definition above are displayed.
 
 
 ### Branches page
 
 1. On the [Tests][2] page, select the **Branches** view.
-
 2. Filter the table to see any branches, services, or commits of interest.
-
 3. The **Failed** column contains the number of failed tests and known flaky failed tests in the latest commit.
 
 {{< img src="ci/known-flaky-failed-tests.png" alt="CI Tests Branches view with a branch selected and a text box in the Failed column displaying 1 tests failed and 1 known flaky" style="width:100%;">}}

--- a/content/en/continuous_integration/guides/flaky_test_management.md
+++ b/content/en/continuous_integration/guides/flaky_test_management.md
@@ -37,14 +37,15 @@ If a flaky test has not failed in the past 30 days, it is automatically removed 
 
 These are tests that exhibit flaky behavior and didn’t previously exist in the Flaky Tests table for the current branch or default branch of the repository.
 
-### In the Test Runs page
+### Test Runs page
 
-1. In the facets list on the left sidebar, in the "Test" section, expand the "New Flaky" facet and check `true`
-2. This displays all test runs that exhibited flakiness behavior for the first time as per the definition above.
+1. Navigate to the [Test Runs][1] page.
+2. In the facets list on the left sidebar, in the **Test** section, expand the **New Flaky** facet and check `true`.
+All test runs that exhibited flakiness behavior for the first time as per the definition above are displayed.
 
-### In the Branches page
+### Branches page
 
-1. On the Tests page, select the **Branches** view.
+1. On the [Tests][2] page, select the **Branches** view.
 
 2. Filter the table to see branches, services, or commits of interest to you.
 
@@ -62,18 +63,22 @@ Click on the **New Flaky** number and then click **Ignore flaky tests**.
 
 Known flaky failed tests are tests that have flaky behavior on the current or default branch of the repository.
 
-### In the Test Runs page
+### Test Runs page
 
-1. In the facets list on the left sidebar, in the "Test" section, expand the "Known Flaky" facet and check `true`
-2. Failed test runs that were known to be flaky as per the definition above are displayed.
+1. Navigate to the [Test Runs][1] page.
+2. In the facets list on the left sidebar, in the **Test** section, expand the **Known Flaky** facet and check `true`.
+Failed test runs that were known to be flaky as per the definition above are displayed.
 
 
-### In the Branches page
+### Branches page
 
-1. On the Tests page, select the **Branches** view.
+1. On the [Tests][2] page, select the **Branches** view.
 
 2. Filter the table to see any branches, services, or commits of interest.
 
 3. The **Failed** column contains the number of failed tests and known flaky failed tests in the latest commit.
 
 {{< img src="ci/known-flaky-failed-tests.png" alt="CI Tests Branches view with a branch selected and a text box in the Failed column displaying 1 tests failed and 1 known flaky" style="width:100%;">}}
+
+[1]: https://app.datadoghq.com/ci/test-runs
+[2]: https://app.datadoghq.com/ci/test-services

--- a/content/en/continuous_integration/guides/flaky_test_management.md
+++ b/content/en/continuous_integration/guides/flaky_test_management.md
@@ -35,13 +35,22 @@ If a flaky test has not failed in the past 30 days, it is automatically removed 
 
 ## Watch for new flaky tests
 
+These are tests that exhibit flaky behavior and didn’t previously exist in the Flaky Tests table for the current branch or default branch of the repository.
+
+### In the Test Runs page
+
+1. In the facets list on the left sidebar, in the "Test" section, expand the "New Flaky" facet and check `true`
+2. This displays all test runs that exhibited flakiness behavior for the first time as per the definition above.
+
+### In the Branches page
+
 1. On the Tests page, select the **Branches** view.
 
 2. Filter the table to see branches, services, or commits of interest to you.
 
-3. Look at the **New Flaky** column to see the number of new flaky tests introduced by the latest commit. These are tests that exhibit flaky behavior and didn’t previously exist in the **Flaky Tests** table for the current branch or default branch of the repository.
+3. Look at the **New Flaky** column to see the number of new flaky tests introduced by the latest commit as per the definition above.
 
-### Ignore new flaky tests detected by mistake
+#### Ignore new flaky tests detected by mistake
 
 You can ignore new flaky tests for a particular commit if you determine that those flaky tests were detected by mistake. The tests reappear if the commit exhibits flakiness again.
 
@@ -51,10 +60,20 @@ Click on the **New Flaky** number and then click **Ignore flaky tests**.
 
 ## Watch for known flaky failed tests
 
+Known flaky failed tests are tests that have flaky behavior on the current or default branch of the repository.
+
+### In the Test Runs page
+
+1. In the facets list on the left sidebar, in the "Test" section, expand the "Known Flaky" facet and check `true`
+2. Failed test runs that were known to be flaky as per the definition above are displayed.
+
+
+### In the Branches page
+
 1. On the Tests page, select the **Branches** view.
 
 2. Filter the table to see any branches, services, or commits of interest.
 
-3. The **Failed** column contains the number of failed tests and known flaky failed tests in the latest commit. Known flaky failed tests are tests that have flaky behavior on the current or default branch of the repository.
+3. The **Failed** column contains the number of failed tests and known flaky failed tests in the latest commit.
 
 {{< img src="ci/known-flaky-failed-tests.png" alt="CI Tests Branches view with a branch selected and a text box in the Failed column displaying 1 tests failed and 1 known flaky" style="width:100%;">}}

--- a/content/en/continuous_integration/guides/flaky_test_management.md
+++ b/content/en/continuous_integration/guides/flaky_test_management.md
@@ -41,7 +41,7 @@ These are tests that exhibit flaky behavior and didn’t previously exist in the
 
 1. Navigate to the [Test Runs][1] page.
 2. In the facets list on the left sidebar, expand the **New Flaky** facet in the **Test** section, and check `true`.
-All test runs that exhibited flakiness behavior for the first time as per the definition above are displayed.
+All test runs that exhibited flakey behavior for the first time as per the definition above are displayed.
 
 ### Branches page
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This PR adds documentation for a new feature: we are adding `new_flaky` and `known_flaky` attributes to test runs, and this PR adds ways to find relevant test runs for both facets.

### Motivation

We need to document that change so that customers are aware.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
