### PR TITLE
API page updates.

### DIFF
--- a/assets/scripts/build-api-pages.js
+++ b/assets/scripts/build-api-pages.js
@@ -6,7 +6,6 @@ const marked = require('marked');
 const slugify = require('slugify');
 const $RefParser = require('@apidevtools/json-schema-ref-parser');
 const safeJsonStringify = require('safe-json-stringify');
-
 const supportedLangs = ['en'];
 
 /**

--- a/assets/scripts/build-api-pages.js
+++ b/assets/scripts/build-api-pages.js
@@ -129,6 +129,7 @@ const createPages = (apiYaml, deref, apiVersion) => {
 
     // create markdown containing summary and description for each endpoint
     // this is for compiling the algolia search index, it is not used for rendering content.
+    // api page content is controlled by layout in most cases.
     const data = Object.keys(deref.paths)
       .filter((path) => isTagMatch(deref.paths[path], tag.name))
       .map((path) => deref.paths[path]);

--- a/assets/scripts/build-api-pages.js
+++ b/assets/scripts/build-api-pages.js
@@ -1005,6 +1005,7 @@ const processSpecs = (specs) => {
 
 const init = () => {
   const specs = ['./data/api/v1/full_spec.yaml', './data/api/v2/full_spec.yaml'];
+  console.info('Building Api Pages now******************')
   processSpecs(specs);
 };
 

--- a/assets/scripts/build-api-pages.js
+++ b/assets/scripts/build-api-pages.js
@@ -126,24 +126,21 @@ const createPages = (apiYaml, deref, apiVersion) => {
 
     // create a copy in /latest/
     indexYamlStr = yaml.safeDump(baseFrontMatter);
-    indexYamlStr = `---\n${indexYamlStr}---\n`;
+    indexYamlStr = `---\n${indexYamlStr}---\n${tag.description}\n\n`;
 
     // create markdown containing summary and description for each endpoint
-    // this is for compiling the search index, it is not used for rendering content.
-    if (tag.name === 'CI Visibility Tests') {
-      // just get this sections data
-      const data = Object.keys(deref.paths)
-        .filter((path) => isTagMatch(deref.paths[path], tag.name))
-        .map((path) => deref.paths[path]);
+    // this is for compiling the algolia search index, it is not used for rendering content.
+    const data = Object.keys(deref.paths)
+      .filter((path) => isTagMatch(deref.paths[path], tag.name))
+      .map((path) => deref.paths[path]);
 
-      data.forEach((actionObj) => {
-        Object.entries(actionObj).forEach(([actionKey, action]) => {
-          const { summary, description } = action
+    data.forEach((actionObj) => {
+      Object.entries(actionObj).forEach(([actionKey, action]) => {
+        const { summary, description } = action
 
-          indexYamlStr += `## ${summary}\n\n${description}\n\n`
-        })
+        indexYamlStr += `## ${summary}\n\n${description}\n\n`
       })
-    }
+    })
 
     fs.mkdirSync(`./content/en/api/latest/${newDirName}`, {recursive: true});
     fs.writeFileSync(`./content/en/api/latest/${newDirName}/_index.md`, indexYamlStr, 'utf8');
@@ -1023,7 +1020,6 @@ const processSpecs = (specs) => {
 
 const init = () => {
   const specs = ['./data/api/v1/full_spec.yaml', './data/api/v2/full_spec.yaml'];
-  console.info('Building Api Pages now******************')
   processSpecs(specs);
 };
 

--- a/assets/scripts/build-api-pages.js
+++ b/assets/scripts/build-api-pages.js
@@ -127,6 +127,24 @@ const createPages = (apiYaml, deref, apiVersion) => {
     // create a copy in /latest/
     indexYamlStr = yaml.safeDump(baseFrontMatter);
     indexYamlStr = `---\n${indexYamlStr}---\n`;
+
+    // create markdown containing summary and description for each endpoint
+    // this is for compiling the search index, it is not used for rendering content.
+    if (tag.name === 'CI Visibility Tests') {
+      // just get this sections data
+      const data = Object.keys(deref.paths)
+        .filter((path) => isTagMatch(deref.paths[path], tag.name))
+        .map((path) => deref.paths[path]);
+
+      data.forEach((actionObj) => {
+        Object.entries(actionObj).forEach(([actionKey, action]) => {
+          const { summary, description } = action
+
+          indexYamlStr += `## ${summary}\n\n${description}\n\n`
+        })
+      })
+    }
+
     fs.mkdirSync(`./content/en/api/latest/${newDirName}`, {recursive: true});
     fs.writeFileSync(`./content/en/api/latest/${newDirName}/_index.md`, indexYamlStr, 'utf8');
 

--- a/content/en/api/latest/_index.md
+++ b/content/en/api/latest/_index.md
@@ -15,6 +15,7 @@ cascade:
     algolia:
         rank: 10
         tags: ["api_latest"]
+render_content: true
 ---
 
 {{< h2 >}}API Reference{{< /h2 >}}

--- a/content/en/api/latest/audit/_index.md
+++ b/content/en/api/latest/audit/_index.md
@@ -1,3 +1,23 @@
 ---
 title: Audit
 ---
+Search your Audit Logs events over HTTP.
+
+## Get a list of Audit Logs events
+
+List endpoint returns events that match a Audit Logs search query.
+[Results are paginated][1].
+
+Use this endpoint to see your latest Audit Logs events.
+
+[1]: https://docs.datadoghq.com/logs/guide/collect-multiple-logs-with-pagination
+
+## Search Audit Logs events
+
+List endpoint returns Audit Logs events that match an Audit search query.
+[Results are paginated][1].
+
+Use this endpoint to build complex Audit Logs events filtering and search.
+
+[1]: https://docs.datadoghq.com/logs/guide/collect-multiple-logs-with-pagination
+

--- a/content/en/api/latest/authentication/_index.md
+++ b/content/en/api/latest/authentication/_index.md
@@ -1,3 +1,17 @@
 ---
 title: Authentication
 ---
+All requests to Datadog’s API must be authenticated.
+Requests that write data require reporting access and require an `API key`.
+Requests that read data require full access and also require an `application key`.
+
+**Note:** All Datadog API clients are configured by default to consume Datadog US site APIs.
+If you are on the Datadog EU site, set the environment variable `DATADOG_HOST` to
+`https://api.datadoghq.eu` or override this value directly when creating your client.
+
+[Manage your account’s API and application keys](https://app.datadoghq.com/account/settings#api).
+
+## Validate API key
+
+Check if the API key (not the APP key) is valid. If invalid, a 403 is returned.
+

--- a/content/en/api/latest/authn-mappings/_index.md
+++ b/content/en/api/latest/authn-mappings/_index.md
@@ -1,3 +1,27 @@
 ---
 title: AuthN Mappings
 ---
+[AuthN Mappings API](https://docs.datadoghq.com/account_management/authn_mapping/?tab=example)
+is used to automatically map group of users to roles in Datadog using attributes
+sent from Identity Providers.
+
+## List all AuthN Mappings
+
+List all AuthN Mappings in the org.
+
+## Create an AuthN Mapping
+
+Create an AuthN Mapping.
+
+## Delete an AuthN Mapping
+
+Delete an AuthN Mapping specified by AuthN Mapping UUID.
+
+## Get an AuthN Mapping by UUID
+
+Get an AuthN Mapping specified by the AuthN Mapping UUID.
+
+## Edit an AuthN Mapping
+
+Edit an AuthN Mapping.
+

--- a/content/en/api/latest/aws-integration/_index.md
+++ b/content/en/api/latest/aws-integration/_index.md
@@ -1,3 +1,45 @@
 ---
 title: AWS Integration
 ---
+Configure your Datadog-AWS integration directly through the Datadog API.
+For more information, see the [AWS integration page](https://docs.datadoghq.com/integrations/amazon_web_services).
+
+## Delete an AWS integration
+
+Delete a Datadog-AWS integration matching the specified `account_id` and `role_name parameters`.
+
+## List all AWS integrations
+
+List all Datadog-AWS integrations available in your Datadog organization.
+
+## Create an AWS integration
+
+Create a Datadog-Amazon Web Services integration.
+Using the `POST` method updates your integration configuration
+by adding your new configuration to the existing one in your Datadog organization.
+A unique AWS Account ID for role based authentication.
+
+## Update an AWS integration
+
+Update a Datadog-Amazon Web Services integration.
+
+## List namespace rules
+
+List all namespace rules for a given Datadog-AWS integration. This endpoint takes no arguments.
+
+## Delete a tag filtering entry
+
+Delete a tag filtering entry.
+
+## Get all AWS tag filters
+
+Get all AWS tag filters.
+
+## Set an AWS tag filter
+
+Set an AWS tag filter.
+
+## Generate a new external ID
+
+Generate a new AWS external ID for a given AWS account ID and role name pair.
+

--- a/content/en/api/latest/aws-logs-integration/_index.md
+++ b/content/en/api/latest/aws-logs-integration/_index.md
@@ -1,3 +1,50 @@
 ---
 title: AWS Logs Integration
 ---
+Configure your Datadog-AWS-Logs integration directly through Datadog API.
+For more information, see the [AWS integration page](https://docs.datadoghq.com/api/?lang=bash#integration-aws-logs).
+
+## Delete an AWS Logs integration
+
+Delete a Datadog-AWS logs configuration by removing the specific Lambda ARN associated with a given AWS account.
+
+## List all AWS Logs integrations
+
+List all Datadog-AWS Logs integrations configured in your Datadog account.
+
+## Add AWS Log Lambda ARN
+
+Attach the Lambda ARN of the Lambda created for the Datadog-AWS log collection to your AWS account ID to enable log collection.
+
+## Check that an AWS Lambda Function exists
+
+Test if permissions are present to add a log-forwarding triggers for the given services and AWS account. The input
+is the same as for Enable an AWS service log collection. Subsequent requests will always repeat the above, so this
+endpoint can be polled intermittently instead of blocking.
+
+- Returns a status of 'created' when it's checking if the Lambda exists in the account.
+- Returns a status of 'waiting' while checking.
+- Returns a status of 'checked and ok' if the Lambda exists.
+- Returns a status of 'error' if the Lambda does not exist.
+
+## Get list of AWS log ready services
+
+Get the list of current AWS services that Datadog offers automatic log collection. Use returned service IDs with the services parameter for the Enable an AWS service log collection API endpoint.
+
+## Enable an AWS Logs integration
+
+Enable automatic log collection for a list of services. This should be run after running `CreateAWSLambdaARN` to save the configuration.
+
+## Check permissions for log services
+
+Test if permissions are present to add log-forwarding triggers for the
+given services and AWS account. Input is the same as for `EnableAWSLogServices`.
+Done async, so can be repeatedly polled in a non-blocking fashion until
+the async request completes.
+
+- Returns a status of `created` when it's checking if the permissions exists
+  in the AWS account.
+- Returns a status of `waiting` while checking.
+- Returns a status of `checked and ok` if the Lambda exists.
+- Returns a status of `error` if the Lambda does not exist.
+

--- a/content/en/api/latest/azure-integration/_index.md
+++ b/content/en/api/latest/azure-integration/_index.md
@@ -1,3 +1,34 @@
 ---
 title: Azure Integration
 ---
+Configure your Datadog-Azure integration directly through the Datadog API.
+For more information, see the [Datadog-Azure integration page](https://docs.datadoghq.com/integrations/azure).
+
+## Delete an Azure integration
+
+Delete a given Datadog-Azure integration from your Datadog account.
+
+## List all Azure integrations
+
+List all Datadog-Azure integrations configured in your Datadog account.
+
+## Create an Azure integration
+
+Create a Datadog-Azure integration.
+
+Using the `POST` method updates your integration configuration by adding your new
+configuration to the existing one in your Datadog organization.
+
+Using the `PUT` method updates your integration configuration by replacing your
+current configuration with the new one sent to your Datadog organization.
+
+## Update an Azure integration
+
+Update a Datadog-Azure integration. Requires an existing `tenant_name` and `client_id`.
+Any other fields supplied will overwrite existing values. To overwrite `tenant_name` or `client_id`,
+use `new_tenant_name` and `new_client_id`. To leave a field unchanged, do not supply that field in the payload.
+
+## Update Azure integration host filters
+
+Update the defined list of host filters for a given Datadog-Azure integration.
+

--- a/content/en/api/latest/ci-visibility-pipelines/_index.md
+++ b/content/en/api/latest/ci-visibility-pipelines/_index.md
@@ -1,3 +1,23 @@
 ---
 title: CI Visibility Pipelines
 ---
+Search or aggregate your CI Visibility pipeline events over HTTP.
+
+## Aggregate pipelines events
+
+The API endpoint to aggregate CI Visibility pipeline events into buckets of computed metrics and timeseries.
+
+## Get a list of pipelines events
+
+List endpoint returns CI Visibility pipeline events that match a log search query.
+[Results are paginated similarly to logs](https://docs.datadoghq.com/logs/guide/collect-multiple-logs-with-pagination).
+
+Use this endpoint to see your latest pipeline events.
+
+## Search pipelines events
+
+List endpoint returns CI Visibility pipeline events that match a log search query.
+[Results are paginated similarly to logs](https://docs.datadoghq.com/logs/guide/collect-multiple-logs-with-pagination).
+
+Use this endpoint to build complex events filtering and search.
+

--- a/content/en/api/latest/ci-visibility-tests/_index.md
+++ b/content/en/api/latest/ci-visibility-tests/_index.md
@@ -1,3 +1,21 @@
 ---
 title: CI Visibility Tests
 ---
+## Aggregate tests events
+
+The API endpoint to aggregate CI Visibility test events into buckets of computed metrics and timeseries.
+
+## Get a list of tests events
+
+List endpoint returns CI Visibility test events that match a log search query.
+[Results are paginated similarly to logs](https://docs.datadoghq.com/logs/guide/collect-multiple-logs-with-pagination).
+
+Use this endpoint to see your latest test events.
+
+## Search tests events
+
+List endpoint returns CI Visibility test events that match a log search query.
+[Results are paginated similarly to logs](https://docs.datadoghq.com/logs/guide/collect-multiple-logs-with-pagination).
+
+Use this endpoint to build complex events filtering and search.
+

--- a/content/en/api/latest/ci-visibility-tests/_index.md
+++ b/content/en/api/latest/ci-visibility-tests/_index.md
@@ -1,6 +1,8 @@
 ---
 title: CI Visibility Tests
 ---
+Search or aggregate your CI Visibility test events over HTTP.
+
 ## Aggregate tests events
 
 The API endpoint to aggregate CI Visibility test events into buckets of computed metrics and timeseries.

--- a/content/en/api/latest/cloud-workload-security/_index.md
+++ b/content/en/api/latest/cloud-workload-security/_index.md
@@ -1,3 +1,32 @@
 ---
 title: Cloud Workload Security
 ---
+Workload activity security rules for generating events using the Datadog security Agent.
+
+## Get the latest Cloud Workload Security policy
+
+The download endpoint generates a Cloud Workload Security policy file from your currently active
+Cloud Workload Security rules, and downloads them as a .policy file. This file can then be deployed to
+your Agents to update the policy running in your environment.
+
+## Get all Cloud Workload Security Agent rules
+
+Get the list of Agent rules.
+
+## Create a Cloud Workload Security Agent rule
+
+Create a new Agent rule with the given parameters.
+
+## Delete a Cloud Workload Security Agent rule
+
+Delete a specific Agent rule.
+
+## Get a Cloud Workload Security Agent rule
+
+Get the details of a specific Agent rule.
+
+## Update a Cloud Workload Security Agent rule
+
+Update a specific Agent rule.
+Returns the Agent rule object when the request is successful.
+

--- a/content/en/api/latest/confluent-cloud/_index.md
+++ b/content/en/api/latest/confluent-cloud/_index.md
@@ -1,3 +1,45 @@
 ---
 title: Confluent Cloud
 ---
+Configure your Datadog Confluent Cloud integration directly through the Datadog API.
+
+## List Confluent accounts
+
+List Confluent accounts.
+
+## Add Confluent account
+
+Create a Confluent account.
+
+## Delete Confluent account
+
+Delete a Confluent account with the provided account ID.
+
+## Get Confluent account
+
+Get the Confluent account with the provided account ID.
+
+## Update Confluent account
+
+Update the Confluent account with the provided account ID.
+
+## List Confluent Account resources
+
+Get a Confluent resource for the account associated with the provided ID.
+
+## Add resource to Confluent account
+
+Create a Confluent resource for the account associated with the provided ID.
+
+## Delete resource from Confluent account
+
+Delete a Confluent resource with the provided resource id for the account associated with the provided account ID.
+
+## Get resource from Confluent account
+
+Get a Confluent resource with the provided resource id for the account associated with the provided account ID.
+
+## Update resource in Confluent account
+
+Update a Confluent resource with the provided resource id for the account associated with the provided account ID.
+

--- a/content/en/api/latest/dashboard-lists/_index.md
+++ b/content/en/api/latest/dashboard-lists/_index.md
@@ -1,3 +1,23 @@
 ---
 title: Dashboard Lists
 ---
+Interact with your dashboard lists through the API to
+organize, find, and share all of your dashboards with your team and
+organization.
+
+## Delete items from a dashboard list
+
+Delete dashboards from an existing dashboard list.
+
+## Get items of a Dashboard List
+
+Fetch the dashboard list’s dashboard definitions.
+
+## Add Items to a Dashboard List
+
+Add dashboards to an existing dashboard list.
+
+## Update items of a dashboard list
+
+Update dashboards of an existing dashboard list.
+

--- a/content/en/api/latest/dashboards/_index.md
+++ b/content/en/api/latest/dashboards/_index.md
@@ -1,3 +1,66 @@
 ---
 title: Dashboards
 ---
+Interact with your dashboard lists through the API to make it easier to organize,
+find, and share all of your dashboards with your team and organization.
+
+## Delete dashboards
+
+Delete dashboards using the specified IDs. If there are any failures, no dashboards will be deleted (partial success is not allowed).
+
+## Get all dashboards
+
+Get all dashboards.
+
+**Note**: This query will only return custom created or cloned dashboards.
+This query will not return preset dashboards.
+
+## Restore deleted dashboards
+
+Restore dashboards using the specified IDs. If there are any failures, no dashboards will be restored (partial success is not allowed).
+
+## Create a new dashboard
+
+Create a dashboard using the specified options. When defining queries in your widgets, take note of which queries should have the `as_count()` or `as_rate()` modifiers appended.
+Refer to the following [documentation](https://docs.datadoghq.com/developers/metrics/type_modifiers/?tab=count#in-application-modifiers) for more information on these modifiers.
+
+## Create a shared dashboard
+
+Share a specified private dashboard, generating a URL at which it can be publicly viewed.
+
+## Revoke a shared dashboard URL
+
+Revoke the public URL for a dashboard (rendering it private) associated with the specified token.
+
+## Get a shared dashboard
+
+Fetch an existing shared dashboard's sharing metadata associated with the specified token.
+
+## Update a shared dashboard
+
+Update a shared dashboard associated with the specified token.
+
+## Revoke shared dashboard invitations
+
+Revoke previously sent invitation emails and active sessions used to access a given shared dashboard for specific email addresses.
+
+## Get all invitations for a shared dashboard
+
+Describe the invitations that exist for the given shared dashboard (paginated).
+
+## Send shared dashboard invitation email
+
+Send emails to specified email addresses containing links to access a given authenticated shared dashboard. Email addresses must already belong to the authenticated shared dashboard's share_list.
+
+## Delete a dashboard
+
+Delete a dashboard using the specified ID.
+
+## Get a dashboard
+
+Get a dashboard using the specified ID.
+
+## Update a dashboard
+
+Update a dashboard using the specified ID.
+

--- a/content/en/api/latest/downtimes/_index.md
+++ b/content/en/api/latest/downtimes/_index.md
@@ -1,3 +1,36 @@
 ---
 title: Downtimes
 ---
+[Downtiming](https://docs.datadoghq.com/monitors/notify/downtimes) gives
+you greater control over monitor notifications by allowing you to globally exclude
+scopes from alerting. Downtime settings, which can be scheduled with start and
+end times, prevent all alerting related to specified Datadog tags.
+
+## Get all downtimes
+
+Get all scheduled downtimes.
+
+## Schedule a downtime
+
+Schedule a downtime.
+
+## Cancel downtimes by scope
+
+Delete all downtimes that match the scope of `X`.
+
+## Cancel a downtime
+
+Cancel a downtime.
+
+## Get a downtime
+
+Get downtime detail by `downtime_id`.
+
+## Update a downtime
+
+Update a single downtime by `downtime_id`.
+
+## Get all downtimes for a monitor
+
+Get all active downtimes for the specified monitor.
+

--- a/content/en/api/latest/embeddable-graphs/_index.md
+++ b/content/en/api/latest/embeddable-graphs/_index.md
@@ -1,3 +1,31 @@
 ---
 title: Embeddable Graphs
 ---
+Interact with embeddable graphs through the API.
+
+## Get all embeds
+
+Gets a list of previously created embeddable graphs.
+
+## Create embed
+
+Creates a new embeddable graph.
+
+Note: If an embed already exists for the exact same query in a given organization,
+the older embed is returned instead of creating a new embed.
+
+If you are interested in using template variables, see
+[Embeddable Graphs with Template Variables](https://docs.datadoghq.com/dashboards/faq/embeddable-graphs-with-template-variables).
+
+## Get specific embed
+
+Get the HTML fragment for a previously generated embed with `embed_id`.
+
+## Enable embed
+
+Enable a specified embed.
+
+## Revoke embed
+
+Revoke a specified embed.
+

--- a/content/en/api/latest/events/_index.md
+++ b/content/en/api/latest/events/_index.md
@@ -1,3 +1,22 @@
 ---
 title: Events
 ---
+The events service allows you to programmatically post events to the event stream
+and fetch events from the event stream. Events are limited to 4000 characters.
+If an event is sent out with a message containing more than 4000 characters, only the
+first 4000 characters are displayed.
+
+## Get a list of events
+
+List endpoint returns events that match an events search query.
+[Results are paginated similarly to logs](https://docs.datadoghq.com/logs/guide/collect-multiple-logs-with-pagination).
+
+Use this endpoint to see your latest events.
+
+## Search events
+
+List endpoint returns events that match an events search query.
+[Results are paginated similarly to logs](https://docs.datadoghq.com/logs/guide/collect-multiple-logs-with-pagination).
+
+Use this endpoint to build complex events filtering and search.
+

--- a/content/en/api/latest/gcp-integration/_index.md
+++ b/content/en/api/latest/gcp-integration/_index.md
@@ -1,3 +1,25 @@
 ---
 title: GCP Integration
 ---
+Configure your Datadog-Google Cloud Platform (GCP) integration directly
+through the Datadog API. Read more about the [Datadog-Google Cloud Platform integration](https://docs.datadoghq.com/integrations/google_cloud_platform).
+
+## Delete a GCP integration
+
+Delete a given Datadog-GCP integration.
+
+## List all GCP integrations
+
+List all Datadog-GCP integrations configured in your Datadog account.
+
+## Create a GCP integration
+
+Create a Datadog-GCP integration.
+
+## Update a GCP integration
+
+Update a Datadog-GCP integrations host_filters and/or auto-mute.
+Requires a `project_id` and `client_email`, however these fields cannot be updated.
+If you need to update these fields, delete and use the create (`POST`) endpoint.
+The unspecified fields will keep their original values.
+

--- a/content/en/api/latest/hosts/_index.md
+++ b/content/en/api/latest/hosts/_index.md
@@ -1,3 +1,25 @@
 ---
 title: Hosts
 ---
+Get information about your live hosts in Datadog.
+
+## Mute a host
+
+Mute a host.
+
+## Unmute a host
+
+Unmutes a host. This endpoint takes no JSON arguments.
+
+## Get all hosts for your organization
+
+This endpoint allows searching for hosts by name, alias, or tag.
+Hosts live within the past 3 hours are included by default.
+Retention is 7 days.
+Results are paginated with a max of 1000 results at a time.
+
+## Get the total number of active hosts
+
+This endpoint returns the total number of active and up hosts in your Datadog account.
+Active means the host has reported in the past hour, and up means it has reported in the past two hours.
+

--- a/content/en/api/latest/incident-services/_index.md
+++ b/content/en/api/latest/incident-services/_index.md
@@ -1,3 +1,26 @@
 ---
 title: Incident Services
 ---
+Create, update, delete, and retrieve services which can be associated with incidents.
+
+## Get a list of all incident services
+
+Get all incident services uploaded for the requesting user's organization. If the `include[users]` query parameter is provided, the included attribute will contain the users related to these incident services.
+
+## Create a new incident service
+
+Creates a new incident service.
+
+## Delete an existing incident service
+
+Deletes an existing incident service.
+
+## Get details of an incident service
+
+Get details of an incident service. If the `include[users]` query parameter is provided,
+the included attribute will contain the users related to these incident services.
+
+## Update an existing incident service
+
+Updates an existing incident service. Only provide the attributes which should be updated as this request is a partial update.
+

--- a/content/en/api/latest/incident-teams/_index.md
+++ b/content/en/api/latest/incident-teams/_index.md
@@ -1,3 +1,26 @@
 ---
 title: Incident Teams
 ---
+Create, update, delete and retrieve teams which can be associated with incidents.
+
+## Get a list of all incident teams
+
+Get all incident teams for the requesting user's organization. If the `include[users]` query parameter is provided, the included attribute will contain the users related to these incident teams.
+
+## Create a new incident team
+
+Creates a new incident team.
+
+## Delete an existing incident team
+
+Deletes an existing incident team.
+
+## Get details of an incident team
+
+Get details of an incident team. If the `include[users]` query parameter is provided,
+the included attribute will contain the users related to these incident teams.
+
+## Update an existing incident team
+
+Updates an existing incident team. Only provide the attributes which should be updated as this request is a partial update.
+

--- a/content/en/api/latest/incidents/_index.md
+++ b/content/en/api/latest/incidents/_index.md
@@ -1,3 +1,33 @@
 ---
 title: Incidents
 ---
+Manage incident response.
+
+## Get a list of incidents
+
+Get all incidents for the user's organization.
+
+## Create an incident
+
+Create an incident.
+
+## Delete an existing incident
+
+Deletes an existing incident from the users organization.
+
+## Get the details of an incident
+
+Get the details of an incident by `incident_id`.
+
+## Update an existing incident
+
+Updates an incident. Provide only the attributes that should be updated as this request is a partial update.
+
+## Get a list of attachments
+
+Get all attachments for a given incident.
+
+## Create, update, and delete incident attachments
+
+The bulk update endpoint for creating, updating, and deleting attachments for a given incident.
+

--- a/content/en/api/latest/ip-ranges/_index.md
+++ b/content/en/api/latest/ip-ranges/_index.md
@@ -1,3 +1,9 @@
 ---
 title: IP Ranges
 ---
+Get a list of IP prefixes belonging to Datadog.
+
+## List IP Ranges
+
+Get information about Datadog IP ranges.
+

--- a/content/en/api/latest/key-management/_index.md
+++ b/content/en/api/latest/key-management/_index.md
@@ -1,3 +1,64 @@
 ---
 title: Key Management
 ---
+Manage your Datadog API and application keys. You need an API key and
+an application key for a user with the required permissions to interact
+with these endpoints. The full list of API and application keys can be
+seen on your [Datadog API page](https://app.datadoghq.com/account/settings#api).
+
+## Get all API keys
+
+List all API keys available for your account.
+
+## Create an API key
+
+Create an API key.
+
+## Delete an API key
+
+Delete an API key.
+
+## Get API key
+
+Get an API key.
+
+## Edit an API key
+
+Update an API key.
+
+## Get all application keys
+
+List all application keys available for your org
+
+## Delete an application key
+
+Delete an application key
+
+## Get an application key
+
+Get an application key for your org.
+
+## Edit an application key
+
+Edit an application key
+
+## Get all application keys owned by current user
+
+List all application keys available for current user
+
+## Create an application key for current user
+
+Create an application key for current user
+
+## Delete an application key owned by current user
+
+Delete an application key owned by current user
+
+## Get one application key owned by current user
+
+Get an application key owned by current user
+
+## Edit an application key owned by current user
+
+Edit an application key owned by current user
+

--- a/content/en/api/latest/logs-archives/_index.md
+++ b/content/en/api/latest/logs-archives/_index.md
@@ -1,3 +1,56 @@
 ---
 title: Logs Archives
 ---
+Archives forward all the logs ingested to a cloud storage system.
+
+See the [Archives Page](https://app.datadoghq.com/logs/pipelines/archives)
+for a list of the archives currently configured in web UI.
+
+## Get archive order
+
+Get the current order of your archives.
+This endpoint takes no JSON arguments.
+
+## Update archive order
+
+Update the order of your archives. Since logs are processed sequentially, reordering an archive may change
+the structure and content of the data processed by other archives.
+
+**Note**: Using the `PUT` method updates your archive's order by replacing the current order
+with the new one.
+
+## Get all archives
+
+Get the list of configured logs archives with their definitions.
+
+## Create an archive
+
+Create an archive in your organization.
+
+## Delete an archive
+
+Delete a given archive from your organization.
+
+## Get an archive
+
+Get a specific archive from your organization.
+
+## Update an archive
+
+Update a given archive configuration.
+
+**Note**: Using this method updates your archive configuration by **replacing**
+your current configuration with the new one sent to your Datadog organization.
+
+## Revoke role from an archive
+
+Removes a role from an archive. ([Roles API](https://docs.datadoghq.com/api/v2/roles/))
+
+## List read roles for an archive
+
+Returns all read roles a given archive is restricted to.
+
+## Grant role to an archive
+
+Adds a read role to an archive. ([Roles API](https://docs.datadoghq.com/api/v2/roles/))
+

--- a/content/en/api/latest/logs-indexes/_index.md
+++ b/content/en/api/latest/logs-indexes/_index.md
@@ -1,3 +1,36 @@
 ---
 title: Logs Indexes
 ---
+Manage configuration of [log indexes](https://docs.datadoghq.com/logs/indexes/).
+You need an API and application key with Admin rights to interact with this endpoint.
+
+## Get indexes order
+
+Get the current order of your log indexes. This endpoint takes no JSON arguments.
+
+## Update indexes order
+
+This endpoint updates the index order of your organization.
+It returns the index order object passed in the request body when the request is successful.
+
+## Get all indexes
+
+The Index object describes the configuration of a log index.
+This endpoint returns an array of the `LogIndex` objects of your organization.
+
+## Create an index
+
+Creates a new index. Returns the Index object passed in the request body when the request is successful.
+
+## Get an index
+
+Get one log index from your organization. This endpoint takes no JSON arguments.
+
+## Update an index
+
+Update an index as identified by its name.
+Returns the Index object passed in the request body when the request is successful.
+
+Using the `PUT` method updates your index’s configuration by **replacing**
+your current configuration with the new one sent to your Datadog organization.
+

--- a/content/en/api/latest/logs-metrics/_index.md
+++ b/content/en/api/latest/logs-metrics/_index.md
@@ -1,3 +1,27 @@
 ---
 title: Logs Metrics
 ---
+Manage configuration of [log-based metrics](https://app.datadoghq.com/logs/pipelines/generate-metrics) for your organization.
+
+## Get all log-based metrics
+
+Get the list of configured log-based metrics with their definitions.
+
+## Create a log-based metric
+
+Create a metric based on your ingested logs in your organization.
+Returns the log-based metric object from the request body when the request is successful.
+
+## Delete a log-based metric
+
+Delete a specific log-based metric from your organization.
+
+## Get a log-based metric
+
+Get a specific log-based metric from your organization.
+
+## Update a log-based metric
+
+Update a specific log-based metric from your organization.
+Returns the log-based metric object from the request body when the request is successful.
+

--- a/content/en/api/latest/logs-pipelines/_index.md
+++ b/content/en/api/latest/logs-pipelines/_index.md
@@ -1,3 +1,67 @@
 ---
 title: Logs Pipelines
 ---
+Pipelines and processors operate on incoming logs, parsing
+and transforming them into structured attributes for easier querying.
+
+- See the [pipelines configuration page](https://app.datadoghq.com/logs/pipelines)
+  for a list of the pipelines and processors currently configured in web UI.
+
+- Additional API-related information about processors can be found in the
+  [processors documentation](https://docs.datadoghq.com/logs/log_configuration/processors/?tab=api#lookup-processor).
+
+- For more information about Pipelines, see the
+  [pipeline documentation](https://docs.datadoghq.com/logs/log_configuration/pipelines).
+
+**Notes:**
+
+These endpoints are only available for admin users.
+Make sure to use an application key created by an admin.
+
+**Grok parsing rules may effect JSON output and require
+returned data to be configured before using in a request.**
+For example, if you are using the data returned from a
+request for another request body, and have a parsing rule
+that uses a regex pattern like `\s` for spaces, you will
+need to configure all escaped spaces as `%{space}` to use
+in the body data.
+
+## Get pipeline order
+
+Get the current order of your pipelines.
+This endpoint takes no JSON arguments.
+
+## Update pipeline order
+
+Update the order of your pipelines. Since logs are processed sequentially, reordering a pipeline may change
+the structure and content of the data processed by other pipelines and their processors.
+
+**Note**: Using the `PUT` method updates your pipeline order by replacing your current order
+with the new one sent to your Datadog organization.
+
+## Get all pipelines
+
+Get all pipelines from your organization.
+This endpoint takes no JSON arguments.
+
+## Create a pipeline
+
+Create a pipeline in your organization.
+
+## Delete a pipeline
+
+Delete a given pipeline from your organization.
+This endpoint takes no JSON arguments.
+
+## Get a pipeline
+
+Get a specific pipeline from your organization.
+This endpoint takes no JSON arguments.
+
+## Update a pipeline
+
+Update a given pipeline configuration to change it’s processors or their order.
+
+**Note**: Using this method updates your pipeline configuration by **replacing**
+your current configuration with the new one sent to your Datadog organization.
+

--- a/content/en/api/latest/logs-restriction-queries/_index.md
+++ b/content/en/api/latest/logs-restriction-queries/_index.md
@@ -1,3 +1,66 @@
 ---
 title: Logs Restriction Queries
 ---
+**Note: This endpoint is in public beta. If you have any feedback, contact [Datadog support](https://docs.datadoghq.com/help/).**
+
+To grant read access on log data at all, you must grant the `logs_read_data` permission.
+From there you can limit what data a role grants read access to by associating a Restriction Query with that role.
+
+A Restriction Query is a logs query that restricts which logs the `logs_read_data` permission grants read access to.
+For users whose roles have Restriction Queries, any log query they make only returns those log events that also match
+one of their Restriction Queries. This is true whether the user queries log events from any log-related feature, including
+the log explorer, Live Tail, re-hydration, or a dashboard widget.
+
+Restriction Queries currently only support use of the following components of log events:
+
+- Reserved attributes
+- The log message
+- Tags
+
+The recommended way to manage restricted read access on log data for customers with large or complicated organizational structures
+is to add a team tag to log events to indicate which team(s) own(s) them, and then to scope Restriction Queries to the appropriate
+values of the team tag. Tags can be applied to log events in many ways, and a log event can have multiple tags with the same key (like team)
+and different values—in this way the same log event can be visible to roles whose restriction queries are scoped to different team values.
+
+You need an API and application key with Admin rights to interact with this endpoint.
+
+## List restriction queries
+
+Returns all restriction queries, including their names and IDs.
+
+## Create a restriction query
+
+Create a new restriction query for your organization.
+
+## Get restriction query for a given role
+
+Get restriction query for a given role.
+
+## Get all restriction queries for a given user
+
+Get all restriction queries for a given user.
+
+## Delete a restriction query
+
+Deletes a restriction query.
+
+## Get a restriction query
+
+Get a restriction query in the organization specified by the restriction query's `restriction_query_id`.
+
+## Update a restriction query
+
+Edit a restriction query.
+
+## Revoke role from a restriction query
+
+Removes a role from a restriction query.
+
+## List roles for a restriction query
+
+Returns all roles that have a given restriction query.
+
+## Grant role to a restriction query
+
+Adds a role to a restriction query.
+

--- a/content/en/api/latest/logs/_index.md
+++ b/content/en/api/latest/logs/_index.md
@@ -1,3 +1,63 @@
 ---
 title: Logs
 ---
+Search your logs and send them to your Datadog platform over HTTP.
+
+## Send logs
+
+Send your logs to your Datadog platform over HTTP. Limits per HTTP request are:
+
+- Maximum content size per payload (uncompressed): 5MB
+- Maximum size for a single log: 1MB
+- Maximum array size if sending multiple logs in an array: 1000 entries
+
+Any log exceeding 1MB is accepted and truncated by Datadog:
+- For a single log request, the API truncates the log at 1MB and returns a 2xx.
+- For a multi-logs request, the API processes all logs, truncates only logs larger than 1MB, and returns a 2xx.
+
+Datadog recommends sending your logs compressed.
+Add the `Content-Encoding: gzip` header to the request when sending compressed logs.
+
+The status codes answered by the HTTP API are:
+- 202: Accepted: the request has been accepted for processing
+- 400: Bad request (likely an issue in the payload formatting)
+- 401: Unauthorized (likely a missing API Key)
+- 403: Permission issue (likely using an invalid API Key)
+- 408: Request Timeout, request should be retried after some time
+- 413: Payload too large (batch is above 5MB uncompressed)
+- 429: Too Many Requests, request should be retried after some time
+- 500: Internal Server Error, the server encountered an unexpected condition that prevented it from fulfilling the request, request should be retried after some time
+- 503: Service Unavailable, the server is not ready to handle the request probably because it is overloaded, request should be retried after some time
+
+## Aggregate events
+
+The API endpoint to aggregate events into buckets and compute metrics and timeseries.
+
+## Get a list of logs
+
+List endpoint returns logs that match a log search query.
+[Results are paginated][1].
+
+Use this endpoint to see your latest logs.
+
+**If you are considering archiving logs for your organization,
+consider use of the Datadog archive capabilities instead of the log list API.
+See [Datadog Logs Archive documentation][2].**
+
+[1]: /logs/guide/collect-multiple-logs-with-pagination
+[2]: https://docs.datadoghq.com/logs/archives
+
+## Search logs
+
+List endpoint returns logs that match a log search query.
+[Results are paginated][1].
+
+Use this endpoint to build complex logs filtering and search.
+
+**If you are considering archiving logs for your organization,
+consider use of the Datadog archive capabilities instead of the log list API.
+See [Datadog Logs Archive documentation][2].**
+
+[1]: /logs/guide/collect-multiple-logs-with-pagination
+[2]: https://docs.datadoghq.com/logs/archives
+

--- a/content/en/api/latest/metrics/_index.md
+++ b/content/en/api/latest/metrics/_index.md
@@ -1,3 +1,92 @@
 ---
 title: Metrics
 ---
+The metrics endpoint allows you to:
+
+- Post metrics data so it can be graphed on Datadog’s dashboards
+- Query metrics from any time period
+- Modify tag configurations for metrics
+- View tags and volumes for metrics
+
+**Note**: A graph can only contain a set number of points
+and as the timeframe over which a metric is viewed increases,
+aggregation between points occurs to stay below that set number.
+
+The Post, Patch, and Delete `manage_tags` API methods can only be performed by
+a user who has the `Manage Tags for Metrics` permission.
+
+## Get a list of metrics
+
+Returns all metrics that can be configured in the Metrics Summary page or with Metrics without Limits™ (matching additional filters if specified).
+
+## Configure tags for multiple metrics
+
+Delete all custom lists of queryable tag keys for a set of existing count, gauge, rate, and distribution metrics.
+Metrics are selected by passing a metric name prefix.
+Results can be sent to a set of account email addresses, just like the same operation in the Datadog web app.
+Can only be used with application keys of users with the `Manage Tags for Metrics` permission.
+
+## Configure tags for multiple metrics
+
+Create and define a list of queryable tag keys for a set of existing count, gauge, rate, and distribution metrics.
+Metrics are selected by passing a metric name prefix. Use the Delete method of this API path to remove tag configurations.
+Results can be sent to a set of account email addresses, just like the same operation in the Datadog web app.
+If multiple calls include the same metric, the last configuration applied (not by submit order) is used, do not
+expect deterministic ordering of concurrent calls.
+Can only be used with application keys of users with the `Manage Tags for Metrics` permission.
+
+## List active tags and aggregations
+
+List tags and aggregations that are actively queried on dashboards and monitors for a given metric name.
+
+## List tags by metric name
+
+View indexed tag key-value pairs for a given metric name.
+
+## Tag Configuration Cardinality Estimator
+
+Returns the estimated cardinality for a metric with a given tag, percentile and number of aggregations configuration using Metrics without Limits&trade;.
+
+## Delete a tag configuration
+
+Deletes a metric's tag configuration. Can only be used with application
+keys from users with the `Manage Tags for Metrics` permission.
+
+## List tag configuration by name
+
+Returns the tag configuration for the given metric name.
+
+## Update a tag configuration
+
+Update the tag configuration of a metric or percentile aggregations of a distribution metric or custom aggregations
+of a count, rate, or gauge metric.
+Can only be used with application keys from users with the `Manage Tags for Metrics` permission.
+
+## Create a tag configuration
+
+Create and define a list of queryable tag keys for an existing count/gauge/rate/distribution metric.
+Optionally, include percentile aggregations on any distribution metric or configure custom aggregations
+on any count, rate, or gauge metric.
+Can only be used with application keys of users with the `Manage Tags for Metrics` permission.
+
+## List distinct metric volumes by metric name
+
+View distinct metrics volumes for the given metric name.
+
+Custom metrics generated in-app from other products will return `null` for ingested volumes.
+
+## Submit metrics
+
+The metrics end-point allows you to post time-series data that can be graphed on Datadog’s dashboards.
+The maximum payload size is 500 kilobytes (512000 bytes). Compressed payloads must have a decompressed size of less than 5 megabytes (5242880 bytes).
+
+If you’re submitting metrics directly to the Datadog API without using DogStatsD, expect:
+
+- 64 bits for the timestamp
+- 64 bits for the value
+- 20 bytes for the metric names
+- 50 bytes for the timeseries
+- The full payload is approximately 100 bytes.
+
+Host name is one of the resources in the Resources field.
+

--- a/content/en/api/latest/monitors/_index.md
+++ b/content/en/api/latest/monitors/_index.md
@@ -1,3 +1,249 @@
 ---
 title: Monitors
 ---
+[Monitors](https://docs.datadoghq.com/monitors) allow you to watch a metric or check that you care about and
+notifies your team when a defined threshold has exceeded.
+
+For more information, see [Creating Monitors](https://docs.datadoghq.com/monitors/create/types/).
+
+## Get all monitor details
+
+Get details about the specified monitor from your organization.
+
+## Create a monitor
+
+Create a monitor using the specified options.
+
+#### Monitor Types
+
+The type of monitor chosen from:
+
+- anomaly: `query alert`
+- APM: `query alert` or `trace-analytics alert`
+- composite: `composite`
+- custom: `service check`
+- event: `event alert`
+- forecast: `query alert`
+- host: `service check`
+- integration: `query alert` or `service check`
+- live process: `process alert`
+- logs: `log alert`
+- metric: `query alert`
+- network: `service check`
+- outlier: `query alert`
+- process: `service check`
+- rum: `rum alert`
+- SLO: `slo alert`
+- watchdog: `event alert`
+- event-v2: `event-v2 alert`
+- audit: `audit alert`
+- error-tracking: `error-tracking alert`
+
+#### Query Types
+
+**Metric Alert Query**
+
+Example: `time_aggr(time_window):space_aggr:metric{tags} [by {key}] operator #`
+
+- `time_aggr`: avg, sum, max, min, change, or pct_change
+- `time_window`: `last_#m` (with `#` between 1 and 10080 depending on the monitor type) or `last_#h`(with `#` between 1 and 168 depending on the monitor type) or `last_1d`, or `last_1w`
+- `space_aggr`: avg, sum, min, or max
+- `tags`: one or more tags (comma-separated), or *
+- `key`: a 'key' in key:value tag syntax; defines a separate alert for each tag in the group (multi-alert)
+- `operator`: <, <=, >, >=, ==, or !=
+- `#`: an integer or decimal number used to set the threshold
+
+If you are using the `_change_` or `_pct_change_` time aggregator, instead use `change_aggr(time_aggr(time_window),
+timeshift):space_aggr:metric{tags} [by {key}] operator #` with:
+
+- `change_aggr` change, pct_change
+- `time_aggr` avg, sum, max, min [Learn more](https://docs.datadoghq.com/monitors/create/types/#define-the-conditions)
+- `time_window` last\_#m (between 1 and 2880 depending on the monitor type), last\_#h (between 1 and 48 depending on the monitor type), or last_#d (1 or 2)
+- `timeshift` #m_ago (5, 10, 15, or 30), #h_ago (1, 2, or 4), or 1d_ago
+
+Use this to create an outlier monitor using the following query:
+`avg(last_30m):outliers(avg:system.cpu.user{role:es-events-data} by {host}, 'dbscan', 7) > 0`
+
+**Service Check Query**
+
+Example: `"check".over(tags).last(count).by(group).count_by_status()`
+
+- `check` name of the check, for example `datadog.agent.up`
+- `tags` one or more quoted tags (comma-separated), or "*". for example: `.over("env:prod", "role:db")`; `over` cannot be blank.
+- `count` must be at greater than or equal to your max threshold (defined in the `options`). It is limited to 100.
+For example, if you've specified to notify on 1 critical, 3 ok, and 2 warn statuses, `count` should be at least 3.
+- `group` must be specified for check monitors. Per-check grouping is already explicitly known for some service checks.
+For example, Postgres integration monitors are tagged by `db`, `host`, and `port`, and Network monitors by `host`, `instance`, and `url`. See [Service Checks](https://docs.datadoghq.com/api/latest/service-checks/) documentation for more information.
+
+**Event Alert Query**
+
+Example: `events('sources:nagios status:error,warning priority:normal tags: "string query"').rollup("count").last("1h")"`
+
+- `event`, the event query string:
+- `string_query` free text query to match against event title and text.
+- `sources` event sources (comma-separated).
+- `status` event statuses (comma-separated). Valid options: error, warn, and info.
+- `priority` event priorities (comma-separated). Valid options: low, normal, all.
+- `host` event reporting host (comma-separated).
+- `tags` event tags (comma-separated).
+- `excluded_tags` excluded event tags (comma-separated).
+- `rollup` the stats roll-up method. `count` is the only supported method now.
+- `last` the timeframe to roll up the counts. Examples: 45m, 4h. Supported timeframes: m, h and d. This value should not exceed 48 hours.
+
+**NOTE** The Event Alert Query is being deprecated and replaced by the Event V2 Alert Query. For more information, see the [Event Migration guide](https://docs.datadoghq.com/events/guides/migrating_to_new_events_features/).
+
+**Event V2 Alert Query**
+
+Example: `events(query).rollup(rollup_method[, measure]).last(time_window) operator #`
+
+- `query` The search query - following the [Log search syntax](https://docs.datadoghq.com/logs/search_syntax/).
+- `rollup_method` The stats roll-up method - supports `count`, `avg` and `cardinality`.
+- `measure` For `avg` and cardinality `rollup_method` - specify the measure or the facet name you want to use.
+- `time_window` #m (between 1 and 2880), #h (between 1 and 48).
+- `operator` `<`, `<=`, `>`, `>=`, `==`, or `!=`.
+- `#` an integer or decimal number used to set the threshold.
+
+**Process Alert Query**
+
+Example: `processes(search).over(tags).rollup('count').last(timeframe) operator #`
+
+- `search` free text search string for querying processes.
+Matching processes match results on the [Live Processes](https://docs.datadoghq.com/infrastructure/process/?tab=linuxwindows) page.
+- `tags` one or more tags (comma-separated)
+- `timeframe` the timeframe to roll up the counts. Examples: 10m, 4h. Supported timeframes: s, m, h and d
+- `operator` <, <=, >, >=, ==, or !=
+- `#` an integer or decimal number used to set the threshold
+
+**Logs Alert Query**
+
+Example: `logs(query).index(index_name).rollup(rollup_method[, measure]).last(time_window) operator #`
+
+- `query` The search query - following the [Log search syntax](https://docs.datadoghq.com/logs/search_syntax/).
+- `index_name` For multi-index organizations, the log index in which the request is performed.
+- `rollup_method` The stats roll-up method - supports `count`, `avg` and `cardinality`.
+- `measure` For `avg` and cardinality `rollup_method` - specify the measure or the facet name you want to use.
+- `time_window` #m (between 1 and 2880), #h (between 1 and 48).
+- `operator` `<`, `<=`, `>`, `>=`, `==`, or `!=`.
+- `#` an integer or decimal number used to set the threshold.
+
+**Composite Query**
+
+Example: `12345 && 67890`, where `12345` and `67890` are the IDs of non-composite monitors
+
+* `name` [*required*, *default* = **dynamic, based on query**]: The name of the alert.
+* `message` [*required*, *default* = **dynamic, based on query**]: A message to include with notifications for this monitor.
+Email notifications can be sent to specific users by using the same '@username' notation as events.
+* `tags` [*optional*, *default* = **empty list**]: A list of tags to associate with your monitor.
+When getting all monitor details via the API, use the `monitor_tags` argument to filter results by these tags.
+It is only available via the API and isn't visible or editable in the Datadog UI.
+
+**SLO Alert Query**
+
+Example: `error_budget("slo_id").over("time_window") operator #`
+
+- `slo_id`: The alphanumeric SLO ID of the SLO you are configuring the alert for.
+- `time_window`: The time window of the SLO target you wish to alert on. Valid options: `7d`, `30d`, `90d`.
+- `operator`: `>=` or `>`
+
+**Audit Alert Query**
+
+Example: `audits(query).rollup(rollup_method[, measure]).last(time_window) operator #`
+
+- `query` The search query - following the [Log search syntax](https://docs.datadoghq.com/logs/search_syntax/).
+- `rollup_method` The stats roll-up method - supports `count`, `avg` and `cardinality`.
+- `measure` For `avg` and cardinality `rollup_method` - specify the measure or the facet name you want to use.
+- `time_window` #m (between 1 and 2880), #h (between 1 and 48).
+- `operator` `<`, `<=`, `>`, `>=`, `==`, or `!=`.
+- `#` an integer or decimal number used to set the threshold.
+
+**NOTE** Only available on US1-FED and in closed beta on US1, EU, US3, and US5.
+
+**CI Pipelines Alert Query**
+
+Example: `ci-pipelines(query).rollup(rollup_method[, measure]).last(time_window) operator #`
+
+- `query` The search query - following the [Log search syntax](https://docs.datadoghq.com/logs/search_syntax/).
+- `rollup_method` The stats roll-up method - supports `count`, `avg`, and `cardinality`.
+- `measure` For `avg` and cardinality `rollup_method` - specify the measure or the facet name you want to use.
+- `time_window` #m (between 1 and 2880), #h (between 1 and 48).
+- `operator` `<`, `<=`, `>`, `>=`, `==`, or `!=`.
+- `#` an integer or decimal number used to set the threshold.
+
+**NOTE** CI Pipeline monitors are in alpha on US1, EU, US3 and US5.
+
+**CI Tests Alert Query**
+
+Example: `ci-tests(query).rollup(rollup_method[, measure]).last(time_window) operator #`
+
+- `query` The search query - following the [Log search syntax](https://docs.datadoghq.com/logs/search_syntax/).
+- `rollup_method` The stats roll-up method - supports `count`, `avg`, and `cardinality`.
+- `measure` For `avg` and cardinality `rollup_method` - specify the measure or the facet name you want to use.
+- `time_window` #m (between 1 and 2880), #h (between 1 and 48).
+- `operator` `<`, `<=`, `>`, `>=`, `==`, or `!=`.
+- `#` an integer or decimal number used to set the threshold.
+
+**NOTE** CI Test monitors are available only in closed beta on US1, EU, US3 and US5.
+
+**Error Tracking Alert Query**
+
+Example(RUM): `error-tracking-rum(query).rollup(rollup_method[, measure]).last(time_window) operator #`
+Example(APM Traces): `error-tracking-traces(query).rollup(rollup_method[, measure]).last(time_window) operator #`
+
+- `query` The search query - following the [Log search syntax](https://docs.datadoghq.com/logs/search_syntax/).
+- `rollup_method` The stats roll-up method - supports `count`, `avg`, and `cardinality`.
+- `measure` For `avg` and cardinality `rollup_method` - specify the measure or the facet name you want to use.
+- `time_window` #m (between 1 and 2880), #h (between 1 and 48).
+- `operator` `<`, `<=`, `>`, `>=`, `==`, or `!=`.
+- `#` an integer or decimal number used to set the threshold.
+
+## Check if a monitor can be deleted
+
+Check if the given monitors can be deleted.
+
+## Monitors group search
+
+Search and filter your monitor groups details.
+
+## Monitors search
+
+Search and filter your monitors details.
+
+## Validate a monitor
+
+Validate the monitor provided in the request.
+
+## Delete a monitor
+
+Delete the specified monitor
+
+## Get a monitor's details
+
+Get details about the specified monitor from your organization.
+
+## Edit a monitor
+
+Edit the specified monitor.
+
+## Mute a monitor
+
+Mute the specified monitor.
+
+## Unmute a monitor
+
+Unmute the specified monitor.
+
+## Validate an existing monitor
+
+Validate the monitor provided in the request.
+
+## Mute all monitors
+
+Muting prevents all monitors from notifying through email and posts to the
+[event stream](https://docs.datadoghq.com/events).
+State changes are only visible by checking the alert page.
+
+## Unmute all monitors
+
+Disables muting all monitors. Throws an error if mute all
+was not enabled previously.
+

--- a/content/en/api/latest/notebooks/_index.md
+++ b/content/en/api/latest/notebooks/_index.md
@@ -1,3 +1,28 @@
 ---
 title: Notebooks
 ---
+Interact with your notebooks through the API to make it easier to organize, find, and
+share all of your notebooks with your team and organization. For more information, see the
+[Notebooks documentation](https://docs.datadoghq.com/notebooks/).
+
+## Get all notebooks
+
+Get all notebooks. This can also be used to search for notebooks with a particular `query` in the notebook
+`name` or author `handle`.
+
+## Create a notebook
+
+Create a notebook using the specified options.
+
+## Delete a notebook
+
+Delete a notebook using the specified ID.
+
+## Get a notebook
+
+Get a notebook using the specified notebook ID.
+
+## Update a notebook
+
+Update a notebook using the specified ID.
+

--- a/content/en/api/latest/opsgenie-integration/_index.md
+++ b/content/en/api/latest/opsgenie-integration/_index.md
@@ -1,3 +1,26 @@
 ---
 title: Opsgenie Integration
 ---
+Configure your [Datadog Opsgenie integration](https://docs.datadoghq.com/integrations/opsgenie/)
+directly through the Datadog API.
+
+## Get all service objects
+
+Get a list of all services from the Datadog Opsgenie integration.
+
+## Create a new service object
+
+Create a new service object in the Opsgenie integration.
+
+## Delete a single service object
+
+Delete a single service object in the Datadog Opsgenie integration.
+
+## Get a single service object
+
+Get a single service from the Datadog Opsgenie integration.
+
+## Update a single service object
+
+Update a single service object in the Datadog Opsgenie integration.
+

--- a/content/en/api/latest/organizations/_index.md
+++ b/content/en/api/latest/organizations/_index.md
@@ -1,3 +1,11 @@
 ---
 title: Organizations
 ---
+Create, edit, and manage your organizations. Read more about [multi-org accounts](https://docs.datadoghq.com/account_management/multi_organization).
+
+## Upload IdP metadata
+
+Endpoint for uploading IdP metadata for SAML setup.
+
+Use this endpoint to upload or replace IdP metadata for SAML login configuration.
+

--- a/content/en/api/latest/pagerduty-integration/_index.md
+++ b/content/en/api/latest/pagerduty-integration/_index.md
@@ -1,3 +1,22 @@
 ---
 title: PagerDuty Integration
 ---
+Configure your [Datadog-PagerDuty integration](https://docs.datadoghq.com/integrations/pagerduty/)
+directly through the Datadog API.
+
+## Create a new service object
+
+Create a new service object in the PagerDuty integration.
+
+## Delete a single service object
+
+Delete a single service object in the Datadog-PagerDuty integration.
+
+## Get a single service object
+
+Get service name in the Datadog-PagerDuty integration.
+
+## Update a single service object
+
+Update a single service object in the Datadog-PagerDuty integration.
+

--- a/content/en/api/latest/processes/_index.md
+++ b/content/en/api/latest/processes/_index.md
@@ -1,3 +1,9 @@
 ---
 title: Processes
 ---
+The processes API allows you to query processes data for your organization.
+
+## Get all processes
+
+Get all processes for your organization.
+

--- a/content/en/api/latest/roles/_index.md
+++ b/content/en/api/latest/roles/_index.md
@@ -1,3 +1,64 @@
 ---
 title: Roles
 ---
+The Roles API is used to create and manage Datadog roles, what
+[global permissions](https://docs.datadoghq.com/account_management/rbac/)
+they grant, and which users belong to them.
+
+Permissions related to specific account assets can be granted to roles
+in the Datadog application without using this API. For example, granting
+read access on a specific log index to a role can be done in Datadog from the
+[Pipelines page](https://app.datadoghq.com/logs/pipelines).
+
+## List permissions
+
+Returns a list of all permissions, including name, description, and ID.
+
+## List roles
+
+Returns all roles, including their names and their unique identifiers.
+
+## Create role
+
+Create a new role for your organization.
+
+## Delete role
+
+Disables a role.
+
+## Get a role
+
+Get a role in the organization specified by the role’s `role_id`.
+
+## Update a role
+
+Edit a role. Can only be used with application keys belonging to administrators.
+
+## Create a new role by cloning an existing role
+
+Clone an existing role
+
+## Revoke permission
+
+Removes a permission from a role.
+
+## List permissions for a role
+
+Returns a list of all permissions for a single role.
+
+## Grant permission to a role
+
+Adds a permission to a role.
+
+## Remove a user from a role
+
+Removes a user from a role.
+
+## Get all users of a role
+
+Gets all users of a role.
+
+## Add a user to a role
+
+Adds a user to a role.
+

--- a/content/en/api/latest/rum/_index.md
+++ b/content/en/api/latest/rum/_index.md
@@ -1,3 +1,47 @@
 ---
 title: RUM
 ---
+Search or aggregate your RUM events over HTTP.
+
+## Aggregate RUM events
+
+The API endpoint to aggregate RUM events into buckets of computed metrics and timeseries.
+
+## List all the RUM applications
+
+List all the RUM applications in your organization.
+
+## Create a new RUM application
+
+Create a new RUM application in your organization.
+
+## Delete a RUM application
+
+Delete an existing RUM application in your organization.
+
+## Get a RUM application
+
+Get the RUM application with given ID in your organization.
+
+## Update a RUM application
+
+Update the RUM application with given ID in your organization.
+
+## Get a list of RUM events
+
+List endpoint returns events that match a RUM search query.
+[Results are paginated][1].
+
+Use this endpoint to see your latest RUM events.
+
+[1]: https://docs.datadoghq.com/logs/guide/collect-multiple-logs-with-pagination
+
+## Search RUM events
+
+List endpoint returns RUM events that match a RUM search query.
+[Results are paginated][1].
+
+Use this endpoint to build complex RUM events filtering and search.
+
+[1]: https://docs.datadoghq.com/logs/guide/collect-multiple-logs-with-pagination
+

--- a/content/en/api/latest/scopes/_index.md
+++ b/content/en/api/latest/scopes/_index.md
@@ -1,4 +1,5 @@
 ---
+render_content: true
 title: Authorization Scopes
 disable_sidebar: true
 ---

--- a/content/en/api/latest/screenboards/_index.md
+++ b/content/en/api/latest/screenboards/_index.md
@@ -1,3 +1,5 @@
 ---
 title: Screenboards
 ---
+This endpoint is outdated. Use the [new Dashboard endpoint](https://docs.datadoghq.com/api/#dashboards) instead.
+

--- a/content/en/api/latest/security-monitoring/_index.md
+++ b/content/en/api/latest/security-monitoring/_index.md
@@ -1,3 +1,83 @@
 ---
 title: Security Monitoring
 ---
+Detection rules for generating signals and listing of generated
+signals.
+
+## Get all security filters
+
+Get the list of configured security filters with their definitions.
+
+## Create a security filter
+
+Create a security filter.
+
+See the [security filter guide](https://docs.datadoghq.com/security_platform/guide/how-to-setup-security-filters-using-security-monitoring-api/)
+for more examples.
+
+## Delete a security filter
+
+Delete a specific security filter.
+
+## Get a security filter
+
+Get the details of a specific security filter.
+
+See the [security filter guide](https://docs.datadoghq.com/security_platform/guide/how-to-setup-security-filters-using-security-monitoring-api/)
+for more examples.
+
+## Update a security filter
+
+Update a specific security filter.
+Returns the security filter object when the request is successful.
+
+## List rules
+
+List rules.
+
+## Create a detection rule
+
+Create a detection rule.
+
+## Delete an existing rule
+
+Delete an existing rule. Default rules cannot be deleted.
+
+## Get a rule's details
+
+Get a rule's details.
+
+## Update an existing rule
+
+Update an existing rule. When updating `cases`, `queries` or `options`, the whole field
+must be included. For example, when modifying a query all queries must be included.
+Default rules can only be updated to be enabled and to change notifications.
+
+## Get a quick list of security signals
+
+The list endpoint returns security signals that match a search query.
+Both this endpoint and the POST endpoint can be used interchangeably when listing
+security signals.
+
+## Get a list of security signals
+
+Returns security signals that match a search query.
+Both this endpoint and the GET endpoint can be used interchangeably for listing
+security signals.
+
+## Get a signal's details
+
+Get a signal's details.
+
+## Modify the triage assignee of a security signal
+
+Modify the triage assignee of a security signal.
+
+## Change the related incidents of a security signal
+
+Change the related incidents for a security signal.
+
+## Change the triage state of a security signal
+
+Change the triage state of a security signal.
+

--- a/content/en/api/latest/service-accounts/_index.md
+++ b/content/en/api/latest/service-accounts/_index.md
@@ -1,3 +1,25 @@
 ---
 title: Service Accounts
 ---
+Create, edit, and disable service accounts.
+
+## List application keys for this service account
+
+List all application keys available for this service account.
+
+## Create an application key for this service account
+
+Create an application key for this service account.
+
+## Delete an application key for this service account
+
+Delete an application key owned by this service account.
+
+## Get one application key for this service account
+
+Get an application key owned by this service account.
+
+## Edit an application key for this service account
+
+Edit an application key owned by this service account.
+

--- a/content/en/api/latest/service-checks/_index.md
+++ b/content/en/api/latest/service-checks/_index.md
@@ -1,3 +1,29 @@
 ---
 title: Service Checks
 ---
+The service check endpoint allows you to post check statuses for use with monitors.
+Service check messages are limited to 500 characters. If a check is posted with a message
+containing more than 500 characters, only the first 500 characters are displayed. Messages
+are limited for checks with a Critical or Warning status, they are dropped for checks with
+an OK status.
+
+- [Read more about Service Check monitors.][1]
+- [Read more about Process Check monitors.][2]
+- [Read more about Network Check monitors.][3]
+- [Read more about Custom Check monitors.][4]
+- [Read more about Service Check and status codes.][5]
+
+[1]: https://docs.datadoghq.com/monitors/create/types/host/?tab=checkalert
+[2]: https://docs.datadoghq.com/monitors/create/types/process_check/?tab=checkalert
+[3]: https://docs.datadoghq.com/monitors/create/types/network/?tab=checkalert
+[4]: https://docs.datadoghq.com/monitors/create/types/custom_check/?tab=checkalert
+[5]: https://docs.datadoghq.com/developers/service_checks/
+
+## Submit a Service Check
+
+Submit a list of Service Checks.
+
+**Notes**:
+- A valid API key is required.
+- Service checks can be submitted up to 10 minutes in the past.
+

--- a/content/en/api/latest/service-definition/_index.md
+++ b/content/en/api/latest/service-definition/_index.md
@@ -1,3 +1,21 @@
 ---
 title: Service Definition
 ---
+API to create, update, retrieve and delete service definitions.
+
+## Get all service definitions
+
+Get a list of all service definitions from the Datadog Service Catalog.
+
+## Create or update service definition
+
+Create or update service definition in the Datadog Service Catalog.
+
+## Delete a single service definition
+
+Delete a single service definition in the Datadog Service Catalog.
+
+## Get a single service definition
+
+Get a single service definition from the Datadog Service Catalog.
+

--- a/content/en/api/latest/service-dependencies/_index.md
+++ b/content/en/api/latest/service-dependencies/_index.md
@@ -1,3 +1,16 @@
 ---
 title: Service Dependencies
 ---
+APM Service Map API. For more information, visit
+the [services map documentation](https://docs.datadoghq.com/tracing/visualization/services_map/).
+
+## Get all APM service dependencies
+
+Get a list of services from APM and their dependencies. The services retrieved are filtered by environment and a
+primary tag, if one is defined.
+
+## Get one APM service's dependencies
+
+Get a specific service's immediate upstream and downstream services.
+The services retrieved are filtered by environment and a primary tag, if one is defined.
+

--- a/content/en/api/latest/service-level-objective-corrections/_index.md
+++ b/content/en/api/latest/service-level-objective-corrections/_index.md
@@ -1,3 +1,28 @@
 ---
 title: Service Level Objective Corrections
 ---
+SLO Status Corrections allow you to prevent specific time periods from negatively impacting
+your SLO’s status and error budget. You can use Status Corrections for various purposes, such
+as removing planned maintenance windows, non-business hours, or other time periods that do
+not correspond to genuine issues.
+
+## Get all SLO corrections
+
+Get all Service Level Objective corrections.
+
+## Create an SLO correction
+
+Create an SLO Correction.
+
+## Delete an SLO correction
+
+Permanently delete the specified SLO correction object.
+
+## Get an SLO correction for an SLO
+
+Get an SLO correction.
+
+## Update an SLO correction
+
+Update the specified SLO correction object.
+

--- a/content/en/api/latest/service-level-objectives/_index.md
+++ b/content/en/api/latest/service-level-objectives/_index.md
@@ -1,3 +1,65 @@
 ---
 title: Service Level Objectives
 ---
+[Service Level Objectives](https://docs.datadoghq.com/monitors/service_level_objectives/#configuration)
+(or SLOs) are a key part of the site reliability engineering toolkit.
+SLOs provide a framework for defining clear targets around application performance,
+which ultimately help teams provide a consistent customer experience,
+balance feature development with platform stability,
+and improve communication with internal and external users.
+
+## Get all SLOs
+
+Get a list of service level objective objects for your organization.
+
+## Create an SLO object
+
+Create a service level objective object.
+
+## Bulk Delete SLO Timeframes
+
+Delete (or partially delete) multiple service level objective objects.
+
+This endpoint facilitates deletion of one or more thresholds for one or more
+service level objective objects. If all thresholds are deleted, the service level
+objective object is deleted as well.
+
+## Check if SLOs can be safely deleted
+
+Check if an SLO can be safely deleted. For example,
+assure an SLO can be deleted without disrupting a dashboard.
+
+## Search for SLOs
+
+Get a list of service level objective objects for your organization.
+
+## Delete an SLO
+
+Permanently delete the specified service level objective object.
+
+If an SLO is used in a dashboard, the `DELETE /v1/slo/` endpoint returns
+a 409 conflict error because the SLO is referenced in a dashboard.
+
+## Get an SLO's details
+
+Get a service level objective object.
+
+## Update an SLO
+
+Update the specified service level objective object.
+
+## Get Corrections For an SLO
+
+Get corrections applied to an SLO
+
+## Get an SLO's history
+
+Get a specific SLO’s history, regardless of its SLO type.
+
+The detailed history data is structured according to the source data type.
+For example, metric data is included for event SLOs that use
+the metric source, and monitor SLO types include the monitor transition history.
+
+**Note:** There are different response formats for event based and time based SLOs.
+Examples of both are shown.
+

--- a/content/en/api/latest/slack-integration/_index.md
+++ b/content/en/api/latest/slack-integration/_index.md
@@ -1,3 +1,49 @@
 ---
 title: Slack Integration
 ---
+Configure your [Datadog-Slack integration](https://docs.datadoghq.com/integrations/slack)
+directly through the Datadog API.
+
+## Delete a Slack integration
+
+Delete a Datadog-Slack integration.
+
+## Get info about a Slack integration
+
+Get all information about your Datadog-Slack integration.
+
+## Create a Slack integration
+
+Create a Datadog-Slack integration. Once created, add a channel to it with the
+[Add channels to Slack integration endpoint](https://docs.datadoghq.com/api/?lang=bash#add-channels-to-slack-integration).
+
+This method updates your integration configuration by **adding**
+your new configuration to the existing one in your Datadog organization.
+
+## Add channels to Slack integration
+
+Add channels to your existing Datadog-Slack integration.
+
+This method updates your integration configuration by **replacing**
+your current configuration with the new one sent to your Datadog organization.
+
+## Get all channels in a Slack integration
+
+Get a list of all channels configured for your Datadog-Slack integration.
+
+## Create a Slack integration channel
+
+Add a channel to your Datadog-Slack integration.
+
+## Remove a Slack integration channel
+
+Remove a channel from your Datadog-Slack integration.
+
+## Get a Slack integration channel
+
+Get a channel configured for your Datadog-Slack integration.
+
+## Update a Slack integration channel
+
+Update a channel used in your Datadog-Slack integration.
+

--- a/content/en/api/latest/snapshots/_index.md
+++ b/content/en/api/latest/snapshots/_index.md
@@ -1,3 +1,10 @@
 ---
 title: Snapshots
 ---
+Take graph snapshots using the API.
+
+## Take graph snapshots
+
+Take graph snapshots.
+**Note**: When a snapshot is created, there is some delay before it is available.
+

--- a/content/en/api/latest/synthetics/_index.md
+++ b/content/en/api/latest/synthetics/_index.md
@@ -1,3 +1,130 @@
 ---
 title: Synthetics
 ---
+Datadog Synthetics uses simulated user requests and browser rendering to help you ensure uptime,
+identify regional issues, and track your application performance. Datadog Synthetics tests come in
+two different flavors, [API tests](https://docs.datadoghq.com/synthetics/api_tests/?tab=httptest)
+and [browser tests](https://docs.datadoghq.com/synthetics/browser_tests). You can use Datadog’s API to
+manage both test types programmatically.
+
+For more information about Synthetics, see the [Synthetics overview](https://docs.datadoghq.com/synthetics/).
+
+## Get details of batch
+
+Get a batch's updated details.
+
+## Get all locations (public and private)
+
+Get the list of public and private locations available for Synthetic
+tests. No arguments required.
+
+## Create a private location
+
+Create a new Synthetics private location.
+
+## Delete a private location
+
+Delete a Synthetics private location.
+
+## Get a private location
+
+Get a Synthetics private location.
+
+## Edit a private location
+
+Edit a Synthetics private location.
+
+## Get the list of all tests
+
+Get the list of all Synthetic tests.
+
+## Create a test
+
+This endpoint is deprecated. To create a test, use [Create an API test](https://docs.datadoghq.com/api/latest/synthetics/#create-an-api-test), or [Create a browser test](https://docs.datadoghq.com/api/latest/synthetics/#create-a-browser-test).
+
+## Create an API test
+
+Create a Synthetic API test.
+
+## Get an API test
+
+Get the detailed configuration associated with
+a Synthetic API test.
+
+## Edit an API test
+
+Edit the configuration of a Synthetic API test.
+
+## Create a browser test
+
+Create a Synthetic browser test.
+
+## Get a browser test
+
+Get the detailed configuration (including steps) associated with
+a Synthetic browser test.
+
+## Edit a browser test
+
+Edit the configuration of a Synthetic browser test.
+
+## Get a browser test's latest results summaries
+
+Get the last 50 test results summaries for a given Synthetics Browser test.
+
+## Get a browser test result
+
+Get a specific full result from a given (browser) Synthetic test.
+
+## Delete tests
+
+Delete multiple Synthetic tests by ID.
+
+## Trigger Synthetics tests
+
+Trigger a set of Synthetics tests.
+
+## Trigger tests from CI/CD pipelines
+
+Trigger a set of Synthetics tests for continuous integration.
+
+## Get a test configuration
+
+Get the detailed configuration associated with a Synthetics test.
+
+## Edit a test
+
+This endpoint is deprecated. To edit a test, use [Edit an API test](https://docs.datadoghq.com/api/latest/synthetics/#edit-an-api-test) or [Edit a browser test](https://docs.datadoghq.com/api/latest/synthetics/#edit-a-browser-test).
+
+## Get an API test's latest results summaries
+
+Get the last 50 test results summaries for a given Synthetics API test.
+
+## Get an API test result
+
+Get a specific full result from a given (API) Synthetic test.
+
+## Pause or start a test
+
+Pause or start a Synthetics test by changing the status.
+
+## Get all global variables
+
+Get the list of all Synthetics global variables.
+
+## Create a global variable
+
+Create a Synthetics global variable.
+
+## Delete a global variable
+
+Delete a Synthetics global variable.
+
+## Get a global variable
+
+Get the detailed configuration of a global variable.
+
+## Edit a global variable
+
+Edit a Synthetics global variable.
+

--- a/content/en/api/latest/tags/_index.md
+++ b/content/en/api/latest/tags/_index.md
@@ -1,3 +1,39 @@
 ---
 title: Tags
 ---
+The tag endpoint allows you to assign tags to hosts,
+for example: `role:database`. Those tags are applied to
+all metrics sent by the host. Refer to hosts by name
+(`yourhost.example.com`) when fetching and applying
+tags to a particular host.
+
+The component of your infrastructure responsible for a tag is identified
+by a source. For example, some valid sources include nagios, hudson, jenkins,
+users, feed, chef, puppet, git, bitbucket, fabric, capistrano, etc.
+
+Read more about tags on the dedicated
+[documentation page](https://docs.datadoghq.com/tagging).
+
+## Get Tags
+
+Return a mapping of tags to hosts for your whole infrastructure.
+
+## Remove host tags
+
+This endpoint allows you to remove all user-assigned tags
+for a single host.
+
+## Get host tags
+
+Return the list of tags that apply to a given host.
+
+## Add tags to a host
+
+This endpoint allows you to add new tags to a host,
+optionally specifying where these tags come from.
+
+## Update host tags
+
+This endpoint allows you to update/replace all tags in
+an integration source with those supplied in the request.
+

--- a/content/en/api/latest/timeboards/_index.md
+++ b/content/en/api/latest/timeboards/_index.md
@@ -1,3 +1,5 @@
 ---
 title: Timeboards
 ---
+This endpoint is outdated. Use the [new Dashboard endpoint](https://docs.datadoghq.com/api/#dashboards) instead.
+

--- a/content/en/api/latest/usage-metering/_index.md
+++ b/content/en/api/latest/usage-metering/_index.md
@@ -1,3 +1,52 @@
 ---
 title: Usage Metering
 ---
+The usage metering API allows you to get hourly, daily, and
+monthly usage across multiple facets of Datadog.
+This API is available to all Pro and Enterprise customers.
+Usage is only accessible for [parent-level organizations](https://docs.datadoghq.com/account_management/multi_organization/).
+
+**Note**: Usage data is delayed by up to 72 hours from when it was incurred.
+It is retained for 15 months.
+
+You can retrieve up to 24 hours of hourly usage data for multiple organizations,
+and up to two months of hourly usage data for a single organization in one request.
+
+## Get hourly usage for application security
+
+Get hourly usage for application security .
+**Note:** hourly usage data for all products is now available in the [Get hourly usage by product family API](https://docs.datadoghq.com/api/latest/usage-metering/#get-hourly-usage-by-product-family)
+
+## Get cost across multi-org account
+
+Get cost across multi-org account.
+Cost by org data for a given month becomes available no later than the 16th of the following month.
+**Note:** This endpoint has been deprecated. Please use the new endpoint
+[`/historical_cost`](https://docs.datadoghq.com/api/latest/usage-metering/#get-historical-cost-across-your-account)
+instead.
+
+## Get estimated cost across your account
+
+Get estimated cost across multi-org and single root-org accounts.
+Estimated cost data is only available for the current month and previous month.
+To access historical costs prior to this, use the `/historical_cost` endpoint.
+
+## Get historical cost across your account
+
+Get historical cost across multi-org and single root-org accounts.
+Cost data for a given month becomes available no later than the 16th of the following month.
+
+## Get hourly usage by product family
+
+Get hourly usage by product family.
+
+## Get hourly usage for lambda traced invocations
+
+Get hourly usage for lambda traced invocations.
+**Note:** hourly usage data for all products is now available in the [Get hourly usage by product family API](https://docs.datadoghq.com/api/latest/usage-metering/#get-hourly-usage-by-product-family)
+
+## Get hourly usage for observability pipelines
+
+Get hourly usage for observability pipelines.
+**Note:** hourly usage data for all products is now available in the [Get hourly usage by product family API](https://docs.datadoghq.com/api/latest/usage-metering/#get-hourly-usage-by-product-family)
+

--- a/content/en/api/latest/users/_index.md
+++ b/content/en/api/latest/users/_index.md
@@ -1,3 +1,50 @@
 ---
 title: Users
 ---
+Create, edit, and disable users.
+
+## Create a service account
+
+Create a service account for your organization.
+
+## Send invitation emails
+
+Sends emails to one or more users inviting them to join the organization.
+
+## Get a user invitation
+
+Returns a single user invitation by its UUID.
+
+## List all users
+
+Get the list of all users in the organization. This list includes
+all users even if they are deactivated or unverified.
+
+## Create a user
+
+Create a user for your organization.
+
+## Disable a user
+
+Disable a user. Can only be used with an application key belonging
+to an administrator user.
+
+## Get user details
+
+Get a user in the organization specified by the user’s `user_id`.
+
+## Update a user
+
+Edit a user. Can only be used with an application key belonging
+to an administrator user.
+
+## Get a user organization
+
+Get a user organization. Returns the user information and all organizations
+joined by this user.
+
+## Get a user permissions
+
+Get a user permission set. Returns a list of the user’s permissions
+granted by the associated user's roles.
+

--- a/content/en/api/latest/using-the-api/_index.md
+++ b/content/en/api/latest/using-the-api/_index.md
@@ -1,4 +1,5 @@
 ---
+render_content: true
 title: Using the API
 type: api
 ---

--- a/content/en/api/latest/webhooks-integration/_index.md
+++ b/content/en/api/latest/webhooks-integration/_index.md
@@ -1,3 +1,42 @@
 ---
 title: Webhooks Integration
 ---
+Configure your Datadog-Webhooks integration directly through the Datadog API.
+For more information about the Datadog-Webhooks integration,
+see the [integration page](https://docs.datadoghq.com/integrations/webhooks).
+
+## Create a custom variable
+
+Creates an endpoint with the name `<CUSTOM_VARIABLE_NAME>`.
+
+## Delete a custom variable
+
+Deletes the endpoint with the name `<CUSTOM_VARIABLE_NAME>`.
+
+## Get a custom variable
+
+Shows the content of the custom variable with the name `<CUSTOM_VARIABLE_NAME>`.
+
+If the custom variable is secret, the value does not return in the
+response payload.
+
+## Update a custom variable
+
+Updates the endpoint with the name `<CUSTOM_VARIABLE_NAME>`.
+
+## Create a webhooks integration
+
+Creates an endpoint with the name `<WEBHOOK_NAME>`.
+
+## Delete a webhook
+
+Deletes the endpoint with the name `<WEBHOOK NAME>`.
+
+## Get a webhook integration
+
+Gets the content of the webhook with the name `<WEBHOOK_NAME>`.
+
+## Update a webhook
+
+Updates the endpoint with the name `<WEBHOOK_NAME>`.
+

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -1,34 +1,36 @@
-{{ $.Scratch.Add "algoliaindex" slice }}
-{{ $section := $.Site.GetPage "section" .Section }}
-{{ $hugo_context := . }}
+{{- if ne hugo.Environment "development" -}}
+    {{ $.Scratch.Add "algoliaindex" slice }}
+    {{ $section := $.Site.GetPage "section" .Section }}
+    {{ $hugo_context := . }}
 
-{{ range (where .Site.AllPages "Kind" "!=" "home") }}
-    {{ $page := . }}
-    {{ if and ($page.IsDescendant $section) (ne $page.Params.private true) (ne $page.Params.kind "faq") (ne $page.Params.beta true) (not $page.Draft) (not (isset .Params "external_redirect")) }}
-        {{ $rel_path := (print $page.File.Lang "/" $page.File.Path) }}
-        {{ $object_id := md5 $rel_path }}
-        {{ $title := $page.Params.integration_title | default $page.Title }}
-        {{ $content := $page.Plain | truncate 10000 }}
-        {{ $tags := $page.Params.algolia.tags | default (slice "docs") }}
-        {{ $rank := $page.Params.algolia.rank | default 50 }}
+    {{ range (where .Site.AllPages "Kind" "!=" "home") }}
+        {{ $page := . }}
+        {{ if and ($page.IsDescendant $section) (ne $page.Params.private true) (ne $page.Params.kind "faq") (ne $page.Params.beta true) (not $page.Draft) (not (isset .Params "external_redirect")) }}
+            {{ $rel_path := (print $page.File.Lang "/" $page.File.Path) }}
+            {{ $object_id := md5 $rel_path }}
+            {{ $title := $page.Params.integration_title | default $page.Title }}
+            {{ $content := $page.Plain | truncate 10000 }}
+            {{ $tags := $page.Params.algolia.tags | default (slice "docs") }}
+            {{ $rank := $page.Params.algolia.rank | default 50 }}
 
-        {{- /* record for each individual section (split by h2 header) */ -}}
-        {{ partial "algolia/page-sections.json" (dict "context" $hugo_context "page" $page "title" $title "tags" $tags "rank" $rank) }}
+            {{- /* record for each individual section (split by h2 header) */ -}}
+            {{ partial "algolia/page-sections.json" (dict "context" $hugo_context "page" $page "title" $title "tags" $tags "rank" $rank) }}
 
-        {{- /* Full page record */ -}}
-        {{- $.Scratch.Add "algoliaindex" (
-            dict "objectID" $object_id 
-            "title" $title
-            "content" $content
-            "type" $page.Type
-            "relpermalink" $page.RelPermalink
-            "full_url" $page.Permalink
-            "language" $page.Language.Lang
-            "tags" $tags
-            "rank" $rank
-        ) -}}
+            {{- /* Full page record */ -}}
+            {{- $.Scratch.Add "algoliaindex" (
+                dict "objectID" $object_id 
+                "title" $title
+                "content" $content
+                "type" $page.Type
+                "relpermalink" $page.RelPermalink
+                "full_url" $page.Permalink
+                "language" $page.Language.Lang
+                "tags" $tags
+                "rank" $rank
+            ) -}}
+        {{ end }}
     {{ end }}
-{{ end }}
 
-{{- /* Outputs final JSON object, copied to public/ folder. */ -}}
-{{- $.Scratch.Get "algoliaindex" | jsonify -}}
+    {{- /* Outputs final JSON object, copied to public/ folder. */ -}}
+    {{- $.Scratch.Get "algoliaindex" | jsonify -}}
+{{- end -}}

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -2,9 +2,9 @@
 
     {{ $dot := . }}
 
-    {{ with .Content}}
+    {{ if .Params.render_content }}
        <div class="col-12 {{if ne $dot.RelPermalink "/api/latest/scopes/"}}col-lg-9{{ end }} pl-0">
-        {{ . }}
+        {{ .Content }}
        </div>
     {{ end }}
 

--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -22,7 +22,7 @@ const getIndexName = () => {
 
 const updateSettings = index => {
     const settings = {
-        searchableAttributes: ['title', 'section_header', 'type, tags', 'unordered(content)'],
+        searchableAttributes: ['title', 'section_header', 'tags', 'type', 'unordered(content)'],
         ranking: ['typo', 'geo', 'words', 'filters', 'proximity', 'attribute', 'exact', 'custom'],
         customRanking: ['asc(tags)', 'desc(rank)'],
         attributesToHighlight: ['title', 'section_header', 'content', 'type', 'tags'],


### PR DESCRIPTION
### What does this PR do?
- Updates `build-api-pages` script to output the summary and description as markdown to the related `_index.md` file.   API page content is controlled by layout, but the proposed indexing strategy relies on markdown content.   These changes allow us to continue building the search index with Hugo and include the API pages.

- After running the script locally this updates markdown files under `content/en/api/latest/` 

- Introduced a frontmatter parameter, `render_content`.   This flag controls whether a specific API page will render the markdown contents of `_index.md`.

### Motivation
API results were broken in our Algolia test preview index.

### Preview
There are no visual changes to API pages.
https://docs-staging.datadoghq.com/brian.deutsch/api-updates/api/latest/ci-visibility-pipelines/
https://docs-staging.datadoghq.com/brian.deutsch/api-updates/api/latest/notebooks/

The following API pages do have markdown content that needs to be rendered.  These should also appear unchanged:
https://docs-staging.datadoghq.com/brian.deutsch/api-updates/api/latest/
https://docs-staging.datadoghq.com/brian.deutsch/api-updates/api/latest/scopes/
https://docs-staging.datadoghq.com/brian.deutsch/api-updates/api/latest/using-the-api/

### Additional Notes
I do have concerns this could cause confusion amongst contributors now that some markdown content will exist in the `api/latest/_index.md` files.    API pages are mostly auto-generated, does it make sense to propose gitignoring those files?  @davidejones what do you think?

We may also need to make some changes to support translation efforts.
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
