### PR TITLE
Remove install/remove service Windows agent commands

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -240,10 +240,8 @@ With Agent v6+, the command line interface is based on subcommands. To run a sub
 | `help`            | Help about any command.                                                     |
 | `hostname`        | Print the hostname used by the Agent.                                       |
 | `import`          | Import and convert configuration files from previous versions of the Agent. |
-| `installservice`  | Install the Agent within the service control manager.                       |
 | `launch-gui`      | Start the Datadog Agent GUI.                                                |
 | `regimport`       | Import the registry settings into `datadog.yaml`.                           |
-| `remove-service`  | Remove the Agent from the service control manager.                          |
 | `restart`         | [Restart the Agent][2].                                                     |
 | `restart-service` | Restart the Agent within the service control manager.                       |
 | `start`           | [Start the Agent][3].                                                       |

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -140,10 +140,8 @@ The execution of the Agent is controlled by the Windows Service Control Manager.
 | help            | Gets help about any command.                                                     |
 | hostname        | Prints the hostname used by the Agent.                                           |
 | import          | Imports and converts configuration files from previous versions of the Agent.    |
-| installservice  | Installs the Agent within the service control manager.                           |
 | launch-gui      | Starts the Datadog Agent Manager.                                                |
 | regimport       | Import the registry settings into `datadog.yaml`.                                |
-| remove-service  | Removes the Agent from the service control manager.                              |
 | restart-service | Restarts the Agent within the service control manager.                           |
 | run             | Starts the Agent.                                                                |
 | start           | Starts the Agent. (Being deprecated, but accepted. Use `run` as an alternative.) |

--- a/content/en/agent/guide/agent-commands.md
+++ b/content/en/agent/guide/agent-commands.md
@@ -264,11 +264,9 @@ Some options have flags and options detailed under `--help`. For example, use he
 | `help`            | Help about any command.                                                     |
 | `hostname`        | Print the hostname used by the Agent.                                       |
 | `import`          | Import and convert configuration files from previous versions of the Agent. |
-| `installservice`  | Install the Agent within the service control manager. Windows only.         |
 | `jmx`             | JMX troubleshooting.                                                        |
 | `launch-gui`      | Start the Datadog Agent GUI.                                                |
 | `regimport`       | Import the registry settings into `datadog.yaml`. Windows only. Deprecated since 7.27.0             |
-| `remove-service`  | Remove the Agent from the service control manager. Windows only.            |
 | `restart-service` | Restart the Agent within the service control manager. Windows only.         |
 | `start-service`   | Start the Agent within the service control manager. Windows only.           |
 | `stream-logs`     | Stream the logs being processed by a running agent.                         |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Removes the `install-service` and `remove-service` Windows agent commands.

Depends on https://github.com/DataDog/datadog-agent/pull/14253

### Motivation
<!-- What inspired you to submit this pull request?-->


<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
