### PR TITLE
Update documentation that mentions install_script.sh

### DIFF
--- a/content/en/agent/faq/agent-downgrade-major.md
+++ b/content/en/agent/faq/agent-downgrade-major.md
@@ -12,17 +12,13 @@ aliases:
 
 First, [uninstall Agent v7 from your system][1].
 
-Then, if you followed the instructions to [upgrade from v6 to v7][2], run the Agent installation command with the environment variable `DD_AGENT_MAJOR_VERSION=6` in order to downgrade your Agent from version 7 to version 6:
+Then, if you followed the instructions to [upgrade from v6 to v7][2], run the following Agent installation command in order to downgrade your Agent from version 7 to version 6:
 
-| Platform     | Command                                                                                                                                                                   |
-|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Amazon Linux | `DD_AGENT_MAJOR_VERSION=6 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"` |
-| CentOS       | `DD_AGENT_MAJOR_VERSION=6 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"` |
-| Debian       | `DD_AGENT_MAJOR_VERSION=6 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"` |
-| Fedora       | `DD_AGENT_MAJOR_VERSION=6 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"` |
-| Red Hat      | `DD_AGENT_MAJOR_VERSION=6 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"` |
-| Ubuntu       | `DD_AGENT_MAJOR_VERSION=6 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"` |
-| SUSE         | `DD_AGENT_MAJOR_VERSION=6 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"` |
+```shell
+DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh)"
+```
+
+The command works on all supported versions of Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu and SUSE.
 
 [1]: /agent/guide/how-do-i-uninstall-the-agent/
 [2]: /agent/versions/upgrade_to_agent_v6/

--- a/content/en/agent/faq/agent-downgrade-major.md
+++ b/content/en/agent/faq/agent-downgrade-major.md
@@ -18,7 +18,7 @@ Then, if you followed the instructions to [upgrade from v6 to v7][2], run the fo
 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh)"
 ```
 
-The command works on all supported versions of Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu and SUSE.
+The command works on all supported versions of Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu, and SUSE.
 
 [1]: /agent/guide/how-do-i-uninstall-the-agent/
 [2]: /agent/versions/upgrade_to_agent_v6/

--- a/content/en/agent/iot/_index.md
+++ b/content/en/agent/iot/_index.md
@@ -52,7 +52,7 @@ Exact resource requirements depend on usage. Datadog found the following when te
 To automatically download and install the correct IoT Agent for your operating system and chipset architecture, use the following command:
 
 ```shell
-DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" DD_AGENT_MAJOR_VERSION=7 DD_AGENT_FLAVOR=datadog-iot-agent bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
+DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" DD_AGENT_FLAVOR=datadog-iot-agent bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 #### Manual

--- a/content/en/agent/versions/upgrade_between_agent_minor_versions.md
+++ b/content/en/agent/versions/upgrade_between_agent_minor_versions.md
@@ -27,7 +27,7 @@ Upgrading to a given Agent 7 minor version:
 
 Upgrading to the latest Agent 7 minor version:
 
-: bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent7.sh)"`
+: `bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent7.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}

--- a/content/en/agent/versions/upgrade_between_agent_minor_versions.md
+++ b/content/en/agent/versions/upgrade_between_agent_minor_versions.md
@@ -11,23 +11,23 @@ aliases:
 {{< tabs >}}
 {{% tab "Linux" %}}
 
-The recommended way to upgrade between minor versions of Agent 6 and 7 is to use the `install_script.sh` script. The following commands work on all supported Linux distributions.
+The recommended way to upgrade between minor versions of Agent 6 and 7 is to use the `install_script_agent6.sh` and `install_script_agent7.sh` scripts. The following commands work on all supported Linux distributions.
 
 Upgrading to a given Agent 6 minor version:
 
-: `DD_AGENT_MAJOR_VERSION=6 DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script.sh)"`
+: `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent6.sh)"`
 
 Upgrading to the latest Agent 6 minor version:
 
-: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script.sh)"`
+: `bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent6.sh)"`
 
 Upgrading to a given Agent 7 minor version:
 
-: `DD_AGENT_MAJOR_VERSION=7 DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script.sh)"`
+: `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent7.sh)"`
 
 Upgrading to the latest Agent 7 minor version:
 
-: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script.sh)"`
+: bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent7.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}

--- a/content/en/agent/versions/upgrade_to_agent_v6.md
+++ b/content/en/agent/versions/upgrade_to_agent_v6.md
@@ -22,7 +22,7 @@ If you have Agent v5 already installed, a script is available to automatically i
 The Agent v6 installer can automatically convert v5 configurations during the upgrade:
 
 The following command works on Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu, and SUSE:
-: `DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"`
+: `DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh)"`
 
 **Note:** The import process won't automatically move **custom** Agent checks. This is by design as Datadog cannot guarantee full backwards compatibility out of the box.
 

--- a/content/en/agent/versions/upgrade_to_agent_v7.md
+++ b/content/en/agent/versions/upgrade_to_agent_v7.md
@@ -16,10 +16,10 @@ Agent v7 only supports Python 3 custom checks. <a href="/agent/guide/python-3">C
 {{< tabs >}}
 {{% tab "Linux" %}}
 
-Run the Agent installation command with the environment variable `DD_AGENT_MAJOR_VERSION=7` in order to upgrade your Agent from version 6 to version 7:
+Run the following Agent installation command in order to upgrade your Agent from version 6 to version 7:
 
 The following command works on Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu, and SUSE:
-: `DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"`
+: `DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -51,10 +51,10 @@ DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https
 {{< tabs >}}
 {{% tab "Linux" %}}
 
-Run the Agent installation command with the environment variable `DD_AGENT_MAJOR_VERSION=7` and `DD_UPGRADE="true"` in order to upgrade your Agent from version 5 to version 7. The Agent v7 installer can automatically convert v5 configurations during the upgrade:
+Run the Agent installation command with the environment variable `DD_UPGRADE="true"` in order to upgrade your Agent from version 5 to version 7. The Agent v7 installer can automatically convert v5 configurations during the upgrade:
 
 The following command works on Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu, and SUSE:
-: `DD_AGENT_MAJOR_VERSION=7 DD_UPGRADE="true" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"`
+: `DD_UPGRADE="true" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}

--- a/content/en/getting_started/agent/_index.md
+++ b/content/en/getting_started/agent/_index.md
@@ -104,7 +104,7 @@ In the Datadog UI, go to the Agent Installation page for Ubuntu by navigating to
 Example Ubuntu one-line install command:
 
 ```shell
-DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
+DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 Go to the in-app [Agent Installation page][18] for your operating system for the most up-to-date installation instructions.

--- a/content/en/getting_started/tracing/_index.md
+++ b/content/en/getting_started/tracing/_index.md
@@ -38,7 +38,7 @@ vagrant ssh
 To install the Datadog Agent on a host, use the [one line install command][6] updated with your [Datadog API key][7]:
 
 ```shell
-DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
+DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 ### Validation

--- a/static/config/99datadog-amazon-linux-2.config
+++ b/static/config/99datadog-amazon-linux-2.config
@@ -21,7 +21,7 @@ files:
     mode: "000700"
     owner: root
     group: root
-    source: https://s3.amazonaws.com/dd-agent/scripts/install_script.sh
+    source: https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh
 
 container_commands:
     05setup_datadog:

--- a/static/config/99datadog.config
+++ b/static/config/99datadog.config
@@ -21,7 +21,7 @@ files:
     mode: "000700"
     owner: root
     group: root
-    source: https://s3.amazonaws.com/dd-agent/scripts/install_script.sh
+    source: https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh
 
 container_commands:
     05setup_datadog:

--- a/static/resources/json/dd-agent-install-eu-site.json
+++ b/static/resources/json/dd-agent-install-eu-site.json
@@ -21,7 +21,7 @@
 			},
 			"inputs": {
 				"runCommand": [
-					"wget -O ddinstall.sh https://s3.amazonaws.com/dd-agent/scripts/install_script.sh",
+					"wget -O ddinstall.sh https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh",
 					"export DD_API_KEY=$(aws --region <AWS_REGION> ssm get-parameters --names dd-api-key-for-ssm --with-decryption --query Parameters[].Value --output text)",
 					"export DD_SITE=datadoghq.eu",
 					"bash ./ddinstall.sh"

--- a/static/resources/json/dd-agent-install-us-site.json
+++ b/static/resources/json/dd-agent-install-us-site.json
@@ -21,7 +21,7 @@
 			},
 			"inputs": {
 				"runCommand": [
-					"wget -O ddinstall.sh https://s3.amazonaws.com/dd-agent/scripts/install_script.sh",
+					"wget -O ddinstall.sh https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh",
 					"export DD_API_KEY=$(aws --region <AWS_REGION> ssm get-parameters --names dd-api-key-for-ssm --with-decryption --query Parameters[].Value --output text)",
 					"bash ./ddinstall.sh"
 				],


### PR DESCRIPTION
### What does this PR do?

Point to new install_script_agent6.sh and install_script_agent7.sh

### Motivation

We've moved install_script to https://github.com/DataDog/agent-linux-install-script and started releasing the two above mentioned flavors, this updates docs to reflect that.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
