### PR TITLE
Rename Cloud SIEM Investigator to Investigator

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2547,10 +2547,10 @@ main:
     parent: cloud_siem
     identifier: cloud_siem_signals_explorer
     weight: 5
-  - name: Cloud SIEM Investigator
-    url: security_platform/cloud_siem/cloud_siem_investigator
+  - name: Investigator
+    url: security_platform/cloud_siem/investigator
     parent: cloud_siem
-    identifier: cloud_siem_cloud_security_investigator
+    identifier: cloud_siem_investigator
     weight: 6
   - name: Guides
     url: security_platform/cloud_siem/guide/

--- a/content/en/security_platform/cloud_siem/investigator.md
+++ b/content/en/security_platform/cloud_siem/investigator.md
@@ -1,8 +1,9 @@
 ---
-title: Cloud SIEM Investigator
+title: Investigator
 kind: documentation
 aliases:
   - /security_platform/cloud_siem/cloud_security_investigator/
+  - /security_platform/cloud_siem/cloud_siem_investigator/
 further_reading:
 - link: "/cloud_siem/explorer/"
   tag: "Documentation"


### PR DESCRIPTION
### What does this PR do?

- Renames doc.
- Drop "Cloud SIEM" in "Cloud SIEM Investigator" in the nav and title.
- Add alias.

### Motivation

Redundant to have "Cloud SIEM". It will also will only be "Investigator" in the app.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
