### PR TITLE
Add agentConfiguration setting to Linux Azure extension documentation

### DIFF
--- a/content/en/integrations/faq/powershell-command-to-install-azure-datadog-extension.md
+++ b/content/en/integrations/faq/powershell-command-to-install-azure-datadog-extension.md
@@ -15,7 +15,7 @@ To run the Datadog Agent in your Azure instances as an extension, use the follow
 {{% tab "Windows" %}}
 
 ```powershell
-Set-AzureVMExtension -Name "DatadogAgent" -Publisher "Datadog.Agent" -Type "DatadogWindowsAgent" -TypeHandlerVersion "6.4" -Settings @{"site" = "datadoghq.com"; "agentVersion" = "latest"} -ProtectedSettings @{"api_key" = "<YOUR_DATADOG_API_KEY>"} -DisableAutoUpgradeMinorVersion
+Set-AzureVMExtension -Name "DatadogAgent" -Publisher "Datadog.Agent" -Type "DatadogWindowsAgent" -TypeHandlerVersion "5.0" -Settings @{"site" = "datadoghq.com"; "agentVersion" = "latest"} -ProtectedSettings @{"api_key" = "<YOUR_DATADOG_API_KEY>"} -DisableAutoUpgradeMinorVersion
 ```
 More information on the syntax to set Azure instance extensions can be found in the [Azure Extension Set-AzureVMExtension documentation][1].
 

--- a/content/en/integrations/faq/powershell-command-to-install-azure-datadog-extension.md
+++ b/content/en/integrations/faq/powershell-command-to-install-azure-datadog-extension.md
@@ -45,7 +45,7 @@ The Datadog Windows Agent Azure Extension will check that the `agentConfiguratio
 The Datataog Agent configuration should be created from the `%PROGRAMDATA%\Datadog` folder.
 
 ```powershell
-Set-AzVMExtension -Name "DatadogAgent" -Publisher "Datadog.Agent" -Type "DatadogWindowsAgent" -TypeHandlerVersion "6.4" -Settings @{"site" = "datadoghq.com"; "agentConfiguration" = "https://<CONFIGURATION_BLOB>.blob.core.windows.net/<FILE_PATH>.zip"; "agentConfigurationChecksum" = "<SHA256_CHECKSUM"} -DisableAutoUpgradeMinorVersion
+Set-AzVMExtension -Name "DatadogAgent" -Publisher "Datadog.Agent" -Type "DatadogWindowsAgent" -TypeHandlerVersion "6.4" -Settings @{"site" = "datadoghq.com"; "agentConfiguration" = "https://<CONFIGURATION_BLOB>.blob.core.windows.net/<FILE_PATH>.zip"; "agentConfigurationChecksum" = "<SHA256_CHECKSUM>"} -DisableAutoUpgradeMinorVersion
 ```
 
 **Note**: Once the Datadog Agent is installed, the configuration can only be changed when upgrading to a newer version.
@@ -76,7 +76,7 @@ The normal settings include:
 |----------|------|--------------|
 | `site` | String | Set the Datadog intake site, for example: `SITE=`{{< region-param key="dd_site" code="true">}} |
 | `agentVersion` | String | The Agent version to install, following the format `x.y.z` or `latest` |
-| `agentConfiguration` | URI | (optional) Url to the Azure blob contaning the Agent configuration as a zip. |
+| `agentConfiguration` | URI | (optional) URI to the Azure blob containing the Agent configuration as a zip. |
 | `agentConfigurationChecksum` | String | The SHA256 checksum of the Agent configuration zip file, mandatory if `agentConfiguration` is specified. |
 
 The protected settings include:
@@ -85,13 +85,13 @@ The protected settings include:
 |----------|------|--------------|
 | `api_key`| String | Adds the Datadog API KEY to the configuration file. |
 
-**Note**: If `agentConfiguration` and `api_key` are specified at the same time, the API key found in the `agentConfiguration` takes precedence. Also note that if an API key is set on the target machine, it's not possible to change it with the `api_key` setting.
+**Note**: If `agentConfiguration` and `api_key` are specified at the same time, the API key found in the `agentConfiguration` takes precedence. If an API key is set on the target machine, it's not possible to change it with the `api_key` setting.
 
 ### Specifying a configuration URI
 This example shows how to specify a configuration for the Datadog Agent to use.
-The Datadog Agent configuration URI must be an Azure blob storage URI.
-The Datadog Linux Agent Azure Extension will check that the `agentConfiguration` URI comes from the `.blob.core.windows.net` domain.
-The Datataog Agent configuration should be created from the `/etc/datadog-agent/` folder.
+- The Datadog Agent configuration URI must be an Azure blob storage URI.
+- The Datadog Linux Agent Azure Extension checks that the `agentConfiguration` URI comes from the `.blob.core.windows.net` domain.
+- The Datataog Agent configuration should be created from the `/etc/datadog-agent/` folder.
 
 ```bash
 az vm extension set --publisher "Datadog.Agent" --name "DatadogLinuxAgent" --version 6.0 --settings '{"site":"datadoghq.com", "agentVersion":"7.40.0", "agentConfiguration":"https://<CONFIGURATION_BLOB>.blob.core.windows.net/<FILE_PATH>.zip", "agentConfigurationChecksum":"<SHA256_CHECKSUM>"}' --protected-settings '{"api_key":"<YOUR_DATADOG_API_KEY>"}' --no-auto-upgrade-minor-version

--- a/content/en/integrations/faq/powershell-command-to-install-azure-datadog-extension.md
+++ b/content/en/integrations/faq/powershell-command-to-install-azure-datadog-extension.md
@@ -15,7 +15,7 @@ To run the Datadog Agent in your Azure instances as an extension, use the follow
 {{% tab "Windows" %}}
 
 ```powershell
-Set-AzureVMExtension -Name "DatadogAgent" -Publisher "Datadog.Agent" -Type "DatadogWindowsAgent" -TypeHandlerVersion "5.0" -Settings @{"site" = "datadoghq.com"; "agentVersion" = "latest"} -ProtectedSettings @{"api_key" = "<YOUR_DATADOG_API_KEY>"} -DisableAutoUpgradeMinorVersion
+Set-AzureVMExtension -Name "DatadogAgent" -Publisher "Datadog.Agent" -Type "DatadogWindowsAgent" -TypeHandlerVersion "6.4" -Settings @{"site" = "datadoghq.com"; "agentVersion" = "latest"} -ProtectedSettings @{"api_key" = "<YOUR_DATADOG_API_KEY>"} -DisableAutoUpgradeMinorVersion
 ```
 More information on the syntax to set Azure instance extensions can be found in the [Azure Extension Set-AzureVMExtension documentation][1].
 
@@ -45,7 +45,7 @@ The Datadog Windows Agent Azure Extension will check that the `agentConfiguratio
 The Datataog Agent configuration should be created from the `%PROGRAMDATA%\Datadog` folder.
 
 ```powershell
-Set-AzVMExtension -Name "DatadogAgent" -Publisher "Datadog.Agent" -Type "DatadogWindowsAgent" -TypeHandlerVersion "5.0" -Settings @{"site" = "datadoghq.com"; "agentConfiguration" = "https://<CONFIGURATION_BLOB>.blob.core.windows.net/<YOUR_DATADOG_API_KEY>.zip"; "agentConfigurationCheckSum" = "9AB6ADCEF012305B32EBDE3A7022F1420C09825D889D3CE11FB8550856D7A474"} -DisableAutoUpgradeMinorVersion
+Set-AzVMExtension -Name "DatadogAgent" -Publisher "Datadog.Agent" -Type "DatadogWindowsAgent" -TypeHandlerVersion "6.4" -Settings @{"site" = "datadoghq.com"; "agentConfiguration" = "https://<CONFIGURATION_BLOB>.blob.core.windows.net/<FILE_PATH>.zip"; "agentConfigurationChecksum" = "<SHA256_CHECKSUM"} -DisableAutoUpgradeMinorVersion
 ```
 
 **Note**: Once the Datadog Agent is installed, the configuration can only be changed when upgrading to a newer version.
@@ -56,7 +56,7 @@ This example shows how to specify a version of the Agent to install. By default 
 **Note**: Downgrades are *not* supported, so it's not possible to install a *lower* version of the Datadog Agent than the one currently installed on the target machine. To install a lower version of the Datadog Agent, uninstall the previous version first by removing the Datadog Windows Agent Azure Extension on the target machine. Removing the Datadog Windows Agent Azure Extension does not remove the Datadog Agent configuration.
 
 ```powershell
-Set-AzureVMExtension -Name "DatadogAgent" -Publisher "Datadog.Agent" -Type "DatadogWindowsAgent" -TypeHandlerVersion "5.0" -Settings @{"site" = "datadoghq.com"; "agentVersion" = "7.39.0"} -ProtectedSettings @{"api_key" = "<YOUR_DATADOG_API_KEY>"} -DisableAutoUpgradeMinorVersion
+Set-AzureVMExtension -Name "DatadogAgent" -Publisher "Datadog.Agent" -Type "DatadogWindowsAgent" -TypeHandlerVersion "6.4" -Settings @{"site" = "datadoghq.com"; "agentVersion" = "7.40.0"} -ProtectedSettings @{"api_key" = "<YOUR_DATADOG_API_KEY>"} -DisableAutoUpgradeMinorVersion
 ```
 
 [1]: https://learn.microsoft.com/en-us/powershell/module/az.compute/set-azvmextension
@@ -64,7 +64,7 @@ Set-AzureVMExtension -Name "DatadogAgent" -Publisher "Datadog.Agent" -Type "Data
 {{% tab "Linux" %}}
 
 ```bash
-az vm extension set --publisher "Datadog.Agent" --name "DatadogLinuxAgent" --version 5.0 --settings '{"site":"datadoghq.com", "agentVersion":"7.39.0"}' --protected-settings '{"api_key":"<YOUR_DATADOG_API_KEY>"}' --no-auto-upgrade-minor-version
+az vm extension set --publisher "Datadog.Agent" --name "DatadogLinuxAgent" --version 6.0 --settings '{"site":"datadoghq.com", "agentVersion":"7.40.0"}' --protected-settings '{"api_key":"<YOUR_DATADOG_API_KEY>"}' --no-auto-upgrade-minor-version
 ```
 More information on the syntax to set Azure instance extensions can be found in the [Azure Extension CLI reference][1].
 
@@ -76,6 +76,8 @@ The normal settings include:
 |----------|------|--------------|
 | `site` | String | Set the Datadog intake site, for example: `SITE=`{{< region-param key="dd_site" code="true">}} |
 | `agentVersion` | String | The Agent version to install, following the format `x.y.z` or `latest` |
+| `agentConfiguration` | URI | (optional) Url to the Azure blob contaning the Agent configuration as a zip. |
+| `agentConfigurationChecksum` | String | The SHA256 checksum of the Agent configuration zip file, mandatory if `agentConfiguration` is specified. |
 
 The protected settings include:
 
@@ -83,6 +85,17 @@ The protected settings include:
 |----------|------|--------------|
 | `api_key`| String | Adds the Datadog API KEY to the configuration file. |
 
+**Note**: If `agentConfiguration` and `api_key` are specified at the same time, the API key found in the `agentConfiguration` takes precedence. Also note that if an API key is set on the target machine, it's not possible to change it with the `api_key` setting.
+
+### Specifying a configuration URI
+This example shows how to specify a configuration for the Datadog Agent to use.
+The Datadog Agent configuration URI must be an Azure blob storage URI.
+The Datadog Linux Agent Azure Extension will check that the `agentConfiguration` URI comes from the `.blob.core.windows.net` domain.
+The Datataog Agent configuration should be created from the `/etc/datadog-agent/` folder.
+
+```bash
+az vm extension set --publisher "Datadog.Agent" --name "DatadogLinuxAgent" --version 6.0 --settings '{"site":"datadoghq.com", "agentVersion":"7.40.0", "agentConfiguration":"https://<CONFIGURATION_BLOB>.blob.core.windows.net/<FILE_PATH>.zip", "agentConfigurationChecksum":"<SHA256_CHECKSUM>"}' --protected-settings '{"api_key":"<YOUR_DATADOG_API_KEY>"}' --no-auto-upgrade-minor-version
+```
 
 [1]: https://learn.microsoft.com/en-us/cli/azure/vm/extension
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds documentation about the `agentConfiguration` setting that was added to the Linux Azure extension in version 6.0.

Updates the Windows `TypeHandlerVersion` and Linux `version` to the latest Azure extension versions.

Updates `agentVersion` in the example commands from `7.39` to `7.40`.

### Motivation
<!-- What inspired you to submit this pull request?-->

`agentConfiguration` feature added to Linux Azure extension.

https://datadoghq.atlassian.net/browse/WA-131

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
