### PR TITLE
Removed line in Intelligence Filter section

### DIFF
--- a/content/en/tracing/trace_pipeline/trace_retention.md
+++ b/content/en/tracing/trace_pipeline/trace_retention.md
@@ -65,7 +65,7 @@ The `Spans Indexed` column for each retention filter is powered by the `datadog.
 
 ### Datadog intelligent retention filter
 
-The intelligent retention filter is always active for your services, and it keeps a proportion of traces to help you monitor the health of your applications. All [service entry spans][5] are indexed for the traces kept by the intelligent retention filter.
+The intelligent retention filter is always active for your services, and it keeps a proportion of traces to help you monitor the health of your applications. 
 
 For 30 days, intelligent retention retains:
 


### PR DESCRIPTION
We are no longer indexing all the service entry spans with the intelligence Filter. Updating doc.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
removes a line in the documentation that is no longer relevant

### Motivation
change in the Intelligence filter https://datadoghq.atlassian.net/browse/SESP-609

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
