### PR TITLE
fixed dead link to leader election option in kubernetes/data_collected

### DIFF
--- a/content/en/containers/kubernetes/data_collected.md
+++ b/content/en/containers/kubernetes/data_collected.md
@@ -98,4 +98,4 @@ As the 5.17.0 release, Datadog Agent now supports built in [leader election opti
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://docs.datadoghq.com/containers/cluster_agent/event_collection/
+[1]: /containers/cluster_agent/event_collection/

--- a/content/en/containers/kubernetes/data_collected.md
+++ b/content/en/containers/kubernetes/data_collected.md
@@ -55,7 +55,7 @@ Note that `kubernetes_state.*` metrics are gathered from the `kube-state-metrics
 
 ## Events
 
-As the 5.17.0 release, Datadog Agent now supports built in [leader election option][9] for the Kubernetes event collector. Once enabled, you no longer need to deploy an additional event collection container to your cluster. Instead, Agents will coordinate to ensure only one Agent instance is gathering events at a given time, events below will be available:
+As the 5.17.0 release, Datadog Agent now supports built in [leader election option][1] for the Kubernetes event collector. Once enabled, you no longer need to deploy an additional event collection container to your cluster. Instead, Agents will coordinate to ensure only one Agent instance is gathering events at a given time, events below will be available:
 
 - Backoff
 - Conflict
@@ -97,3 +97,5 @@ As the 5.17.0 release, Datadog Agent now supports built in [leader election opti
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://github.com/DataDog/documentation/blob/master/content/en/containers/cluster_agent/event_collection.md

--- a/content/en/containers/kubernetes/data_collected.md
+++ b/content/en/containers/kubernetes/data_collected.md
@@ -98,4 +98,4 @@ As the 5.17.0 release, Datadog Agent now supports built in [leader election opti
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://www.datadoghq.com/blog/datadog-cluster-agent/
+[1]: https://docs.datadoghq.com/containers/cluster_agent/event_collection/

--- a/content/en/containers/kubernetes/data_collected.md
+++ b/content/en/containers/kubernetes/data_collected.md
@@ -98,4 +98,4 @@ As the 5.17.0 release, Datadog Agent now supports built in [leader election opti
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/documentation/blob/master/content/en/containers/cluster_agent/event_collection.md
+[1]: https://www.datadoghq.com/blog/datadog-cluster-agent/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
fixed dead link to 'leader election option' in kubernetes/data_collected

### Motivation
<!-- What inspired you to submit this pull request?-->
Closing #15854

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
