### PR TITLE
Add instructions for IMDSv2 in ECS docs

### DIFF
--- a/content/en/containers/amazon_ecs/apm.md
+++ b/content/en/containers/amazon_ecs/apm.md
@@ -80,7 +80,7 @@ The [Amazon’s EC2 metadata endpoint][1] allows discovery of the private IP add
 curl http://169.254.169.254/latest/meta-data/local-ipv4
 {{< /code-block >}}
 
-If you are using the Version 2 of the Instance Metadata Service (IMDSv2):
+If you are using Version 2 of the Instance Metadata Service (IMDSv2):
 
 {{< code-block lang="curl" >}}
 TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")

--- a/content/en/containers/amazon_ecs/apm.md
+++ b/content/en/containers/amazon_ecs/apm.md
@@ -80,8 +80,15 @@ The [Amazon’s EC2 metadata endpoint][1] allows discovery of the private IP add
 curl http://169.254.169.254/latest/meta-data/local-ipv4
 {{< /code-block >}}
 
+If you are using the Version 2 of the Instance Metadata Service (IMDSv2):
+
+{{< code-block lang="curl" >}}
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+curl http://169.254.169.254/latest/meta-data/local-ipv4 -H "X-aws-ec2-metadata-token: $TOKEN"
+{{< /code-block >}}
 
 [1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+[2]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
 {{% /tab %}}
 {{% tab "ECS container metadata file" %}}
 


### PR DESCRIPTION
### What does this PR do?

IMDSv2 is a security mechanism that is recommended to enable in AWS (c.f. https://securitylabs.datadoghq.com/articles/state-of-aws-cloud-security-followup/#enforce-usage-of-the-ec2-instance-metadata-service-v2-(imdsv2))

Consequently we should have instructions for customers who enforce it according to best practices

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
