### PR TITLE
Add "native" name to ddprof documentation

### DIFF
--- a/content/en/profiler/enabling/ddprof.md
+++ b/content/en/profiler/enabling/ddprof.md
@@ -1,5 +1,5 @@
 ---
-title: Enabling the Profiler for Compiled Languages
+title: Enabling the Native Profiler for Compiled Languages
 kind: Documentation
 code_lang: ddprof
 type: multi-code-lang
@@ -17,10 +17,11 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-The profiler for compiled languages, <code>ddprof</code> is in public beta. Datadog recommends evaluating the profiler in a non-sensitive environment before deploying in production.
+The native profiler for compiled languages, <code>ddprof</code> is in public beta. Datadog recommends evaluating the profiler in a non-sensitive environment before deploying in production.
 </div>
 
-The Datadog Continuous Profiler for compiled languages (`ddprof`) uses OS level APIs to collect profiling data. It is ideally suited for applications written in compiled languages, such as C, C++, or Rust.
+The native profiler for compiled languages (`ddprof`) uses OS level APIs to collect profiling data. It is ideally suited for applications written in compiled languages, such as C, C++, or Rust.
+Profiles sent from `ddprof` show up under the _native_ runtime in the Datadog web app.
 
 ## Requirements
 


### PR DESCRIPTION
 ### What does this PR do?

This PR tweaks the `ddprof` onboarding documentation to mention that `ddprof` is the native profiler.

 ### Motivation

This PR started from the following observation: In the Datadog web app, we present profiles from the "Profiler for Compiled Languages" as coming from the `native` runtime.

Nowhere in the documentation do we make the connection between "Profiler for Compiled Languages" and `native`. And nowhere else we seem to call it "the Profiler for Compiled Languages".

Unfortunately, we seem to have decided to name this profiler in three different ways, and all three seem to be user-visibile:

* ddprof: repository, binary, docs
* native profiler: web app, [repository](https://github.com/DataDog/ddprof/blob/8cfee2c1482e9eb14ec8615b229924118564bb0b/Readme.md?plain=1#L3)
* profiler for compiled languages: only docs (added in #14783)

While I'm not a fan of this confusion, I decided to take a first small step: let's at least state in the documentation the word "native" as that's what the web app is using.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

 ### Additional Notes

See also <https://dd.slack.com/archives/GK1JL5FAB/p1666965919163029> (slack link to internal profiling team thread) for a discussion on this.

---

 ### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
