### PR TITLE
update privatelink docs

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -205,13 +205,13 @@ The VPCs with Private Hosted Zone (PHZ) attached need to have a couple of settin
 
     ```yaml
     logs_config:
-        use_http: true
+        force_use_http: true
     ```
 
     If you are using the container Agent, set the following environment variable instead:
 
     ```
-    DD_LOGS_CONFIG_USE_HTTP=true
+    DD_LOGS_CONFIG_FORCE_USE_HTTP=true
     ```
 
     This configuration is required when sending logs to Datadog with AWS PrivateLink and the Datadog Agent, and is not required for the Lambda Extension. For more details, see [Agent log collection][8].


### PR DESCRIPTION
### What does this PR do?

fixes refrence to `use_http` setting for agent `log_config`. Option is now called `force_use_http`, looks like this was changed in DD agent [#11381](https://github.com/DataDog/datadog-agent/commit/42f52e8f8eaf999147c91763746fbee774dcaaad)

### Motivation

This was confusing for me until I did a git blame on the example agent config file. Figured it would be good to get updated for anyone who comes after.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
