### PR TITLE
Fix typo "in" vs "is"

### DIFF
--- a/content/en/dynamic_instrumentation/_index.md
+++ b/content/en/dynamic_instrumentation/_index.md
@@ -97,7 +97,7 @@ To create a metric probe:
 
 ### Selecting instrumented instances
 
-By default, Dynamic Instrumentation in enabled on only one randomly selected instance of your service for each environment and version combination. If the enabled instance is destroyed, a new one is selected at random from the remaining ones.
+By default, Dynamic Instrumentation is enabled on only one randomly selected instance of your service for each environment and version combination. If the enabled instance is destroyed, a new one is selected at random from the remaining ones.
 
 Alternatively, you can explicitly configure which instances of your service are enabled. You can use this feature to enable Dynamic Instrumentation on more service instances, or to restrict enablement in certain environments.
 


### PR DESCRIPTION
### What does this PR do?
Fix a typo: "Dynamic Instrumentation ~~in~~ **is** enabled on only ..."

### Motivation
Documentation without typos.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
