### PR TITLE
DOCS-4366 Clarifying permanent role stripping with SAML login

### DIFF
--- a/content/en/account_management/org_settings.md
+++ b/content/en/account_management/org_settings.md
@@ -30,9 +30,9 @@ To learn about default and custom roles in Datadog, read the [Role Based Access 
 
 #### SAML Group Mappings
 
-When enabled, users logging in with SAML to your Datadog account are stripped of their current roles and reassigned to new roles based on the details in their SAML assertion passed on from your Identity Provider and the mappings you've created.
+When enabled, users logging in with SAML to your Datadog account are permanently stripped of their current roles and reassigned to new roles. The SAML assertion passed on from the Identity Provider and the mappings you create determine each user's new roles.
 
-Users who log in with SAML and do not have the values that map to a Datadog role are stripped of all roles and are not allowed to log in.
+Users who log in with SAML and do not have values that map to a Datadog role are permanently stripped of all roles. That user may no longer log in.
 To learn how to create and set mappings, read the [Mapping SAML attributes documentation][5].
 
 ##### SAML settings

--- a/content/en/account_management/saml/troubleshooting.md
+++ b/content/en/account_management/saml/troubleshooting.md
@@ -62,9 +62,9 @@ To validate your metadata file:
 
 ## Roles errors
 
-When mappings are enabled, users logging in with SAML to a Datadog account are stripped of their current roles and reassigned to new roles based on the details in their SAML assertion passed on from your IdP.
+When mappings are enabled, users logging in with SAML to a Datadog account are permanently stripped of their current roles. Datadog assigns new roles based on the details in the SAML assertion passed on from your IdP.
 
-Users who log in with SAML and do not have the values that map to a Datadog role are stripped of all roles and are not allowed to log in.
+Users who log in with SAML and do not have values that map to a Datadog role are permanently stripped of all roles. That user may no longer log in.
 
 {{< img src="account_management/saml/unknown_user_error.png" alt="No AuthNMappings for this user" style="width:80%;">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates wording around SAML login mapping to clarify the permanence of the role changes.

### Motivation
Request from Support

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
