### PR TITLE
Remove request access link from USM beta callout

### DIFF
--- a/content/en/tracing/universal_service_monitoring/_index.md
+++ b/content/en/tracing/universal_service_monitoring/_index.md
@@ -19,7 +19,7 @@ further_reading:
   text: "Read about the Service Map"
 ---
 
-{{< beta-callout url="http://d-sh.io/universal" d-toggle="modal" d_target="#signupModal" custom_class="sign-up-trigger">}}
+{{< beta-callout url="#" d-toggle="modal" btn_hidden="true" d_target="#signupModal" custom_class="sign-up-trigger">}}
   Universal Service Monitoring (USM) is in public beta. There is currently no billing impact for enabling and using USM.
 {{< /beta-callout >}}
 


### PR DESCRIPTION
Removes a link that loops back to the same docs page.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
