### PR TITLE
Update python.md

### DIFF
--- a/content/en/logs/log_collection/python.md
+++ b/content/en/logs/log_collection/python.md
@@ -87,7 +87,7 @@ The log file contains the following log record (inline):
 }
 ```
 
-[1]: https://pypi.python.org/pypi/JSON-log-formatter/0.1.0
+[1]: https://pypi.python.org/pypi/JSON-log-formatter/
 {{% /tab %}}
 {{% tab "Python-json-logger" %}}
 


### PR DESCRIPTION
### What does this PR do?
Remove the version of the JSON-log-formatter library in the link (currently set to 0.1.0) so that customers get directed to the latest library version. Missed one of the links in the previous PR.