### PR TITLE
removed yellow beta bar

### DIFF
--- a/content/en/real_user_monitoring/generate_metrics/_index.md
+++ b/content/en/real_user_monitoring/generate_metrics/_index.md
@@ -17,10 +17,6 @@ further_reading:
   text: "Generate metrics from ingested logs"
 ---
 
-<div class="alert alert-warning">
-Generating custom metrics from RUM events is in beta. Access to this feature is provisioned to customers using Real User Monitoring. Contact <a href="/help">Datadog Support</a> to provide feedback.
-</div>
-
 ## Overview
 
 Real User Monitoring (RUM) allows you to capture events that occur in your browser and mobile applications using the Datadog RUM SDKs and collect data from events at a [sample rate][1]. Datadog retains this event data in the [RUM Explorer][2], where you can create search queries and visualizations.


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
It removes a yellow bar at the top of the article that lets readers know the feature is in beta.

### Motivation
Amina requested that this be removed on 11/15/22 since the feature will no longer be in beta.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
