### PR TITLE
Add deprecation warning on daily usage attribution

### DIFF
--- a/content/en/account_management/billing/usage_attribution.md
+++ b/content/en/account_management/billing/usage_attribution.md
@@ -78,6 +78,8 @@ Monthly data can also be pulled using the tool's public API. For more informatio
 {{< site-region region="us,eu" >}}
 ### Daily usage attribution
 
+<div class="alert alert-warning">Datadog plans to deprecate daily usage attribution reports on February 1, 2023. As an alternative, use the <a href="/api/latest/usage-metering/#get-hourly-usage-attribution">hourly usage attribution API endpoint</a>.</div>
+
 This section provides daily reports at an hourly granularity to dig into time frames. It also provides a concatenation of all reports during a given month.
 
 - Clicking on a specific time period expands a view on the right where reports can be downloaded as a TSV file.
@@ -87,7 +89,6 @@ This section provides daily reports at an hourly granularity to dig into time fr
 
 Daily data can also be pulled using the tool's public API. For more information, see the [API endpoint documentation][2].
 
-[2]: https://docs.datadoghq.com/api/v1/usage-metering/#get-hourly-usage-attribution
 {{< /site-region >}}
 
 ### Interpreting the data
@@ -131,4 +132,5 @@ Each color block represents a unique tag value for each tag.
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://docs.datadoghq.com/api/v1/usage-metering/#get-monthly-usage-attribution
+[2]: https://docs.datadoghq.com/api/v1/usage-metering/#get-hourly-usage-attribution
 [3]: https://docs.datadoghq.com/getting_started/tagging/#defining-tags

--- a/content/en/account_management/billing/usage_attribution.md
+++ b/content/en/account_management/billing/usage_attribution.md
@@ -89,6 +89,7 @@ This section provides daily reports at an hourly granularity to dig into time fr
 
 Daily data can also be pulled using the tool's public API. For more information, see the [API endpoint documentation][2].
 
+[2]: https://docs.datadoghq.com/api/v1/usage-metering/#get-hourly-usage-attribution
 {{< /site-region >}}
 
 ### Interpreting the data
@@ -132,5 +133,4 @@ Each color block represents a unique tag value for each tag.
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://docs.datadoghq.com/api/v1/usage-metering/#get-monthly-usage-attribution
-[2]: https://docs.datadoghq.com/api/v1/usage-metering/#get-hourly-usage-attribution
 [3]: https://docs.datadoghq.com/getting_started/tagging/#defining-tags


### PR DESCRIPTION
### What does this PR do?
Adds a colored alert box warning users that daily usage attribution reports will be deprecated in February.
Screenshot: https://share.getcloudapp.com/JruyPBe0

### Motivation
Product manager request.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
