### PR TITLE
fix text to yaml formatting for ad_identifiers

### DIFF
--- a/content/en/agent/guide/ad_identifiers.md
+++ b/content/en/agent/guide/ad_identifiers.md
@@ -20,7 +20,7 @@ Autodiscovery container identifiers, or `ad_identifiers`, allow you to apply an 
 
 To apply the following Autodiscovery configuration template to a given container, use the **container short image** name as the `<INTEGRATION_AUTODISCOVERY_IDENTIFIER>`:
 
-```text
+```yaml
 ad_identifiers:
   <INTEGRATION_AUTODISCOVERY_IDENTIFIER>
 
@@ -68,7 +68,7 @@ ad_identifiers:
 
 To apply different Autodiscovery configuration templates to containers running the same image, use a custom value `<INTEGRATION_AUTODISCOVERY_IDENTIFIER>` and apply it with the `com.datadoghq.ad.check.id` label to identify your container. Using the following configuration file:
 
-```text
+```yaml
 ad_identifiers:
   <INTEGRATION_AUTODISCOVERY_IDENTIFIER>
 
@@ -81,7 +81,7 @@ instances:
 
 Add the following label to apply this Autodiscovery configuration template to a specific container.
 
-```text
+```yaml
 com.datadoghq.ad.check.id: <INTEGRATION_AUTODISCOVERY_IDENTIFIER>
 ```
 


### PR DESCRIPTION
Just updating some formatting to replace `text` formatting with more easy to read `yaml` formatting.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Just updating some formatting to replace `text` formatting with more easy to read `yaml` formatting.

### Motivation
Cleaning up Containers docs

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
