### PR TITLE
Fix link to wrap decorator documentation

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/python.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/python.md
@@ -63,7 +63,7 @@ def make_sandwich_request(request):
 API details for the decorator can be found for `ddtrace.Tracer.wrap()` [here][1].
 
 
-[1]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace.Tracer.wrap
+[1]: https://ddtrace.readthedocs.io/en/stable/api.html#ddtrace.Tracer.wrap
 {{% /tab %}}
 {{% tab "Context Manager" %}}
 


### PR DESCRIPTION
### What does this PR do?

This updates the link to the `wrap()` decorator such that the user gets taken directly to the appropriate documentation.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
