### PR TITLE
Add ruby instructions to dbm/apm linking guide

### DIFF
--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -127,9 +127,9 @@ require 'mysql2'
 require 'ddtrace'
 
 Datadog.configure do |c|
-  c.service = 'billing-api'
-  c.env = 'production'
-  c.version = '1.3-alpha'
+	c.service = 'billing-api'
+	c.env = 'production'
+	c.version = '1.3-alpha'
 
 	c.tracing.instrument :mysql2, comment_propagation: ENV['DD_DBM_PROPAGATION_MODE']
 end

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -14,7 +14,7 @@ This guide assumes that you have configured [Datadog Monitoring][1] and are usin
 ## Before you begin
 
 Supported tracers
-: [dd-trace-go][3] >= 1.42.0 (support for [database/sql][4] and [sqlx][5] packages)
+: [dd-trace-go][3] >= 1.42.0 (support for [database/sql][4] and [sqlx][5] packages)<br />
 : [dd-trace-rb][6] >= 1.6.0 (support for [mysql2][7] and [pg][8] gems)
 
 Supported databases
@@ -113,7 +113,7 @@ Enable the database monitoring propagation feature using one of the following me
 1. Env variable:
    `DD_DBM_PROPAGATION_MODE=service`
 
-2. Option `comment_propagation` (default: ENV['DD_DBM_PROPAGATION_MODE']), for [mysql2][9] or [pg][10]:
+2. Option `comment_propagation` (default: `ENV['DD_DBM_PROPAGATION_MODE']`), for [mysql2][2] or [pg][3]:
    ```rb
 	Datadog.configure do |c|
 		c.tracing.instrument :mysql2, comment_propagation: 'service'
@@ -139,6 +139,8 @@ client.query("SELECT 1;")
 ```
 
 [1]: https://github.com/dataDog/dd-trace-rb
+[2]: /tracing/trace_collection/dd_libraries/ruby/#mysql2
+[3]: /tracing/trace_collection/dd_libraries/ruby/#postgres
 
 {{% /tab %}}
 
@@ -153,5 +155,3 @@ client.query("SELECT 1;")
 [6]: https://github.com/dataDog/dd-trace-rb
 [7]: https://github.com/brianmario/mysql2
 [8]: https://github.com/ged/ruby-pg
-[9]: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/ruby/#mysql2
-[10]: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/ruby/#postgres

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -15,7 +15,7 @@ This guide assumes that you have configured [Datadog Monitoring][1] and are usin
 
 Supported tracers
 : [dd-trace-go][3] >= 1.42.0 (support for [database/sql][4] and [sqlx][5] packages)<br />
-: [dd-trace-rb][6] >= 1.6.0 (support for [mysql2][7] and [pg][8] gems)
+[dd-trace-rb][6] >= 1.6.0 (support for [mysql2][7] and [pg][8] gems)
 
 Supported databases
 : postgres, mysql

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -15,6 +15,7 @@ This guide assumes that you have configured [Datadog Monitoring][1] and are usin
 
 Supported tracers
 : [dd-trace-go][3] >= 1.42.0 (support for [database/sql][4] and [sqlx][5] packages)
+: [dd-trace-rb][6] >= 1.6.0 (support for [mysql2][7] and [ruby-pg][8] gems)
 
 Supported databases
 : postgres, mysql
@@ -94,6 +95,44 @@ func main() {
 [1]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1
 
 {{% /tab %}}
+
+{{% tab "Ruby" %}}
+
+Update your app dependencies to include [dd-trace-rb 1.6.0][1] or greater:
+```
+<TODO>
+```
+
+Enable the database monitoring propagation feature using one of the following methods:
+1. Env variable: 
+   `DD_DBM_PROPAGATION_MODE=service`
+
+2. Using code during the driver configuration:
+   ```rb
+	Datadog.configure do |c|
+    	c.tracing.sql_comment_propagation = 'full'
+		c.tracing.instrument :mysql2, **options
+	end
+   ```
+
+Full example:
+```rb
+require 'mysql2'
+require 'ddtrace'
+
+Datadog.configure do |c|
+	c.tracing.sql_comment_propagation = 'full'
+	c.tracing.instrument :mysql2, **options
+end
+
+client = Mysql2::Client.new(:host => "localhost", :username => "root")
+client.query("SELECT * FROM users WHERE group='x'")
+```
+
+[1]: https://github.com/dataDog/dd-trace-rb
+
+{{% /tab %}}
+
 {{< /tabs >}}
 
 
@@ -102,3 +141,6 @@ func main() {
 [3]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1
 [4]: https://pkg.go.dev/database/sql
 [5]: https://pkg.go.dev/github.com/jmoiron/sqlx
+[6]: https://github.com/dataDog/dd-trace-rb
+[7]: https://github.com/brianmario/mysql2
+[8]: https://github.com/ged/ruby-pg


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This adds instructions for the ruby tracer to our DBM/APM linking guide. 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
