### PR TITLE
Update Service check monitor

### DIFF
--- a/content/en/monitors/create/types/custom_check.md
+++ b/content/en/monitors/create/types/custom_check.md
@@ -18,7 +18,7 @@ further_reading:
 
 ## Overview
 
-Service check monitors include any service check not reported by one of the [more than {{< translate key="integration_count" >}} integrations][1] included with the Agent. Service checks can be sent to Datadog using a [custom Agent check][2], [DogStatsD][3], or the [API][4].
+Service check monitors include any service check not reported by one of the [more than {{< translate key="integration_count" >}} integrations][1] included with the Agent. Service checks can be sent to Datadog using a [custom Agent check][2], [DogStatsD][3], or the [API][4]. For more information, see the [Service Check Overview][11]
 
 ## Monitor creation
 
@@ -47,20 +47,16 @@ A check alert tracks consecutive statuses submitted per check grouping and compa
 Set up the check alert:
 
 1. Trigger a separate alert for each `<GROUP>` reporting your check.
-
-    Check grouping is specified either from a list of known groupings or by you. For service check monitors, the per-check grouping is unknown, so you must specify it.
+    * Check grouping is specified either from a list of known groupings or by you. For service check monitors, the per-check grouping is unknown, so you must specify it.
 
 2. Trigger the alert after selected consecutive failures: `<NUMBER>`
+    * Choose how many consecutive runs with the `CRITICAL` status trigger a notification. For example, to be notified immediately when your check fails, trigger the monitor alert on `1` critical status.
 
-    Each check run submits a single status of `OK`, `WARN`, `CRITICAL`, or `UNKNOWN`. Choose how many consecutive runs with the `WARN` and `CRITICAL` status trigger a notification. For example, to be notified immediately when your check fails, trigger the monitor alert on `1` critical status or `1` warning status.
-
-3. Choose `Do not notify` or `Notify` for Unknown status.
-
-    If enabled, a state transition to `UNKNOWN` triggers a notification. In the [monitor status page][1], the status bar of a group in `UNKNOWN` state uses `NODATA` grey. The overall status of the monitor stays in `OK`.
+3. Select `Do not notify` or `Notify` for Unknown status.
+    * If `Notify` is selected, a state transition to `UNKNOWN` triggers a notification. In the [monitor status page][1], the status bar of a group in `UNKNOWN` state uses `NODATA` grey. The overall status of the monitor stays in `OK`.
 
 4. Resolve the alert after selected consecutive successes: `<NUMBER>`.
-
-    Choose how many consecutive runs with the `OK` status resolve the alert. For example, to ensure an issue is fixed, resolve the monitor on `4` OK statuses.
+    * Choose how many consecutive runs with the `OK` status resolve the alert. For example, to ensure an issue is fixed, resolve the monitor on `4` `OK` statuses.
 
 
 [1]: /monitors/manage/status
@@ -69,17 +65,18 @@ Set up the check alert:
 
 A cluster alert calculates the percent of checks in a given status and compares it to your thresholds.
 
-Set up a cluster alert:
-
-1. Decide whether or not to group your checks according to a tag. `Ungrouped` calculates the status percentage across all sources. `Grouped` calculates the status percentage on a per-group basis.
-
-2. Select the percentage for alert and warn thresholds. Only one setting (alert or warn) is required.
-
 Each check tagged with a distinct combination of tags is considered to be a distinct check in the cluster. Only the status of the last check of each combination of tags is taken into account in the cluster percentage calculation.
 
 {{< img src="monitors/monitor_types/process_check/cluster_check_thresholds.png" alt="Cluster Check Thresholds" style="width:90%;">}}
 
 For example, a cluster check monitor grouped by environment can alert if more that 70% of the checks on any of the environments submit a `CRITICAL` status, and warn if more that 70% of the checks on any of the environments submit a `WARN` status.
+
+Set up a cluster alert:
+
+1. Decide whether or not to group your checks according to a tag. `Ungrouped` calculates the status percentage across all sources. `Grouped` calculates the status percentage on a per-group basis.
+
+2. Select the percentage for alert and warn thresholds. Only one setting (alert or warn) is required.
+    
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -105,3 +102,4 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 [8]: /monitors/create/configuration/#auto-resolve
 [9]: /monitors/create/configuration/#new-group-delay
 [10]: /monitors/notify/
+[11]: /developers/service_checks/#overview

--- a/content/en/monitors/create/types/custom_check.md
+++ b/content/en/monitors/create/types/custom_check.md
@@ -71,7 +71,7 @@ Each check tagged with a distinct combination of tags is considered to be a dist
 
 For example, a cluster check monitor grouped by environment can alert if more that 70% of the checks on any of the environments submit a `CRITICAL` status, and warn if more that 70% of the checks on any of the environments submit a `WARN` status.
 
-Set up a cluster alert:
+To set up a cluster alert:
 
 1. Decide whether or not to group your checks according to a tag. `Ungrouped` calculates the status percentage across all sources. `Grouped` calculates the status percentage on a per-group basis.
 
@@ -97,7 +97,7 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 [3]: /developers/dogstatsd/
 [4]: /api/v1/service-checks/
 [5]: /developers/service_checks/#overview
-[6]: https://app.datadoghq.com/monitors#create/custom
+[6]: https://app.datadoghq.com/monitors/create/custom
 [7]: /monitors/create/configuration/#advanced-alert-conditions
 [8]: /monitors/create/configuration/#no-data
 [9]: /monitors/create/configuration/#auto-resolve

--- a/content/en/monitors/create/types/custom_check.md
+++ b/content/en/monitors/create/types/custom_check.md
@@ -18,11 +18,11 @@ further_reading:
 
 ## Overview
 
-Service check monitors include any service check not reported by one of the [more than {{< translate key="integration_count" >}} integrations][1] included with the Agent. Service checks can be sent to Datadog using a [custom Agent check][2], [DogStatsD][3], or the [API][4]. For more information, see the [Service Check Overview][5]
+Service check monitors include any service check not reported by one of the [more than {{< translate key="integration_count" >}} integrations][1] included with the Agent. Service checks can be sent to Datadog using a [custom Agent check][2], [DogStatsD][3], or the [API][4]. For more information, see the [Service Check Overview][5].
 
 ## Monitor creation
 
-To create a [service check monitor][6] in Datadog, use the main navigation: *Monitors --> New Monitor --> Service Check*.
+To create a [service check monitor][6] in Datadog, use the main navigation: **Monitors** --> **New Monitor** --> **Service Check**.
 
 ### Pick a service check
 

--- a/content/en/monitors/create/types/custom_check.md
+++ b/content/en/monitors/create/types/custom_check.md
@@ -18,11 +18,11 @@ further_reading:
 
 ## Overview
 
-Service check monitors include any service check not reported by one of the [more than {{< translate key="integration_count" >}} integrations][1] included with the Agent. Service checks can be sent to Datadog using a [custom Agent check][2], [DogStatsD][3], or the [API][4]. For more information, see the [Service Check Overview][11]
+Service check monitors include any service check not reported by one of the [more than {{< translate key="integration_count" >}} integrations][1] included with the Agent. Service checks can be sent to Datadog using a [custom Agent check][2], [DogStatsD][3], or the [API][4]. For more information, see the [Service Check Overview][5]
 
 ## Monitor creation
 
-To create a [service check monitor][5] in Datadog, use the main navigation: *Monitors --> New Monitor --> Service Check*.
+To create a [service check monitor][6] in Datadog, use the main navigation: *Monitors --> New Monitor --> Service Check*.
 
 ### Pick a service check
 
@@ -82,11 +82,11 @@ Set up a cluster alert:
 
 #### Advanced alert conditions
 
-See the [Monitor configuration][6] documentation for information on [No data][7], [Auto resolve][8], and [New group delay][9] options.
+See the [Monitor configuration][7] documentation for information on [No data][8], [Auto resolve][9], and [New group delay][10] options.
 
 ### Notifications
 
-For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][10] page.
+For detailed instructions on the **Say what's happening** and **Notify your team** sections, see the [Notifications][11] page.
 
 ## Further Reading
 
@@ -96,10 +96,10 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 [2]: /developers/custom_checks/write_agent_check/
 [3]: /developers/dogstatsd/
 [4]: /api/v1/service-checks/
-[5]: https://app.datadoghq.com/monitors#create/custom
-[6]: /monitors/create/configuration/#advanced-alert-conditions
-[7]: /monitors/create/configuration/#no-data
-[8]: /monitors/create/configuration/#auto-resolve
-[9]: /monitors/create/configuration/#new-group-delay
-[10]: /monitors/notify/
-[11]: /developers/service_checks/#overview
+[5]: /developers/service_checks/#overview
+[6]: https://app.datadoghq.com/monitors#create/custom
+[7]: /monitors/create/configuration/#advanced-alert-conditions
+[8]: /monitors/create/configuration/#no-data
+[9]: /monitors/create/configuration/#auto-resolve
+[10]: /monitors/create/configuration/#new-group-delay
+[11]: /monitors/notify/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the [Service Check Monitor](https://docs.datadoghq.com/monitors/create/types/custom_check/?tab=checkalert) page 
- Removed the `WARN` option for triggering alerts since it's not available as an option
- Added the Service Check overview as another resource
- Shifted information around for Cluster Alerts

### Motivation
[DOCS-4395](https://datadoghq.atlassian.net/browse/DOCS-4395)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
