### PR TITLE
[DOCS-3754] Move optional step to end in Rsyslogs doc

### DIFF
--- a/content/en/integrations/rsyslog.md
+++ b/content/en/integrations/rsyslog.md
@@ -57,7 +57,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
    sudo systemctl restart rsyslog
    ```
 
-5. Associate your logs with the host metrics and tags:
+5. Associate your logs with the host metrics and tags.
    
    To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
    - If you specified a hostname in `datadog.conf` or `datadog.yaml`, replace the `%HOSTNAME%` value in `rsyslog.conf` to match your hostname.
@@ -65,7 +65,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
 
 6. To get the best use out of your logs in Datadog, set a source for the logs.
    - If you [forward your logs to the Datadog Agent][1], you can set the source in the Agent configuration file.
-   - If you're not forwarding your logs to the Datadog Agent, create a distinct configuration file for each source in `/etc/rsyslog.d/`:
+   - If you're not forwarding your logs to the Datadog Agent, create a distinct configuration file for each source in `/etc/rsyslog.d/`.
 
      To set the source, use the following format (if you have several sources, change the name of the format in each file):
 

--- a/content/en/integrations/rsyslog.md
+++ b/content/en/integrations/rsyslog.md
@@ -52,51 +52,18 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"
     ```
 
-{{< site-region region="us,us3,us5,gov">}}
-4. Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
-   1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
-      ```shell
-      sudo apt-get install rsyslog-gnutls ca-certificates
-      ```
-   2. Add the following line to the bottom of your `/etc/rsyslog.d/datadog.conf` file:
-      ```conf
-      ## Define the destination for the logs
-      $DefaultNetstreamDriverCAFile /etc/ssl/certs/ca-certificates.crt
-      ruleset(name="infiles") {
-          action(type="omfwd" protocol="tcp" target="intake.logs.datadoghq.com" port="10516" template="DatadogFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.logs.datadoghq.com" )
-      }
-      ```
-{{< /site-region >}}
-{{< site-region region="eu" >}}
-
-4. Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
-   1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
-      ```shell
-      sudo apt-get install rsyslog-gnutls ca-certificates
-      ```
-
-   2. Add the following line to the bottom of your `/etc/rsyslog.d/datadog.conf` file:
-      ```conf
-      ## Define the destination for the logs
-      $DefaultNetstreamDriverCAFile /etc/ssl/certs/ca-certificates.crt
-      ruleset(name="infiles") {
-          action(type="omfwd" protocol="tcp" target="tcp-intake.logs.datadoghq.eu" port="443" template="DatadogFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.logs.datadoghq.eu" )
-      }
-       ```
-{{< /site-region >}}
-
-5. Restart Rsyslog. Your new logs are forwarded directly to your Datadog account.
+4. Restart Rsyslog. Your new logs are forwarded directly to your Datadog account.
    ```shell
    sudo systemctl restart rsyslog
    ```
 
-6. Associate your logs with the host metrics and tags:
+5. Associate your logs with the host metrics and tags:
    
    To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
    - If you specified a hostname in `datadog.conf` or `datadog.yaml`, replace the `%HOSTNAME%` value in `rsyslog.conf` to match your hostname.
    - If you did not specify a hostname in `datadog.conf` or `datadog.yaml`, you do not need to change anything.
 
-7. To get the best use out of your logs in Datadog, set a source for the logs.
+6. To get the best use out of your logs in Datadog, set a source for the logs.
    - If you [forward your logs to the Datadog Agent][1], you can set the source in the Agent configuration file.
    - If you're not forwarding your logs to the Datadog Agent, create a distinct configuration file for each source in `/etc/rsyslog.d/`:
 
@@ -112,7 +79,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
      $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\" ddtags=\"env:dev,<KEY:VALUE>\"] %msg%\n"
      ```
 
-8. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
+7. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
    
    1. Add the following two lines to your Rsyslog configuration file:
 
@@ -126,6 +93,50 @@ Configure Rsyslog to gather logs from your host, containers, & services.
       ```shell
       sudo systemctl restart rsyslog
       ```
+
+{{< site-region region="us">}}
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+   1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
+      ```shell
+      sudo apt-get install rsyslog-gnutls ca-certificates
+      ```
+   2. Add the following line to the bottom of your `/etc/rsyslog.d/datadog.conf` file:
+      ```conf
+      ## Define the destination for the logs
+      $DefaultNetstreamDriverCAFile /etc/ssl/certs/ca-certificates.crt
+      ruleset(name="infiles") {
+          action(type="omfwd" protocol="tcp" target="intake.logs.datadoghq.com" port="10516" template="DatadogFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.logs.datadoghq.com" )
+      }
+      ```
+   3. Restart the Rsyslog service:
+
+      ```shell
+      sudo systemctl restart rsyslog
+      ```
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+   1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
+      ```shell
+      sudo apt-get install rsyslog-gnutls ca-certificates
+      ```
+
+   2. Add the following line to the bottom of your `/etc/rsyslog.d/datadog.conf` file:
+      ```conf
+      ## Define the destination for the logs
+      $DefaultNetstreamDriverCAFile /etc/ssl/certs/ca-certificates.crt
+      ruleset(name="infiles") {
+          action(type="omfwd" protocol="tcp" target="tcp-intake.logs.datadoghq.eu" port="443" template="DatadogFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.logs.datadoghq.eu" )
+      }
+       ```
+   3. Restart the Rsyslog service:
+
+      ```shell
+      sudo systemctl restart rsyslog
+      ```
+{{< /site-region >}}
+
 [1]: /agent/logs/
 {{% /tab %}}
 
@@ -148,52 +159,18 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"
     ```
 
-{{< site-region region="us,us3,us5,gov">}}
-4. Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
-   1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
-      ```shell
-      sudo yum install rsyslog-gnutls ca-certificates
-      ```
-   2. Add the following line to the bottom of your `/etc/rsyslog.d/datadog.conf` file:
-      ```conf
-      ## Define the destination for the logs
-      $DefaultNetstreamDriverCAFile /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-      ruleset(name="infiles") {
-          action(type="omfwd" protocol="tcp" target="intake.logs.datadoghq.com" port="10516" template="DatadogFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.logs.datadoghq.com" )
-      }
-      ```
-{{< /site-region >}}
-
-{{< site-region region="eu" >}}
-
-4. Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
-   1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
-      ```shell
-      sudo yum install rsyslog-gnutls ca-certificates
-      ```
-
-   2. Add the following line to the bottom of your `/etc/rsyslog.d/datadog.conf` file:
-      ```conf
-      ## Define the destination for the logs
-      $DefaultNetstreamDriverCAFile /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-      ruleset(name="infiles") {
-          action(type="omfwd" protocol="tcp" target="tcp-intake.logs.datadoghq.eu" port="443" template="DatadogFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.logs.datadoghq.eu" )
-      }
-       ```
-{{< /site-region >}}
-
-5. Restart Rsyslog. Your new logs are forwarded directly to your Datadog account.
+4. Restart Rsyslog. Your new logs are forwarded directly to your Datadog account.
    ```shell
    sudo systemctl restart rsyslog
    ```
 
-6. Associate your logs with the host metrics and tags:
+5. Associate your logs with the host metrics and tags:
    
    To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
    - If you specified a hostname in `datadog.conf` or `datadog.yaml`, replace the `%HOSTNAME%` value in `rsyslog.conf` to match your hostname.
    - If you did not specify a hostname in `datadog.conf` or `datadog.yaml`, you do not need to change anything.
 
-7. To get the best use out of your logs in Datadog, set a source for the logs. 
+6. To get the best use out of your logs in Datadog, set a source for the logs. 
    - If you [forward your logs to the Datadog Agent][1], you can set the source in the Agent configuration file.
    - If you're not forwarding your logs to the Datadog Agent, create a distinct configuration file for each source in `/etc/rsyslog.d/`:
 
@@ -209,7 +186,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
      $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\" ddtags=\"env:dev,<KEY:VALUE>\"] %msg%\n"
      ```
 
-8. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
+7. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
    
    1. Add the following two lines to your Rsyslog configuration file:
 
@@ -223,6 +200,51 @@ Configure Rsyslog to gather logs from your host, containers, & services.
       ```shell
       sudo systemctl restart rsyslog
       ```
+
+{{< site-region region="us">}}
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+   1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
+      ```shell
+      sudo yum install rsyslog-gnutls ca-certificates
+      ```
+   2. Add the following line to the bottom of your `/etc/rsyslog.d/datadog.conf` file:
+      ```conf
+      ## Define the destination for the logs
+      $DefaultNetstreamDriverCAFile /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+      ruleset(name="infiles") {
+          action(type="omfwd" protocol="tcp" target="intake.logs.datadoghq.com" port="10516" template="DatadogFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.logs.datadoghq.com" )
+      }
+      ```
+   3. Restart the Rsyslog service:
+
+      ```shell
+      sudo systemctl restart rsyslog
+      ```
+{{< /site-region >}}
+
+{{< site-region region="eu" >}}
+
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+   1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
+      ```shell
+      sudo yum install rsyslog-gnutls ca-certificates
+      ```
+
+   2. Add the following line to the bottom of your `/etc/rsyslog.d/datadog.conf` file:
+      ```conf
+      ## Define the destination for the logs
+      $DefaultNetstreamDriverCAFile /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+      ruleset(name="infiles") {
+          action(type="omfwd" protocol="tcp" target="tcp-intake.logs.datadoghq.eu" port="443" template="DatadogFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.logs.datadoghq.eu" )
+      }
+       ```
+   3. Restart the Rsyslog service:
+
+      ```shell
+      sudo systemctl restart rsyslog
+      ```
+{{< /site-region >}}
+
 [1]: /agent/logs/
 {{% /tab %}}
 
@@ -246,52 +268,18 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"
     ```
 
-{{< site-region region="us,us3,us5,gov">}}
-4. Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
-   1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
-      ```shell
-      sudo dnf install rsyslog-gnutls ca-certificates
-      ```
-   2. Add the following line to the bottom of your `/etc/rsyslog.d/datadog.conf` file:
-      ```conf
-      ## Define the destination for the logs
-      $DefaultNetstreamDriverCAFile /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-      ruleset(name="infiles") {
-          action(type="omfwd" protocol="tcp" target="intake.logs.datadoghq.com" port="10516" template="DatadogFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.logs.datadoghq.com" )
-      }
-      ```
-{{< /site-region >}}
-
-{{< site-region region="eu" >}}
-
-4. Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
-   1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
-      ```shell
-      sudo dnf install rsyslog-gnutls ca-certificates
-      ```
-
-   2. Add the following line to the bottom of your `/etc/rsyslog.d/datadog.conf` file:
-      ```conf
-      ## Define the destination for the logs
-      $DefaultNetstreamDriverCAFile /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-      ruleset(name="infiles") {
-          action(type="omfwd" protocol="tcp" target="tcp-intake.logs.datadoghq.eu" port="443" template="DatadogFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.logs.datadoghq.eu" )
-      }
-       ```
-{{< /site-region >}}
-
-5. Restart Rsyslog. Your new logs are forwarded directly to your Datadog account.
+4. Restart Rsyslog. Your new logs are forwarded directly to your Datadog account.
    ```shell
    sudo systemctl restart rsyslog
    ```
 
-6. Associate your logs with the host metrics and tags:
+5. Associate your logs with the host metrics and tags:
    
    To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
    - If you specified a hostname in `datadog.conf` or `datadog.yaml`, replace the `%HOSTNAME%` value in `rsyslog.conf` to match your hostname.
    - If you did not specify a hostname in `datadog.conf` or `datadog.yaml`, you do not need to change anything.
 
-7. To get the best use out of your logs in Datadog, set a source for the logs. 
+6. To get the best use out of your logs in Datadog, set a source for the logs. 
    - If you [forward your logs to the Datadog Agent][1], you can set the source in the Agent configuration file.
    - If you're not forwarding your logs to the Datadog Agent, create a distinct configuration file for each source in `/etc/rsyslog.d/`:
 
@@ -307,7 +295,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
      $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\" ddtags=\"env:dev,<KEY:VALUE>\"] %msg%\n"
      ```
 
-8. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
+7. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
    
    1. Add the following two lines to your Rsyslog configuration file:
 
@@ -321,6 +309,51 @@ Configure Rsyslog to gather logs from your host, containers, & services.
       ```shell
       sudo systemctl restart rsyslog
       ```
+
+{{< site-region region="us">}}
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+   1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
+      ```shell
+      sudo dnf install rsyslog-gnutls ca-certificates
+      ```
+   2. Add the following line to the bottom of your `/etc/rsyslog.d/datadog.conf` file:
+      ```conf
+      ## Define the destination for the logs
+      $DefaultNetstreamDriverCAFile /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+      ruleset(name="infiles") {
+          action(type="omfwd" protocol="tcp" target="intake.logs.datadoghq.com" port="10516" template="DatadogFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.logs.datadoghq.com" )
+      }
+      ```
+   3. Restart the Rsyslog service:
+
+      ```shell
+      sudo systemctl restart rsyslog
+      ```
+{{< /site-region >}}
+
+{{< site-region region="eu" >}}
+
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+   1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
+      ```shell
+      sudo dnf install rsyslog-gnutls ca-certificates
+      ```
+
+   2. Add the following line to the bottom of your `/etc/rsyslog.d/datadog.conf` file:
+      ```conf
+      ## Define the destination for the logs
+      $DefaultNetstreamDriverCAFile /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+      ruleset(name="infiles") {
+          action(type="omfwd" protocol="tcp" target="tcp-intake.logs.datadoghq.eu" port="443" template="DatadogFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.logs.datadoghq.eu" )
+      }
+       ```
+   3. Restart the Rsyslog service:
+
+      ```shell
+      sudo systemctl restart rsyslog
+      ```
+{{< /site-region >}}
+
 [1]: /agent/logs/
 {{% /tab %}}
 
@@ -354,9 +387,53 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     ## Set the Datadog Format to send the logs
     $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"
     ```
-    
-{{< site-region region="us,us3,us5,gov">}}
-4. Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+
+4. Restart Rsyslog. Your new logs are forwarded directly to your Datadog account.
+
+    ```shell
+    sudo systemctl restart rsyslog
+    ```
+
+5. Associate your logs with the host metrics and tags:
+   
+   To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
+
+   - If you specified a hostname in `datadog.conf` or `datadog.yaml`, replace the `%HOSTNAME%` value in `rsyslog.conf` to match your hostname.
+   - If you did not specify a hostname in `datadog.conf` or `datadog.yaml`, you do not need to change anything.
+
+6. To get the best use out of your logs in Datadog, set a source for the logs.
+   - If you [forward your logs to the Datadog Agent][1], you can set the source in the Agent configuration file.
+   - If you're not forwarding your logs to the Datadog Agent, create a distinct configuration file for each source in `/etc/rsyslog.d/`:
+
+   To set the source, use the following format (if you have several sources, change the name of the format in each file):
+
+   ```conf
+   $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\"] %msg%\n"
+   ```
+
+   You can also add custom tags with the `ddtags` attribute:
+
+   ```conf
+   $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\" ddtags=\"env:dev,<KEY:VALUE>\"] %msg%\n"
+   ```
+
+7. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
+   
+   1. Add the following two lines to your Rsyslog configuration:
+
+      ```conf
+      $ModLoad immark
+      $MarkMessagePeriod 20
+      ```
+
+   2. Restart the Rsyslog service:
+
+      ```shell
+      sudo systemctl restart rsyslog
+      ```
+
+{{< site-region region="us">}}
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
 
     1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
 
@@ -375,11 +452,16 @@ Configure Rsyslog to gather logs from your host, containers, & services.
         $ActionSendStreamDriverPermittedPeer *.logs.datadoghq.com
         *.* @@intake.logs.datadoghq.com:10516;DatadogFormat
         ```
+   3. Restart the Rsyslog service:
+
+      ```shell
+      sudo systemctl restart rsyslog
+      ```
 {{< /site-region >}}
 
 {{< site-region region="eu" >}}
 
-4. Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
 
     1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
 
@@ -399,51 +481,12 @@ Configure Rsyslog to gather logs from your host, containers, & services.
         $ActionSendStreamDriverPermittedPeer *.logs.datadoghq.eu
         *.* @@tcp-intake.logs.datadoghq.eu:443;DatadogFormat
         ```
-{{< /site-region >}}
-
-5. Restart Rsyslog. Your new logs are forwarded directly to your Datadog account.
-
-    ```shell
-    sudo systemctl restart rsyslog
-    ```
-
-6. Associate your logs with the host metrics and tags:
-   
-   To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
-
-   - If you specified a hostname in `datadog.conf` or `datadog.yaml`, replace the `%HOSTNAME%` value in `rsyslog.conf` to match your hostname.
-   - If you did not specify a hostname in `datadog.conf` or `datadog.yaml`, you do not need to change anything.
-
-7. To get the best use out of your logs in Datadog, set a source for the logs.
-   - If you [forward your logs to the Datadog Agent][1], you can set the source in the Agent configuration file.
-   - If you're not forwarding your logs to the Datadog Agent, create a distinct configuration file for each source in `/etc/rsyslog.d/`:
-
-   To set the source, use the following format (if you have several sources, change the name of the format in each file):
-
-   ```conf
-   $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\"] %msg%\n"
-   ```
-
-   You can also add custom tags with the `ddtags` attribute:
-
-   ```conf
-   $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\" ddtags=\"env:dev,<KEY:VALUE>\"] %msg%\n"
-   ```
-
-8. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
-   
-   1. Add the following two lines to your Rsyslog configuration:
-
-      ```conf
-      $ModLoad immark
-      $MarkMessagePeriod 20
-      ```
-
-   2. Restart the Rsyslog service:
+   3. Restart the Rsyslog service:
 
       ```shell
       sudo systemctl restart rsyslog
       ```
+{{< /site-region >}}
 
 [1]: /agent/logs/
 {{% /tab %}}
@@ -474,8 +517,52 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"
     ```
 
-{{< site-region region="us,us3,us5,gov">}}
-4. Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+4. Restart Rsyslog. Your new logs are forwarded directly to your Datadog account.
+
+    ```shell
+    sudo systemctl restart rsyslog
+    ```
+
+5. Associate your logs with the host metrics and tags:
+   
+   To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
+
+   - If you specified a hostname in `datadog.conf` or `datadog.yaml`, replace the `%HOSTNAME%` value in `rsyslog.conf` to match your hostname.
+   - If you did not specify a hostname in `datadog.conf` or `datadog.yaml`, you do not need to change anything.
+
+6. To get the best use out of your logs in Datadog, set a source for the logs.
+   - If you [forward your logs to the Datadog Agent][1], you can set the source in the Agent configuration file.
+   - If you're not forwarding your logs to the Datadog Agent, create a distinct configuration file for each source in `/etc/rsyslog.d/`:
+
+   To set the source, use the following format (if you have several sources, change the name of the format in each file):
+
+   ```conf
+   $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\"] %msg%\n"
+   ```
+
+   You can also add custom tags with the `ddtags` attribute:
+
+   ```conf
+   $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\" ddtags=\"env:dev,<KEY:VALUE>\"] %msg%\n"
+   ```
+
+7. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
+   
+   1. Add the following two lines to your Rsyslog configuration:
+
+      ```conf
+      $ModLoad immark
+      $MarkMessagePeriod 20
+      ```
+
+   2. Restart the Rsyslog service:
+
+      ```shell
+      sudo systemctl restart rsyslog
+      ```
+
+{{< site-region region="us">}}
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
 
     1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
 
@@ -494,10 +581,15 @@ Configure Rsyslog to gather logs from your host, containers, & services.
         $ActionSendStreamDriverPermittedPeer *.logs.datadoghq.com
         *.* @@intake.logs.datadoghq.com:10516;DatadogFormat
         ```
+   3. Restart the Rsyslog service:
+
+      ```shell
+      sudo systemctl restart rsyslog
+      ```
 {{< /site-region >}}
 
 {{< site-region region="eu" >}}
-4. Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
 
     1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
 
@@ -517,51 +609,13 @@ Configure Rsyslog to gather logs from your host, containers, & services.
         $ActionSendStreamDriverPermittedPeer *.logs.datadoghq.eu
         *.* @@tcp-intake.logs.datadoghq.eu:443;DatadogFormat
         ```
-{{< /site-region >}}
-
-5. Restart Rsyslog. Your new logs are forwarded directly to your Datadog account.
-
-    ```shell
-    sudo systemctl restart rsyslog
-    ```
-
-6. Associate your logs with the host metrics and tags:
-   
-   To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
-
-   - If you specified a hostname in `datadog.conf` or `datadog.yaml`, replace the `%HOSTNAME%` value in `rsyslog.conf` to match your hostname.
-   - If you did not specify a hostname in `datadog.conf` or `datadog.yaml`, you do not need to change anything.
-
-7. To get the best use out of your logs in Datadog, set a source for the logs.
-   - If you [forward your logs to the Datadog Agent][1], you can set the source in the Agent configuration file.
-   - If you're not forwarding your logs to the Datadog Agent, create a distinct configuration file for each source in `/etc/rsyslog.d/`:
-
-   To set the source, use the following format (if you have several sources, change the name of the format in each file):
-
-   ```conf
-   $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\"] %msg%\n"
-   ```
-
-   You can also add custom tags with the `ddtags` attribute:
-
-   ```conf
-   $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\" ddtags=\"env:dev,<KEY:VALUE>\"] %msg%\n"
-   ```
-
-8. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
-   
-   1. Add the following two lines to your Rsyslog configuration:
-
-      ```conf
-      $ModLoad immark
-      $MarkMessagePeriod 20
-      ```
-
-   2. Restart the Rsyslog service:
+   3. Restart the Rsyslog service:
 
       ```shell
       sudo systemctl restart rsyslog
       ```
+{{< /site-region >}}
+
 [1]: /agent/logs/
 {{% /tab %}}
 
@@ -591,8 +645,52 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"
     ```
 
-{{< site-region region="us,us3,us5,gov">}}
-4. Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+4. Restart Rsyslog. Your new logs are forwarded directly to your Datadog account.
+
+    ```shell
+    sudo systemctl restart rsyslog
+    ```
+
+5. Associate your logs with the host metrics and tags:
+   
+   To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
+
+   - If you specified a hostname in `datadog.conf` or `datadog.yaml`, replace the `%HOSTNAME%` value in `rsyslog.conf` to match your hostname.
+   - If you did not specify a hostname in `datadog.conf` or `datadog.yaml`, you do not need to change anything.
+
+6. To get the best use out of your logs in Datadog, set a source for the logs.
+   - If you [forward your logs to the Datadog Agent][1], you can set the source in the Agent configuration file.
+   - If you're not forwarding your logs to the Datadog Agent, create a distinct configuration file for each source in `/etc/rsyslog.d/`:
+
+   To set the source, use the following format (if you have several sources, change the name of the format in each file):
+
+   ```conf
+   $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\"] %msg%\n"
+   ```
+
+   You can also add custom tags with the `ddtags` attribute:
+
+   ```conf
+   $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\" ddtags=\"env:dev,<KEY:VALUE>\"] %msg%\n"
+   ```
+
+7. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
+   
+   1. Add the following two lines to your Rsyslog configuration:
+
+      ```conf
+      $ModLoad immark
+      $MarkMessagePeriod 20
+      ```
+
+   2. Restart the Rsyslog service:
+
+      ```shell
+      sudo systemctl restart rsyslog
+      ```
+
+{{< site-region region="us">}}
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
 
     1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
 
@@ -611,11 +709,16 @@ Configure Rsyslog to gather logs from your host, containers, & services.
         $ActionSendStreamDriverPermittedPeer *.logs.datadoghq.com
         *.* @@intake.logs.datadoghq.com:10516;DatadogFormat
         ```
+   3. Restart the Rsyslog service:
+
+      ```shell
+      sudo systemctl restart rsyslog
+      ```
 {{< /site-region >}}
 
 {{< site-region region="eu" >}}
 
-4. Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
 
     1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
 
@@ -635,51 +738,12 @@ Configure Rsyslog to gather logs from your host, containers, & services.
         $ActionSendStreamDriverPermittedPeer *.logs.datadoghq.eu
         *.* @@tcp-intake.logs.datadoghq.eu:443;DatadogFormat
         ```
-{{< /site-region >}}
-
-5. Restart Rsyslog. Your new logs are forwarded directly to your Datadog account.
-
-    ```shell
-    sudo systemctl restart rsyslog
-    ```
-
-6. Associate your logs with the host metrics and tags:
-   
-   To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
-
-   - If you specified a hostname in `datadog.conf` or `datadog.yaml`, replace the `%HOSTNAME%` value in `rsyslog.conf` to match your hostname.
-   - If you did not specify a hostname in `datadog.conf` or `datadog.yaml`, you do not need to change anything.
-
-7. To get the best use out of your logs in Datadog, set a source for the logs.
-   - If you [forward your logs to the Datadog Agent][1], you can set the source in the Agent configuration file.
-   - If you're not forwarding your logs to the Datadog Agent, create a distinct configuration file for each source in `/etc/rsyslog.d/`:
-
-   To set the source, use the following format (if you have several sources, change the name of the format in each file):
-
-   ```conf
-   $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\"] %msg%\n"
-   ```
-
-   You can also add custom tags with the `ddtags` attribute:
-
-   ```conf
-   $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\" ddtags=\"env:dev,<KEY:VALUE>\"] %msg%\n"
-   ```
-
-8. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
-   
-   1. Add the following two lines to your Rsyslog configuration:
-
-      ```conf
-      $ModLoad immark
-      $MarkMessagePeriod 20
-      ```
-
-   2. Restart the Rsyslog service:
+   3. Restart the Rsyslog service:
 
       ```shell
       sudo systemctl restart rsyslog
       ```
+{{< /site-region >}}
 
 [1]: /agent/logs/
 {{% /tab %}}

--- a/content/en/integrations/rsyslog.md
+++ b/content/en/integrations/rsyslog.md
@@ -81,7 +81,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
 
 7. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
    
-   1. Add the following two lines to your Rsyslog configuration file:
+   1. Add the following lines to your Rsyslog configuration file:
 
       ```conf
       $ModLoad immark
@@ -95,7 +95,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
       ```
 
 {{< site-region region="us">}}
-8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account.
    1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
       ```shell
       sudo apt-get install rsyslog-gnutls ca-certificates
@@ -116,7 +116,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
 {{< /site-region >}}
 {{< site-region region="eu" >}}
 
-8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account.
    1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
       ```shell
       sudo apt-get install rsyslog-gnutls ca-certificates
@@ -202,7 +202,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
       ```
 
 {{< site-region region="us">}}
-8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account.
    1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
       ```shell
       sudo yum install rsyslog-gnutls ca-certificates
@@ -311,7 +311,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
       ```
 
 {{< site-region region="us">}}
-8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account.
    1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
       ```shell
       sudo dnf install rsyslog-gnutls ca-certificates
@@ -333,7 +333,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
 
 {{< site-region region="eu" >}}
 
-8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account.
    1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
       ```shell
       sudo dnf install rsyslog-gnutls ca-certificates
@@ -419,7 +419,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
 
 7. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
    
-   1. Add the following two lines to your Rsyslog configuration:
+   1. Add the following lines to your Rsyslog configuration:
 
       ```conf
       $ModLoad immark
@@ -461,7 +461,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
 
 {{< site-region region="eu" >}}
 
-8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account.
 
     1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
 
@@ -523,7 +523,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     sudo systemctl restart rsyslog
     ```
 
-5. Associate your logs with the host metrics and tags:
+5. Associate your logs with the host metrics and tags.
    
    To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
 
@@ -562,7 +562,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
       ```
 
 {{< site-region region="us">}}
-8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account.
 
     1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
 
@@ -589,7 +589,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
 {{< /site-region >}}
 
 {{< site-region region="eu" >}}
-8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account.
 
     1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
 
@@ -651,7 +651,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
     sudo systemctl restart rsyslog
     ```
 
-5. Associate your logs with the host metrics and tags:
+5. Associate your logs with the host metrics and tags.
    
    To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
 
@@ -690,7 +690,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
       ```
 
 {{< site-region region="us">}}
-8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account.
 
     1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
 
@@ -718,7 +718,7 @@ Configure Rsyslog to gather logs from your host, containers, & services.
 
 {{< site-region region="eu" >}}
 
-8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account:
+8. (Optional) Add TLS Encryption to logs sent from Rsyslog to your Datadog account.
 
     1. Install the `rsyslog-gnutls` and `ca-certificates` packages:
 


### PR DESCRIPTION
### What does this PR do?

- Moves TLC encryption step (Step 4 in original) to end (Step 8 in revised doc) and make it optional.
- Remove TLC encryption for US3, US5, and US1-FED because those endpoints aren't available.

No new information is added.

### Motivation
DOCS-3754

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
