### PR TITLE
Remove a misleading link

### DIFF
--- a/content/en/logs/log_configuration/logs_to_metrics.md
+++ b/content/en/logs/log_configuration/logs_to_metrics.md
@@ -9,9 +9,6 @@ further_reading:
     - link: 'logs/log_configuration/processors'
       tag: 'Documentation'
       text: 'Learn how to process your logs'
-    - link: 'logs/logging_without_limits'
-      tag: 'Documentation'
-      text: 'Control the volume of logs indexed by Datadog'
 ---
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The Further Reading link entitled "Control the volume of logs indexed by Datadog" is linked to https://docs.datadoghq.com/logs/logging_without_limits. That, however, redirects to https://docs.datadoghq.com/logs/ which is a general introduction of Logs. This is the link removed by this PR.

### Motivation
I was doing research for a Health Check and followed the link, a couple of times until I realized it wasn't relevant.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
https://docs.datadoghq.com/KateYoak/patch-1/logs/log_configuration/logs_to_metrics/
### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
