### PR TITLE
(DOCS-4430) Add guidance on configuring Agent ports

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -38,9 +38,9 @@ On Windows the services are listed as:
 
 | Service               | Description             |
 |-----------------------|-------------------------|
-| DatadogAgent          | “Datadog Agent”         |
-| datadog-trace-agent   | “Datadog Trace Agent”   |
-| datadog-process-agent | "Datadog Process Agent” |
+| DatadogAgent          | "Datadog Agent"         |
+| datadog-trace-agent   | "Datadog Trace Agent"   |
+| datadog-process-agent | "Datadog Process Agent" |
 
 By default the Agent binds 3 [ports][3] on Linux and 4 on Windows and OSX:
 
@@ -51,9 +51,11 @@ By default the Agent binds 3 [ports][3] on Linux and 4 on Windows and OSX:
 | 5002 | Serves the GUI server on Windows and OSX.                                                   |
 | 8125 | Used for the DogStatsD server to receive external metrics.                                  |
 
+For information on configuring the ports, see [Network Traffic][4].
+
 ### Collector
 
-The collector gathers all standard metrics every 15 seconds. Agent v6 embeds a Python 2.7 interpreter to run integrations and [custom checks][4].
+The collector gathers all standard metrics every 15 seconds. Agent v6 embeds a Python 2.7 interpreter to run integrations and [custom checks][5].
 
 ### Forwarder
 
@@ -61,14 +63,15 @@ The Agent forwarder send metrics over HTTPS to Datadog. Buffering prevents netwo
 
 ### DogStatsD
 
-In v6, DogStatsD is a Golang implementation of [Etsy's StatsD][5] metric aggregation daemon. It is used to receive and roll up arbitrary metrics over UDP or Unix socket, thus allowing custom code to be instrumented without adding latency. Learn more about [DogStatsD][6].
+In v6, DogStatsD is a Golang implementation of [Etsy's StatsD][6] metric aggregation daemon. It is used to receive and roll up arbitrary metrics over UDP or Unix socket, thus allowing custom code to be instrumented without adding latency. Learn more about [DogStatsD][7].
 
 [1]: /metrics/custom_metrics/dogstatsd_metrics_submission/#metrics
 [2]: /tracing/guide/terminology/
 [3]: /agent/guide/network/#open-ports
-[4]: /developers/custom_checks/write_agent_check/
-[5]: https://github.com/etsy/statsd
-[6]: /metrics/custom_metrics/dogstatsd_metrics_submission/
+[4]: /agent/guide/network#configure-ports
+[5]: /developers/custom_checks/write_agent_check/
+[6]: https://github.com/etsy/statsd
+[7]: /metrics/custom_metrics/dogstatsd_metrics_submission/
 {{% /tab %}}
 {{% tab "Agent v5" %}}
 

--- a/content/en/agent/basic_agent_usage/aix.md
+++ b/content/en/agent/basic_agent_usage/aix.md
@@ -2,6 +2,12 @@
 title: Basic Agent Usage for AIX
 kind: documentation
 further_reading:
+- link: "/agent/basic_agent_usage/#agent-architecture"
+  tag: "Documentation"
+  text: "Find out more about the Agent's architecture"
+- link: "/agent/guide/network#configure-ports"
+  tag: "Documentation"
+  text: "Configure inbound ports"
 - link: "https://www.datadoghq.com/blog/announcing-ibm-aix-agent/"
   tag: "Blog"
   text: "Monitor AIX with the Datadog Unix Agent"

--- a/content/en/agent/basic_agent_usage/amazonlinux.md
+++ b/content/en/agent/basic_agent_usage/amazonlinux.md
@@ -14,6 +14,12 @@ further_reading:
 - link: "/tracing/"
   tag: "Documentation"
   text: "Collect your traces"
+- link: "/agent/basic_agent_usage/#agent-architecture"
+  tag: "Documentation"
+  text: "Find out more about the Agent's architecture"
+- link: "/agent/guide/network#configure-ports"
+  tag: "Documentation"
+  text: "Configure inbound ports"
 ---
 
 ## Overview

--- a/content/en/agent/basic_agent_usage/centos.md
+++ b/content/en/agent/basic_agent_usage/centos.md
@@ -14,6 +14,12 @@ further_reading:
 - link: "/tracing/"
   tag: "Documentation"
   text: "Collect your traces"
+- link: "/agent/basic_agent_usage/#agent-architecture"
+  tag: "Documentation"
+  text: "Find out more about the Agent's architecture"
+- link: "/agent/guide/network#configure-ports"
+  tag: "Documentation"
+  text: "Configure inbound ports"
 ---
 
 ## Overview

--- a/content/en/agent/basic_agent_usage/deb.md
+++ b/content/en/agent/basic_agent_usage/deb.md
@@ -16,6 +16,12 @@ further_reading:
 - link: "/tracing/"
   tag: "Documentation"
   text: "Collect your traces"
+- link: "/agent/basic_agent_usage/#agent-architecture"
+  tag: "Documentation"
+  text: "Find out more about the Agent's architecture"
+- link: "/agent/guide/network#configure-ports"
+  tag: "Documentation"
+  text: "Configure inbound ports"
 ---
 
 ## Overview

--- a/content/en/agent/basic_agent_usage/fedora.md
+++ b/content/en/agent/basic_agent_usage/fedora.md
@@ -14,6 +14,12 @@ further_reading:
 - link: "/tracing/"
   tag: "Documentation"
   text: "Collect your traces"
+- link: "/agent/basic_agent_usage/#agent-architecture"
+  tag: "Documentation"
+  text: "Find out more about the Agent's architecture"
+- link: "/agent/guide/network#configure-ports"
+  tag: "Documentation"
+  text: "Configure inbound ports"
 ---
 
 ## Overview

--- a/content/en/agent/basic_agent_usage/osx.md
+++ b/content/en/agent/basic_agent_usage/osx.md
@@ -15,6 +15,12 @@ further_reading:
 - link: "/tracing/"
   tag: "Documentation"
   text: "Collect your traces"
+- link: "/agent/basic_agent_usage/#agent-architecture"
+  tag: "Documentation"
+  text: "Find out more about the Agent's architecture"
+- link: "/agent/guide/network#configure-ports"
+  tag: "Documentation"
+  text: "Configure inbound ports"
 ---
 
 ## Overview

--- a/content/en/agent/basic_agent_usage/redhat.md
+++ b/content/en/agent/basic_agent_usage/redhat.md
@@ -14,6 +14,12 @@ further_reading:
 - link: "/tracing/"
   tag: "Documentation"
   text: "Collect your traces"
+- link: "/agent/basic_agent_usage/#agent-architecture"
+  tag: "Documentation"
+  text: "Find out more about the Agent's architecture"
+- link: "/agent/guide/network#configure-ports"
+  tag: "Documentation"
+  text: "Configure inbound ports"
 ---
 
 ## Overview

--- a/content/en/agent/basic_agent_usage/source.md
+++ b/content/en/agent/basic_agent_usage/source.md
@@ -14,6 +14,12 @@ further_reading:
 - link: "/tracing/"
   tag: "Documentation"
   text: "Collect your traces"
+- link: "/agent/basic_agent_usage/#agent-architecture"
+  tag: "Documentation"
+  text: "Find out more about the Agent's architecture"
+- link: "/agent/guide/network#configure-ports"
+  tag: "Documentation"
+  text: "Configure inbound ports"
 ---
 ## Overview
 

--- a/content/en/agent/basic_agent_usage/suse.md
+++ b/content/en/agent/basic_agent_usage/suse.md
@@ -14,6 +14,12 @@ further_reading:
 - link: "/tracing/"
   tag: "Documentation"
   text: "Collect your traces"
+- link: "/agent/basic_agent_usage/#agent-architecture"
+  tag: "Documentation"
+  text: "Find out more about the Agent's architecture"
+- link: "/agent/guide/network#configure-ports"
+  tag: "Documentation"
+  text: "Configure inbound ports"
 ---
 
 ## Overview

--- a/content/en/agent/basic_agent_usage/ubuntu.md
+++ b/content/en/agent/basic_agent_usage/ubuntu.md
@@ -14,6 +14,12 @@ further_reading:
 - link: "/tracing/"
   tag: "Documentation"
   text: "Collect your traces"
+- link: "/agent/basic_agent_usage/#agent-architecture"
+  tag: "Documentation"
+  text: "Find out more about the Agent's architecture"
+- link: "/agent/guide/network#configure-ports"
+  tag: "Documentation"
+  text: "Configure inbound ports"
 ---
 
 ## Overview

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -15,6 +15,12 @@ further_reading:
 - link: "/tracing/"
   tag: "Documentation"
   text: "Collect your traces"
+- link: "/agent/basic_agent_usage/#agent-architecture"
+  tag: "Documentation"
+  text: "Find out more about the Agent's architecture"
+- link: "/agent/guide/network#configure-ports"
+  tag: "Documentation"
+  text: "Configure inbound ports"
 ---
 
 ## Setup

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -343,6 +343,16 @@ See [default NTP targets][2].
 {{% /tab %}}
 {{< /tabs >}}
 
+## Configure ports
+
+If you need to change an inbound port because the default port is already in use by an existing service on your network, use the `datadog.yaml` configuration file. You can find most of the ports in the **Advanced Configuration** section of the file:
+
+{{< agent-config type="advanced configuration" filename="datadog.yaml" collapsible="true" disable_copy="true">}}
+
+The APM receiver port is located in the **Trace Collection Configuration** section of the `datadog.yaml` configuration file:
+
+{{< agent-config type="trace collection configuration" filename="datadog.yaml" collapsible="true" disable_copy="true">}}
+
 ## Using proxies
 
 For a detailed configuration guide on proxy setup, see [Agent Proxy Configuration][9].

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -345,7 +345,7 @@ See [default NTP targets][2].
 
 ## Configure ports
 
-If you need to change an inbound port because the default port is already in use by an existing service on your network, use the `datadog.yaml` configuration file. You can find most of the ports in the **Advanced Configuration** section of the file:
+If you need to change an inbound port because the default port is already in use by an existing service on your network, edit the `datadog.yaml` configuration file. You can find most of the ports in the **Advanced Configuration** section of the file:
 
 {{< agent-config type="advanced configuration" filename="datadog.yaml" collapsible="true" disable_copy="true">}}
 

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -347,11 +347,51 @@ See [default NTP targets][2].
 
 If you need to change an inbound port because the default port is already in use by an existing service on your network, edit the `datadog.yaml` configuration file. You can find most of the ports in the **Advanced Configuration** section of the file:
 
-{{< agent-config type="advanced configuration" filename="datadog.yaml" collapsible="true" disable_copy="true">}}
+{{< code-block lang="yaml" filename="datadog.yaml" disable_copy="true" collapsible="true" >}}
+## @param expvar_port - integer - optional - default: 5000
+## @env DD_EXPVAR_PORT - integer - optional - default: 5000
+## The port for the go_expvar server.
+#
+# expvar_port: 5000
 
-The APM receiver port is located in the **Trace Collection Configuration** section of the `datadog.yaml` configuration file:
+## @param cmd_port - integer - optional - default: 5001
+## @env DD_CMD_PORT - integer - optional - default: 5001
+## The port on which the IPC api listens.
+#
+# cmd_port: 5001
 
-{{< agent-config type="trace collection configuration" filename="datadog.yaml" collapsible="true" disable_copy="true">}}
+## @param GUI_port - integer - optional
+## @env DD_GUI_PORT - integer - optional
+## The port for the browser GUI to be served.
+## Setting 'GUI_port: -1' turns off the GUI completely
+## Default is:
+##  * Windows & macOS : `5002`
+##  * Linux: `-1`
+##
+#
+# GUI_port: <GUI_PORT>
+
+{{< /code-block >}}
+
+The APM receiver and the DogStatsD ports are located in the **Trace Collection Configuration** and **DogStatsD Configuration** sections of the `datadog.yaml` configuration file, respectively:
+
+{{< code-block lang="yaml" filename="datadog.yaml" disable_copy="true" collapsible="true" >}}
+## @param dogstatsd_port - integer - optional - default: 8125
+## @env DD_DOGSTATSD_PORT - integer - optional - default: 8125
+## Override the Agent DogStatsD port.
+## Note: Make sure your client is sending to the same UDP port.
+#
+# dogstatsd_port: 8125
+
+[...]
+
+## @param receiver_port - integer - optional - default: 8126
+## @env DD_APM_RECEIVER_PORT - integer - optional - default: 8126
+## The port that the trace receiver should listen on.
+## Set to 0 to disable the HTTP receiver.
+#
+# receiver_port: 8126
+{{< /code-block >}}
 
 ## Using proxies
 


### PR DESCRIPTION
### What does this PR do?
Adds information on configuring inbound ports to the Agent network doc and links to it from architecture. Also adds related information links to all of basic usage docs for OS / Windows / Linux.

### Motivation
[DOCS-4430](https://datadoghq.atlassian.net/browse/DOCS-4430)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
