### PR TITLE
[WEB-2882] JA glossary style fix

### DIFF
--- a/assets/styles/pages/_glossary.scss
+++ b/assets/styles/pages/_glossary.scss
@@ -25,10 +25,18 @@
             width: 100%;
             height: 50px;
             top: 89px;
+
+            &:lang(ja) {
+                height: 130px;
+            }
         }
 
         @include media-breakpoint-up(lg) {
             top: 95px;
+
+            &:lang(ja) {
+                height: 140px;
+            }
         }
 
         .btn {

--- a/assets/styles/pages/_glossary.scss
+++ b/assets/styles/pages/_glossary.scss
@@ -35,7 +35,7 @@
             top: 95px;
 
             &:lang(ja) {
-                height: 140px;
+                height: 150px;
             }
         }
 


### PR DESCRIPTION
### What does this PR do?
Style adjustment for Japanese Glossary page, fixing nav overlapping with content.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2882

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/ja-glossary-fix/ja/glossary/ - the sticky nav (with the letters) does not overlap with content across all screen sizes

https://docs-staging.datadoghq.com/brian.deutsch/ja-glossary-fix/glossary/ - the english site is unaffected.

There is a bug w/ the JA glossary nav where clicking the JA chars dont get highlighted, we will fix that in a separate PR.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
