### PR TITLE
(maint) Adds a "status" flag to the script

### DIFF
--- a/local/bin/sh/nohooks.sh
+++ b/local/bin/sh/nohooks.sh
@@ -2,12 +2,22 @@
 
 mkdir -p ~/.nohooks
 hooks=`git config --get core.hooksPath`
-if [[ $hooks == *nohooks* ]]; then
-    git config --global core.hooksPath /usr/local/dd/global_hooks/
-    echo "Hooks enabled"
-    echo "Hooks directory set to $(git config --get core.hooksPath)"
-else
-    git config --global core.hooksPath ~/.nohooks
-    echo "Hooks disabled"
-    echo "Hooks directory set to $(git config --get core.hooksPath)"
+
+if [[ $1 && $1 == status && $hooks == *nohooks* ]]; then
+  echo "Hooks are currently disabled"
+elif [[ $1 && $1 == status && $hooks != *nohooks* ]]; then
+  echo "Hooks are currently enabled"
+elif [[ $1 ]]; then
+  echo "Flag not recognized"
+  exit 1
+elif [[ $# -eq 0 ]]; then
+  if [[ $hooks == *nohooks* ]]; then
+      git config --global core.hooksPath /usr/local/dd/global_hooks/
+      echo "Hooks enabled"
+      echo "Hooks directory set to $(git config --get core.hooksPath)"
+  else
+      git config --global core.hooksPath ~/.nohooks
+      echo "Hooks disabled"
+      echo "Hooks directory set to $(git config --get core.hooksPath)"
+  fi
 fi


### PR DESCRIPTION
This adds a "status" flag which tells you the status of your hooks without enabling/disabling them.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
