### PR TITLE
Replaces labels with annotations to align with the feature

### DIFF
--- a/content/en/containers/kubernetes/prometheus.md
+++ b/content/en/containers/kubernetes/prometheus.md
@@ -277,7 +277,7 @@ The autodiscovery configuration can be based on container names or kubernetes an
 
 `kubernetes_container_names` is a list of container names to target, it supports the `*` wildcard.
 
-`kubernetes_annotations` contains two maps of labels to define the discovery rules: `include` and `exclude`.
+`kubernetes_annotations` contains two maps of annotations to define the discovery rules: `include` and `exclude`.
 
 **Note:** The default value of `kubernetes_annotations` in the Datadog Agent configuration is the following:
 
@@ -291,7 +291,7 @@ kubernetes_annotations:
 
 **Example:**
 
-In this example we're defining an advanced configuration targeting a container named `my-app` running in a pod labeled `app=my-app`. We're customizing the OpenMetrics check configuration as well, by enabling the `send_distribution_buckets` option and defining a custom timeout of 5 seconds.
+In this example we're defining an advanced configuration targeting a container named `my-app` running in a pod with the annotation `app=my-app`. We're customizing the OpenMetrics check configuration as well, by enabling the `send_distribution_buckets` option and defining a custom timeout of 5 seconds.
 
 ```yaml
 datadog:
@@ -327,7 +327,7 @@ The Autodiscovery configuration can be based on container names or Kubernetes an
 
 `kubernetes_container_names` is a list of container names to target, it supports the `*` wildcard.
 
-`kubernetes_annotations` contains two maps of labels to define the discovery rules: `include` and `exclude`.
+`kubernetes_annotations` contains two maps of annotations to define the discovery rules: `include` and `exclude`.
 
 **Note:** The default value of `kubernetes_annotations` in the Datadog Agent configuration is the following:
 
@@ -338,7 +338,7 @@ The Autodiscovery configuration can be based on container names or Kubernetes an
 
 **Example:**
 
-In this example we're defining an advanced configuration targeting a container named `my-app` running in a pod labeled `app=my-app`. We're customizing the OpenMetrics check configuration as well, by enabling the `send_distribution_buckets` option and defining a custom timeout of 5 seconds.
+In this example we're defining an advanced configuration targeting a container named `my-app` running in a pod with the annotation `app=my-app`. We're customizing the OpenMetrics check configuration as well, by enabling the `send_distribution_buckets` option and defining a custom timeout of 5 seconds.
 
 ```yaml
 - name: DD_PROMETHEUS_SCRAPE_ENABLED


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* Replaces mentions of labels with annotations for `prometheusScrape`
### Motivation
<!-- What inspired you to submit this pull request?-->
* Customer reached out and mentioned the documentation is confusing as it refers to labels despite the feature referring to K8s annotations

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
