### PR TITLE
[APM] Add a bit more details in the network troubleshooting doc

### DIFF
--- a/content/en/tracing/troubleshooting/connection_errors.md
+++ b/content/en/tracing/troubleshooting/connection_errors.md
@@ -195,11 +195,13 @@ In containerized setups, submitting traces to `localhost` or `127.0.0.1` is ofte
 Determine if the networking between the application and the Datadog Agent matches what is needed for that configuration.
 
 In particular, check to make sure that the Datadog Agent has access to port `8126` (or to the port you have defined) and that your application is able to direct traces to the Datadog Agent’s location.
-To do so, you can run the following command, from the application container and by replacing the `{agent_ip}`, `{agent_port}` variables:
+To do so, you can run the following command from the application container, replacing the `{agent_ip}` and `{agent_port}` variables:
 
-`curl -X GET http://{agent_ip}:{agent_port}/info`.
+```
+curl -X GET http://{agent_ip}:{agent_port}/info
+```
 
-If this command fails, your container cannot access the agent. Refer to the following sections to get hints on what could be causing this issue.
+If this command fails, your container cannot access the Agent. Refer to the following sections to get hints on what could be causing this issue.
 
 A great place to get started is the [APM in-app setup documentation][6].
 
@@ -216,7 +218,7 @@ See the table below for example setups. Some require setting up additional netwo
 | [AWS EKS on Fargate][9] | Do not set `DD_AGENT_HOST` |
 | [AWS Elastic Beanstalk - Single Container][10] | Gateway IP (usually `172.17.0.1`) |
 | [AWS Elastic Beanstalk - Multiple Containers][11] | Link pointing to the Datadog Agent container name |
-| [Kubernetes][12] | 1) [Unix Domain Socket][13], 2) [`status.hostIP`][14] added manually, or 3) through the [Admission Controller][15]. Also, if using TCP, don't forget to check the [network policies][21] applied on your container |
+| [Kubernetes][12] | 1) [Unix Domain Socket][13], 2) [`status.hostIP`][14] added manually, or 3) through the [Admission Controller][15]. If using TCP, check the [network policies][21] applied on your container |
 | [AWS EKS (non Fargate)][16] | 1) [Unix Domain Socket][13], 2) [`status.hostIP`][14] added manually, or 3) through the [Admission Controller][15] |
 | [Datadog Agent and Application Docker Containers][17] | Datadog Agent container |
 

--- a/content/en/tracing/troubleshooting/connection_errors.md
+++ b/content/en/tracing/troubleshooting/connection_errors.md
@@ -5,7 +5,7 @@ aliases:
   - /tracing/faq/why-am-i-getting-errno-111-connection-refused-errors-in-my-application-logs/
 ---
 
-If the application with the tracing library cannot reach the Datadog Agent, look for connection errors in the [tracer startup logs][1] or [tracer debug logs][2], which can be found with your application logs. 
+If the application with the tracing library cannot reach the Datadog Agent, look for connection errors in the [tracer startup logs][1] or [tracer debug logs][2], which can be found with your application logs.
 
 ## Errors that indicate an APM Connection problem
 
@@ -176,12 +176,12 @@ Whether it’s the tracing library or the Datadog Agent displaying the error, th
 
 ### Host-based setups
 
-If your application and the Datadog Agent are not containerized, the application with the tracing library should be trying to send traces to `localhost:8126` or `127.0.0.1:8126`, because that is where the Datadog Agent is listening. 
+If your application and the Datadog Agent are not containerized, the application with the tracing library should be trying to send traces to `localhost:8126` or `127.0.0.1:8126`, because that is where the Datadog Agent is listening.
 
 If the Datadog Agent shows that APM is not listening, check for port conflicts with port 8126, which is what the APM component of the Datadog Agent uses by default.
 
 If you cannot isolate the root cause, [contact Datadog Support][4] with:
-- Information about the environment in which you’re deploying the application and Datadog Agent. 
+- Information about the environment in which you’re deploying the application and Datadog Agent.
 - If you are using proxies, information about how they’ve been configured.
 - If you are trying to change the default port from 8126 to another port, information about that port.
 - A [Datadog Agent flare][5].
@@ -192,11 +192,16 @@ If you cannot isolate the root cause, [contact Datadog Support][4] with:
 
 In containerized setups, submitting traces to `localhost` or `127.0.0.1` is often incorrect since the Datadog Agent is also containerized and located elsewhere. **Note**: AWS ECS on Fargate and AWS EKS on Fargate are exceptions to this rule.
 
-Determine if the networking between the application and the Datadog Agent matches what is needed for that configuration. 
+Determine if the networking between the application and the Datadog Agent matches what is needed for that configuration.
 
-In particular, check to make sure that the Datadog Agent has access to port `8126` and that your application is able to direct traces to the Datadog Agent’s location. 
+In particular, check to make sure that the Datadog Agent has access to port `8126` (or to the port you have defined) and that your application is able to direct traces to the Datadog Agent’s location.
+To do so, you can run the following command, from the application container and by replacing the `{agent_ip}`, `{agent_port}` variables:
 
-A great place to get started is the [APM in-app setup documentation][6]. 
+`curl -X GET http://{agent_ip}:{agent_port}/info`.
+
+If this command fails, your container cannot access the agent. Refer to the following sections to get hints on what could be causing this issue.
+
+A great place to get started is the [APM in-app setup documentation][6].
 
 #### Review where your tracing library is trying to send traces
 
@@ -211,7 +216,7 @@ See the table below for example setups. Some require setting up additional netwo
 | [AWS EKS on Fargate][9] | Do not set `DD_AGENT_HOST` |
 | [AWS Elastic Beanstalk - Single Container][10] | Gateway IP (usually `172.17.0.1`) |
 | [AWS Elastic Beanstalk - Multiple Containers][11] | Link pointing to the Datadog Agent container name |
-| [Kubernetes][12] | 1) [Unix Domain Socket][13], 2) [`status.hostIP`][14] added manually, or 3) through the [Admission Controller][15] |
+| [Kubernetes][12] | 1) [Unix Domain Socket][13], 2) [`status.hostIP`][14] added manually, or 3) through the [Admission Controller][15]. Also, if using TCP, don't forget to check the [network policies][21] applied on your container |
 | [AWS EKS (non Fargate)][16] | 1) [Unix Domain Socket][13], 2) [`status.hostIP`][14] added manually, or 3) through the [Admission Controller][15] |
 | [Datadog Agent and Application Docker Containers][17] | Datadog Agent container |
 
@@ -248,7 +253,7 @@ APM Agent
 ```
 
 If the configuration is correct, but you’re still seeing connection errors, [contact Datadog Support][4] with:
-- Information about the environment in which you’re deploying the application and Datadog Agent. 
+- Information about the environment in which you’re deploying the application and Datadog Agent.
 - If you’re using proxies, information about how they’ve been configured.
 - Any configuration files used to set up the application and the Datadog Agent.
 - Startup logs or tracer debug logs outlining the connection error.
@@ -275,3 +280,4 @@ If the configuration is correct, but you’re still seeing connection errors, [c
 [18]: /tracing/trace_collection/dd_libraries/php/?tab=containers#apache
 [19]: /tracing/trace_collection/dd_libraries/php/?tab=containers#nginx
 [20]: /agent/troubleshooting/send_a_flare/?tab=agentv6v7#trace-agent
+[21]: https://kubernetes.io/docs/concepts/services-networking/network-policies/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a bit more details in the network troubleshooting doc. It aims at guiding the users to troubleshoot more easily connectivity issues in containerized environments.

### Motivation
We had a customer call where the users had an egress rule that prevented them to connect the tracer to the agent.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
