### PR TITLE
Remove private flag to make doc searchable

### DIFF
--- a/content/en/logs/log_configuration/forwarding_custom_destinations.md
+++ b/content/en/logs/log_configuration/forwarding_custom_destinations.md
@@ -2,7 +2,6 @@
 title: Forwarding Logs to Custom Destinations
 kind: documentation
 is_beta: true
-private: true
 further_reading:
 - link: "https://www.datadoghq.com/blog/route-logs-with-datadog-log-forwarding/"
   tag: "Blog"


### PR DESCRIPTION
### What does this PR do?

Makes "Forwarding Logs to Custom Destinations" doc searchable.

### Motivation

T2/PM request in #documentation.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
