### PR TITLE
Document granular access controls for security rules

### DIFF
--- a/content/en/account_management/rbac/_index.md
+++ b/content/en/account_management/rbac/_index.md
@@ -179,13 +179,15 @@ When creating or updating a role on the Datadog site, use a Datadog role templat
 
 {{< img src="account_management/rbac/role_templates.png" alt="Role Templates dropdown menu with Datadog Billing Admin Role selected" style="width:90%;">}}
 
-## Restrict access to dashboards, monitors, and synthetic tests
+## Restrict access to individual resources
 
-Once you have RBAC roles set up, you can restrict access to dashboards, monitors, and synthetic tests by user role. For more information, see [Dashboard Permissions][10], [Monitors Permissions][11], and [Synthetics Permissions][12].
+Once you have RBAC roles set up, you can restrict access to individual resources by user role.
 
-## Granular access control
-
-To learn how to restrict edit access to individual security rules, see [Detection rules][13].
+The following resources allow granular access control:
+- [Dashboards][10]
+- [Monitors][11]
+- [Security rules][12]
+- [Synthetic tests][13]
 
 ## Further Reading
 
@@ -202,5 +204,5 @@ To learn how to restrict edit access to individual security rules, see [Detectio
 [9]: /api/latest/roles/#create-role
 [10]: /dashboards/#permissions
 [11]: /monitors/notify/#permissions
-[12]: /synthetics/browser_tests/#permissions
-[13]: /security_platform/detection_rules/#limit-edit-access
+[12]: /security_platform/detection_rules/#limit-edit-access
+[13]: /synthetics/browser_tests/#permissions

--- a/content/en/account_management/rbac/_index.md
+++ b/content/en/account_management/rbac/_index.md
@@ -179,9 +179,13 @@ When creating or updating a role on the Datadog site, use a Datadog role templat
 
 {{< img src="account_management/rbac/role_templates.png" alt="Role Templates dropdown menu with Datadog Billing Admin Role selected" style="width:90%;">}}
 
-## Restrict access to dashboards and monitors
+## Restrict access to dashboards, monitors, and synthetic tests
 
 Once you have RBAC roles set up, you can restrict access to dashboards, monitors, and synthetic tests by user role. For more information, see [Dashboard Permissions][10], [Monitors Permissions][11], and [Synthetics Permissions][12].
+
+## Granular access control
+
+To learn how to restrict edit access to individual security rules, see [Detection rules][13].
 
 ## Further Reading
 
@@ -199,3 +203,4 @@ Once you have RBAC roles set up, you can restrict access to dashboards, monitors
 [10]: /dashboards/#permissions
 [11]: /monitors/notify/#permissions
 [12]: /synthetics/browser_tests/#permissions
+[13]: /security_platform/detection_rules/#limit-edit-access

--- a/content/en/security_platform/detection_rules/_index.md
+++ b/content/en/security_platform/detection_rules/_index.md
@@ -67,7 +67,28 @@ Click on the three dot menu, next to the rule toggle, and select any of the prov
   -  **Note**: You can only edit an out-of-the-box (OOTB) rule by first cloning the rule, and then modifying the rule. To edit a default rule, click **Edit** and scroll to the bottom of the rule configuration page. Click **Clone**, and then modify the rule.
 - Cloning a rule is helpful if you wish to duplicate an existing rule and lightly modify settings to cover other areas of detection. For example, you could duplicate a log detection rule and modify it from **Threshold** to **Anomaly** to add new dimension to threat detection using the same queries and triggers.
 - The delete option is **only** available for custom rules. You cannot delete an out-of-the-box (OOTB) rule as they are native to the platform. To permanently delete a custom rule, click **Delete**. To disable an OOTB rule, click the disable toggle.
-- Click **View generated signals** to pivot to the [Signals Explorer][6] and query by a rule's ID. This is useful when correlating signals across multiple sources by rule, or when completeing an audit of rules. 
+- Click **View generated signals** to pivot to the [Signals Explorer][6] and query by a rule's ID. This is useful when correlating signals across multiple sources by rule, or when completing an audit of rules. 
+
+#### Limit edit access
+
+By default, all users can view, edit, or delete security rules.
+
+Use granular access controls to limit the roles that may edit a single rule:
+1. Click on the three dot menu for the rule.
+1. Select **Permissions**.
+1. Click **Restrict Access**.
+1. The dialog box updates to show that members of your organization have **Viewer** access by default.
+1. Use the drop-down to select one or more [roles][10] that may edit the security rule.
+1. Click **Add**.
+1. The dialog box updates to show that the role you selected has the **Editor** permission.
+1. Click **Save**
+**Note:** To maintain your edit access to the rule, the system requires you to include at least one role that you are a member of before saving. 
+
+To restore general access to a rule with restricted access, follow the steps below:
+1. Click on the three dot menu on the right of the rule.
+1. Select **Permissions**.
+1. Click **Restore Full Access**.
+1. Click **Save**.
 
 ## Further Reading
 {{< partial name="whats-next/whats-next.html" >}}
@@ -82,3 +103,4 @@ Click on the three dot menu, next to the rule toggle, and select any of the prov
 [7]: /tracing/
 [8]: /agent/
 [9]: https://app.datadoghq.com/security/configuration/rules
+[10]: /account_management/rbac/

--- a/content/en/security_platform/detection_rules/_index.md
+++ b/content/en/security_platform/detection_rules/_index.md
@@ -73,12 +73,12 @@ Click on the three dot menu, next to the rule toggle, and select any of the prov
 
 By default, all users can view, edit, or delete security rules.
 
-Use granular access controls to limit the roles that may edit a single rule:
+Use granular access controls to limit the [roles][10] that may edit a single rule:
 1. Click on the three dot menu for the rule.
 1. Select **Permissions**.
 1. Click **Restrict Access**.
 1. The dialog box updates to show that members of your organization have **Viewer** access by default.
-1. Use the drop-down to select one or more [roles][10] that may edit the security rule.
+1. Use the drop-down to select one or more roles that may edit the security rule.
 1. Click **Add**.
 1. The dialog box updates to show that the role you selected has the **Editor** permission.
 1. Click **Save**

--- a/content/en/security_platform/detection_rules/_index.md
+++ b/content/en/security_platform/detection_rules/_index.md
@@ -71,7 +71,7 @@ Click on the three dot menu, next to the rule toggle, and select any of the prov
 
 #### Limit edit access
 
-By default, all users can view, edit, or delete security rules.
+By default, all users have full access to security rules.
 
 Use granular access controls to limit the [roles][10] that may edit a single rule:
 1. Click on the three dot menu for the rule.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds documentation for the new granular access controls on security rules:
- security rule permission section under "Security detection rules"
- Reorganize granular access section on RBAC page and add link to security rules permissions

### Motivation
Alert from Product that this feature will be generally available in early December after the code freeze is lifted.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
