### PR TITLE
Update SAML configuration documentation

### DIFF
--- a/content/en/account_management/saml/_index.md
+++ b/content/en/account_management/saml/_index.md
@@ -42,6 +42,8 @@ Configuring [SAML (Security Assertion Markup Language)][1] for your Datadog acco
 
 5. After you upload the IdP Meta-data and configure your IdP, enable SAML in Datadog by clicking the **Enable** button.
     {{< img src="account_management/saml/saml_enable.png" alt="saml enable"  >}}
+    
+   - **note**: In some cases, you may not see the **Enable** button on the SAML configuration page. In these cases, you'll need to return to the **Login Methods** page and enable SAML by default using the `on/off` dropdown.
 
 6. Once SAML is configured in Datadog and your IdP is set up to accept requests from Datadog, users can log in:
 

--- a/content/en/account_management/saml/_index.md
+++ b/content/en/account_management/saml/_index.md
@@ -43,7 +43,7 @@ Configuring [SAML (Security Assertion Markup Language)][1] for your Datadog acco
 5. After you upload the IdP Meta-data and configure your IdP, enable SAML in Datadog by clicking the **Enable** button.
     {{< img src="account_management/saml/saml_enable.png" alt="saml enable"  >}}
     
-   - **note**: In some cases, you may not see the **Enable** button on the SAML configuration page. In these cases, you'll need to return to the **Login Methods** page and enable SAML by default using the `on/off` dropdown.
+   - **note**: In some cases, you may not see the **Enable** button on the SAML configuration page. In these cases, you will need to return to the **Login Methods** page and enable SAML by default using the `on/off` dropdown.
 
 6. Once SAML is configured in Datadog and your IdP is set up to accept requests from Datadog, users can log in:
 

--- a/content/en/account_management/saml/_index.md
+++ b/content/en/account_management/saml/_index.md
@@ -40,12 +40,12 @@ Configuring [SAML (Security Assertion Markup Language)][1] for your Datadog acco
 
 4. Download Datadog's [Service Provider metadata][18] to configure your IdP to recognize Datadog as a Service Provider.
 
-5. After you upload the IdP Meta-data and configure your IdP, enable SAML in Datadog by clicking the **Enable** button.
+5. After you upload the IdP Meta-data and configure your IdP, enable SAML in Datadog by clicking the **Upload and Enable** button.
     {{< img src="account_management/saml/saml_enable.png" alt="saml enable"  >}}
     
-   - **note**: In some cases, you may not see the **Enable** button on the SAML configuration page. In these cases, you will need to return to the **Login Methods** page and enable SAML by default using the `on/off` dropdown.
+6. After uploading the IdP metadata, return to the **Login Methods** page and turn SAML `on` by default. 
 
-6. Once SAML is configured in Datadog and your IdP is set up to accept requests from Datadog, users can log in:
+7. Once SAML is configured in Datadog and your IdP is set up to accept requests from Datadog, users can log in:
 
    - **If using SP-initiated login** (Service Provider, or login initiated from Datadog): By using the **Single Sign-on URL** shown in the Status box at the top of the [SAML Configuration page][19]. The **Single Sign-on URL** is also displayed on the [Team page][20]. Loading this URL initiates a SAML authentication against your IdP. **Note**: This URL isn't displayed unless SAML is enabled for your account and you are using SP-initiated login.
     {{< img src="account_management/saml/saml_enabled.png" alt="Saml Enabled"  >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds instructions for users to follow for configuring SAML when the UI differs from our documentation.

### Motivation
Some organizations see a different configuration page for SAML that has led to some confusion on how to enable SAML. For organizations that have never uploaded IdP metadata, there is a `upload and enable` button on the SAML configuration page, but for organizations that have previously, there is not. To enable SAML in both cases they need to enable the method by default for all users to enable SAML. This is to address that possibility and give users direction if it applies to them.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
