### PR TITLE
[doc] Corrected misleading Java compatibility

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/dd_libraries/java.md
@@ -21,7 +21,7 @@ further_reading:
 ---
 ## Compatibility requirements
 
-The latest Java Tracer supports all JVMs version 8 and higher. For JVM versions below 8, please see [Supported JVM runtimes][10].
+The latest Java Tracer supports all JVMs version 8 and higher. For additional information about JVM versions below 8, read [Supported JVM runtimes][10].
 
 For a full list of Datadog’s Java version and framework support (including legacy and maintenance versions), read [Compatibility Requirements][1].
 
@@ -279,4 +279,4 @@ If needed, configure the tracing library to send application performance telemet
 [7]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
 [8]: https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html
 [9]: /tracing/trace_collection/library_config/java/
-[10]: https://docs.datadoghq.com/tracing/trace_collection/compatibility/java/#supported-jvm-runtimes
+[10]: /tracing/trace_collection/compatibility/java/#supported-jvm-runtimes

--- a/content/en/tracing/trace_collection/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/dd_libraries/java.md
@@ -21,8 +21,6 @@ further_reading:
 ---
 ## Compatibility requirements
 
-The latest Java Tracer supports all JVMs version 7 and higher on all platforms.
-
 For a full list of Datadog’s Java version and framework support (including legacy and maintenance versions), read [Compatibility Requirements][1].
 
 ## Installation and getting started

--- a/content/en/tracing/trace_collection/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/dd_libraries/java.md
@@ -21,6 +21,8 @@ further_reading:
 ---
 ## Compatibility requirements
 
+The latest Java Tracer supports all JVMs version 8 and higher. For JVM versions below 8, please see [Supported JVM runtimes][10].
+
 For a full list of Datadog’s Java version and framework support (including legacy and maintenance versions), read [Compatibility Requirements][1].
 
 ## Installation and getting started
@@ -277,3 +279,4 @@ If needed, configure the tracing library to send application performance telemet
 [7]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
 [8]: https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html
 [9]: /tracing/trace_collection/library_config/java/
+[10]: https://docs.datadoghq.com/tracing/trace_collection/compatibility/java/#supported-jvm-runtimes


### PR DESCRIPTION
Since the release of Java tracer v1.x, Java 8 is the minimum requirement, making the following misleading:
 "The latest Java Tracer supports all JVMs version 7 and higher on all platforms."

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR removed our previous language "The latest Java Tracer supports all JVMs version 7 and higher on all platforms."

### Motivation
[https://github.com/DataDog/dd-trace-java/releases/tag/v1.0.0](url)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
