### PR TITLE
Update Continuous Testing integration docs

### DIFF
--- a/content/en/continuous_testing/cicd_integrations/_index.md
+++ b/content/en/continuous_testing/cicd_integrations/_index.md
@@ -42,12 +42,13 @@ To get started, see [Integrations](#integrations) and [use the API](#use-the-api
 
 ## Integrations
 
-{{< whatsnext desc="With Continuous Testing and CI/CD, you can run Continuous Testing tests in any CI platform provider of choice. See the documentation for information about the following integrations:" >}}
+{{< whatsnext desc="With Continuous Testing and CI/CD, you can run Continuous Testing tests in any CI platform provider of choice. See the documentation for information about the following integrations, or read more about our NPM package:">}}
     {{< nextlink href="synthetics/cicd_integrations/azure_devops_extension" >}}Azure DevOps Extension{{< /nextlink >}}
     {{< nextlink href="synthetics/cicd_integrations/circleci_orb" >}}CircleCI Orb{{< /nextlink >}}
     {{< nextlink href="synthetics/cicd_integrations/github_actions" >}}GitHub Actions{{< /nextlink >}}
     {{< nextlink href="synthetics/cicd_integrations/gitlab" >}}GitLab{{< /nextlink >}}
     {{< nextlink href="synthetics/cicd_integrations/jenkins" >}}Jenkins{{< /nextlink >}}
+    {{< nextlink href="synthetics/cicd_integrations/configuration" >}}NPM package{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ## Use the CLI

--- a/content/en/continuous_testing/cicd_integrations/_index.md
+++ b/content/en/continuous_testing/cicd_integrations/_index.md
@@ -42,7 +42,7 @@ To get started, see [Integrations](#integrations) and [use the API](#use-the-api
 
 ## Integrations
 
-{{< whatsnext desc="With Continuous Testing and CI/CD, you can run Continuous Testing tests in any CI platform provider of choice. See the documentation for information about the following integrations, or read more about our NPM package:">}}
+{{< whatsnext desc="With Continuous Testing and CI/CD, you can run Continuous Testing tests in any CI platform provider of choice. See the documentation for information about the following integrations, or read more about the Datadog CI NPM package:">}}
     {{< nextlink href="synthetics/cicd_integrations/azure_devops_extension" >}}Azure DevOps Extension{{< /nextlink >}}
     {{< nextlink href="synthetics/cicd_integrations/circleci_orb" >}}CircleCI Orb{{< /nextlink >}}
     {{< nextlink href="synthetics/cicd_integrations/github_actions" >}}GitHub Actions{{< /nextlink >}}

--- a/content/en/continuous_testing/settings/_index.md
+++ b/content/en/continuous_testing/settings/_index.md
@@ -19,10 +19,6 @@ further_reading:
   text: "Create and manage tests with Terraform"
 ---
 
-<div class="alert alert-info">
-If you would like to enable Continuous Testing and customize your parallelization, reach out to <a href="https://docs.datadoghq.com/help/">Datadog support</a>.
-</div>
-
 ## Overview
 
 You can access Continuous Testing settings on the [Synthetic Monitoring Settings page][1].


### PR DESCRIPTION
Clarify that the NPM package is another integration that can be used if a CI provider is not documented.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
