### PR TITLE
Add scrape disclaimer to check before enabling

### DIFF
--- a/content/en/containers/kubernetes/prometheus.md
+++ b/content/en/containers/kubernetes/prometheus.md
@@ -216,7 +216,7 @@ With Prometheus Autodiscovery, the Datadog Agent is able to detect native Promet
 
 ### Configuration
 
-It's recommended to first check which pods and services have the `prometheus.io/scrape=true` annotation before enabling this feature. This can be done with commands like:
+It's recommended to first check which pods and services have the `prometheus.io/scrape=true` annotation before enabling this feature. This can be done with the following commands:
 
 ```shell
 kubectl get pods -o=jsonpath='{.items[?(@.metadata.annotations.prometheus\.io/scrape=="true")].metadata.name}' --all-namespaces
@@ -224,7 +224,7 @@ kubectl get pods -o=jsonpath='{.items[?(@.metadata.annotations.prometheus\.io/sc
 kubectl get services -o=jsonpath='{.items[?(@.metadata.annotations.prometheus\.io/scrape=="true")].metadata.name}' --all-namespaces
 ```
 
-Once the Prometheus Scrape feature is enabled the Datadog Agent will collect custom metrics from these resources. If you do not want to collect the custom metrics from these resources you can remove this annotation or update the autodiscovery rules as described in the [advanced configuration](#advanced-configuration).
+Once the Prometheus Scrape feature is enabled the Datadog Agent collects custom metrics from these resources. If you do not want to collect the custom metrics from these resources you can remove this annotation or update the autodiscovery rules as described in the [advanced configuration section](#advanced-configuration).
 
 #### Basic configuration
 

--- a/content/en/containers/kubernetes/prometheus.md
+++ b/content/en/containers/kubernetes/prometheus.md
@@ -216,6 +216,16 @@ With Prometheus Autodiscovery, the Datadog Agent is able to detect native Promet
 
 ### Configuration
 
+It's recommended to first check which pods and services have the `prometheus.io/scrape=true` annotation before enabling this feature. This can be done with commands like:
+
+```shell
+kubectl get pods -o=jsonpath='{.items[?(@.metadata.annotations.prometheus\.io/scrape=="true")].metadata.name}' --all-namespaces
+
+kubectl get services -o=jsonpath='{.items[?(@.metadata.annotations.prometheus\.io/scrape=="true")].metadata.name}' --all-namespaces
+```
+
+Once the Prometheus Scrape feature is enabled the Datadog Agent will collect custom metrics from these resources. If you do not want to collect the custom metrics from these resources you can remove this annotation or update the autodiscovery rules as described in the [advanced configuration](#advanced-configuration).
+
 #### Basic configuration
 
 {{< tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add a disclaimer to double check which pods and services have the prometheus scrape annotation before enabling the prometheus scrape feature. As well as provide some sample commands to do so.

### Motivation
<!-- What inspired you to submit this pull request?-->
The prometheus scrape annotation can often be present on pods/services which customers were not aware of. Which means the Agent will start collecting billable custom metrics from these pods/services that they were not anticipating. Adding this to avoid that pain point when enabling this feature for the first time.

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/jack.davenport/prometheus-scrape-disclaimer/containers/kubernetes/prometheus/?tab=kubernetesadv2#configuration-1

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Sample output:
```shell
$ kubectl get pods -o=jsonpath='{.items[?(@.metadata.annotations.prometheus\.io/scrape=="true")].metadata.name}' --all-namespaces
istiod-69774dbfdf-4fjcx kube-dns-b8976dfcd-hm6cq kube-dns-b8976dfcd-rwnjf 

$ kubectl get services -o=jsonpath='{.items[?(@.metadata.annotations.prometheus\.io/scrape=="true")].metadata.name}' --all-namespaces
kube-state-metrics
```
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
