### PR TITLE
Adds AKS selectors env var and simplifies Operator

### DIFF
--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -109,6 +109,10 @@ datadog:
           fieldPath: spec.nodeName
     hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
     tlsVerify: false # Required as of Agent 7.35. See Notes.
+clusterAgent:
+  env: 
+    - name: DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS
+      value: true
 ```
 
 {{% /tab %}}
@@ -137,10 +141,9 @@ spec:
     image:
       name: "gcr.io/datadoghq/cluster-agent:latest"
     config:
-      externalMetrics:
-        enabled: false
-      admissionController:
-        enabled: false
+      env:
+          - name: DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS
+            value: "true"
 ```
 
 {{% /tab %}}

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -112,7 +112,7 @@ datadog:
 clusterAgent:
   env: 
     - name: DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS
-      value: true
+      value: "true"
 ```
 
 {{% /tab %}}

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -142,8 +142,8 @@ spec:
       name: "gcr.io/datadoghq/cluster-agent:latest"
     config:
       env:
-          - name: DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS
-            value: "true"
+        - name: DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS
+          value: "true"
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
* Adds the environment variable `DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS` to AKS deployment, as without this variable, the Cluster Agent will send an important number of logs of the form : 

```
CLUSTER | INFO | (pkg/clusteragent/admission/controllers/webhook/controller_base.go:171 in processNextWorkItem) | Couldn't reconcile Webhook datadog-webhook: Operation cannot be fulfilled on mutatingwebhookconfigurations.admissionregistration.k8s.io "datadog-webhook": the object has been modified; please apply your changes to the latest version and try again
```

* Simplifies the Operator configuration as the values `clusterAgent.config.admissionController` and `clusterAgent.config.externalMetrics` are set to `false` by default
### Motivation
<!-- What inspired you to submit this pull request?-->
* Multiple tickets of customers reaching out because the Cluster Agent writes an important number of logs on AKS without this variable, while the admission controller is enabled (by default in Helm, or manually in AKS)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
