### PR TITLE
Cucumber versions using JUnit5 are not supported

### DIFF
--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -23,7 +23,7 @@ further_reading:
 
 Supported test frameworks:
 * JUnit >= 4.10 and >= 5.3
-  * Also includes any test framework based on JUnit, such as Spock Framework and Cucumber-Junit (note: Cucumber is only supported with JUnit v4)
+  * Also includes any test framework based on JUnit, such as Spock Framework and Cucumber-Junit. **Note**: Cucumber is only supported with JUnit v4.
 * TestNG >= 6.4
 
 ## Configuring reporting method

--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -23,7 +23,7 @@ further_reading:
 
 Supported test frameworks:
 * JUnit >= 4.10 and >= 5.3
-  * Also includes any test framework based on JUnit, such as Spock Framework and Cucumber-Junit
+  * Also includes any test framework based on JUnit, such as Spock Framework and Cucumber-Junit (note: Cucumber is only supported with JUnit v4)
 * TestNG >= 6.4
 
 ## Configuring reporting method


### PR DESCRIPTION
### What does this PR do?
Cucumber v2 and later, which use JUnit v5, don't work at the moment despite JUnit v5 being supported.

### Motivation
We never tested Cucumber with JUnit 5. I tested it and our instrumentation doesn't work.


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
