### PR TITLE
[DBM] Update troubleshooting pg_stat_statements not in search_path

### DIFF
--- a/content/en/database_monitoring/setup_postgres/troubleshooting.md
+++ b/content/en/database_monitoring/setup_postgres/troubleshooting.md
@@ -97,6 +97,24 @@ psql -h localhost -U datadog -d postgres -c "select * from pg_stat_statements LI
 
 If you specified a `dbname` other than the default `postgres` in your Agent config, you must run `CREATE EXTENSION pg_stat_statements` in that database.
 
+If you have created the extension in your target database and you still see this warning, the extension may have been created in a schema that is not accessible to the `datadog` user. To verify this, check which schema `pg_stat_statements` was created in:
+
+```bash
+psql -h localhost -U datadog -d postgres -c "select nspname from pg_extension, pg_namespace where extname = 'pg_stat_statements' and pg_extension.extnamespace = pg_namespace.oid;"
+```
+
+Then check which schemas are visible to the `datadog` user with:
+
+```bash
+psql -h localhost -U datadog -d <your_database> -c "show search_path;"
+```
+
+If you do not see the `pg_stat_statements` schema in the `datadog` user's `search_path`, you will need to add it to the `datadog` user. For example:
+
+```sql
+ALTER ROLE datadog SET search_path = "$user",public,schema_with_pg_stat_statements;
+```
+
 ### Certain queries are missing
 
 If you have data from some queries, but do not see a particular query or set of queries in Database Monitoring that you're expecting to see , follow this guide.

--- a/content/en/database_monitoring/setup_postgres/troubleshooting.md
+++ b/content/en/database_monitoring/setup_postgres/troubleshooting.md
@@ -97,19 +97,19 @@ psql -h localhost -U datadog -d postgres -c "select * from pg_stat_statements LI
 
 If you specified a `dbname` other than the default `postgres` in your Agent config, you must run `CREATE EXTENSION pg_stat_statements` in that database.
 
-If you have created the extension in your target database and you still see this warning, the extension may have been created in a schema that is not accessible to the `datadog` user. To verify this, check which schema `pg_stat_statements` was created in:
+If you created the extension in your target database and you still see this warning, the extension may have been created in a schema that is not accessible to the `datadog` user. To verify this, run this command to check which schema `pg_stat_statements` was created in:
 
 ```bash
 psql -h localhost -U datadog -d postgres -c "select nspname from pg_extension, pg_namespace where extname = 'pg_stat_statements' and pg_extension.extnamespace = pg_namespace.oid;"
 ```
 
-Then check which schemas are visible to the `datadog` user with:
+Then, run this command to check which schemas are visible to the `datadog` user:
 
 ```bash
 psql -h localhost -U datadog -d <your_database> -c "show search_path;"
 ```
 
-If you do not see the `pg_stat_statements` schema in the `datadog` user's `search_path`, you will need to add it to the `datadog` user. For example:
+If you do not see the `pg_stat_statements` schema in the `datadog` user's `search_path`, you need to add it to the `datadog` user. For example:
 
 ```sql
 ALTER ROLE datadog SET search_path = "$user",public,schema_with_pg_stat_statements;


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
Explains how to diagnose an edge case where pg_stat_statements is not accessible to the datadog user in dbm.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
