### PR TITLE
Add Websites to some files for reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,3 +26,12 @@ package.json              @DataDog/corpweb @DataDog/documentation
 
 # Partners
 /content/en/partners/                                   @KateYoak @DataDog/documentation
+
+# Websites
+.github/workflows                                       @DataDog/corpweb
+.gitlab-ci.yml                                          @DataDog/corpweb
+Makefile                                                @DataDog/corpweb
+translate.yaml                                          @DataDog/corpweb
+.translate                                              @DataDog/corpweb
+docker-compose-docs.yml                                 @DataDog/corpweb
+.htmltest.yml                                           @DataDog/corpweb


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds specific files and directories to the corpweb scope in CODEOWNERS

### Motivation
<!-- What inspired you to submit this pull request?-->
Certain files can have unseen ripple effects when changed that may not be noticed or caught in preview branches. In an attempt to do some proactive checks, the websites team would like to provide review on any build related files for the documentation site. The scope of this shouldn't effect any current workflows for the docs and other outside teams since these files are 90% of the time maintained by the websites team. 

These changes will hopefully allows us to catch any unintended changed before they go out, but in the event something does go through and causes some kind of issues or outage of docs, we should at least have a better context around it allowing us to get a fix out for it quicker.

If there is any questions please don't hesitate to slack me directly @devinford
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
N/A
### Additional Notes
<!-- Anything else we should know when reviewing?-->
If you see any files you think the websites team should have more visibility into when they are changed.
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
