### PR TITLE
Fix link to statsd sets documentation

### DIFF
--- a/content/en/metrics/types.md
+++ b/content/en/metrics/types.md
@@ -338,7 +338,7 @@ Below is a summary of all available metric submission sources and methods. This 
 [1]: /metrics/custom_metrics/type_modifiers/
 [2]: /dashboards/functions/
 [3]: /metrics/summary/
-[4]: https://statsd.readthedocs.io/en/v3.2.2/types.html#sets
+[4]: https://statsd.readthedocs.io/en/v3.3/types.html#sets
 [5]: /metrics/custom_metrics/agent_metrics_submission/
 [6]: /metrics/custom_metrics/dogstatsd_metrics_submission/
 [7]: /api/v1/metrics/#submit-metrics


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixed the link to statsd's sets documentation

### Motivation
The link was broken

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
