### PR TITLE
Adds Integration Tile Partial in Continuous Testing Product Landing Page

### DIFF
--- a/content/en/continuous_testing/_index.md
+++ b/content/en/continuous_testing/_index.md
@@ -42,6 +42,10 @@ Instead of having to implement test code, you can build software using [Syntheti
 
 Fast-track your application development by testing and troubleshooting in one platform. Use integrations with CI providers such as [GitHub][5], [GitLab][6], [Jenkins][7], [CircleCI][8], and [Azure DevOps][9], and collaboration tools such as Slack or Jira to merge workflows and prevent context switching. 
 
+{{< partial name="continuous_testing/ct-getting-started.html" >}}
+
+</br>
+
 You can use the [Datadog Terraform provider][10] to control test creation and state management. Leverage your Synthetic tests as [integration and end-to-end tests][11] for your staging, pre-prod, and canary deployments, or run them directly in your [CI pipelines][11].
 
 ## Accelerate troubleshooting

--- a/content/en/continuous_testing/_index.md
+++ b/content/en/continuous_testing/_index.md
@@ -40,7 +40,7 @@ Instead of having to implement test code, you can build software using [Syntheti
 
 ## Increase efficiency through seamless integrations
 
-Fast-track your application development by testing and troubleshooting in one platform. Use integrations with CI providers such as [GitHub][5], [GitLab][6], [Jenkins][7], [CircleCI][8], and [Azure DevOps][9], and collaboration tools such as Slack or Jira to merge workflows and prevent context switching. 
+Fast-track your application development by testing and troubleshooting in one platform. Select from the following types of CI providers and collaboration tools such as Slack or Jira to merge workflows and avoid context switching. 
 
 {{< partial name="continuous_testing/ct-getting-started.html" >}}
 

--- a/content/en/continuous_testing/_index.md
+++ b/content/en/continuous_testing/_index.md
@@ -68,11 +68,6 @@ Once you have configured some [Synthetic tests][4], see the documentation for yo
 [2]: /synthetics/browser_tests
 [3]: /continuous_testing/settings
 [4]: /synthetics/
-[5]: /continuous_testing/cicd_integrations/github_actions
-[6]: /continuous_testing/cicd_integrations/gitlab
-[7]: /continuous_testing/cicd_integrations/jenkins
-[8]: /continuous_testing/cicd_integrations/circleci_orb
-[9]: /continuous_testing/cicd_integrations/azure_devops_extension
 [10]: https://registry.terraform.io/providers/DataDog/datadog/latest/
 [11]: /continuous_testing/explorer
 [12]: /synthetics/apm/

--- a/layouts/partials/continuous_testing/ct-getting-started.html
+++ b/layouts/partials/continuous_testing/ct-getting-started.html
@@ -1,0 +1,33 @@
+{{ $dot := . }}
+<div class="rum-platforms">
+  <div class="container cards-dd col-num-3">
+    <div class="card-deck">
+      <a class="card" href="/continuous_testing/cicd_integrations/github_actions/">
+        <div class="card-body text-center py-2 px-1">
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/github.png" "class" "img-fluid" "alt" "github actions" "width" "200") }}
+        </div>
+      </a>
+      <a class="card" href="/continuous_testing/cicd_integrations/gitlab/">
+        <div class="card-body text-center py-2 px-1">
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/gitlab.png" "class" "img-fluid" "alt" "gitlab" "width" "200") }}
+        </div>
+      </a>
+      <a class="card" href="/continuous_testing/cicd_integrations/jenkins/">
+        <div class="card-body text-center py-2 px-1">
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/jenkins.png" "class" "img-fluid" "alt" "jenkins" "width" "200") }}
+        </div>
+      </a>
+      <a class="card" href="/continuous_testing/cicd_integrations/circleci_orb/">
+        <div class="card-body text-center py-2 px-1">
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/circleci.png" "class" "img-fluid" "alt" "circleci orb" "width" "200") }}
+        </div>
+      </a>
+      <br>
+      <a class="card" href="/continuous_testing/cicd_integrations/azure_devops_extension/">
+        <div class="card-body text-center py-2 px-1">
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/azure_devops.png" "class" "img-fluid" "alt" "azure devops extension" "width" "200") }}
+        </div>
+      </a>
+    </div>
+  </div>
+</div>

--- a/layouts/partials/continuous_testing/ct-getting-started.html
+++ b/layouts/partials/continuous_testing/ct-getting-started.html
@@ -1,6 +1,6 @@
 {{ $dot := . }}
-<div class="rum-platforms">
-  <div class="container cards-dd col-num-3">
+<div class="ci-cd-integrations">
+  <div class="container cards-dd col-num-4">
     <div class="card-deck">
       <a class="card" href="/continuous_testing/cicd_integrations/github_actions/">
         <div class="card-body text-center py-2 px-1">
@@ -26,6 +26,16 @@
       <a class="card" href="/continuous_testing/cicd_integrations/azure_devops_extension/">
         <div class="card-body text-center py-2 px-1">
           {{ partial "img.html" (dict "root" . "src" "integrations_logos/azure_devops.png" "class" "img-fluid" "alt" "azure devops extension" "width" "200") }}
+        </div>
+      </a>
+      <a class="card" href="/integrations/slack/">
+        <div class="card-body text-center py-2 px-1">
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/slack.png" "class" "img-fluid" "alt" "slack" "width" "200") }}
+        </div>
+      </a>
+      <a class="card" href="/integrations/jira/">
+        <div class="card-body text-center py-2 px-1">
+          {{ partial "img.html" (dict "root" . "src" "integrations_logos/jira.png" "class" "img-fluid" "alt" "jira" "width" "200") }}
         </div>
       </a>
     </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds a tile selector for the CI/CD integrations.

### Motivation
<!-- What inspired you to submit this pull request?-->

The RUM product landing page, chat with Beth.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
