### PR TITLE
WEB-2889 | Update Github Workflows

### DIFF
--- a/.github/workflows/approved_status.yml
+++ b/.github/workflows/approved_status.yml
@@ -30,7 +30,7 @@ jobs:
           private_key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
           repository: DataDog/datadog-api-spec
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Post PR review status check
         uses: DataDog/github-actions/post-review-status@v1.0.0
         with:

--- a/.github/workflows/bump_versions.yml
+++ b/.github/workflows/bump_versions.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - id: set-versions
         name: Load latest SDK versions
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           result-encoding: string
@@ -27,7 +27,7 @@ jobs:
               'datadog-api-client-typescript'
             ]
             const versions = await Promise.all(clients.map(async (repo) => {
-              const releases = await github.repos.listReleases({
+              const releases = await github.rest.repos.listReleases({
                 owner: 'DataDog',
                 repo: repo
               })
@@ -35,7 +35,7 @@ jobs:
             }))
             console.log(versions)
             return JSON.stringify(versions)
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Write version
         run: |-
           echo '${{steps.set-versions.outputs.result}}' | jq > ./data/sdk_versions.json
@@ -45,13 +45,13 @@ jobs:
           git add .
           git commit -m "Bump SDK"
           git push -f origin HEAD:refs/heads/sdk/versions
-      - uses: actions/github-script@v4
+      - uses: actions/github-script@v6
         name: Propose change with latest versions
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           result-encoding: string
           script: |
-            await github.pulls.create({
+            await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "[SDK] new versions are available",

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,7 +11,7 @@ jobs:
 
     - name: Set documentation preview
       if: github.event.pull_request.head.repo.fork == false
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@6.3.3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          github.rest.repos.createStatus({
+          github.rest.repos.createCommitStatus({
             "owner": context.repo.owner,
             "repo": context.repo.repo,
             "sha": context.payload.pull_request.head.sha,

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,7 +11,7 @@ jobs:
 
     - name: Set documentation preview
       if: github.event.pull_request.head.repo.fork == false
-      uses: actions/github-script@6.3.3
+      uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          github.repos.createStatus({
+          github.rest.repos.createStatus({
             "owner": context.repo.owner,
             "repo": context.repo.repo,
             "sha": context.payload.pull_request.head.sha,

--- a/.github/workflows/preview_link.yml
+++ b/.github/workflows/preview_link.yml
@@ -11,19 +11,19 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
-    - run: pip install Mako  
-    
+    - run: pip install Mako
+
     - name: Find changed files
       id: changed_files
       uses: tj-actions/changed-files@v23
-      with: 
-        include_all_old_new_renamed_files: true      
-    
+      with:
+        include_all_old_new_renamed_files: true
+
     - name: Generate links
       env:
         branch: ${{ github.head_ref }}
@@ -36,20 +36,20 @@ jobs:
 
     - name: Render template
       id: template
-      uses: chuhlomin/render-template@v1.4
+      uses: chuhlomin/render-template@v1.6
       with:
         template: .github/preview-links-template.md
 
     - name: Find existing comment
-      uses: peter-evans/find-comment@v2.0.0
+      uses: peter-evans/find-comment@v2.1.0
       id: find_comment
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'github-actions[bot]'
         body-includes: "Preview links ("
-    
+
     - name: Post comment
-      uses: peter-evans/create-or-update-comment@v2.0.0
+      uses: peter-evans/create-or-update-comment@v2.1.0
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find_comment.outputs.comment-id }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update (most) of the github workflows so they are in compliance with the Node 12 deprecation in GH actions.

I believe the only one 
### Motivation
<!-- What inspired you to submit this pull request?-->
Github Actions is deprecating Node 12 which a lot of these actions used
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
N/A
### Additional Notes
<!-- Anything else we should know when reviewing?-->

The actions maintained by Datadog will need PRs to be updated first, then we can update them here.
Specifically `DataDog/labeler@glob-all` used in the label job and `DataDog/github-actions/post-review-status` in the PR approval status job

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
