### PR TITLE
Add additional troubleshooting documentation for sqlserver connection issues

### DIFF
--- a/content/en/database_monitoring/setup_sql_server/troubleshooting.md
+++ b/content/en/database_monitoring/setup_sql_server/troubleshooting.md
@@ -164,7 +164,7 @@ At the moment, the only character known to cause this specific connectivity issu
 
 ### Data source name not found, and no default driver specified
 
-This is a common error seen when using the default setting for the ODBC driver. This can happen due the [DSN][10], which is set for your driver in the `/etc/odbcinst.ini` file, not matching the name of the driver that is set in your agent config.
+This is a common error seen on linux when using the default setting for the ODBC driver. This can happen due the [DSN][10], which is set for your driver in the `/etc/odbcinst.ini` file, not matching the name of the driver that is set in your agent config.
 
 For example, if you wanted to use the default ODBC driver for the Agent (`{ODBC Driver 18 for SQL Server}`), your instance config should contain the following:
 
@@ -202,6 +202,25 @@ In your instance config, you would then set the `dsn` field:
   connector: odbc
   dsn: "Custom"
 ```
+
+### Provider or driver not found
+
+This error message can vary in wording across the different drivers, but typically it looks like the following for `ODBC`:
+
+1. `Can't open lib .* file not found`
+2. `Data source name not found.* and no default driver specified`
+
+And for `MSOLEDBSQL` providers the error message looks like:
+
+  ```text
+  Provider cannot be found. It may not be properly installed.
+  ```
+
+This means that the driver/provider is not properly installed on the host where the agent is running. You should ensure that you have followed all the installation directions for the driver you have chosen to use.
+
+It's possible that the agent is not properly finding the driver. This is more common with ODBC drivers on linux. Please see [this section](#connecting-to-sql-server-on-a-linux-host) for more instructions on how to install the ODBC driver on linux.
+
+For help choosing a driver, please see [this section](#picking-a-sql-server-driver) on how to properly configure your driver with the agent.
 
 ### Connecting to SQL Server on a Linux host
 

--- a/content/en/database_monitoring/setup_sql_server/troubleshooting.md
+++ b/content/en/database_monitoring/setup_sql_server/troubleshooting.md
@@ -166,15 +166,15 @@ At the moment, the only character known to cause this specific connectivity issu
 
 This is a common error seen when using the default setting for the ODBC driver. This can happen due the [DSN][10], which is set for your driver in the `/etc/odbcinst.ini` file, not matching the name of the driver that is set in your agent config.
 
-For example, if you wanted to use the default odbc driver for the agent (`{ODBC Driver 18 for SQL Server}`), your instance config should contain the following:
+For example, if you wanted to use the default ODBC driver for the Agent (`{ODBC Driver 18 for SQL Server}`), your instance config should contain the following:
 
 ```yaml
   connector: odbc
 ```
 
-when the agent starts up and tries to establish a connection to your SQL Server instance, it will look for the `/etc/odbcinst.ini` file to find the path to the driver binaries.
+When the Agent starts and tries to establish a connection to your SQL Server instance, it looks for the `/etc/odbcinst.ini` file to find the path to the driver binaries.
 
-For example, this `/etc/odbcinst.ini` file sets the driver like so:
+For example, this `/etc/odbcinst.ini` file sets the driver:
 
     ```text
     $ cat /etc/odbcinst.ini
@@ -184,7 +184,7 @@ For example, this `/etc/odbcinst.ini` file sets the driver like so:
     UsageCount=1
     ```
 
-The DSN in the above example is `[ODBC Driver 18 for SQL Server]`, which matches the default driver name the agent is using. If the DSN for your driver does not match the name of driver the agent is using, you will get the `Data source not found` error.
+The DSN in the above example is `[ODBC Driver 18 for SQL Server]`, which matches the default driver name the Agent is using. If the DSN for your driver does not match the name of driver the Agent is using, you will get the `Data source not found` error.
 
 It is possible to set the `dsn` name in your instance config to match what is set in your `/etc/odbcinst.ini` file. For example:
 
@@ -196,7 +196,7 @@ It is possible to set the `dsn` name in your instance config to match what is se
     UsageCount=1
     ```
 
-And then in your instance config, you would set the `dsn` field:
+In your instance config, you would then set the `dsn` field:
 
 ```yaml
   connector: odbc

--- a/content/en/database_monitoring/setup_sql_server/troubleshooting.md
+++ b/content/en/database_monitoring/setup_sql_server/troubleshooting.md
@@ -160,6 +160,8 @@ OperationalError: (KeyError('Python string format error in connection string->',
 
 At the moment, the only character known to cause this specific connectivity issue is the `%` character. If you want to use the "%" character in your `sqlserver.yaml`, that is if your Datadog SQL Server user password includes a `%`), you need to escape that character by including a double `%%` in place of each single `%`.
 
+## Diagnosing common SQL Server driver issues
+
 ### Data source name not found, and no default driver specified
 
 This is a common error seen when using the default setting for the ODBC driver. This can happen due the [DSN][10], which is set for your driver in the `/etc/odbcinst.ini` file, not matching the name of the driver that is set in your agent config.
@@ -236,8 +238,6 @@ To connect SQL Server (either hosted on Linux or Windows) to a Linux host:
         password: <PASSWORD>
     ```
 
-## Other common questions
-
 ### Picking a SQL Server driver
 
 In order for the agent to connect to the SQL Server instance, you must install either the [Microsoft ODBC driver][12] or the [OLE DB driver][13].
@@ -270,6 +270,8 @@ In the latest version of the [Microsoft OLE DB driver][13], the driver name was 
   ```
 
 It is recommended to stay up to date with the latest available version of the driver you select.
+
+## Other common questions
 
 ### SQL Server user tag is missing on the Query Metrics and Plan Samples
 

--- a/content/en/database_monitoring/setup_sql_server/troubleshooting.md
+++ b/content/en/database_monitoring/setup_sql_server/troubleshooting.md
@@ -80,14 +80,14 @@ If neither step produces meaningful help, or the error code you are seeing is no
 
 ### SQL Server 'Unable to connect: Adaptive Server is unavailable or does not exist' {#adaptive-server-unavailable}
 
-This error can sometimes just be the result of not properly setting the `host` field. For the integration, you should the `host` field with the following syntax: `host:server,port`.
+This error can sometimes be the result of not properly setting the `host` field. For the integration, set the `host` field with the following syntax: `host:server,port`.
 
-For example:
+For example, if you've set `host` this way:
 
 ```
 host: sqlserver-foo.cfxxae8cilce.us-east-1.rds.amazonaws.com
 ```
-Should be set as:
+You must add the port, and instead set it as the following:
 ```
 host: sqlserver-foo.cfxxae8cilce.us-east-1.rds.amazonaws.com,1433
 ```
@@ -151,19 +151,19 @@ This issue is described in more detail in this [Microsoft blog post][9]
 
 ### Empty connection string {#empty-connection-string}
 
-Datadog's SQL Server check relies on the adodbapi Python library, which has some limitations in the characters that it is able to use in making a connection string to a SQL Server. If your Agent experiences trouble connecting to your SQL Server, and if you find errors similar to the following in your Agent's collector.logs, your `sqlserver.yaml` probably includes some character that causes issues with adodbapi.
+Datadog's SQL Server check relies on the `adodbapi` Python library, which has some limitations in the characters that it is able to use in making a connection string to a SQL Server. If your Agent experiences trouble connecting to your SQL Server, and if you find errors similar to the following in your Agent's collector.logs, your `sqlserver.yaml` may include some characters that cause issues with `adodbapi`.
 
 ```text
 OperationalError: (KeyError('Python string format error in connection string->',), 'Error opening connection to ""')
 ```
 
-At the moment, the only character known to cause this specific connectivity issue is the `%` character. If you want to use the "%" character in your `sqlserver.yaml`, that is if your Datadog SQL Server user password includes a `%`), you need to escape that character by including a double `%%` in place of each single `%`.
+At the moment, the only character known to cause this specific connectivity issue is the `%` character. If you need to use the `%` character in your `sqlserver.yaml` file, (for example, if your Datadog SQL Server user password includes a `%`), you must escape that character by including a double `%%` in place of each single `%`.
 
 ## Diagnosing common SQL Server driver issues {#common-driver-issues}
 
 ### Data source name not found, and no default driver specified {#data-source-name-not-found}
 
-This is a common error seen on linux when using the default setting for the ODBC driver. This can happen due the [DSN][10], which is set for your driver in the `/etc/odbcinst.ini` file, not matching the name of the driver that is set in your agent config.
+This is a common error seen on Linux when using the default setting for the ODBC driver. This can happen due the [DSN][10], which is set for your driver in the `/etc/odbcinst.ini` file, not matching the name of the driver that is set in your agent config.
 
 For example, if you wanted to use the default ODBC driver for the Agent (`{ODBC Driver 18 for SQL Server}`), your instance config should contain the following:
 
@@ -185,7 +185,7 @@ For example, this `/etc/odbcinst.ini` file sets the driver:
 
 The DSN in the above example is `[ODBC Driver 18 for SQL Server]`, which matches the default driver name the Agent is using. If the DSN for your driver does not match the name of driver the Agent is using, you will get the `Data source not found` error.
 
-It is possible to set the `dsn` name in your instance config to match what is set in your `/etc/odbcinst.ini` file. For example:
+It is possible to set the `dsn` in your instance config to match what is set in your `/etc/odbcinst.ini` file. For example:
 
     ```text
     $ cat /etc/odbcinst.ini
@@ -215,11 +215,11 @@ And for `MSOLEDBSQL` providers the error message looks like:
   Provider cannot be found. It may not be properly installed.
   ```
 
-This means that the driver/provider is not properly installed on the host where the agent is running. You should ensure that you have followed all the installation directions for the driver you have chosen to use.
+This means that the driver or provider is not properly installed on the host where the Agent is running. You should ensure that you have followed all the installation directions for the driver you have chosen to use.
 
-It's possible that the agent is not properly finding the driver. This is more common with ODBC drivers on linux. Please see [this section](#connecting-to-sql-server-on-a-linux-host) for more instructions on how to install the ODBC driver on linux.
+It's possible that the Agent is not finding the driver. This is more common with ODBC drivers on Linux. See the [connecting to SQL Server on a Linux host](#connecting-to-sql-server-on-a-linux-host) section for more instructions on how to install the ODBC driver on Linux.
 
-For help choosing a driver, please see [this section](#picking-a-sql-server-driver) on how to properly configure your driver with the agent.
+For help choosing a driver, see the [picking a SQL Server driver section](#picking-a-sql-server-driver) on how to properly configure your driver with the agent.
 
 ### Connecting to SQL Server on a Linux host
 
@@ -260,7 +260,7 @@ To connect SQL Server (either hosted on Linux or Windows) to a Linux host:
 
 In order for the agent to connect to the SQL Server instance, you must install either the [Microsoft ODBC driver][12] or the [OLE DB driver][13].
 
-Depending on which driver you pick, this will influence what you set for the [connector][14] field in your instance config.
+The driver you choose, determines what you set for the [connector][14] field in your instance config.
 
 For example, for the [Microsoft ODBC driver][12]:
 
@@ -289,7 +289,7 @@ In the latest version of the [Microsoft OLE DB driver][13], the driver name was 
 
 It is recommended to stay up to date with the latest available version of the driver you select.
 
-## Other common questions
+## Other common issues
 
 ### SQL Server user tag is missing on the Query Metrics and Plan Samples
 

--- a/content/en/database_monitoring/setup_sql_server/troubleshooting.md
+++ b/content/en/database_monitoring/setup_sql_server/troubleshooting.md
@@ -6,9 +6,9 @@ description: Troubleshoot Database Monitoring setup for SQL Server
 
 This page details common issues with setting up and using Database Monitoring with SQL Server, and how to resolve them. Datadog recommends staying on the latest stable Agent version and adhering to the latest [setup documentation][1], as it can change with Agent version releases.
 
-## Diagnosing common connection issues
+## Diagnosing common connection issues {#common-connection-issues}
 
-### SQL Server unable to connect 'Login Failed for user'
+### SQL Server unable to connect 'Login Failed for user' {#login-failed-for-user}
 
 There are two ways that the agent can connect to a SQL Server instance:
 
@@ -41,7 +41,7 @@ If the `datadog` user is unable to log into the SQL Server instance, please ensu
 
 Microsoft also provides a helpful doc on troubleshooting these types of errors, which can be [followed here][5].
 
-### SQL Server Unable to connect due to “Invalid connection string attribute”
+### SQL Server Unable to connect due to “Invalid connection string attribute” {#tcp-connection-error}
 
 The following ADO Providers are supported on Windows: `SQLOLEDB`, `MSOLEDBSQL`, `MSOLEDBSQL19`, `SQLNCLI11`.
 
@@ -78,7 +78,21 @@ To troubleshoot:
 
 If neither step produces meaningful help, or the error code you are seeing is not listed, Datadog recommends to use the `MSOLEDBSQL` driver or the `Microsoft ODBC Driver for SQL Server`. Either of these options will produce more meaningful error messages, which should help troubleshooting why the connection is failing.
 
-### SSL Provider: The certificate chain was issued by an authority that is not trusted
+### SQL Server 'Unable to connect: Adaptive Server is unavailable or does not exist' {#adaptive-server-unavailable}
+
+This error can sometimes just be the result of not properly setting the `host` field. For the integration, you should the `host` field with the following syntax: `host:server,port`.
+
+For example:
+
+```
+host: sqlserver-foo.cfxxae8cilce.us-east-1.rds.amazonaws.com
+```
+Should be set as:
+```
+host: sqlserver-foo.cfxxae8cilce.us-east-1.rds.amazonaws.com,1433
+```
+
+### SSL Provider: The certificate chain was issued by an authority that is not trusted {#certificate-verify-fail}
 
 This error is common after upgrading to the latest [MSOLEDBSQL][6] driver due to [breaking changes][7] that were introduced. In the latest version of the driver, all connections to the SQL instance are encrypted by default.
 
@@ -127,7 +141,7 @@ If you are using a driver **other than `MSOLEDBSQL` 2019**, this error can be re
       driver: '{ODBC Driver 17 for SQL Server}'
   ```
 
-### SQL Server unable to connect 'SSL Security error (18)'
+### SQL Server unable to connect 'SSL Security error (18)' {#ssl-security-error}
 
 This is a known issue for older versions of the SQL Server ODBC driver. You can check which version of the driver is being used by the agent by looking at the connection string in the error message.
 
@@ -135,22 +149,7 @@ For example, if you see `Provider=SQL Server` in the connection string of the er
 
 This issue is described in more detail in this [Microsoft blog post][9]
 
-
-### SQL Server 'Unable to connect: Adaptive Server is unavailable or does not exist'
-
-This error can sometimes just be the result of not properly setting the `host` field. For the integration, you should the `host` field with the following syntax: `host:server,port`.
-
-For example:
-
-```
-host: sqlserver-foo.cfxxae8cilce.us-east-1.rds.amazonaws.com
-```
-Should be set as:
-```
-host: sqlserver-foo.cfxxae8cilce.us-east-1.rds.amazonaws.com,1433
-```
-
-### Empty connection string
+### Empty connection string {#empty-connection-string}
 
 Datadog's SQL Server check relies on the adodbapi Python library, which has some limitations in the characters that it is able to use in making a connection string to a SQL Server. If your Agent experiences trouble connecting to your SQL Server, and if you find errors similar to the following in your Agent's collector.logs, your `sqlserver.yaml` probably includes some character that causes issues with adodbapi.
 
@@ -160,9 +159,9 @@ OperationalError: (KeyError('Python string format error in connection string->',
 
 At the moment, the only character known to cause this specific connectivity issue is the `%` character. If you want to use the "%" character in your `sqlserver.yaml`, that is if your Datadog SQL Server user password includes a `%`), you need to escape that character by including a double `%%` in place of each single `%`.
 
-## Diagnosing common SQL Server driver issues
+## Diagnosing common SQL Server driver issues {#common-driver-issues}
 
-### Data source name not found, and no default driver specified
+### Data source name not found, and no default driver specified {#data-source-name-not-found}
 
 This is a common error seen on linux when using the default setting for the ODBC driver. This can happen due the [DSN][10], which is set for your driver in the `/etc/odbcinst.ini` file, not matching the name of the driver that is set in your agent config.
 
@@ -203,7 +202,7 @@ In your instance config, you would then set the `dsn` field:
   dsn: "Custom"
 ```
 
-### Provider or driver not found
+### Provider or driver not found {#provider-not-found}
 
 This error message can vary in wording across the different drivers, but typically it looks like the following for `ODBC`:
 
@@ -257,7 +256,7 @@ To connect SQL Server (either hosted on Linux or Windows) to a Linux host:
         password: <PASSWORD>
     ```
 
-### Picking a SQL Server driver
+### Picking a SQL Server driver {#picking-a-driver}
 
 In order for the agent to connect to the SQL Server instance, you must install either the [Microsoft ODBC driver][12] or the [OLE DB driver][13].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds a new `Diagnosing common SQL Server driver issues` section to the SQL Server troubleshooting docs to support additional agent warnings we are adding the integration. Also adds permanent anchors for headers so we can use that as links in our agent warnings.

### Motivation
<!-- What inspired you to submit this pull request?-->

Adding this additional context for diagnosing known connection issues can be used to support emitting agent warnings in the SQL Server integration. PR for that work is here https://github.com/DataDog/integrations-core/pull/13436.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
