### PR TITLE
Cleanup and add more samples for ECS/EC2 log collection

### DIFF
--- a/content/en/containers/amazon_ecs/logs.md
+++ b/content/en/containers/amazon_ecs/logs.md
@@ -144,7 +144,7 @@ Use [datadog-agent-ecs-win-logs.json][1] as a reference point for the required b
 {{% /tab %}}
 {{< /tabs >}}
 
-These Task Definitions set the environment variable `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true` to collect logs from every container that the Agent discovers.  Set this environment variable to `false` to only collect logs when containers have [Autodiscovery Labels](#autodiscovery-labels) present.
+These Task Definitions set the environment variable `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true` to collect logs from every container that the Agent discovers. Set this environment variable to `false` to only collect logs when containers have [Autodiscovery Labels](#autodiscovery-labels) present.
 
 If you have a local file for your Agent's Task Definition you can repeat the steps to [register your updated Task Definition][8]. This creates a new revision for you. You can then reference this updated revision in the Daemon Service for the Datadog Agent.
 

--- a/content/en/containers/amazon_ecs/logs.md
+++ b/content/en/containers/amazon_ecs/logs.md
@@ -18,14 +18,14 @@ Datadog Agent 6+ collects logs from containers. The recommended way to collect l
 
 Once enabled the Datadog Agent container collects the logs emitted from the other application containers on the same respective host as itself. This is limited to the logs emitted to the `stdout` and `stderr` log stream when using the `default` or `json-file` logging driver.
 
-- If your containers are creating log files isolated within *their* containers you will need to perform some [extra steps](#log-file-within-a-container) to ensure the Agent container has visibility to those log files.
-- If your containers are using the `awslogs` [logging driver to send the logs to cloudwatch][9] then those logs will not be visible to the Agent, and you will instead need to use one of the [AWS log collection integrations][10] in order to collect those.
+- If your containers are creating log files isolated within *their* container you need to perform some [extra steps](#log-file-within-a-container) to ensure the Agent container has visibility to those log files.
+- If your containers are using the `awslogs` [logging driver to send the logs to cloudwatch][9] then those logs are not be visible to the Agent, and you instead need to use one of the [AWS log collection integrations][10] in order to collect those.
 
 ## Installation
 
-### ECS Task Definition
+### ECS task definition
 
-To collect all logs written by running applications in your ECS containers, update your Agent's Task Definition from the [original ECS Setup][11] with the environment variables and mounts below.
+To collect all logs from your running ECS containers, update your Agent's Task Definition from the [original ECS Setup][11] with the environment variables and mounts below.
 
 {{< tabs >}}
 {{% tab "Linux" %}}
@@ -146,14 +146,14 @@ Use [datadog-agent-ecs-win-logs.json][1] as a reference point for the required b
 
 These Task Definitions set the environment variable `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true` to collect logs from every container that the Agent discovers. This can be disabled if you'd like to only collect logs when containers have [Autodiscovery Labels](#autodiscovery-labels) present.
 
-If you have a local file for your Agent's Task Definition you can repeat the steps to [register your updated Task Definition][8]. This will create a new revision for you. You can then reference this updated revision in the Daemon Service for the Datadog Agent.
+If you have a local file for your Agent's Task Definition you can repeat the steps to [register your updated Task Definition][8]. This creates a new revision for you. You can then reference this updated revision in the Daemon Service for the Datadog Agent.
 
 ## Custom log collection
 
 ### Autodiscovery labels
-If the environment variable `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true` is set the Agent will collect logs from all containers by default. When doing so it will set the `service` and `source` tags on the logs to the short image name of the container that emitted those logs. You can provide Docker Labels on your ECS application containers as Autodisocovery labels to customize the log configuration that the Agent will use for *that* container.
+If the environment variable `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true` is set, the Agent collects logs from all containers it discovers by default. These collected logs have the `service` and `source` tags set to the short image name of the respective container. You can provide Docker Labels on your ECS application containers for Autodiscovery to customize the log configuration that the Agent uses for *that* container.
 
-You can consult [the Docker Log Collection setup instructions][12] for information on how to utilize Autodiscovery configurations. For example a log configuration like the following can be used to override the `source` and `service` of the logs collected:
+You can consult [the Docker Log Collection setup instructions][12] for information on how to use Autodiscovery configurations. For example a log configuration like the following can be used to override the `source` and `service` of the logs collected:
 
 ```json
 [{"source": "example-source", "service": "example-service"}]
@@ -179,7 +179,7 @@ You can further customize this by [adding tags to your log configuration][4] or 
 
 ### Log file within a container
 
-Docker with the `default` or `json-file` driver will expose the `stdout` and `stderr` log streams in a format that the Agent can readily find. However, if an application container is creating a log file isolated within its container then the Agent won't natively have visibility to that file. Datadog recommends that you use the `stdout` and `stderr` output streams for containerized applications when possible, so that you can more automatically set up log collection. Otherwise this can be done by providing Autodiscovery Labels to point towards the desired file path, while also having the Agent container and application container share a directory on the host.
+Docker with the `default` or `json-file` driver exposes the `stdout` and `stderr` log streams in a format that the Agent can readily find. However, if a container is creating a log file isolated within its container then the Agent does not natively have visibility to that file. Datadog recommends using the `stdout` and `stderr` output streams for containerized applications when possible, to more automatically set up log collection. If not possible, this can be done by providing an Autodiscovery log configuration to point towards the desired file path. While also having the Agent container and application container share the directory on the host containing the log file.
 
 The log configuration below can be provided to tell the Agent to [collect this custom log file][3] at the `/var/log/example/app.log` path.
 ```json

--- a/content/en/containers/amazon_ecs/logs.md
+++ b/content/en/containers/amazon_ecs/logs.md
@@ -14,181 +14,257 @@ further_reading:
 
 ## Overview
 
-Datadog Agent 6+ collects logs from containers. The recommended way to collect logs from ECS containers is to enable containerized logging within your `datadog-agent-ecs.json` or `datadog-agent-ecs1.json` file. However, if your application emits logs to files in any capacity (logs that are not written to `stdout`/`stderr`), you need to use [autodiscovery][1] with [container labels](#container-label) (available for Agent v7.25.0+/6.25.0+) or [deploy the Datadog Agent on your host](#custom-log-collection) and use custom log collection to tail files.
+Datadog Agent 6+ collects logs from containers. The recommended way to collect logs from ECS containers is to enable log collection within your Agent's Task Definition. This can be done by modifying the previously used [Task Definition file][7] and [registering your updated Task Definition][8]. Alternatively you can edit the Task Definition directly from the Amazon Web UI.
+
+Once enabled the Datadog Agent container collects the logs emitted from the other application containers on the same respective host as itself. This is limited to the logs emitted to the `stdout` and `stderr` log stream when using the `default` or `json-file` logging driver.
+
+- If your containers are creating log files isolated within *their* containers you will need to perform some [extra steps](#log-file-within-a-container) to ensure the Agent container has visibility to those log files.
+- If your containers are using the `awslogs` [logging driver to send the logs to cloudwatch][9] then those logs will not be visible to the Agent, and you will instead need to use one of the [AWS log collection integrations][10] in order to collect those.
 
 ## Installation
 
-### ECS file
+### ECS Task Definition
 
-To collect all logs written by running applications in your ECS containers and send it to your Datadog application:
+To collect all logs written by running applications in your ECS containers, update your Agent's Task Definition from the [original ECS Setup][11] with the environment variables and mounts below.
 
 {{< tabs >}}
 {{% tab "Linux" %}}
 
-1. Follow the [Amazon ECS setup instructions][1].
-2. Update your [datadog-agent-ecs.json][2] file ([datadog-agent-ecs1.json][3] if you are using an original Amazon Linux AMI) with the following configuration:
+Use [datadog-agent-ecs-logs.json][1] as a reference point for the required base configuration. Your Task Definition should have:
 
-    ```text
-    {
-        "containerDefinitions": [
+  ```json
+  {
+    "containerDefinitions": [
+      {
         (...)
-          "mountPoints": [
-            (...)
-            {
-              "containerPath": "/opt/datadog-agent/run",
-              "sourceVolume": "pointdir",
-              "readOnly": false
-            },
-            {
-              "containerPath": "/var/lib/docker/containers",
-              "sourceVolume": "containers_root",
-              "readOnly": true
-            },
-            (...)
-          ],
-          "environment": [
-            (...)
-            {
-              "name": "DD_LOGS_ENABLED",
-              "value": "true"
-            },
-            {
-              "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
-              "value": "true"
-            },
-            (...)
-          ]
-        }
-      ],
-      "volumes": [
-        (...)
-        {
-          "host": {
-            "sourcePath": "/opt/datadog-agent/run"
+        "mountPoints": [
+          (...)
+          {
+            "containerPath": "/opt/datadog-agent/run",
+            "sourceVolume": "pointdir",
+            "readOnly": false
           },
-          "name": "pointdir"
-        },
-        {
-          "host": {
-            "sourcePath": "/var/lib/docker/containers/"
+          {
+            "containerPath": "/var/lib/docker/containers",
+            "sourceVolume": "containers_root",
+            "readOnly": true
+          }
+        ],
+        "environment": [
+          (...)
+          {
+            "name": "DD_LOGS_ENABLED",
+            "value": "true"
           },
-          "name": "containers_root"
+          {
+            "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
+            "value": "true"
+          }
+        ]
+      }
+    ],
+    "volumes": [
+      (...)
+      {
+        "host": {
+          "sourcePath": "/opt/datadog-agent/run"
         },
-        (...)
-      ],
-      "family": "datadog-agent-task"
-    }
-    ```
+        "name": "pointdir"
+      },
+      {
+        "host": {
+          "sourcePath": "/var/lib/docker/containers/"
+        },
+        "name": "containers_root"
+      }
+    ],
+    "family": "datadog-agent-task"
+  }
+  ```
 
-3. Make sure your container definition doesn't contain a `logConfiguration.logDriver` parameter, so that the logs are written to `stdout/stderr` and collected by the Agent. If this parameter is set to `awslogs`, collect your Amazon ECS logs without the Agent by using [AWS Lambda to collect ECS logs from CloudWatch][4].
-
-[1]: https://docs.datadoghq.com/agent/amazon_ecs/
-[2]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs.json
-[3]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs1.json
-[4]: https://www.datadoghq.com/blog/monitoring-ecs-with-datadog/
+[1]: /resources/json/datadog-agent-ecs-logs.json
 {{% /tab %}}
 {{% tab "Windows" %}}
 
-1. Follow the [Amazon ECS setup instructions][1].
-2. Update your [datadog-agent-ecs-win.json][2] file with the following configuration:
+Use [datadog-agent-ecs-win-logs.json][1] as a reference point for the required base configuration. Your Task Definition should have:
 
-    ```text
-    {
-      "containerDefinitions": [
+  ```json
+  {
+    "containerDefinitions": [
+      {
         (...)
-          "mountPoints": [
-            (...)
-            {
-              "containerPath": "C:/programdata/datadog/run",
-              "sourceVolume": "pointdir",
-              "readOnly": false
-            },
-            {
-              "containerPath": "c:/programdata/docker/containers",
-              "sourceVolume": "containers_root",
-              "readOnly": true
-            },
-            (...)
-          ],
-          "environment": [
-            (...)
-            {
-              "name": "DD_LOGS_ENABLED",
-              "value": "true"
-            },
-            {
-              "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
-              "value": "true"
-            },
-            (...)
-          ]
-        }
-      ],
-      "volumes": [
-        (...)
-        {
-          "name": "pointdir",
-          "dockerVolumeConfiguration": {
-            "autoprovision": true,
-            "scope": "shared",
-            "driver": "local"
-          }
-        },
-        {
-          "host": {
-            "sourcePath": "c:/programdata/docker/containers"
+        "mountPoints": [
+          (...)
+          {
+            "containerPath": "C:/programdata/datadog/run",
+            "sourceVolume": "pointdir",
+            "readOnly": false
           },
-          "name": "containers_root"
+          {
+            "containerPath": "c:/programdata/docker/containers",
+            "sourceVolume": "containers_root",
+            "readOnly": true
+          }
+        ],
+        "environment": [
+          (...)
+          {
+            "name": "DD_LOGS_ENABLED",
+            "value": "true"
+          },
+          {
+            "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
+            "value": "true"
+          }
+        ]
+      }
+    ],
+    "volumes": [
+      (...)
+      {
+        "name": "pointdir",
+        "dockerVolumeConfiguration": {
+          "autoprovision": true,
+          "scope": "shared",
+          "driver": "local"
+        }
+      },
+      {
+        "host": {
+          "sourcePath": "c:/programdata/docker/containers"
         },
-        (...)
-      ]
-      "family": "datadog-agent-task"
-    }
-    ```
+        "name": "containers_root"
+      }
+    ],
+    "family": "datadog-agent-task"
+  }
+  ```
 
-3. Make sure your container definition doesn't contain a `logConfiguration.logDriver` parameter, so that the logs are written to `stdout/stderr` and collected by the Agent. If this parameter is set to `awslogs`, collect your Amazon ECS logs without the Agent by using [AWS Lambda to collect ECS logs from CloudWatch][3].
-
-[1]: https://docs.datadoghq.com/agent/amazon_ecs/
-[2]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs-win.json
-[3]: https://www.datadoghq.com/blog/monitoring-ecs-with-datadog/
+[1]: /resources/json/datadog-agent-ecs-win-logs.json
 {{% /tab %}}
 {{< /tabs >}}
 
-### Custom log collection
+These Task Definitions set the environment variable `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true` to collect logs from every container that the Agent discovers. This can be disabled if you'd like to only collect logs when containers have [Autodiscovery Labels](#autodiscovery-labels) present.
 
-#### Configuration file
+If you have a local file for your Agent's Task Definition you can repeat the steps to [register your updated Task Definition][8]. This will create a new revision for you. You can then reference this updated revision in the Daemon Service for the Datadog Agent.
 
-If your container writes any logs to files, follow the [Custom Log Collection documentation][2] to tail files for logs.
+## Custom log collection
 
-To gather logs from your `<APP_NAME>` application stored in `<PATH_LOG_FILE>/<LOG_FILE_NAME>.log` create a `<APP_NAME>.d/conf.yaml` file at the root of your [Agent's configuration directory][3] with the following content:
+### Autodiscovery labels
+If the environment variable `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true` is set the Agent will collect logs from all containers by default. When doing so it will set the `service` and `source` tags on the logs to the short image name of the container that emitted those logs. You can provide Docker Labels on your ECS application containers as Autodisocovery labels to customize the log configuration that the Agent will use for *that* container.
 
-```yaml
-logs:
-  - type: file
-    path: "<PATH_LOG_FILE>/<LOG_FILE_NAME>.log"
-    service: "<APP_NAME>"
-    source: "<SOURCE>"
+You can consult [the Docker Log Collection setup instructions][12] for information on how to utilize Autodiscovery configurations. For example a log configuration like the following can be used to override the `source` and `service` of the logs collected:
+
+```json
+[{"source": "example-source", "service": "example-service"}]
 ```
 
-**Note**: Container metadata is not retrieved with custom log collection, therefore the Agent does not automatically assign container tags to logs. Use [custom tags][4] to create container tags.
+With respect to ECS, this can be added to the label `com.datadoghq.ad.logs` within the `dockerLabels` of the Task Definition for the application container emitting those logs.
 
-#### Container label
+```json
+{
+  "containerDefinitions": [
+    {
+      "name": "<CONTAINER_NAME>",
+      "image": "<CONTAINER_IMAGE>",
+      "dockerLabels": {
+        "com.datadoghq.ad.logs": "[{\"source\": \"example-source\", \"service\": \"example-service\"}]"
+      }
+    }
+  ]
+}
+```
 
-With Agent v7.25.0+/6.25.0+, it is possible to enable file tailing by using a container label so the logs collected receive the tags of the container on which the label was set. See this [example][5] that details the exact label to use.
+You can further customize this by [adding tags to your log configuration][4] or any `log_processing_rules` for [advanced log collection options][5].
 
-**Note**: The file paths are always relative to the Agent. So, this requires extra configuration for involved ECS tasks to share a directory between the container writing to the file and the Agent container. See the [AWS Bind mounts documentation][6] for additional details on volume management with ECS.
+### Log file within a container
+
+Docker with the `default` or `json-file` driver will expose the `stdout` and `stderr` log streams in a format that the Agent can readily find. However, if an application container is creating a log file isolated within its container then the Agent won't natively have visibility to that file. Datadog recommends that you use the `stdout` and `stderr` output streams for containerized applications when possible, so that you can more automatically set up log collection. Otherwise this can be done by providing Autodiscovery Labels to point towards the desired file path, while also having the Agent container and application container share a directory on the host.
+
+The log configuration below can be provided to tell the Agent to [collect this custom log file][3] at the `/var/log/example/app.log` path.
+```json
+[{
+  "type": "file",
+  "path": "/var/log/example/app.log",
+  "source": "example-source",
+  "service": "example-service"
+}]
+```
+
+As an example the Task Definition below is
+1. Writing some logs to that file `/var/log/example/app.log` file
+2. Has the `dockerLabels` present to setup the log configuration
+3. Has the host path `volumes` and `mountPoints` specified for this `/var/log/example` directory
+
+```json
+{
+  "containerDefinitions": [
+    {
+      "name": "example-logger",
+      "image": "busybox",
+      "entryPoint": ["/bin/sh", "-c", "--"],
+      "command": ["while true; do sleep 1; echo `date` example file log >> /var/log/example/app.log; done;"],
+      "mountPoints": [
+        {
+          "containerPath": "/var/log/example",
+          "sourceVolume": "applogs"
+        }
+      ],
+      "dockerLabels": {
+        "com.datadoghq.ad.logs": "[{\"type\":\"file\",\"path\":\"/var/log/example/app.log\",\"source\":\"example-source\",\"service\":\"example-service\"}]"
+      }
+    }
+  ],
+  "volumes": [
+    {
+      "host": {
+        "sourcePath": "/var/log/example"
+      },
+      "name": "applogs"
+    }
+  ],
+  "family": "example-logger"
+}
+```
+
+The file paths for the configuration are always relative to the Agent. So that same `volume` and `mountPoint` need to be present within the Agent's Task Definition as well to give visibility to that log file.
+
+See the [AWS Bind mounts documentation][6] for additional details on volume management with ECS.
+
+**Note**: When using this kind of configuration with a container the `stdout` and `stderr` logs streams are not collected automatically from the container, only the file. If collection from both the container streams and a file are needed it should be explicitly enabled in the configuration. For example:
+
+```json
+[
+  {
+    "type": "file",
+    "path": "/var/log/example/app.log",
+    "source": "example-file",
+    "service": "example-service"
+  },
+  {
+    "source": "example-stream",
+    "service": "example-service"
+  }
+]
+```
 
 ## Activate log integrations
 
-The `source` attribute is used to identify the integration to use for each container. Override it directly in your containers labels to start using [log integrations][2]. Read Datadog's [Autodiscovery guide for logs][1] to learn more about this process.
+The `source` attribute is used to identify the integration to use for each container. Override it directly in your containers labels to start using [the Datadog log integrations][2]. Read Datadog's [Autodiscovery guide for logs][1] to learn more about this process.
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/docker/log/?tab=containerinstallation#log-integrations
-[2]: /agent/logs/?tab=tailfiles#custom-log-collection
-[3]: /agent/logs/#custom-log-collection
+[2]: https://app.datadoghq.com/logs/pipelines/pipeline/library
+[3]: /agent/logs/?tab=tailfiles#custom-log-collection
 [4]: /getting_started/tagging/assigning_tags/?tab=noncontainerizedenvironments#methods-for-assigning-tags
-[5]: /agent/docker/log/?tab=logcollectionfromfile#examples
+[5]: /agent/logs/advanced_log_collection?tab=docker
 [6]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html
+[7]: /containers/amazon_ecs/?tab=awscli#managing-the-task-definition-file
+[8]: /containers/amazon_ecs/?tab=awscli#registering-the-task-definition
+[9]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html
+[10]: /integrations/amazon_web_services/?tab=allpermissions#log-collection
+[11]: /containers/amazon_ecs/?tab=awscli#setup
+[12]: /containers/docker/log/?tab=dockerfile#log-integrations

--- a/content/en/containers/amazon_ecs/logs.md
+++ b/content/en/containers/amazon_ecs/logs.md
@@ -16,10 +16,10 @@ further_reading:
 
 Datadog Agent 6+ collects logs from containers. The recommended way to collect logs from ECS containers is to enable log collection within your Agent's Task Definition. This can be done by modifying the previously used [Task Definition file][7] and [registering your updated Task Definition][8]. Alternatively you can edit the Task Definition directly from the Amazon Web UI.
 
-Once enabled the Datadog Agent container collects the logs emitted from the other application containers on the same respective host as itself. This is limited to the logs emitted to the `stdout` and `stderr` log stream when using the `default` or `json-file` logging driver.
+Once enabled, the Datadog Agent container collects the logs emitted from the other application containers on the same host as itself. This is limited to the logs emitted to the `stdout` and `stderr` log stream when using the `default` or `json-file` logging driver.
 
-- If your containers are creating log files isolated within *their* container you need to perform some [extra steps](#log-file-within-a-container) to ensure the Agent container has visibility to those log files.
-- If your containers are using the `awslogs` [logging driver to send the logs to cloudwatch][9] then those logs are not be visible to the Agent, and you instead need to use one of the [AWS log collection integrations][10] in order to collect those.
+- If your containers are creating log files isolated within *their* containers, you need to perform some [extra steps](#log-file-within-a-container) to ensure the Agent container has visibility to those log files.
+- If your containers are using the `awslogs` [logging driver to send the logs to CloudWatch][9], then those logs are not be visible to the Agent. Instead, use one of the [AWS log collection integrations][10] in order to collect those logs.
 
 ## Installation
 
@@ -144,7 +144,7 @@ Use [datadog-agent-ecs-win-logs.json][1] as a reference point for the required b
 {{% /tab %}}
 {{< /tabs >}}
 
-These Task Definitions set the environment variable `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true` to collect logs from every container that the Agent discovers. This can be disabled if you'd like to only collect logs when containers have [Autodiscovery Labels](#autodiscovery-labels) present.
+These Task Definitions set the environment variable `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true` to collect logs from every container that the Agent discovers.  Set this environment variable to `false` to only collect logs when containers have [Autodiscovery Labels](#autodiscovery-labels) present.
 
 If you have a local file for your Agent's Task Definition you can repeat the steps to [register your updated Task Definition][8]. This creates a new revision for you. You can then reference this updated revision in the Daemon Service for the Datadog Agent.
 
@@ -153,7 +153,7 @@ If you have a local file for your Agent's Task Definition you can repeat the ste
 ### Autodiscovery labels
 If the environment variable `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true` is set, the Agent collects logs from all containers it discovers by default. These collected logs have the `service` and `source` tags set to the short image name of the respective container. You can provide Docker Labels on your ECS application containers for Autodiscovery to customize the log configuration that the Agent uses for *that* container.
 
-You can consult [the Docker Log Collection setup instructions][12] for information on how to use Autodiscovery configurations. For example a log configuration like the following can be used to override the `source` and `service` of the logs collected:
+You can consult [the Docker Log Collection setup instructions][12] for information on how to use Autodiscovery configurations. For example, the following log configuration overrides the `source` and `service` of the logs collected:
 
 ```json
 [{"source": "example-source", "service": "example-service"}]
@@ -179,9 +179,9 @@ You can further customize this by [adding tags to your log configuration][4] or 
 
 ### Log file within a container
 
-Docker with the `default` or `json-file` driver exposes the `stdout` and `stderr` log streams in a format that the Agent can readily find. However, if a container is creating a log file isolated within its container then the Agent does not natively have visibility to that file. Datadog recommends using the `stdout` and `stderr` output streams for containerized applications when possible, to more automatically set up log collection. If not possible, this can be done by providing an Autodiscovery log configuration to point towards the desired file path. While also having the Agent container and application container share the directory on the host containing the log file.
+Docker (with the `default` or `json-file` driver) exposes the `stdout` and `stderr` log streams in a format that the Agent can readily find. However, if a container is creating a log file isolated within its container, then the Agent does not natively have visibility to that file. Datadog recommends using the `stdout` and `stderr` output streams for containerized applications to more automatically set up log collection. If this is not possible, you can provide an Autodiscovery log configuration to point towards the desired file path, and ensure that the Agent container and application container share a directory on the host containing the log file.
 
-The log configuration below can be provided to tell the Agent to [collect this custom log file][3] at the `/var/log/example/app.log` path.
+The log configuration below tells the Agent to [collect this custom log file][3] at the `/var/log/example/app.log` path.
 ```json
 [{
   "type": "file",
@@ -191,10 +191,10 @@ The log configuration below can be provided to tell the Agent to [collect this c
 }]
 ```
 
-As an example the Task Definition below is
-1. Writing some logs to that file `/var/log/example/app.log` file
-2. Has the `dockerLabels` present to setup the log configuration
-3. Has the host path `volumes` and `mountPoints` specified for this `/var/log/example` directory
+Example: the Task Definition below performs the following:
+* Writing some logs to that file `/var/log/example/app.log` file
+* Has the `dockerLabels` present to setup the log configuration
+* Has the host path `volumes` and `mountPoints` specified for this `/var/log/example` directory
 
 ```json
 {
@@ -227,11 +227,11 @@ As an example the Task Definition below is
 }
 ```
 
-The file paths for the configuration are always relative to the Agent. So that same `volume` and `mountPoint` need to be present within the Agent's Task Definition as well to give visibility to that log file.
+The file paths for the configuration are always relative to the Agent. The same `volume` and `mountPoint` also need to be present within the Agent's Task Definition to give visibility to that log file.
 
 See the [AWS Bind mounts documentation][6] for additional details on volume management with ECS.
 
-**Note**: When using this kind of configuration with a container the `stdout` and `stderr` logs streams are not collected automatically from the container, only the file. If collection from both the container streams and a file are needed it should be explicitly enabled in the configuration. For example:
+**Note**: When using this kind of configuration with a container, the `stdout` and `stderr` logs streams are not collected automatically from the container—only the file. If collection from both the container streams and a file are needed, explicitly enable this in the configuration. For example:
 
 ```json
 [

--- a/static/resources/json/datadog-agent-ecs-logs.json
+++ b/static/resources/json/datadog-agent-ecs-logs.json
@@ -18,14 +18,19 @@
           "readOnly": null
         },
         {
+          "containerPath": "/host/proc",
+          "sourceVolume": "proc",
+          "readOnly": null
+        },
+        {
           "containerPath": "/opt/datadog-agent/run",
           "sourceVolume": "pointdir",
           "readOnly": false
         },
         {
-          "containerPath": "/host/proc",
-          "sourceVolume": "proc",
-          "readOnly": null
+          "containerPath": "/var/lib/docker/containers",
+          "sourceVolume": "containers_root",
+          "readOnly": true
         }
       ],
       "environment": [
@@ -34,16 +39,16 @@
           "value": "<YOUR_API_KEY>"
         },
         {
+          "name": "DD_SITE",
+          "value": "datadoghq.com"
+        },
+        {
           "name": "DD_LOGS_ENABLED",
           "value": "true"
         },
         {
           "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
           "value": "true"
-        },
-        {
-          "name": "SD_BACKEND",
-          "value": "docker"
         }
       ]
     }
@@ -63,15 +68,21 @@
     },
     {
       "host": {
+        "sourcePath": "/sys/fs/cgroup/"
+      },
+      "name": "cgroup"
+    },
+    {
+      "host": {
         "sourcePath": "/opt/datadog-agent/run"
       },
       "name": "pointdir"
     },
     {
       "host": {
-        "sourcePath": "/sys/fs/cgroup/"
+        "sourcePath": "/var/lib/docker/containers/"
       },
-      "name": "cgroup"
+      "name": "containers_root"
     }
   ],
   "family": "datadog-agent-task"

--- a/static/resources/json/datadog-agent-ecs-win-logs.json
+++ b/static/resources/json/datadog-agent-ecs-win-logs.json
@@ -1,0 +1,69 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "datadog-agent",
+      "image": "public.ecr.aws/datadog/agent:latest",
+      "cpu": 512,
+      "memory": 512,
+      "essential": true,
+      "mountPoints": [
+        {
+          "containerPath": "\\\\.\\pipe\\docker_engine",
+          "sourceVolume": "docker_sock",
+          "readOnly": null
+        },
+        {
+          "containerPath": "C:/programdata/datadog/run",
+          "sourceVolume": "pointdir",
+          "readOnly": false
+        },
+        {
+          "containerPath": "c:/programdata/docker/containers",
+          "sourceVolume": "containers_root",
+          "readOnly": true
+        }
+      ],
+      "environment": [
+        {
+          "name": "DD_API_KEY",
+          "value": "<YOUR_DATADOG_API_KEY>"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "datadoghq.com"
+        },
+        {
+          "name": "DD_LOGS_ENABLED",
+          "value": "true"
+        },
+        {
+          "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
+          "value": "true"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "host": {
+        "sourcePath": "\\\\.\\pipe\\docker_engine"
+      },
+      "name": "docker_sock"
+    },
+    {
+      "name": "pointdir",
+      "dockerVolumeConfiguration": {
+        "autoprovision": true,
+        "scope": "shared",
+        "driver": "local"
+      }
+    },
+    {
+      "host": {
+        "sourcePath": "c:/programdata/docker/containers"
+      },
+      "name": "containers_root"
+    }
+  ],
+  "family": "datadog-agent-task"
+}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Make some large changes to the ECS Log Collection doc similar to the recent one for the core ECS Agent setup:

- https://github.com/DataDog/documentation/pull/15999

The main goal here was to provide simpler instructions with more detailed examples configurations. While also providing more context into some of the important details for the configuration. Changes like:

- Cleaning up and referencing the `datadog-agent-ecs-logs.json` Task Definition file (existed but unreferenced)
- Adding an example Task Definition file for Windows log collection `datadog-agent-ecs-win-logs.json`
- Provide example Task Definitions for customizing autodiscovery labels
- Provide example Task Definition for file collection / file and stream collection
- Re-frame the context towards what the Agent is collecting vs not (json files vs local files vs awslogs)
- Point users towards the in-app Pipeline Library

### Motivation
<!-- What inspired you to submit this pull request?-->
Similar to the core ECS Agent. Clarify the setup instructions from both a context/strategy perspective. With a large focus on providing valid samples to use. 

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
- preview:
  - https://docs-staging.datadoghq.com/jack.davenport/ecs-logs/containers/amazon_ecs/logs/?tab=linux
- current: 
  - https://docs.datadoghq.com/containers/amazon_ecs/logs/?tab=linux

### Additional Notes
<!-- Anything else we should know when reviewing?-->
The log collection from file samples is pretty much the same sample I used for Kubernetes and validated in ECS:
- https://docs.datadoghq.com/containers/kubernetes/log/?tab=daemonset#examples---log-collection-from-file-configured-in-an-annotation

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
