### PR TITLE
DBM-1895 Add troubleshooting entry for high-pg-stat-statements-max-configuration

### DIFF
--- a/content/en/database_monitoring/setup_postgres/troubleshooting.md
+++ b/content/en/database_monitoring/setup_postgres/troubleshooting.md
@@ -240,7 +240,7 @@ The default Agent configuration for Database Monitoring is conservative, but you
 
 #### High value for `pg_stat_statements.max` {#high-pg-stat-statements-max-configuration}
 The recommended value for `pg_stat_statements.max` is `10000`. Setting this configuration to a higher value
-causes the collection query to take longer to run which can lead to query timeouts and gaps in query metric collection. If the Agent reports this warning, make sure that `pg_stat_statements.max` is set to `10000` on the database. 
+may cause the collection query to take longer to run which can lead to query timeouts and gaps in query metric collection. If the Agent reports this warning, make sure that `pg_stat_statements.max` is set to `10000` on the database. 
 
 
 [1]: /database_monitoring/setup_postgres/

--- a/content/en/database_monitoring/setup_postgres/troubleshooting.md
+++ b/content/en/database_monitoring/setup_postgres/troubleshooting.md
@@ -234,6 +234,15 @@ sudo apt-get install postgresql-contrib-10
 
 For more information, see the appropriate version of the [Postgres `contrib` documentation][22].
 
+### Queries from Agent are slow and/or have a high impact on the database
+
+The default Agent configuration for Database Monitoring is conservative, but you can adjust settings such as the collection interval and query sampling rate to better suit your needs. For most workloads, the Agent represents less than one percent of query execution time on the database and less than one percent of CPU. Below are possible reasons for Agent queries to require more resources.
+
+#### High value for `pg_stat_statements.max` {#high-pg-stat-statements-max-configuration}
+The recommended value for `pg_stat_statements.max` is `10000`. Setting this configuration to a higher value
+causes the collection query to take longer to run which can lead to query timeouts and gaps in query metric collection. If the Agent reports this warning, make sure that `pg_stat_statements.max` is set to `10000` on the database. 
+
+
 [1]: /database_monitoring/setup_postgres/
 [2]: /agent/troubleshooting/
 [3]: /agent/guide/agent-commands/?tab=agentv6v7#agent-status-and-information


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The postgres integration is now going to start emitting a new warning as part of [this fix](https://github.com/DataDog/integrations-core/pull/13426) and this warning will point to the troubleshooting documentation for more details. This adds the new troubleshooting entry along. Note that it very importantly has a anchor so that the permanent link is stable and valid when users follow this link for help.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
