### PR TITLE
Fixes serverless source code integration syntax error

### DIFF
--- a/content/en/serverless/configuration/_index.md
+++ b/content/en/serverless/configuration/_index.md
@@ -465,7 +465,7 @@ If you are using a runtime or custom logger that isn't supported, follow these s
 {{< tabs >}}
 {{% tab "Datadog CLI" %}}
 
-Run `datadog-ci lambda instrument` with `--source-code-integration true` to automatically send Git metadata in the current local directory and add the required tags to your Lambda functions.
+Run `datadog-ci lambda instrument` with `--source-code-integration=true` to automatically send Git metadata in the current local directory and add the required tags to your Lambda functions.
 
 **Note**: You must set environment variable `DATADOG_API_KEY` for `datadog-ci` to upload Git metadata. `DATADOG_API_KEY` is also set on your Lambda functions to send telemetry unless you also have `DATADOG_API_KEY_SECRET_ARN` defined, which takes precedence over `DATADOG_API_KEY`.
 
@@ -480,7 +480,7 @@ export DATADOG_API_KEY=<DATADOG_API_KEY>
 export DATADOG_API_KEY_SECRET_ARN=<DATADOG_API_KEY_SECRET_ARN>
 
 datadog-ci lambda instrument \
-    --source-code-integration true
+    --source-code-integration=true
     # ... other required arguments, such as function names
 ```
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Syntax fix in the example for enabling source code integration. The code snippet and text display the wrong syntax for enabling source code integration using the cli.

Attempting to use the current documentation's examples produces the following error.

```sh
Unknown Syntax Error: Extraneous positional argument ("true").
```

### Motivation
<!-- What inspired you to submit this pull request?-->

I followed the incorrect docs and it caused this error. I don't want others to have to find out the same way.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

We could also suggest using `-s` or not including true at all `--source-code-integration`. 

Mentioned in https://docs.datadoghq.com/serverless/libraries_integrations/cli/#arguments

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
