### PR TITLE
Swapping error.type and error.message to match description

### DIFF
--- a/content/en/tracing/trace_collection/tracing_naming_convention/_index.md
+++ b/content/en/tracing/trace_collection/tracing_naming_convention/_index.md
@@ -117,8 +117,8 @@ The following span tags can be used to describe errors associated with spans:
 
 | **Name**    | **Type** | **Description**                                                  |
 |-----------------|----------|------------------------------------------------------------------|
-| `error.message` | `string` | The error type or kind (or code in some cases).                  |
-| `error.type`    | `string` | A concise, human-readable, one-line message explaining the event. |
+| `error.type` | `string` | The error type or kind (or code in some cases).                  |
+| `error.message`    | `string` | A concise, human-readable, one-line message explaining the event. |
 | `error.stack`   | `string` | The stack trace or the complementary information about the error. |
 
 ## Further reading


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Changes error.type and error.message so that the values accurately match the description. It looks like they were swapped!

### Motivation
Ticket about error messages on traces: https://datadog.zendesk.com/agent/tickets/1023409

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
