### PR TITLE
[Tracer][.NET] IIS app pools should have `No Managed Code` options to run .net core apps.

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/dd_libraries/dotnet-core.md
@@ -200,7 +200,7 @@ For information about the different methods for setting environment variables, s
 1. The .NET Tracer MSI installer adds all required environment variables. There are no environment variables you need to configure.
 
    <div class="alert alert-warning">
-     <strong>Note:</strong> The only requirement needed is to run the application pool with the <strong>No Managed Code</strong> setting as recommended by <a href='https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-3.1#create-the-iis-site'> Microsoft</a>.
+     <strong>Note:</strong> You must set the <strong>.NET CLR version</strong> for the application pool to <strong>No Managed Code</strong> as recommended by <a href='https://learn.microsoft.com/aspnet/core/host-and-deploy/iis/advanced#create-the-iis-site'> Microsoft</a>.
    </div>
 
 2. To automatically instrument applications hosted in IIS, completely stop and start IIS by running the following commands as an administrator:

--- a/content/en/tracing/trace_collection/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/dd_libraries/dotnet-core.md
@@ -199,6 +199,10 @@ For information about the different methods for setting environment variables, s
 
 1. The .NET Tracer MSI installer adds all required environment variables. There are no environment variables you need to configure.
 
+   <div class="alert alert-warning">
+     <strong>Note:</strong> The only requirement needed is to run the application pool with the <strong>No Managed Code</strong> setting as recommended by <a href='https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-3.1#create-the-iis-site'> Microsoft</a>.
+   </div>
+
 2. To automatically instrument applications hosted in IIS, completely stop and start IIS by running the following commands as an administrator:
 
    ```cmd


### PR DESCRIPTION
### What does this PR do?
Add a small note to prevent customers to fall into a known pitfall.

### Motivation
We had an escalation recently on this topic.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
