### PR TITLE
feat: update index_algolia jobs to use base template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,7 +150,9 @@ missing_tms_preview:
   interruptible: true
 
 index_algolia_preview:
-  <<: *base_template
+  image:
+    name: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:docsearch-scraper-latest
+    entrypoint: [""] # force an empty entrypoint (see https://gitlab.com/gitlab-org/gitlab-runner/issues/2692)
   tags: ["runner:main"]
   stage: post-deploy
   cache: []
@@ -281,8 +283,12 @@ test_live_link_checks:
       - ./tmp/.htmltest
 
 index_algolia:
-  <<: *base_template
+  image:
+    name: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:docsearch-scraper-latest
+    entrypoint: [ "" ] # force an empty entrypoint (see https://gitlab.com/gitlab-org/gitlab-runner/issues/2692)
   tags: ["runner:main"]
+  before_script:
+    - "[ -f /usr/local/bin/helpers.sh ] && source /usr/local/bin/helpers.sh"  # source helpers
   stage: post-deploy
   environment: "live"
   timeout: 2h 30m

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,9 +150,7 @@ missing_tms_preview:
   interruptible: true
 
 index_algolia_preview:
-  image:
-    name: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:docsearch-scraper-latest
-    entrypoint: [""] # force an empty entrypoint (see https://gitlab.com/gitlab-org/gitlab-runner/issues/2692)
+  <<: *base_template
   tags: ["runner:main"]
   stage: post-deploy
   cache: []
@@ -283,9 +281,7 @@ test_live_link_checks:
       - ./tmp/.htmltest
 
 index_algolia:
-  image:
-    name: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:docsearch-scraper-latest
-    entrypoint: [ "" ] # force an empty entrypoint (see https://gitlab.com/gitlab-org/gitlab-runner/issues/2692)
+  <<: *base_template
   tags: ["runner:main"]
   stage: post-deploy
   environment: "live"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
 - Update the `index_algolia` jobs to use the shared image from the base template
### Motivation
<!-- What inspired you to submit this pull request?-->
- Job failing due to the before script looking for git which wasn't installed on the image it was pulling from
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
