### PR TITLE
Add NodeJS to dbm/apm connect guide

### DIFF
--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -15,7 +15,8 @@ This guide assumes that you have configured [Datadog Monitoring][1] and are usin
 
 Supported tracers
 : [dd-trace-go][3] >= 1.42.0 (support for [database/sql][4] and [sqlx][5] packages)<br />
-[dd-trace-rb][6] >= 1.6.0 (support for [mysql2][7] and [pg][8] gems)
+[dd-trace-rb][6] >= 1.6.0 (support for [mysql2][7] and [pg][8] gems)<br />
+[dd-trace-js][9] >= 3.9.0 or >= 2.22.0 (support for [postgres client][10])
 
 Supported databases
 : postgres, mysql
@@ -144,6 +145,56 @@ client.query("SELECT 1;")
 
 {{% /tab %}}
 
+{{% tab "NodeJS" %}}
+
+Install or udpate [dd-trace-js][1] to version greater than `3.9.0` (or `2.22.0` if using end-of-life Node.js version 12):
+
+```
+npm install dd-trace@3.9.0
+```
+
+Update your code to import and initialize the tracer:
+```javascript
+// This line must come before importing any instrumented module.
+const tracer = require('dd-trace').init();
+```
+
+Enable the database monitoring propagation feature using one of the following methods:
+1. Env variable:
+   `DD_DBM_PROPAGATION_MODE=full`
+
+2. Option `dbmPropagationMode` (default: `ENV['DD_DBM_PROPAGATION_MODE']`):
+   ```javascript
+	tracer.use('pg', { dbmPropagationMode: 'full', service: 'my-db-service' })
+   ```
+
+Full example:
+```javascript
+const tracer = require('dd-trace').init()
+
+tracer.use('pg', { dbmPropagationMode: 'full', service: 'my-db-service' })
+
+const client = new pg.Client({
+	user: 'postgres',
+	password: 'postgres',
+	database: 'postgres'
+})
+
+client.connect(err => done(err))
+
+client.query('SELECT $1::text as message', ['Hello world!'], (err, result) => {
+	if (err) return done(err)
+
+	client.end((err) => {
+		if (err) return done(err)
+	})
+})
+```
+
+[1]: https://github.com/DataDog/dd-trace-js
+
+{{% /tab %}}
+
 {{< /tabs >}}
 
 
@@ -155,3 +206,5 @@ client.query("SELECT 1;")
 [6]: https://github.com/dataDog/dd-trace-rb
 [7]: https://github.com/brianmario/mysql2
 [8]: https://github.com/ged/ruby-pg
+[9]: https://github.com/DataDog/dd-trace-js
+[10]: https://node-postgres.com/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This adds Node.js instructions to the dbm/apm connect guide. 

### Motivation
We now have support for dbm propagation for postgres in Node.JS >= 3.9.0 / 2.22.0. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
