### PR TITLE
Add explanation that trace scopes need to be closed

### DIFF
--- a/content/en/tracing/guide/instrument_custom_method.md
+++ b/content/en/tracing/guide/instrument_custom_method.md
@@ -77,6 +77,10 @@ public class BackupLedger {
     for (Transaction transaction : transactions) {
       // Use `GlobalTracer` to trace blocks of inline code
       Tracer tracer = GlobalTracer.get();
+      // Please note that the scope in the try with resource
+      // block below will be automatically closed at the end
+      // of the code block and if you do not use a try with
+      // resource statement you need to call scope.close().
       try (Scope scope = tracer.buildSpan("BackupLedger.persist").startActive(true)) {
         // Add custom metadata to the span
         scope.span().setTag("transaction.id", transaction.getId());

--- a/content/en/tracing/guide/instrument_custom_method.md
+++ b/content/en/tracing/guide/instrument_custom_method.md
@@ -77,10 +77,10 @@ public class BackupLedger {
     for (Transaction transaction : transactions) {
       // Use `GlobalTracer` to trace blocks of inline code
       Tracer tracer = GlobalTracer.get();
-      // Note: The scope in the try with resource
-      // block below will be automatically closed at the end
-      // of the code block. If you do not use a try with
-      // resource statement, you need to call scope.close().
+      // Note: The scope in the try with resource block below
+      // will be automatically closed at the end of the code block.
+      // If you do not use a try with resource statement, you need
+      // to call scope.close().
       try (Scope scope = tracer.buildSpan("BackupLedger.persist").startActive(true)) {
         // Add custom metadata to the span
         scope.span().setTag("transaction.id", transaction.getId());

--- a/content/en/tracing/guide/instrument_custom_method.md
+++ b/content/en/tracing/guide/instrument_custom_method.md
@@ -77,7 +77,7 @@ public class BackupLedger {
     for (Transaction transaction : transactions) {
       // Use `GlobalTracer` to trace blocks of inline code
       Tracer tracer = GlobalTracer.get();
-      // Please note that the scope in the try with resource
+      // Note: The scope in the try with resource
       // block below will be automatically closed at the end
       // of the code block and if you do not use a try with
       // resource statement you need to call scope.close().

--- a/content/en/tracing/guide/instrument_custom_method.md
+++ b/content/en/tracing/guide/instrument_custom_method.md
@@ -80,7 +80,7 @@ public class BackupLedger {
       // Note: The scope in the try with resource
       // block below will be automatically closed at the end
       // of the code block. If you do not use a try with
-      // resource statement you need to call scope.close().
+      // resource statement, you need to call scope.close().
       try (Scope scope = tracer.buildSpan("BackupLedger.persist").startActive(true)) {
         // Add custom metadata to the span
         scope.span().setTag("transaction.id", transaction.getId());

--- a/content/en/tracing/guide/instrument_custom_method.md
+++ b/content/en/tracing/guide/instrument_custom_method.md
@@ -79,7 +79,7 @@ public class BackupLedger {
       Tracer tracer = GlobalTracer.get();
       // Note: The scope in the try with resource
       // block below will be automatically closed at the end
-      // of the code block and if you do not use a try with
+      // of the code block. If you do not use a try with
       // resource statement you need to call scope.close().
       try (Scope scope = tracer.buildSpan("BackupLedger.persist").startActive(true)) {
         // Add custom metadata to the span

--- a/content/en/tracing/trace_collection/custom_instrumentation/java.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/java.md
@@ -128,6 +128,10 @@ import io.opentracing.util.Tracer;
 
 Tracer tracer = GlobalTracer.get();
 final Span span = tracer.buildSpan("<OPERATION_NAME>").start();
+// Please note that the scope in the try with resource
+// block below will be automatically closed at the end
+// of the code block and if you do not use a try with
+// resource statement you need to call scope.close().
 try (final Scope scope = tracer.activateSpan(span)) {
     // exception thrown here
 } catch (final Exception e) {
@@ -227,6 +231,10 @@ class SomeClass {
             .withTag(DDTags.SERVICE_NAME, "<SERVICE_NAME>")
             .withTag(DDTags.RESOURCE_NAME, "<RESOURCE_NAME>")
             .start();
+        // Please note that the scope in the try with resource
+        // block below will be automatically closed at the end
+        // of the code block and if you do not use a try with
+        // resource statement you need to call scope.close().
         try (Scope scope = tracer.activateSpan(span)) {
             // Alternatively, set tags after creation
             span.setTag("my.tag", "value");

--- a/content/en/tracing/trace_collection/custom_instrumentation/java.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/java.md
@@ -128,10 +128,10 @@ import io.opentracing.util.Tracer;
 
 Tracer tracer = GlobalTracer.get();
 final Span span = tracer.buildSpan("<OPERATION_NAME>").start();
-// Please note that the scope in the try with resource
-// block below will be automatically closed at the end
-// of the code block and if you do not use a try with
-// resource statement you need to call scope.close().
+// Note: The scope in the try with resource block below
+// will be automatically closed at the end of the code block.
+// If you do not use a try with resource statement, you need
+// to call scope.close().
 try (final Scope scope = tracer.activateSpan(span)) {
     // exception thrown here
 } catch (final Exception e) {
@@ -231,10 +231,10 @@ class SomeClass {
             .withTag(DDTags.SERVICE_NAME, "<SERVICE_NAME>")
             .withTag(DDTags.RESOURCE_NAME, "<RESOURCE_NAME>")
             .start();
-        // Please note that the scope in the try with resource
-        // block below will be automatically closed at the end
-        // of the code block and if you do not use a try with
-        // resource statement you need to call scope.close().
+        // Note: The scope in the try with resource block below
+        // will be automatically closed at the end of the code block.
+        // If you do not use a try with resource statement, you need
+        // to call scope.close().
         try (Scope scope = tracer.activateSpan(span)) {
             // Alternatively, set tags after creation
             span.setTag("my.tag", "value");


### PR DESCRIPTION
### What does this PR do?

Adds an explanatory comment to Java code examples that the `scope` returned when activating a `span` needs to be closed.

### Motivation

Customer escalations with broken traces where they had missed that part since the code in the samples uses a _try with resource_ block that will close the `scope` automatically.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
