### PR TITLE
Update Go instructions in dbm/apm connect guide to match latest naming

### DIFF
--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -14,7 +14,7 @@ This guide assumes that you have configured [Datadog Monitoring][1] and are usin
 ## Before you begin
 
 Supported tracers
-: [dd-trace-go][3] >= 1.42.0 (support for [database/sql][4] and [sqlx][5] packages)<br />
+: [dd-trace-go][3] >= 1.44.0 (support for [database/sql][4] and [sqlx][5] packages)<br />
 [dd-trace-rb][6] >= 1.6.0 (support for [mysql2][7] and [pg][8] gems)
 
 Supported databases
@@ -31,9 +31,9 @@ Data privacy
 {{< tabs >}}
 {{% tab "Go" %}}
 
-Update your app dependencies to include [dd-trace-go@v1.42.0][1] or greater:
+Update your app dependencies to include [dd-trace-go@v1.44.0][1] or greater:
 ```
-go get gopkg.in/DataDog/dd-trace-go.v1@v1.42.0
+go get gopkg.in/DataDog/dd-trace-go.v1@v1.44.0
 ```
 
 Update your code to import the `contrib/database/sql` package:
@@ -47,18 +47,18 @@ import (
 
 Enable the database monitoring propagation feature using one of the following methods:
 1. Env variable:
-   `DD_TRACE_SQL_COMMENT_INJECTION_MODE=full`
+   `DD_DBM_PROPAGATION_MODE=full`
 
 2. Using code during the driver registration:
    ```go
-   sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithSQLCommentInjection(tracer.SQLInjectionModeFull), sqltrace.WithServiceName("my-db-service"))
+   sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithDBMPropagation(tracer.DBMPropagationModeFull), sqltrace.WithServiceName("my-db-service"))
    ```
 
 3. Using code on `sqltrace.Open`:
    ```go
    sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithServiceName("my-db-service"))
 
-   db, err := sqltrace.Open("postgres", "postgres://pqgotest:password@localhost/pqgotest?sslmode=disable", sqltrace.WithSQLCommentInjection(tracer.SQLInjectionModeFull))
+   db, err := sqltrace.Open("postgres", "postgres://pqgotest:password@localhost/pqgotest?sslmode=disable", sqltrace.WithDBMPropagation(tracer.DBMPropagationModeFull))
    if err != nil {
 	   log.Fatal(err)
    }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Go was the first tracer to get dbm propagation and this was initially using a different naming than what we settled on with other tracers. With [release 1.44.0](https://github.com/DataDog/dd-trace-go/releases/tag/v1.44.0), the Go tracer adopted the standard naming used for other tracers so this updates the documentation for the Go tracer to match the standard naming. 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
