### PR TITLE
Fix the format of the Timeshift Further reading section

### DIFF
--- a/content/en/dashboards/functions/timeshift.md
+++ b/content/en/dashboards/functions/timeshift.md
@@ -78,7 +78,6 @@ Here is an example of `aws.ec2.cpuutilization` with the `month_before()` value s
     {{< nextlink href="/dashboards/functions/smoothing" >}}Smoothing: Smooth your metric variations.{{< /nextlink >}}
 {{< /whatsnext >}}
 
-<br>
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Fix the format of the Further Reading section in Timeshift page
![image](https://user-images.githubusercontent.com/41168354/206008067-d1fabf1d-8732-4c3c-a701-05f86ab59615.png)

### Motivation
Noticed it as I was browsing

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
