### PR TITLE
Updating Helm options for Auto_conf

### DIFF
--- a/content/en/agent/guide/auto_conf.md
+++ b/content/en/agent/guide/auto_conf.md
@@ -53,20 +53,13 @@ The auto configuration logic only supports the default configuration for any int
 
 ## Disabling auto-configuration
 
-To disable the Agent from using the `auto_conf.yaml` configuration you can add the environment variable `DD_IGNORE_AUTOCONF` for the desired integration(s) to disable. The following examples would have the Agent ignore the [`redisdb.d/auto_conf.yaml`][38] and [`istio.d/auto_conf.yaml`][22] file and avoid automatically setting up these integrations.
+To disable the Agent from using the `auto_conf.yaml` configuration, you can add the `DD_IGNORE_AUTOCONF` environment variable for the desired integration(s) to disable. The following examples would have the Agent ignore the [`redisdb.d/auto_conf.yaml`][38] and [`istio.d/auto_conf.yaml`][22] file and avoid automatically setting up these integrations.
 
 {{< tabs >}}
-{{% tab "DaemonSet" %}}
-To disable auto configuration integration(s) with your DaemonSet:
-
-Add the `DD_IGNORE_AUTOCONF` variable to your Agent manifest:
-```yaml
-DD_IGNORE_AUTOCONF="redisdb istio"
-```
-{{% /tab %}}
 {{% tab "Helm" %}}
 
-To disable auto configuration integration(s) with Helm, add `datadog.ignoreAutoconfig` to your `values.yaml`
+To disable auto configuration integration(s) with Helm, add `datadog.ignoreAutoconfig` to your `values.yaml`:
+
 ```yaml
 datadog:
  #List of integration(s) to ignore auto_conf.yaml.
@@ -75,8 +68,14 @@ datadog:
     - istio
 ```
 {{% /tab %}}
-{{< /tabs >}}
+{{% tab "DaemonSet" %}}
+To disable auto configuration integration(s) with your DaemonSet, add the `DD_IGNORE_AUTOCONF` variable to your Agent manifest:
 
+```yaml
+DD_IGNORE_AUTOCONF="redisdb istio"
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Further Reading
 

--- a/content/en/agent/guide/auto_conf.md
+++ b/content/en/agent/guide/auto_conf.md
@@ -53,11 +53,30 @@ The auto configuration logic only supports the default configuration for any int
 
 ## Disabling auto-configuration
 
-To disable the Agent from using the `auto_conf.yaml` configuration you can add the environment variable `DD_IGNORE_AUTOCONF` for the desired integration(s) to disable. The environment variable:
-```
+To disable the Agent from using the `auto_conf.yaml` configuration you can add the environment variable `DD_IGNORE_AUTOCONF` for the desired integration(s) to disable. The following examples would have the Agent ignore the [`redisdb.d/auto_conf.yaml`][38] and [`istio.d/auto_conf.yaml`][22] file and avoid automatically setting up these integrations.
+
+{{< tabs >}}
+{{% tab "DaemonSet" %}}
+To disable auto configuration integration(s) with your DaemonSet:
+
+Add the `DD_IGNORE_AUTOCONF` variable to your Agent manifest:
+```yaml
 DD_IGNORE_AUTOCONF="redisdb istio"
 ```
-would have the Agent ignore the [`redisdb.d/auto_conf.yaml`][38] and [`istio.d/auto_conf.yaml`][22] file and avoid automatically setting up these integrations.
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+To disable auto configuration integration(s) with Helm, add `datadog.ignoreAutoconfig` to your `values.yaml`
+```yaml
+datadog:
+ #List of integration(s) to ignore auto_conf.yaml.
+  ignoreAutoConfig:
+    - redisdb
+    - istio
+```
+{{% /tab %}}
+{{< /tabs >}}
+
 
 ## Further Reading
 


### PR DESCRIPTION

### What does this PR do? 
Adding Helm options for auto_conf `datadog.ignoreAutoConfig`

### Motivation
Getting documentation updated with relevant Helm config

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
