### PR TITLE
[us1.prod]JasSpencer/Added small note to _index.md

### DIFF
--- a/content/en/monitors/configuration/_index.md
+++ b/content/en/monitors/configuration/_index.md
@@ -156,6 +156,8 @@ Notifications for missing data are useful if you expect a metric to always be re
 
 In this case, you should enable notifications for missing data. The sections below explain how to accomplish this with each option.
 
+**Note**: Alerting on missing data only works when data is first present. The monitor must be able to evaluate before alerting on missing data. For example, creating a monitor for `service:abc` when data from that `service` has not yet reported to Datadog will result in no alerts.
+
 There are two ways to deal with missing data:
 - Metric-based monitors using the limited `Notify no data` option
 - The `On missing data` option is supported by APM Trace Analytics, Audit Logs, CI Pipelines, Error Tracking, Events, Logs, and RUM monitors


### PR DESCRIPTION
I added a small disclaimer to the doc explaining that monitors need to have data to evaluate before they can alert on missing data. We've had some tickets asking about this, thinking that monitors are bugged. Having this will help to clarify to customers.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Clarifies that monitors cannot alert on missing data if data doesn't exist to begin with. Monitors must first be able to evaluate data before they can detect no data.

### Motivation
We've had a few tickets from customers thinking that monitor are bugged because they have configured them to alert on missing data, when their data does not yet exist in Datadog.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
