### PR TITLE
[DOCS-4512] Add link to AWS config for Cloud SIEM doc

### DIFF
--- a/content/en/security_platform/cloud_siem/_index.md
+++ b/content/en/security_platform/cloud_siem/_index.md
@@ -24,6 +24,7 @@ Threats are surfaced in Datadog as Security Signals and can be correlated and tr
 
 {{< whatsnext >}}
   {{< nextlink href="/security_platform/cloud_siem/getting_started">}}Complete setup and configuration{{< /nextlink >}}
+  {{< nextlink href="/security_platform/cloud_siem/guide/aws-config-guide-for-cloud-siem/">}}Set up the AWS integration for Cloud SIEM{{< /nextlink >}}
   {{< nextlink href="/security_platform/default_rules#cat-cloud-siem">}}Start using out-of-the-box Cloud SIEM detection rules{{< /nextlink >}}
   {{< nextlink href="/security_platform/detection_rules">}}Create your own custom detection rules{{< /nextlink >}}
 {{< /whatsnext >}}


### PR DESCRIPTION
### What does this PR do?

Adds a link to the AWS configuration for Cloud SIEM doc.

### Motivation

DOCS-4512, PM request.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
