### PR TITLE
[WEB-2847]module bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.3.69-0.20221123190742-5dc0f7298bcb // indirect
+require github.com/DataDog/websites-modules v1.3.71 // indirect
 
 // replace github.com/DataDog/websites-modules => /Users/carlos.santos/GitHub/websites-modules

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/DataDog/websites-modules v1.3.69-0.20221123190742-5dc0f7298bcb h1:7IKoJR1lMW8w5rMB9FdpFwCENb6CGtYoyrXL5vy6cEw=
-github.com/DataDog/websites-modules v1.3.69-0.20221123190742-5dc0f7298bcb/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.3.71 h1:YFakk9ivpUebDnmhXVXcSHAwaFbgChVfo+jJ9wEUbFc=
+github.com/DataDog/websites-modules v1.3.71/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Bump module version on Documentation

### Motivation
<!-- What inspired you to submit this pull request?-->
Careers has been moved off of corp and now lives on it's own domain https://careers.datadoghq.com/

Links to careers in the nav and footer have been updated to reflect that change and the Documentation site can consume the most recent version of modules.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/brooklyne.finni/module_bump/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
