### PR TITLE
Update multi_line_aggregation code example

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -368,7 +368,7 @@ logs:
    log_processing_rules:
       - type: multi_line
         name: new_log_start_with_date
-        pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])\s
+        pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
 ```
 
 {{% /tab %}}
@@ -385,7 +385,7 @@ In a Docker environment, use the label `com.datadoghq.ad.logs` on your container
         "log_processing_rules": [{
           "type": "multi_line",
           "name": "log_start_with_date",
-          "pattern" : "\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])\\s"
+          "pattern" : "\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])"
         }]
       }]
 ```
@@ -414,7 +414,7 @@ spec:
             "log_processing_rules": [{
               "type": "multi_line",
               "name": "log_start_with_date",
-              "pattern" : "\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])\\s"
+              "pattern" : "\\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])"
             }]
           }]
       labels:


### PR DESCRIPTION
Previously, the rule displayed included an ending "\s" for the regex pattern to match for Java logging formats that start with a timestamp in yyyy-dd-mm format - however, the log examples provided actually have a "yyyy-mm-ddThh:mm:sssZ" format that does not match (because of the "T" separator that doesn't match as a whitespace character).

I'm updating the rule example to remove this so that the match truly applies for a pattern of yyyy-mm-dd.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
