### PR TITLE
Update PHP profiling configuration

### DIFF
--- a/content/en/profiler/enabling/php.md
+++ b/content/en/profiler/enabling/php.md
@@ -65,7 +65,7 @@ To begin profiling applications:
 Set the environment variables before calling PHP, for example:
 
 ```
-export DD_PROFILING_ENABLED=true
+export DD_PROFILING_ENABLED=true # Not required for v0.82.0+
 export DD_SERVICE=app-name
 export DD_ENV=prod
 export DD_VERSION=1.3.2
@@ -79,7 +79,7 @@ php hello.php
 Use the `env` directive in the php-fpm’s `www.conf` file, for example:
 
 ```
-env[DD_PROFILING_ENABLED] = true
+env[DD_PROFILING_ENABLED] = true # Not required for v0.82.0+
 env[DD_SERVICE] = app-name
 env[DD_ENV] = prod
 env[DD_VERSION] = 1.3.2
@@ -91,7 +91,7 @@ env[DD_VERSION] = 1.3.2
 Use `SetEnv` from the server config, virtual host, directory, or `.htaccess` file:
 
 ```
-SetEnv DD_PROFILING_ENABLED true
+SetEnv DD_PROFILING_ENABLED true # Not required for v0.82.0+
 SetEnv DD_SERVICE app-name
 SetEnv DD_ENV prod
 SetEnv DD_VERSION 1.3.2

--- a/content/en/profiler/enabling/php.md
+++ b/content/en/profiler/enabling/php.md
@@ -65,7 +65,9 @@ To begin profiling applications:
 Set the environment variables before calling PHP, for example:
 
 ```
-export DD_PROFILING_ENABLED=true # Not required for v0.82.0+
+# DD_PROFILING_ENABLED is not required for v0.82.0+.
+export DD_PROFILING_ENABLED=true
+
 export DD_SERVICE=app-name
 export DD_ENV=prod
 export DD_VERSION=1.3.2
@@ -79,7 +81,9 @@ php hello.php
 Use the `env` directive in the php-fpm’s `www.conf` file, for example:
 
 ```
-env[DD_PROFILING_ENABLED] = true # Not required for v0.82.0+
+; DD_PROFILING_ENABLED is not required for v0.82.0+
+env[DD_PROFILING_ENABLED] = true
+
 env[DD_SERVICE] = app-name
 env[DD_ENV] = prod
 env[DD_VERSION] = 1.3.2
@@ -91,7 +95,9 @@ env[DD_VERSION] = 1.3.2
 Use `SetEnv` from the server config, virtual host, directory, or `.htaccess` file:
 
 ```
-SetEnv DD_PROFILING_ENABLED true # Not required for v0.82.0+
+# DD_PROFILING_ENABLED is not required for v0.82.0+.
+SetEnv DD_PROFILING_ENABLED true
+
 SetEnv DD_SERVICE app-name
 SetEnv DD_ENV prod
 SetEnv DD_VERSION 1.3.2

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -105,19 +105,24 @@ Whether to enable distributed tracing.
 Set an application’s environment, for example: `prod`, `pre-prod`, `stage`. Added in version `0.47.0`.
 
 `DD_PROFILING_ENABLED`
-: **INI**: Not available<br>
-**Default**: `0`<br>
-Enable the Datadog profiler. Added in version `0.69.0`. See [Enabling the PHP Profiler][4].
+: **INI**: `datadog.profiling.enabled`. INI available since `0.82.0`.<br>
+**Default**: `1`<br>
+Enable the Datadog profiler. Added in version `0.69.0`. See [Enabling the PHP Profiler][4]. For version `0.81.0` and below it defaulted to `0`.
+
+`DD_PROFILING_ENDPOINT_COLLECTION_ENABLED`
+: **INI**: `datadog.profiling.endpoint_collection_enabled`. INI available since `0.82.0`.<br>
+**Default**: `1`<br>
+Whether to enable the endpoint data collection in profiles. Added in version `0.79.0`.
 
 `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED`
-: **INI**: Not available<br>
+: **INI**: `datadog.profiling.experimental_cpu_time_enabled`. INI available since `0.82.0`.<br>
 **Default**: `1`<br>
 Enable the experimental CPU profile type. Added in version `0.69.0`. For version `0.76` and below it defaulted to `0`.
 
 `DD_PROFILING_LOG_LEVEL`
-: **INI**: Not available<br>
+: **INI**: `datadog.profiling.log_level`. INI available since `0.82.0`.<br>
 **Default**: `off`<br>
-Set the profiler's log level. Acceptable values are `off`, `error`, `warn`, `info`, and `debug`. The profiler's logs are written to the standard error stream of the process. Added in version `0.69.0`.
+Set the profiler's log level. Acceptable values are `off`, `error`, `warn`, `info`, `debug`, and `trace`. The profiler's logs are written to the standard error stream of the process. Added in version `0.69.0`.
 
 `DD_PRIORITY_SAMPLING`
 : **INI**: `datadog.priority_sampling`<br>


### PR DESCRIPTION
### What does this PR do?

Update PHP profiling configuration:

1. ddtrace v0.82.0 has profiling INI support, so update those. It also makes the profiler enabled by default (if it's installed, it is not installed by default).
2. Add missing `DD_PROFILING_ENDPOINT_COLLECTION_ENABLED`.
3. Add missing `trace` level for `DD_PROFILING_LOG_LEVEL`. It has been there for quite a few versions.

### Motivation

A new ddtrace version was released.

### Additional Notes

I would like to also update the profiling and tracing installation docs to prefer setting INI settings in a file over doing it in Apache and nginx configuration files. However, it's not easy to tell users where these files are. I'm hoping we can fix this in a future update of `datadog-setup.php`.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
