### PR TITLE
Update Fluent Bit configuration-file URL

### DIFF
--- a/content/en/integrations/fluentbit.md
+++ b/content/en/integrations/fluentbit.md
@@ -81,7 +81,7 @@ Need help? Contact [Datadog support][11].
 [5]: https://app.datadoghq.com/logs/activation
 [6]: https://docs.fluentbit.io/manual/installation/sources/build-and-install
 [7]: https://docs.fluentbit.io/manual/administration/configuring-fluent-bit
-[8]: https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file
+[8]: https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/configuration-file
 [9]: https://app.datadoghq.com/logs
 [10]: /getting_started/tagging/
 [11]: /help/


### PR DESCRIPTION
The current link to the Fluent Bit configuration-file does not exist now. It has changed to https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/configuration-file

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update the link to the Fluent Bit configuration-file 

### Motivation
<!-- What inspired you to submit this pull request?-->
https://docs.datadoghq.com/integrations/fluentbit/#overview 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
