### PR TITLE
legacy code examples fix

### DIFF
--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -239,24 +239,30 @@
     {{ $items := . }}
     {{ $s := newScratch }}
     {{ range $k, $lang := $context.Site.Params.code_languages }}
+      {{ $newItems := slice }}
       {{ $file_extension := $k }}
       {{ $count := 0 }}
       {{ range $i, $item := $items }}
         {{ $fileStr := (printf "%s%s.%s" $operationid $item.suffix $file_extension) }}
         {{ with $resourcePage.Resources.Match $fileStr }}
-          {{ $count = add $count 1 }}
+          {{ with . }}
+            {{ $newItems = $newItems | append $item }}
+            {{ $count = add $count 1 }}
+          {{ end }}
         {{ end }}
       {{ end }}
       {{ $s.SetInMap "itemCounts" $lang.name $count }}
+      {{ $s.SetInMap "items" $lang.name $newItems }}
     {{ end }}
 
     {{ range $k, $lang := $context.Site.Params.code_languages }}
       {{ $file_extension := $k }}
       {{ $numOfCodeExamples := (index ($s.Get "itemCounts") $lang.name) }}
+      {{ $myItems := (index ($s.Get "items") $lang.name) }}
       {{ if gt $numOfCodeExamples 0 }}
       <div class="code-snippet-wrapper js-code-block" data-code-lang-block="{{ $lang.name }}">
         {{ if gt $numOfCodeExamples 1 }}<div class="example-accordion" id="accordion-{{ $operationid | lower }}-{{ $version }}-{{ $lang.name }}">{{ end }}
-          {{ range $i, $item := $items | first 3 }}
+          {{ range $i, $item := $myItems | first 3 }}
               {{ $fileStr := (printf "%s%s.%s" $operationid $item.suffix $file_extension) }}
               {{ with $resourcePage.Resources.Match $fileStr }}
                   {{ range . }}


### PR DESCRIPTION
### What does this PR do?

Some of the legacy code examples were not showing. The reason being we were limiting to the first 3, however because we included examples in the slice that don't exist we would limit to the first 3 non existant examples and then show nothing because the existing example is index 4. This PR makes sure we are dealing with existing examples only when iterating.

### Motivation

Api channel

### Preview

Check `python[legacy]` or `ruby[legacy]` code examples in various places. E.g create a monitor or create a dashboard are good examples

https://docs-staging.datadoghq.com/david.jones/legacy-example/api/latest/monitors/?code-lang=python-legacy#create-a-monitor
https://docs-staging.datadoghq.com/david.jones/legacy-example/api/latest/dashboards/?code-lang=python-legacy#create-a-new-dashboard

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
