### PR TITLE
(DOCS-4541) Clarify RUM span ingestion vs indexing

### DIFF
--- a/content/fr/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/fr/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -151,7 +151,7 @@ Datadog utilise un protocole de tracing distribué et configure les en-têtes HT
 
 ## Cela a-t-il une incidence sur les quotas de l'APM ?
 
-L'en-tête `x-datadog-origin: rum` indique au backend APM que les traces sont générées depuis la fonctionnalité RUM. Les traces générées n'ont par conséquent aucun impact sur le calcul de vos spans indexées.
+Relier RUM aux traces peut considérablement augmenter le volume de traces ingérées par l'APM. L'en-tête `x-datadog-origin: rum` indique au backend APM que les traces sont générées depuis la fonctionnalité RUM. Les traces générées n'ont par conséquent aucun impact sur le calcul de vos spans indexées, uniquement sur vos spans ingérés.
 
 ## Combien de temps les traces sont-elles conservées ?
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Make people take in consideration than RUM can increase APM ingested volume.

### Motivation
<!-- What inspired you to submit this pull request?-->
We got it implemented assuming as there is no impact on indexing, it was same on ingestion.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
