### PR TITLE
Re-enable translations

### DIFF
--- a/translate.yaml
+++ b/translate.yaml
@@ -1,11 +1,11 @@
 ---
 # New params
-receive_enabled: false
-sync_enabled: false
+receive_enabled: true
+sync_enabled: true
 
 # if true, no github or transifex api writes will happen.
 # instead logs will be created to simulate results.
-sync_dry_run_enabled: true
+sync_dry_run_enabled: false
 
 # These files will be ignored or deleted when syncing with Transifex.
 ignores:


### PR DESCRIPTION
### What does this PR do?
Re-enables the translation pipeline, which was frozen temporarily while migrating `security_platform/` URLs to `security/`

### Motivation
URL migration completed

### Preview


### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
