### PR TITLE
Add dd.trace.header.baggage config description for java tracing.

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -115,7 +115,7 @@ Available since version 0.96.0.
 **Default**: `null`<br>
 **Example**: `CASE-insensitive-Header:my-baggage-name,User-ID:userId,My-Header-And-Baggage-Name`<br>
 Accepts a map of case-insensitive header keys to baggage keys and automatically applies matching request header values as baggage on traces. On propagation the reverse mapping is applied: Baggage is mapped to headers.<br>
-Available since version TODO: XX.XX.XX.
+Available since version 1.3.0.
 
 `dd.trace.annotations`
 : **Environment Variable**: `DD_TRACE_ANNOTATIONS`<br>

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -110,8 +110,8 @@ Available since version 0.96.0.
 Accepts a map of case-insensitive header keys to tag names and automatically applies matching response header values as tags on traces. Also accepts entries without a specified tag name that are automatically mapped to tags of the form `http.response.headers.<header-name>`.<br>
 Available since version 0.96.0.
 
-`dd.trace.baggage.mapping`
-: **Environment Variable**: `DD_TRACE_BAGGAGE_MAPPING`<br>
+`trace.header.baggage`
+: **Environment Variable**: `DD_TRACE_HEADER_BAGGAGE`<br>
 **Default**: `null`<br>
 **Example**: `CASE-insensitive-Header:my-baggage-name,User-ID:userId,My-Header-And-Baggage-Name`<br>
 Accepts a map of case-insensitive header keys to baggage keys and automatically applies matching request header values as baggage on traces. On propagation the reverse mapping is applied: Baggage is mapped to headers.<br>

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -110,6 +110,13 @@ Available since version 0.96.0.
 Accepts a map of case-insensitive header keys to tag names and automatically applies matching response header values as tags on traces. Also accepts entries without a specified tag name that are automatically mapped to tags of the form `http.response.headers.<header-name>`.<br>
 Available since version 0.96.0.
 
+`dd.trace.baggage.mapping`
+: **Environment Variable**: `DD_TRACE_BAGGAGE_MAPPING`<br>
+**Default**: `null`<br>
+**Example**: `CASE-insensitive-Header:my-baggage-name,User-ID:userId,My-Header-And-Baggage-Name`<br>
+Accepts a map of case-insensitive header keys to baggage keys and automatically applies matching request header values as baggage on traces. On propagation the reverse mapping is applied: Baggage is mapped to headers.<br>
+Available since version TODO: XX.XX.XX.
+
 `dd.trace.annotations`
 : **Environment Variable**: `DD_TRACE_ANNOTATIONS`<br>
 **Default**: ([listed here][4])<br>

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -110,7 +110,7 @@ Available since version 0.96.0.
 Accepts a map of case-insensitive header keys to tag names and automatically applies matching response header values as tags on traces. Also accepts entries without a specified tag name that are automatically mapped to tags of the form `http.response.headers.<header-name>`.<br>
 Available since version 0.96.0.
 
-`trace.header.baggage`
+`dd.trace.header.baggage`
 : **Environment Variable**: `DD_TRACE_HEADER_BAGGAGE`<br>
 **Default**: `null`<br>
 **Example**: `CASE-insensitive-Header:my-baggage-name,User-ID:userId,My-Header-And-Baggage-Name`<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds documentation about baggage mapping configuration parameters implemented by PR:  https://github.com/DataDog/dd-trace-java/pull/4404

### Motivation
<!-- What inspired you to submit this pull request?-->
I created the implementation, therefore the documentation must be kept up to date.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

- [ ] The "available from" version must be updated before merging.
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
