### PR TITLE
Update minimum supported Ruby version for Ruby profiler

### DIFF
--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -25,7 +25,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 ## Requirements
 
-The Datadog Profiler requires MRI Ruby 2.1+.
+The Datadog Profiler requires MRI Ruby 2.2+.
 
 The following operating systems and architectures are supported:
 - Linux (GNU libc) x86-64, aarch64


### PR DESCRIPTION
### What does this PR do?

Update minimum supported Ruby version for Ruby profiler from 2.1 to 2.2.

### Motivation

We've dropped support for Ruby 2.1 some time ago
(<https://github.com/DataDog/dd-trace-rb/pull/2140>) and I spotted that the documentation was outdated.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes

(N/A)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
