### PR TITLE
Action catalog anchors

### DIFF
--- a/assets/styles/components/_grouped-item-listings.scss
+++ b/assets/styles/components/_grouped-item-listings.scss
@@ -9,9 +9,9 @@
   &:before {
     content: ' ';
     display: block;
-    height: 80px;
+    height: 100px;
     visibility: hidden;
-    margin-top: -80px;
+    margin-top: -100px;
     pointer-events: none;
   }
 }

--- a/assets/styles/components/_grouped-item-listings.scss
+++ b/assets/styles/components/_grouped-item-listings.scss
@@ -5,14 +5,25 @@
   }
 }
 
+.js-group {
+  &:before {
+    content: ' ';
+    display: block;
+    height: 80px;
+    visibility: hidden;
+    margin-top: -80px;
+    pointer-events: none;
+  }
+}
+
 .js-group-header {
   transition: box-shadow 0.125s;
   position: relative;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.25); 
-  margin-bottom: 9px; 
-  border-radius: 4px; 
-  cursor: pointer; 
-  overflow: hidden; 
+  box-shadow: 0 1px 3px rgba(0,0,0,0.25);
+  margin-bottom: 9px;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
   height: 28px;
 
   .group-header-text {
@@ -20,7 +31,7 @@
   }
 
   &:hover {
-    box-shadow: 0 2px 3px rgba(0,0,0,0.3); 
+    box-shadow: 0 2px 3px rgba(0,0,0,0.3);
   }
   &.active + div {
     display: block !important;

--- a/layouts/partials/grouped-item-listings.html
+++ b/layouts/partials/grouped-item-listings.html
@@ -20,8 +20,8 @@
 <div class="list-group">
   <div class="js-empty-results d-none font-semibold"></div>
   {{ range $i, $v := $listGroups }}
-  <div class="js-group js-group-{{ $i }}">
-    <div class="js-group-header mb-1 d-flex align-items-center active">
+  <div class="js-group js-group-{{ $i }}" id="{{ $v.Key | anchorize }}">
+    <div class="js-group-header mb-1 d-flex align-items-center active" id="">
       <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2">
         {{ range last 1 $v.Pages }}
           {{ $basename := .Params.integration_id | default .Params.source }}

--- a/layouts/partials/grouped-item-listings.html
+++ b/layouts/partials/grouped-item-listings.html
@@ -17,7 +17,7 @@
   <input type="input" data-ref="search" class="form-control grouped-item-search mb-3" id="keywords" placeholder="Search here" aria-label="keywords"/>
 </div>
 
-<div class="list-group">
+<div>
   <div class="js-empty-results d-none font-semibold"></div>
   {{ range $i, $v := $listGroups }}
   <div class="js-group js-group-{{ $i }}" id="{{ $v.Key | anchorize }}">


### PR DESCRIPTION
### What does this PR do?

Adds the ability to link directly to items in the Workflow Action Catalog.

### Motivation

https://datadoghq.atlassian.net/browse/WEB-2816

### Preview

Here are some examples. The links are easily constructed by just adding the item you want to link to at the end and replacing spaces with hyphens.

https://docs-staging.datadoghq.com/fitzage/action-catalog-anchors/workflows/actions_catalog/#aws-eventbridge
https://docs-staging.datadoghq.com/fitzage/action-catalog-anchors/workflows/actions_catalog/#aws-resources-tagging

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
