### PR TITLE
APM Python - Decribe pip requirement for profiling

### DIFF
--- a/content/en/profiler/enabling/python.md
+++ b/content/en/profiler/enabling/python.md
@@ -35,6 +35,8 @@ The following profiling features are available depending on your Python version:
 | Lock profiling       | Python >= 2.7                      |
 | Memory profiling     | Python >= 3.5                      |
 
+The installation requires pip version 18 or above.
+
 ## Installation
 
 Install `ddtrace`, which provides both tracing and profiling functionalities:

--- a/content/en/profiler/profiler_troubleshooting.md
+++ b/content/en/profiler/profiler_troubleshooting.md
@@ -163,9 +163,11 @@ If you've configured the profiler and don't see profiles in the profile search p
 - Operating system type and version (for example, Linux Ubuntu 20.04)
 - Runtime type, version, and vendor (for example, Python 3.9.5)
 
+Please refer to the python APM client [troubleshooting documentation][3] for additional guidance.  
 
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/
+[3]: https://ddtrace.readthedocs.io/en/stable/troubleshooting.html
 {{< /programming-lang >}}
 {{< programming-lang lang="go" >}}
 

--- a/content/en/profiler/profiler_troubleshooting.md
+++ b/content/en/profiler/profiler_troubleshooting.md
@@ -163,7 +163,7 @@ If you've configured the profiler and don't see profiles in the profile search p
 - Operating system type and version (for example, Linux Ubuntu 20.04)
 - Runtime type, version, and vendor (for example, Python 3.9.5)
 
-Please refer to the python APM client [troubleshooting documentation][3] for additional guidance.  
+Refer to the python APM client [troubleshooting documentation][3] for additional guidance.  
 
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/


### PR DESCRIPTION
#  Description

Ensure pip requirement is described in the install. If pip is at an older version we are getting the following error 

```
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-ymqm0401/ddtrace/setup.py", line 11, in <module>
        from Cython.Build import cythonize  # noqa: I100
    ModuleNotFoundError: No module named 'Cython'
```

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
I was failing during installation for unknown reasons.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
