### PR TITLE
Add debugging to build site script 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,7 +60,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: public.ecr.aws/x2b9z2t7/webops/site-build:latest
+  image: public.ecr.aws/x2b9z2t7/webops/site-build:test
   tags:
     - "runner:main"
   except:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "prebuild": "rimraf public && npx hugo mod clean",
         "build": "yarn run prebuild && yarn run build:hugo",
         "build:preview": "yarn run build:hugo:preview",
-        "build:hugo": "./node_modules/.bin/hugo -d ./public -s ./ -v --minify",
+        "build:hugo": "./node_modules/.bin/hugo -d ./public -s ./ -v --minify --debug",
         "build:hugo:preview": "yarn run build:hugo -D -F --environment preview",
         "build:hugo:live": "yarn run build:hugo -D -F --environment live",
         "build:live": "yarn run build:hugo:live",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "prebuild": "rimraf public && npx hugo mod clean",
         "build": "yarn run prebuild && yarn run build:hugo",
         "build:preview": "yarn run build:hugo:preview",
-        "build:hugo": "./node_modules/.bin/hugo -d ./public -s ./ -v --minify --debug --log",
+        "build:hugo": "./node_modules/.bin/hugo -d ./public -s ./ -v --minify",
         "build:hugo:preview": "yarn run build:hugo -D -F --environment preview",
         "build:hugo:live": "yarn run build:hugo -D -F --environment live",
         "build:live": "yarn run build:hugo:live",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "prebuild": "rimraf public && npx hugo mod clean",
         "build": "yarn run prebuild && yarn run build:hugo",
         "build:preview": "yarn run build:hugo:preview",
-        "build:hugo": "./node_modules/.bin/hugo -d ./public -s ./ -v --minify --debug",
+        "build:hugo": "./node_modules/.bin/hugo -d ./public -s ./ -v --minify --debug --log",
         "build:hugo:preview": "yarn run build:hugo -D -F --environment preview",
         "build:hugo:live": "yarn run build:hugo -D -F --environment live",
         "build:live": "yarn run build:hugo:live",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds debugging to the build_site script in the gitlab runner
### Motivation
<!-- What inspired you to submit this pull request?-->
We need to try and identify why some build fail to complete before deploying
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
