### PR TITLE
Update Required Permissions to Delete an Index

### DIFF
--- a/content/en/logs/log_configuration/indexes.md
+++ b/content/en/logs/log_configuration/indexes.md
@@ -49,7 +49,7 @@ Use the "New Index" button to create a new index. There is a maximum number of i
 
 ### Delete indexes
 
-To delete an index from your organization, use the "Delete icon" in the index action tray. Only users with both `Modify index` and `User manage access` permissions can use this option. 
+To delete an index from your organization, use the "Delete icon" in the index action tray. Only users with both `Logs delete data` and `User manage access` permissions can use this option. 
 
 {{< img src="logs/indexes/delete-index.png" alt="Delete index" style="width:70%;">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

- Initially, the permissions required to delete and index where "Modify index" and "User manage access."
- There's now a [Logs delete data](https://docs.datadoghq.com/account_management/rbac/permissions/#log-management) permission that is required. Having "Modify index" does not allow you to delete. 

### Motivation
<!-- What inspired you to submit this pull request?-->

- I found this out through one of my customers who was stuck trying to get their roles to work such that they could delete an index.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
