### PR TITLE
[WEB-2986] Fixes search input on Default Rules page

### DIFF
--- a/assets/styles/components/_grouped-item-listings.scss
+++ b/assets/styles/components/_grouped-item-listings.scss
@@ -1,4 +1,6 @@
 .grouped-item-search {
+  z-index: 1;
+
   &:focus {
     box-shadow: 4px 4px 12px rgba(0,0,0,0.3);
     border: 1px solid transparent;

--- a/layouts/partials/grouped-item-listings.html
+++ b/layouts/partials/grouped-item-listings.html
@@ -14,7 +14,7 @@
 {{ end }}
 
 <div class="form-group clearfix">
-  <input type="input" data-ref="search" class="form-control grouped-item-search mb-3" id="keywords" placeholder="Search here" aria-label="keywords"/>
+  <input type="input" data-ref="search" class="form-control grouped-item-search mb-3 position-relative" id="keywords" placeholder="Search here" aria-label="keywords"/>
 </div>
 
 <div>


### PR DESCRIPTION
### What does this PR do?
CSS fix so the search input is not disabled on Chrome.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2986

### Preview 
https://docs-staging.datadoghq.com/brian.deutsch/ootb-rules-search/security/default_rules/
https://docs-staging.datadoghq.com/brian.deutsch/ootb-rules-search/workflows/actions_catalog/

Search bar is not disabled and it is working properly on both Chrome and FF

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
