### PR TITLE
Add information on new and existing flaky tests to CI monitors page

### DIFF
--- a/content/en/monitors/types/ci.md
+++ b/content/en/monitors/types/ci.md
@@ -187,6 +187,12 @@ The `duration` metric can be used to identify pipeline and test performance regr
 ### Track new flaky tests
 Test monitors have the `New Flaky Test`, `Test Failures`, and `Test Performance` common monitor types for simple monitor setup. This monitor sends alerts when new flaky tests are added to your codebase. The query is grouped by `Test Full Name` so you don't get alerted on the same new flaky test more than once.
 
+A test run will be marked as `flaky` if it exhibits flakiness within the same commit after some retries. If it exhibits flakiness multiple times (because multiple retries were executed), the `is_flaky` tag will only be added to the first test run that we detected as flaky.
+
+A test run will be marked as `new flaky` if that particular test has not been detected to be flaky within the same branch or default branch. Only the first test run that is detected as new flaky will be marked with the `is_new_flaky` tag (regardless of the number of retries).
+
+For more information on flaky tests, see the [flaky test management guide][6]. 
+
 {{< img src="ci/flaky_test_monitor.png" alt="CI flaky test monitor" style="width:100%;">}}
 
 ### Maintain code coverage percentage
@@ -205,3 +211,4 @@ Test monitors have the `New Flaky Test`, `Test Failures`, and `Test Performance`
 [3]: /monitors/create/configuration/#advanced-alert-conditions
 [4]: /monitors/notify/
 [5]: https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/?tab=linux
+[6]: https://docs.datadoghq.com/continuous_integration/guides/flaky_test_management/

--- a/content/en/monitors/types/ci.md
+++ b/content/en/monitors/types/ci.md
@@ -187,7 +187,7 @@ The `duration` metric can be used to identify pipeline and test performance regr
 ### Track new flaky tests
 Test monitors have the `New Flaky Test`, `Test Failures`, and `Test Performance` common monitor types for simple monitor setup. This monitor sends alerts when new flaky tests are added to your codebase. The query is grouped by `Test Full Name` so you don't get alerted on the same new flaky test more than once.
 
-A test run is marked as `flaky` if it exhibits flakiness within the same commit after some retries. If it exhibits flakiness multiple times (because multiple retries were executed), the `is_flaky` tag is only be added to the first test run that is detected as flaky.
+A test run is marked as `flaky` if it exhibits flakiness within the same commit after some retries. If it exhibits flakiness multiple times (because multiple retries were executed), the `is_flaky` tag is added to the first test run that is detected as flaky.
 
 A test run is marked as `new flaky` if that particular test has not been detected to be flaky within the same branch or default branch. Only the first test run that is detected as new flaky is marked with the `is_new_flaky` tag (regardless of the number of retries).
 

--- a/content/en/monitors/types/ci.md
+++ b/content/en/monitors/types/ci.md
@@ -187,9 +187,9 @@ The `duration` metric can be used to identify pipeline and test performance regr
 ### Track new flaky tests
 Test monitors have the `New Flaky Test`, `Test Failures`, and `Test Performance` common monitor types for simple monitor setup. This monitor sends alerts when new flaky tests are added to your codebase. The query is grouped by `Test Full Name` so you don't get alerted on the same new flaky test more than once.
 
-A test run will be marked as `flaky` if it exhibits flakiness within the same commit after some retries. If it exhibits flakiness multiple times (because multiple retries were executed), the `is_flaky` tag will only be added to the first test run that we detected as flaky.
+A test run is marked as `flaky` if it exhibits flakiness within the same commit after some retries. If it exhibits flakiness multiple times (because multiple retries were executed), the `is_flaky` tag is only be added to the first test run that is detected as flaky.
 
-A test run will be marked as `new flaky` if that particular test has not been detected to be flaky within the same branch or default branch. Only the first test run that is detected as new flaky will be marked with the `is_new_flaky` tag (regardless of the number of retries).
+A test run is marked as `new flaky` if that particular test has not been detected to be flaky within the same branch or default branch. Only the first test run that is detected as new flaky is marked with the `is_new_flaky` tag (regardless of the number of retries).
 
 For more information on flaky tests, see the [flaky test management guide][6]. 
 


### PR DESCRIPTION
### What does this PR do?
Add information on new and existing flaky tests to CI monitors page

### Motivation
There was a clarifying question in the #ci-app channel about flaky test monitors

### Preview

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
