### PR TITLE
rename human-readable NodeJS to Node.js

### DIFF
--- a/content/en/containers/amazon_ecs/apm.md
+++ b/content/en/containers/amazon_ecs/apm.md
@@ -151,12 +151,12 @@ tracer.configure(hostname=get_aws_ip())
 {{< programming-lang lang="nodeJS" >}}
 
 #### Launch time variable
-Update the Task Definition's `entryPoint` with the following, substituting your `<NodeJS Startup Command>`:
+Update the Task Definition's `entryPoint` with the following, substituting your `<Node.js Startup Command>`:
 ```json
 "entryPoint": [
   "sh",
   "-c",
-  "export DD_AGENT_HOST=$(curl http://169.254.169.254/latest/meta-data/local-ipv4); <NodeJS Startup Command>"
+  "export DD_AGENT_HOST=$(curl http://169.254.169.254/latest/meta-data/local-ipv4); <Node.js Startup Command>"
 ]
 ```
 

--- a/content/en/continuous_integration/tests/javascript.md
+++ b/content/en/continuous_integration/tests/javascript.md
@@ -148,7 +148,7 @@ You can add custom tags to your tests by using the current active span:
   })
 ```
 
-To create filters or `group by` fields for these tags, you must first create facets. For more information about adding tags, see the [Adding Tags][1] section of the NodeJS custom instrumentation documentation.
+To create filters or `group by` fields for these tags, you must first create facets. For more information about adding tags, see the [Adding Tags][1] section of the Node.js custom instrumentation documentation.
 
 [1]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
 {{% /tab %}}
@@ -197,7 +197,7 @@ You can add custom tags to your test by grabbing the current active span:
   })
 ```
 
-To create filters or `group by` fields for these tags, you must first create facets. For more information about adding tags, see the [Adding Tags][1] section of the NodeJS custom instrumentation documentation.
+To create filters or `group by` fields for these tags, you must first create facets. For more information about adding tags, see the [Adding Tags][1] section of the Node.js custom instrumentation documentation.
 
 [1]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
 {{% /tab %}}
@@ -301,7 +301,7 @@ it('renders a hello world', () => {
 })
 ```
 
-To create filters or `group by` fields for these tags, you must first create facets. For more information about adding tags, see the [Adding Tags][5] section of the NodeJS custom instrumentation documentation.
+To create filters or `group by` fields for these tags, you must first create facets. For more information about adding tags, see the [Adding Tags][5] section of the Node.js custom instrumentation documentation.
 
 ### Cypress - RUM integration
 
@@ -395,7 +395,7 @@ If you are running tests in non-supported CI providers or with no `.git` folder,
 ## Known limitations
 
 ### ES modules
-[Mocha >=9.0.0][8] uses an ESM-first approach to load test files. That means that if ES modules are used (for example, by defining test files with the `.mjs` extension), _the instrumentation is limited_. Tests are detected, but there isn't visibility into your test. For more information about ES modules, see the [NodeJS documentation][9].
+[Mocha >=9.0.0][8] uses an ESM-first approach to load test files. That means that if ES modules are used (for example, by defining test files with the `.mjs` extension), _the instrumentation is limited_. Tests are detected, but there isn't visibility into your test. For more information about ES modules, see the [Node.js documentation][9].
 
 ### Browser tests
 Browser tests executed with `mocha`, `jest`, `cucumber` and `cypress` are instrumented by `dd-trace-js`, but visibility into the browser session itself is not provided by default (for example, network calls, user actions, page loads, and so on).

--- a/content/en/continuous_integration/tests/junit_upload.md
+++ b/content/en/continuous_integration/tests/junit_upload.md
@@ -36,7 +36,7 @@ npm install -g @datadog/datadog-ci
 
 <div class="alert alert-warning"><strong>Note</strong>: The standalone binaries are in <strong>beta</strong> and their stability is not guaranteed.</div>
 
-If installing NodeJS in the CI is an issue, standalone binaries are provided with [Datadog CI releases][4]. Only _linux-x64_, _darwin-x64_ (MacOS) and _win-x64_ (Windows) are supported. To install, run the following from your terminal:
+If installing Node.js in the CI is an issue, standalone binaries are provided with [Datadog CI releases][4]. Only _linux-x64_, _darwin-x64_ (MacOS) and _win-x64_ (Windows) are supported. To install, run the following from your terminal:
 
 {{< tabs >}}
 {{% tab "Linux" %}}

--- a/content/en/continuous_testing/cicd_integrations/jenkins.md
+++ b/content/en/continuous_testing/cicd_integrations/jenkins.md
@@ -36,11 +36,11 @@ Install and run the Node.js and npm packages within your Jenkins environment wit
 
 For more information about the existing Datadog-Jenkins integration, see [Set up Tracing on a Jenkins Pipeline][5].
 
-### Add a NodeJS installation
+### Add a Node.js installation
 
 Navigate to the global Jenkins Configuration panel and add a Node.js installation.
 
-{{< img src="synthetics/cicd_integrations/jenkins/nodejs-installation.png" alt="NodeJS Installations in Jenkins" style="width:80%;">}}
+{{< img src="synthetics/cicd_integrations/jenkins/nodejs-installation.png" alt="Node.js Installations in Jenkins" style="width:80%;">}}
 
 Install `@datadog/datadog-ci` globally for all relevant Node.js installations.
 

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -145,7 +145,7 @@ client.query("SELECT 1;")
 
 {{% /tab %}}
 
-{{% tab "NodeJS" %}}
+{{% tab "Node.js" %}}
 
 Install or udpate [dd-trace-js][1] to version greater than `3.9.0` (or `2.22.0` if using end-of-life Node.js version 12):
 

--- a/content/en/logs/error_tracking/backend.md
+++ b/content/en/logs/error_tracking/backend.md
@@ -20,7 +20,7 @@ If you aren’t already collecting logs with Datadog, see the [Logs documentatio
 
 For languages such as **Python**, **Java**, and **Ruby**, no additional configuration is needed if the `source` tag in your logs is configured correctly. All required attributes are automatically tagged and sent to Datadog. 
 
-For backend languages such as **C#**, **.NET**, **Go**, and **NodeJS**, the code examples in each section demonstrate how to properly configure an error log and attach the required stack trace in the log's `error.stack`.
+For backend languages such as **C#**, **.NET**, **Go**, and **Node.js**, the code examples in each section demonstrate how to properly configure an error log and attach the required stack trace in the log's `error.stack`.
 
 If you are already sending stack traces to Datadog but they are not in `error.stack`, you can set up a [generic log remapper][8] to remap the stack trace to the correct attribute in Datadog.
 
@@ -180,11 +180,11 @@ try {
 {{% /tab %}}
 {{< /tabs >}}
 
-### NodeJS
+### Node.js
 
 #### Winston (JSON)
 
-If you have not setup log collection for NodeJS, see the [NodeJS Log Collection documentation][5].
+If you have not setup log collection for Node.js, see the [Node.js Log Collection documentation][5].
 
 To log a caught exception yourself, you may optionally use:
 

--- a/content/en/logs/log_collection/nodejs.md
+++ b/content/en/logs/log_collection/nodejs.md
@@ -1,5 +1,5 @@
 ---
-title: NodeJS Log Collection
+title: Node.js Log Collection
 kind: documentation
 aliases:
   - /logs/languages/nodejs
@@ -24,7 +24,7 @@ further_reading:
 
 ## Configure your logger
 
-To send your logs to Datadog, log to a file and tail that file with your Datadog Agent. Use the [Winston][1] logging library to log from your NodeJS application.
+To send your logs to Datadog, log to a file and tail that file with your Datadog Agent. Use the [Winston][1] logging library to log from your Node.js application.
 
 Winston is available through [NPM][2], to get started, you want to add the dependency to your code:
 
@@ -136,7 +136,7 @@ If logs are in JSON format, Datadog automatically [parses the log messages][11] 
 ## Connect your service across logs and traces
 
 If APM is enabled for this application, connect your logs and traces by automatically adding trace IDs, span IDs,
-`env`, `service`, and `version` to your logs by [following the APM NodeJS instructions][3].
+`env`, `service`, and `version` to your logs by [following the APM Node.js instructions][3].
 
 **Note**: If the APM tracer injects `service` into your logs, it overrides the value set in the Agent configuration.
 

--- a/content/en/security/application_security/add-user-info.md
+++ b/content/en/security/application_security/add-user-info.md
@@ -230,7 +230,7 @@ function handle () {
 }
 ```
 
-For information and options, read [the NodeJS tracer documentation][1].
+For information and options, read [the Node.js tracer documentation][1].
 
 
 

--- a/content/en/security/application_security/getting_started/nodejs.md
+++ b/content/en/security/application_security/getting_started/nodejs.md
@@ -1,5 +1,5 @@
 ---
-title: NodeJS Getting Started with ASM
+title: Node.js Getting Started with ASM
 kind: documentation
 code_lang: nodejs
 type: multi-code-lang
@@ -12,7 +12,7 @@ further_reading:
       text: "Adding user information to traces"
     - link: 'https://github.com/DataDog/dd-trace-js'
       tag: 'GitHub'
-      text: 'NodeJS Datadog Library source code'
+      text: 'Node.js Datadog Library source code'
     - link: "/security/default_rules/#cat-application-security"
       tag: "Documentation"
       text: "OOTB Application Security Management Rules"
@@ -21,13 +21,13 @@ further_reading:
       text: "Troubleshooting Application Security Management"
 ---
 
-You can monitor application security for NodeJS apps running in Docker, Kubernetes, AWS ECS, and AWS Fargate. 
+You can monitor application security for Node.js apps running in Docker, Kubernetes, AWS ECS, and AWS Fargate. 
 
 {{% appsec-getstarted %}}
 
 ## Get started
 
-1. **Update your Datadog NodeJS library package** to at least version 2.0.0, by running:
+1. **Update your Datadog Node.js library package** to at least version 2.0.0, by running:
    ```shell
    npm install dd-trace
    ```
@@ -39,7 +39,7 @@ You can monitor application security for NodeJS apps running in Docker, Kubernet
 
    For information about which language and framework versions are supported by the library, see [Compatibility][2].
 
-2. **Where you import and initialize the NodeJS library for APM, also enable ASM.** This might be either in your code or with environment variables. If you initialized APM in code, add `{appsec: true}` to your init statement:
+2. **Where you import and initialize the Node.js library for APM, also enable ASM.** This might be either in your code or with environment variables. If you initialized APM in code, add `{appsec: true}` to your init statement:
       {{< tabs >}}
 {{% tab "In JavaScript code" %}}
 

--- a/content/en/security/application_security/setup_and_configure.md
+++ b/content/en/security/application_security/setup_and_configure.md
@@ -179,11 +179,11 @@ It supports the use of all PHP frameworks, and also the use no framework.
 
 {{< programming-lang lang="nodejs" >}}
 
-### Supported NodeJS versions
+### Supported Node.js versions
 
-The Datadog NodeJS library supports the following NodeJS versions:
+The Datadog Node.js library supports the following Node.js versions:
 
-- NodeJS 14 and higher
+- Node.js 14 and higher
 
 These are supported on the following architectures:
 
@@ -192,7 +192,7 @@ These are supported on the following architectures:
 - macOS (Darwin) x86-64
 - Windows (msvc) x86, x86-64
 
-You can monitor application security for NodeJS apps running in Docker, Kubernetes, AWS ECS, and AWS Fargate.
+You can monitor application security for Node.js apps running in Docker, Kubernetes, AWS ECS, and AWS Fargate.
 
 ### Supported frameworks
 

--- a/content/en/security/application_security/troubleshooting.md
+++ b/content/en/security/application_security/troubleshooting.md
@@ -216,7 +216,7 @@ If your framework is not supported, [create a new issue][7] in the Go repository
 {{< /programming-lang >}}
 {{< programming-lang lang="NodeJS" >}}
 
-For [NodeJS][1], the HTTP integration is required.
+For [Node.js][1], the HTTP integration is required.
 <p></p>
 
 [1]: /security/application_security/setup_and_configure/
@@ -374,9 +374,9 @@ Enable debug logs with the environment variable `DD_TRACE_DEBUG=1`. The ASM libr
 {{< /programming-lang >}}
 {{< programming-lang lang="NodeJS" >}}
 
-Use this [migration guide][1] to assess any breaking changes if you upgraded your NodeJS library from 1.x to 2.x.
+Use this [migration guide][1] to assess any breaking changes if you upgraded your Node.js library from 1.x to 2.x.
 
-If you don’t see ASM threat information in the [Trace and Signals Explorer][2] for your NodeJS application, follow these steps to troubleshoot the issue:
+If you don’t see ASM threat information in the [Trace and Signals Explorer][2] for your Node.js application, follow these steps to troubleshoot the issue:
 
 1. Confirm the latest version of ASM is running by checking that `appsec_enabled` is `true` in the [startup logs][3]
 

--- a/content/en/security/application_security/troubleshooting.md
+++ b/content/en/security/application_security/troubleshooting.md
@@ -47,7 +47,7 @@ ASM data is sent with APM traces. See [APM troubleshooting][4] to [confirm APM s
 
  To test your ASM setup, trigger the [Security Scanner Detected][7] rule by running a file that contains the following curl script:
 
-{{< programming-lang-wrapper langs="java,.NET,go,ruby,PHP,NodeJS,python" >}}
+{{< programming-lang-wrapper langs="java,.NET,go,ruby,PHP,Node.js,python" >}}
 {{< programming-lang lang="java" >}}
 
 ```bash
@@ -119,7 +119,7 @@ done
 **Note:** The `dd-test-scanner-log` value is supported in the most recent releases.
 
 {{< /programming-lang >}}
-{{< programming-lang lang="NodeJS" >}}
+{{< programming-lang lang="Node.js" >}}
 
 ```bash
 for ((i=1;i<=200;i++));
@@ -158,7 +158,7 @@ ASM relies on certain tracer integrations. If they are deactivated, ASM won't wo
 
 The required integrations vary by language.
 
-{{< programming-lang-wrapper langs="java,.NET,go,ruby,PHP,NodeJS,python" >}}
+{{< programming-lang-wrapper langs="java,.NET,go,ruby,PHP,Node.js,python" >}}
 {{< programming-lang lang="java" >}}
 
 For [Java][1], if you are using any of the following technologies, the respective integration is required:
@@ -214,7 +214,7 @@ If your framework is not supported, [create a new issue][7] in the Go repository
 [6]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/contrib/go-chi/chi.v5#example-package
 [7]: https://github.com/DataDog/dd-trace-go/issues/new?title=Missing%20appsec%20framework%20support
 {{< /programming-lang >}}
-{{< programming-lang lang="NodeJS" >}}
+{{< programming-lang lang="Node.js" >}}
 
 For [Node.js][1], the HTTP integration is required.
 <p></p>
@@ -270,7 +270,7 @@ If spans are not being transmitted, then the tracer logs will contain logs simil
 
 Below are additional troubleshooting steps for specific languages.
 
-{{< programming-lang-wrapper langs="java,.NET,go,ruby,PHP,NodeJS,python" >}}
+{{< programming-lang-wrapper langs="java,.NET,go,ruby,PHP,Node.js,python" >}}
 {{< programming-lang lang="java" >}}
 The Java library uses [SLF4J][1] for logging. Add the following runtime flags so that the tracer logs to a file:
 
@@ -372,7 +372,7 @@ Enable debug logs with the environment variable `DD_TRACE_DEBUG=1`. The ASM libr
 
 [1]: /tracing/troubleshooting/tracer_startup_logs/
 {{< /programming-lang >}}
-{{< programming-lang lang="NodeJS" >}}
+{{< programming-lang lang="Node.js" >}}
 
 Use this [migration guide][1] to assess any breaking changes if you upgraded your Node.js library from 1.x to 2.x.
 

--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -64,7 +64,7 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"] (adapt this line to your needs)
 
 ```
 
-See [Tracing NodeJS Applications][1] for detailed instructions. [Sample code for a simple NodeJS application][2].
+See [Tracing Node.js Applications][1] for detailed instructions. [Sample code for a simple Node.js application][2].
 
 [1]: /tracing/setup_overview/setup/nodejs/?tabs=containers
 [2]: https://github.com/DataDog/crpb/tree/main/js

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -64,7 +64,7 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"] (adapt this line to your needs)
 
 ```
 
-See [Tracing NodeJS Applications][1] for detailed instructions. [Sample code for a simple NodeJS application][2].
+See [Tracing Node.js Applications][1] for detailed instructions. [Sample code for a simple Node.js application][2].
 
 [1]: /tracing/setup_overview/setup/nodejs/?tabs=containers
 [2]: https://github.com/DataDog/crpb/tree/main/js

--- a/content/en/tracing/guide/configuring-primary-operation.md
+++ b/content/en/tracing/guide/configuring-primary-operation.md
@@ -148,7 +148,7 @@ span.setTag('span.type', 'web')
 span.finish();
 ```
 
-For more information, see [Setting up NodeJS and OpenTracing][1].
+For more information, see [Setting up Node.js and OpenTracing][1].
 
 
 [1]: /tracing/trace_collection/open_standards/nodejs/#opentracing

--- a/content/en/tracing/metrics/runtime_metrics/nodejs.md
+++ b/content/en/tracing/metrics/runtime_metrics/nodejs.md
@@ -1,7 +1,7 @@
 ---
-title: NodeJS Runtime Metrics
+title: Node.js Runtime Metrics
 kind: documentation
-description: "Gain additional insights into your NodeJS application's performance with the runtime metrics associated to your traces."
+description: "Gain additional insights into your Node.js application's performance with the runtime metrics associated to your traces."
 aliases:
 - /tracing/runtime_metrics/nodejs
 code_lang: nodejs

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/nodejs.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/nodejs.md
@@ -1,7 +1,7 @@
 ---
-title: Connecting NodeJS Logs and Traces
+title: Connecting Node.js Logs and Traces
 kind: documentation
-description: 'Connect your NodeJS logs and traces to correlate them in Datadog.'
+description: 'Connect your Node.js logs and traces to correlate them in Datadog.'
 code_lang: nodejs
 type: multi-code-lang
 code_lang_weight: 50
@@ -35,7 +35,7 @@ const tracer = require('dd-trace').init({
 
 This enables automatic trace ID injection for `bunyan`, `paperplane`, `pino`, and `winston`.
 
-If you haven't done so already, configure the NodeJS tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best
+If you haven't done so already, configure the Node.js tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best
 experience for adding `env`, `service`, and `version` (see [Unified Service Tagging][1] for more details).
 
 **Note**: Automatic injection only works for logs formatted as JSON.

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -78,7 +78,7 @@ log.info("Example log line with trace correlation info")
 [3]: https://github.com/DataDog/trace-examples/blob/98626d924f82666de60d6b2d6a65d87eebebdff1/opentelemetry/python-microservice/ddlogging/injection.py#L3
 {{% /tab %}}
 
-{{% tab "NodeJS" %}}
+{{% tab "Node.js" %}}
 
 To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [winston logging library][1]. For other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][2]. You can also find [an example OpenTelemetry instrumented Node.js application with trace and log correlation][3] in the `trace-examples` GitHub repository.
 

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -80,7 +80,7 @@ log.info("Example log line with trace correlation info")
 
 {{% tab "NodeJS" %}}
 
-To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [winston logging library][1]. For other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][2]. You can also find [an example OpenTelemetry instrumented NodeJS application with trace and log correlation][3] in the `trace-examples` GitHub repository.
+To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [winston logging library][1]. For other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][2]. You can also find [an example OpenTelemetry instrumented Node.js application with trace and log correlation][3] in the `trace-examples` GitHub repository.
 
 ```js
 // ########## logger.js

--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -1,7 +1,7 @@
 ---
-title: NodeJS Compatibility Requirements
+title: Node.js Compatibility Requirements
 kind: documentation
-description: 'Compatibility Requirements for the NodeJS tracer'
+description: 'Compatibility Requirements for the Node.js tracer'
 aliases:
   - /tracing/compatibility_requirements/nodejs
   - /tracing/setup_overview/compatibility_requirements/nodejs

--- a/content/en/tracing/trace_collection/custom_instrumentation/nodejs.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/nodejs.md
@@ -1,12 +1,12 @@
 ---
-title: NodeJS Custom Instrumentation
+title: Node.js Custom Instrumentation
 kind: documentation
 aliases:
     - /tracing/opentracing/nodejs
     - /tracing/manual_instrumentation/nodejs
     - /tracing/custom_instrumentation/nodejs
     - /tracing/setup_overview/custom_instrumentation/nodejs
-description: 'Manually instrument your NodeJS application to send custom traces to Datadog.'
+description: 'Manually instrument your Node.js application to send custom traces to Datadog.'
 code_lang: nodejs
 code_lang_weight: 40
 type: multi-code-lang
@@ -20,7 +20,7 @@ further_reading:
 ---
 
 <div class="alert alert-info">
-If you have not yet read the instructions for auto-instrumentation and setup, please start with the <a href="https://docs.datadoghq.com/tracing/setup/nodejs/">NodeJS Setup Instructions</a>.
+If you have not yet read the instructions for auto-instrumentation and setup, please start with the <a href="https://docs.datadoghq.com/tracing/setup/nodejs/">Node.js Setup Instructions</a>.
 </div>
 
 If you aren’t using supported library instrumentation (see [library compatibility][1]), you may want to manually instrument your code.

--- a/content/en/tracing/trace_collection/library_config/nodejs.md
+++ b/content/en/tracing/trace_collection/library_config/nodejs.md
@@ -1,5 +1,5 @@
 ---
-title: Configuring the NodeJS Tracing Library
+title: Configuring the Node.js Tracing Library
 kind: documentation
 code_lang: nodejs
 type: multi-code-lang

--- a/content/en/tracing/trace_collection/open_standards/nodejs.md
+++ b/content/en/tracing/trace_collection/open_standards/nodejs.md
@@ -1,9 +1,9 @@
 ---
-title: NodeJS Open Standards
+title: Node.js Open Standards
 kind: documentation
 aliases:
 - /tracing/setup_overview/open_standards/nodejs
-description: 'Open Standards for NodeJS'
+description: 'Open Standards for Node.js
 code_lang: nodejs
 type: multi-code-lang
 code_lang_weight: 40
@@ -28,7 +28,7 @@ The following tags are available to override Datadog specific options:
 * `resource.name`: The resource name to be used for the span. The operation name will be used if this is not provided.
 * `span.type`: The span type to be used for the span. Will fallback to `custom` if not provided.
 
-See [opentracing.io][1] for OpenTracing NodeJS usage.
+See [opentracing.io][1] for OpenTracing Node.js usage.
 
 
 

--- a/content/en/tracing/trace_collection/open_standards/nodejs.md
+++ b/content/en/tracing/trace_collection/open_standards/nodejs.md
@@ -3,7 +3,7 @@ title: Node.js Open Standards
 kind: documentation
 aliases:
 - /tracing/setup_overview/open_standards/nodejs
-description: 'Open Standards for Node.js
+description: 'Open Standards for Node.js'
 code_lang: nodejs
 type: multi-code-lang
 code_lang_weight: 40

--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -156,7 +156,7 @@ tracer.init({
 
 Configure a rate limit by setting the environment variable `DD_TRACE_RATE_LIMIT` to a number of traces per second per service instance. If no `DD_TRACE_RATE_LIMIT` value is set, a limit of 100 traces per second is applied.
 
-Read more about sampling controls in the [NodeJS tracing library documentation][1].
+Read more about sampling controls in the [Node.js tracing library documentation][1].
 
 [1]: /tracing/trace_collection/dd_libraries/nodejs
 {{% /tab %}}

--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -136,7 +136,7 @@ Read more about sampling controls in the [Go tracing library documentation][1].
 
 [1]: /tracing/trace_collection/dd_libraries/go
 {{% /tab %}}
-{{% tab "NodeJS" %}}
+{{% tab "Node.js" %}}
 For Node.js applications, set a global sampling rate in the library using the `DD_TRACE_SAMPLE_RATE` environment variable.
 
 You can also set by-service sampling rates. For instance, to send 50% of the traces for the service named `my-service` and 10% for the rest of the traces:
@@ -599,7 +599,7 @@ Read more about sampling controls in the [Go tracing library documentation][2].
 [1]: https://github.com/DataDog/dd-trace-go/releases/tag/v1.41.0
 [2]: /tracing/trace_collection/dd_libraries/go
 {{% /tab %}}
-{{% tab "NodeJS" %}}
+{{% tab "Node.js" %}}
 For Node.js applications, set by-service and by-operation name **span** sampling rules with the `DD_SPAN_SAMPLING_RULES` environment variable.
 
 For example, to collect `100%` of the spans from the service named `my-service`, for the operation `http.request`, up to `50` spans per second:

--- a/content/en/tracing/troubleshooting/tracer_startup_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_startup_logs.md
@@ -185,7 +185,7 @@ DATADOG TRACER CONFIGURATION - {"date":"2020-07-02T18:51:18.294Z","os_name":"Dar
 
 **Diagnostics:**
 
-The NodeJS Tracer prints a diagnostic line when the Agent cannot be reached.
+The Node.js Tracer prints a diagnostic line when the Agent cannot be reached.
 
 ```text
 DATADOG TRACER DIAGNOSTIC - Agent Error: Network error trying to reach the agent: connect ECONNREFUSED 127.0.0.1:8126


### PR DESCRIPTION
### What does this PR do?
- renames all human-readable instances of "NodeJS" to "Node.js"
- does not rename the isntances that are used for stating language name or for tabs

### Motivation
- the correct spelling is Node.js, see https://nodejs.org/en/
- the documentation did use Node.js in some places so this fixes consistency

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
