### PR TITLE
Add public folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Hugo
-public/
+public/*
+!public/.gitkeep
 data/service_checks/
 data/npm
 integrations_data

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,7 +60,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: public.ecr.aws/x2b9z2t7/webops/site-build:test
+  image: public.ecr.aws/x2b9z2t7/webops/site-build:devin
   tags:
     - "runner:main"
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,7 +60,7 @@ before_script:
 
 # ================== templates ================== #
 .base_template: &base_template
-  image: public.ecr.aws/x2b9z2t7/webops/site-build:devin
+  image: public.ecr.aws/x2b9z2t7/webops/site-build:test
   tags:
     - "runner:main"
   except:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds the public folder so that it is always in the directory (still excludes all the files except for the `.gitkeep` file)
### Motivation
<!-- What inspired you to submit this pull request?-->
A possible workaround for how we handle static assets. This was a [hugo issue](https://github.com/gohugoio/hugo/issues/8166) that was somewhat similar to what we have. Due to how we place the `static` directory into `assets` I'm wondering if this may possibly be the issue. This change may mitigate our problem or it may not, but this will not effect anything negatively having the empty directory in the repo prior to build.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
