### PR TITLE
Add configuration example for connecting to sql server named instances

### DIFF
--- a/layouts/shortcodes/dbm-sqlserver-agent-config-examples.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-config-examples.md
@@ -137,3 +137,16 @@ instances:
     password: '<PASSWORD>'
     reported_hostname: products-replica-1
 ```
+
+### Using port autodiscovery
+
+Some services like SQL Server Browser Service or Named Instances allow the user to not worry about hardcoded port numbers in the connection string. In order to use the agent with one of these services, the `port` field should be set to `0`.
+
+For example:
+
+```yaml
+init_config:
+instances:
+  - host: <hostname\instance name>
+    port: 0
+```

--- a/layouts/shortcodes/dbm-sqlserver-agent-config-examples.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-config-examples.md
@@ -142,7 +142,7 @@ instances:
 
 Some services like SQL Server Browser Service or Named Instances allow the user to not worry about hardcoded port numbers in the connection string. In order to use the agent with one of these services, the `port` field should be set to `0`.
 
-For example:
+For example, a Named Instance config:
 
 ```yaml
 init_config:

--- a/layouts/shortcodes/dbm-sqlserver-agent-config-examples.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-config-examples.md
@@ -138,9 +138,9 @@ instances:
     reported_hostname: products-replica-1
 ```
 
-### Using port autodiscovery
+### Discovering ports automatically
 
-Some services like SQL Server Browser Service or Named Instances allow the user to not worry about hardcoded port numbers in the connection string. In order to use the agent with one of these services, the `port` field should be set to `0`.
+SQL Server Browser Service, Named Instances, and other services can automatically detect port numbers. You can use this instead of hardcoding port numbers in connection strings. To use the Agent with one of these services, set the `port` field to `0`.
 
 For example, a Named Instance config:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds an example config for connecting to sql server instances that utilize port autodiscovery for connections, e.g.: named instances or sql server browser service

### Motivation
<!-- What inspired you to submit this pull request?-->

Based on discussion from this PR https://github.com/DataDog/integrations-core/pull/13148#discussion_r1047195535

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
