### PR TITLE
DOCS-4562 add redirect that is getting 404s

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -228,6 +228,7 @@
           - /tracing/setup_overview/ruby/
           - /agent/apm/ruby/
           - /tracing/setup_overview/setup/ruby
+          - /tracing/trace_collection/ruby
 
   - repo_name: datadog-serverless-functions
     contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -229,6 +229,7 @@
           - /tracing/setup_overview/ruby/
           - /agent/apm/ruby/
           - /tracing/setup_overview/setup/ruby
+          - /tracing/trace_collection/ruby
 
   - repo_name: datadog-serverless-functions
     contents:


### PR DESCRIPTION
### What does this PR do?

Adds an alias for the single-sourced ruby APM setup page

### Motivation

DOCS-4562, 404s report

### Preview 

The following links should redirect to a real page, not 404: https://docs-staging.datadoghq.com/kari/docs-4562-ruby-redirect/tracing/trace_collection/ruby

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
