### PR TITLE
fix otracing nav bug

### DIFF
--- a/content/en/tracing/trace_collection/open_standards/_index.md
+++ b/content/en/tracing/trace_collection/open_standards/_index.md
@@ -1,0 +1,20 @@
+---
+title: OpenTracing setup
+kind: documentation
+type: multi-code-lang
+---
+
+
+
+{{< whatsnext desc="Set up your application to send traces using OpenTracing." >}}
+    {{< nextlink href="/tracing/trace_collection/open_standards/java" >}}Java{{< /nextlink >}}
+    {{< nextlink href="/tracing/trace_collection/open_standards/python" >}}Python{{< /nextlink >}}
+    {{< nextlink href="/tracing/trace_collection/open_standards/ruby" >}}Ruby{{< /nextlink >}}
+    {{< nextlink href="/tracing/trace_collection/open_standards/go" >}}Go{{< /nextlink >}}
+    {{< nextlink href="/tracing/trace_collection/open_standards/nodejs" >}}NodeJS{{< /nextlink >}}
+    {{< nextlink href="/tracing/trace_collection/open_standards/php" >}}PHP{{< /nextlink >}}
+    {{< nextlink href="/tracing/trace_collection/open_standards/dotnet" >}}.NET{{< /nextlink >}}
+{{< /whatsnext >}}
+
+<br>
+


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fixes a navigation problem with the language tabs at https://docs.datadoghq.com/tracing/trace_collection/open_standards/java/ (If you click the other language tabs, nothing happens). This is fixed by adding a mostly blank "parent page" for the multi-code-lang pages. They seem to need it to function properly.

To test, go to https://docs-staging.datadoghq.com/kari/fix-otrace-nav/tracing/trace_collection/open_standards/java and check that the language tabs at the top take you to other pages.

### Motivation
Product manager reported the issue.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
