### PR TITLE
Mtoff add latency breakdown info

### DIFF
--- a/content/en/tracing/trace_explorer/visualize.md
+++ b/content/en/tracing/trace_explorer/visualize.md
@@ -28,7 +28,7 @@ The default sort for spans in the list visualization is by timestamp, with the m
 
 The configuration of the columns is stored alongside other elements of your troubleshooting context in saved views.
 
-You may see spans without data under the "LATENCY BREAKDOWN" column (There are some examples pictured in the GIF above). This can happen if the trace is somehow malformed, for example if there is a loop in the trace or if the root span is missing. Sometimes, the root service may decide to drop the trace but a downstream service thinks it’s interesting to keep. This means that only the downstream-service spans are ingested, resulting in an incomplete trace. It would be misleading to display a latency breakdown for an incomplete trace, so in these cases, the data is omitted instead. 
+If the trace is somehow malformed (for example if there is a loop in the trace or if the root span is missing) it could result in spans without data under the "LATENCY BREAKDOWN" column. In some cases, a root service may decide to drop a trace while a downstream service decides to keep it. Only the downstream-service spans are ingested in this case, resulting in an incomplete trace. It is misleading to display a latency breakdown for an incomplete trace, so the data is omitted. 
 
 ## Timeseries
 

--- a/content/en/tracing/trace_explorer/visualize.md
+++ b/content/en/tracing/trace_explorer/visualize.md
@@ -28,7 +28,7 @@ The default sort for spans in the list visualization is by timestamp, with the m
 
 The configuration of the columns is stored alongside other elements of your troubleshooting context in saved views.
 
-If the trace is somehow malformed (for example if there is a loop in the trace or if the root span is missing) it could result in spans without data under the "LATENCY BREAKDOWN" column. In some cases, a root service may decide to drop a trace while a downstream service decides to keep it. Only the downstream-service spans are ingested in this case, resulting in an incomplete trace. It is misleading to display a latency breakdown for an incomplete trace, so the data is omitted. 
+The `Latency Breakdown` of the trace might be missing for some spans if the trace is malformed or incomplete. For instance, the error and the rare samplers capture pieces of traces, without the guarantee of capturing the complete trace. In this case, the data is omitted to avoid displaying inconsistent of misleading latency information that would only make sense when the trace is complete.
 
 ## Timeseries
 

--- a/content/en/tracing/trace_explorer/visualize.md
+++ b/content/en/tracing/trace_explorer/visualize.md
@@ -28,6 +28,8 @@ The default sort for spans in the list visualization is by timestamp, with the m
 
 The configuration of the columns is stored alongside other elements of your troubleshooting context in saved views.
 
+You may see spans without data under the "LATENCY BREAKDOWN" column (There are some examples pictured in the GIF above). This can happen if the trace is somehow malformed, for example if there is a loop in the trace or if the root span is missing. Sometimes, the root service may decide to drop the trace but a downstream service thinks it’s interesting to keep (rare resource, or error trace for eg). This means that only the downstream-service spans are ingested, resulting in an incomplete trace. It would be misleading to display a latency breakdown for an incomplete trace, so in these cases, the data is omitted instead. 
+
 ## Timeseries
 
 Use timeseries to visualize the evolution of a [measure][3] (or a count of unique tag values) over a selected time frame, and optionally split the data by up to three tags (grouping).

--- a/content/en/tracing/trace_explorer/visualize.md
+++ b/content/en/tracing/trace_explorer/visualize.md
@@ -28,7 +28,7 @@ The default sort for spans in the list visualization is by timestamp, with the m
 
 The configuration of the columns is stored alongside other elements of your troubleshooting context in saved views.
 
-You may see spans without data under the "LATENCY BREAKDOWN" column (There are some examples pictured in the GIF above). This can happen if the trace is somehow malformed, for example if there is a loop in the trace or if the root span is missing. Sometimes, the root service may decide to drop the trace but a downstream service thinks it’s interesting to keep (rare resource, or error trace for eg). This means that only the downstream-service spans are ingested, resulting in an incomplete trace. It would be misleading to display a latency breakdown for an incomplete trace, so in these cases, the data is omitted instead. 
+You may see spans without data under the "LATENCY BREAKDOWN" column (There are some examples pictured in the GIF above). This can happen if the trace is somehow malformed, for example if there is a loop in the trace or if the root span is missing. Sometimes, the root service may decide to drop the trace but a downstream service thinks it’s interesting to keep. This means that only the downstream-service spans are ingested, resulting in an incomplete trace. It would be misleading to display a latency breakdown for an incomplete trace, so in these cases, the data is omitted instead. 
 
 ## Timeseries
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds information about the "latency breakdown" column in the public docs

### Motivation
[<!-- What inspired you to submit this pull request?-->](https://datadoghq.atlassian.net/browse/APMS-8435)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[APMS-8435]: https://datadoghq.atlassian.net/browse/APMS-8435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ