### PR TITLE
add redirect for blog link

### DIFF
--- a/content/en/security/cloud_siem/investigator.md
+++ b/content/en/security/cloud_siem/investigator.md
@@ -5,6 +5,7 @@ aliases:
   - /security_platform/cloud_siem/cloud_security_investigator/
   - /security_platform/cloud_siem/cloud_siem_investigator/
   - /security_platform/cloud_siem/investigator/
+  - /security/cloud_siem/cloud_security_investigator/
 further_reading:
 - link: "/cloud_siem/explorer/"
   tag: "Documentation"


### PR DESCRIPTION
> slack:

I'm wondering where I can report a broken link on a public facing blog post? The "documentation" link at the end of the following article leads to a 404 Error page: https://www.datadoghq.com/blog/visualize-cloud-activity-datadog-cloud-siem-investigator/. Thanks!