### PR TITLE
Clarified aes example option

### DIFF
--- a/content/en/network_monitoring/devices/snmp_metrics.md
+++ b/content/en/network_monitoring/devices/snmp_metrics.md
@@ -69,7 +69,7 @@ To monitor individual devices:
       user: 'user'
       authProtocol: 'SHA256'  # choices: MD5, SHA, SHA224, SHA256, SHA384, SHA512
       authKey: 'fakeKey'  # enclose with single quote
-      privProtocol: 'AES256'  # choices: DES, AES (128 bits), AES192, AES192C, AES256, AES256C
+      privProtocol: 'AES256'  # choices: DES, AES, AES192, AES192C, AES256, AES256C
       privKey: 'fakePrivKey'  # enclose with single quote
       tags:
         - 'key1:val1'
@@ -146,7 +146,7 @@ snmp_listener:
       user: 'user'
       authProtocol: 'SHA256'  # choices: MD5, SHA, SHA224, SHA256, SHA384, SHA512
       authKey: 'fakeKey'  # enclose with single quote
-      privProtocol: 'AES256'  # choices: DES, AES (128 bits), AES192, AES192C, AES256, AES256C
+      privProtocol: 'AES256'  # choices: DES, AES, AES192, AES192C, AES256, AES256C
       privKey: 'fakePrivKey'  # enclose with single quote
       tags:
         - 'key1:val1'


### PR DESCRIPTION
- Easy to have an accidental error if you take things litearlly:

```
 error: Error building params for device 192.168.19.119: Unsupported privacy protocol: AES (128 bits)
 ```

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes the extra space and brackets around 
<!-- A brief description of the change being made with this pull request.-->

### Motivation
All the other examples can be added 'as is' but the 128 option doesnt, leading to a hard to figure out error: 

```
error: Error building params for device [192.168.19.119](http://192.168.19.119/): Unsupported privacy protocol: AES (128 bits)
```

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
