### PR TITLE
[.NET Profiler] Add requirements for .NET allocation and lock contention profiling

### DIFF
--- a/content/en/profiler/enabling/dotnet.md
+++ b/content/en/profiler/enabling/dotnet.md
@@ -43,6 +43,9 @@ Supported .NET runtimes (64-bit applications)
 .NET 5<br/>
 .NET 6<br/>
 .NET 7
+<div class="alert alert-warning">
+  <strong>Note:</strong> The beta for lock contention and allocation profiling is only available for .NET 5+.
+</div>
 
 Supported languages
 : Any language that targets the .NET runtime, such as C#, F#, and Visual Basic.

--- a/content/en/profiler/search_profiles.md
+++ b/content/en/profiler/search_profiles.md
@@ -204,10 +204,10 @@ CPU
 Thrown Exceptions (beta)
 : The number of caught or uncaught exceptions raised by each method, as well as their type and message.
 
-Allocations (beta)
+Allocations (beta for .NET 5+ only)
 : The number and size of allocated objects by each method, as well as their type.
 
-Lock (beta)
+Lock (beta for .NET 5+ only)
 : The number of times threads are waiting for a lock and for how long.
 
 {{< /programming-lang >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add runtime version requirement for .NET profiling

### Motivation
<!-- What inspired you to submit this pull request?-->
Customers support cases have shown that version requirement was missing 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
