### PR TITLE
Update DBM's Postgres extended query protocol troubleshooting

### DIFF
--- a/content/en/database_monitoring/setup_postgres/troubleshooting.md
+++ b/content/en/database_monitoring/setup_postgres/troubleshooting.md
@@ -189,15 +189,16 @@ See the section on [truncated query samples](#query-samples-are-truncated) for i
 
 #### Postgres extended query protocol
 
-If a client is using the Postgres [extended query protocol][9] or prepared statements on Postgres version 12 or newer, enable the following beta feature in the [Postgres integration config][19].
+If a client is using the Postgres [extended query protocol][9] or prepared statements, the Datadog Agent is unable to collect explain plans due to the separation of the parsed query and raw bind parameters. Below are a few options for addressing the problem.
+
+For Postgres version 12 or newer, enable the following beta feature in the [Postgres integration config][19].
 ```
 query_samples:
   explain_parameterized_queries: true
   ...
 ```
-This enables the Agent to explain parameterized queries with generic values for the parameters. This may cause inaccuracies when the query references tables with partial indexes, or partition tables with varying indexes across child tables.
 
-For versions previous to Postgres 12 this feature is not supported, and the Datadog Agent is unable to collect explain plans due to the separation of the parsed query and raw bind parameters. If the client provides an option to force using the simple query protocol, the Datadog Agent is enabled to collect execution plans.
+For versions prior to Postgres 12, this feature is not supported. However, if your client provides an option to force using the simple query protocol, the Datadog Agent is enabled to collect execution plans.
 
 | Language | Client | Configuration for simple query protocol|
 |----------|--------|----------------------------------------|

--- a/content/en/database_monitoring/setup_postgres/troubleshooting.md
+++ b/content/en/database_monitoring/setup_postgres/troubleshooting.md
@@ -189,7 +189,15 @@ See the section on [truncated query samples](#query-samples-are-truncated) for i
 
 #### Postgres extended query protocol
 
-If a client is using the Postgres [extended query protocol][9] or prepared statements, the Datadog Agent is unable to collect explain plans due to the separation of the parsed query and raw bind parameters. If the client provides an option to force using the simple query protocol, then turning that on enables the Datadog Agent to collect execution plans.
+If a client is using the Postgres [extended query protocol][9] or prepared statements on Postgres version 12 or newer, enable the following beta feature in the [Postgres integration config](https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example).
+```
+query_samples:
+  explain_parameterized_queries: true
+  ...
+```
+This enables the Agent to explain parameterized queries with generic values for the parameters. This may cause inaccuracies when the query references tables with partial indexes, or partition tables with varying indexes across child tables.
+
+For versions older than Postgres 12, this feature is currently not supported and the Datadog Agent is unable to collect explain plans due to the separation of the parsed query and raw bind parameters. If the client provides an option to force using the simple query protocol, then turning that on enables the Datadog Agent to collect execution plans.
 
 | Language | Client | Configuration for simple query protocol|
 |----------|--------|----------------------------------------|

--- a/content/en/database_monitoring/setup_postgres/troubleshooting.md
+++ b/content/en/database_monitoring/setup_postgres/troubleshooting.md
@@ -189,7 +189,7 @@ See the section on [truncated query samples](#query-samples-are-truncated) for i
 
 #### Postgres extended query protocol
 
-If a client is using the Postgres [extended query protocol][9] or prepared statements on Postgres version 12 or newer, enable the following beta feature in the [Postgres integration config](https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example).
+If a client is using the Postgres [extended query protocol][9] or prepared statements on Postgres version 12 or newer, enable the following beta feature in the [Postgres integration config][19].
 ```
 query_samples:
   explain_parameterized_queries: true

--- a/content/en/database_monitoring/setup_postgres/troubleshooting.md
+++ b/content/en/database_monitoring/setup_postgres/troubleshooting.md
@@ -197,7 +197,7 @@ query_samples:
 ```
 This enables the Agent to explain parameterized queries with generic values for the parameters. This may cause inaccuracies when the query references tables with partial indexes, or partition tables with varying indexes across child tables.
 
-For versions older than Postgres 12, this feature is currently not supported and the Datadog Agent is unable to collect explain plans due to the separation of the parsed query and raw bind parameters. If the client provides an option to force using the simple query protocol, then turning that on enables the Datadog Agent to collect execution plans.
+For versions previous to Postgres 12 this feature is not supported, and the Datadog Agent is unable to collect explain plans due to the separation of the parsed query and raw bind parameters. If the client provides an option to force using the simple query protocol, the Datadog Agent is enabled to collect execution plans.
 
 | Language | Client | Configuration for simple query protocol|
 |----------|--------|----------------------------------------|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updates DBM's Postgres extended query protocol troubleshooting docs to include a new feature that enables the Agent to explain parameterized queries for Postgres version 12 or newer.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
