### PR TITLE
[.NET Profiler] Fix version error for .NET allocation profiling

### DIFF
--- a/content/en/profiler/enabling/dotnet.md
+++ b/content/en/profiler/enabling/dotnet.md
@@ -44,7 +44,7 @@ Supported .NET runtimes (64-bit applications)
 .NET 6<br/>
 .NET 7
 <div class="alert alert-warning">
-  <strong>Note:</strong> The beta for lock contention and allocation profiling is only available for .NET 5+.
+  <strong>Note:</strong> The beta for lock contention is only available for .NET 5+ and only in .NET 6+ for allocation profiling.
 </div>
 
 Supported languages

--- a/content/en/profiler/search_profiles.md
+++ b/content/en/profiler/search_profiles.md
@@ -204,7 +204,7 @@ CPU
 Thrown Exceptions (beta)
 : The number of caught or uncaught exceptions raised by each method, as well as their type and message.
 
-Allocations (beta for .NET 5+ only)
+Allocations (beta for .NET 6+ only)
 : The number and size of allocated objects by each method, as well as their type.
 
 Lock (beta for .NET 5+ only)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix .NET version requirement for allocation profiling

### Motivation
<!-- What inspired you to submit this pull request?-->
Should be .NET 6+ instead of .NET 5+

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
