### PR TITLE
Add cli dog dashboard reference

### DIFF
--- a/content/en/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
+++ b/content/en/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
@@ -66,6 +66,7 @@ For reference, [find the code for Dogshell][4]. But once you have Dogshell insta
 * `dog downtime`
 * `dog timeboard`
 * `dog screenboard`
+* `dog dashboard`
 * `dog host`
 * `dog tag`
 * `dog search`

--- a/content/fr/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
+++ b/content/fr/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
@@ -65,6 +65,7 @@ Vous pouvez [consulter le code de Dogshell][4] à des fins de référence. Toute
 * `dog downtime`
 * `dog timeboard`
 * `dog screenboard`
+* `dog dashboard`
 * `dog host`
 * `dog tag`
 * `dog search`

--- a/content/ja/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
+++ b/content/ja/developers/guide/dogshell-quickly-use-datadog-s-api-from-terminal-shell.md
@@ -63,6 +63,7 @@ appkey = <YOUR_APPLICATION_KEY>
 * `dog downtime`
 * `dog timeboard`
 * `dog screenboard`
+* `dog dashboard`
 * `dog host`
 * `dog tag`
 * `dog search`


### PR DESCRIPTION
`dog dashboard` is a supported command but not listed in the docs.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add reference to `dog dashboard` as a valid command.

### Motivation

[#750](https://github.com/DataDog/datadogpy/issues/750)  where I read the web docs and didn't notice there was an additional command available in the cli, which caused some confusion.


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
