### PR TITLE
Update Sidenav Icon - Cloud Sec Management

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2608,7 +2608,7 @@ main:
   - name: Cloud Security Management
     url: security/cloud_security_management
     parent: security_platform_heading
-    pre: cspm
+    pre: cloud-security-management
     identifier: csm
     weight: 181500
   - name: Cloud Security Posture Management


### PR DESCRIPTION
### What does this PR do?
Updates **sidenav** item "Cloud Security Management" icon to the new icon currently used in the main nav product dropdown

### Motivation
https://datadoghq.atlassian.net/browse/WEB-3011

### Preview
Sidenav icon updated for CSM: https://docs-staging.datadoghq.com/davidweid/web-3011-csm-sidenav-icon/security/cloud_security_management

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the Preview section.