### PR TITLE
refactor connect logs and traces - Node.js

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -89,95 +89,15 @@ To manually correlate your traces with your logs, patch the logging module you a
 // https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/id.js
 const opentelemetry = require('@opentelemetry/api');
 const winston = require('winston')
-const UINT_MAX = 4294967296
-
-// Convert a buffer to a numerical string.
-function toNumberString (buffer, radix) {
-  let high = readInt32(buffer, 0)
-  let low = readInt32(buffer, 4)
-  let str = ''
-
-  radix = radix || 10
-
-  while (1) {
-    const mod = (high % radix) * UINT_MAX + low
-
-    high = Math.floor(high / radix)
-    low = Math.floor(mod / radix)
-    str = (mod % radix).toString(radix) + str
-
-    if (!high && !low) break
-  }
-
-  return str
-}
-
-// Convert a numerical string to a buffer using the specified radix.
-function fromString (str, raddix) {
-  const buffer = new Uint8Array(8)
-  const len = str.length
-
-  let pos = 0
-  let high = 0
-  let low = 0
-
-  if (str[0] === '-') pos++
-
-  const sign = pos
-
-  while (pos < len) {
-    const chr = parseInt(str[pos++], raddix)
-
-    if (!(chr >= 0)) break // NaN
-
-    low = low * raddix + chr
-    high = high * raddix + Math.floor(low / UINT_MAX)
-    low %= UINT_MAX
-  }
-
-  if (sign) {
-    high = ~high
-
-    if (low) {
-      low = UINT_MAX - low
-    } else {
-      high++
-    }
-  }
-
-  writeUInt32BE(buffer, high, 0)
-  writeUInt32BE(buffer, low, 4)
-
-  return buffer
-}
-
-// Write unsigned integer bytes to a buffer.
-function writeUInt32BE (buffer, value, offset) {
-  buffer[3 + offset] = value & 255
-  value = value >> 8
-  buffer[2 + offset] = value & 255
-  value = value >> 8
-  buffer[1 + offset] = value & 255
-  value = value >> 8
-  buffer[0 + offset] = value & 255
-}
-
-// Read a buffer to unsigned integer bytes.
-function readInt32 (buffer, offset) {
-  return (buffer[offset + 0] * 16777216) +
-    (buffer[offset + 1] << 16) +
-    (buffer[offset + 2] << 8) +
-    buffer[offset + 3]
-}
 
 const tracingFormat = function () {
   return winston.format(info => {
     const span = opentelemetry.trace.getSpan(opentelemetry.context.active());
     if (span) {
-      const context = span.context();
-      const traceIdEnd = context.traceId.slice(context.traceId.length / 2)
-      info['dd.trace_id'] = toNumberString(fromString(traceIdEnd,16))
-      info['dd.span_id'] = toNumberString(fromString(context.spanId,16))
+      const { spanId, traceId } = span.spanContext();
+      const traceIdEnd = traceId.slice(traceId.length / 2);
+      info['dd.trace_id'] = BigInt(`0x${traceIdEnd}`).toString();
+      info['dd.span_id'] = BigInt(`0x${spanId}`).toString();
     }
     return info;
   })();


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Use [BigInt()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) to convert hex strings to 64bit unsigned int strings.

### Motivation

The amount of custom logic currently documented was quite large, perhaps BigInt() was not available at the time.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

There is an example where this code is duplicated [here](https://github.com/DataDog/trace-examples/blob/98626d924f82666de60d6b2d6a65d87eebebdff1/opentelemetry/node-microservice/logger.js#L86)

The PR to change it is https://github.com/DataDog/trace-examples/pull/124

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
