### PR TITLE
[opentelemetry] Use new style ${env:ENV} syntax on Collector examples

### DIFF
--- a/content/en/opentelemetry/otel_collector_datadog_exporter.md
+++ b/content/en/opentelemetry/otel_collector_datadog_exporter.md
@@ -81,7 +81,7 @@ exporters:
   datadog:
     api:
       site: <DD_SITE>
-      key: ${DD_API_KEY}
+      key: ${env:DD_API_KEY}
 
 service:
   pipelines:
@@ -345,7 +345,7 @@ To deploy the OpenTelemetry Collector and Datadog Exporter in a Kubernetes Gatew
      datadog:
        api:
          site: <DD_SITE>
-         key: ${DD_API_KEY}
+         key: ${env:DD_API_KEY}
    # ...
    ```
 
@@ -427,7 +427,7 @@ To use the OpenTelemetry Operator:
        exporters:
          datadog:
            api:
-             key: ${DD_API_KEY}
+             key: ${env:DD_API_KEY}
        service:
          pipelines:
            metrics:
@@ -461,7 +461,7 @@ To use the OpenTelemetry Collector alongside the Datadog Agent:
    # ...
    exporters:
      otlp:
-       endpoint: "${HOST_IP}:4317"
+       endpoint: "${env:HOST_IP}:4317"
    # ...
    ```
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates OpenTelemetry Collector examples to use new `${env:ENV}` style syntax.

### Motivation
<!-- What inspired you to submit this pull request?-->

See open-telemetry/opentelemetry-collector-contrib/issues/17299

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
