### PR TITLE
[Java Tracing Library] Update the default value for dd.http.server.tag.query-string

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -183,7 +183,7 @@ A range of errors can be accepted. By default 5xx status codes are reported as e
 
 `dd.http.server.tag.query-string`
 : **Environment Variable**: `DD_HTTP_SERVER_TAG_QUERY_STRING`<br>
-**Default**: `false`<br>
+**Default**: `true`<br>
 When set to `true` query string parameters and fragment get added to web server spans
 
 `dd.trace.enabled`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
It updates the documentation of Java Tracing Library, namely the default value for one of the configuration parameters (`dd.http.server.tag.query-string`).


### Motivation
Current version of the documentation does not reflect accurately how one of the configuration parameters is handled. Here [in the code](https://github.com/DataDog/dd-trace-java/blob/v1.3.0/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java#L48) we can see that an actual default value is `true` but [the documentation says](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) that it's `false`. It looks like it was changed in the code from `false` to `true` in [this commit](https://github.com/DataDog/dd-trace-java/commit/5e21cc217673ac6c84bc9f344bd37fef853d623c#diff-334fc9f6f4ddff0730a0861096a18ebc01c5a86394047b40c67db0d9cf650db2L45).

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
