### PR TITLE
removed beta warning banner

### DIFF
--- a/content/en/security/cspm/getting_started.md
+++ b/content/en/security/cspm/getting_started.md
@@ -93,10 +93,6 @@ Use one of the following methods to enable CSPM for your Azure subscriptions:
 
 {{% tab "GCP" %}}
 
-<div class="alert alert-warning">
-CSPM support for GCP is in public beta.
-</div>
-
 ### Set up the Datadog GCP integration
 
 If you haven't already, set up the [Google Cloud Platform integration][1] and make sure that you have successfully completed the steps for enabling [metric collection][2].


### PR DESCRIPTION
CSPM for GCP is now GA, updated docs to reflect this change

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
