### PR TITLE
updated readOnly values

### DIFF
--- a/static/resources/json/datadog-agent-ecs.json
+++ b/static/resources/json/datadog-agent-ecs.json
@@ -10,17 +10,17 @@
         {
           "containerPath": "/var/run/docker.sock",
           "sourceVolume": "docker_sock",
-          "readOnly": null
+          "readOnly": true
         },
         {
           "containerPath": "/host/sys/fs/cgroup",
           "sourceVolume": "cgroup",
-          "readOnly": null
+          "readOnly": true
         },
         {
           "containerPath": "/host/proc",
           "sourceVolume": "proc",
-          "readOnly": null
+          "readOnly": true
         }
       ],
       "environment": [


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updated the readOnly values from `null` to `true`.

### Motivation
[DOCS-4519](https://datadoghq.atlassian.net/browse/DOCS-4519), which is reader feedback pointing out that the JSON file provides an invalid value for the property called `MountPoint` in Amazon AWS.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4519]: https://datadoghq.atlassian.net/browse/DOCS-4519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-4519]: https://datadoghq.atlassian.net/browse/DOCS-4519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ