### PR TITLE
Update the instructions for finding Tenant Name

### DIFF
--- a/content/en/integrations/guide/azure-troubleshooting.md
+++ b/content/en/integrations/guide/azure-troubleshooting.md
@@ -13,7 +13,7 @@ further_reading:
 
 1. Navigate to [portal.azure.com][1].
 2. In the left sidebar, select **Azure Active Directory**.
-3. Under **Basic information**, you will find the **Name** value.
+3. Under **Basic information**, find the **Name** value.
 
 ## Unable to login
 

--- a/content/en/integrations/guide/azure-troubleshooting.md
+++ b/content/en/integrations/guide/azure-troubleshooting.md
@@ -13,11 +13,7 @@ further_reading:
 
 1. Navigate to [portal.azure.com][1].
 2. In the left sidebar, select **Azure Active Directory**.
-3. Under **Properties**, your tenant name is the **Directory ID** value.
-
-Your tenant name is also available from the URL when using the [classic portal][2]. It is the text in between (**not including**) the `@` and `#` symbol:
-
-{{< img src="integrations/guide/azure_troubleshooting/azure_tenant_url.png" alt="The azure tenant url with the text yourcompanyname.onmicrosoft.com highlighted between the @ and # symbols" style="width:70%">}}
+3. Under **Basic information**, you will find the **Name** value.
 
 ## Unable to login
 


### PR DESCRIPTION
Also remove reference to decommissioned classic portal

### What does this PR do?
Update instructions on how to find Tenant Name.

### Motivation
Saw out of date content.

<img width="1069" alt="image" src="https://user-images.githubusercontent.com/1248411/210487124-8dcb9f7b-ca1f-45a3-a857-07db86409468.png">

### Preview
https://docs-staging.datadoghq.com/islam/az-troubleshooting-update/integrations/guide/azure-troubleshooting/

### Additional Notes
N/A.

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
