### PR TITLE
📝 improve RUM proxy security warning formatting

### DIFF
--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -74,7 +74,9 @@ To successfully proxy request to Datadog:
 2. Forward the request to the URL set in the `ddforward` query parameter using the POST method.
 4. The request body must remain unchanged.
 
-Ensure the `ddforward` attribute points to a valid Datadog endpoint for your [Datadog site][2]. Failure to do so may result in an insecure configuration. 
+<div class="alert alert-error">
+Ensure the `ddforward` attribute points to a valid Datadog endpoint for your [Datadog site][2]. <strong>Failure to do so may result in an insecure configuration.</strong>
+</div>
 
 The site parameter is an SDK [initialization parameter][1]. Valid intake URL patterns for each site are listed below:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Improve the security warning formatting


![Screenshot 2023-01-04 at 14 36 29](https://user-images.githubusercontent.com/61787/210566800-e8140246-d505-4583-97f8-a95e27321ddc.png)

### Motivation

Make it more visible.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
