### PR TITLE
RUM & Logs package bump

### DIFF
--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -27,7 +27,7 @@ if (window.DD_RUM) {
             trackFrustrations: true,
             enableExperimentalFeatures: ["clickmap"],
             sampleRate: 50,
-            premiumSampleRate: 50,
+            sessionReplaySampleRate: 50,
             allowedTracingOrigins: [window.location.origin],
             internalAnalyticsSubdomain: 'iam-rum-intake'
         });

--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -2,6 +2,7 @@
 import configDocs from '../config/config-docs';
 const { env, branch } = document.documentElement.dataset;
 const lang = document.documentElement.lang || 'en';
+
 function getConfig() {
     if (env === 'live') {
         return configDocs['live'];
@@ -11,7 +12,9 @@ function getConfig() {
         return configDocs['development'];
     }
 }
+
 const Config = getConfig();
+
 if (window.DD_RUM) {
     if (env === 'preview' || env === 'live') {
         window.DD_RUM.init({
@@ -22,17 +25,21 @@ if (window.DD_RUM) {
             version: CI_COMMIT_SHORT_SHA,
             trackInteractions: true,
             trackFrustrations: true,
-            enableExperimentalFeatures: ["frustration-signals","clickmap"],
+            enableExperimentalFeatures: ["clickmap"],
             sampleRate: 50,
             premiumSampleRate: 50,
-            allowedTracingOrigins: [window.location.origin]
+            allowedTracingOrigins: [window.location.origin],
+            internalAnalyticsSubdomain: 'iam-rum-intake'
         });
+
         window.DD_RUM.startSessionReplayRecording();
+
         if (branch) {
             window.DD_RUM.addRumGlobalContext('branch', branch);
         }
     }
 }
+
 if (window.DD_LOGS) {
     // init browser logs
     window.DD_LOGS.init({
@@ -40,15 +47,19 @@ if (window.DD_LOGS) {
         forwardErrorsToLogs: true,
         env,
         service: 'docs',
-        version: CI_COMMIT_SHORT_SHA
+        version: CI_COMMIT_SHORT_SHA,
+        internalAnalyticsSubdomain: 'iam-rum-intake'
     });
+
     // global context
     window.DD_LOGS.addLoggerGlobalContext('host', window.location.host);
     window.DD_LOGS.addLoggerGlobalContext('referrer', document.referrer);
     window.DD_LOGS.addLoggerGlobalContext('lang', lang);
+
     if (branch) {
         window.DD_LOGS.addLoggerGlobalContext('branch', branch);
     }
+
     // Locally log to console
     window.DD_LOGS.logger.setHandler(Config.loggingHandler);
 }

--- a/assets/scripts/config/config-docs.js
+++ b/assets/scripts/config/config-docs.js
@@ -13,7 +13,7 @@ module.exports = {
         gaTag: 'UA-21102638-5'
     },
     preview: {
-        ddClientToken: 'pub36877d3864fab670b5ae7e1d5d26cb08',
+        ddClientToken: 'pub16bb5ef3e9bf55f156338987e27246c7',
         ddApplicationId: '3493b4e7-ab12-4852-8836-ba96af7bc745',
         loggingHandler: 'http',
         algoliaConfig: {

--- a/assets/scripts/config/config-docs.js
+++ b/assets/scripts/config/config-docs.js
@@ -14,7 +14,7 @@ module.exports = {
     },
     preview: {
         ddClientToken: 'pub36877d3864fab670b5ae7e1d5d26cb08',
-        ddApplicationId: 'c4e83ad8-4eda-4d2e-aae1-d943abce0463',
+        ddApplicationId: '3493b4e7-ab12-4852-8836-ba96af7bc745',
         loggingHandler: 'http',
         algoliaConfig: {
             index: 'docsearch_docs_preview',

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^8.0.0",
         "@babel/polyfill": "^7.4.4",
-        "@datadog/browser-logs": "^4.19.1",
-        "@datadog/browser-rum": "^4.19.1",
+        "@datadog/browser-logs": "^4.28.1",
+        "@datadog/browser-rum": "^4.28.1",
         "a11y": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/a11y-v1.0.1.tgz",
         "algoliasearch": "4.14.2",
         "bootstrap": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^8.0.0",
         "@babel/polyfill": "^7.4.4",
-        "@datadog/browser-logs": "^4.28.1",
-        "@datadog/browser-rum": "^4.28.1",
+        "@datadog/browser-logs": "^4.29.1",
+        "@datadog/browser-rum": "^4.29.1",
         "a11y": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/a11y-v1.0.1.tgz",
         "algoliasearch": "4.14.2",
         "bootstrap": "4.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1673,48 +1673,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/browser-core@npm:4.19.1":
-  version: 4.19.1
-  resolution: "@datadog/browser-core@npm:4.19.1"
-  checksum: ee6df60ecf6bbcae8f7d397d9b8ac0b5e830fdc045a8e56cdd93599dd602ff2987a9e56179b4ed0212c3546f3cdaecebb8161b17b3bab67ebd249444222ddc03
+"@datadog/browser-core@npm:4.28.1":
+  version: 4.28.1
+  resolution: "@datadog/browser-core@npm:4.28.1"
+  checksum: d4eed86af95a63ef6d68da71c16367b2f879d3bfeb18c1f81609102d3abbf716c491e6ec2e770f8fb0227e0cc8b66468a824bac1beaa05e6f3d3dc64821b44f6
   languageName: node
   linkType: hard
 
-"@datadog/browser-logs@npm:^4.19.1":
-  version: 4.19.1
-  resolution: "@datadog/browser-logs@npm:4.19.1"
+"@datadog/browser-logs@npm:^4.28.1":
+  version: 4.28.1
+  resolution: "@datadog/browser-logs@npm:4.28.1"
   dependencies:
-    "@datadog/browser-core": 4.19.1
+    "@datadog/browser-core": 4.28.1
   peerDependencies:
-    "@datadog/browser-rum": 4.19.1
+    "@datadog/browser-rum": 4.28.1
   peerDependenciesMeta:
     "@datadog/browser-rum":
       optional: true
-  checksum: 3c2b1029bcd44fdc70713b7adb8bec8d9861f68d9e22c83f876a730bd2ad443c2262dfdc38219146d7511b458da062e7c37bd293af81833d7adaa596b5bc6bee
+  checksum: 126d609c0bab58b754bf90a5500cf14f2b0a09b30353a11c0b364da3a50452aa1d6e74467e2a6ad0e2ca5074a2c1d08fe812a8d77b96adf3ee28e2d2bfde3701
   languageName: node
   linkType: hard
 
-"@datadog/browser-rum-core@npm:4.19.1":
-  version: 4.19.1
-  resolution: "@datadog/browser-rum-core@npm:4.19.1"
+"@datadog/browser-rum-core@npm:4.28.1":
+  version: 4.28.1
+  resolution: "@datadog/browser-rum-core@npm:4.28.1"
   dependencies:
-    "@datadog/browser-core": 4.19.1
-  checksum: fd9b471a380a6ecc585981b9b116b8e36cc005f443e08db884df1ae3fdee64758c6129fdc514cd40c37ea8e3ddc49f0d19f24397a4d1961eebb24248c111129b
+    "@datadog/browser-core": 4.28.1
+  checksum: 7e5dcaeeb5b8461a1a9e0b3554e8a36e5ee6e90778c4fff1812e549fb2f7a7c574c8312699ac8c24d959dd84c58750e2c282f9ef57f0424e591e337e94e36063
   languageName: node
   linkType: hard
 
-"@datadog/browser-rum@npm:^4.19.1":
-  version: 4.19.1
-  resolution: "@datadog/browser-rum@npm:4.19.1"
+"@datadog/browser-rum@npm:^4.28.1":
+  version: 4.28.1
+  resolution: "@datadog/browser-rum@npm:4.28.1"
   dependencies:
-    "@datadog/browser-core": 4.19.1
-    "@datadog/browser-rum-core": 4.19.1
+    "@datadog/browser-core": 4.28.1
+    "@datadog/browser-rum-core": 4.28.1
   peerDependencies:
-    "@datadog/browser-logs": 4.19.1
+    "@datadog/browser-logs": 4.28.1
   peerDependenciesMeta:
     "@datadog/browser-logs":
       optional: true
-  checksum: 2f158dd5b0c3fb77167898eea7d682b78b8b03610cbfbb3681821346263ffcc913d864b9cee7b1039f06491ed961de11d9c18a7ffc53aaed483306c2f391f55f
+  checksum: ce01749236f278cb584fec97045e8254402156aa9aa53fa052cf1a1368edb41e1627d94328a4db88e47a0681c28501e4bfafe505d5cc8d92069b141029cb3915
   languageName: node
   linkType: hard
 
@@ -4404,8 +4404,8 @@ __metadata:
     "@babel/plugin-proposal-object-rest-spread": ^7.18.6
     "@babel/polyfill": ^7.4.4
     "@babel/preset-env": ^7.18.6
-    "@datadog/browser-logs": ^4.19.1
-    "@datadog/browser-rum": ^4.19.1
+    "@datadog/browser-logs": ^4.28.1
+    "@datadog/browser-rum": ^4.28.1
     "@datadog/datadog-ci": ^1.2.0
     a11y: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/a11y-v1.0.1.tgz"
     acorn: ^7.1.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1673,48 +1673,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/browser-core@npm:4.28.1":
-  version: 4.28.1
-  resolution: "@datadog/browser-core@npm:4.28.1"
-  checksum: d4eed86af95a63ef6d68da71c16367b2f879d3bfeb18c1f81609102d3abbf716c491e6ec2e770f8fb0227e0cc8b66468a824bac1beaa05e6f3d3dc64821b44f6
+"@datadog/browser-core@npm:4.29.1":
+  version: 4.29.1
+  resolution: "@datadog/browser-core@npm:4.29.1"
+  checksum: 8bc45cf4151cb8c07b09de8c670c0484c478c23d9151f18e652f32d19c69bbd889f861db3742dc605ec0c601bc79483cb346ab6bb527b3c237827e5c5bef0475
   languageName: node
   linkType: hard
 
-"@datadog/browser-logs@npm:^4.28.1":
-  version: 4.28.1
-  resolution: "@datadog/browser-logs@npm:4.28.1"
+"@datadog/browser-logs@npm:^4.29.1":
+  version: 4.29.1
+  resolution: "@datadog/browser-logs@npm:4.29.1"
   dependencies:
-    "@datadog/browser-core": 4.28.1
+    "@datadog/browser-core": 4.29.1
   peerDependencies:
-    "@datadog/browser-rum": 4.28.1
+    "@datadog/browser-rum": 4.29.1
   peerDependenciesMeta:
     "@datadog/browser-rum":
       optional: true
-  checksum: 126d609c0bab58b754bf90a5500cf14f2b0a09b30353a11c0b364da3a50452aa1d6e74467e2a6ad0e2ca5074a2c1d08fe812a8d77b96adf3ee28e2d2bfde3701
+  checksum: 45e2cde795710d8d537e72eda166c5ed9b7c4ef54e842326db79d98a9fb0c72443d25ef7992423625d866f84c8a82929dce2fd27a128cb022977a78b73693999
   languageName: node
   linkType: hard
 
-"@datadog/browser-rum-core@npm:4.28.1":
-  version: 4.28.1
-  resolution: "@datadog/browser-rum-core@npm:4.28.1"
+"@datadog/browser-rum-core@npm:4.29.1":
+  version: 4.29.1
+  resolution: "@datadog/browser-rum-core@npm:4.29.1"
   dependencies:
-    "@datadog/browser-core": 4.28.1
-  checksum: 7e5dcaeeb5b8461a1a9e0b3554e8a36e5ee6e90778c4fff1812e549fb2f7a7c574c8312699ac8c24d959dd84c58750e2c282f9ef57f0424e591e337e94e36063
+    "@datadog/browser-core": 4.29.1
+  checksum: 8870d4bc24d6a1d7a3d86cb64c2edabde18c0c478df0a221b33d4f7655e6b0f6ec79a40969982c95b5fbe83cd39baa133ea8f8475c65e9c82254031aefddb8a8
   languageName: node
   linkType: hard
 
-"@datadog/browser-rum@npm:^4.28.1":
-  version: 4.28.1
-  resolution: "@datadog/browser-rum@npm:4.28.1"
+"@datadog/browser-rum@npm:^4.29.1":
+  version: 4.29.1
+  resolution: "@datadog/browser-rum@npm:4.29.1"
   dependencies:
-    "@datadog/browser-core": 4.28.1
-    "@datadog/browser-rum-core": 4.28.1
+    "@datadog/browser-core": 4.29.1
+    "@datadog/browser-rum-core": 4.29.1
   peerDependencies:
-    "@datadog/browser-logs": 4.28.1
+    "@datadog/browser-logs": 4.29.1
   peerDependenciesMeta:
     "@datadog/browser-logs":
       optional: true
-  checksum: ce01749236f278cb584fec97045e8254402156aa9aa53fa052cf1a1368edb41e1627d94328a4db88e47a0681c28501e4bfafe505d5cc8d92069b141029cb3915
+  checksum: 6c6433f130ec9b503a2b25afb05d1374e7e5e85f798808015622eeb6139dedb97a6c045a90cc70401ad3de8d442a54484166f4ce7ae03d94c6ad937f65154608
   languageName: node
   linkType: hard
 
@@ -4404,8 +4404,8 @@ __metadata:
     "@babel/plugin-proposal-object-rest-spread": ^7.18.6
     "@babel/polyfill": ^7.4.4
     "@babel/preset-env": ^7.18.6
-    "@datadog/browser-logs": ^4.28.1
-    "@datadog/browser-rum": ^4.28.1
+    "@datadog/browser-logs": ^4.29.1
+    "@datadog/browser-rum": ^4.29.1
     "@datadog/datadog-ci": ^1.2.0
     a11y: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/a11y-v1.0.1.tgz"
     acorn: ^7.1.1


### PR DESCRIPTION
### What does this PR do?
- bumps package version for DD Rum & Logs
- adds IA subdomain param to config
- updates config so data populates in the `Documentation - Prod` RUM application in DD

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2989

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/rum-bump

- [ ] RUM data is populating correctly ([my preview session here](https://dd-corpsite.datadoghq.com/rum/explorer?query=%40application.id%3A3493b4e7-ab12-4852-8836-ba96af7bc745%20%40type%3Asession%20env%3Apreview&cols=&event=AgAAAYWXcsrRjyubmQAAAAAAAAAYAAAAAEFZV1hjc3JSQUFDVzRaXzRxaEV4REFHQQAAACQAAAAAMDE4NTk3ODYtNzRkNS00M2MwLWExMmEtMDMwYTg5NWQ2OGM3&from_ts=1673198704034&to_ts=1673285104034&live=true))
- [ ] RUM data surfaces in the `Documentation - Prod` application in DD under `preview` env.
- [ ] frustration signals still work
- [ ] confirm RUM SDK requests are using the `iam-rum-intake` subdomain (in browser tools navigate to `Network`, filter results by `Fetch/XHR`, inspect headers.   This should work in Chrome and FF.)

### Additional Notes
We'll remove the `Documentation - Staging` app in DD once the current data is no longer retained
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[WEB-2989]: https://datadoghq.atlassian.net/browse/WEB-2989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ