### PR TITLE
[go] Update B3 header environment variable documentation

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/go.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go.md
@@ -206,10 +206,16 @@ configuring injection/extraction styles. Two styles are
 supported: `Datadog` and `B3`.
 
 Configure injection styles using the environment variable:
-`DD_PROPAGATION_STYLE_INJECT=Datadog,B3`
+`DD_TRACE_PROPAGATION_STYLE_INJECT=Datadog,B3`
 
 Configure extraction styles using the environment variable:
-`DD_PROPAGATION_STYLE_EXTRACT=Datadog,B3`
+`DD_TRACE_PROPAGATION_STYLE_EXTRACT=Datadog,B3`
+
+Configure both styles using the environment variable:
+`DD_TRACE_PROPAGATION_STYLE=Datadog,B3`
+
+Values from the respective injection and extraction style environment variables
+take precedence over `DD_TRACE_PROPAGATION_STYLE`.
 
 The values of these environment variables are comma separated lists of
 header styles that are enabled for injection or extraction. By default,

--- a/content/en/tracing/trace_collection/custom_instrumentation/go.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go.md
@@ -212,10 +212,9 @@ Configure extraction styles using the environment variable:
 `DD_TRACE_PROPAGATION_STYLE_EXTRACT=Datadog,B3`
 
 Configure both styles using the environment variable:
-`DD_TRACE_PROPAGATION_STYLE=Datadog,B3`
-
-Values from the respective injection and extraction style environment variables
-take precedence over `DD_TRACE_PROPAGATION_STYLE`.
+`DD_TRACE_PROPAGATION_STYLE=Datadog,B3`.
+Note that if either `DD_TRACE_PROPAGATION_STYLE_INJECT` or 
+`DD_TRACE_PROPAGATION_STYLE_EXTRACT` are set, those will take precedence.
 
 The values of these environment variables are comma separated lists of
 header styles that are enabled for injection or extraction. By default,

--- a/content/en/tracing/trace_collection/custom_instrumentation/go.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go.md
@@ -213,8 +213,7 @@ Configure extraction styles using the environment variable:
 
 Configure both styles using the environment variable:
 `DD_TRACE_PROPAGATION_STYLE=Datadog,B3`.
-Note that if either `DD_TRACE_PROPAGATION_STYLE_INJECT` or 
-`DD_TRACE_PROPAGATION_STYLE_EXTRACT` are set, those will take precedence.
+*Note*: `DD_TRACE_PROPAGATION_STYLE_INJECT` and `DD_TRACE_PROPAGATION_STYLE_EXTRACT`, if set, take precedence.
 
 The values of these environment variables are comma separated lists of
 header styles that are enabled for injection or extraction. By default,


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update the documentation for configuring B3 header injection and extraction for
the Go tracer.

### Motivation

The Go tracer has changed the environment variables for configuring B3
headers injection and extraction, including a new environment variable
to configure both. See https://github.com/DataDog/dd-trace-go/pull/1603.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
