### PR TITLE
Standardize "Synthetic" Modifier in Dashboard Docs

### DIFF
--- a/content/en/synthetics/_index.md
+++ b/content/en/synthetics/_index.md
@@ -60,7 +60,7 @@ Use the [integration between Synthetic tests and APM traces][16] to find the roo
 
 ## Access out-of-the-box dashboards
 
-Analyze performance information about your API tests, multistep API tests, browser tests, and private locations, as well as Datadog events, with [out-of-the-box Synthetics dashboards][17]. 
+Analyze performance information about your API tests, multistep API tests, browser tests, and private locations, as well as Datadog events, with [out-of-the-box Synthetic dashboards][17]. 
 
 {{< img src="synthetics/test_summary_dashboard.png" alt="Test Summary Dashboard" style="width:100%;">}}
 

--- a/content/en/synthetics/dashboards/_index.md
+++ b/content/en/synthetics/dashboards/_index.md
@@ -1,7 +1,7 @@
 ---
-title: Synthetics Dashboards
+title: Synthetic Dashboards
 kind: documentation
-description: Explore out-of-the-box Synthetics dashboards to learn more about your Synthetic tests.  
+description: Explore out-of-the-box Synthetic dashboards to learn more about your Synthetic tests.  
 further_reading:
 - link: '/synthetics/'
   tag: 'Documentation'
@@ -13,36 +13,36 @@ further_reading:
 
 ## Overview
 
-When you create a Synthetics test, Datadog [collects data][1] and generates dashboards about your stack, browser applications, or overall tests' performance, private locations, and events. 
+When you create a Synthetic test, Datadog [collects data][1] and generates dashboards about your stack, browser applications, or overall tests' performance, private locations, and events. 
 
-Access your Synthetics dashboards by filtering for `Synthetics` in the search query of the [**Dashboard List**][2] or by clicking on the dropdown menu under [**Dashboards**][3] on the [Synthetic Monitoring homepage][4].
+Access your Synthetic dashboards by filtering for `Synthetics` in the search query of the [**Dashboard List**][2] or by clicking on the dropdown menu under [**Dashboards**][3] on the [Synthetic Monitoring homepage][4].
 
 {{< img src="synthetics/dashboards/synthetic_tests_dashboards.png" alt="Synthetic Monitoring Dashboards" style="width:100%;">}}
 
-{{< whatsnext desc="You can explore the following out-of-the-box Synthetics dashboards:" >}}
+{{< whatsnext desc="You can explore the following out-of-the-box Synthetic dashboards:" >}}
   {{< nextlink href="/synthetics/dashboards/api_test" >}}<u>API Test Performance</u>: Monitor your endpoints and services. {{< /nextlink >}}
   {{< nextlink href="/synthetics/dashboards/browser_test" >}}<u>Browser Test Performance</u>: View your browser tests' web performance, insights into third-party providers, and Core Web Vitals. {{< /nextlink >}}
     {{< nextlink href="/synthetics/dashboards/testing_coverage" >}}<u>Testing Coverage</u>: Evaluate your browser tests' application coverage and identify popular elements in your application to track using RUM and Synthetics data. {{< /nextlink >}}
   {{< nextlink href="/synthetics/dashboards/test_summary" >}}<u>Test Summary</u>: See insights about your Synthetic tests by region, environment, or team. {{< /nextlink >}}
 {{< /whatsnext >}}
 
-## Interact with Synthetics dashboards
+## Interact with Synthetic dashboards
 
 You can clone [dashboards][5] and customize them by team, environment, or region using template variables.
 
 ### Template variables
 
-The generated Synthetics dashboards automatically contain a set of default template variables. Use the template variable dropdown menus to narrow the data shown in the dashboard. For example, you can filter for a specific browser type with the `Browser` template variable.
+The generated Synthetic dashboards automatically contain a set of default template variables. Use the template variable dropdown menus to narrow the data shown in the dashboard. For example, you can filter for a specific browser type with the `Browser` template variable.
 
 ### Saved views
 
-The Synthetics dashboard has a default view. To adjust the dashboard view, click the **Edit** icon and customize your template variables. 
+The Synthetic dashboard has a default view. To adjust the dashboard view, click the **Edit** icon and customize your template variables. 
 
 Once you are done editing, click **Save** and select **Save selections as view** from the left hand dropdown menu. Enter a name for your saved view and click **Save**.
 
 ### Customize dashboards
 
-To clone your Synthetics dashboard, click the **Settings** icon and select **Clone dashboard**. To add more widgets, powerpacks, or apps, scroll down to the bottom and click the **+** icon. 
+To clone your Synthetic dashboard, click the **Settings** icon and select **Clone dashboard**. To add more widgets, powerpacks, or apps, scroll down to the bottom and click the **+** icon. 
 
 ## Further Reading
 

--- a/content/en/synthetics/dashboards/api_test.md
+++ b/content/en/synthetics/dashboards/api_test.md
@@ -1,5 +1,5 @@
 ---
-title: Synthetics API Test Performance Dashboard
+title: Synthetic API Test Performance Dashboard
 kind: documentation
 further_reading:
 - link: '/synthetics/ci_results_explorer'

--- a/content/en/synthetics/dashboards/browser_test.md
+++ b/content/en/synthetics/dashboards/browser_test.md
@@ -1,7 +1,7 @@
 ---
-title: Synthetics Browser Test Performance Dashboard
+title: Synthetic Browser Test Performance Dashboard
 kind: documentation
-description: Learn about the out-of-the-box Synthetics browser test performance dashboard.
+description: Learn about the out-of-the-box Synthetic browser test performance dashboard.
 further_reading:
 - link: '/synthetics/ci_results_explorer'
   tag: 'Documentation'

--- a/content/en/synthetics/dashboards/test_summary.md
+++ b/content/en/synthetics/dashboards/test_summary.md
@@ -1,5 +1,5 @@
 ---
-title: Synthetics Test Summary Dashboard
+title: Synthetic Test Summary Dashboard
 kind: documentation
 further_reading:
 - link: '/synthetics/ci_results_explorer'


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Standardize "Synthetic" as the modifier for the Synthetic Monitoring product.

### Motivation
<!-- What inspired you to submit this pull request?-->

Conversation in Transifex with Spanish translators (https://www.transifex.com/datadog/documentation_loc/translate/#es_ES/content_en_getting_started_synthetics_private_location_md/190359746).

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
