### PR TITLE
[ccm] add support for parquet format

### DIFF
--- a/content/en/cloud_cost_management/_index.md
+++ b/content/en/cloud_cost_management/_index.md
@@ -30,8 +30,8 @@ Select the following Delivery options:
 
 * Time granularity: **Hourly**
 * Report versioning: **Create new report version**
-* Compression type: **GZIP**
-* Format: `text/csv`
+* Compression type: **GZIP** or **Parquet**
+* Format: `text/csv` or `Parquet`
 
 ### Configure the AWS integration
 


### PR DESCRIPTION
### What does this PR do?
Indicates that Parquet format is acceptable for reports ingested by CCM (in addition to GZIP csv)

### Motivation
We want to make it clear that we support both formats.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Here's what the setup screen looks like

![image](https://user-images.githubusercontent.com/1075271/210619977-01bf30ec-7fbc-47a2-b24b-ef03816be160.png)

![image](https://user-images.githubusercontent.com/1075271/210620020-88b4d3d2-9dfc-4c28-a889-a270572e117d.png)

![image](https://user-images.githubusercontent.com/1075271/210620048-ea3e2a2a-91ac-4373-b3fb-72e1a29a58ea.png)


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
