### PR TITLE
Revamp the ASM blocking page configuration section to include in 2 pages

### DIFF
--- a/content/en/security/application_security/how-appsec-works.md
+++ b/content/en/security/application_security/how-appsec-works.md
@@ -89,6 +89,8 @@ From there, all services already protected by ASM block incoming requests perfor
 
 {{% asm-protection-page-configuration %}}
 
+{{< img src="/security/application_security/asm-blocking-page-html.png" alt="The page displayed as ASM blocks requests originating from blocked IPs" width="75%" >}}
+
 ## Coverage
 
 Datadog ASM categorizes attack attempts into different threat types:

--- a/content/en/security/application_security/how-appsec-works.md
+++ b/content/en/security/application_security/how-appsec-works.md
@@ -87,13 +87,7 @@ From there, all services already protected by ASM block incoming requests perfor
 
 {{< img src="/security/application_security/asm-blocking-ui.png" alt="A security signal panel in Datadog ASM, allowing to block the attackers' IPs" width="75%">}}
 
-The blocked requests feature JSON or HTML content. If the [`Accept` HTTP header][19] is pointing to HTML - like `text/html` -, the HTML content is used, otherwise the JSON one is. 
-
-Both sets of content is embedded in the Datadog tracer library package and loaded locally. See the examples of the templates for [HTML][17] and [JSON][18] in the Datadog Java tracer source code on Github.
-
-The HTML and JSON content can both be changed using the `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML` and `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON` environment variables. Alternatively, you can use the `dd.appsec.http.blocked.template.html` / `dd.appsec.http.blocked.template.json` configuration entries.
-
-{{< img src="/security/application_security/asm-blocking-page-html.png" alt="The page displayed as ASM blocks requests originating from blocked IPs" width="75%">}}
+{{% asm-protection-page-configuration %}}
 
 ## Coverage
 

--- a/content/en/security/application_security/setup_and_configure.md
+++ b/content/en/security/application_security/setup_and_configure.md
@@ -303,6 +303,10 @@ To disable ASM, remove the `DD_APPSEC_ENABLED=true` environment variable from yo
 
 If you need additional help, contact [Datadog support][6].
 
+## Configure a Custom Blocking Page / Payload
+
+{{% asm-protection-page-configuration %}}
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/security/application_security/setup_and_configure.md
+++ b/content/en/security/application_security/setup_and_configure.md
@@ -303,9 +303,11 @@ To disable ASM, remove the `DD_APPSEC_ENABLED=true` environment variable from yo
 
 If you need additional help, contact [Datadog support][6].
 
-## Configure a Custom Blocking Page or Payload
+## Configure a custom blocking page or payload
 
 {{% asm-protection-page-configuration %}}
+
+{{<img src="/security/application_security/asm-blocking-page-html.png" alt="The page displayed as ASM blocks requests originating from blocked IPs" width="75%" >}}
 
 ## Further Reading
 

--- a/content/en/security/application_security/setup_and_configure.md
+++ b/content/en/security/application_security/setup_and_configure.md
@@ -303,7 +303,7 @@ To disable ASM, remove the `DD_APPSEC_ENABLED=true` environment variable from yo
 
 If you need additional help, contact [Datadog support][6].
 
-## Configure a Custom Blocking Page / Payload
+## Configure a Custom Blocking Page or Payload
 
 {{% asm-protection-page-configuration %}}
 

--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -4,7 +4,7 @@ Both sets of content is embedded in the Datadog Tracer library package and loade
 
 The HTML and JSON content can both be changed using the `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML` and `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON` environment variables. Alternatively, you can use the `dd.appsec.http.blocked.template.html` or `dd.appsec.http.blocked.template.json` configuration entries.
 
-< img src="/security/application_security/asm-blocking-page-html.png" alt="The page displayed as ASM blocks requests originating from blocked IPs" width="75%" style="center" >
+<img src="/security/application_security/asm-blocking-page-html.png" alt="The page displayed as ASM blocks requests originating from blocked IPs" width="75%" style="center">
 
 [101]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/resources/datadog/trace/bootstrap/blocking/template.html
 [102]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/resources/datadog/trace/bootstrap/blocking/template.json

--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -1,0 +1,7 @@
+The blocked requests feature JSON or HTML content. If the [`Accept` HTTP header][19] is pointing to HTML - like `text/html` -, the HTML content is used, otherwise the JSON one is. 
+
+Both sets of content is embedded in the Datadog tracer library package and loaded locally. See the examples of the templates for [HTML][17] and [JSON][18] in the Datadog Java tracer source code on Github.
+
+The HTML and JSON content can both be changed using the `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML` and `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON` environment variables. Alternatively, you can use the `dd.appsec.http.blocked.template.html` / `dd.appsec.http.blocked.template.json` configuration entries.
+
+{{< img src="/security/application_security/asm-blocking-page-html.png" alt="The page displayed as ASM blocks requests originating from blocked IPs" width="75%">}}

--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -1,7 +1,10 @@
-The blocked requests feature JSON or HTML content. If the [`Accept` HTTP header][19] is pointing to HTML - like `text/html` -, the HTML content is used, otherwise the JSON one is. 
+The blocked requests feature JSON or HTML content. If the [`Accept` HTTP header][19] is pointing to HTML—like `text/html`—, the HTML content is used; otherwise, the JSON one is used. 
 
-Both sets of content is embedded in the Datadog tracer library package and loaded locally. See the examples of the templates for [HTML][17] and [JSON][18] in the Datadog Java tracer source code on Github.
+Both sets of content is embedded in the Datadog Tracer library package and loaded locally. See examples of the templates for [HTML][101] and [JSON][102] in the Datadog Java tracer source code on GitHub.
 
-The HTML and JSON content can both be changed using the `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML` and `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON` environment variables. Alternatively, you can use the `dd.appsec.http.blocked.template.html` / `dd.appsec.http.blocked.template.json` configuration entries.
+The HTML and JSON content can both be changed using the `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML` and `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON` environment variables. Alternatively, you can use the `dd.appsec.http.blocked.template.html` or `dd.appsec.http.blocked.template.json` configuration entries.
 
-{{< img src="/security/application_security/asm-blocking-page-html.png" alt="The page displayed as ASM blocks requests originating from blocked IPs" width="75%">}}
+< img src="/security/application_security/asm-blocking-page-html.png" alt="The page displayed as ASM blocks requests originating from blocked IPs" width="75%" style="center" >
+
+[101]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/resources/datadog/trace/bootstrap/blocking/template.html
+[102]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/resources/datadog/trace/bootstrap/blocking/template.json

--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -4,7 +4,5 @@ Both sets of content is embedded in the Datadog Tracer library package and loade
 
 The HTML and JSON content can both be changed using the `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML` and `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON` environment variables. Alternatively, you can use the `dd.appsec.http.blocked.template.html` or `dd.appsec.http.blocked.template.json` configuration entries.
 
-<img src="/security/application_security/asm-blocking-page-html.png" alt="The page displayed as ASM blocks requests originating from blocked IPs" width="75%" style="center">
-
 [101]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/resources/datadog/trace/bootstrap/blocking/template.html
 [102]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/resources/datadog/trace/bootstrap/blocking/template.json


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
