### PR TITLE
updating to reflect that you no longer email support

### DIFF
--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -48,7 +48,7 @@
   },
 
   "email_support_sentence": {
-    "other": "Datadog サポートチームには、メール（<a href=\"mailto:support@datadoghq.com\">support@datadoghq.com</a>）でお問い合わせいただけます（すべてのサイト）"
+    "other": "help.datadoghq.com にアクセスして、サポート チームに連絡することができます。"
   },
 
   "live_chat_support_sentence": {


### PR DESCRIPTION
### What does this PR do?
Updates the JA support page to indicate that you no longer email support. 

This is one of the rare things NOT handled by transifex, but it is officially translated. 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
