### PR TITLE
forgot to make it an href

### DIFF
--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -48,7 +48,7 @@
   },
 
   "email_support_sentence": {
-    "other": "help.datadoghq.com にアクセスして、サポート チームに連絡することができます。"
+    "other": "<a href=\"http://help.datadoghq.com\" target=\"_blank\" rel=\"noopener\">help.datadoghq.com</a> にアクセスして、サポート チームに連絡することができます。"
   },
 
   "live_chat_support_sentence": {


### PR DESCRIPTION
### What does this PR do?
I forgot to make https://github.com/DataDog/documentation/pull/16371 a href 🙃

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
