### PR TITLE
removed CREATE TEMP TABLE from mysql instructions

### DIFF
--- a/content/en/database_monitoring/setup_mysql/rds.md
+++ b/content/en/database_monitoring/setup_mysql/rds.md
@@ -107,7 +107,6 @@ Create the following schema:
 ```sql
 CREATE SCHEMA IF NOT EXISTS datadog;
 GRANT EXECUTE ON datadog.* to datadog@'%';
-GRANT CREATE TEMPORARY TABLES ON datadog.* TO datadog@'%';
 ```
 
 Create the the `explain_statement` procedure to enable the Agent to collect explain plans:

--- a/content/fr/database_monitoring/setup_mysql/rds.md
+++ b/content/fr/database_monitoring/setup_mysql/rds.md
@@ -107,7 +107,6 @@ Créez le schéma suivant :
 ```sql
 CREATE SCHEMA IF NOT EXISTS datadog;
 GRANT EXECUTE ON datadog.* to datadog@'%';
-GRANT CREATE TEMPORARY TABLES ON datadog.* TO datadog@'%';
 ```
 
 Créez la procédure `explain_statement` afin d'activer la collecte de plans d'exécution par l'Agent :

--- a/content/ja/database_monitoring/setup_mysql/rds.md
+++ b/content/ja/database_monitoring/setup_mysql/rds.md
@@ -106,7 +106,6 @@ GRANT SELECT ON performance_schema.* TO datadog@'%';
 ```sql
 CREATE SCHEMA IF NOT EXISTS datadog;
 GRANT EXECUTE ON datadog.* to datadog@'%';
-GRANT CREATE TEMPORARY TABLES ON datadog.* TO datadog@'%';
 ```
 
 Agent が説明プランを収集できるようにするには、`explain_statement` プロシージャを作成します。


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The mysql monitoring account doesn't require CREATE TEMP TABLE privilege anymore. The documentation has been updated to reflect that.

### Motivation
The SQL statement sampling has been redesigned in https://github.com/DataDog/integrations-core/pull/13561 .

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
