### PR TITLE
[DOCS-4556] Add Observability Pipelines Worker Aggregator Architecture doc

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2513,6 +2513,11 @@ main:
     parent: observability_pipelines_production_deployment_overview
     identifier: observability_pipelines_architecture_design_and_principles
     weight: 201
+  - name: Aggregator Architecture
+    url: observability_pipelines/production_deployment_overview/aggregator_architecture/
+    parent: observability_pipelines_production_deployment_overview
+    identifier: observability_pipelines_aggregator_architecture
+    weight: 202
   - name: Vector Configurations
     url: observability_pipelines/vector_configurations/
     parent: observability_pipelines

--- a/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
+++ b/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
@@ -153,7 +153,7 @@ For push-based sources, front your Observability Pipelines Worker instances with
 
 A load balancer is not required for pull-based sources; just deploy Observability Pipelines Worker and scale it up and down. Your pub-sub system coordinates exclusive access to the data when Observability Pipelines Worker asks to read it.
 
-See the [Advanced configurations](#advanced-configurations) for more information on mixed workloads (push and pull-based sources).
+See [Advanced configurations](#advanced-configurations) for more information on mixed workloads (push and pull-based sources).
 
 #### Load balancing
 

--- a/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
+++ b/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
@@ -20,27 +20,6 @@ This guide walks you through the recommended aggregator architecture for new Obs
 - Using the Observability Pipelines Worker as part of your [disaster recovery](#disaster-recovery).
 - More [advanced configurations](#advanced-configurations) for deploying multiple aggregators, publish-subscribe systems, and global aggregation.
 
-### Comparison
-
-Compared to the Observability Pipelines Worker agent architecture, the aggregator architecture has the following advantages and disadvantages.
-
-#### Advantages
-
-- **Easy to set up.** Deploy Observability Pipelines Worker like any other service.
-- **Easy to adopt.** Data sources can be onboarded incrementally, one source at a time.
-- **Reduced footprint.** This architecture touches fewer nodes.
-- **High availability.** Multi-node failover mitigates failure scenarios.
-- **High durability.** Centralized routing allows for sophisticated durability strategies.
-- **Improved security.** Edge nodes can be locked down, aggregator nodes can be hardened.
-- **Optimized delivery.** Data can be streamlined for optimal delivery to destinations.
-- **Service reliability.** Doing less on the edge reduces agent-induced incidents.
-- **Reduced lock-in.** Collect data from any source and send it to any destination.
-- **Global aggregation.** Data can be aggregated and analyzed across multiple nodes.
-
-#### Disadvantages
-
-- An entire aggregator outage can be a single point of failure for your observability data pipeline. Therefore, use [high availability](#high-availability) tactics to help mitigate this issue.
-
  ## Requirements
 
 | Type              | Minimum Value                                         			|
@@ -201,7 +180,7 @@ In these cases, the following respective mitigation tactics are recommended:
 
 ### Vertical scaling
 
-Observability Pipelines Worker's concurrency model automatically scales to take advantage of all vCPUs. There are no concurrency settings or configuration changes required. When vertically scaling, Datadog recommends capping an instance's size to process no more than 50% of your total volume to force deploy at least two Observability Pipelines Worker instances for high availability.
+Observability Pipelines Worker's concurrency model automatically scales to take advantage of all vCPUs. There are no concurrency settings or configuration changes required. When vertically scaling, Datadog recommends capping an instance's size to process no more than 50% of your total volume and deploying at least two Observability Pipelines Worker instances for high availability.
 
 ### Autoscaling
 

--- a/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
+++ b/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
@@ -9,58 +9,58 @@ The Observability Pipelines Worker's aggregator architecture deploys Observabili
 
 Deploy Observability Pipelines Worker into your infrastructure, like any other service to intercept and manipulate data, and then forward it to your destinations. Each Observability Pipelines Worker instance operates independently, so that you can scale the architecture with a simple load balancer.
 
-This guide walks you through the recommended aggregator architecture for new Observability Pipelines Worker users, specifically:
+This guide walks you through the recommended aggregator architecture for new Observability Pipelines Worker users. Specifically, these topics:
 
-- [Configuring the Observability Pipelines Worker][Link to section] to collect, process, and route data. 
-- [Optimizing instance size][Link to section] so you can horizontally scale the Observability Pipelines Worker aggregator. 
-- Starting points to estimate your resource capacity for [capacity planning][Link to section].
-- [Scaling][Link to section] the Observability Pipelines Worker.
-- Determining your [network topology][Link to section] with the Observability Pipelines Worker and network configurations.
-- Achieving [high durability] and [high availability].
-- Using the Observability Pipelines Worker as part of your Disaster Recovery.
-- More [advanced configurations][Link to section]: deploying multiple aggregators, pub-sub systems and global aggregation
+- [Configuring the Observability Pipelines Worker](#configuring-observability-pipelines-worker) to collect, process, and route data. 
+- [Optimizing the instance](#optimizing-the-instance) so you can horizontally scale the Observability Pipelines Worker aggregator. 
+- Starting points to estimate your resource capacity for [capacity planning](#capacity-planning).
+- [Scaling](#scaling) the Observability Pipelines Worker.
+- Determining your [network topology and configurations](#networking) for the Observability Pipelines Worker.
+- Achieving [high durability](#high-durability) and [high availability](#high-availability).
+- Using the Observability Pipelines Worker as part of your [disaster recovery](#disaster-recovery).
+- More [advanced configurations](#advanced-configurations) for deploying multiple aggregators, pub-sub systems, and global aggregation
 
-## Comparison
+### Comparison
 
 Compared to the Observability Pipelines Worker agent architecture, the aggregator architecture has the following advantages and disadvantages.
 
-### Advantages
+#### Advantages
 
-- **Easy to set up**: Deploy Observability Pipelines Worker like any other service.
-- **Easy to adopt**: Data sources can be onboarded incrementally, one source at a time.
-- **Reduced footprint**. This architecture touches fewer nodes.
-- **High availability**. Multi-node failover mitigates failure scenarios.
-- **High durability**. Centralized routing allows for sophisticated durability strategies.
-- **Improved security**. Edge nodes can be locked down, aggregator nodes can be hardened.
-- **Optimized delivery**. Data can be streamlined for optimal delivery to destinations.
-- **Service reliability**. Doing less on the edge reduces agent-induced incidents.
-- **Reduced lock-in**. Collect data from any source and send it to any destination.
-- **Global aggregation**. Data can be aggregated and analyzed across multiple nodes.
+- **Easy to set up.** Deploy Observability Pipelines Worker like any other service.
+- **Easy to adopt.** Data sources can be onboarded incrementally, one source at a time.
+- **Reduced footprint.** This architecture touches fewer nodes.
+- **High availability.** Multi-node failover mitigates failure scenarios.
+- **High durability.** Centralized routing allows for sophisticated durability strategies.
+- **Improved security.** Edge nodes can be locked down, aggregator nodes can be hardened.
+- **Optimized delivery.** Data can be streamlined for optimal delivery to destinations.
+- **Service reliability.** Doing less on the edge reduces agent-induced incidents.
+- **Reduced lock-in.** Collect data from any source and send it to any destination.
+- **Global aggregation.** Data can be aggregated and analyzed across multiple nodes.
 
-### Disadvantages
+#### Disadvantages
 
-- An entire aggregator outage can be a single point of failure for your observability data pipeline. Therefore, use high availability[link to high availability section] tactics to help mitigate this issue.
- 
+- An entire aggregator outage can be a single point of failure for your observability data pipeline. Therefore, use [high availability](#high-availability) tactics to help mitigate this issue.
+
+ ## Requirements
+
+| Type              | Minimum Value                                         			|
+| ----------------- | ----------------------------------------------------------------- |
+| CPU Cores         | ≥ 2 vCPUs (see [CPU sizing](#cpu-sizing))             			|
+| CPU Architectures | X86_64, AMD64, ARM64, ARMHF, ARMv7                   		 		|
+| Memory            | ≥ 2 GiB per vCPU (see [memory sizing](#memory-sizing))			|
+| Disk              | ≥ 1 Gib, more for disk buffers (see [disk sizing](#disk-sizing))  |
+
  ## Quickstart
 
  See [Setup][link to come] for installing the Observability Pipelines Worker.
 
- ## Requirements
-
-| Type              | Minimum Value                                         |
-| ----------------- | ----------------------------------------------------- |
-| CPU Cores         | ≥ 2 vCPUs (See [CPU sizing][link])                    |
-| CPU Architectures | X86_64, AMD64, ARM64, ARMHF, ARMv7                    |
-| Memory            | ≥ 2 GiB per vCPU (See [memory sizing]())              |
-| Disk              | ≥ 1 Gib, more for disk buffers (See [disk sizing]())  |
-
-## Configuring
+## Configuring Observability Pipelines Worker
 
 While your configuration may deviate, it should still follow the primary goals below.
 
 ### Collecting data
 
-Make it easy to send data to your Observability Pipelines Worker aggregator by integrating as many sources as possible. It’s not uncommon for Observability Pipelines Worker aggregators to have dozens of sources. Configure the source component as long as it supports your security and durability requirements. This makes it easy for users across your company to adopt the Observability Pipelines Worker aggregator, even if they are using legacy services.
+Make it easy to send data to your Observability Pipelines Worker aggregator by integrating as many sources as possible. It's not uncommon for Observability Pipelines Worker aggregators to have dozens of sources. Configure the source component as long as it supports your security and durability requirements. This makes it easy for users across your company to adopt the Observability Pipelines Worker aggregator, even if they are using legacy services.
 
 ### Processing data
 
@@ -72,18 +72,18 @@ Use the Observability Pipelines Worker aggregator for processing most of your da
 
 Separate your system of analysis (for example, Datadog) from your system of record (for example, AWS S3). This allows you to optimize them independently towards their respective goals.
 
-## Sizing
+## Optimizing the instance
 
 ### Instance sizing
 
 Compute optimized instances with at least 8 vCPUs and 16 GiB of memory. These are good units for horizontally scaling the Observability Pipelines Worker aggregator. Observability Pipelines Worker can vertically scale and automatically take advantage of additional resources if you choose larger instances. Choose a size that allows for at least two Observability Pipelines Worker instances for your data volume to improve availability.
 
-| Cloud Provider| Recommendation                                    |
-| ------------- | ------------------------------------------------- |
-| AWS           | c6i.2xlarge (Recommended) or c6g.2xlarge          |
-| Azure         | f8                                                |
-| GCP           | c2 (8 vCPUs, 16 GiB memory)                       |
-| Private       | 8 vCPUs, 16 GiB of memory, local disk not required|
+| Cloud Provider| Recommendation                                    	|
+| ------------- | ----------------------------------------------------- |
+| AWS           | c6i.2xlarge (recommended) or c6g.2xlarge          	|
+| Azure         | f8                                                	|
+| GCP           | c2 (8 vCPUs, 16 GiB memory)                       	|
+| Private       | 8 vCPUs, 16 GiB of memory, local disk is not required	|
 
 ### CPU sizing
 
@@ -100,13 +100,13 @@ Most Observability Pipelines Worker workloads are CPU constrained and benefit fr
 
 Observability Pipelines Worker runs on modern CPU architectures. Benchmarks indicate that X86_64 architectures offer the best return on performance for Observability Pipelines Worker.
 
-## Memory sizing
+### Memory sizing
 
 Due to Observability Pipelines Worker's affine type system, memory is rarely constrained for Observability Pipelines Worker workloads. Therefore,  ≥2 GiB of memory per vCPU as a starting point is recommended. Memory usage increases with the number of sinks due to the in-memory buffering and batching. If you have a lot of sinks, consider increasing the memory or switching to disk buffers.
 
-## Disk sizing
+### Disk sizing
 
-If you're using Observability Pipelines Worker's disk buffers for high durability (recommended) then you should provision at least 36 GiB per vCPU * of disk space. Following the recommendation of 8 vCPUs, you would then provision 288 GiB of disk space (10 MiB * 60 seconds * 60 minutes * 8 vCPUs).
+If you're using Observability Pipelines Worker's disk buffers for high durability (recommended) then you should provision at least 36 GiB per vCPU* of disk space. Following the recommendation of 8 vCPUs, you would then provision 288 GiB of disk space (10 MiB * 60 seconds * 60 minutes * 8 vCPUs).
 
 | Cloud Provider| Recommendation*                                               |
 | ------------- | --------------------------------------------------------------|
@@ -115,15 +115,15 @@ If you're using Observability Pipelines Worker's disk buffers for high durabilit
 | GCP           | Balanced or SSD persistent disks, 36 GiB per vCPU             |
 | Private       | Network-based block storage equivalent, 36 GiB per vCPU       |
 
-* The recommended sizes are calculated at Observability Pipelines Worker's 10 MiB/s/vCPU throughput for one hour. For example, an 8 vCPU machine would require 288 GiB of disk space (10 MiB * 60 seconds * 60 minutes * 8 vCPUs).
+*The recommended sizes are calculated at Observability Pipelines Worker's 10 MiB/s/vCPU throughput for one hour. For example, an 8 vCPU machine would require 288 GiB of disk space (10 MiB * 60 seconds * 60 minutes * 8 vCPUs).
 
-### Disk types
+#### Disk types
 
 Choose a disk type that optimizes for durability and recovery. For example, standard block storage is ideal since it is decoupled from the instance and replicates data across multiple disks for high durability. High-performance local drives are not recommended since their throughput exceeds Observability Pipelines Worker's needs, and their durability is reduced relative to block storage.
 
-See [High durability] for more information on why disks are used in this architecture.
+See [High durability](#high-durability) for more information on why disks are used in this architecture.
 
-### Operating systems and GCC
+#### Operating systems and GCC
 
 Choose a Linux-based operating system with glibc (GNU) ≥ 2.14 (released in 2011) if possible. Observability Pipelines Worker runs on other platforms, but this combination produces the best performance in our benchmarks.
 
@@ -153,20 +153,20 @@ For push-based sources, front your Observability Pipelines Worker instances with
 
 A load balancer is not required for pull-based sources; just deploy Observability Pipelines Worker and scale it up and down. Your pub-sub system coordinates exclusive access to the data when Observability Pipelines Worker asks to read it.
 
-See the [Advanced] section for more information on mixed workloads (push and pull-based sources).
+See the [Advanced configurations](#advanced-configurations) for more information on mixed workloads (push and pull-based sources).
 
-## Load balancing
+#### Load balancing
 
 A load balancer is only required for push-based sources, such as agents. You do not need a load balancer if you are exclusively using pull-based sources, such as Kafka.
 
-### Client-side load balancing
+##### Client-side load balancing
 
 Client-side load balancing is not recommended. Client-side load balancing refers to clients doing the load balancing of traffic across multiple Observability Pipelines Worker instances. While this approach sounds simpler, it may be less reliable and more complicated because:
 
 - Load balancing with proper failover is complex. Issues in this area are sensitive as they can result in data loss or incidents that disrupt your services. This is exacerbated if you are working with multiple types of clients.
 - The point of the Observability Pipelines Worker aggregator is to shift responsibility away from your agents and taking on load balancing helps to do that.
 
-### Load balancer types
+##### Load balancer types
 
 Datadog recommends layer-4 load balancers (network load balancers) since they support Observability Pipelines Worker's protocols (TCP, UDP, and HTTP). Even if you're exclusively sending HTTP traffic (layer-7), layer-4 load balancers are still recommended for their performance and simplicity. 
 
@@ -177,20 +177,20 @@ Datadog recommends layer-4 load balancers (network load balancers) since they su
 | GCP           | Internal TCP/UDP Network Load Balancer                        |
 | Private       | HAProxy, Nginx, or another load balancer with layer-4 support |
 
-### Load balancer configurations
+##### Load balancer configurations
 
 When configuring clients and load balancers, the following general settings are recommended:
 
 - Use a simple round-robin load balancing strategy.
 - Do not enable cross-zone load balancing unless the traffic across zones is very imbalanced.
-- Configure load balancers to use Observability Pipelines Worker’s health API endpoint for target health.
-- Ensure that your Observability Pipelines Worker instances automatically register/deregister as they scale (see the service discovery section).
-- Enable keep-alive for both your clients and load balancers with no more than one minute idle timeout.
+- Configure load balancers to use Observability Pipelines Worker's health API endpoint for target health.
+- Ensure that your Observability Pipelines Worker instances automatically register/deregister as they scale. See [service discovery](#dns-and-service-discovery) for more information).
+- Enable keep-alive with no more than one minute idle timeout for both your clients and load balancers.
 - If supported, enable connection concurrency/pooling on your agents. If that is not supported, consider the unified architecture which deploys Observability Pipelines Worker at the edge. Connection pooling ensures large volumes of data are spread across multiple connections to help balance traffic.
 
-### Load balancer hot spots
+##### Load balancer hot spots
 
-Load balancing hot spots refers to one or more Observability Pipelines Worker instances receiving disproportionate traffic. Hot spots usually happens due to one of two reasons:
+Load balancing hot spots refer to one or more Observability Pipelines Worker instances receiving disproportionate traffic. Hot spots usually happens due to one of two reasons:
 
 1. A substantial amount of traffic is being sent over a single connection.
 2. Traffic in one availability zone is much higher than in the others.
@@ -206,7 +206,7 @@ Observability Pipelines Worker's concurrency model automatically scales to take 
 
 ### Autoscaling
 
-Autoscaling should be based on average CPU utilization. In the vast majority of workloads, Observability Pipelines Worker is CPU constrained, and CPU utilization is the strongest signal for autoscaling since it does not produce false positives. Datadog recommends the following settings, adjust as necessary:
+Autoscaling should be based on average CPU utilization. In the vast majority of workloads, Observability Pipelines Worker is CPU constrained, and CPU utilization is the strongest signal for autoscaling since it does not produce false positives. The following settings are recommended, adjust as necessary:
 
 - Average CPU with a 85% utilization target.
 - A five minute stabilization period for scaling up and down.
@@ -219,13 +219,13 @@ Autoscaling should be based on average CPU utilization. In the vast majority of 
 
 Most users have complex production environments with many network boundaries, including multiple clouds, regions, VPCs, and clusters. It can get complicated when determining where Observability Pipelines Worker fits within those boundaries. Therefore, **starting with one Observability Pipelines Worker aggregator per region is recommended**, even if you have multiple accounts, VPCs, and clusters. This boundary is the broadest networking granularity that avoids sending data over the public internet. If you have multiple clusters, deploy Observability Pipelines Worker into your utility or tools cluster, or pick a cluster that is most appropriate for shared services like Observability Pipelines Worker.
 
-As your Observability Pipelines Worker usage increases, it can become clear where multiple Observability Pipelines Worker deployments fit in.
+As your Observability Pipelines Worker usage increases, it can then become clear where multiple Observability Pipelines Worker deployments fit in.
 
-See the [Advanced]() section for more information on multiple deployments.
+See [Advanced configurations](#advanced-configurations) for more information on multiple deployments.
 
 #### DNS and service discovery
 
-Your organization might have adopted some form of service discovery, even if it’s facilitated through basic DNS. Discovery of your Observability Pipelines Worker aggregators and services should resolve through your service discovery mechanism.
+Your organization might have adopted some form of service discovery, even if it's facilitated through basic DNS. Discovery of your Observability Pipelines Worker aggregators and services should resolve through your service discovery mechanism.
 
 Service discovery allows you to configure your agents with named hostnames (not static IP addresses), facilitating routing and load balancing of your traffic. This is how your agents discover your load balancers and how your load balancers discover your Observability Pipelines Worker aggregators.
 
@@ -252,7 +252,7 @@ Be sure to review your own Observability Pipelines Worker configuration for the 
 
 The Observability Pipelines Worker is designed to receive and send data over a variety of protocols. Datadog recommends using the protocol best supported for your integration. Choose HTTP-based protocols for their application-level delivery acknowledgments and ubiquitous support across platforms when possible. Otherwise, choose TCP-based protocols. We do not recommend UDP, as there is risk of losing data. 
 
-##### Observability Pipelines Worker to Observability Pipelines Worker Communication
+##### Observability Pipelines Worker to Observability Pipelines Worker communication
 
 Use the Observability Pipelines Worker source and sink to send data between Observability Pipelines Worker instances (for example, with the unified architecture). These sources use the GRPC protocol for efficient lossless communication.
 
@@ -275,10 +275,10 @@ To achieve high durability:
 
 2. Choose a highly durable destination that serves as your system of record (for example, AWS S3). This system is responsible for the durability of data at rest and commonly referred to as archives or data lakes.
 
-Finally, configure the Observability Pipelines Worker sink(s) that writes to your system of record to enable end-to-end acknowledgments and disk buffers. For example:
+Finally, configure the Observability Pipelines Worker sink(s) that writes to your system of record to enable [end-to-end acknowledgments](#using-end-to-end-acknowledgment) and disk buffers. For example:
 
 ```
- sinks:
+sinks:
 	aws_s3:
 		acknowledgments: true
 		buffer:
@@ -287,20 +287,127 @@ Finally, configure the Observability Pipelines Worker sink(s) that writes to you
 
 ## Preventing data loss
 
-### Using end-to-end acknowledgements
+### Using end-to-end acknowledgment
+
+An issue with the Observability Pipelines Worker operating system process could risk losing data held in memory during the time of the issue. Enable Observability Pipelines Worker's end-to-end acknowledgment feature to mitigate the risk of losing data:
+
+```
+sinks:
+	aws_s3:
+		acknowledgments: true
+```
+
+With this feature enabled, Observability Pipelines Worker does not respond to agents until the data has been durably persisted. Thus, preventing the agent from releasing the data prematurely and sending it again if an acknowledgment has not been received.
+
+### Handling node failure
+
+Node failures deal with the full failure of an individual node. These can also be addressed using end-to-end acknowledgements. See [Using end-to-end acknowledgment](#using-end-to-end-acknowledgment) for more details.
+
+### Handling disk failure
+
+Disk failures deal with the failure of an individual disk. Data loss related to disk failures can be mitigated by using a highly durable file system where data is replicated across multiple disks, such as block storage (for example, AWS EBS).
+
+### Handling data processing failure
+
+The Observability Pipelines Worker can have problems, such as failing to parse a log, when trying to process malformed data. There are two ways to mitigate this issue:
+
+1. **Direct archiving**: Route data directly from your sources to your archive. This ensures that data makes it to your archive without risk of being dropped. In addition, this data can be replayed after correcting the processing error.
+
+2. **Failed event routing**: The Observability Pipelines Worker offers failed event routing for users who wish to archive processed data, such as structured and enriched data. Certain Observability Pipelines Worker transforms come with a dropped output that can be connected to a sink for durability and replay.
+
+#### Which strategy is best?
+
+If durability is the most important criteria, use the direct archiving method because it addresses data loss scenarios. Use the failed event routing method, also commonly referred to as a data lake, if you prefer to analyze data in your archive. It has the advantage of using your archive/data lake for long-term analysis. Datadog [Log Archives][2] and AWS Athena are examples of archive storage solutions.
+
+### Handling destination failure
+
+Finally, destination failures refer to the total failure of a downstream destination (for example Elasticsearch). Data loss can be mitigated for issues with the downstream destination by using disk buffers large enough to sustain the outage time. This allows data to durably buffer while the service is down and then drain when the service comes back up. For this reason, disk buffers large enough to hold at least one hour's worth of data are recommended. See [disk sizing](#disk-sizing) for more details.
+
+## High availability
+
+High availability refers to Observability Pipelines Worker remaining available if there are any system issues.
+
+To achieve high durability:
+
+1. Deploy at least two Observability Pipelines Worker instances in each Availability Zone.
+2. Deploy Observability Pipelines Worker in at least two Availability Zones.
+3. Front your Observability Pipelines Worker instances with a load balancer that balances traffic across Observability Pipelines Worker instances. See the horizontal scaling section for more information.
+
+### Mitigating failure scenarios
+
+#### Handling Observability Pipelines Worker process issues
 
 To mitigate a system process issue, distribute Observability Pipelines Worker across multiple nodes and front them with a network load balancer that can redirect traffic to another Observability Pipelines Worker instance as needed. In addition, platform-level automated self-healing should eventually restart the process or replace the node.
 
-### Node Failure
+#### Mitigating node failure
 
-To mitigate node issues, distribute the Observability Pipelines Worker across multiple nodes and fronting them with a network load balancer that can redirect traffic to another Observability Pipelines Worker node. In addition, platform-level automated self-healing should eventually replace the node.
+To mitigate node issues, distribute the Observability Pipelines Worker across multiple nodes and front them with a network load balancer that can redirect traffic to another Observability Pipelines Worker node. In addition, platform-level automated self-healing should eventually replace the node.
 
-### Availability Zone Failure
+#### Handling availability zones failure
 
-To mitigate issues with availability zones, deploying the Observability Pipelines Worker across multiple availability zones.
+To mitigate issues with availability zones, deploy the Observability Pipelines Worker across multiple availability zones.
 
-### Region Failure
+#### Mitigating region failure
 
-Observability Pipelines Worker is designed to route internal observability data, and it should not failover to another region. Instead, Observability Pipelines Worker should be deployed in all of your regions as recommended in the network boundaries section. Therefore, if your entire network or region fails, Observability Pipelines Worker should fail with it.
+Observability Pipelines Worker is designed to route internal observability data, and it should not failover to another region. Instead, Observability Pipelines Worker should be deployed in all of your regions as recommended in the [network boundaries](#network-boundaries) section. Therefore, if your entire network or region fails, Observability Pipelines Worker would fail with it.
+
+## Disaster recovery
+
+### Internal disaster recovery
+
+Observability Pipelines Worker is an infrastructure-level tool designed to route internal observability data. It implements a shared-nothing architecture and does not manage state that should be replicated or transferred to a disaster recovery (DR) site. Therefore, if your entire region fails, Observability Pipelines Worker would fail with it. Therefore, you should install the Observability Pipelines Worker in your DR site as part of your broader DR plan.
+
+### External disaster recovery
+
+If you're using a managed destination, such as Datadog, Observability Pipelines Worker can facilitate automatic routing data to your Datadog DR site using Observability Pipelines Worker's circuit breaker feature.
+
+## Advanced configurations
+
+### Multiple aggregator deployments
+
+As covered in [network boundaries](#network-boundaries), it is recommended to start with one Observability Pipelines Worker aggregator per region. This is to prevent overcomplicating your initial deployment of Observability Pipelines Worker, but there are circumstances where starting with multiple deployments makes sense:
+
+1. **Prevent sending data over the public internet.** If you have multiple clouds and regions, deploy the Observability Pipelines Worker aggregator in each of them to prevent sending large amounts of data over the internet. Your Observability Pipelines Worker aggregator should receive internal data and serve as the single point of egress for your network.
+
+2. **Independent management.** You have teams that can operate and manage a Observability Pipelines Worker aggregator independently for their use case. For example, your Data Science team may be responsible for operating their own infrastructure and has the means to independently operate their own Observability Pipelines Worker aggregator.
+
+### Multiple cloud accounts
+
+Many users have multiple cloud accounts with VPCs and clusters inside. It is still recommended in this case to deploy one Observability Pipelines Worker aggregator per region. Deploy Observability Pipelines Worker into your utility/tools cluster and configure all your cloud accounts to send data to this cluster. See [network boundaries](#network-boundaries) for more information.
+
+### Pub-sub systems
+
+Using a pub-sub system, like Kafka, is not required to make this architecture highly available or highly durable (see the high durability and high availability sections), but they do offer the following advantages:
+
+1. **Improved reliability.** Pub-sub systems are designed to be highly reliable and durable systems that change infrequently. They are especially reliable if you are using a managed option. The Observability Pipelines Worker is likely to change more often by nature of its purpose. Insulate Observability Pipelines Worker downtime behind a pub-sub system to increase availability from the perception of your clients and make recovery simpler.
+
+
+2. **Load balancer not required.** Pub-sub systems eliminate the need for a load balancer. Your pub-sub system handles the coordination of consumers, making it easy to scale Observability Pipelines Worker horizontally.
+
+#### Pub-sub partitioning
+
+Partitioning, or "topics" in Kafka terminology, refers to separating data in your pub-sub systems. It is strongly recommended to partition along data origin lines, such as the service or host that generated the data.
+
+#### Pub-sub configuration
+
+When using a pub-sub system, the following configuration changes for Observability Pipelines Worker are recommended:
+
+- **Enable end-to-end acknowledgements for all sinks.** This setting ensures that the pub-sub checkpoint is not advanced until data is successfully written.
+- **Use memory buffers.** There is no need to use Observability Pipelines Worker’s disk buffers when it sits behind a pub-sub system. Your pub-sub system is designed for long-term buffering with high durability. Observability Pipelines Worker should only be responsible for reading, processing, and routing the data (not durability).
+
+### Global aggregation
+
+This section provides recommendations for performing global calculations for legacy destinations. Modern destinations already support global calculations. For example, Datadog supports distributions (DDSketch) that solve global observations of your metrics data.
+
+Global aggregation refers to the ability to aggregate data for an entire region. For example, computing global quantiles for CPU load averages. To achieve this, a single Observability Pipelines Worker instance must have access to every node's CPU load average statistics. This is not possible with horizontal scaling; each individual Observability Pipelines Worker instance only has access to a slice of the overall data. Therefore, aggregation should be tiered.
+
+The structure is that tier 2 aggregators receive an aggregated sub-stream of the overall data from tier 1 aggregators. This allows a single instance to get a global view without processing the entire stream and introducing a single point of failure.
+
+#### Recommendations
+
+- Limit global aggregation to tasks that can reduce data, such as computing global histograms. Never send all data to your global aggregators.
+- Continue to use your local aggregators to process and deliver most data so that you do notintroduce a single point of failure.
+
 
 [1]: https://wiki.archlinux.org/title/Domain_name_resolution
+[2]: /logs/log_configuration/archives

--- a/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
+++ b/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
@@ -5,7 +5,7 @@ kind: Documentation
 
 ## Overview
 
-The Observability Pipelines Worker's aggregator architecture deploys Observability Pipelines Worker as a standalone service for centralized data processing and routing.
+The Observability Pipelines Worker's aggregator architecture deploys the Observability Pipelines Worker as a standalone service for centralized data processing and routing.
 
 Deploy Observability Pipelines Worker into your infrastructure, like any other service to intercept and manipulate data, and then forward it to your destinations. Each Observability Pipelines Worker instance operates independently, so that you can scale the architecture with a simple load balancer.
 
@@ -18,7 +18,7 @@ This guide walks you through the recommended aggregator architecture for new Obs
 - Determining your [network topology and configurations](#networking) for the Observability Pipelines Worker.
 - Achieving [high durability](#high-durability) and [high availability](#high-availability).
 - Using the Observability Pipelines Worker as part of your [disaster recovery](#disaster-recovery).
-- More [advanced configurations](#advanced-configurations) for deploying multiple aggregators, pub-sub systems, and global aggregation
+- More [advanced configurations](#advanced-configurations) for deploying multiple aggregators, publish-subscribe systems, and global aggregation.
 
 ### Comparison
 
@@ -56,11 +56,11 @@ Compared to the Observability Pipelines Worker agent architecture, the aggregato
 
 ## Configuring Observability Pipelines Worker
 
-While your configuration may deviate, it should still follow the primary goals below.
+While your configuration may vary, it should follow the following primary goals.
 
 ### Collecting data
 
-Make it easy to send data to your Observability Pipelines Worker aggregator by integrating as many sources as possible. It's not uncommon for Observability Pipelines Worker aggregators to have dozens of sources. Configure the source component as long as it supports your security and durability requirements. This makes it easy for users across your company to adopt the Observability Pipelines Worker aggregator, even if they are using legacy services.
+Make it easy to send data to your Observability Pipelines Worker aggregator by integrating as many sources as possible. It's not uncommon for Observability Pipelines Worker aggregators to have dozens of sources. Configure the source component as long as it supports your security and durability requirements. This enables users across your company to adopt the Observability Pipelines Worker aggregator, even if they are using legacy services.
 
 ### Processing data
 
@@ -76,7 +76,7 @@ Separate your system of analysis (for example, Datadog) from your system of reco
 
 ### Instance sizing
 
-Compute optimized instances with at least 8 vCPUs and 16 GiB of memory. These are good units for horizontally scaling the Observability Pipelines Worker aggregator. Observability Pipelines Worker can vertically scale and automatically take advantage of additional resources if you choose larger instances. Choose a size that allows for at least two Observability Pipelines Worker instances for your data volume to improve availability.
+Compute optimized instances with at least 8 vCPUs and 16 GiB of memory. These are ideal units for horizontally scaling the Observability Pipelines Worker aggregator. Observability Pipelines Worker can vertically scale and automatically take advantage of additional resources if you choose larger instances. Choose a size that allows for at least two Observability Pipelines Worker instances for your data volume to improve availability.
 
 | Cloud Provider| Recommendation                                    	|
 | ------------- | ----------------------------------------------------- |
@@ -98,15 +98,15 @@ Most Observability Pipelines Worker workloads are CPU constrained and benefit fr
 
 ### CPU architectures
 
-Observability Pipelines Worker runs on modern CPU architectures. Benchmarks indicate that X86_64 architectures offer the best return on performance for Observability Pipelines Worker.
+Observability Pipelines Worker runs on modern CPU architectures. X86_64 architectures offer the best return on performance for Observability Pipelines Worker.
 
 ### Memory sizing
 
-Due to Observability Pipelines Worker's affine type system, memory is rarely constrained for Observability Pipelines Worker workloads. Therefore,  ≥2 GiB of memory per vCPU as a starting point is recommended. Memory usage increases with the number of sinks due to the in-memory buffering and batching. If you have a lot of sinks, consider increasing the memory or switching to disk buffers.
+Due to Observability Pipelines Worker's affine type system, memory is rarely constrained for Observability Pipelines Worker workloads. Therefore, Datadog recommends ≥2 GiB of memory per vCPU minimum. Memory usage increases with the number of sinks due to the in-memory buffering and batching. If you have a lot of sinks, consider increasing the memory or switching to disk buffers.
 
 ### Disk sizing
 
-If you're using Observability Pipelines Worker's disk buffers for high durability (recommended), provision at least 36 GiB per vCPU* of disk space. Following the recommendation of 8 vCPUs, provision 288 GiB of disk space (10 MiB * 60 seconds * 60 minutes * 8 vCPUs).
+If you're using Observability Pipelines Worker's disk buffers for high durability (recommended), provision at least 36 GiB per vCPU of disk space. Following the recommendation of 8 vCPUs, provision 288 GiB of disk space (10 MiB * 60 seconds * 60 minutes * 8 vCPUs).
 
 | Cloud Provider| Recommendation*                                               |
 | ------------- | --------------------------------------------------------------|
@@ -119,13 +119,13 @@ If you're using Observability Pipelines Worker's disk buffers for high durabilit
 
 #### Disk types
 
-Choose a disk type that optimizes for durability and recovery. For example, standard block storage is ideal since it is decoupled from the instance and replicates data across multiple disks for high durability. High-performance local drives are not recommended since their throughput exceeds Observability Pipelines Worker's needs, and their durability is reduced relative to block storage.
+Choose a disk type that optimizes for durability and recovery. For example, standard block storage is ideal because it is decoupled from the instance and replicates data across multiple disks for high durability. High-performance local drives are not recommended because their throughput exceeds Observability Pipelines Worker's needs, and their durability is reduced relative to block storage.
 
 See [High durability](#high-durability) for more information on why disks are used in this architecture.
 
 #### Operating systems and GCC
 
-Choose a Linux-based operating system with glibc (GNU) ≥ 2.14 (released in 2011) if possible. Observability Pipelines Worker runs on other platforms, but this combination produces the best performance in our benchmarks.
+Choose a Linux-based operating system with glibc (GNU) ≥ 2.14 (released in 2011) if possible. Observability Pipelines Worker runs on other platforms, but this combination produces the best performance in Datadog's benchmarks.
 
 ## Capacity planning
 
@@ -151,7 +151,7 @@ Horizontal scaling refers to distributing traffic across multiple Observability 
 
 For push-based sources, front your Observability Pipelines Worker instances with a network load balancer and scale them up and down as needed.
 
-A load balancer is not required for pull-based sources; just deploy Observability Pipelines Worker and scale it up and down. Your pub-sub system coordinates exclusive access to the data when Observability Pipelines Worker asks to read it.
+A load balancer is not required for pull-based sources; deploy Observability Pipelines Worker and scale it up and down as needed. Your publish-subscription system coordinates exclusive access to the data when Observability Pipelines Worker asks to read it.
 
 See [Advanced configurations](#advanced-configurations) for more information on mixed workloads (push and pull-based sources).
 
@@ -168,7 +168,7 @@ Client-side load balancing is not recommended. Client-side load balancing refers
 
 ##### Load balancer types
 
-Datadog recommends layer-4 load balancers (network load balancers) since they support Observability Pipelines Worker's protocols (TCP, UDP, and HTTP). Even if you're exclusively sending HTTP traffic (layer-7), layer-4 load balancers are still recommended for their performance and simplicity. 
+Datadog recommends Layer 4 (L4) load balancers (network load balancers) since they support Observability Pipelines Worker's protocols (TCP, UDP, and HTTP). Even if you're exclusively sending HTTP traffic (Layer 7), Datadog recommends L4 load balancers for their performance and simplicity. 
 
 | Cloud Provider| Recommendation                                                |
 | ------------- | --------------------------------------------------------------|
@@ -179,25 +179,25 @@ Datadog recommends layer-4 load balancers (network load balancers) since they su
 
 ##### Load balancer configurations
 
-When configuring clients and load balancers, the following general settings are recommended:
+When configuring clients and load balancers, Datadog recommends the following general settings:
 
 - Use a simple round-robin load balancing strategy.
 - Do not enable cross-zone load balancing unless the traffic across zones is very imbalanced.
 - Configure load balancers to use Observability Pipelines Worker's health API endpoint for target health.
-- Ensure that your Observability Pipelines Worker instances automatically register/deregister as they scale. See [service discovery](#dns-and-service-discovery) for more information).
+- Ensure that your Observability Pipelines Worker instances automatically register or de-register as they scale. See [service discovery](#dns-and-service-discovery) for more information).
 - Enable keep-alive with no more than one minute idle timeout for both your clients and load balancers.
-- If supported, enable connection concurrency/pooling on your agents. If that is not supported, consider the unified architecture which deploys Observability Pipelines Worker at the edge. Connection pooling ensures large volumes of data are spread across multiple connections to help balance traffic.
+- If supported, enable connection concurrency and pooling on your agents. If that is not supported, consider the unified architecture which deploys Observability Pipelines Worker at the edge. Connection pooling ensures large volumes of data are spread across multiple connections to help balance traffic.
 
 ##### Load balancer hot spots
 
-Load balancing hot spots occur when one or more Observability Pipelines Worker instances receives disproportionate traffic. Hot spots usually happen due to one of two reasons:
+Load balancing hot spots occur when one or more Observability Pipelines Worker instance receives disproportionate traffic. Hot spots usually happen due to one of two reasons:
 
 1. A substantial amount of traffic is being sent over a single connection.
 2. Traffic in one availability zone is much higher than in the others.
 
 In these cases, the following respective mitigation tactics are recommended:
 
-1. Split large connections into multiple connections. Most clients allow connection concurrency/pooling that distributes data over multiple connections. This tactic allows your load balancer to distribute the connection across multiple Observability Pipelines Worker instances. If your client does not support this, consider the unified architecture, where Observability Pipelines Worker can be additionally deployed to the edge.
+1. Split large connections into multiple connections. Most clients allow connection concurrency and pooling that distributes data over multiple connections. This tactic allows your load balancer to distribute the connection across multiple Observability Pipelines Worker instances. If your client does not support this, consider the unified architecture, where Observability Pipelines Worker can be additionally deployed to the edge.
 2. Enable cross-zone load balancing on your load balancer. Cross-zone balancing balances all availability zone traffic across all Observability Pipelines Worker instances.
 
 ### Vertical scaling
@@ -206,7 +206,7 @@ Observability Pipelines Worker's concurrency model automatically scales to take 
 
 ### Autoscaling
 
-Autoscaling should be based on average CPU utilization. For the vast majority of workloads, Observability Pipelines Worker is CPU constrained. CPU utilization is the strongest signal for autoscaling since it does not produce false positives. The following settings are recommended, adjust as necessary:
+Autoscaling should be based on average CPU utilization. For the vast majority of workloads, Observability Pipelines Worker is CPU constrained. CPU utilization is the strongest signal for autoscaling since it does not produce false positives. Datadog recommends you use the following settings, adjusting as necessary:
 
 - Average CPU with a 85% utilization target.
 - A five minute stabilization period for scaling up and down.
@@ -225,7 +225,7 @@ See [Advanced configurations](#advanced-configurations) for more information on 
 
 #### DNS and service discovery
 
-Your organization might have adopted some form of service discovery, even if it's facilitated through basic DNS. Discovery of your Observability Pipelines Worker aggregators and services should resolve through your service discovery mechanism.
+Your organization may have adopted some form of service discovery, even if it's facilitated through basic DNS. Discovery of your Observability Pipelines Worker aggregators and services should resolve through your service discovery mechanism.
 
 Service discovery allows you to configure your agents with named hostnames (not static IP addresses), facilitating routing and load balancing of your traffic. This is how your agents discover your load balancers and how your load balancers discover your Observability Pipelines Worker aggregators.
 
@@ -246,13 +246,13 @@ The Observability Pipelines Worker requires all ports to be explicitly configure
 | 8282 | Datadog Agent  | HTTP      | Incoming | Accepts data from the fluent source.   |
 | 123  | Files          | Syslog    | Incoming | Accepts data from the Syslog source.   |
 
-Be sure to review your own Observability Pipelines Worker configuration for the exact ports exposed as your administrator may have changed them.
+Be sure to review your Observability Pipelines Worker configuration for the exact ports exposed, as your administrator may have changed them.
 
 #### Protocols
 
-The Observability Pipelines Worker is designed to receive and send data over a variety of protocols. Using the protocol best supported for your integration is recommended. Choose HTTP-based protocols for their application-level delivery acknowledgments and ubiquitous support across platforms when possible. Otherwise, choose TCP-based protocols. UDP is not recommended, as there is risk of losing data. 
+The Observability Pipelines Worker is designed to receive and send data over a variety of protocols. Datadog recommends using the protocol best supported for your integration. Choose HTTP-based protocols for their application-level delivery acknowledgments and ubiquitous support across platforms when possible. Otherwise, choose TCP-based protocols. UDP is not recommended, as there is risk of losing data. 
 
-##### Observability Pipelines Worker to Observability Pipelines Worker communication
+##### Worker-to-worker communication
 
 Use the Observability Pipelines Worker source and sink to send data between Observability Pipelines Worker instances (for example, with the unified architecture). These sources use the GRPC protocol for efficient lossless communication.
 
@@ -262,7 +262,7 @@ The Observability Pipelines Worker provides specific sources for many agents. Fo
 
 #### Compression
 
-Compression can impose a ~50% decrease in throughput based on our benchmarks. Use compression with caution and monitor performance after enabling.
+Compression can impose a 50% decrease in throughput based on Datadog benchmarks. Use compression with caution and monitor performance after enabling.
 
 Compression of network traffic should only be used for cost-sensitive egress scenarios due to its impact on performance (for example, sending data over the public internet). Therefore, compression is not recommended for internal network traffic.
 
@@ -298,7 +298,7 @@ sinks:
 		acknowledgments: true
 ```
 
-With this feature enabled, Observability Pipelines Worker does not respond to agents until the data has been durably persisted. Thus, preventing the agent from releasing the data prematurely and sending it again if an acknowledgment has not been received.
+With this feature enabled, Observability Pipelines Worker does not respond to agents until the data has been durably persisted. This prevents the agent from releasing the data prematurely and sending it again if an acknowledgment has not been received.
 
 ### Handling node failures
 
@@ -322,7 +322,7 @@ If durability is the most important criteria, use the direct archiving method be
 
 ### Handling destination failures
 
-Finally, destination failures refer to the total failure of a downstream destination (for example Elasticsearch). Data loss can be mitigated for issues with the downstream destination by using disk buffers large enough to sustain the outage time. This allows data to durably buffer while the service is down and then drain when the service comes back up. For this reason, disk buffers large enough to hold at least one hour's worth of data are recommended. See [disk sizing](#disk-sizing) for more details.
+Destination failures refer to the total failure of a downstream destination (for example, Elasticsearch). Data loss can be mitigated for issues with the downstream destination by using disk buffers large enough to sustain the outage time. This allows data to durably buffer while the service is down and then drain when the service comes back up. For this reason, disk buffers large enough to hold at least one hour's worth of data are recommended. See [disk sizing](#disk-sizing) for more details.
 
 ## High availability
 
@@ -338,7 +338,7 @@ To achieve high durability:
 
 #### Handling Observability Pipelines Worker process issues
 
-To mitigate a system process issue, distribute Observability Pipelines Worker across multiple nodes and front them with a network load balancer that can redirect traffic to another Observability Pipelines Worker instance as needed. In addition, platform-level automated self-healing should eventually restart the process or replace the node.
+To mitigate a system process issue, distribute the Observability Pipelines Worker across multiple nodes and front them with a network load balancer that can redirect traffic to another Observability Pipelines Worker instance as needed. In addition, platform-level automated self-healing should eventually restart the process or replace the node.
 
 #### Mitigating node failures
 
@@ -366,48 +366,48 @@ If you're using a managed destination, such as Datadog, Observability Pipelines 
 
 ### Multiple aggregator deployments
 
-As covered in [network boundaries](#network-boundaries), Datadog recommends to start with one Observability Pipelines Worker aggregator per region. This is to prevent overcomplicating your initial deployment of Observability Pipelines Worker, but there are circumstances where starting with multiple deployments makes sense:
+As covered in [network boundaries](#network-boundaries), Datadog recommends to start with one Observability Pipelines Worker aggregator per region. This is to prevent overcomplicating your initial deployment of Observability Pipelines Worker, but there are circumstances where starting with multiple deployments is ideal:
 
 1. **Prevent sending data over the public internet.** If you have multiple clouds and regions, deploy the Observability Pipelines Worker aggregator in each of them to prevent sending large amounts of data over the internet. Your Observability Pipelines Worker aggregator should receive internal data and serve as the single point of egress for your network.
 
-2. **Independent management.** You have teams that can operate and manage a Observability Pipelines Worker aggregator independently for their use case. For example, your Data Science team may be responsible for operating their own infrastructure and has the means to independently operate their own Observability Pipelines Worker aggregator.
+2. **Independent management.** You have teams that can operate and manage an Observability Pipelines Worker aggregator independently for their use case. For example, your Data Science team may be responsible for operating their own infrastructure and has the means to independently operate their own Observability Pipelines Worker aggregator.
 
 ### Multiple cloud accounts
 
-Many users have multiple cloud accounts with VPCs and clusters inside. Datadog still recommends in this case to deploy one Observability Pipelines Worker aggregator per region. Deploy Observability Pipelines Worker into your utility/tools cluster and configure all your cloud accounts to send data to this cluster. See [network boundaries](#network-boundaries) for more information.
+Many users have multiple cloud accounts with VPCs and clusters inside. Datadog still recommends in this case to deploy one Observability Pipelines Worker aggregator per region. Deploy Observability Pipelines Worker into your utility or tools cluster and configure all your cloud accounts to send data to this cluster. See [network boundaries](#network-boundaries) for more information.
 
-### Pub-sub systems
+### Publish-subscribe (pub-sub) systems
 
-Using a pub-sub system, like Kafka, is not required to make this architecture highly available or highly durable (see the high durability and high availability sections), but they do offer the following advantages:
+Using a pub-sub system such as Kafka is not required to make your architecture highly available or highly durable (see the high durability and high availability sections), but they do offer the following advantages:
 
-1. **Improved reliability.** Pub-sub systems are designed to be highly reliable and durable systems that change infrequently. They are especially reliable if you are using a managed option. The Observability Pipelines Worker is likely to change more often by nature of its purpose. Insulate Observability Pipelines Worker downtime behind a pub-sub system to increase availability from the perception of your clients and make recovery simpler.
+1. **Improved reliability.** Pub-sub systems are designed to be highly reliable and durable systems that change infrequently. They are especially reliable if you are using a managed option. The Observability Pipelines Worker is likely to change more often based on its purpose. Isolate Observability Pipelines Worker downtime behind a pub-sub system to increase availability from the perception of your clients and make recovery simpler.
 
 
 2. **Load balancer not required.** Pub-sub systems eliminate the need for a load balancer. Your pub-sub system handles the coordination of consumers, making it easy to scale Observability Pipelines Worker horizontally.
 
 #### Pub-sub partitioning
 
-Partitioning, or "topics" in Kafka terminology, refers to separating data in your pub-sub systems. Datadog strongly recommends partitioning along data origin lines, such as the service or host that generated the data.
+Partitioning, or "topics" in Kafka terminology, refers to separating data in your pub-sub systems. You should partition along data origin lines, such as the service or host that generated the data.
 
 #### Pub-sub configuration
 
-When using a pub-sub system, the following configuration changes for Observability Pipelines Worker are recommended:
+When using a pub-sub system, Datadog recommends the following configuration changes for Observability Pipelines Worker:
 
 - **Enable end-to-end acknowledgements for all sinks.** This setting ensures that the pub-sub checkpoint is not advanced until data is successfully written.
 - **Use memory buffers.** There is no need to use Observability Pipelines Worker's disk buffers when it sits behind a pub-sub system. Your pub-sub system is designed for long-term buffering with high durability. Observability Pipelines Worker should only be responsible for reading, processing, and routing the data (not durability).
 
 ### Global aggregation
 
-This section provides recommendations for performing global calculations for legacy destinations. Modern destinations already support global calculations. For example, Datadog supports distributions (DDSketch) that solve global observations of your metrics data.
+This section provides recommendations for performing global calculations for legacy destinations. Modern destinations already support global calculations. For example, Datadog supports distributions (such as DDSketch) that solve global observations of your metrics data.
 
 Global aggregation refers to the ability to aggregate data for an entire region. For example, computing global quantiles for CPU load averages. To achieve this, a single Observability Pipelines Worker instance must have access to every node's CPU load average statistics. This is not possible with horizontal scaling; each individual Observability Pipelines Worker instance only has access to a slice of the overall data. Therefore, aggregation should be tiered.
 
-The structure is that tier 2 aggregators receive an aggregated sub-stream of the overall data from tier 1 aggregators. This allows a single instance to get a global view without processing the entire stream and introducing a single point of failure.
+The structure is that tier two aggregators receive an aggregated sub-stream of the overall data from tier one aggregators. This allows a single instance to get a global view without processing the entire stream and introducing a single point of failure.
 
 #### Recommendations
 
 - Limit global aggregation to tasks that can reduce data, such as computing global histograms. Never send all data to your global aggregators.
-- Continue to use your local aggregators to process and deliver most data so that you do notintroduce a single point of failure.
+- Continue to use your local aggregators to process and deliver most data so that you do not introduce a single point of failure.
 
 
 [1]: https://wiki.archlinux.org/title/Domain_name_resolution

--- a/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
+++ b/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
@@ -216,7 +216,7 @@ Autoscaling should be based on average CPU utilization. For the vast majority of
 
 #### Network boundaries
 
-Most users have complex production environments with many network boundaries, including multiple clouds, regions, VPCs, and clusters. It can get complicated when determining where Observability Pipelines Worker fits within those boundaries. Therefore, **starting with one Observability Pipelines Worker aggregator per region is recommended**, even if you have multiple accounts, VPCs, and clusters. This boundary is the broadest networking granularity that avoids sending data over the public internet. If you have multiple clusters, deploy Observability Pipelines Worker into your utility or tools cluster, or pick a cluster that is most appropriate for shared services.
+Most users have complex production environments with many network boundaries, including multiple clouds, regions, VPCs, and clusters. It can get complicated when determining where Observability Pipelines Worker fits within those boundaries. Therefore, Datadog recommends starting with one Observability Pipelines Worker aggregator per region, even if you have multiple accounts, VPCs, and clusters. This boundary is the broadest networking granularity that avoids sending data over the public internet. If you have multiple clusters, deploy Observability Pipelines Worker into your utility or tools cluster, or pick a cluster that is most appropriate for shared services.
 
 As your Observability Pipelines Worker usage increases, it can then become clear where multiple Observability Pipelines Worker deployments fit in.
 

--- a/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
+++ b/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
@@ -66,7 +66,7 @@ Make it easy to send data to your Observability Pipelines Worker aggregator by i
 
 Use the Observability Pipelines Worker aggregator for processing most of your data, so that the responsibility is shifted away from your agents. This reduces your dependence on them, making it easier to change agents later on. 
 
-### Routing Data
+### Routing data
 
 #### Choose a system of record 
 
@@ -96,7 +96,7 @@ Most Observability Pipelines Worker workloads are CPU constrained and benefit fr
 | GCP           | Latest generation Intel Xeon, 8 vCPUs (recommended), at least 4 vCPUs |
 | Private       | Latest generation Intel Xeon, 8 vCPUs (recommended), at least 4 vCPUs |
 
-### CPU Architectures
+### CPU architectures
 
 Observability Pipelines Worker runs on modern CPU architectures. Benchmarks indicate that X86_64 architectures offer the best return on performance for Observability Pipelines Worker.
 
@@ -190,7 +190,7 @@ When configuring clients and load balancers, the following general settings are 
 
 ##### Load balancer hot spots
 
-Load balancing hot spots refer to one or more Observability Pipelines Worker instances receiving disproportionate traffic. Hot spots usually happens due to one of two reasons:
+Load balancing hot spots occur when one or more Observability Pipelines Worker instances receives disproportionate traffic. Hot spots usually happen due to one of two reasons:
 
 1. A substantial amount of traffic is being sent over a single connection.
 2. Traffic in one availability zone is much higher than in the others.
@@ -250,7 +250,7 @@ Be sure to review your own Observability Pipelines Worker configuration for the 
 
 #### Protocols
 
-The Observability Pipelines Worker is designed to receive and send data over a variety of protocols. Datadog recommends using the protocol best supported for your integration. Choose HTTP-based protocols for their application-level delivery acknowledgments and ubiquitous support across platforms when possible. Otherwise, choose TCP-based protocols. We do not recommend UDP, as there is risk of losing data. 
+The Observability Pipelines Worker is designed to receive and send data over a variety of protocols. Using the protocol best supported for your integration is recommended. Choose HTTP-based protocols for their application-level delivery acknowledgments and ubiquitous support across platforms when possible. Otherwise, choose TCP-based protocols. UDP is not recommended, as there is risk of losing data. 
 
 ##### Observability Pipelines Worker to Observability Pipelines Worker communication
 

--- a/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
+++ b/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
@@ -106,7 +106,7 @@ Due to Observability Pipelines Worker's affine type system, memory is rarely con
 
 ### Disk sizing
 
-If you're using Observability Pipelines Worker's disk buffers for high durability (recommended) then you should provision at least 36 GiB per vCPU* of disk space. Following the recommendation of 8 vCPUs, you would then provision 288 GiB of disk space (10 MiB * 60 seconds * 60 minutes * 8 vCPUs).
+If you're using Observability Pipelines Worker's disk buffers for high durability (recommended), provision at least 36 GiB per vCPU* of disk space. Following the recommendation of 8 vCPUs, provision 288 GiB of disk space (10 MiB * 60 seconds * 60 minutes * 8 vCPUs).
 
 | Cloud Provider| Recommendation*                                               |
 | ------------- | --------------------------------------------------------------|
@@ -206,7 +206,7 @@ Observability Pipelines Worker's concurrency model automatically scales to take 
 
 ### Autoscaling
 
-Autoscaling should be based on average CPU utilization. In the vast majority of workloads, Observability Pipelines Worker is CPU constrained, and CPU utilization is the strongest signal for autoscaling since it does not produce false positives. The following settings are recommended, adjust as necessary:
+Autoscaling should be based on average CPU utilization. For the vast majority of workloads, Observability Pipelines Worker is CPU constrained. CPU utilization is the strongest signal for autoscaling since it does not produce false positives. The following settings are recommended, adjust as necessary:
 
 - Average CPU with a 85% utilization target.
 - A five minute stabilization period for scaling up and down.
@@ -217,7 +217,7 @@ Autoscaling should be based on average CPU utilization. In the vast majority of 
 
 #### Network boundaries
 
-Most users have complex production environments with many network boundaries, including multiple clouds, regions, VPCs, and clusters. It can get complicated when determining where Observability Pipelines Worker fits within those boundaries. Therefore, **starting with one Observability Pipelines Worker aggregator per region is recommended**, even if you have multiple accounts, VPCs, and clusters. This boundary is the broadest networking granularity that avoids sending data over the public internet. If you have multiple clusters, deploy Observability Pipelines Worker into your utility or tools cluster, or pick a cluster that is most appropriate for shared services like Observability Pipelines Worker.
+Most users have complex production environments with many network boundaries, including multiple clouds, regions, VPCs, and clusters. It can get complicated when determining where Observability Pipelines Worker fits within those boundaries. Therefore, **starting with one Observability Pipelines Worker aggregator per region is recommended**, even if you have multiple accounts, VPCs, and clusters. This boundary is the broadest networking granularity that avoids sending data over the public internet. If you have multiple clusters, deploy Observability Pipelines Worker into your utility or tools cluster, or pick a cluster that is most appropriate for shared services.
 
 As your Observability Pipelines Worker usage increases, it can then become clear where multiple Observability Pipelines Worker deployments fit in.
 
@@ -263,6 +263,7 @@ The Observability Pipelines Worker provides specific sources for many agents. Fo
 #### Compression
 
 Compression can impose a ~50% decrease in throughput based on our benchmarks. Use compression with caution and monitor performance after enabling.
+
 Compression of network traffic should only be used for cost-sensitive egress scenarios due to its impact on performance (for example, sending data over the public internet). Therefore, compression is not recommended for internal network traffic.
 
 ## High durability
@@ -299,15 +300,15 @@ sinks:
 
 With this feature enabled, Observability Pipelines Worker does not respond to agents until the data has been durably persisted. Thus, preventing the agent from releasing the data prematurely and sending it again if an acknowledgment has not been received.
 
-### Handling node failure
+### Handling node failures
 
 Node failures deal with the full failure of an individual node. These can also be addressed using end-to-end acknowledgements. See [Using end-to-end acknowledgment](#using-end-to-end-acknowledgment) for more details.
 
-### Handling disk failure
+### Handling disk failures
 
 Disk failures deal with the failure of an individual disk. Data loss related to disk failures can be mitigated by using a highly durable file system where data is replicated across multiple disks, such as block storage (for example, AWS EBS).
 
-### Handling data processing failure
+### Handling data processing failures
 
 The Observability Pipelines Worker can have problems, such as failing to parse a log, when trying to process malformed data. There are two ways to mitigate this issue:
 
@@ -319,7 +320,7 @@ The Observability Pipelines Worker can have problems, such as failing to parse a
 
 If durability is the most important criteria, use the direct archiving method because it addresses data loss scenarios. Use the failed event routing method, also commonly referred to as a data lake, if you prefer to analyze data in your archive. It has the advantage of using your archive/data lake for long-term analysis. Datadog [Log Archives][2] and AWS Athena are examples of archive storage solutions.
 
-### Handling destination failure
+### Handling destination failures
 
 Finally, destination failures refer to the total failure of a downstream destination (for example Elasticsearch). Data loss can be mitigated for issues with the downstream destination by using disk buffers large enough to sustain the outage time. This allows data to durably buffer while the service is down and then drain when the service comes back up. For this reason, disk buffers large enough to hold at least one hour's worth of data are recommended. See [disk sizing](#disk-sizing) for more details.
 
@@ -339,15 +340,15 @@ To achieve high durability:
 
 To mitigate a system process issue, distribute Observability Pipelines Worker across multiple nodes and front them with a network load balancer that can redirect traffic to another Observability Pipelines Worker instance as needed. In addition, platform-level automated self-healing should eventually restart the process or replace the node.
 
-#### Mitigating node failure
+#### Mitigating node failures
 
 To mitigate node issues, distribute the Observability Pipelines Worker across multiple nodes and front them with a network load balancer that can redirect traffic to another Observability Pipelines Worker node. In addition, platform-level automated self-healing should eventually replace the node.
 
-#### Handling availability zones failure
+#### Handling availability zone failures
 
 To mitigate issues with availability zones, deploy the Observability Pipelines Worker across multiple availability zones.
 
-#### Mitigating region failure
+#### Mitigating region failures
 
 Observability Pipelines Worker is designed to route internal observability data, and it should not failover to another region. Instead, Observability Pipelines Worker should be deployed in all of your regions as recommended in the [network boundaries](#network-boundaries) section. Therefore, if your entire network or region fails, Observability Pipelines Worker would fail with it.
 

--- a/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
+++ b/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
@@ -140,8 +140,7 @@ The following units are starting points for estimating your resource capacity, b
 | Metric event          | ~256 bytes| ~25 MiB/s/vCPU                            |
 | Trace span event      | ~1.5 KB   | ~25 MiB/s/vCPU                            |
 
-*These numbers are conservative for estimation purposes.
-*1 vCPU = 1 ARM physical CPU and 0.5 Intel physical CPU.
+*These numbers are conservative for estimation purposes. 1 vCPU = 1 ARM physical CPU and 0.5 Intel physical CPU.
 
 ## Scaling
 

--- a/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
+++ b/content/en/observability_pipelines/production_deployment_overview/aggregator_architecture.md
@@ -366,7 +366,7 @@ If you're using a managed destination, such as Datadog, Observability Pipelines 
 
 ### Multiple aggregator deployments
 
-As covered in [network boundaries](#network-boundaries), it is recommended to start with one Observability Pipelines Worker aggregator per region. This is to prevent overcomplicating your initial deployment of Observability Pipelines Worker, but there are circumstances where starting with multiple deployments makes sense:
+As covered in [network boundaries](#network-boundaries), Datadog recommends to start with one Observability Pipelines Worker aggregator per region. This is to prevent overcomplicating your initial deployment of Observability Pipelines Worker, but there are circumstances where starting with multiple deployments makes sense:
 
 1. **Prevent sending data over the public internet.** If you have multiple clouds and regions, deploy the Observability Pipelines Worker aggregator in each of them to prevent sending large amounts of data over the internet. Your Observability Pipelines Worker aggregator should receive internal data and serve as the single point of egress for your network.
 
@@ -374,7 +374,7 @@ As covered in [network boundaries](#network-boundaries), it is recommended to st
 
 ### Multiple cloud accounts
 
-Many users have multiple cloud accounts with VPCs and clusters inside. It is still recommended in this case to deploy one Observability Pipelines Worker aggregator per region. Deploy Observability Pipelines Worker into your utility/tools cluster and configure all your cloud accounts to send data to this cluster. See [network boundaries](#network-boundaries) for more information.
+Many users have multiple cloud accounts with VPCs and clusters inside. Datadog still recommends in this case to deploy one Observability Pipelines Worker aggregator per region. Deploy Observability Pipelines Worker into your utility/tools cluster and configure all your cloud accounts to send data to this cluster. See [network boundaries](#network-boundaries) for more information.
 
 ### Pub-sub systems
 
@@ -387,14 +387,14 @@ Using a pub-sub system, like Kafka, is not required to make this architecture hi
 
 #### Pub-sub partitioning
 
-Partitioning, or "topics" in Kafka terminology, refers to separating data in your pub-sub systems. It is strongly recommended to partition along data origin lines, such as the service or host that generated the data.
+Partitioning, or "topics" in Kafka terminology, refers to separating data in your pub-sub systems. Datadog strongly recommends partitioning along data origin lines, such as the service or host that generated the data.
 
 #### Pub-sub configuration
 
 When using a pub-sub system, the following configuration changes for Observability Pipelines Worker are recommended:
 
 - **Enable end-to-end acknowledgements for all sinks.** This setting ensures that the pub-sub checkpoint is not advanced until data is successfully written.
-- **Use memory buffers.** There is no need to use Observability Pipelines Worker’s disk buffers when it sits behind a pub-sub system. Your pub-sub system is designed for long-term buffering with high durability. Observability Pipelines Worker should only be responsible for reading, processing, and routing the data (not durability).
+- **Use memory buffers.** There is no need to use Observability Pipelines Worker's disk buffers when it sits behind a pub-sub system. Your pub-sub system is designed for long-term buffering with high durability. Observability Pipelines Worker should only be responsible for reading, processing, and routing the data (not durability).
 
 ### Global aggregation
 


### PR DESCRIPTION
### What does this PR do?

Adds the new Obs Pipelines Worker Aggregator Architecture doc. 

### Motivation

DOCS-4556, PM request.

### Additional notes

This branch is created off of may/opw-production-deployment. Once this PR looks good, the plan is to merge this PR into the original branch.

Images won't be ready until 1/20. Since we are planning to publish this doc by 1/18, I will create a separate PR to add the images and content that refer to the images.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
