### PR TITLE
[DOCS-4652] Change log forwarding banner from beta to limited availability

### DIFF
--- a/content/en/logs/log_configuration/forwarding_custom_destinations.md
+++ b/content/en/logs/log_configuration/forwarding_custom_destinations.md
@@ -14,9 +14,9 @@ further_reading:
   text: "Learn about log pipelines"
 ---
 
-{{< beta-callout url="https://www.datadoghq.com/log-forwarding-limited-availability/" >}}
-  Log Forwarding is currently in beta. Fill out this form to request access.
-{{< /beta-callout >}}
+<div class="alert alert-warning">
+Log forwarding is in limited availability. Fill out this <a href="https://www.datadoghq.com/log-forwarding-limited-availability/">form</a> to request access.
+</div>
 
 ## Overview
 


### PR DESCRIPTION
### What does this PR do?

- Updates banner to say limited availability. Use alert box because the "Join the beta!" text can't be changed for the beta call-out.

### Motivation

DOCS-4652, PM request.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
