### PR TITLE
Fixing broken resource link

### DIFF
--- a/config/live/config.yaml
+++ b/config/live/config.yaml
@@ -17,7 +17,7 @@ deployment:
     targets:
     - name: "live"
       URL: "s3://datadog-docs-live-hugo?region=us-east-1"
-      exclude: "**.{go,java,sh,py,rb}"
+      exclude: "**.{go,java,py,rb}"
       # cloudFrontDistributionID: E2B2OODXRYOXSA
     - name: "liveAssets"
       URL: "s3://origin-static-assets?region=us-east-1&prefix=documentation/"

--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -17,7 +17,7 @@ deployment:
     targets:
     - name: "preview"
       URL: "s3://datadog-docs-preview?region=us-east-1&prefix=$CI_COMMIT_REF_NAME/"
-      exclude: "**.{go,java,sh,py,rb}"
+      exclude: "**.{go,java,py,rb}"
       cloudFrontDistributionID: E3EYIYXXL26MK1
     - name: "previewAssets"
       URL: "s3://dd-staging-static-assets?region=us-east-1&prefix=documentation/"


### PR DESCRIPTION
### What does this PR do?

Some resources aren't being deployed because of an exclusion
e.g https://docs.datadoghq.com/resources/sh/rpm_check.sh

### Motivation

Fixing a 404

### Preview

clicking `this script` shouldn't 404
https://docs-staging.datadoghq.com/david.jones/deploy-resource/agent/faq/circleci-incident-impact-on-datadog-agent/#verifying-installed-agent-packages

This script links to `https://docs-staging.datadoghq.com/david.jones/deploy-resource/resources/sh/rpm_check.sh`

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
