### PR TITLE
Rtrieu/docs 4588 supported prometheus parameters

### DIFF
--- a/content/en/containers/kubernetes/prometheus.md
+++ b/content/en/containers/kubernetes/prometheus.md
@@ -281,9 +281,7 @@ You can define advanced OpenMetrics check configurations or custom Autodiscovery
 
 `additionalConfigs` is a list of structures containing OpenMetrics check configurations and Autodiscovery rules.
 
-Every [configuration field][1] supported by the OpenMetrics check can be passed in the configurations list.
-
-**Note**: Only the parameters [on this page][15] are supported for OpenmetricsV2 with autodiscovery.
+Only the parameters [on this page][2] are supported for OpenMetrics v2 with autodiscovery and can be passed in the configurations list.
 
 The autodiscovery configuration can be based on container names or kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
@@ -333,9 +331,7 @@ You can define advanced OpenMetrics check configurations or custom Autodiscovery
 
 `DD_PROMETHEUS_SCRAPE_CHECKS` is a list of structures containing OpenMetrics check configurations and Autodiscovery rules.
 
-Every [configuration field][1] supported by the OpenMetrics check can be passed in the configurations list.
-
-**Note**: Only the parameters [on this page][15] are supported for OpenmetricsV2 with autodiscovery.
+Only the parameters [on this page][2] are supported for OpenMetrics v2 with autodiscovery and can be passed in the configurations list.
 
 The Autodiscovery configuration can be based on container names or Kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
@@ -365,6 +361,7 @@ In this example we're defining an advanced configuration targeting a container n
 
 
 [1]: https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+[2]: https://github.com/DataDog/datadog-agent/blob/main/pkg/autodiscovery/common/types/prometheus.go#L92-L100
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -392,4 +389,3 @@ Official integrations have their own dedicated directories. There's a default in
 [12]: https://app.datadoghq.com/metric/summary
 [13]: /agent/faq/template_variables/
 [14]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy
-[15]: https://github.com/DataDog/datadog-agent/blob/main/pkg/autodiscovery/common/types/prometheus.go#L92-L100

--- a/content/en/containers/kubernetes/prometheus.md
+++ b/content/en/containers/kubernetes/prometheus.md
@@ -324,6 +324,7 @@ datadog:
 
 
 [1]: https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+[2]: https://github.com/DataDog/datadog-agent/blob/main/pkg/autodiscovery/common/types/prometheus.go#L92-L100
 {{% /tab %}}
 {{% tab "DaemonSet" %}}
 

--- a/content/en/containers/kubernetes/prometheus.md
+++ b/content/en/containers/kubernetes/prometheus.md
@@ -283,6 +283,8 @@ You can define advanced OpenMetrics check configurations or custom Autodiscovery
 
 Every [configuration field][1] supported by the OpenMetrics check can be passed in the configurations list.
 
+**Note**: Only the parameters [on this page][15] are supported for OpenmetricsV2 with autodiscovery.
+
 The autodiscovery configuration can be based on container names or kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
 `kubernetes_container_names` is a list of container names to target, it supports the `*` wildcard.
@@ -332,6 +334,8 @@ You can define advanced OpenMetrics check configurations or custom Autodiscovery
 `DD_PROMETHEUS_SCRAPE_CHECKS` is a list of structures containing OpenMetrics check configurations and Autodiscovery rules.
 
 Every [configuration field][1] supported by the OpenMetrics check can be passed in the configurations list.
+
+**Note**: Only the parameters [on this page][15] are supported for OpenmetricsV2 with autodiscovery.
 
 The Autodiscovery configuration can be based on container names or Kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
@@ -388,3 +392,4 @@ Official integrations have their own dedicated directories. There's a default in
 [12]: https://app.datadoghq.com/metric/summary
 [13]: /agent/faq/template_variables/
 [14]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy
+[15]: https://github.com/DataDog/datadog-agent/blob/main/pkg/autodiscovery/common/types/prometheus.go#L92-L100

--- a/content/en/containers/kubernetes/prometheus.md
+++ b/content/en/containers/kubernetes/prometheus.md
@@ -281,9 +281,9 @@ You can define advanced OpenMetrics check configurations or custom Autodiscovery
 
 `additionalConfigs` is a list of structures containing OpenMetrics check configurations and Autodiscovery rules.
 
-Only the parameters [on this page][2] are supported for OpenMetrics v2 with autodiscovery and can be passed in the configurations list.
+Only the parameters [on this page][2] are supported for OpenMetrics v2 with Autodiscovery and can be passed in the configurations list.
 
-The autodiscovery configuration can be based on container names or kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
+The Autodiscovery configuration can be based on container names, Kubernetes annotations, or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
 `kubernetes_container_names` is a list of container names to target, it supports the `*` wildcard.
 
@@ -332,9 +332,9 @@ You can define advanced OpenMetrics check configurations or custom Autodiscovery
 
 `DD_PROMETHEUS_SCRAPE_CHECKS` is a list of structures containing OpenMetrics check configurations and Autodiscovery rules.
 
-Only the parameters [on this page][2] are supported for OpenMetrics v2 with autodiscovery and can be passed in the configurations list.
+Only the parameters [on this page][2] are supported for OpenMetrics v2 with Autodiscovery and can be passed in the configurations list.
 
-The Autodiscovery configuration can be based on container names or Kubernetes annotations or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
+The Autodiscovery configuration can be based on container names, Kubernetes annotations, or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
 `kubernetes_container_names` is a list of container names to target, it supports the `*` wildcard.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the following:

> Every [configuration field](https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example) supported by the OpenMetrics check can be passed in the configurations list.

to this:

> Only the parameters [on this page](https://github.com/DataDog/datadog-agent/blob/main/pkg/autodiscovery/common/types/prometheus.go#L92-L100) are supported for OpenMetrics v2 with autodiscovery and can be passed in the configurations list.

### Motivation
[DOCS-4588](https://datadoghq.atlassian.net/browse/DOCS-4588), which is intended to provide a more accurate description of what is supported.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4588]: https://datadoghq.atlassian.net/browse/DOCS-4588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ