### PR TITLE
Add DD_TRACE_FORKED_PROCESS env var to PHP config

### DIFF
--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -184,6 +184,11 @@ Enable tracing of PHP scripts from the CLI. See [Tracing CLI scripts](#tracing-c
 **Default**: `0`<br>
 Enable debug mode. When `1`, log messages are sent to the device or file set in the `error_log` INI setting. The actual value of `error_log` might be different than the output of `php -i` as it can be overwritten in the PHP-FPM/Apache configuration files.
 
+`DD_TRACE_FORKED_PROCESS`
+: **INI**: `datadog.trace.forked_process`<br>
+**Default**: `1`<br>
+Start a fresh or a distributed trace, depending on `DD_DISTRIBUTED_TRACING`. If set to `0`, the tracer will be disabled in the forked process. It then can be manually re-enabled in code with `ini_set("datadog.trace.enabled", "1");`.
+
 `DD_TRACE_ENABLED`
 : **INI**: `datadog.trace.enabled`<br>
 **Default**: `1`<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -187,7 +187,7 @@ Enable debug mode. When `1`, log messages are sent to the device or file set in 
 `DD_TRACE_FORKED_PROCESS`
 : **INI**: `datadog.trace.forked_process`<br>
 **Default**: `1`<br>
-Start a fresh or a distributed trace, depending on `DD_DISTRIBUTED_TRACING`. If set to `0`, the tracer will be disabled in the forked process. It then can be manually re-enabled in code with `ini_set("datadog.trace.enabled", "1");`.
+Indicates whether to trace a forked process. Set to `1` to trace forked processes, or to `0` to disable tracing in forked processes. If set to `0`, you can still manually re-enable a process' trace in code with `ini_set("datadog.trace.enabled", "1");`, but it will be presented as a fresh trace. Forked process traces are shown as whole distributed traces only when both `DD_TRACE_FORKED_PROCESS` and `DD_DISTRIBUTED_TRACING` are configured to `1` (on).
 
 `DD_TRACE_ENABLED`
 : **INI**: `datadog.trace.enabled`<br>


### PR DESCRIPTION
### What does this PR do?

Adds `DD_TRACE_FORKED_PROCESS` and describe how to re-enable if set to 0.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
