### PR TITLE
Added info on logs exlusion query

### DIFF
--- a/content/en/logs/explorer/search_syntax.md
+++ b/content/en/logs/explorer/search_syntax.md
@@ -39,7 +39,7 @@ To combine multiple terms into a complex query, you can use any of the following
 | **Operator** | **Description**                                                                                        | **Example**                  |
 | `AND`        | **Intersection**: both terms are in the selected events (if nothing is added, AND is taken by default) | authentication AND failure   |
 | `OR`         | **Union**: either term is contained in the selected events                                             | authentication OR password   |
-| `-`          | **Exclusion**: the following term is NOT in the event                                                  | authentication AND -password |
+| `-`          | **Exclusion**: the following term is NOT in the event (apply to each individual raw text search)                                                  | authentication AND -password |
 
 ## Autocomplete
 

--- a/content/en/metrics/advanced-filtering.md
+++ b/content/en/metrics/advanced-filtering.md
@@ -23,7 +23,7 @@ Whether you're using the Metrics Explorer, monitors, or dashboards to query metr
 
 {{< img src="metrics/advanced-filtering/tags.png" alt="Filter with tags" style="width:80%;" >}}
 
-You can also perform advanced filtering with Boolean or Wildcard tag value filters. For queries outside of metrics data such as logs, traces, network monitoring, real user monitoring, synthetics, or security, see the [log search][1] documentation for configuration.
+You can also perform advanced filtering with Boolean or Wildcard tag value filters. For queries outside of metrics data such as logs, traces, Network Monitoring, Real User Monitoring, Synthetics, or Security, see the [Log Search Syntax documentation][1] for configuration.
 
 ### Boolean filtered queries 
 
@@ -41,7 +41,7 @@ When including or excluding multiple tags:
 * Include uses `AND` logic
 * Exclude uses `OR` logic
 
-For more information on tags, see the guide for [Getting Started Using Tags][2].
+For more information on tags, see the [Getting Started With Using Tags][2] guide.
 
 **Note:** Symbolic boolean syntax (`!`, `,`) cannot be used with functional syntax operators (`NOT`, `AND`, `OR`, `IN`, `NOT IN`). The following query is considered _invalid_: 
 `avg:mymetric{env:prod AND !region:us-east}`

--- a/content/en/metrics/advanced-filtering.md
+++ b/content/en/metrics/advanced-filtering.md
@@ -12,6 +12,9 @@ further_reading:
   - link: "/metrics/distributions/"
     tag: "Documentation"
     text: "Metrics Distributions"
+  - link: "/logs/explorer/search_syntax/"
+    tag: "Documentation"
+    text: "Logs Query Filter and Search Syntax"
 ---
 
 ## Overview
@@ -20,7 +23,7 @@ Whether you're using the Metrics Explorer, monitors, or dashboards to query metr
 
 {{< img src="metrics/advanced-filtering/tags.png" alt="Filter with tags" style="width:80%;" >}}
 
-You can also perform advanced filtering with Boolean or Wildcard tag value filters.
+You can also perform advanced filtering with Boolean or Wildcard tag value filters. For queries outside of metrics data such as logs, traces, network monitoring, real user monitoring, synthetics, or security, see the [log search][1] documentation for configuration.
 
 ### Boolean filtered queries 
 
@@ -38,7 +41,7 @@ When including or excluding multiple tags:
 * Include uses `AND` logic
 * Exclude uses `OR` logic
 
-For more information on tags, see the guide for [Getting Started Using Tags][1].
+For more information on tags, see the guide for [Getting Started Using Tags][2].
 
 **Note:** Symbolic boolean syntax (`!`, `,`) cannot be used with functional syntax operators (`NOT`, `AND`, `OR`, `IN`, `NOT IN`). The following query is considered _invalid_: 
 `avg:mymetric{env:prod AND !region:us-east}`
@@ -94,3 +97,4 @@ sum:kubernetes.pods.running{service:*-canary} by {service}
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /getting_started/tagging/using_tags/
+[2]: /logs/explorer/search_syntax/

--- a/content/en/metrics/advanced-filtering.md
+++ b/content/en/metrics/advanced-filtering.md
@@ -96,5 +96,5 @@ sum:kubernetes.pods.running{service:*-canary} by {service}
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /getting_started/tagging/using_tags/
-[2]: /logs/explorer/search_syntax/
+[1]: /logs/explorer/search_syntax/
+[2]: /getting_started/tagging/using_tags/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Added information regarding Logs query syntax, specifically the exclusion query and needing to apply it to each individual raw text search
- Added a reference link to the logs query page in the Metrics Advanced Filtering, users are applying the metrics filtering to events queries and they are not the same.

### Motivation
[DOCS-4625](https://datadoghq.atlassian.net/browse/DOCS-4625)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4625]: https://datadoghq.atlassian.net/browse/DOCS-4625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ