### PR TITLE
Added example of `error.msg` to scrub APM span

### DIFF
--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -222,9 +222,9 @@ apm_config:
     # Remove all "error.stack" tag's value
     - name: "error.stack"
       pattern: "(?s).*"
-    # Replace postal codes in error messages
+    # Replace series of numbers in error messages
     - name: "error.msg"
-      pattern: "\(?:\d{5}-\d{4}|\d{5}|[A-Z]\d[A-Z] \d[A-Z]\d)"
+      pattern: "[0-9]{10}"
       repl: "[REDACTED]"
 ```
 
@@ -254,7 +254,7 @@ DD_APM_REPLACE_TAGS=[
       },
       {
         "name": "error.msg",
-        "pattern": "\(?:\d{5}-\d{4}|\d{5}|[A-Z]\d[A-Z] \d[A-Z]\d)",
+        "pattern": "[0-9]{10}",
         "repl": "[REDACTED]"
       }
 ]
@@ -289,7 +289,7 @@ Put this environment variable in the trace-agent container if you are using the 
             },
             {
               "name": "error.msg",
-              "pattern": "\(?:\d{5}-\d{4}|\d{5}|[A-Z]\d[A-Z] \d[A-Z]\d)",
+              "pattern": "[0-9]{10}",
               "repl": "[REDACTED]"
             }
           ]'
@@ -301,7 +301,7 @@ Put this environment variable in the trace-agent container if you are using the 
 {{% tab "docker-compose" %}}
 
 ```docker-compose.yaml
-- DD_APM_REPLACE_TAGS=[{"name":"http.url","pattern":"token/(.*)","repl":"?"},{"name":"resource.name","pattern":"(.*)\/$","repl": "$1"},{"name":"*","pattern":"foo","repl":"bar"},{"name":"error.stack","pattern":"(?s).*"}, {"name": "error.msg", "pattern": "\(?:\d{5}-\d{4}|\d{5}|[A-Z]\d[A-Z] \d[A-Z]\d)", "repl": "[REDACTED]"}]
+- DD_APM_REPLACE_TAGS=[{"name":"http.url","pattern":"token/(.*)","repl":"?"},{"name":"resource.name","pattern":"(.*)\/$","repl": "$1"},{"name":"*","pattern":"foo","repl":"bar"},{"name":"error.stack","pattern":"(?s).*"}, {"name": "error.msg", "pattern": "[0-9]{10}", "repl": "[REDACTED]"}]
 ```
 
 {{% /tab %}}

--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -207,7 +207,7 @@ For example:
 ```yaml
 apm_config:
   replace_tags:
-    # Replace all characters starting at the `token/` string in the tag "http.url" with "?":
+    # Replace all characters starting at the `token/` string in the tag "http.url" with "?"
     - name: "http.url"
       pattern: "token/(.*)"
       repl: "?"
@@ -215,13 +215,17 @@ apm_config:
     - name: "resource.name"
       pattern: "(.*)\/$"
       repl: "$1"
-    # Replace all the occurrences of "foo" in any tag with "bar":
+    # Replace all the occurrences of "foo" in any tag with "bar"
     - name: "*"
       pattern: "foo"
       repl: "bar"
-    # Remove all "error.stack" tag's value.
+    # Remove all "error.stack" tag's value
     - name: "error.stack"
       pattern: "(?s).*"
+    # Replace postal codes in error messages
+    - name: "error.msg"
+      pattern: "\(?:\d{5}-\d{4}|\d{5}|[A-Z]\d[A-Z] \d[A-Z]\d)"
+      repl: "[REDACTED]"
 ```
 
 {{% /tab %}}
@@ -235,8 +239,8 @@ DD_APM_REPLACE_TAGS=[
         "repl": "?"
       },
       {
-        "name": "resource.name"
-        "pattern": "(.*)\/$"
+        "name": "resource.name",
+        "pattern": "(.*)\/$",
         "repl": "$1"
       },
       {
@@ -247,6 +251,11 @@ DD_APM_REPLACE_TAGS=[
       {
         "name": "error.stack",
         "pattern": "(?s).*"
+      },
+      {
+        "name": "error.msg",
+        "pattern": "\(?:\d{5}-\d{4}|\d{5}|[A-Z]\d[A-Z] \d[A-Z]\d)",
+        "repl": "[REDACTED]"
       }
 ]
 ```
@@ -265,8 +274,8 @@ Put this environment variable in the trace-agent container if you are using the 
               "repl": "?"
             },
             {
-              "name": "resource.name"
-              "pattern": "(.*)\/$"
+              "name": "resource.name",
+              "pattern": "(.*)\/$",
               "repl": "$1"
             },
             {
@@ -277,6 +286,11 @@ Put this environment variable in the trace-agent container if you are using the 
             {
               "name": "error.stack",
               "pattern": "(?s).*"
+            },
+            {
+              "name": "error.msg",
+              "pattern": "\(?:\d{5}-\d{4}|\d{5}|[A-Z]\d[A-Z] \d[A-Z]\d)",
+              "repl": "[REDACTED]"
             }
           ]'
 ```
@@ -287,7 +301,7 @@ Put this environment variable in the trace-agent container if you are using the 
 {{% tab "docker-compose" %}}
 
 ```docker-compose.yaml
-- DD_APM_REPLACE_TAGS=[{"name":"http.url","pattern":"token/(.*)","repl":"?"},{"name":"resource.name","pattern":"(.*)\/$","repl": "$1"},{"name":"*","pattern":"foo","repl":"bar"},{"name":"error.stack","pattern":"(?s).*"}]
+- DD_APM_REPLACE_TAGS=[{"name":"http.url","pattern":"token/(.*)","repl":"?"},{"name":"resource.name","pattern":"(.*)\/$","repl": "$1"},{"name":"*","pattern":"foo","repl":"bar"},{"name":"error.stack","pattern":"(?s).*"}, {"name": "error.msg", "pattern": "\(?:\d{5}-\d{4}|\d{5}|[A-Z]\d[A-Z] \d[A-Z]\d)", "repl": "[REDACTED]"}]
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Add configuration example for `error.msg` in the `replace_tags` setting/`DD_APM_REPLACE_TAGS` environment variable to replace sensitive data in spans
### Motivation
[DOCS-4638](https://datadoghq.atlassian.net/browse/DOCS-4638)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4638]: https://datadoghq.atlassian.net/browse/DOCS-4638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ