### PR TITLE
[DSFL-1101] Update faulty_deployment_detection.md

### DIFF
--- a/content/en/watchdog/faulty_deployment_detection.md
+++ b/content/en/watchdog/faulty_deployment_detection.md
@@ -11,7 +11,14 @@ When Watchdog finds that a currently active version is faulty, this is indicated
 
 {{< img src="watchdog/faulty_deployment.png" alt="The APM services page showing the yellow banner at the top and deployments table at the bottom" >}}
 
-Click **View Details** in the yellow banner to open a slide-out panel with additional information about the faulty deployment. This view provides details about the faulty deployment, which can include graphs of error rate increases, the error type of newly detected errors, the affected endpoint, and the HTTP status code. This view can also be accessed by clicking on any version in the Deployments table. The screenshot below gives an example of this detailed view, in which the error type `db.utils.OperationalError` is affecting the ` /inventory` endpoint, resulting in HTTP status code `(500)`.
+Click **View Details** in the banner to open a slide-out panel with additional information about the faulty deployment. This view provides details about the faulty deployment, which can include the following:
+
+- Graphs of error rate increases
+- The error type of newly detected errors
+- The affected endpoint
+- The HTTP status code
+
+This view can also be accessed by clicking on any version in the Deployments table. The screenshot below gives an example of this detailed view, in which the error type `db.utils.OperationalError` is affecting the ` /inventory` endpoint, resulting in HTTP status code `(500)`.
 
 {{< img src="watchdog/faulty_deployment_details.png" alt="The faulty deployment tracking details panel" >}}
 

--- a/content/en/watchdog/faulty_deployment_detection.md
+++ b/content/en/watchdog/faulty_deployment_detection.md
@@ -5,13 +5,13 @@ kind: documentation
 
 ## Overview
 
-Automatic Faulty Deployment Detection finds faulty code deployments within minutes, reducing mean time to detection (MTTD). Whenever code is deployed to production, Watchdog compares the performance of the new code version with previous versions to spot new types of errors introduced in a deployment. If Watchdog determines that a new deployment is faulty, details about the affected service appears on the APM service page, as well as the resource page of the affected endpoints.
+Automatic Faulty Deployment Detection finds faulty code deployments within minutes, reducing mean time to detection (MTTD). Whenever code is deployed to production, Watchdog compares the performance of the new code version with previous versions to spot new types of errors or increases in error rates introduced in a deployment. If Watchdog determines that a new deployment is faulty, details about the affected service appears on the APM service page, as well as the resource page of the affected endpoints.
 
 When Watchdog finds that a currently active version is faulty, this is indicated by a yellow banner at the top of the [APM services][1] page, as in the screenshot below. The Deployments table at the bottom of the screen, which presents a history of deployments for the service, also indicates which versions Watchdog found to be faulty in the past.
 
 {{< img src="watchdog/faulty_deployment.png" alt="The APM services page showing the yellow banner at the top and deployments table at the bottom" >}}
 
-Click **View Details** in the yellow banner to open a slide-out panel with additional information about the faulty deployment. This view provides details about the faulty deployment, including the error type of newly detected errors, the affected endpoint, and the HTTP status code. This view can also be accessed by clicking on any version in the Deployments table. The screenshot below gives an example of this detailed view, in which the error type `db.utils.OperationalError` is affecting the ` /inventory` endpoint, resulting in HTTP status code `(500)`.
+Click **View Details** in the yellow banner to open a slide-out panel with additional information about the faulty deployment. This view provides details about the faulty deployment, which can include graphs of error rate increases, the error type of newly detected errors, the affected endpoint, and the HTTP status code. This view can also be accessed by clicking on any version in the Deployments table. The screenshot below gives an example of this detailed view, in which the error type `db.utils.OperationalError` is affecting the ` /inventory` endpoint, resulting in HTTP status code `(500)`.
 
 {{< img src="watchdog/faulty_deployment_details.png" alt="The faulty deployment tracking details panel" >}}
 
@@ -30,6 +30,8 @@ Watchdog attempts to determine if the new deployment is a plausible cause of the
 - Errors of this type do not appear to be new; they appear either in preceding versions or during recent deployments.
 - Errors of this type are few and transient, disappearing over time even as the new version remains in place.
 - There were not enough previous deployments in the recent history for Watchdog to establish a baseline for the analysis.
+- The error rate in the new version was not significantly higher than in preceding versions
+- This error pattern is common during deployments of the service, even when the new code version is not faulty
 
 [1]: https://app.datadoghq.com/apm/services
 [2]: /events/explorer

--- a/content/en/watchdog/faulty_deployment_detection.md
+++ b/content/en/watchdog/faulty_deployment_detection.md
@@ -37,8 +37,8 @@ Watchdog attempts to determine if the new deployment is a plausible cause of the
 - Errors of this type do not appear to be new; they appear either in preceding versions or during recent deployments.
 - Errors of this type are few and transient, disappearing over time even as the new version remains in place.
 - There were not enough previous deployments in the recent history for Watchdog to establish a baseline for the analysis.
-- The error rate in the new version was not significantly higher than in preceding versions
-- This error pattern is common during deployments of the service, even when the new code version is not faulty
+- The error rate in the new version was not significantly higher than in preceding versions.
+- This error pattern is common during deployments of the service, even when the new code version is not faulty.
 
 [1]: https://app.datadoghq.com/apm/services
 [2]: /events/explorer


### PR DESCRIPTION
Minor updates to include extension to the feature, which now also cover error rate increases. See also [this doc](https://docs.google.com/document/d/1IGNesQthu1EEDewt9vgdgBU2jIhVx2W2z2HRgcAKbSU/edit#) for a more detailed description.

Ideally, we would also update the screenshots to include the new Watchdog design for the Faulty Deployments UI. If we do, we should also update the text to say that the banner is purple rather than yellow.

- [New banner design](https://app.datadoghq.com/apm/resource/inventory-api/http.request/19b3b005b24dcb6b?query=env%3Aprod%20cluster-name%3Ademo-11287-us-prod-west%20service%3Ainventory-api%20operation_name%3Ahttp.request%20resource_name%3A%22PUT%20%2Finventory%22&env=prod&hostGroup=demo-11287-us-prod-west&spanType=all&topGraphs=latency%3Ahistorical%2Cerrors%3Aversion_count%2Chits%3Aversion_count&traces=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&start=1673427660000&end=1673471543000&paused=true)
- [New slide-out panel design](https://app.datadoghq.com/apm/resource/inventory-api/http.request/19b3b005b24dcb6b?query=env%3Aprod%20cluster-name%3Ademo-11287-us-prod-west%20service%3Ainventory-api%20operation_name%3Ahttp.request%20resource_name%3A%22PUT%20%2Finventory%22&compareVersionEnd=1673471543000&compareVersionMain=vcb11ck01gf-c1ba2e&compareVersionPaused=true&compareVersionShowOtherVersions=true&compareVersionStart=1673427660000&compareVersionTarget=vca113001ge-bde46a&env=prod&hostGroup=demo-11287-us-prod-west&spanType=all&topGraphs=latency%3Ahistorical%2Cerrors%3Aversion_count%2Chits%3Aversion_count&traces=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&start=1673427660000&end=1673471543000&paused=true)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Updates the Automatic Faulty Deployment Detection docs to also mention analysis of error rate increases.

### Motivation
The feature now also covers error rate increases, but the docs address only the older "new error" analysis.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
