### PR TITLE
Dead URL Fix

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/dd_libraries/dotnet-framework.md
@@ -204,7 +204,7 @@ Docker examples are also available in the [repository][2].
 
 
 
-[1]: https://github.com/DataDog/dd-trace-dotnet/tree/master/docs.Datadog.Trace.Bundle/README.md
+[1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/docs/Datadog.Trace.Bundle/README.md
 [2]: https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples/NugetDeployment
 {{% /tab %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Found a dead github link when trying to find docs for a customer. 

Fixed the URL with the correct link 👍 

Dead URL - https://github.com/DataDog/dd-trace-dotnet/tree/master/docs.Datadog.Trace.Bundle/README.md
Fixed URL - https://github.com/DataDog/dd-trace-dotnet/blob/master/docs/Datadog.Trace.Bundle/README.md

### Motivation
<!-- What inspired you to submit this pull request?-->
Keep public docs up-to-date

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
