### PR TITLE
DOCS-4614 Add GraphQL to list of supported Java frameworks

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -200,6 +200,7 @@ Don't see your desired datastores? Datadog is continually adding additional supp
 | ----------------- | -------- | --------------- | ---------------------------------------------- |
 | Datanucleus JDO   | 4.0+     | Fully Supported | `datanucleus`                                  |
 | Dropwizard Views  | 0.7+     | Fully Supported | `dropwizard`, `dropwizard-view`                |
+| GraphQL         | 14.0+     | Fully Supported | `graphql-java`                  |
 | Hibernate         | 3.5+     | Fully Supported | `hibernate`, `hibernate-core`                  |
 | Hystrix           | 1.4+     | Fully Supported | `hystrix`                                      |
 | JSP Rendering     | 2.3+     | Fully Supported | `jsp`, `jsp-render`, `jsp-compile`             |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds GraphQL to the list of supported Java frameworks.

### Motivation
[DOCS-4614](https://datadoghq.atlassian.net/browse/DOCS-4614) (internal feedback).

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4614]: https://datadoghq.atlassian.net/browse/DOCS-4614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ