### PR TITLE
Remove mentions of the old Agent RPM GPG key

### DIFF
--- a/content/en/agent/faq/agent-downgrade-major.md
+++ b/content/en/agent/faq/agent-downgrade-major.md
@@ -130,7 +130,7 @@ This guide assumes you upgraded to the Agent v6 using the [upgrade guide][1]. If
 
     ```shell
     rm /etc/yum.repos.d/datadog-beta.repo
-    [ ! -f /etc/yum.repos.d/datadog.repo ] && echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/   \nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\npriority=1\ngpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public\n       https://keys.datadoghq.com/DATADOG_RPM_KEY.public\n       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public\n       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public' | sudo tee /etc/yum.repos.d/datadog.repo
+    [ ! -f /etc/yum.repos.d/datadog.repo ] && echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/   \nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\npriority=1\ngpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public\n       https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public\n       https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public' | sudo tee /etc/yum.repos.d/datadog.repo
     ```
 
     **Note**: due to a [bug in dnf][1], use `repo_gpgcheck=0` instead of `repo_gpgcheck=1` on RHEL/CentOS 8.1.

--- a/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
+++ b/content/en/agent/faq/rpm-gpg-key-rotation-agent-6.md
@@ -96,7 +96,6 @@ repo_gpgcheck=1
 gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
        https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-       https://keys.datadoghq.com/DATADOG_RPM_KEY.public
 ```
 
 {{% /tab %}}

--- a/content/en/agent/versions/upgrade_to_agent_v6.md
+++ b/content/en/agent/versions/upgrade_to_agent_v6.md
@@ -73,7 +73,6 @@ Find below the manual upgrade instructions for:
     gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
            https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
            https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. Update your local Yum repo and install the Agent:
@@ -117,7 +116,6 @@ Find below the manual upgrade instructions for:
     gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
            https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
            https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
    **Note**: due to a [bug in dnf][1], use `repo_gpgcheck=0` instead of `repo_gpgcheck=1` on CentOS 8.1.
@@ -209,7 +207,6 @@ Find below the manual upgrade instructions for:
     gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
            https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
            https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
 2. Update your local Yum repo and install the Agent:
@@ -247,7 +244,6 @@ Find below the manual upgrade instructions for:
     gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
            https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
            https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-           https://keys.datadoghq.com/DATADOG_RPM_KEY.public
     ```
 
    **Note**: due to a [bug in dnf][1], use `repo_gpgcheck=0` instead of `repo_gpgcheck=1` on RHEL 8.1.
@@ -347,7 +343,6 @@ Find below the manual upgrade instructions for:
   gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
          https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
          https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-         https://keys.datadoghq.com/DATADOG_RPM_KEY.public
   ```
 
 2. Update your local Zypper repo and install the Agent:
@@ -356,7 +351,6 @@ Find below the manual upgrade instructions for:
   sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
   sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
   sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-  sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY.public
   sudo zypper install datadog-agent
   ```
 

--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -24,7 +24,6 @@ The official repositories and binary packages of the Agent are signed. Verify th
 - Linux RPM packages and repo metadata:
   - [C6559B690CA882F023BDF3F63F4D1729FD4BF915][5]
   - [A4C0B90D7443CF6E4E8AA341F1068E14E09422B3][6]
-  - [60A389A44A0C32BAE3C03F0B069B56F54172A230][7] (Agent 6 and older only)
 - Windows MSI:
   - DigiCert certificate fingerprint `21fe8679bdfb16b879a87df228003758b62abf5e`
 - MacOS PKG:
@@ -38,11 +37,11 @@ The Datadog Agent submits data to Datadog over a TLS-encrypted TCP connection by
 
 ## Networking and proxying
 
-Datadog is a SaaS product: you need to establish an outbound connection from your network to the public internet in order to submit monitoring data. Traffic is always initiated by the Agent to Datadog from TLS-encrypted TCP connection by default. No sessions are ever initiated from Datadog back to the Agent. See the Agent's [Network][8] page for more information on configuring firewalls to allow list the required Datadog domains and ports. Additionally, if you want to monitor hosts with no direct connectivity to the public internet, or with restricted outbound traffic, consider submitting monitoring data from a [proxy][9].
+Datadog is a SaaS product: you need to establish an outbound connection from your network to the public internet in order to submit monitoring data. Traffic is always initiated by the Agent to Datadog from TLS-encrypted TCP connection by default. No sessions are ever initiated from Datadog back to the Agent. See the Agent's [Network][7] page for more information on configuring firewalls to allow list the required Datadog domains and ports. Additionally, if you want to monitor hosts with no direct connectivity to the public internet, or with restricted outbound traffic, consider submitting monitoring data from a [proxy][8].
 
 ## Agent logs obfuscation
 
-The Datadog Agent generates local logs in order to support [Agent troubleshooting][10] as required. As a safety precaution, these local logs are filtered for some specific keywords and patterns that could indicate a potential credential (for example, API key, password, and token keywords), which are then obfuscated before being written to disk.
+The Datadog Agent generates local logs in order to support [Agent troubleshooting][9] as required. As a safety precaution, these local logs are filtered for some specific keywords and patterns that could indicate a potential credential (for example, API key, password, and token keywords), which are then obfuscated before being written to disk.
 
 ## Local HTTPS server
 
@@ -56,13 +55,13 @@ Agent v6 comes bundled with a Graphical User Interface (GUI) by default, which l
 
 Datadog's Vulnerability Management program includes regular assessments of supporting infrastructure and application components, including active scans of core supporting services. Datadog Security teams perform monthly scans to identify configuration and software vulnerabilities, and track remediation of findings according to Datadog's Vulnerability Management policy.
 
-Regarding its Container Agent specifically, Datadog performs regular vulnerability static analysis using [clair by CoreOS][11] and [snyk.io][12]. Additionally, Datadog leverages security scanning as part of its releases of the Container Agent to the [Docker Trusted Registry][13], as well as the [Red Hat Container Catalog][14]. In addition to Datadog's internal Vulnerability Management program, Datadog also partners with container security vendors.
+Regarding its Container Agent specifically, Datadog performs regular vulnerability static analysis using [clair by CoreOS][10] and [snyk.io][11]. Additionally, Datadog leverages security scanning as part of its releases of the Container Agent to the [Docker Trusted Registry][12], as well as the [Red Hat Container Catalog][13]. In addition to Datadog's internal Vulnerability Management program, Datadog also partners with container security vendors.
 
-If you believe you've discovered a bug in Datadog's security, get in touch at [security@datadoghq.com][15] and we will get back to you within 24 hours. Datadog's [PGP key][16] is available for download in case you need to encrypt communications with us. We request that you not publicly disclose the issue until we have had a chance to address it.
+If you believe you've discovered a bug in Datadog's security, get in touch at [security@datadoghq.com][14] and we will get back to you within 24 hours. Datadog's [PGP key][15] is available for download in case you need to encrypt communications with us. We request that you not publicly disclose the issue until we have had a chance to address it.
 
 ## Running as an unprivileged user
 
-By default, the Agent runs as the `dd-agent` user on Linux and as the `ddagentuser` account on [Windows][17]. The exceptions are as follows:
+By default, the Agent runs as the `dd-agent` user on Linux and as the `ddagentuser` account on [Windows][16]. The exceptions are as follows:
 
 - The `system-probe` runs as `root` on Linux and as `LOCAL_SYSTEM` on Windows.
 - The `process-agent` runs as `LOCAL_SYSTEM` on Windows.
@@ -70,9 +69,9 @@ By default, the Agent runs as the `dd-agent` user on Linux and as the `ddagentus
 
 ## Secrets management
 
-If you have a requirement to avoid storing secrets in plaintext in the Agent's configuration files, you can leverage the [secrets management][18] package. This package allows the Agent to call a user-provided executable to handle retrieval or decryption of secrets, which are then loaded in memory by the Agent. You can design your executable according to your preferred key management service, authentication method, and continuous integration workflow.
+If you have a requirement to avoid storing secrets in plaintext in the Agent's configuration files, you can leverage the [secrets management][17] package. This package allows the Agent to call a user-provided executable to handle retrieval or decryption of secrets, which are then loaded in memory by the Agent. You can design your executable according to your preferred key management service, authentication method, and continuous integration workflow.
 
-For more information, see the [Secrets Management][19] documentation.
+For more information, see the [Secrets Management][18] documentation.
 
 ### Further Reading
 
@@ -84,16 +83,15 @@ For more information, see the [Secrets Management][19] documentation.
 [4]: https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
 [5]: https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
 [6]: https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
-[7]: https://keys.datadoghq.com/DATADOG_RPM_KEY.public
-[8]: /agent/faq/network/
-[9]: /agent/proxy/
-[10]: /agent/troubleshooting/
-[11]: https://coreos.com/clair
-[12]: https://snyk.io
-[13]: https://docs.docker.com/v17.09/datacenter/dtr/2.4/guides
-[14]: https://access.redhat.com/containers
-[15]: mailto:security@datadoghq.com
-[16]: https://www.datadoghq.com/8869756E.asc.txt
-[17]: /agent/faq/windows-agent-ddagent-user/
-[18]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets.md
-[19]: /agent/guide/secrets-management/
+[7]: /agent/faq/network/
+[8]: /agent/proxy/
+[9]: /agent/troubleshooting/
+[10]: https://coreos.com/clair
+[11]: https://snyk.io
+[12]: https://docs.docker.com/v17.09/datacenter/dtr/2.4/guides
+[13]: https://access.redhat.com/containers
+[14]: mailto:security@datadoghq.com
+[15]: https://www.datadoghq.com/8869756E.asc.txt
+[16]: /agent/faq/windows-agent-ddagent-user/
+[17]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets.md
+[18]: /agent/guide/secrets-management/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Removes mentions of the old Agent RPM GPG key that was used to sign old versions of Agent 5 and 6.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
