### PR TITLE
footer lang link updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ placeholders:
 
 # create the virtual environment
 hugpython: local/etc/requirements3.txt
-	@${PY3} -m venv --clear $@ && . $@/bin/activate && $@/bin/pip install -r $<
+	@${PY3} -m venv --clear $@ && . $@/bin/activate && $@/bin/pip install --upgrade pip wheel && $@/bin/pip install -r $<
 
 update_pre_build:
 	@. hugpython/bin/activate && GITHUB_TOKEN=$(GITHUB_TOKEN) CONFIGURATION_FILE=$(CONFIGURATION_FILE) ./local/bin/py/build/update_pre_build.py

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -193,7 +193,7 @@
                                         <option value="{{ replace .Permalink (printf "/%s/" $dot.Language.Lang) "/" }}?lang_pref=en">English</a>
                                     {{ end }}
                                     {{ range where .Translations "Language.Lang" "!=" "en" }}
-                                        <option value="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
+                                        <option value="{{ "" | absLangURL }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
                                     {{ end }}
                                 </select>
                                 {{ partial "svg" (dict "context" $dot "src" "arrow.svg" "size" "15px" "color" "#ffffff"  )}}
@@ -211,7 +211,7 @@
                                         <a href="{{ replace .Permalink (printf "/%s/" $dot.Language.Lang) "/" }}?lang_pref=en">English</a>
                                     {{ end }}
                                     {{ range where .Translations "Language.Lang" "!=" "en" }}
-                                        <a href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
+                                        <a href="{{ "" | absLangURL }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
                                     {{ end }}
                                </div>
                             </div>

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -187,13 +187,13 @@
                                 <span class="d-flex align-items-center">{{ partial "svg" (dict "context" $dot "src" "world.svg" "size" "15px" "color" "#ffffff"  )}}&nbsp;</span>
                                 <label class="sr-only" for="mobile-lang-select">Language Selection</label>
                                 <select class="mobile-lang-select" id="mobile-lang-select" id="" onchange="javascript:location.href = this.value;">
-                                    <option value="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
+                                    <option value="{{ "" | absURL }}{{ cond (eq .Sites.First .Site) "" (printf "%s/" .Language.Lang) }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
                                     {{ if ne .Sites.First .Site }}
                                         <!-- if non eng site manually add english entry -->
-                                        <option value="{{ replace .Permalink (printf "/%s/" $dot.Language.Lang) "/" }}?lang_pref=en">English</a>
+                                        <option value="{{ "" | absURL }}?lang_pref=en">English</a>
                                     {{ end }}
                                     {{ range where .Translations "Language.Lang" "!=" "en" }}
-                                        <option value="{{ "" | absLangURL }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
+                                        <option value="{{ "" | absURL }}{{ (printf "%s/" .Language.Lang) }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
                                     {{ end }}
                                 </select>
                                 {{ partial "svg" (dict "context" $dot "src" "arrow.svg" "size" "15px" "color" "#ffffff"  )}}
@@ -205,13 +205,13 @@
                                     <span class="d-flex align-items-center lang-toggle-arrow">{{ partial "svg" (dict "context" $dot "src" "arrow.svg" "size" "15px" "color" "#ffffff"  )}}</span>
                                 </div>
                                 <div class="js-lang-popup lang-popup">
-                                    <a class="active" href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</span></a>
+                                    <a class="active" href="{{ "" | absURL }}{{ cond (eq .Sites.First .Site) "" (printf "%s/" .Language.Lang) }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</span></a>
                                     {{ if ne .Sites.First .Site }}
                                         <!-- if non eng site manually add english entry -->
-                                        <a href="{{ replace .Permalink (printf "/%s/" $dot.Language.Lang) "/" }}?lang_pref=en">English</a>
+                                        <a href="{{ "" | absURL }}?lang_pref=en">English</a>
                                     {{ end }}
                                     {{ range where .Translations "Language.Lang" "!=" "en" }}
-                                        <a href="{{ "" | absLangURL }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
+                                        <a href="{{ "" | absURL }}{{ (printf "%s/" .Language.Lang) }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
                                     {{ end }}
                                </div>
                             </div>


### PR DESCRIPTION
### What does this PR do?

We picked up some inconsistencies with the footer language links when using partialCached
This PR attempts to solve these by directing to the home page.

This update also includes a change to the pip install to avoid some bdist_wheel errors we have seen in the build.

### Motivation

FIxing incorrect language links in footer

### Preview

Check the toggle language at the very bottom of the footer
https://docs-staging.datadoghq.com/david.jones/footer-lang/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
