### PR TITLE
Make troubleshooting TCP errors easier to follow

### DIFF
--- a/content/en/database_monitoring/setup_sql_server/troubleshooting.md
+++ b/content/en/database_monitoring/setup_sql_server/troubleshooting.md
@@ -41,7 +41,33 @@ If the `datadog` user is unable to log into the SQL Server instance, please ensu
 
 Microsoft also provides a helpful doc on troubleshooting these types of errors, which can be [followed here][5].
 
-### SQL Server Unable to connect {#tcp-connection-error}
+### SQL Server TCP connection error {#tcp-connection-error}
+
+TCP connection issues are common when there is a setup misconfiguration with the Agent. The error messages produced by the driver are not always clear.
+
+For example, the following error is because the TCP connection failed:
+
+```shell
+TCP-connection(ERROR: getaddrinfo failed). Exception: unable to connect: could not open database requested by login
+```
+
+Some common errors are:
+
+**"login failed for user"**: this means the agent succeeded in establishing a connection to the host, but the login was rejected for some reason.
+
+To troubleshoot:
+
+1. Check the agent’s login credentials
+
+2. Try to login with those credentials manually using sqlcmd. For example: `sqlcmd -S localhost -U datadog -P ${SQL_PASSWORD} -d master`
+
+**"could not open database requested for login"**: this error appears either due to network issues or due to an unknown database. To troubleshoot:
+
+To troubleshoot:
+
+1. Check the TCP connection from the agent to the host by running `telnet {host} {port}` to make sure there is network connectivity from the Agent to the database.
+
+2. Try to login manually using sqlcmd and see if there’s an issue with the configured database. For example: `sqlcmd -S localhost -U datadog -P ${SQL_PASSWORD} -d master`
 
 ####  Due to “Invalid connection string attribute”
 
@@ -62,33 +88,11 @@ This same error is produced regardless of failure reason (unknown hostname, coul
 
 Look in the error message for HResult error codes. Here are some known codes:
 
-`-2147217843` **“login failed for user”**: this means the agent succeeded in establishing a connection to the host but the login was rejected for some reason.
+`-2147217843` **"login failed for user"**: this means the agent succeeded in establishing a connection to the host, but the login was rejected for some reason.
 
-`-2147467259` **“could not open database requested for login”**: this error appears either due to network issues or due to an unknown database.
+`-2147467259` **"could not open database requested for login"**: this error appears either due to network issues or due to an unknown database.
 
-Please see the section below for tips on how to troubleshoot
-
-If neither step produces meaningful help, or the error code you are seeing is not listed, Datadog recommends to use the `MSOLEDBSQL` driver or the `Microsoft ODBC Driver for SQL Server`. Either of these options will produce more meaningful error messages, which should help troubleshooting why the connection is failing.
-
-#### Due to general TCP connection error
-
-TCP connection issues are common when there is a setup misconfiguration with the agent. Some common errors are:
-
-**“login failed for user”**: this means the agent succeeded in establishing a connection to the host but the login was rejected for some reason.
-
-To troubleshoot:
-
-1. Check the agent’s login credentials
-
-2. Try to login with those credentials manually using sqlcmd. For example: `sqlcmd -S localhost -U datadog -P ${SQL_PASSWORD} -d master`
-
-**“could not open database requested for login”**: this error appears either due to network issues or due to an unknown database. To troubleshoot:
-
-To troubleshoot:
-
-1. Check the TCP connection from the agent to the host by running `telnet {host} {port}` to make sure there is network connectivity from the Agent to the database.
-
-2. Try to login manually using sqlcmd and see if there’s an issue with the configured database. For example: `sqlcmd -S localhost -U datadog -P ${SQL_PASSWORD} -d master`
+If neither step helps with the issue, or the error code you see is not listed, Datadog recommends using the `MSOLEDBSQL` driver or the `Microsoft ODBC Driver for SQL Server`. The drivers produce more meaningful error messages, which can help with troubleshooting why the connection is failing.
 
 ### SQL Server 'Unable to connect: Adaptive Server is unavailable or does not exist' {#adaptive-server-unavailable}
 

--- a/content/en/database_monitoring/setup_sql_server/troubleshooting.md
+++ b/content/en/database_monitoring/setup_sql_server/troubleshooting.md
@@ -43,7 +43,7 @@ Microsoft also provides a helpful doc on troubleshooting these types of errors, 
 
 ### SQL Server TCP connection error {#tcp-connection-error}
 
-TCP connection issues are common when there is a setup misconfiguration with the Agent. The error messages produced by the driver are not always clear.
+TCP connection issues are common when there is a setup misconfiguration with the Agent. The error messages provided by the driver are not always clear.
 
 For example, the following error is because the TCP connection failed:
 
@@ -53,7 +53,7 @@ TCP-connection(ERROR: getaddrinfo failed). Exception: unable to connect: could n
 
 Some common errors are:
 
-**"login failed for user"**: this means the agent succeeded in establishing a connection to the host, but the login was rejected for some reason.
+**"login failed for user"**: this means the Agent succeeded in establishing a connection to the host, but the login was rejected for some reason.
 
 To troubleshoot:
 
@@ -61,7 +61,7 @@ To troubleshoot:
 
 2. Try to login with those credentials manually using sqlcmd. For example: `sqlcmd -S localhost -U datadog -P ${SQL_PASSWORD} -d master`
 
-**"could not open database requested for login"**: this error appears either due to network issues or due to an unknown database. To troubleshoot:
+**"could not open database requested for login"**: this error appears either due to network issues or due to an unknown database.
 
 To troubleshoot:
 
@@ -73,7 +73,7 @@ To troubleshoot:
 
 The following ADO Providers are supported on Windows: `SQLOLEDB`, `MSOLEDBSQL`, `MSOLEDBSQL19`, `SQLNCLI11`.
 
-The `SQLOLEDB` and `SQLNCLI11` providers produce the error message `Invalid connection string attribute` for a wide variety of possible issues. For example:
+The `SQLOLEDB` and `SQLNCLI11` providers could show the error message `Invalid connection string attribute` due to several issues. For example:
 
 ```
 datadog_checks.sqlserver.connection.SQLConnectionError:
@@ -84,15 +84,15 @@ OperationalError(com_error(-2147352567, 'Exception occurred.',
 'Error opening connection to "ConnectRetryCount=2;Provider=SQLOLEDB;Data Source=foo.com,1433;Initial Catalog=master;User ID=datadog;Password=******;"')
 ```
 
-This same error is produced regardless of failure reason (unknown hostname, could not establish TCP connection, invalid login credentials, unknown database).
+This same error is shown regardless of the reason for the failure (for example, due to an unknown hostname, the TCP connection not established, invalid login credentials, or an unknown database).
 
-Look in the error message for HResult error codes. Here are some known codes:
+Look in the error message for the HResult error codes. These are examples of known codes:
 
 `-2147217843` **"login failed for user"**: this means the agent succeeded in establishing a connection to the host, but the login was rejected for some reason.
 
 `-2147467259` **"could not open database requested for login"**: this error appears either due to network issues or due to an unknown database.
 
-If neither step helps with the issue, or the error code you see is not listed, Datadog recommends using the `MSOLEDBSQL` driver or the `Microsoft ODBC Driver for SQL Server`. The drivers produce more meaningful error messages, which can help with troubleshooting why the connection is failing.
+If neither step helps with the issue, or the error code you see is not listed, Datadog recommends using the `MSOLEDBSQL` driver or the `Microsoft ODBC Driver for SQL Server`. The drivers provide more detailed error messages, which can help with troubleshooting why the connection is failing.
 
 ### SQL Server 'Unable to connect: Adaptive Server is unavailable or does not exist' {#adaptive-server-unavailable}
 

--- a/content/en/database_monitoring/setup_sql_server/troubleshooting.md
+++ b/content/en/database_monitoring/setup_sql_server/troubleshooting.md
@@ -41,7 +41,9 @@ If the `datadog` user is unable to log into the SQL Server instance, please ensu
 
 Microsoft also provides a helpful doc on troubleshooting these types of errors, which can be [followed here][5].
 
-### SQL Server Unable to connect due to “Invalid connection string attribute” {#tcp-connection-error}
+### SQL Server Unable to connect {#tcp-connection-error}
+
+####  Due to “Invalid connection string attribute”
 
 The following ADO Providers are supported on Windows: `SQLOLEDB`, `MSOLEDBSQL`, `MSOLEDBSQL19`, `SQLNCLI11`.
 
@@ -62,21 +64,31 @@ Look in the error message for HResult error codes. Here are some known codes:
 
 `-2147217843` **“login failed for user”**: this means the agent succeeded in establishing a connection to the host but the login was rejected for some reason.
 
+`-2147467259` **“could not open database requested for login”**: this error appears either due to network issues or due to an unknown database.
+
+Please see the section below for tips on how to troubleshoot
+
+If neither step produces meaningful help, or the error code you are seeing is not listed, Datadog recommends to use the `MSOLEDBSQL` driver or the `Microsoft ODBC Driver for SQL Server`. Either of these options will produce more meaningful error messages, which should help troubleshooting why the connection is failing.
+
+#### Due to general TCP connection error
+
+TCP connection issues are common when there is a setup misconfiguration with the agent. Some common errors are:
+
+**“login failed for user”**: this means the agent succeeded in establishing a connection to the host but the login was rejected for some reason.
+
 To troubleshoot:
 
 1. Check the agent’s login credentials
 
 2. Try to login with those credentials manually using sqlcmd. For example: `sqlcmd -S localhost -U datadog -P ${SQL_PASSWORD} -d master`
 
-`-2147467259` **“could not open database requested for login”**: this error appears either due to network issues or due to an unknown database. To troubleshoot:
+**“could not open database requested for login”**: this error appears either due to network issues or due to an unknown database. To troubleshoot:
 
 To troubleshoot:
 
 1. Check the TCP connection from the agent to the host by running `telnet {host} {port}` to make sure there is network connectivity from the Agent to the database.
 
 2. Try to login manually using sqlcmd and see if there’s an issue with the configured database. For example: `sqlcmd -S localhost -U datadog -P ${SQL_PASSWORD} -d master`
-
-If neither step produces meaningful help, or the error code you are seeing is not listed, Datadog recommends to use the `MSOLEDBSQL` driver or the `Microsoft ODBC Driver for SQL Server`. Either of these options will produce more meaningful error messages, which should help troubleshooting why the connection is failing.
 
 ### SQL Server 'Unable to connect: Adaptive Server is unavailable or does not exist' {#adaptive-server-unavailable}
 

--- a/layouts/shortcodes/dbm-sqlserver-before-you-begin.md
+++ b/layouts/shortcodes/dbm-sqlserver-before-you-begin.md
@@ -1,5 +1,5 @@
 Supported Agent versions
-: 7.38.0+
+: 7.41.0+
 
 Performance impact
 : The default Agent configuration for Database Monitoring is conservative, but you can adjust settings such as the collection interval and query sampling rate to better suit your needs. For most workloads, the Agent represents less than one percent of query execution time on the database and less than one percent of CPU. <br/><br/>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Splits out the different types of TCP error messages we see in the agent since as of 7.40 we no longer allow the agent to emit the "Invalid connection string attribute" error. I am leaving the reference to it for people who are using older versions of the agent, but this error is due to a tcp connection issue & so it should be documented that way. 

**Also** bumps min agent version to 7.41 (latest release, which includes this fix https://github.com/DataDog/integrations-core/pull/13089)

### Motivation
<!-- What inspired you to submit this pull request?-->

Support request where customer was seeing
```
TCP-connection(ERROR: getaddrinfo failed). Exception: unable to connect: could not open database requested by login
```

due to a port misconfiguration && was not able to troubleshoot on their own. Had they tried to telnet on port 1433 they would've figured out quickly that sqlserver wasn't running on that port

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
