### PR TITLE
DOCS-4538 add directory/user access clarification

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/dd_libraries/java.md
@@ -109,7 +109,7 @@ For other environments, please refer to the [Integrations][5] documentation for 
 
 After the agent is installed, to begin tracing your applications:
 
-1. Download `dd-java-agent.jar` that contains the latest Agent class files:
+1. Download `dd-java-agent.jar` that contains the latest tracer class files, to a folder that is accessible by your Datadog user:
 
    ```shell
    wget -O dd-java-agent.jar https://dtdg.co/latest-java-tracer


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
mentions that the folder you download the tracing library jar to must be accessible by your datadog user

### Motivation
DOCS-4538

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
