### PR TITLE
Configuration for OTel support in Browser RUM

### DIFF
--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -59,7 +59,7 @@ Use frontend data from RUM, as well as backend, infrastructure, and log informat
         clientToken: '<DATADOG_CLIENT_TOKEN>',
         ...otherConfig,
         service: "my-web-application",
-        allowedTracingUrls: ["https://api.example.com", /https:\/\/.*\.my-api-domain\.com/, (origin) => origin === "https://api.example.com"]
+        allowedTracingUrls: ["https://api.example.com", /https:\/\/.*\.my-api-domain\.com/, (url) => url.startsWith("https://api.example.com")]
     })
     ```
 
@@ -191,7 +191,7 @@ RUM also supports several propagator types to connect resources with backends in
 {{< tabs >}} {{% tab "Browser RUM" %}}
 1. Setup RUM to connect with APM as described above
 
-2. Modify allowedTracingUrls such as:
+2. Modify `allowedTracingUrls` such as:
     ```javascript
     import { datadogRum } from '@datadog/browser-rum'
 
@@ -202,7 +202,7 @@ RUM also supports several propagator types to connect resources with backends in
         ]
     })
     ```
-    `match` accepts the same parameter types (string, RegExp or function) as when used in its simple form.
+    `match` accepts the same parameter types (`string`, `RegExp` or `function`) as when used in its simple form.
 
     `propagatorTypes` accepts a list of strings for desired propagators:
       - `datadog`: Datadog's propagator (x-datadog-*)

--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -65,9 +65,9 @@ Use frontend data from RUM, as well as backend, infrastructure, and log informat
 
     To connect RUM to Traces, you need to specify your browser application in the `service` field.
 
-    `allowedTracingUrls` will match against the full URL (`<scheme>://<host>[:<port>]/<path>[?<query>][#<fragment>]`). It accepts the following types:
-      - `string`: matches any URL starting with the provided value, so `https://api.example.com` will match `https://api.example.com/v1/resource`.
-      - `RegExp`: executes a test with the provided RegExp and the URL
+    `allowedTracingUrls` matches the full URL (`<scheme>://<host>[:<port>]/<path>[?<query>][#<fragment>]`). It accepts the following types:
+      - `string`: matches any URL that starts with the value, so `https://api.example.com` matches `https://api.example.com/v1/resource`.
+      - `RegExp`: executes a test with the provided RegExp and the URL.
       - `function`: evaluates with the URL as parameter. Returning a `boolean` set to `true` indicates a match.
 
 3.  _(Optional)_ Configure the `tracingSampleRate` initialization parameter to keep a defined percentage of the backend traces. If not set, 100% of the traces coming from browser requests are sent to Datadog. To keep 20% of backend traces:
@@ -184,14 +184,14 @@ The following Datadog tracing libraries are supported:
 | [.NET][14]                  | [1.18.2][15]                |
 
 
-## Open Telemetry support
+## OpenTelemetry support
 
-RUM also supports several propagator types to connect resources with backends instrumented with Open Telemetry libraries.
+RUM supports several propagator types to connect resources with backends that are instrumented with OpenTelemetry libraries.
 
 {{< tabs >}} {{% tab "Browser RUM" %}}
-1. Setup RUM to connect with APM as described above
+1. Set up RUM to connect with APM as described above.
 
-2. Modify `allowedTracingUrls` such as:
+2. Modify `allowedTracingUrls` as follows:
     ```javascript
     import { datadogRum } from '@datadog/browser-rum'
 
@@ -202,13 +202,13 @@ RUM also supports several propagator types to connect resources with backends in
         ]
     })
     ```
-    `match` accepts the same parameter types (`string`, `RegExp` or `function`) as when used in its simple form.
+    `match` accepts the same parameter types (`string`, `RegExp` or `function`) as when used in its simple form, described above.
 
     `propagatorTypes` accepts a list of strings for desired propagators:
-      - `datadog`: Datadog's propagator (x-datadog-*)
-      - `tracecontext`: [W3C Trace Context](https://www.w3.org/TR/trace-context/) (traceparent)
-      - `b3`: [B3 single header](https://github.com/openzipkin/b3-propagation#single-header) (b3)
-      - `b3multi`: [B3 multiple headers](https://github.com/openzipkin/b3-propagation#multiple-headers) (X-B3-*)
+      - `datadog`: Datadog's propagator (`x-datadog-*`)
+      - `tracecontext`: [W3C Trace Context](https://www.w3.org/TR/trace-context/) (`traceparent`)
+      - `b3`: [B3 single header](https://github.com/openzipkin/b3-propagation#single-header) (`b3`)
+      - `b3multi`: [B3 multiple headers](https://github.com/openzipkin/b3-propagation#multiple-headers) (`X-B3-*`)
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -231,19 +231,19 @@ Datadog uses the distributed tracing protocol and sets up the following HTTP hea
 {{% /tab %}}
 {{% tab "W3C Trace Context" %}}
 `traceparent: [version]-[trace id]-[parent id]-[trace flags]`
-: version: The current specification assumes version is set to 00.
-: trace id: 128 bits trace ID, hexadecimal on 32 characters (The source trace id is 64 bits to keep compatibility with APM)
-: parent id: 64 bits span ID, hexadecimal on 16 characters
-: trace flags: Sampled (01) or not sampled (00)
+: `version`: The current specification assumes version is set to `00`.
+: `trace id`: 128 bits trace ID, hexadecimal on 32 characters. The source trace ID is 64 bits to keep compatibility with APM.
+: `parent id`: 64 bits span ID, hexadecimal on 16 characters.
+: `trace flags`: Sampled (`01`) or not sampled (`00`)
 
 Example:
 : `traceparent: 00-00000000000000008448eb211c80319c-b7ad6b7169203331s-01`
 {{% /tab %}}
 {{% tab "b3 / b3 Multiple Headers" %}}
 `b3: [trace id]-[span id]-[sampled]`
-: trace id: 64 bits trace ID, hexadecimal on 16 characters
-: span id: 64 bits span ID, hexadecimal on 16 characters
-: sampled: True (1) or False (0)
+: `trace id`: 64 bits trace ID, hexadecimal on 16 characters.
+: `span id`: 64 bits span ID, hexadecimal on 16 characters.
+: `sampled`: True (`1`) or False (`0`)
 
 Example for b3 single header:
 : `b3: 8448eb211c80319c-b7ad6b7169203331-1`

--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -66,9 +66,9 @@ Use frontend data from RUM, as well as backend, infrastructure, and log informat
     To connect RUM to Traces, you need to specify your browser application in the `service` field.
 
     `allowedTracingUrls` will match against the full URL (`<scheme>://<host>[:<port>]/<path>[?<query>][#<fragment>]`). It accepts the following types:
-      - `string`: evaluated using startsWith, so `https://api.example.com` will match `https://api.example.com/v1/resource`.
-      - `RegExp`: evaluated against the full URL
-      - `function`: evaluated with the full URL as parameter. Returning a `boolean` set to `true` indicates a match.
+      - `string`: matches any URL starting with the provided value, so `https://api.example.com` will match `https://api.example.com/v1/resource`.
+      - `RegExp`: executes a test with the provided RegExp and the URL
+      - `function`: evaluates with the URL as parameter. Returning a `boolean` set to `true` indicates a match.
 
 3.  _(Optional)_ Configure the `tracingSampleRate` initialization parameter to keep a defined percentage of the backend traces. If not set, 100% of the traces coming from browser requests are sent to Datadog. To keep 20% of backend traces:
 
@@ -232,17 +232,17 @@ Datadog uses the distributed tracing protocol and sets up the following HTTP hea
 {{% tab "W3C Trace Context" %}}
 `traceparent: [version]-[trace id]-[parent id]-[trace flags]`
 : version: The current specification assumes version is set to 00.
-: trace id: 128 bits trace ID, expressed as padded hexadecimal
-: parent id: 64 bits span ID, expressed as padded hexadecimal
+: trace id: 128 bits trace ID, hexadecimal on 32 characters (The source trace id is 64 bits to keep compatibility with APM)
+: parent id: 64 bits span ID, hexadecimal on 16 characters
 : trace flags: Sampled (01) or not sampled (00)
 
 Example:
-: `traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331s-01`
+: `traceparent: 00-00000000000000008448eb211c80319c-b7ad6b7169203331s-01`
 {{% /tab %}}
 {{% tab "b3 / b3 Multiple Headers" %}}
 `b3: [trace id]-[span id]-[sampled]`
-: trace id: 64 bits trace ID, expressed as padded hexadecimal
-: span id: 64 bits span ID, expressed as padded hexadecimal
+: trace id: 64 bits trace ID, hexadecimal on 16 characters
+: span id: 64 bits span ID, hexadecimal on 16 characters
 : sampled: True (1) or False (0)
 
 Example for b3 single header:

--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -38,9 +38,9 @@ Use frontend data from RUM, as well as backend, infrastructure, and log informat
 -   Your services use an HTTP server.
 -   Your HTTP servers are using [a library that supports distributed tracing](#supported-libraries).
 -   You have the following set up based on your SDK:
-    - With the **Browser SDK**, you have added the XMLHttpRequest (XHR) or Fetch resources on the RUM Explorer to your `allowedTracingOrigins`.
+    - With the **Browser SDK**, you have added the XMLHttpRequest (XHR) or Fetch resources on the RUM Explorer to your `allowedTracingUrls`.
     - With the **Mobile SDK**, you have added the Native or XMLHttpRequest (XHR) to your `firstPartyHosts`.
--   You have a corresponding trace for requests to `allowedTracingOrigins` or `firstPartyHosts`.
+-   You have a corresponding trace for requests to `allowedTracingUrls` or `firstPartyHosts`.
 
 ### Setup RUM
 
@@ -49,7 +49,7 @@ Use frontend data from RUM, as well as backend, infrastructure, and log informat
 
 1.  Set up [RUM Browser Monitoring][1].
 
-2.  Initialize the RUM SDK. Configure the `allowedTracingOrigins` initialization parameter with the list of internal, first-party origins called by your browser application.
+2.  Initialize the RUM SDK. Configure the `allowedTracingUrls` initialization parameter with the list of internal, first-party origins called by your browser application.
 
     ```javascript
     import { datadogRum } from '@datadog/browser-rum'
@@ -59,13 +59,16 @@ Use frontend data from RUM, as well as backend, infrastructure, and log informat
         clientToken: '<DATADOG_CLIENT_TOKEN>',
         ...otherConfig,
         service: "my-web-application",
-        allowedTracingOrigins: ["https://api.example.com", /https:\/\/.*\.my-api-domain\.com/, (origin) => origin === "https://api.example.com"]
+        allowedTracingUrls: ["https://api.example.com", /https:\/\/.*\.my-api-domain\.com/, (origin) => origin === "https://api.example.com"]
     })
     ```
 
     To connect RUM to Traces, you need to specify your browser application in the `service` field.
 
-    `allowedTracingOrigins` accepts JavaScript strings, regular expressions, and functions that match the origins called by your browser application, defined as: `<scheme> "://" <hostname> [ ":" <port> ]`.
+    `allowedTracingUrls` will match against the full URL (`<scheme>://<host>[:<port>]/<path>[?<query>][#<fragment>]`). It accepts the following types:
+      - `string`: evaluated using startsWith, so `https://api.example.com` will match `https://api.example.com/v1/resource`.
+      - `RegExp`: evaluated against the full URL
+      - `function`: evaluated with the full URL as parameter. Returning a `boolean` set to `true` indicates a match.
 
 3.  _(Optional)_ Configure the `tracingSampleRate` initialization parameter to keep a defined percentage of the backend traces. If not set, 100% of the traces coming from browser requests are sent to Datadog. To keep 20% of backend traces:
 
@@ -90,7 +93,7 @@ Use frontend data from RUM, as well as backend, infrastructure, and log informat
 
 2.  Configure the `OkHttpClient` interceptor with the list of internal, first-party origins called by your Android application.
     ```java
-    val tracedHosts =  listOf("example.com", "example.eu")
+    val tracedHosts = listOf("example.com", "example.eu")
 
     val okHttpClient = OkHttpClient.Builder()
         .addInterceptor(DatadogInterceptor(tracedHosts))
@@ -160,7 +163,6 @@ Use frontend data from RUM, as well as backend, infrastructure, and log informat
             .build()
     )
     ```
-
 **Note**: `tracingSamplingRate` **does not** impact RUM sessions sampling. Only backend traces are sampled out.
 
 [1]: /real_user_monitoring/ios/
@@ -182,10 +184,39 @@ The following Datadog tracing libraries are supported:
 | [.NET][14]                  | [1.18.2][15]                |
 
 
+## Open Telemetry support
+
+RUM also supports several propagator types to connect resources with backends instrumented with Open Telemetry libraries.
+
+{{< tabs >}} {{% tab "Browser RUM" %}}
+1. Setup RUM to connect with APM as described above
+
+2. Modify allowedTracingUrls such as:
+    ```javascript
+    import { datadogRum } from '@datadog/browser-rum'
+
+    datadogRum.init({
+        ...otherConfig,
+        allowedTracingUrls: [
+          { match: "https://api.example.com", propagatorTypes: ["tracecontext"]}
+        ]
+    })
+    ```
+    `match` accepts the same parameter types (string, RegExp or function) as when used in its simple form.
+
+    `propagatorTypes` accepts a list of strings for desired propagators:
+      - `datadog`: Datadog's propagator (x-datadog-*)
+      - `tracecontext`: [W3C Trace Context](https://www.w3.org/TR/trace-context/) (traceparent)
+      - `b3`: [B3 single header](https://github.com/openzipkin/b3-propagation#single-header) (b3)
+      - `b3multi`: [B3 multiple headers](https://github.com/openzipkin/b3-propagation#multiple-headers) (X-B3-*)
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## How are RUM resources linked to traces?
 
 Datadog uses the distributed tracing protocol and sets up the following HTTP headers:
-
+{{< tabs >}} {{% tab "Datadog" %}}
 `x-datadog-trace-id`
 : Generated from the Real User Monitoring SDK. Allows Datadog to link the trace with the RUM resource.
 
@@ -197,6 +228,32 @@ Datadog uses the distributed tracing protocol and sets up the following HTTP hea
 
 `x-datadog-sampling-priority: 1`
 : To make sure that the Agent keeps the trace.
+{{% /tab %}}
+{{% tab "W3C Trace Context" %}}
+`traceparent: [version]-[trace id]-[parent id]-[trace flags]`
+: version: The current specification assumes version is set to 00.
+: trace id: 128 bits trace ID, expressed as padded hexadecimal
+: parent id: 64 bits span ID, expressed as padded hexadecimal
+: trace flags: Sampled (01) or not sampled (00)
+
+Example:
+: `traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331s-01`
+{{% /tab %}}
+{{% tab "b3 / b3 Multiple Headers" %}}
+`b3: [trace id]-[span id]-[sampled]`
+: trace id: 64 bits trace ID, expressed as padded hexadecimal
+: span id: 64 bits span ID, expressed as padded hexadecimal
+: sampled: True (1) or False (0)
+
+Example for b3 single header:
+: `b3: 8448eb211c80319c-b7ad6b7169203331-1`
+
+Example for b3 multiple headers:
+: `X-B3-TraceId: 8448eb211c80319c`
+: `X-B3-SpanId:  b7ad6b7169203331`
+: `X-B3-Sampled: 1`
+{{% /tab %}}
+{{< /tabs >}}
 
 These HTTP headers are not CORS-safelisted, so you need to [configure Access-Control-Allow-Headers][16] on your server handling requests that the SDK is set up to monitor. The server must also accept [preflight requests][17] (OPTIONS requests), which are made by the SDK prior to every request.
 


### PR DESCRIPTION
### What does this PR do?
RUM now supports correlation with APM through Open Telemetry. This PR updates the documentation with new configuration parameters to use the functionality.

### Additional Notes
This is the PR for Browser RUM. iOS and Android will soon follow.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
