### PR TITLE
WEB-3054 | Link Check Job bug

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,6 +117,7 @@ link_checks_preview:
   stage: post-deploy
   cache: {}
   environment: "preview"
+  allow_failure: true
   variables:
     URL: ${PREVIEW_DOMAIN}
     GIT_STRATEGY: none

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,7 +1,7 @@
 DirectoryPath: "public"
 
 # Speeds things up but may cause errors in some cases, the two other settings limit the amount of docs and links processed at one time
-TestFilesConcurrently: true
+TestFilesConcurrently: false
 DocumentConcurrencyLimit: 32 #defaults to 128
 HTTPConcurrencyLimit: 8 #defaults to 16
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Removes the concurrency flag from `htmltest` in an attempt to conserve resources for now until we can work with the CI team for a more permanent fix. This also allows the job to fail on `preview` branches just incase this solution is also flaky.

### Motivation
<!-- What inspired you to submit this pull request?-->

Jobs failing in CI for link checking

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
