### PR TITLE
[DOCS-4478] Clarify domains are for RUM traffic

### DIFF
--- a/content/en/getting_started/site/_index.md
+++ b/content/en/getting_started/site/_index.md
@@ -25,34 +25,37 @@ You can identify which site you are on by matching your Datadog website URL to t
 | EU1     | `https://app.datadoghq.eu`  | `datadoghq.eu`      | EU       |
 | US1-FED | `https://app.ddog-gov.com`  | `ddog-gov.com`      | US       |
 
-All Datadog traffic is transmitted over SSL (default 443) to the following domains:
+
+## RUM domains
+
+All Datadog RUM traffic is transmitted over SSL (default 443) to the following domains:
 
 ### Logs
 
-| Site | Site URL                                      |
-|------|-----------------------------------------------|
-| US1  | https://logs.browser-intake-datadoghq.com     |
-| US3  | https://logs.browser-intake-us3-datadoghq.com |
-| US5  | https://logs.browser-intake-us5-datadoghq.com |
-| EU1  | https://mobile-http-intake.logs.datadoghq.eu  |
+| Site | Site URL                                        |
+|------|-------------------------------------------------|
+| US1  | `https://logs.browser-intake-datadoghq.com`     |
+| US3  | `https://logs.browser-intake-us3-datadoghq.com` |
+| US5  | `https://logs.browser-intake-us5-datadoghq.com` |
+| EU1  | `https://mobile-http-intake.logs.datadoghq.eu`  |
 
 ### Traces
 
-| Site | Site URL                                           |
-|------|----------------------------------------------------|
-| US1  | https://trace.browser-intake-datadoghq.com         |
-| US3  | https://trace.browser-intake-us3-datadoghq.com     |
-| US5  | https://trace.browser-intake-us5-datadoghq.com     |
-| EU1  | https://public-trace-http-intake.logs.datadoghq.eu |
+| Site | Site URL                                             |
+|------|------------------------------------------------------|
+| US1  | `https://trace.browser-intake-datadoghq.com`         |
+| US3  | `https://trace.browser-intake-us3-datadoghq.com`     |
+| US5  | `https://trace.browser-intake-us5-datadoghq.com`     |
+| EU1  | `https://public-trace-http-intake.logs.datadoghq.eu` |
 
 ### RUM
 
-| Site | Site URL                                     |
-|------|----------------------------------------------|
-| US1  | https://rum.browser-intake-datadoghq.com     |
-| US3  | https://rum.browser-intake-us3-datadoghq.com |
-| US5  | https://rum.browser-intake-us5-datadoghq.com |
-| EU1  | https://rum-http-intake.logs.datadoghq.eu    |
+| Site | Site URL                                       |
+|------|------------------------------------------------|
+| US1  | `https://rum.browser-intake-datadoghq.com`     |
+| US3  | `https://rum.browser-intake-us3-datadoghq.com` |
+| US5  | `https://rum.browser-intake-us5-datadoghq.com` |
+| EU1  | `https://rum-http-intake.logs.datadoghq.eu`    |
 
 ## Navigate the Datadog documentation by site
 

--- a/content/en/getting_started/site/_index.md
+++ b/content/en/getting_started/site/_index.md
@@ -26,7 +26,7 @@ You can identify which site you are on by matching your Datadog website URL to t
 | US1-FED | `https://app.ddog-gov.com`  | `ddog-gov.com`      | US       |
 
 
-## RUM domains
+## Real User Monitoring (RUM) domains
 
 All Datadog RUM traffic is transmitted over SSL (default 443) to the following domains:
 
@@ -48,7 +48,7 @@ All Datadog RUM traffic is transmitted over SSL (default 443) to the following d
 | US5  | `https://trace.browser-intake-us5-datadoghq.com`     |
 | EU1  | `https://public-trace-http-intake.logs.datadoghq.eu` |
 
-### RUM
+### RUM Events
 
 | Site | Site URL                                       |
 |------|------------------------------------------------|


### PR DESCRIPTION
### What does this PR do?

Adds text to make it clear that the domains are for RUM traffic.

### Motivation

[DOCS-4478](https://datadoghq.atlassian.net/browse/DOCS-4478)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4478]: https://datadoghq.atlassian.net/browse/DOCS-4478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ