### PR TITLE
Remove references to deprecated cloud foundry buildpack environment variable

### DIFF
--- a/content/en/integrations/vmware_tanzu_application_service.md
+++ b/content/en/integrations/vmware_tanzu_application_service.md
@@ -70,7 +70,6 @@ Log collection is not supported for this site.
 To start collecting logs from your application in VMware Tanzu Application Service, the Agent contained in the buildpack needs to be activated and log collection enabled.
 
 ```shell
-cf set-env <YOUR_APP_NAME> RUN_AGENT true
 cf set-env <YOUR_APP_NAME> DD_LOGS_ENABLED true
 # Disable the Agent core checks to disable system metrics collection
 cf set-env <YOUR_APP_NAME> DD_ENABLE_CHECKS false
@@ -88,7 +87,6 @@ The following table describes the parameters above, and how they can be used to 
 
 | Parameter                 | Description                                                                                                                                |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `RUN_AGENT`               | Set to `true` to start the Datadog Agent.                                                                                                  |
 | `DD_LOGS_ENABLED`         | Set to `true` to enable Datadog Agent log collection.                                                                                      |
 | `DD_ENABLE_CHECKS`        | Set to `false` to disable the Agent's system metrics collection through core checks.                                                       |
 | `STD_LOG_COLLECTION_PORT` | Must be used when collecting logs from `stdout` or `stderr`. It redirects the `stdout` or `stderr` stream to the corresponding local port value. |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes references to the deprecated cloud foundry buildpack environment variable RUN_AGENT in the PCF docs
### Motivation
It no longer needs to be set in the buildpack
### Preview 
https://docs-staging.datadoghq.com/sarah.witt/remove-deprecated-param/integrations/vmware_tanzu_application_service/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
