### PR TITLE
Add more explicit ECS/EC2 DogStatsD instructions for endpoint

### DIFF
--- a/content/en/containers/amazon_ecs/_index.md
+++ b/content/en/containers/amazon_ecs/_index.md
@@ -136,9 +136,11 @@ If you're using [DogStatsD][8], add in a Host Port mapping for 8125/udp to your 
 ]
 ```
 
-You can also set the environment variable `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` to `true`.
+In addition to this port mapping, set the environment variable `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` to `true`.
 
-For APM and DogStatsD double check the security group settings on your EC2 instances. Make sure these ports are not open to the public. Datadog recommends using the host's private IP to route data from the application containers to the Datadog Agent container.
+This setup allows the DogStatsD traffic to route from the application containers, through the host and host port, to the Datadog Agent container. However, this setup requires the application container to use the host's private IP Address for this traffic. This can be done by setting the enviroment variable `DD_AGENT_HOST` to to the private IP address of the EC2 Instance fetched from the Instance Metadata Service (IMDS). Alternatively this can be set in the code during initialization. This strategy for DogStatsD is the same as for APM, you can see the [APM documentation for examples of setting the Agent endpoint][17].
+
+For APM and DogStatsD double check the security group settings on your EC2 instances. Make sure these ports are not open to the public.
 
 #### Process collection
 
@@ -242,6 +244,7 @@ Need help? Contact [Datadog support][11].
 [14]: https://app.datadoghq.com/organization-settings/api-keys
 [15]: https://www.datadoghq.com/blog/amazon-ecs-anywhere-monitoring/
 [16]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-tutorial.html
+[17]: /containers/amazon_ecs/apm/?tab=ec2metadataendpoint#configure-the-trace-agent-endpoint
 [20]: /resources/json/datadog-agent-ecs.json
 [21]: /resources/json/datadog-agent-ecs1.json
 [22]: /resources/json/datadog-agent-ecs-win.json

--- a/content/en/containers/amazon_ecs/_index.md
+++ b/content/en/containers/amazon_ecs/_index.md
@@ -138,9 +138,9 @@ If you're using [DogStatsD][8], add in a Host Port mapping for 8125/udp to your 
 
 In addition to this port mapping, set the environment variable `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` to `true`.
 
-This setup allows the DogStatsD traffic to route from the application containers, through the host and host port, to the Datadog Agent container. However, this setup requires the application container to use the host's private IP Address for this traffic. This can be done by setting the enviroment variable `DD_AGENT_HOST` to to the private IP address of the EC2 Instance fetched from the Instance Metadata Service (IMDS). Alternatively this can be set in the code during initialization. This strategy for DogStatsD is the same as for APM, you can see the [APM documentation for examples of setting the Agent endpoint][17].
+This setup allows the DogStatsD traffic to route from the application containers, through the host and host port, to the Datadog Agent container. However, this setup requires the application container to use the host's private IP address for this traffic. This can be done by setting the environment variable `DD_AGENT_HOST` to the private IP address of the EC2 instance fetched from the Instance Metadata Service (IMDS). Alternatively, this can be set in the code during initialization. The implementation for DogStatsD is the same as for APM, see [configure the trace agent endpoint][17] for examples of setting the Agent endpoint.
 
-For APM and DogStatsD double check the security group settings on your EC2 instances. Make sure these ports are not open to the public.
+Ensure that the security group settings on your EC2 instances do not publicly expose the ports for APM and DogStatsD.
 
 #### Process collection
 

--- a/content/en/containers/amazon_ecs/_index.md
+++ b/content/en/containers/amazon_ecs/_index.md
@@ -138,7 +138,7 @@ If you're using [DogStatsD][8], add in a Host Port mapping for 8125/udp to your 
 
 In addition to this port mapping, set the environment variable `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` to `true`.
 
-This setup allows the DogStatsD traffic to route from the application containers, through the host and host port, to the Datadog Agent container. However, this setup requires the application container to use the host's private IP address for this traffic. This can be done by setting the environment variable `DD_AGENT_HOST` to the private IP address of the EC2 instance fetched from the Instance Metadata Service (IMDS). Alternatively, this can be set in the code during initialization. The implementation for DogStatsD is the same as for APM, see [configure the trace agent endpoint][17] for examples of setting the Agent endpoint.
+This setup allows the DogStatsD traffic to be routed from the application containers, through the host and host port, to the Datadog Agent container. However, the application container must use the host's private IP address for this traffic. This can be enabled by setting the environment variable `DD_AGENT_HOST` to the private IP address of the EC2 instance, which can be retrieved from the Instance Metadata Service (IMDS). Alternatively, this can be set in the code during initialization. The implementation for DogStatsD is the same as for APM, see [configure the Trace Agent endpoint][17] for examples of setting the Agent endpoint.
 
 Ensure that the security group settings on your EC2 instances do not publicly expose the ports for APM and DogStatsD.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add more explicit steps for the DogStatsD setup in ECS. DogStatsD setup is often a two step process:
1. Make sure the Agent container can receive that data
2. Make sure the App container can send that data

In this case making it more explicit that the DogStatsD client needs the EC2 Instance's private IP Address as the endpoint for the DogStatsD data. This leans on the existing documentation for setting this in APM, as the strategy / steps are pretty much exactly the same. 

### Motivation
<!-- What inspired you to submit this pull request?-->
Clear up setup steps / support cases

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
https://docs-staging.datadoghq.com/jack.davenport/ecs-dogstatsd/containers/amazon_ecs/?tab=awscli#dogstatsd

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
