### PR TITLE
Update frustration_signals_dashboard.md

### DIFF
--- a/content/en/real_user_monitoring/dashboards/frustration_signals_dashboard.md
+++ b/content/en/real_user_monitoring/dashboards/frustration_signals_dashboard.md
@@ -15,8 +15,8 @@ further_reading:
 The frustration signals dashboard provides insight into elements where users experience the most friction in your application. It shows:
 
 - **Rage clicks**: Measures when a user clicks the same button more than three times in a one-second sliding window.
-- **Error clicks**: Measures when a user clicks on a static element, thinking it is interactive.
-- **Dead clicks**: Measures when a user clicks an element and encounters a JavaScript error.
+- **Dead clicks**: Measures when a user clicks on a static element, thinking it is interactive.
+- **Error clicks**: Measures when a user clicks an element and encounters a JavaScript error.
 
 {{< img src="real_user_monitoring/dashboards/frustration_signals_ootb_dashboard.png" alt="Frustration signals dashboard" style="width:100%;" >}}
 


### PR DESCRIPTION
There was a typo for frustration signals and I just updated a fix -- the definition of dead clicks was attached to the definition of error and vice versa