### PR TITLE
tracing/trace_collector/library_config: updated propagation in go tracer

### DIFF
--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -120,24 +120,27 @@ The [APM environment name][7] may be configured [in the Agent][8] or using the [
 
 ## Trace context propagation for distributed tracing
 
-The Datadog APM tracer supports [B3 headers][9], [W3C][14] extraction and injection for distributed tracing.
+The Datadog APM tracer supports extraction and injection of [B3][9] and [W3C][14] headers for distributed tracing.
 
 Distributed headers injection and extraction is controlled by
 configuring injection/extraction styles. Supported styles are:
 `tracecontext`, `Datadog`, [`B3`][9] and `B3 single header`.
 
-- Configure injection styles using the `DD_PROPAGATION_STYLE_INJECT=tracecontext,B3` environment variable
-- Configure extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=tracecontext,B3` environment variable
-- Configure both injection and extraction styles using the `DD_TRACE_PROPAGATION_STYLE=tracecontext,B3` environment variable
+- Configure injection styles using the `DD_PROPAGATION_STYLE_INJECT=tracecontext,B3` environment variable.
+- Configure extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=tracecontext,B3` environment variable.
+- Configure both injection and extraction styles using the `DD_TRACE_PROPAGATION_STYLE=tracecontext,B3` environment variable.
 
 The values of these environment variables are comma-separated lists of
 header styles enabled for injection or extraction. By default,
 the `tracecontext,Datadog` styles are enabled.
 
 To disable trace context propagation, set the value of the environment variables to `none`.
-- Disable injection styles using the `DD_PROPAGATION_STYLE_INJECT=none` environment variable
-- Disable extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=none` environment variable
-- Disable trace context propagation using the `DD_PROPAGATION_STYLE=none` environment variable
+- Disable injection styles using the `DD_PROPAGATION_STYLE_INJECT=none` environment variable.
+- Disable extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=none` environment variable.
+- Disable all trace context propagation (both inject and extract) using the `DD_PROPAGATION_STYLE=none` environment variable.
+
+If multiple environment variables are set, `DD_PROPAGATION_STYLE_INJECT` and `DD_PROPAGATION_STYLE_EXTRACT`
+override any value provided in `DD_PROPAGATION_STYLE`.
 
 If multiple extraction styles are enabled, extraction attempts are made
 in the order that those styles are specified. The first successfully

--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -124,7 +124,7 @@ The Datadog APM tracer supports extraction and injection of [B3][9] and [W3C][14
 
 Distributed headers injection and extraction is controlled by
 configuring injection/extraction styles. Supported styles are:
-`tracecontext`, `Datadog`, [`B3`][9] and `B3 single header`.
+`tracecontext`, `Datadog`, [`B3`][9], and `B3 single header`.
 
 - Configure injection styles using the `DD_PROPAGATION_STYLE_INJECT=tracecontext,B3` environment variable.
 - Configure extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=tracecontext,B3` environment variable.

--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -118,20 +118,26 @@ Datadog may collect [environmental and diagnostic information about your system]
 
 The [APM environment name][7] may be configured [in the Agent][8] or using the [WithEnv][3] start option of the tracer.
 
-## B3 headers extraction and injection
+## Trace context propagation for distributed tracing
 
-The Datadog APM tracer supports [B3 headers extraction][9] and injection for distributed tracing.
+The Datadog APM tracer supports [B3 headers][9], [W3C][14] extraction and injection for distributed tracing.
 
 Distributed headers injection and extraction is controlled by
-configuring injection/extraction styles. Two styles are
-supported: `Datadog` and `B3`.
+configuring injection/extraction styles. Supported styles are:
+`tracecontext`, `Datadog`, [`B3`][9] and `B3 single header`.
 
-- Configure injection styles using the `DD_PROPAGATION_STYLE_INJECT=Datadog,B3` environment variable
-- Configure extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=Datadog,B3` environment variable
+- Configure injection styles using the `DD_PROPAGATION_STYLE_INJECT=tracecontext,B3` environment variable
+- Configure extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=tracecontext,B3` environment variable
+- Configure both injection and extraction styles using the `DD_TRACE_PROPAGATION_STYLE=tracecontext,B3` environment variable
 
 The values of these environment variables are comma-separated lists of
-header styles enabled for injection or extraction. By default, only
-the `Datadog` extraction style is enabled.
+header styles enabled for injection or extraction. By default,
+the `tracecontext,Datadog` styles are enabled.
+
+To disable trace context propagation, set the value of the environment variables to `none`.
+- Disable injection styles using the `DD_PROPAGATION_STYLE_INJECT=none` environment variable
+- Disable extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=none` environment variable
+- Disable trace context propagation using the `DD_PROPAGATION_STYLE=none` environment variable
 
 If multiple extraction styles are enabled, extraction attempts are made
 in the order that those styles are specified. The first successfully
@@ -151,3 +157,4 @@ extracted value is used.
 [8]: /getting_started/tracing/#environment-name
 [9]: https://github.com/openzipkin/b3-propagation
 [13]: /agent/guide/network/#configure-ports
+[14]: https://github.com/w3c/trace-context


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updates trace context propagation docs in Go.
-  Includes **new** W3c and B3 single header styles. 
- Includes an option to disable propagation. 

### Motivation
<!-- What inspired you to submit this pull request?-->
Relates to changes in [dd-trace-go PR]( https://github.com/DataDog/dd-trace-go/pull/1630)
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
