### PR TITLE
feat: remove allow failure flag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,6 @@ before_script:
   image: public.ecr.aws/x2b9z2t7/webops/site-build:latest
   tags:
     - "runner:main"
-    - "size:2xlarge"
   except:
     - tags
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,7 +117,6 @@ link_checks_preview:
   stage: post-deploy
   cache: {}
   environment: "preview"
-  allow_failure: true
   variables:
     URL: ${PREVIEW_DOMAIN}
     GIT_STRATEGY: none


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Remove allow failure flag from preview link check job
Remove a deprecated tag

### Motivation
<!-- What inspired you to submit this pull request?-->

Now that the link check preview job has been passing consistently, only true failures should trigger an actual failure, so we want to block deploys if links are broken.

The tag removal is a tac on, and has no effect on the CI

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
