### PR TITLE
Update rpm_check.sh script with grep fixes

### DIFF
--- a/static/resources/sh/rpm_check.sh
+++ b/static/resources/sh/rpm_check.sh
@@ -5,7 +5,7 @@
 # Checks the system for packages signed with the 069b56f54172a230 GPG key,
 # and verifies the hash of all Datadog packages installed on the system.
 
-script_version=1.1.0
+script_version=1.2.0
 
 status=0
 datadog_fingerprint=069b56f54172a230
@@ -380,7 +380,7 @@ find_version_rhel_hash() {
     local version=$1
 
     for hash in ${rhel_hashes[@]}; do
-        found=$(echo "$hash" | grep "$version")
+        found=$(echo "$hash" | grep --color=never "$version")
         if [ -n "$found" ]; then
             # Extract the part after the second colon
             echo "${found#*:*:}"
@@ -393,7 +393,7 @@ find_version_suse_hash() {
     local version=$1
 
     for hash in ${suse_hashes[@]}; do
-        found=$(echo "$hash" | grep "$version")
+        found=$(echo "$hash" | grep --color=never "$version")
         if [ -n "$found" ]; then
             # Extract the part after the second colon
             echo "${found#*:*:}"
@@ -411,10 +411,10 @@ get_non_datadog_packages() {
     # Suffix package names with : to not match packages that are superstrings of known packages
     # : is not allowed in package names, so it should be safe to use
     read -d "\n" -r -a packages_suffixed <<< ${datadog_packages[@]/%/:}
-    # grep -v ${packages_suffixed[@]/#/-e } will be rendered as:
-    # grep -v -e <package name 1>: -e <package name 2>: ...
+    # grep --color=never -v ${packages_suffixed[@]/#/-e } will be rendered as:
+    # grep --color=never -v -e <package name 1>: -e <package name 2>: ...
     # which will exclude all lines that contain one of the package names
-    packages_string=$(rpm -qa --qf '%{NAME}:%{VERSION}-%{RELEASE} %{SIGPGP:pgpsig} %{SIGGPG:pgpsig}\n' | grep $datadog_fingerprint | grep -v ${packages_suffixed[@]/#/-e } | cut -d ' ' -f1)
+    packages_string=$(rpm -qa --qf '%{NAME}:%{VERSION}-%{RELEASE} %{SIGPGP:pgpsig} %{SIGGPG:pgpsig}\n' | grep --color=never $datadog_fingerprint | grep --color=never -v ${packages_suffixed[@]/#/-e } | cut -d ' ' -f1)
     read -d "\n" -r -a packages <<< $packages_string
 
     if [ -n "$packages" ]; then
@@ -433,7 +433,7 @@ check_datadog_package() {
     local package_name=$1
     # Suffix package names with : to not match packages that are superstrings of known packages
     # : is not allowed in package names, so it should be safe to use
-    datadog_package_version=$(rpm -qa --qf '%{NAME}:%{VERSION}-%{RELEASE}.%{ARCH}\n' | grep "$package_name:")
+    datadog_package_version=$(rpm -qa --qf '%{NAME}:%{VERSION}-%{RELEASE}.%{ARCH}\n' | grep --color=never "$package_name:")
 
     if [ -z "$datadog_package_version" ]; then
         # No version installed


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates the `rpm_check.sh` script to fix an issue on hosts where `grep` output is colored by default.

### Motivation
<!-- What inspired you to submit this pull request?-->

Prevent the script from erroring in some edge cases where it shouldn't.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
