### PR TITLE
Move the interpolation FAQ to Metrics Guides

### DIFF
--- a/content/en/metrics/guide/interpolation-the-fill-modifier-explained.md
+++ b/content/en/metrics/guide/interpolation-the-fill-modifier-explained.md
@@ -3,6 +3,7 @@ title: Interpolation and the Fill Modifier
 kind: faq
 aliases:
     - /graphing/faq/interpolation-the-fill-modifier-explained
+    - /dashboards/faq/interpolation-the-fill-modifier-explained
 ---
 
 ## Why interpolation?


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Move the **Interpolation and the Fill Modifier** FAQ doc to the Metrics Guide
- Add alias of former location

### Motivation
- Noticed this was not discoverable outside of a link

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
- Will add this to Guides index in a separate PR

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
