### PR TITLE
Update ad_identifiers.md

### DIFF
--- a/content/en/agent/guide/ad_identifiers.md
+++ b/content/en/agent/guide/ad_identifiers.md
@@ -87,6 +87,12 @@ com.datadoghq.ad.check.id: <INTEGRATION_AUTODISCOVERY_IDENTIFIER>
 
 **Note**: The `com.datadoghq.ad.check.id` label takes precedence over the image/name.
 
+In Kubernetes pods, you can add the following pod annotation instead:
+
+```yaml
+ad.datadoghq.com/<CONTAINER_NAME>.check.id: <INTEGRATION_AUTODISCOVERY_IDENTIFIER>
+```
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
We have extended the same `check.id` functionality to Kubernetes pod annotations via this PR: https://github.com/DataDog/datadog-agent/pull/6819.

The document can be organized better e.g., have a docker and kubernetes tabs, but this PR should surface the functionality in the meantime.