### PR TITLE
Correlated Logs Are Not Showing Up In The Trace ID Panel Edit

### DIFF
--- a/content/en/tracing/troubleshooting/correlated-logs-not-showing-up-in-the-trace-id-panel.md
+++ b/content/en/tracing/troubleshooting/correlated-logs-not-showing-up-in-the-trace-id-panel.md
@@ -18,7 +18,7 @@ The [trace][1] panel contains information about the trace, host, and correlated 
 
 {{< img src="tracing/troubleshooting/tracing_no_logs_in_trace.png" alt="A trace page showing an empty log section" style="width:90%;">}}
 
-There are two types of logs that appear in a [trace][1]:
+There are four types of logs that appear in a [trace][1]:
 
 - `trace_id`: Display logs that have the corresponding trace ID.
 - `host`: Display logs from the trace's host within the trace's timeframe.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Fixes a typo in the number of logs that are available in a Traces side panel.

### Motivation
<!-- What inspired you to submit this pull request?-->

Typo flagged from translators in Transifex

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
