### PR TITLE
Fix Test Suite from @classname code snippet

### DIFF
--- a/content/en/continuous_integration/tests/junit_upload.md
+++ b/content/en/continuous_integration/tests/junit_upload.md
@@ -373,7 +373,7 @@ To change `test.suite` tags from `value 1`, `value 2` to `SomeTestSuiteClass`, `
 
 {{< code-block lang="bash" >}}
 datadog-ci junit upload --service service_name \
-  --xpath-tag test.suite=/testcase/@aclassname ./junit.xml
+  --xpath-tag test.suite=/testcase/@classname ./junit.xml
 {{< /code-block >}}
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes a typo in the `Test Suite from @classname` example CLI command

### Motivation
<!-- What inspired you to submit this pull request?-->
I noticed the typo while working with the example CLI usage

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
