### PR TITLE
[DOCS-4730] Add instructions for Java compiler plugin configuration

### DIFF
--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -127,7 +127,7 @@ dependencies {
 
 ### Installing the Java compiler plugin
 
-Java compiler plugin works in combination with the tracer, providing it with additional source code information.
+The Java compiler plugin works in combination with the tracer, providing it with additional source code information.
 Installing the plugin is an optional step that improves performance and accuracy of certain CI visibility features.
 
 > The plugin works with the standard `javac` compiler (Eclipse JDT compiler is not supported).

--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -191,8 +191,8 @@ Additionally, if you are using JDK 16 or newer, add the following lines to the [
 {{% /tab %}}
 {{% tab "Gradle" %}}
 
-Add plugin-client JAR to the project's classpath, add plugin JAR to the compiler's annotation processor path, and pass
-the plugin argument to the tasks that compile Java classes.
+Add plugin-client JAR to the project's classpath, add plugin JAR to the compiler's annotation processor path, and pass the plugin argument to the tasks that compile Java classes.
+
 Replace `$VERSION` with the latest version of the artifacts accessible from the [Maven Repository][1] (without the preceding `v`): ![Maven Central][2]
 
 {{< code-block lang="groovy" filename="build.gradle" >}}

--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -174,8 +174,7 @@ Replace `$VERSION` with the latest version of the artifacts accessible from the 
 
 Maven compiler plugin supports [annotationProcessorPaths][3] property starting with version 3.5. If you absolutely must use an older version, declare Datadog compiler plugin as a regular dependency in your project.
 
-Additionally, if you are using JDK 16 or newer, add the following lines
-to [.mvn/jvm.config][4] in your project base directory:
+Additionally, if you are using JDK 16 or newer, add the following lines to the [.mvn/jvm.config][4] file in your project base directory:
 
 {{< code-block lang="properties" filename=".mvn/jvm.config" >}}
 --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED

--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -172,10 +172,7 @@ Replace `$VERSION` with the latest version of the artifacts accessible from the 
 </build>
 {{< /code-block >}}
 
-> Maven compiler plugin supports
-> [annotationProcessorPaths][3]
-> property starting with version 3.5.
-> If you absolutely must use an older version, declare Datadog compiler plugin as a regular dependency in your project.
+Maven compiler plugin supports [annotationProcessorPaths][3] property starting with version 3.5. If you absolutely must use an older version, declare Datadog compiler plugin as a regular dependency in your project.
 
 Additionally, if you are using JDK 16 or newer, add the following lines
 to [.mvn/jvm.config][4] in your project base directory:

--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -138,7 +138,7 @@ If the configuration is successful, you should see the line `DatadogCompilerPlug
 {{% tab "Maven" %}}
 
 Include the snippets below in the relevant sections of the same Maven profile that you have added to your root `pom.xml` for the tracer config.
-Replace `$VERSION` with the latest version of the plugin accessible from the [Maven Repository][1] (without the preceding `v`): ![Maven Central][2]
+Replace `$VERSION` with the latest version of the artifacts accessible from the [Maven Repository][1] (without the preceding `v`): ![Maven Central][2]
 
 {{< code-block lang="xml" filename="pom.xml" >}}
 <dependency>
@@ -177,7 +177,7 @@ Replace `$VERSION` with the latest version of the plugin accessible from the [Ma
 > property starting with version 3.5.
 > If you absolutely must use an older version, declare Datadog compiler plugin as a regular dependency in your project.
 
-Additionally, if you are using JDK 16 or newer, add the following flags
+Additionally, if you are using JDK 16 or newer, add the following lines
 to [.mvn/jvm.config][4] in your project base directory:
 
 {{< code-block lang="properties" filename=".mvn/jvm.config" >}}
@@ -196,8 +196,8 @@ to [.mvn/jvm.config][4] in your project base directory:
 {{% tab "Gradle" %}}
 
 Add plugin-client JAR to the project's classpath, add plugin JAR to the compiler's annotation processor path, and pass
-the plugin argument to the task that compiles the tests.
-Replace `$VERSION` with the latest version of the tracer accessible from the [Maven Repository][1] (without the preceding `v`): ![Maven Central][2]
+the plugin argument to the tasks that compile Java classes.
+Replace `$VERSION` with the latest version of the artifacts accessible from the [Maven Repository][1] (without the preceding `v`): ![Maven Central][2]
 
 {{< code-block lang="groovy" filename="build.gradle" >}}
 if (project.hasProperty("dd-civisibility")) {
@@ -213,7 +213,7 @@ if (project.hasProperty("dd-civisibility")) {
 }
 {{< /code-block >}}
 
-Additionally, if you are using JDK 16 or newer, add the following flags to your
+Additionally, if you are using JDK 16 or newer, add the following lines to your
 [gradle.properties][3]
 file:
 

--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -125,6 +125,113 @@ dependencies {
 {{% /tab %}}
 {{< /tabs >}}
 
+### Installing the Java compiler plugin
+
+Java compiler plugin works in combination with the tracer, providing it with additional source code information.
+Installing the plugin is an optional step that improves performance and accuracy of certain CI visibility features.
+
+> The plugin works with the standard `javac` compiler (Eclipse JDT compiler is not supported).
+
+If the configuration is successful, you should see the line `DatadogCompilerPlugin initialized` in your compiler's output.
+
+{{< tabs >}}
+{{% tab "Maven" %}}
+
+Include the snippets below in the relevant sections of the same Maven profile that you have added to your root `pom.xml` for the tracer config.
+Replace `$VERSION` with the latest version of the plugin accessible from the [Maven Repository][1] (without the preceding `v`): ![Maven Central][2]
+
+{{< code-block lang="xml" filename="pom.xml" >}}
+<dependency>
+    <groupId>com.datadoghq</groupId>
+    <artifactId>dd-javac-plugin-client</artifactId>
+    <version>$VERSION</version>
+</dependency>
+{{< /code-block >}}
+
+{{< code-block lang="xml" filename="pom.xml" >}}
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.5</version>
+            <configuration>
+                <annotationProcessorPaths>
+                    <annotationProcessorPath>
+                        <groupId>com.datadoghq</groupId>
+                        <artifactId>dd-javac-plugin</artifactId>
+                        <version>$VERSION</version>
+                    </annotationProcessorPath>
+                </annotationProcessorPaths>
+                <compilerArgs>
+                    <arg>-Xplugin:DatadogCompilerPlugin</arg>
+                </compilerArgs>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+{{< /code-block >}}
+
+> Maven compiler plugin supports
+> [annotationProcessorPaths][3]
+> property starting with version 3.5.
+> If you absolutely must use an older version, declare Datadog compiler plugin as a regular dependency in your project.
+
+Additionally, if you are using JDK 16 or newer, add the following flags
+to [.mvn/jvm.config][4] in your project base directory:
+
+{{< code-block lang="properties" filename=".mvn/jvm.config" >}}
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+{{< /code-block >}}
+
+[1]: https://mvnrepository.com/artifact/com.datadoghq/dd-javac-plugin
+[2]: https://img.shields.io/maven-central/v/com.datadoghq/dd-javac-plugin?style=flat-square
+[3]: https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#annotationProcessorPaths
+[4]: https://maven.apache.org/configure.html#mvn-jvm-config-file
+
+{{% /tab %}}
+{{% tab "Gradle" %}}
+
+Add plugin-client JAR to the project's classpath, add plugin JAR to the compiler's annotation processor path, and pass
+the plugin argument to the task that compiles the tests.
+Replace `$VERSION` with the latest version of the tracer accessible from the [Maven Repository][1] (without the preceding `v`): ![Maven Central][2]
+
+{{< code-block lang="groovy" filename="build.gradle" >}}
+if (project.hasProperty("dd-civisibility")) {
+    dependencies {
+        implementation 'com.datadoghq:dd-javac-plugin-client:$VERSION'
+        annotationProcessor 'com.datadoghq:dd-javac-plugin:$VERSION'
+        testAnnotationProcessor 'com.datadoghq:dd-javac-plugin:$VERSION'
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+        options.compilerArgs.add('-Xplugin:DatadogCompilerPlugin')
+    }
+}
+{{< /code-block >}}
+
+Additionally, if you are using JDK 16 or newer, add the following flags to your
+[gradle.properties][3]
+file:
+
+{{< code-block lang="properties" filename="gradle.properties" >}}
+org.gradle.jvmargs=\
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED  \
+--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+{{< /code-block >}}
+
+[1]: https://mvnrepository.com/artifact/com.datadoghq/dd-javac-plugin
+[2]: https://img.shields.io/maven-central/v/com.datadoghq/dd-javac-plugin?style=flat-square
+[3]: https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Instrumenting your tests
 
 {{< tabs >}}

--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -130,7 +130,7 @@ dependencies {
 The Java compiler plugin works in combination with the tracer, providing it with additional source code information.
 Installing the plugin is an optional step that improves performance and accuracy of certain CI visibility features.
 
-> The plugin works with the standard `javac` compiler (Eclipse JDT compiler is not supported).
+The plugin works with the standard `javac` compiler (Eclipse JDT compiler is not supported).
 
 If the configuration is successful, you should see the line `DatadogCompilerPlugin initialized` in your compiler's output.
 

--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -209,9 +209,7 @@ if (project.hasProperty("dd-civisibility")) {
 }
 {{< /code-block >}}
 
-Additionally, if you are using JDK 16 or newer, add the following lines to your
-[gradle.properties][3]
-file:
+Additionally, if you are using JDK 16 or newer, add the following lines to your [gradle.properties][3] file:
 
 {{< code-block lang="properties" filename="gradle.properties" >}}
 org.gradle.jvmargs=\


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR updates CI visibility config instructions for Java with a new section that explains how to configure Java compiler plugin.

### Motivation
<!-- What inspired you to submit this pull request?-->
The Java compiler plugin is a new component of the CI visibility system.
Datadog clients who use CI visibility will need to add the plugin to their projects' compilation step, and this PR adds the necessary instructions to do so.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
