### PR TITLE
Add marketplace as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,10 @@ package.json              @DataDog/corpweb @DataDog/documentation
 # Partners
 /content/en/partners/                                   @KateYoak @DataDog/documentation
 
+# Marketplace
+/content/en/developers/marketplace/                     @Datadog/marketplace-product-management @DataDog/documentation
+/layouts/shortcodes/integration-assets.md               @Datadog/marketplace-product-management @DataDog/documentation
+
 # Websites
 .github/workflows                                       @DataDog/corpweb
 .gitlab-ci.yml                                          @DataDog/corpweb


### PR DESCRIPTION
Adds marketplace as code owners of /marketplace

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
