### PR TITLE
(DOCS-4563) Add missing govcloud warnings to some DBM pages

### DIFF
--- a/content/en/database_monitoring/_index.md
+++ b/content/en/database_monitoring/_index.md
@@ -17,6 +17,9 @@ further_reading:
   text: "Troubleshooting"
 
 ---
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
+{{< /site-region >}}
 
 {{< img src="database_monitoring/dbm-main.png" alt="Database Monitoring" style="width:100%;">}}
 

--- a/content/en/database_monitoring/architecture.md
+++ b/content/en/database_monitoring/architecture.md
@@ -14,7 +14,9 @@ further_reading:
   text: "Troubleshooting"
 
 ---
-
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
+{{< /site-region >}}
 
 ## Overview
 

--- a/content/en/database_monitoring/guide/_index.md
+++ b/content/en/database_monitoring/guide/_index.md
@@ -4,6 +4,9 @@ kind: guide
 private: true
 disable_toc: true
 ---
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
+{{< /site-region >}}
 
 {{< whatsnext desc="General guides:" >}}
     {{< nextlink href="database_monitoring/guide/heroku-postgres" >}}Setting up Heroku Postgres for Database Monitoring{{< /nextlink >}}

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -4,6 +4,9 @@ kind: guide
 beta: true
 private: true
 ---
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
+{{< /site-region >}}
 
 <div class="alert alert-warning">
 The features described on this page are in beta. Contact your Customer Success Manager to learn more about them.

--- a/content/en/database_monitoring/setup_sql_server/troubleshooting.md
+++ b/content/en/database_monitoring/setup_sql_server/troubleshooting.md
@@ -4,6 +4,10 @@ kind: documentation
 description: Troubleshoot Database Monitoring setup for SQL Server
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Database Monitoring is not supported for this site.</div>
+{{< /site-region >}}
+
 This page details common issues with setting up and using Database Monitoring with SQL Server, and how to resolve them. Datadog recommends staying on the latest stable Agent version and adhering to the latest [setup documentation][1], as it can change with Agent version releases.
 
 ## Diagnosing common connection issues {#common-connection-issues}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds warnings in some pages that were missing them that DBM is not available for govcloud

### Motivation
support request

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
