### PR TITLE
Update private-link.md to clarify product avaliability

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -14,6 +14,18 @@ further_reading:
 <div class="alert alert-warning">Datadog PrivateLink does not support the Datadog for Government site.</div>
 {{< /site-region >}}
 
+{{< site-region region="us3" >}}
+<div class="alert alert-warning">Datadog PrivateLink does not support the Datadog US3 site.</div>
+{{< /site-region >}}
+
+{{< site-region region="us5" >}}
+<div class="alert alert-warning">Datadog PrivateLink does not support the Datadog US5 site.</div>
+{{< /site-region >}}
+
+{{< site-region region="eu" >}}
+<div class="alert alert-warning">Datadog PrivateLink does not support the Datadog EU site.</div>
+{{< /site-region >}}
+
 This guide walks you through how to configure [AWS PrivateLink][1] for use with Datadog.
 
 ## Overview


### PR DESCRIPTION
The AWS PrivateLink service is not available in other Datadog sites. If a user selects the `Site` dropdown for other sites this should be reflected in the documentation. Network Edge owns PrivateLink and we do not offer this functionality in US5. 

### What does this PR do?
This will display a message for sites that are not suppoted.

### Motivation
A customer reached out stating that our documentation indicated they would be able to establish an AWS PrivateLink to `US5`. 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
