### PR TITLE
Change to use the full Datadog Watchdog Trademark

### DIFF
--- a/content/en/watchdog/_index.md
+++ b/content/en/watchdog/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Watchdog
+title: Datadog Watchdog™
 kind: Documentation
 description: Automatically detect potential application and infrastructure issues
 aliases:


### PR DESCRIPTION
I am Datadog's Trademark Attorney and we need to use the full trademark "Datadog Watchdog" (not just "Watchdog") in a few spots on our website in order to keep the Trademark registered and avoid it going abandoned.  I'm making this change myself since I'm able to submit edits to our public documentation.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
