### PR TITLE
Adding Migration documentation to Node.js Setup

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -116,7 +116,7 @@ After the Agent is installed, follow these steps to add the Datadog tracing libr
     npm install dd-trace@latest-node12
     ```
     For more information on our distribution tags and Node.js runtime version support, see the [Compatibility Requirements][1] page.
-    Use this [migration guide][5] to assess any breaking changes if you upgraded your library from 0.x to 2.x.
+    Use this [migration guide][5] to assess any breaking changes if you upgraded your library from 0.x/1.x to 2.x.
 
 2. Import and initialize the tracer either in code or via command line arguments. The Node.js tracing library needs to be imported and initialized **before** any other module.
 

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -116,6 +116,7 @@ After the Agent is installed, follow these steps to add the Datadog tracing libr
     npm install dd-trace@latest-node12
     ```
     For more information on our distribution tags and Node.js runtime version support, see the [Compatibility Requirements][1] page.
+    Use this [migration guide][5] to assess any breaking changes if you upgraded your library from 0.x to 2.x.
 
 2. Import and initialize the tracer either in code or via command line arguments. The Node.js tracing library needs to be imported and initialized **before** any other module.
 
@@ -179,3 +180,4 @@ If needed, configure the tracing library to send application performance telemet
 [2]: https://app.datadoghq.com/apm/service-setup
 [3]: https://datadog.github.io/dd-trace-js/#tracer-settings
 [4]: /tracing/trace_collection/library_config/nodejs/
+[5]: https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -116,7 +116,7 @@ After the Agent is installed, follow these steps to add the Datadog tracing libr
     npm install dd-trace@latest-node12
     ```
     For more information on our distribution tags and Node.js runtime version support, see the [Compatibility Requirements][1] page.
-    Use this [migration guide][5] to assess any breaking changes if you upgraded your library from 0.x/1.x to 2.x.
+    If you are upgrading from a previous major version of the library (0.x, 1.x, or 2.x) to another major version (2.x or 3.x), read the [Migration Guide][5] to assess any breaking changes.
 
 2. Import and initialize the tracer either in code or via command line arguments. The Node.js tracing library needs to be imported and initialized **before** any other module.
 


### PR DESCRIPTION
As referred by engineering, customers who upgrade from previous versions of the agent to the latest version should use the migration documentation to avoid any issues in terms of upgrading. Therefore, updating documentation to allow customers to be aware of this migration in case they are upgrading from the previous version.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds line similar to ASM documentation highlighting the migration documentation: https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md 

### Motivation
Ticket where customer raised this inquiry and reflected on importance of documentation not being visible in main installation guide. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
