### PR TITLE
Add missing alias

### DIFF
--- a/content/en/observability_pipelines/guide/configure_observability_pipelines_with_datadog.md
+++ b/content/en/observability_pipelines/guide/configure_observability_pipelines_with_datadog.md
@@ -5,6 +5,7 @@ aliases:
   - /agent/vector_aggregation/
   - /integrations/observability_pipelines/integrate_vector_with_datadog/
   - /observability_pipelines/integrate_vector_with_datadog/
+  - /observability_pipelines/integrations/integrate_vector_with_datadog/
 further_reading:
 - link: "/logs/"
   tag: "Documentation"


### PR DESCRIPTION
### What does this PR do?

Add missing alias.
This link should work: https://docs.datadoghq.com/observability_pipelines/integrations/integrate_vector_with_datadog/?tab=yaml

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
