### PR TITLE
DOCS-3701 - escaping json

### DIFF
--- a/content/en/containers/docker/integrations.md
+++ b/content/en/containers/docker/integrations.md
@@ -73,10 +73,15 @@ labels:
   com.datadoghq.ad.instances: '[<INSTANCE_CONFIG>]'
 ```
 
-**`docker run`, `nerdctl run`, or `podman run` commands**:
+**using `docker run`, `nerdctl run`, or `podman run` commands**:
 
 ```shell
 -l com.datadoghq.ad.check_names='[<INTEGRATION_NAME>]' -l com.datadoghq.ad.init_configs='[<INIT_CONFIG>]' -l com.datadoghq.ad.instances='[<INSTANCE_CONFIG>]'
+```
+
+**Note**: You can escape JSON while configuring these labels. For example:
+```shell
+docker run --label "com.datadoghq.ad.check_names=[\"redisdb\"]" --label "com.datadoghq.ad.init_configs=[{}]" --label "com.datadoghq.ad.instances=[{\"host\":\"%%host%%\",\"port\":6379}]" --label "com.datadoghq.ad.logs=[{\"source\":\"redis\"}]" --name redis redis
 ```
 
 **Docker Swarm**:

--- a/content/en/containers/docker/integrations.md
+++ b/content/en/containers/docker/integrations.md
@@ -73,7 +73,7 @@ labels:
   com.datadoghq.ad.instances: '[<INSTANCE_CONFIG>]'
 ```
 
-**using `docker run`, `nerdctl run`, or `podman run` commands**:
+**Using `docker run`, `nerdctl run`, or `podman run` commands**:
 
 ```shell
 -l com.datadoghq.ad.check_names='[<INTEGRATION_NAME>]' -l com.datadoghq.ad.init_configs='[<INIT_CONFIG>]' -l com.datadoghq.ad.instances='[<INSTANCE_CONFIG>]'


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
adds an example of how to escape JSON, if necessary, while configuring docker labels

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
