### PR TITLE
Remove beta flag for monitor tag policies

### DIFF
--- a/content/en/monitors/settings/_index.md
+++ b/content/en/monitors/settings/_index.md
@@ -10,10 +10,6 @@ further_reading:
   text: "Monitor Notifications"
 ---
 
-{{< beta-callout url="#" btn_hidden="true" >}}
-Monitor tag policies are in private beta. To request access, contact Support at support@datadoghq.com.
-{{< /beta-callout >}}
-
 Monitor tag policies allow you to enforce the presence of certain tags and tag values on your Datadog monitors. This is useful for attribution purposes and for ensuring that alerts are routed to the correct downstream systems and workflows for triage and processing.
 
 Once set up, tag policies apply to **all** Datadog monitors and Synthetic tests.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Removes beta flag for monitor tag policies since it's been GA'd.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
