### PR TITLE
[DOCS-4692] Move and rename Configure OP with Datadog 

### DIFF
--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -162,11 +162,11 @@ function getPathElement(event = null) {
         );
     }
 
-    // redirect support. if agent/aggregating agents is selected, highlight `observability_pipelines/integrations/integrate_vector_with_datadog` in the sidenav.
-    if (path.includes('observability_pipelines/guide')) {
+    // redirect support. if agent/aggregating agents is selected, highlight `observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker` in the sidenav.
+    if (path.includes('observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker')) {
         const observabilityPipelineEl = document.querySelector('.side .nav-top-level > [data-path*="observability_pipelines"]');
         sideNavPathElement = observabilityPipelineEl.nextElementSibling.querySelector(
-            '[data-path*="observability_pipelines/guide"]'
+            '[data-path*="observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker"]'
         );
         mobileNavPathElement = sideNavPathElement;
     }

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2461,6 +2461,11 @@ main:
     parent: observability_pipelines_production_deployment_overview
     identifier: observability_pipelines_aggregator_architecture
     weight: 202
+  - name: Integrate Datadog and the Worker
+    url: observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker/
+    parent: observability_pipelines_production_deployment_overview
+    identifier: observability_pipelines_integrate_datadog_and_the_op_worker
+    weight: 203
   - name: Working with Data
     url: observability_pipelines/working_with_data/
     parent: observability_pipelines
@@ -3696,7 +3701,7 @@ main:
     parent: administration_heading
     weight: 240000
   - name: Aggregating Agents
-    url: observability_pipelines/guide/configure_observability_pipelines_with_datadog/
+    url: observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker/
     parent: agent
     identifier: vector_aggregation
     weight: 13

--- a/content/en/observability_pipelines/_index.md
+++ b/content/en/observability_pipelines/_index.md
@@ -13,7 +13,7 @@ further_reading:
   - link: /observability_pipelines/configurations/
     tag: Documentation
     text: Learn more about Observability Pipelines configurations
-  - link: /observability_pipelines/guide/configure_observability_pipelines_with_datadog/
+  - link: /observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker/
     tag: Documentation
     text: Configure Datadog Agents to send data to Observability Pipelines
 ---

--- a/content/en/observability_pipelines/configurations.md
+++ b/content/en/observability_pipelines/configurations.md
@@ -8,7 +8,7 @@ further_reading:
   - link: /observability_pipelines/working_with_data/
     tag: Documentation
     text: Working with data using Observability Pipelines
-  - link: /observability_pipelines/guide/configure_observability_pipelines_with_datadog/
+  - link: /observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker/
     tag: Documentation
     text: Configure Datadog Agents to send data to Observability Pipelines
 ---

--- a/content/en/observability_pipelines/guide/_index.md
+++ b/content/en/observability_pipelines/guide/_index.md
@@ -8,5 +8,4 @@ disable_toc: true
 {{< whatsnext desc="General guides:" >}}
     {{< nextlink href="/observability_pipelines/guide/custom-metrics-governance" >}}Custom Metrics Governance{{< /nextlink >}}
     {{< nextlink href="/observability_pipelines/guide/control_log_volume_and_size" >}}Control Log Volume and Size{{< /nextlink >}}
-    {{< nextlink href="/observability_pipelines/guide/configure_observability_pipelines_with_datadog" >}}Configure Observability Pipelines with Datadog{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker.md
+++ b/content/en/observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker.md
@@ -1,11 +1,12 @@
 ---
-title: Configure Observability Pipelines with Datadog
+title: Integrate Datadog and the Observability Pipelines Worker
 kind: documentation
 aliases:
   - /agent/vector_aggregation/
   - /integrations/observability_pipelines/integrate_vector_with_datadog/
   - /observability_pipelines/integrate_vector_with_datadog/
   - /observability_pipelines/integrations/integrate_vector_with_datadog/
+  - /observability_pipelines/guide/configure_observability_pipelines_with_datadog/
 further_reading:
 - link: "/logs/"
   tag: "Documentation"

--- a/content/en/observability_pipelines/working_with_data.md
+++ b/content/en/observability_pipelines/working_with_data.md
@@ -22,7 +22,7 @@ further_reading:
   - link: https://vector.dev/guides/level-up/csv-enrichment-guide/
     tag: Documentation
     text: Use CSV enrichment to provide more context to your data
-  - link: /observability_pipelines/guide/configure_observability_pipelines_with_datadog/
+  - link: /observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker/
     tag: Documentation
     text: Configure Datadog Agents to send data to Observability Pipelines
   - link: /observability_pipelines/configurations/


### PR DESCRIPTION
### What does this PR do?

- Moves "Configure OP with Datadog" out of Guide section and  under Production Deployment Overview.
- Renames doc to "Integrate Datadog and the Observability Pipelines Worker"
- Adds alias
- Adds nav entry
- Update old links
- The JS script update is to make Agent > Aggregating Agents in the nav jump down to the "Integrate Datadog and the Worker" in the Obs Pipelines section of the nav.

### Motivation

[DOCS-4692](https://datadoghq.atlassian.net/browse/DOCS-4692)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4692]: https://datadoghq.atlassian.net/browse/DOCS-4692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ