### PR TITLE
Dual Shipping Link Fix

### DIFF
--- a/content/en/agent/guide/dual-shipping.md
+++ b/content/en/agent/guide/dual-shipping.md
@@ -362,4 +362,4 @@ and add the relevant settings to `customAgentConfig`.
         is_reliable: true
 ```
 
-If you're using the [Datadog Agent operator](https://github.com/DataDog/datadog-operator) similarly you can set the `agent.customConfig.configData` key. All configurable keys are documented [here](https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.md).
+If you're using the [Datadog Agent operator],(https://github.com/DataDog/datadog-operator) similarly, you can set the `agent.customConfig.configData` key. All configurable keys are documented in [v1](https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v1alpha1.md) and [v2](https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md).

--- a/content/en/agent/guide/dual-shipping.md
+++ b/content/en/agent/guide/dual-shipping.md
@@ -362,4 +362,8 @@ and add the relevant settings to `customAgentConfig`.
         is_reliable: true
 ```
 
-If you're using the [Datadog Agent operator],(https://github.com/DataDog/datadog-operator) similarly, you can set the `agent.customConfig.configData` key. All configurable keys are documented in [v1](https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v1alpha1.md) and [v2](https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md).
+If you're using the [Datadog Agent operator][1], similarly, you can set the `agent.customConfig.configData` key. All configurable keys are documented in [v1][2] and [v2][3].
+
+[1]: https://github.com/DataDog/datadog-operator
+[2]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v1alpha1.md
+[3]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates a 404 link to the Configuration file (https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.md) that is now divided into V1 and V2.

### Motivation
<!-- What inspired you to submit this pull request?-->

Hotjar

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
