### PR TITLE
DOCS-4654 Otel support for RUM Flutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ content/en/real_user_monitoring/flutter/setup.md
 content/en/real_user_monitoring/flutter/advanced_configuration.md
 content/en/real_user_monitoring/flutter/data_collected.md
 content/en/real_user_monitoring/flutter/mobile_vitals.md
+content/en/real_user_monitoring/flutter/otel_support.md
 content/en/real_user_monitoring/flutter/troubleshooting.md
 
 # Continuous Testing

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3117,11 +3117,16 @@ main:
     parent: rum_flutter
     identifier: rum_flutter_mobile_vitals
     weight: 504
+  - name: Open Telemetry Support
+    url: real_user_monitoring/flutter/otel_support/
+    parent: rum_flutter
+    identifier: rum_flutter_otel_support
+    weight: 505
   - name: Troubleshooting
     url: real_user_monitoring/flutter/troubleshooting/
     parent: rum_flutter
     identifier: rum_flutter_troubleshooting
-    weight: 505
+    weight: 506
   - name: Session Replay
     url: real_user_monitoring/session_replay/
     parent: rum

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3117,7 +3117,7 @@ main:
     parent: rum_flutter
     identifier: rum_flutter_mobile_vitals
     weight: 504
-  - name: Open Telemetry Support
+  - name: OpenTelemetry Support
     url: real_user_monitoring/flutter/otel_support/
     parent: rum_flutter
     identifier: rum_flutter_otel_support

--- a/content/en/real_user_monitoring/flutter/otel_support.md
+++ b/content/en/real_user_monitoring/flutter/otel_support.md
@@ -15,7 +15,7 @@ further_reading:
 kind: documentation
 title: OpenTelemetry Support
 ---
-The [Datadog Tracking Http Client][1] package and [gRPC Interceptor][2] package both support distributed traces through both automatic header generation and header ingestion.
+The [Datadog Tracking HTTP Client][1] package and [gRPC Interceptor][2] package both support distributed traces through both automatic header generation and header ingestion.
 
 ## Datadog Header Generation
 

--- a/content/en/real_user_monitoring/flutter/otel_support.md
+++ b/content/en/real_user_monitoring/flutter/otel_support.md
@@ -1,17 +1,54 @@
 ---
 dependencies:
 - https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/otel_support.md
-description: Learn about using Open Telemetry with RUM Flutter
+description: Learn about using OpenTelemetry with RUM Flutter.
 further_reading:
-  - link: "https://www.datadoghq.com/blog/monitor-flutter-application-performance-with-mobile-rum/"
-    tag: "Blog"
-    text: "Monitor Flutter application performance with Datadog Mobile RUM"
-  - link: "https://github.com/DataDog/dd-sdk-flutter"
-    tag: "GitHub"
-    text: "dd-sdk-flutter Source code"
-  - link: "real_user_monitoring/explorer/"
-    tag: "Documentation"
-    text: "Learn how to explore your RUM data"
+- link: https://www.datadoghq.com/blog/monitor-flutter-application-performance-with-mobile-rum/
+  tag: Blog
+  text: Monitor Flutter application performance with Datadog Mobile RUM
+- link: https://github.com/DataDog/dd-sdk-flutter
+  tag: GitHub
+  text: dd-sdk-flutter Source code
+- link: real_user_monitoring/explorer/
+  tag: Documentation
+  text: Learn how to explore your RUM data
 kind: documentation
-title: Open Telemetry Support
+title: OpenTelemetry Support
 ---
+The [Datadog Tracking Http Client][1] package and [gRPC Interceptor][2] package both support distributed traces through both automatic header generation and header ingestion.
+
+## Datadog Header Generation
+
+When configuring your tracking client or gRPC Interceptor, you can specify the types of tracing headers you want Datadog to generate. For example, if you want to send `b3` headers to `example.com` and `tracecontext` headers for `myapi.names`, you can do so with the following code:
+
+```dart
+final hostHeaders = {
+    'example.com': { TracingHeaderType.b3 },
+    'myapi.names': { TracingHeaderType.tracecontext}
+};
+```
+
+You can use this object during initial configuration:
+
+```dart
+// For default Datadog HTTP tracing:
+final configuration = DdSdkConfiguration(
+    // configuration
+    firstPartyHostsWithTracingHeaders: hostHeaders,
+);
+```
+
+Then enable tracing as normal.
+
+This information is merged with any hosts set on `DdSdkConfiguration.firstPartyHosts`. Hosts specified in `firstPartyHosts` generate Datadog Tracing Headers by default.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+
+[1]: https://pub.dev/packages/datadog_tracking_http_client
+[2]: https://pub.dev/packages/datadog_grpc_interceptor
+[3]: https://github.com/openzipkin/b3-propagation#single-headers
+[4]: https://github.com/openzipkin/b3-propagation#multiple-headers
+[5]: https://www.w3.org/TR/trace-context/#tracestate-header

--- a/content/en/real_user_monitoring/flutter/otel_support.md
+++ b/content/en/real_user_monitoring/flutter/otel_support.md
@@ -1,0 +1,17 @@
+---
+dependencies:
+- https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/otel_support.md
+description: Learn about using Open Telemetry with RUM Flutter
+further_reading:
+  - link: "https://www.datadoghq.com/blog/monitor-flutter-application-performance-with-mobile-rum/"
+    tag: "Blog"
+    text: "Monitor Flutter application performance with Datadog Mobile RUM"
+  - link: "https://github.com/DataDog/dd-sdk-flutter"
+    tag: "GitHub"
+    text: "dd-sdk-flutter Source code"
+  - link: "real_user_monitoring/explorer/"
+    tag: "Documentation"
+    text: "Learn how to explore your RUM data"
+kind: documentation
+title: Open Telemetry Support
+---

--- a/content/en/real_user_monitoring/flutter/otel_support.md
+++ b/content/en/real_user_monitoring/flutter/otel_support.md
@@ -17,7 +17,7 @@ title: OpenTelemetry Support
 ---
 The [Datadog Tracking HTTP Client][1] package and [gRPC Interceptor][2] package both support distributed traces through both automatic header generation and header ingestion.
 
-## Datadog Header Generation
+## Datadog header generation
 
 When configuring your tracking client or gRPC Interceptor, you can specify the types of tracing headers you want Datadog to generate. For example, if you want to send `b3` headers to `example.com` and `tracecontext` headers for `myapi.names`, you can do so with the following code:
 

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -1062,7 +1062,7 @@
               tag: "Documentation"
               text: "Learn how to explore your RUM data"
     - action: pull-and-push-file
-      branch: main
+      branch: develop
       globs:
       - 'packages/datadog_flutter_plugin/doc/rum/otel_support.md'
       options:
@@ -1072,7 +1072,7 @@
           title: OpenTelemetry Support
           kind: documentation
           description: "Learn about using OpenTelemetry with RUM Flutter."
-          dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/otel_support.md"]
+          dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/develop/packages/datadog_flutter_plugin/doc/rum/otel_support.md"]
           further_reading:
             - link: "https://www.datadoghq.com/blog/monitor-flutter-application-performance-with-mobile-rum/"
               tag: "Blog"

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -1062,7 +1062,7 @@
               tag: "Documentation"
               text: "Learn how to explore your RUM data"
     - action: pull-and-push-file
-      branch: develop
+      branch: main
       globs:
       - 'packages/datadog_flutter_plugin/doc/rum/otel_support.md'
       options:
@@ -1072,7 +1072,7 @@
           title: OpenTelemetry Support
           kind: documentation
           description: "Learn about using OpenTelemetry with RUM Flutter."
-          dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/develop/packages/datadog_flutter_plugin/doc/rum/otel_support.md"]
+          dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/otel_support.md"]
           further_reading:
             - link: "https://www.datadoghq.com/blog/monitor-flutter-application-performance-with-mobile-rum/"
               tag: "Blog"

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -1069,9 +1069,9 @@
         dest_path: '/real_user_monitoring/flutter/'
         file_name: 'otel_support.md'
         front_matters:
-          title: Open Telemetry Support
+          title: OpenTelemetry Support
           kind: documentation
-          description: "Learn about using Open Telemetry with RUM Flutter."
+          description: "Learn about using OpenTelemetry with RUM Flutter."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/otel_support.md"]
           further_reading:
             - link: "https://www.datadoghq.com/blog/monitor-flutter-application-performance-with-mobile-rum/"

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -1064,6 +1064,28 @@
     - action: pull-and-push-file
       branch: main
       globs:
+      - 'packages/datadog_flutter_plugin/doc/rum/otel_support.md'
+      options:
+        dest_path: '/real_user_monitoring/flutter/'
+        file_name: 'otel_support.md'
+        front_matters:
+          title: Open Telemetry Support
+          kind: documentation
+          description: "Learn about using Open Telemetry with RUM Flutter."
+          dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/otel_support.md"]
+          further_reading:
+            - link: "https://www.datadoghq.com/blog/monitor-flutter-application-performance-with-mobile-rum/"
+              tag: "Blog"
+              text: "Monitor Flutter application performance with Datadog Mobile RUM"
+            - link: "https://github.com/DataDog/dd-sdk-flutter"
+              tag: "GitHub"
+              text: "dd-sdk-flutter Source code"
+            - link: "real_user_monitoring/explorer/"
+              tag: "Documentation"
+              text: "Learn how to explore your RUM data"
+    - action: pull-and-push-file
+      branch: main
+      globs:
       - 'packages/datadog_flutter_plugin/doc/troubleshooting.md'
       options:
         dest_path: '/real_user_monitoring/flutter/'

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1067,7 +1067,7 @@
               tag: "Documentation"
               text: "Learn how to explore your RUM data"
     - action: pull-and-push-file
-      branch: main
+      branch: develop
       globs:
       - 'packages/datadog_flutter_plugin/doc/rum/otel_support.md'
       options:
@@ -1077,7 +1077,7 @@
           title: OpenTelemetry Support
           kind: documentation
           description: "Learn about using OpenTelemetry with RUM Flutter."
-          dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/otel_support.md"]
+          dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/develop/packages/datadog_flutter_plugin/doc/rum/otel_support.md"]
           further_reading:
             - link: "https://www.datadoghq.com/blog/monitor-flutter-application-performance-with-mobile-rum/"
               tag: "Blog"

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1067,6 +1067,28 @@
               tag: "Documentation"
               text: "Learn how to explore your RUM data"
     - action: pull-and-push-file
+      branch: jward/otel-docs
+      globs:
+      - 'packages/datadog_flutter_plugin/doc/rum/otel_support.md'
+      options:
+        dest_path: '/real_user_monitoring/flutter/'
+        file_name: 'otel_support.md'
+        front_matters:
+          title: Open Telemetry Support
+          kind: documentation
+          description: "Learn about using Open Telemetry with RUM Flutter."
+          dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/otel_support.md"]
+          further_reading:
+            - link: "https://www.datadoghq.com/blog/monitor-flutter-application-performance-with-mobile-rum/"
+              tag: "Blog"
+              text: "Monitor Flutter application performance with Datadog Mobile RUM"
+            - link: "https://github.com/DataDog/dd-sdk-flutter"
+              tag: "GitHub"
+              text: "dd-sdk-flutter Source code"
+            - link: "real_user_monitoring/explorer/"
+              tag: "Documentation"
+              text: "Learn how to explore your RUM data"
+    - action: pull-and-push-file
       branch: main
       globs:
       - 'packages/datadog_flutter_plugin/doc/troubleshooting.md'

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1067,7 +1067,7 @@
               tag: "Documentation"
               text: "Learn how to explore your RUM data"
     - action: pull-and-push-file
-      branch: jward/otel-docs
+      branch: main
       globs:
       - 'packages/datadog_flutter_plugin/doc/rum/otel_support.md'
       options:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1067,7 +1067,7 @@
               tag: "Documentation"
               text: "Learn how to explore your RUM data"
     - action: pull-and-push-file
-      branch: develop
+      branch: main
       globs:
       - 'packages/datadog_flutter_plugin/doc/rum/otel_support.md'
       options:
@@ -1077,7 +1077,7 @@
           title: OpenTelemetry Support
           kind: documentation
           description: "Learn about using OpenTelemetry with RUM Flutter."
-          dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/develop/packages/datadog_flutter_plugin/doc/rum/otel_support.md"]
+          dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/otel_support.md"]
           further_reading:
             - link: "https://www.datadoghq.com/blog/monitor-flutter-application-performance-with-mobile-rum/"
               tag: "Blog"

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1074,9 +1074,9 @@
         dest_path: '/real_user_monitoring/flutter/'
         file_name: 'otel_support.md'
         front_matters:
-          title: Open Telemetry Support
+          title: OpenTelemetry Support
           kind: documentation
-          description: "Learn about using Open Telemetry with RUM Flutter."
+          description: "Learn about using OpenTelemetry with RUM Flutter."
           dependencies: ["https://github.com/DataDog/dd-sdk-flutter/blob/main/packages/datadog_flutter_plugin/doc/rum/otel_support.md"]
           further_reading:
             - link: "https://www.datadoghq.com/blog/monitor-flutter-application-performance-with-mobile-rum/"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a new page about Open Telemetry Support for RUM Flutter and single sources it from the `dd-sdk-flutter` repo.

### Motivation
[DOCS-4654](https://datadoghq.atlassian.net/browse/DOCS-4654), which is an internal contribution.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4654]: https://datadoghq.atlassian.net/browse/DOCS-4654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ