### PR TITLE
DOCS-4249 add pack command in google cloud run

### DIFF
--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -120,7 +120,7 @@ RUN apt-get update && apt-get install -y ca-certificates
 
 #### Build with the Datadog buildpack
 
-1. Build your application by running the following:
+1. Use [`pack`][4] to build your application by running the following:
    ```
    pack build --builder=gcr.io/buildpacks/builder \
    --buildpack from=builder \
@@ -145,11 +145,11 @@ Below are instructions for deploying a Cloud Run service using standard GCP tool
    gcloud builds submit --tag gcr.io/YOUR_PROJECT/YOUR_APP_NAME
    ```
 4. Create a secret from your Datadog API key.
-   Go to [Secret Manager][4] in your GCP console and click on **Create secret**.
+   Go to [Secret Manager][5] in your GCP console and click on **Create secret**.
 
    Set a name (for example, `datadog-api-key`) in the **Name** field. Then, paste your Datadog API key in the **Secret value** field.
 5. Deploy your service.
-   Go to [Cloud Run][5] in your GCP console. and click on **Create service**.
+   Go to [Cloud Run][6] in your GCP console. and click on **Create service**.
 
    Select **Deploy one revision from an existing container image**. Choose your previously built image.
 
@@ -164,7 +164,7 @@ Below are instructions for deploying a Cloud Run service using standard GCP tool
    Under the **Environment variables** section, ensure that the name is set to `DD_API_KEY`.
 
 ### Custom metrics
-You can submit custom metrics using a [DogStatsd client][6].
+You can submit custom metrics using a [DogStatsd client][7].
 
 **Note**: Only `DISTRIBUTION` metrics should be used.
 
@@ -174,13 +174,13 @@ You can submit custom metrics using a [DogStatsd client][6].
 
 | Variable | Description |
 | -------- | ----------- |
-| `DD_SITE` | [Datadog site][7]. |
+| `DD_SITE` | [Datadog site][8]. |
 | `DD_LOGS_ENABLED` | When true, send logs (stdout and stderr) to Datadog. Defaults to false. |
-| `DD_SERVICE` | See [Unified Service Tagging][8]. |
-| `DD_VERSION` | See [Unified Service Tagging][8]. |
-| `DD_ENV` | See [Unified Service Tagging][8]. |
-| `DD_SOURCE` | See [Unified Service Tagging][8]. |
-| `DD_TAGS` | See [Unified Service Tagging][8]. |
+| `DD_SERVICE` | See [Unified Service Tagging][9]. |
+| `DD_VERSION` | See [Unified Service Tagging][9]. |
+| `DD_ENV` | See [Unified Service Tagging][9]. |
+| `DD_SOURCE` | See [Unified Service Tagging][9]. |
+| `DD_TAGS` | See [Unified Service Tagging][9]. |
 
 ## Log collection
 
@@ -194,8 +194,9 @@ You can use the [GCP integration][1] to collect logs. Alternatively, you can set
 [1]: /integrations/google_cloud_platform/#log-collection
 [2]: /tracing/trace_collection/#for-setup-instructions-select-your-language
 [3]: https://registry.hub.docker.com/r/datadog/serverless-init
-[4]: https://console.cloud.google.com/security/secret-manager
-[5]: https://console.cloud.google.com/run
-[6]: /metrics/custom_metrics/dogstatsd_metrics_submission/
-[7]: /getting_started/site/
-[8]: /getting_started/tagging/unified_service_tagging/
+[4]: https://buildpacks.io/docs/tools/pack/
+[5]: https://console.cloud.google.com/security/secret-manager
+[6]: https://console.cloud.google.com/run
+[7]: /metrics/custom_metrics/dogstatsd_metrics_submission/
+[8]: /getting_started/site/
+[9]: /getting_started/tagging/unified_service_tagging/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
hotjar question asked about the [pack](https://buildpacks.io/docs/tools/pack/) command, updating with context and a link to pack

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
