### PR TITLE
trace_collection/custom_instrumentation: updated propagation in go tr…

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/go.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go.md
@@ -199,7 +199,7 @@ There are additional configurations possible for both the tracing client and Dat
 
 ## Trace context propagation for distributed tracing
 
-The Datadog APM tracer supports extraction and injection of [B3][9] and [W3C][10] headers for distributed tracing.
+The Datadog APM tracer supports extraction and injection of [B3][8] and [W3C][10] headers for distributed tracing.
 
 Distributed headers injection and extraction is controlled by
 configuring injection/extraction styles. Supported styles are:

--- a/content/en/tracing/trace_collection/custom_instrumentation/go.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go.md
@@ -197,27 +197,29 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 There are additional configurations possible for both the tracing client and Datadog Agent for context propagation with B3 Headers, as well as excluding specific resources from sending traces to Datadog in the event these traces are not wanted in metrics calculated, such as Health Checks.
 
-### B3 headers extraction and injection
+## Trace context propagation for distributed tracing
 
-The Datadog APM tracer supports [B3 headers extraction][8] and injection for distributed tracing.
+The Datadog APM tracer supports extraction and injection of [B3][9] and [W3C][10] headers for distributed tracing.
 
 Distributed headers injection and extraction is controlled by
-configuring injection/extraction styles. Two styles are
-supported: `Datadog` and `B3`.
+configuring injection/extraction styles. Supported styles are:
+`tracecontext`, `Datadog`, `B3` and `B3 single header`.
 
-Configure injection styles using the environment variable:
-`DD_TRACE_PROPAGATION_STYLE_INJECT=Datadog,B3`
+- Configure injection styles using the `DD_PROPAGATION_STYLE_INJECT=tracecontext,B3` environment variable.
+- Configure extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=tracecontext,B3` environment variable.
+- Configure both injection and extraction styles using the `DD_TRACE_PROPAGATION_STYLE=tracecontext,B3` environment variable.
 
-Configure extraction styles using the environment variable:
-`DD_TRACE_PROPAGATION_STYLE_EXTRACT=Datadog,B3`
+The values of these environment variables are comma-separated lists of
+header styles enabled for injection or extraction. By default,
+the `tracecontext,Datadog` styles are enabled.
 
-Configure both styles using the environment variable:
-`DD_TRACE_PROPAGATION_STYLE=Datadog,B3`.
-*Note*: `DD_TRACE_PROPAGATION_STYLE_INJECT` and `DD_TRACE_PROPAGATION_STYLE_EXTRACT`, if set, take precedence.
+To disable trace context propagation, set the value of the environment variables to `none`.
+- Disable injection styles using the `DD_PROPAGATION_STYLE_INJECT=none` environment variable.
+- Disable extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=none` environment variable.
+- Disable all trace context propagation (both inject and extract) using the `DD_PROPAGATION_STYLE=none` environment variable.
 
-The values of these environment variables are comma separated lists of
-header styles that are enabled for injection or extraction. By default,
-the `Datadog` extraction style is enabled.
+If multiple environment variables are set, `DD_PROPAGATION_STYLE_INJECT` and `DD_PROPAGATION_STYLE_EXTRACT`
+override any value provided in `DD_PROPAGATION_STYLE`.
 
 If multiple extraction styles are enabled, extraction attempts are made
 in the order that those styles are specified. The first successfully
@@ -240,3 +242,4 @@ Traces can be excluded based on their resource name, to remove synthetic traffic
 [7]: /tracing/glossary/#trace
 [8]: https://github.com/openzipkin/b3-propagation
 [9]: /tracing/security
+[10]: https://github.com/w3c/trace-context


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates trace context propagation docs in Go.

Includes new W3c and B3 single header styles.
Includes an option to disable propagation.
### Motivation
<!-- What inspired you to submit this pull request?-->
Relates to changes in https://github.com/DataDog/dd-trace-go/pull/1630 and identical docs update in #16488 
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
