### PR TITLE
document php allocation profiling

### DIFF
--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -194,6 +194,12 @@ Wall Time
 CPU
 : Shows the time each function spent running on the CPU.
 
+Allocations
+: The number of allocations by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.
+
+Allocated memory
+: The amount of heap memory allocated by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.
+
 [1]: /profiler/enabling/php/#requirements
 {{< /programming-lang >}}
 {{< programming-lang lang="ddprof" >}}

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -114,6 +114,11 @@ Enable the Datadog profiler. Added in version `0.69.0`. See [Enabling the PHP Pr
 **Default**: `1`<br>
 Whether to enable the endpoint data collection in profiles. Added in version `0.79.0`.
 
+`DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED`
+: **INI**: `datadog.profiling.experimental_allocation_enabled`. INI available since `0.84.0`.<br>
+**Default**: `0`<br>
+Enable the experimental allocation size and allocation bytes profile type. Added in version `0.84.0`.
+
 `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED`
 : **INI**: `datadog.profiling.experimental_cpu_time_enabled`. INI available since `0.82.0`.<br>
 **Default**: `1`<br>


### PR DESCRIPTION
### What does this PR do?

Document allocation profiling feature in upcoming PHP profiler release.

### Motivation

With the upcoming release of the PHP profiler and tracer we will bring allocation profiling support as a beta release to PHP and we should have documentation for this 🎉 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
