### PR TITLE
[content/en/opentelemetry] Mention different signals request different batch processor configs

### DIFF
--- a/content/en/opentelemetry/otel_collector_datadog_exporter.md
+++ b/content/en/opentelemetry/otel_collector_datadog_exporter.md
@@ -95,7 +95,9 @@ service:
 
 Where `<DD_SITE>` is your site, {{< region-param key="dd_site" code="true" >}}.
 
-The above configuration enables the receiving of OTLP data from OpenTelemetry instrumentation libraries over HTTP and gRPC, and sets up a [batch processor][5], which is mandatory for any non-development environment. Note that you may get 413 - Request Entity Too Large errors if you batch too much telemetry data in the batch processor. The exact config of batch processor depends on your specific workload as well as the signal types - Datadog intake has different payload size limits for the 3 signal types:
+The above configuration enables the receiving of OTLP data from OpenTelemetry instrumentation libraries over HTTP and gRPC, and sets up a [batch processor][5], which is mandatory for any non-development environment. Note that you may get `413 - Request Entity Too Large` errors if you batch too much telemetry data in the batch processor.
+
+The exact configuration of the batch processor depends on your specific workload as well as the signal types. Datadog intake has different payload size limits for the 3 signal types:
 - Trace intake: 3.2MB
 - Log intake: https://docs.datadoghq.com/api/latest/logs/
 - Metrics V2 intake: https://docs.datadoghq.com/api/latest/metrics/#submit-metrics

--- a/content/en/opentelemetry/otel_collector_datadog_exporter.md
+++ b/content/en/opentelemetry/otel_collector_datadog_exporter.md
@@ -71,10 +71,8 @@ receivers:
 
 processors:
   batch:
-    # Datadog APM Intake limit is 3.2MB. Let's make sure the batches do not
-    # go over that.
-    send_batch_max_size: 1000
-    send_batch_size: 100
+    send_batch_max_size: 100
+    send_batch_size: 10
     timeout: 10s
 
 exporters:
@@ -97,7 +95,10 @@ service:
 
 Where `<DD_SITE>` is your site, {{< region-param key="dd_site" code="true" >}}.
 
-The above configuration enables the receiving of OTLP data from OpenTelemetry instrumentation libraries over HTTP and gRPC, and sets up a [batch processor][5], which is mandatory for any non-development environment.
+The above configuration enables the receiving of OTLP data from OpenTelemetry instrumentation libraries over HTTP and gRPC, and sets up a [batch processor][5], which is mandatory for any non-development environment. Note that you may get 413 - Request Entity Too Large errors if you batch too much telemetry data in the batch processor. The exact config of batch processor depends on your specific workload as well as the signal types - Datadog intake has different payload size limits for the 3 signal types:
+- Trace intake: 3.2MB
+- Log intake: https://docs.datadoghq.com/api/latest/logs/
+- Metrics V2 intake: https://docs.datadoghq.com/api/latest/metrics/#submit-metrics
 
 #### Advanced configuration
 
@@ -419,10 +420,8 @@ To use the OpenTelemetry Operator:
        processors:
          k8sattributes:
          batch:
-           # Datadog APM Intake limit is 3.2MB. Let's make sure the batches do not
-           # go over that.
-           send_batch_max_size: 1000
-           send_batch_size: 100
+           send_batch_max_size: 100
+           send_batch_size: 10
            timeout: 10s
        exporters:
          datadog:

--- a/content/en/opentelemetry/otel_collector_datadog_exporter.md
+++ b/content/en/opentelemetry/otel_collector_datadog_exporter.md
@@ -99,8 +99,8 @@ The above configuration enables the receiving of OTLP data from OpenTelemetry in
 
 The exact configuration of the batch processor depends on your specific workload as well as the signal types. Datadog intake has different payload size limits for the 3 signal types:
 - Trace intake: 3.2MB
-- Log intake: https://docs.datadoghq.com/api/latest/logs/
-- Metrics V2 intake: https://docs.datadoghq.com/api/latest/metrics/#submit-metrics
+- Log intake: [5MB uncompressed][15]
+- Metrics V2 intake: [500KB or 5MB after decompression][16]
 
 #### Advanced configuration
 
@@ -546,3 +546,5 @@ The OpenTelemetry Collector has [two primary deployment methods][14]: Agent and 
 [8]: /getting_started/tagging/unified_service_tagging/
 [9]: https://opentelemetry.io/docs/reference/specification/resource/sdk/#sdk-provided-resource-attributes
 [14]: https://opentelemetry.io/docs/collector/deployment/
+[15]: https://docs.datadoghq.com/api/latest/logs/
+[16]: https://docs.datadoghq.com/api/latest/metrics/#submit-metrics


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Remind the readers that they may need different batch sizes for batch processor for different signal types (traces/metrics/logs) when using datadog exporter.

### Motivation
<!-- What inspired you to submit this pull request?-->
The previous comment and config in the batch processor only refers to the payload size limit of trace intake. When customers use the same config for metrics or logs pipeline, they may get 413 errors because metrics and logs have a smaller payload size limit than that in trace. This led to customer confusions and issues being filed in https://github.com/open-telemetry/opentelemetry-collector-contrib.

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Related customer issues:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16834
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17566

Also note that the payload size limits in metrics and logs intake are in the public document, but traces intake doesn't have a public reference.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
