### PR TITLE
Update mobile menu link for Integrate Datadog and the Worker

### DIFF
--- a/assets/scripts/components/mobile-nav.js
+++ b/assets/scripts/components/mobile-nav.js
@@ -77,11 +77,11 @@ export function setMobileNav () {
     const dataPath = window.location.pathname.slice(1,-1)
     let mobileSelection = ''
     // redirect the AGENT/aggregating agent path to observability_pipelines/integrations/... on mobile nav
-    if(dataPath.includes('observability_pipelines/guide')){
+    if(dataPath.includes('observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker')){
         const observabilityPipelineMobile = document.querySelector('#mobile-nav a[data-path$="observability_pipelines"]');
 
         mobileSelection = observabilityPipelineMobile.nextElementSibling.querySelector(
-            'a[data-path*="observability_pipelines/guide"]'
+            'a[data-path*="observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker"]'
         );
     }else{
         mobileSelection = document.querySelector(`#mobile-nav a[data-path="${dataPath}"]`) || false


### PR DESCRIPTION
### What does this PR do?

Updates the nav menu so that clicking on "Agent> Aggregating Agents" in the nav jumps down to "Integrate Datadog and the Worker" in the Obs Pipelines section of the nav.

### Motivation

[DOCS-4692](https://datadoghq.atlassian.net/browse/DOCS-4692)
[WEB-3093](https://datadoghq.atlassian.net/browse/WEB-3093)

https://docs-staging.datadoghq.com/may/update-mobile-menu-op/observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker/

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4692]: https://datadoghq.atlassian.net/browse/DOCS-4692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-3093]: https://datadoghq.atlassian.net/browse/WEB-3093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ