### PR TITLE
explain the updates to error sampler in 7.41.x and fix manual drop examples

### DIFF
--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -231,9 +231,19 @@ With Agent version 7.33 and forward, you can configure the error sampler in the 
 @env DD_APM_ERROR_TPS - integer - optional - default: 10
 ```
 
-**Note**: Set the parameter to `0` to disable the error sampler.
+**Notes**: 
+1. Set the parameter to `0` to disable the error sampler.
+2. The error sampler captures local traces with error spans at the Agent level. If the trace is distributed, there is no way to guarantee that the complete trace will be sent to Datadog.
+3. By default, spans dropped by tracing library rules or custom logic such as `manual.keep` are **excluded** under the `error` sampler.
 
-**Note**: The error sampler captures local traces with error spans at the Agent level. If the trace is distributed, there is no way to guarantee that the complete trace will be sent to Datadog.
+#### Datadog Agent 6/7.41.0 and higher
+
+To override the default behavior so that spans dropped by the tracing library rules or custom logic such as `manual.keep` are **included** by the error sampler, enable the feature with: `DD_APM_FEATURES=error_rare_sample_tracer_drop` in the Trace Agent.
+
+
+#### Datadog Agent 6/7.33 to 6/7.40.x
+
+No further customization exist. To customize the default behavior, upgrade the Datadog Agent to Datadog Agent 6/7.41.0 and higher.
 
 
 ### Rare traces

--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -233,12 +233,12 @@ With Agent version 7.33 and forward, you can configure the error sampler in the 
 
 **Notes**: 
 1. Set the parameter to `0` to disable the error sampler.
-2. The error sampler captures local traces with error spans at the Agent level. If the trace is distributed, there is no way to guarantee that the complete trace will be sent to Datadog.
+2. The error sampler captures local traces with error spans at the Agent level. If the trace is distributed, there is no guarantee that the complete trace is sent to Datadog.
 3. By default, spans dropped by tracing library rules or custom logic such as `manual.drop` are **excluded** under the error sampler.
 
 #### Datadog Agent 6/7.41.0 and higher
 
-To override the default behavior so that spans dropped by the tracing library rules or custom logic such as `manual.drop` are **included** by the error sampler, enable the feature with: `DD_APM_FEATURES=error_rare_sample_tracer_drop` in the Trace Agent.
+To override the default behavior so that spans dropped by the tracing library rules or custom logic such as `manual.drop` are **included** by the error sampler, enable the feature with: `DD_APM_FEATURES=error_rare_sample_tracer_drop` in the Datadog Agent (or the dedicated Trace Agent container within the Datadog Agent pod in Kubernetes).
 
 
 #### Datadog Agent 6/7.33 to 6/7.40.x

--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -234,11 +234,11 @@ With Agent version 7.33 and forward, you can configure the error sampler in the 
 **Notes**: 
 1. Set the parameter to `0` to disable the error sampler.
 2. The error sampler captures local traces with error spans at the Agent level. If the trace is distributed, there is no way to guarantee that the complete trace will be sent to Datadog.
-3. By default, spans dropped by tracing library rules or custom logic such as `manual.keep` are **excluded** under the `error` sampler.
+3. By default, spans dropped by tracing library rules or custom logic such as `manual.drop` are **excluded** under the `error` sampler.
 
 #### Datadog Agent 6/7.41.0 and higher
 
-To override the default behavior so that spans dropped by the tracing library rules or custom logic such as `manual.keep` are **included** by the error sampler, enable the feature with: `DD_APM_FEATURES=error_rare_sample_tracer_drop` in the Trace Agent.
+To override the default behavior so that spans dropped by the tracing library rules or custom logic such as `manual.drop` are **included** by the error sampler, enable the feature with: `DD_APM_FEATURES=error_rare_sample_tracer_drop` in the Trace Agent.
 
 
 #### Datadog Agent 6/7.33 to 6/7.40.x
@@ -257,7 +257,7 @@ The rare sampler sends a set of rare spans to Datadog. It catches combinations o
 
 By default, the rare sampler is **not enabled**.
 
-**Note**: When **enabled**, spans dropped by tracing library rules or custom logic such as `manual.keep` are **excluded** under this sampler.
+**Note**: When **enabled**, spans dropped by tracing library rules or custom logic such as `manual.drop` are **excluded** under this sampler.
 
 To configure the rare sampler, update the `apm_config.enable_rare_sampler` setting in the Agent main configuration file (`datadog.yaml`) or with the environment variable `DD_APM_ENABLE_RARE_SAMPLER`:
 
@@ -266,7 +266,7 @@ To configure the rare sampler, update the `apm_config.enable_rare_sampler` setti
 @env DD_APM_ENABLE_RARE_SAMPLER - boolean - optional - default: false
 ```
 
-To evaluate spans dropped by tracing library rules or custom logic such as `manual.keep`,
+To evaluate spans dropped by tracing library rules or custom logic such as `manual.drop`,
  enable the feature with: `DD_APM_FEATURES=error_rare_sample_tracer_drop` in the Trace Agent.
 
 
@@ -274,7 +274,7 @@ To evaluate spans dropped by tracing library rules or custom logic such as `manu
 
 By default, the rare sampler is enabled.
 
-**Note**: When **enabled**, spans dropped by tracing library rules or custom logic such as `manual.keep` **are excluded** under this sampler. To include these spans in this logic, upgrade to Datadog Agent 6.41.0/7.41.0 or higher.
+**Note**: When **enabled**, spans dropped by tracing library rules or custom logic such as `manual.drop` **are excluded** under this sampler. To include these spans in this logic, upgrade to Datadog Agent 6.41.0/7.41.0 or higher.
 
 To change the default rare sampler settings, update the `apm_config.disable_rare_sampler` setting in the Agent main configuration file (`datadog.yaml`) or with the environment variable `DD_APM_DISABLE_RARE_SAMPLER`:
 

--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -234,7 +234,7 @@ With Agent version 7.33 and forward, you can configure the error sampler in the 
 **Notes**: 
 1. Set the parameter to `0` to disable the error sampler.
 2. The error sampler captures local traces with error spans at the Agent level. If the trace is distributed, there is no way to guarantee that the complete trace will be sent to Datadog.
-3. By default, spans dropped by tracing library rules or custom logic such as `manual.drop` are **excluded** under the `error` sampler.
+3. By default, spans dropped by tracing library rules or custom logic such as `manual.drop` are **excluded** under the error sampler.
 
 #### Datadog Agent 6/7.41.0 and higher
 

--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -243,7 +243,7 @@ To override the default behavior so that spans dropped by the tracing library ru
 
 #### Datadog Agent 6/7.33 to 6/7.40.x
 
-No further customization exist. To customize the default behavior, upgrade the Datadog Agent to Datadog Agent 6/7.41.0 and higher.
+Error sampling default behavior can't be changed for these Agent versions. Upgrade the Datadog Agent to Datadog Agent 6/7.41.0 and higher.
 
 
 ### Rare traces


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR updates the ingestion mechanisms to explain how it is configured based on these this Datadog Agent PR for 7.41.0: https://github.com/DataDog/datadog-agent/pull/14102

### Motivation
<!-- What inspired you to submit this pull request?-->

Explain how the error sampler works. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/wantsui/error-sampler-update/tracing/trace_pipeline/ingestion_mechanisms

### Additional Notes
<!-- Anything else we should know when reviewing?-->



---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
