### PR TITLE
Update USM docs to support kernel header downloading

### DIFF
--- a/content/en/universal_service_monitoring/_index.md
+++ b/content/en/universal_service_monitoring/_index.md
@@ -77,6 +77,14 @@ datadog:
     enabled: true
 ```
 
+If your cluster is running Google Container-Optimized OS, add the following to your values file as well:
+
+```
+providers:
+  gke:
+    cos: true
+```
+
 {{% /tab %}}
 {{% tab "Kubernetes without Helm" %}}
 
@@ -167,7 +175,40 @@ datadog:
              mountPath: /sys/kernel/debug
            - name: sysprobe-socket-dir
              mountPath: /var/run/sysprobe
+           - name: modules
+             mountPath: /lib/modules
+             readOnly: true
+           - name: src
+             mountPath: /usr/src
+             readOnly: true
+           - name: runtime-compiler-output-dir
+             mountPath: /var/tmp/datadog-agent/system-probe/build
+           - name: kernel-headers-download-dir
+             mountPath: /var/tmp/datadog-agent/system-probe/kernel-headers
+             readOnly: false
+           - name: apt-config-dir
+             mountPath: /host/etc/apt
+             readOnly: true
+           - name: yum-repos-dir
+             mountPath: /host/etc/yum.repos.d
+             readOnly: true
+           - name: opensuse-repos-dir
+             mountPath: /host/etc/zypp
+             readOnly: true
+           - name: public-key-dir
+             mountPath: /host/etc/pki
+             readOnly: true
+           - name: yum-vars-dir
+             mountPath: /host/etc/yum/vars
+             readOnly: true
+           - name: dnf-vars-dir
+             mountPath: /host/etc/dnf/vars
+             readOnly: true
+           - name: rhel-subscription-dir
+             mountPath: /host/etc/rhsm
+             readOnly: true
    ```
+
    And add the following volumes to your manifest:
    ```
    volumes:
@@ -176,7 +217,55 @@ datadog:
      - name: debugfs
        hostPath:
          path: /sys/kernel/debug
+     - hostPath:
+         path: /lib/modules
+       name: modules
+     - hostPath:
+         path: /usr/src
+       name: src
+     - hostPath:
+         path: /var/tmp/datadog-agent/system-probe/build
+       name: runtime-compiler-output-dir
+     - hostPath:
+         path: /var/tmp/datadog-agent/system-probe/kernel-headers
+       name: kernel-headers-download-dir
+     - hostPath:
+         path: /etc/apt
+       name: apt-config-dir
+     - hostPath:
+         path: /etc/yum.repos.d
+       name: yum-repos-dir
+     - hostPath:
+         path: /etc/zypp
+       name: opensuse-repos-dir
+     - hostPath:
+         path: /etc/pki
+       name: public-key-dir
+     - hostPath:
+         path: /etc/yum/vars
+       name: yum-vars-dir
+     - hostPath:
+         path: /etc/dnf/vars
+       name: dnf-vars-dir
+     - hostPath:
+         path: /etc/rhsm
+       name: rhel-subscription-dir
+
    ```
+
+    **Note**: If your cluster is running on Google Container-Optimized OS (COS), you will need to remove the `src` mount. In order to do this, remove the following from your container definition:
+   ```
+    - name: src
+      mountPath: /usr/src
+      readOnly: true
+   ```
+    and the following from your manifest:
+   ```
+    - hostPath:
+        path: /usr/src
+      name: src
+   ```
+
 5. For optional HTTPS support, add the following to the `system-probe` container:
 
    ```
@@ -204,6 +293,18 @@ Add the following to your `docker run` command:
 
 ```
 -v /sys/kernel/debug:/sys/kernel/debug \
+-v /:/host/root:ro \
+-v /lib/modules:/lib/modules:ro \
+-v /usr/src:/usr/src:ro \
+-v /var/tmp/datadog-agent/system-probe/build:/var/tmp/datadog-agent/system-probe/build \
+-v /var/tmp/datadog-agent/system-probe/kernel-headers:/var/tmp/datadog-agent/system-probe/kernel-headers \
+-v /etc/apt:/host/etc/apt:ro \
+-v /etc/yum.repos.d:/host/etc/yum.repos.d:ro \
+-v /etc/zypp:/host/etc/zypp:ro \
+-v /etc/pki:/host/etc/pki:ro \
+-v /etc/yum/vars:/host/etc/yum/vars:ro \
+-v /etc/dnf/vars:/host/etc/dnf/vars:ro \
+-v /etc/rhsm:/host/etc/rhsm:ro \
 -e DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED=true \
 --security-opt apparmor:unconfined \
 --cap-add=SYS_ADMIN \
@@ -236,6 +337,17 @@ services:
      - DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED: 'true'
     volumes:
      - /sys/kernel/debug:/sys/kernel/debug
+     - /lib/modules:/lib/modules
+     - /usr/src:/usr/src
+     - /var/tmp/datadog-agent/system-probe/build:/var/tmp/datadog-agent/system-probe/build
+     - /var/tmp/datadog-agent/system-probe/kernel-headers:/var/tmp/datadog-agent/system-probe/kernel-headers
+     - /etc/apt:/host/etc/apt
+     - /etc/yum.repos.d:/host/etc/yum.repos.d
+     - /etc/zypp:/host/etc/zypp
+     - /etc/pki:/host/etc/pki
+     - /etc/yum/vars:/host/etc/yum/vars
+     - /etc/dnf/vars:/host/etc/dnf/vars
+     - /etc/rhsm:/host/etc/rhsm
     cap_add:
      - SYS_ADMIN
      - SYS_RESOURCE

--- a/content/en/universal_service_monitoring/_index.md
+++ b/content/en/universal_service_monitoring/_index.md
@@ -77,7 +77,7 @@ datadog:
     enabled: true
 ```
 
-If your cluster is running Google Container-Optimized OS, add the following to your values file as well:
+If your cluster is running Google Container-Optimized OS (COS), add the following to your values file as well:
 
 ```
 providers:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updates the USM setup documentation in order for containerized environments to support kernel header downloading.

### Motivation
<!-- What inspired you to submit this pull request?-->
This information is missing from our current documentation

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
