### PR TITLE
fixed spacing after code blocks

### DIFF
--- a/assets/styles/pages/_reference.scss
+++ b/assets/styles/pages/_reference.scss
@@ -1,9 +1,6 @@
 .announcement .main h5 {
   pointer-events:all;
 }
-.main pre {
-  margin:0;
-}
 .main h5:before {
   display: none;
 }
@@ -36,6 +33,7 @@
 #accordion pre,
 .example-accordion pre {
   border-bottom: 3px solid rgba(119,0,255,.3);
+  margin:0;
 }
 .code-snippet-wrapper button:disabled,
 .code-snippet-wrapper button[disabled], {


### PR DESCRIPTION
### What does this PR do?

Moves a styling override for code block margins into the correct scope so it doesn’t override the standard code block margins.

### Motivation

Spacing issues between code blocks and following content reported on Slack. You can see [an example here](https://docs.datadoghq.com/database_monitoring/setup_sql_server/selfhosted/). 
<img width="826" alt="image" src="https://user-images.githubusercontent.com/1958/214631188-fa231e35-5495-4e53-9307-176353d20589.png">


### Preview

https://docs-staging.datadoghq.com/fitzage/code-spacing/database_monitoring/setup_sql_server/selfhosted/?tab=sqlserver2014

<img width="843" alt="image" src="https://user-images.githubusercontent.com/1958/214638897-682bf7bb-6a52-493f-8beb-d3113d4136c6.png">

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
