### PR TITLE
Fixed reference link to image

### DIFF
--- a/content/en/monitors/guide/create-monitor-dependencies.md
+++ b/content/en/monitors/guide/create-monitor-dependencies.md
@@ -42,7 +42,7 @@ And the webhook content for both:
 ```
 
 Then, create "Alert A" - for example- a no-data alert for a grouped percentage of hosts for each Availability zone.
-{{< img src="monitors/guide/alert_example.png" alt="alert_example"  >}}
+{{< img src="monitors/guide/alert_exammple.png" alt="alert_example"  >}}
 
 Then, in the alert message, you'll want to use the @notify webhook to mute all subsequent hosts in that Availability Zone when it triggers, and unmute when the alert resolves:
 {{< img src="monitors/guide/mute_demo_msg.png" alt="mute_demo_msg"  >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Reference the correct image source in [docs](https://docs.datadoghq.com/monitors/guide/create-monitor-dependencies/)

### Motivation
![image](https://user-images.githubusercontent.com/41168354/214676165-66467cdf-0ba7-4a08-a2d6-70298ad61c68.png)
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
- I tried renaming the image path name at first, but the reference would not load the image. However, renaming the source somehow works.
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
