### PR TITLE
[DOCS-4712] Make AWS PrivateLink doc available only for us1

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -10,22 +10,11 @@ further_reading:
       text: 'Collect logs from your AWS services'
 ---
 
-{{< site-region region="gov" >}}
-<div class="alert alert-warning">Datadog PrivateLink does not support the Datadog for Government site.</div>
+{{< site-region region="us3,us5,eu,gov" >}}
+<div class="alert alert-warning">Datadog PrivateLink does not support the selected Datadog site.</div>
 {{< /site-region >}}
 
-{{< site-region region="us3" >}}
-<div class="alert alert-warning">Datadog PrivateLink does not support the Datadog US3 site.</div>
-{{< /site-region >}}
-
-{{< site-region region="us5" >}}
-<div class="alert alert-warning">Datadog PrivateLink does not support the Datadog US5 site.</div>
-{{< /site-region >}}
-
-{{< site-region region="eu" >}}
-<div class="alert alert-warning">Datadog PrivateLink does not support the Datadog EU site.</div>
-{{< /site-region >}}
-
+{{< site-region region="us" >}}
 This guide walks you through how to configure [AWS PrivateLink][1] for use with Datadog.
 
 ## Overview
@@ -255,3 +244,4 @@ The VPCs with Private Hosted Zone (PHZ) attached need to have a couple of settin
 
 [1]: https://aws.amazon.com/privatelink/
 [2]: https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html
+{{< /site-region >}}


### PR DESCRIPTION
### What does this PR do?

- Makes docs only available for US1, the only supported site.
- Consolidate unsupported alert box.

### Motivation

[DOCS-4712](https://datadoghq.atlassian.net/browse/DOCS-4712)


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4712]: https://datadoghq.atlassian.net/browse/DOCS-4712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ