### PR TITLE
Less confusing for customers

### DIFF
--- a/content/en/agent/troubleshooting/send_a_flare.md
+++ b/content/en/agent/troubleshooting/send_a_flare.md
@@ -129,7 +129,7 @@ aws ecs execute-command --cluster <CLUSTER_NAME> \
 
 | Platform   | Command                                                             |
 |------------|---------------------------------------------------------------------|
-| Kubernetes | `kubectl exec <POD_NAME> -it datadog-cluster-agent flare <CASE_ID>` |
+| Kubernetes | `kubectl exec <CLUSTER_POD_NAME> -it datadog-cluster-agent flare <CASE_ID>` |
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
Customers tend to consider <POD_NAME> as the node agent pod and not the cluster agent one. I believe adjusting it like this would save a lot of confusion in the future.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adjusting <POD_NAME> to <CLUSTER_POD_NAME> will allow customers to use the correct cluster pod name to send cluster agent flares. Often customers have this confusion and this would save some time in support tickets. 
### Motivation
<!-- What inspired you to submit this pull request?-->
Reduce MTTR for support tickets. 
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
