### PR TITLE
fix chrome scroll to issue - [WEB-3105]

### DIFF
--- a/assets/scripts/components/table-of-contents.js
+++ b/assets/scripts/components/table-of-contents.js
@@ -1,6 +1,18 @@
 let sidenavMapping = [];
 // let apiNavMapping = [];
 
+// fixes Chrome issue where pages with hash params are not scrolling to anchor
+document.addEventListener('DOMContentLoaded', function () {
+    const isChrome = /Chrome/.test(navigator.userAgent);
+    if (window.location.hash && isChrome) {
+        setTimeout(function () {
+            const hash = window.location.hash;
+            window.location.hash = "";
+            window.location.hash = hash;
+        }, 300);
+    }
+}, false);
+
 let tocContainer = document.querySelector('.js-toc-container');
 let tocMobileToggle = document.querySelector('.js-mobile-toc-toggle');
 const tocMobileBackdrop = document.querySelector('.js-mobile-toc-bg');


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

fix to scroll-to anchor for pages using hash params loaded on Chrome browsers 

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/browse/WEB-3105

### Preview 
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/stefon.simmons/fix-scrollto-page-load/serverless/google_cloud_run/#advanced-options-and-configurations

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
