### PR TITLE
Document that Ruby profiler depends on pkg-config

### DIFF
--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -34,9 +34,9 @@ The following operating systems and architectures are supported:
 You also need either the [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/) or the [`pkgconf`](https://github.com/pkgconf/pkgconf) Linux system utility installed.
 This utility is available on the software repositories of most Linux distributions. For example:
 
-- The `pkg-config` package is available for [Homebrew](https://formulae.brew.sh/formula/pkg-config) and [Debian](https://packages.debian.org/search?keywords=pkg-config) and [Ubuntu](https://packages.ubuntu.com/search?keywords=pkg-config)-based Linux
-- The `pkgconf` package is available for [Arch](https://archlinux.org/packages/?q=pkgconf) and [Alpine](https://pkgs.alpinelinux.org/packages?name=pkgconf)-based Linux
-- The `pkgconf-pkg-config` package is available for [Fedora](https://packages.fedoraproject.org/pkgs/pkgconf/pkgconf-pkg-config/) and [Red Hat](https://rpmfind.net/linux/rpm2html/search.php?query=pkgconf-pkg-config)-based Linux
+- The `pkg-config` package is available for [Homebrew](https://formulae.brew.sh/formula/pkg-config), and [Debian](https://packages.debian.org/search?keywords=pkg-config)- and [Ubuntu](https://packages.ubuntu.com/search?keywords=pkg-config)-based Linux
+- The `pkgconf` package is available for [Arch](https://archlinux.org/packages/?q=pkgconf)- and [Alpine](https://pkgs.alpinelinux.org/packages?name=pkgconf)-based Linux
+- The `pkgconf-pkg-config` package is available for [Fedora](https://packages.fedoraproject.org/pkgs/pkgconf/pkgconf-pkg-config/)- and [Red-Hat](https://rpmfind.net/linux/rpm2html/search.php?query=pkgconf-pkg-config)-based Linux
 
 Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
 

--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -31,6 +31,13 @@ The following operating systems and architectures are supported:
 - Linux (GNU libc) x86-64, aarch64
 - Alpine Linux (musl libc) x86-64, aarch64
 
+You will also need either the [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/) or the [`pkgconf`](https://github.com/pkgconf/pkgconf) Linux system utility installed.
+This utility is available on the software repositories of most Linux distributions. You will find it on:
+
+- The `pkg-config` package on [Homebrew](https://formulae.brew.sh/formula/pkg-config) and [Debian](https://packages.debian.org/search?keywords=pkg-config)/[Ubuntu](https://packages.ubuntu.com/search?keywords=pkg-config)-based Linux
+- The `pkgconf` package on [Arch](https://archlinux.org/packages/?q=pkgconf) and [Alpine](https://pkgs.alpinelinux.org/packages?name=pkgconf)-based Linux
+- The `pkgconf-pkg-config` package on [Fedora](https://packages.fedoraproject.org/pkgs/pkgconf/pkgconf-pkg-config/)/[Red Hat](https://rpmfind.net/linux/rpm2html/search.php?query=pkgconf-pkg-config)-based Linux
+
 Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
 
 ## Installation

--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -31,13 +31,6 @@ The following operating systems and architectures are supported:
 - Linux (GNU libc) x86-64, aarch64
 - Alpine Linux (musl libc) x86-64, aarch64
 
-The following profiling features are available in the following minimum versions of the `dd-trace-rb` library:
-
-|      Feature         | Required `dd-trace-rb` version          |
-|----------------------|-----------------------------------------|
-| [Code Hotspots][12]        | 0.49.0+                       |
-| [Endpoint Profiling][13]            | 0.54.0+                       |
-
 Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
 
 ## Installation

--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -31,12 +31,12 @@ The following operating systems and architectures are supported:
 - Linux (GNU libc) x86-64, aarch64
 - Alpine Linux (musl libc) x86-64, aarch64
 
-You will also need either the [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/) or the [`pkgconf`](https://github.com/pkgconf/pkgconf) Linux system utility installed.
-This utility is available on the software repositories of most Linux distributions. You will find it on:
+You also need either the [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/) or the [`pkgconf`](https://github.com/pkgconf/pkgconf) Linux system utility installed.
+This utility is available on the software repositories of most Linux distributions. For example:
 
-- The `pkg-config` package on [Homebrew](https://formulae.brew.sh/formula/pkg-config) and [Debian](https://packages.debian.org/search?keywords=pkg-config)/[Ubuntu](https://packages.ubuntu.com/search?keywords=pkg-config)-based Linux
-- The `pkgconf` package on [Arch](https://archlinux.org/packages/?q=pkgconf) and [Alpine](https://pkgs.alpinelinux.org/packages?name=pkgconf)-based Linux
-- The `pkgconf-pkg-config` package on [Fedora](https://packages.fedoraproject.org/pkgs/pkgconf/pkgconf-pkg-config/)/[Red Hat](https://rpmfind.net/linux/rpm2html/search.php?query=pkgconf-pkg-config)-based Linux
+- The `pkg-config` package is available for [Homebrew](https://formulae.brew.sh/formula/pkg-config) and [Debian](https://packages.debian.org/search?keywords=pkg-config) and [Ubuntu](https://packages.ubuntu.com/search?keywords=pkg-config)-based Linux
+- The `pkgconf` package is available for [Arch](https://archlinux.org/packages/?q=pkgconf) and [Alpine](https://pkgs.alpinelinux.org/packages?name=pkgconf)-based Linux
+- The `pkgconf-pkg-config` package is available for [Fedora](https://packages.fedoraproject.org/pkgs/pkgconf/pkgconf-pkg-config/) and [Red Hat](https://rpmfind.net/linux/rpm2html/search.php?query=pkgconf-pkg-config)-based Linux
 
 Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the "Enabling the Ruby profiler" page to list that the Ruby profiler requires the `pkg-config` tool installed.
    
It also lists out common names for this system tool in common Linux distributions.

Finally, it removes the "profiling features list" table, because the 0.54.0 version mentioned is by now 15 months old, and 0.49.0 is 20 months old, so I don't think it's relevant anymore to mention them -- customers should be on the 1.x release, and all 1.x releases include these features.

### Motivation

We've had the `pkg-config` dependency for quite some time, and unfortunately some customers discovered that we need it because we check and emit an error message.
    
To improve this experience, I'm listing this on the documentation so that customers can refer back to it if they run into issues.

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
(N/A)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
