### PR TITLE
[Tracing] [PHP] Symfony 6 support

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/php.md
+++ b/content/en/tracing/trace_collection/compatibility/php.md
@@ -107,9 +107,7 @@ The following table enumerates some of the frameworks and versions Datadog succe
 | Phalcon        | 1.3, 3.4             | All supported PHP versions | Generic web tracing             |
 | RoadRunner     | 2.x                  | All supported PHP versions | Framework-level instrumentationq |
 | Slim           | 2.x, 3.x, 4.x        | All supported PHP versions | Framework-level instrumentation |
-| Symfony 3      | 3.3, 3.4             | All supported PHP versions | Framework-level instrumentation |
-| Symfony 4      | 4.x                  | All supported PHP versions | Framework-level instrumentation |
-| Symfony 5      | 5.x (tracer `0.50.0+`) | All supported PHP versions | Framework-level instrumentation |
+| Symfony        | 3.3, 3.4, 4.x, 5.x, 6.x | All supported PHP versions | Framework-level instrumentation |
 | WordPress      | 4.x, 5.x             | PHP 7+                     | Framework-level instrumentation |
 | Yii            | 1.1, 2.0             | All supported PHP versions | Framework-level instrumentation |
 | Zend Framework | 1.12                 | All supported PHP versions | Framework-level instrumentation |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
States that we support Symfony 6 in the PHP tracer

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
