### PR TITLE
remove inline js

### DIFF
--- a/layouts/partials/header-scripts.html
+++ b/layouts/partials/header-scripts.html
@@ -46,8 +46,11 @@ hugo defaults to environment development with hugo server
 {{/* inline datadog rum & logs libs, then load config after as config changes every builds due to version */}}
 {{ $dd_rum := resources.Get "node_modules/datadog-rum.js" }}
 {{ $dd_logs := resources.Get "node_modules/datadog-logs.js" }}
-{{ $dd_libs_js := slice $dd_rum $dd_logs | resources.Concat "js/dd-libs.js" }}
-<script>{{ $dd_libs_js.Content | safeJS }}</script>
+{{ $dd_libs_js := slice $dd_rum $dd_logs | resources.Concat "static/dd-libs.js" }}
+{{ if $isProd }}
+  {{ $dd_libs_js = $dd_libs_js | fingerprint "sha512" }}
+{{ end }}
+<script type="text/javascript" src="{{ $dd_libs_js.Permalink }}" {{ if $isProd }} integrity="{{ $dd_libs_js.Data.Integrity }}" {{ end }}></script>
 
 
 {{ $opts := dict "targetPath" "static/dd-browser-logs-rum.js" "defines" $defines "sourceMap" $sourcemap "minify" $isProd }}


### PR DESCRIPTION
### What does this PR do?

Stop inlining the dd libs to reduce html size, we don't need to inline it anymore

### Motivation

After reviewing artifacts seeing the difference

### Preview

Preview should be the same, check that rum data still appears
https://docs-staging.datadoghq.com/david.jones/reduce-html-size/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
