### PR TITLE
[ci-visibility] Add playwright instructions

### DIFF
--- a/content/en/continuous_integration/tests/javascript.md
+++ b/content/en/continuous_integration/tests/javascript.md
@@ -37,7 +37,7 @@ Supported test frameworks:
 The instrumentation works at runtime, so any transpilers such as TypeScript, Webpack, Babel, or others are supported out of the box.
 
 ### Test suite level visibility compatibility
-[Test suite level visibility][4] is supported from `dd-trace>=3.10.0` and only Jest, Mocha and Playwright are currently supported.
+[Test suite level visibility][4] is supported from `dd-trace>=3.10.0`. Jest, Mocha, and Playwright are supported.
 
 * Jest >= 24.8.0
   * From `dd-trace>=3.10.0`.
@@ -162,7 +162,7 @@ NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app yarn t
 
 ### Adding custom tags to tests
 
-Custom tags are not supported in playwright yet.
+Custom tags are not supported for Playwright.
 
 {{% /tab %}}
 
@@ -173,7 +173,7 @@ Set the `NODE_OPTIONS` environment variable to `-r dd-trace/ci/init`. Run your t
 NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app yarn test
 ```
 
-**Important**: if you set a value for `NODE_OPTIONS`, make sure it does not overwrite `-r dd-trace/ci/init`. This can be done using the `${NODE_OPTIONS:-}` clause:
+**Note**: If you set a value for `NODE_OPTIONS`, make sure it does not overwrite `-r dd-trace/ci/init`. This can be done using the `${NODE_OPTIONS:-}` clause:
 
 {{< code-block lang="json" filename="package.json" >}}
 {
@@ -411,7 +411,7 @@ If you are running tests in non-supported CI providers or with no `.git` folder,
 [Mocha >=9.0.0][8] uses an ESM-first approach to load test files. That means that if ES modules are used (for example, by defining test files with the `.mjs` extension), _the instrumentation is limited_. Tests are detected, but there isn't visibility into your test. For more information about ES modules, see the [Node.js documentation][9].
 
 ### Browser tests
-Browser tests executed with `mocha`, `jest`, `cucumber`, `cypress` and `playwright` are instrumented by `dd-trace-js`, but visibility into the browser session itself is not provided by default (for example, network calls, user actions, page loads, and so on).
+Browser tests executed with `mocha`, `jest`, `cucumber`, `cypress`, and `playwright` are instrumented by `dd-trace-js`, but visibility into the browser session itself is not provided by default (for example, network calls, user actions, page loads, etc.).
 
 If you want visibility into the browser process, consider using [RUM & Session Replay][10]. When using Cypress, test results and their generated RUM browser sessions and session replays are automatically linked. Learn more in the [RUM integration][11] guide.
 

--- a/content/en/continuous_integration/tests/javascript.md
+++ b/content/en/continuous_integration/tests/javascript.md
@@ -32,7 +32,7 @@ Supported test frameworks:
 * Cypress >= 6.7.0
   * From `dd-trace>=1.4.0`
 * Playwright >= 1.18.0
-  * From `dd-trace>=TBD`
+  * From `dd-trace>=3.13.0` and `dd-trace>=2.26.0` for 2.x release line.
 
 The instrumentation works at runtime, so any transpilers such as TypeScript, Webpack, Babel, or others are supported out of the box.
 
@@ -45,7 +45,7 @@ The instrumentation works at runtime, so any transpilers such as TypeScript, Web
 * Mocha >= 5.2.0
   * From `dd-trace>=3.10.0`.
 * Playwright >= 1.18.0
-  * From `dd-trace>=TBD`.
+  * From `dd-trace>=3.13.0` and `dd-trace>=2.26.0` for 2.x release line.
 
 ## Configuring reporting method
 
@@ -162,7 +162,7 @@ NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app yarn t
 
 ### Adding custom tags to tests
 
-This is currently not supported in playwright.
+Custom tags are not supported in playwright yet.
 
 {{% /tab %}}
 

--- a/content/en/continuous_integration/tests/javascript.md
+++ b/content/en/continuous_integration/tests/javascript.md
@@ -153,6 +153,39 @@ To create filters or `group by` fields for these tags, you must first create fac
 [1]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
 {{% /tab %}}
 
+{{% tab "Playwright" %}}
+Set the `NODE_OPTIONS` environment variable to `-r dd-trace/ci/init`. Run your tests as you normally would, specifying the environment where the tests are run in the `DD_ENV` environment variable. For example, set `DD_ENV` to `local` when running tests on a developer workstation, or `ci` when running them on a CI provider:
+
+```bash
+NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app yarn test
+```
+
+**Important**: if you set a value for `NODE_OPTIONS`, make sure it does not overwrite `-r dd-trace/ci/init`. This can be done using the `${NODE_OPTIONS:-}` clause:
+
+{{< code-block lang="json" filename="package.json" >}}
+{
+  "scripts": {
+    "test": "NODE_OPTIONS=\"--max-old-space-size=12288 ${NODE_OPTIONS:-}\" jest"
+  }
+}
+{{< /code-block >}}
+
+### Using Yarn >=2
+
+If you're using `yarn>=2` and a `.pnp.cjs` file, and you get the following error message when using `NODE_OPTIONS`:
+
+```text
+ Error: Cannot find module 'dd-trace/ci/init'
+```
+
+You can fix it by setting `NODE_OPTIONS` to the following:
+
+```bash
+NODE_OPTIONS="-r $(pwd)/.pnp.cjs -r dd-trace/ci/init" yarn test
+```
+
+{{% /tab %}}
+
 {{% tab "Cucumber" %}}
 Set the `NODE_OPTIONS` environment variable to `-r dd-trace/ci/init`. Run your tests as you normally would, specifying the environment where the tests are run in the `DD_ENV` environment variable. For example, set `DD_ENV` to `local` when running tests on a developer workstation, or `ci` when running them on a CI provider:
 

--- a/content/en/continuous_integration/tests/javascript.md
+++ b/content/en/continuous_integration/tests/javascript.md
@@ -31,17 +31,21 @@ Supported test frameworks:
 * Cucumber-js >= 7.0.0
 * Cypress >= 6.7.0
   * From `dd-trace>=1.4.0`
+* Playwright >= 1.18.0
+  * From `dd-trace>=TBD`
 
 The instrumentation works at runtime, so any transpilers such as TypeScript, Webpack, Babel, or others are supported out of the box.
 
 ### Test suite level visibility compatibility
-[Test suite level visibility][4] is supported from `dd-trace>=3.3.0`, only in Agentless mode, and only Jest and Mocha are currently supported.
+[Test suite level visibility][4] is supported from `dd-trace>=3.10.0` and only Jest, Mocha and Playwright are currently supported.
 
 * Jest >= 24.8.0
-  * From `dd-trace>=3.3.0`.
+  * From `dd-trace>=3.10.0`.
   * Only [`jest-circus`][1] is supported as [`testRunner`][3].
 * Mocha >= 5.2.0
-  * From `dd-trace>=3.3.0`.
+  * From `dd-trace>=3.10.0`.
+* Playwright >= 1.18.0
+  * From `dd-trace>=TBD`.
 
 ## Configuring reporting method
 
@@ -121,20 +125,6 @@ NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app yarn t
 }
 {{< /code-block >}}
 
-### Using Yarn >=2
-
-If you're using `yarn>=2` and a `.pnp.cjs` file, and you get the following error message when using `NODE_OPTIONS`:
-
-```text
- Error: Cannot find module 'dd-trace/ci/init'
-```
-
-You can fix it by setting `NODE_OPTIONS` to the following:
-
-```bash
-NODE_OPTIONS="-r $(pwd)/.pnp.cjs -r dd-trace/ci/init" yarn test
-```
-
 ### Adding custom tags to tests
 
 You can add custom tags to your tests by using the current active span:
@@ -170,19 +160,9 @@ NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app yarn t
 }
 {{< /code-block >}}
 
-### Using Yarn >=2
+### Adding custom tags to tests
 
-If you're using `yarn>=2` and a `.pnp.cjs` file, and you get the following error message when using `NODE_OPTIONS`:
-
-```text
- Error: Cannot find module 'dd-trace/ci/init'
-```
-
-You can fix it by setting `NODE_OPTIONS` to the following:
-
-```bash
-NODE_OPTIONS="-r $(pwd)/.pnp.cjs -r dd-trace/ci/init" yarn test
-```
+This is currently not supported in playwright.
 
 {{% /tab %}}
 
@@ -202,20 +182,6 @@ NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app yarn t
   }
 }
 {{< /code-block >}}
-
-### Using Yarn >=2
-
-If you're using `yarn>=2` and a `.pnp.cjs` file, and you get the following error message when using `NODE_OPTIONS`:
-
-```text
- Error: Cannot find module 'dd-trace/ci/init'
-```
-
-You can fix this by setting `NODE_OPTIONS` to the following:
-
-```
-NODE_OPTIONS="-r $(pwd)/.pnp.cjs -r dd-trace/ci/init" yarn test
-```
 
 ### Adding custom tags to tests
 
@@ -351,6 +317,20 @@ If the browser application being tested is instrumented using [RUM][6], your Cyp
 
 {{< /tabs >}}
 
+### Using Yarn >=2
+
+If you're using `yarn>=2` and a `.pnp.cjs` file, and you get the following error message when using `NODE_OPTIONS`:
+
+```text
+ Error: Cannot find module 'dd-trace/ci/init'
+```
+
+You can fix it by setting `NODE_OPTIONS` to the following:
+
+```bash
+NODE_OPTIONS="-r $(pwd)/.pnp.cjs -r dd-trace/ci/init" yarn test
+```
+
 
 ## Configuration settings
 
@@ -431,7 +411,7 @@ If you are running tests in non-supported CI providers or with no `.git` folder,
 [Mocha >=9.0.0][8] uses an ESM-first approach to load test files. That means that if ES modules are used (for example, by defining test files with the `.mjs` extension), _the instrumentation is limited_. Tests are detected, but there isn't visibility into your test. For more information about ES modules, see the [Node.js documentation][9].
 
 ### Browser tests
-Browser tests executed with `mocha`, `jest`, `cucumber` and `cypress` are instrumented by `dd-trace-js`, but visibility into the browser session itself is not provided by default (for example, network calls, user actions, page loads, and so on).
+Browser tests executed with `mocha`, `jest`, `cucumber`, `cypress` and `playwright` are instrumented by `dd-trace-js`, but visibility into the browser session itself is not provided by default (for example, network calls, user actions, page loads, and so on).
 
 If you want visibility into the browser process, consider using [RUM & Session Replay][10]. When using Cypress, test results and their generated RUM browser sessions and session replays are automatically linked. Learn more in the [RUM integration][11] guide.
 


### PR DESCRIPTION
### What does this PR do?
Add instructions to run `playwright` tests with CI Visibility.

### Motivation
Expand support for CI Visibility.

### Preview
[Link to preview](https://docs-staging.datadoghq.com/juan-fernandez/add-playwright-support/continuous_integration/tests/javascript/?tab=playwright)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
