### PR TITLE
Fix Heatmaps request for access beta callout

### DIFF
--- a/content/en/real_user_monitoring/heatmaps/_index.md
+++ b/content/en/real_user_monitoring/heatmaps/_index.md
@@ -8,7 +8,7 @@ further_reading:
   text: 'Session Replay'
 ---
 
-{{< beta-callout url="https://forms.gle/48wkkRoZfwhn74ycA" d-toggle="modal" d_target="#signupModal" custom_class="sign-up-trigger">}}
+{{< beta-callout url="https://forms.gle/48wkkRoZfwhn74ycA" >}}
 Heatmaps are in private beta, but you can request access using this form. We'll reach out directly once approved.
 {{< /beta-callout >}} 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Remove the optional attributes for beta-callout, this was causing the button to open the Sign Up modal, rather than opening up the Google form.

### Motivation
- Request to documentation [[slack](https://dd.slack.com/archives/C0DESMBQU/p1674831245279849)]

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
