### PR TITLE
[Dashboard] Generate/Revoke Option Moved to the Upload Icon

### DIFF
--- a/content/en/dashboards/sharing.md
+++ b/content/en/dashboards/sharing.md
@@ -31,7 +31,7 @@ When you share a dashboard by URL or email link, the shared page shows live, rea
 
 To share an entire dashboard publicly, generate a URL:
 
-1. On the dashboard's page, click the settings cog in the upper right.
+1. On the dashboard's page, click the settings upload icon in the upper right.
 2. Select **Generate public URL**.
 3. Under **Time & Variable Settings**, configure your desired options for the time frame and whether users can change it, as well as which tags are visible for selectable template variables.
 4. Copy the URL and click **Done**.
@@ -42,7 +42,8 @@ To share an entire dashboard publicly, generate a URL:
 
  To authorize one or more specific email addresses to view a dashboard page:
 
-1. On the dashboard's page, click the settings cog in the upper right.
+1. On the dashboard's page, click the settings 
+in the upper right.
 2. Select **Generate public URL**.
 3. Select **Only specified people** for indicating who can access this dashboard.
 4. Input the email addresses for people you would like to share your dashboard with.
@@ -62,7 +63,7 @@ To revoke a shared dashboard:
 
 1. Navigate to the [Dashboard List][1].
 2. Select the dashboard you want to revoke access to.
-3. Click on the settings cog in the upper right.
+3. Click on the settings upload icon in the upper right.
 4. Click **Configure sharing**.
 5. Click **Revoke public URL**.
 


### PR DESCRIPTION
Change in shared dashboard feature.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
