### PR TITLE
[cayetano.delgado] fixing broken link to #trace-merging

### DIFF
--- a/content/en/serverless/distributed_tracing/_index.md
+++ b/content/en/serverless/distributed_tracing/_index.md
@@ -340,7 +340,7 @@ ddlambda.WrapFunction(handler, cfg)
 [3]: /tracing/trace_collection/compatibility/python
 [4]: /tracing/trace_collection/compatibility/nodejs
 [5]: /serverless/installation/
-[6]: /serverless/distributed_tracing/serverless_trace_merging
+[6]: /serverless/distributed_tracing/#trace-merging
 [7]: https://docs.datadoghq.com/help/
 [8]: /tracing/trace_collection/compatibility/ruby
 [9]: /tracing/trace_collection/compatibility/go


### PR DESCRIPTION
Before was pointing to alias /serverless/distributed_tracing/serverless_trace_merging instead of the anchor one

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes a link that was just reloading the page, now it's pointing to the proper anchor.


### Motivation
<!-- What inspired you to submit this pull request?-->
Good docs FTW

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
