### PR TITLE
[cayetano.delgado] fixing broken links to anchors

### DIFF
--- a/content/en/serverless/configuration/_index.md
+++ b/content/en/serverless/configuration/_index.md
@@ -740,9 +740,9 @@ If you have trouble configuring your installations, set the environment variable
 [30]: /agent/proxy/
 [31]: https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring#aws-privatelink-support
 [32]: /agent/guide/dual-shipping/
-[33]: /serverless/distributed_tracing/serverless_trace_propagation/
+[33]: /serverless/distributed_tracing/#trace-propagation
 [34]: /integrations/amazon_xray/
-[35]: /serverless/distributed_tracing/serverless_trace_merging
+[35]: /serverless/distributed_tracing/#trace-merging
 [36]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html
 [37]: /serverless/guide/extension_motivation/
 [38]: /serverless/guide#install-using-the-datadog-forwarder


### PR DESCRIPTION
Fixing broken links to trace propagaiion and merging anchors

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updates the links to use the anchors

### Motivation
<!-- What inspired you to submit this pull request?-->
Good docs FTW!

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
