### PR TITLE
Hotfix: run artifact jobs in isolation for live

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -237,8 +237,8 @@ build_live:
     - yarn run prebuild
     - build_site
     - in-isolation deploy_site
-    - create_artifact
-    - create_artifact_ignored
+    - in-isolation create_artifact
+    - in-isolation create_artifact_ignored
     - remove_static_from_repo
   artifacts:
     when: on_success


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds the `in-isolation` flag to artifact jobs on the live pipeline
### Motivation
<!-- What inspired you to submit this pull request?-->
Due to changes in the k8 system, these functions need to run isolated for permissions

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
