### PR TITLE
add line item about ddtracepy gunicorn support to python trace compatibility listing

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -53,6 +53,7 @@ The `ddtrace` library includes support for a number of web frameworks, including
 | [Falcon][8]               | >= 1.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#falcon  |
 | [Flask][9]                | >= 0.10           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#flask   |
 | [FastAPI][10]              | >= 0.51           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#fastapi |
+| [Gunicorn][61]            | >= 20.0.04        | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#gunicorn |
 | [Molten][11]               | >= 0.7.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#molten  |
 | [Pylons][12]              | >= 0.9.6          | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#pylons  |
 | [Pyramid][13]             | >= 1.7            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#pyramid |
@@ -181,3 +182,4 @@ The `ddtrace` library includes support for the following libraries:
 [58]: https://requests.readthedocs.io/en/master/
 [59]: https://urllib3.readthedocs.io/en/stable/
 [60]: https://graphql-core-3.readthedocs.io/en/latest/intro.html
+[61]: https://gunicorn.org/


### PR DESCRIPTION
### What does this PR do?

This change adds a line item and link describing [`dd-trace-py`](https://github.com/DataDog/dd-trace-py)'s support for the `gunicorn` web framework. The link currently points to a nonexistent anchor, which will exist once the current [`latest`](https://ddtrace.readthedocs.io/en/stable/integrations.html#gunicorn) documentation becomes `stable`.

### Motivation

My work in https://github.com/DataDog/dd-trace-py/pull/4962 uncovered some new guidelines for using `dd-trace-py` with gunicorn and I want to make them as accessible to users as possible.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
