### PR TITLE
Adds the aws_lambda_permission resource to the Terraform example

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -139,7 +139,7 @@ If you are collecting logs from a CloudWatch log group, configure the trigger to
 {{% /tab %}}
 {{% tab "Terraform" %}}
 
-For Terraform users, you can provision and manage your triggers using the [aws_cloudwatch_log_subscription_filter][1] resource. See sample code below.
+For Terraform users, you can provision and manage your triggers using the [aws_cloudwatch_log_subscription_filter][1] resource in conjunction with [permission to invoke the function][2]. See sample code below.
 
 ```conf
 resource "aws_cloudwatch_log_subscription_filter" "datadog_log_subscription_filter" {
@@ -148,9 +148,17 @@ resource "aws_cloudwatch_log_subscription_filter" "datadog_log_subscription_filt
   destination_arn = <DATADOG_FORWARDER_ARN> # for example,  arn:aws:lambda:us-east-1:123:function:datadog-forwarder
   filter_pattern  = ""
 }
+
+resource "aws_lambda_permission" "datadog_log_permission" {
+  action        = "lambda:InvokeFunction"
+  function_name = "datadog-forwarder"
+  principal     = "logs.us-east-1.amazonaws.com"
+  source_arn    = "arn:aws:logs:us-east-1:123:log-group:<CLOUDWATCH_LOG_GROUP_NAME>:*"
+}
 ```
 
 [1]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter
+[2]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission
 {{% /tab %}}
 {{% tab "CloudFormation" %}}
 


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds an example of the `aws_lambda_permission` Terraform resource to the manual triggers documentation.

### Motivation
Log forwarding will not work without the `aws_lambda_permission` in place.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
