### PR TITLE
Remove vector link

### DIFF
--- a/content/en/observability_pipelines/working_with_data.md
+++ b/content/en/observability_pipelines/working_with_data.md
@@ -19,9 +19,6 @@ further_reading:
   - link: /observability_pipelines/reference/transforms/#metrictolog
     tag: Documentation
     text: Convert metrics to log events
-  - link: https://vector.dev/guides/level-up/csv-enrichment-guide/
-    tag: Documentation
-    text: Use CSV enrichment to provide more context to your data
   - link: /observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker/
     tag: Documentation
     text: Configure Datadog Agents to send data to Observability Pipelines


### PR DESCRIPTION
### What does this PR do?

Removes link to Vector doc

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
