### PR TITLE
Remove escape backslash for Windows paths in the logs configuration

### DIFF
--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -65,7 +65,7 @@ logs:
     source: "<SOURCE>"
 ```
 
-On Windows, use the path `"<DRIVE_LETTER>:\\<PATH_LOG_FILE>\\<LOG_FILE_NAME>.log"`, and verify that the user `ddagentuser` has read and write access to the log file.
+On **Windows**, use the path `"<DRIVE_LETTER>:\<PATH_LOG_FILE>\<LOG_FILE_NAME>.log"`, and verify that the user `ddagentuser` has read and write access to the log file.
 
 [1]: /agent/guide/agent-configuration-files/
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
On Windows we don't need to escape the backslash in the logs configuration.

### Motivation
<!-- What inspired you to submit this pull request?-->
Better docs.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
