### PR TITLE
Added specific modal where the sharing options are configured

### DIFF
--- a/content/en/dashboards/sharing.md
+++ b/content/en/dashboards/sharing.md
@@ -33,7 +33,7 @@ To share an entire dashboard publicly, generate a URL:
 
 
 1. On the dashboard's page, click the export icon in the upper right.
-2. Select **Generate public URL** which opens up a *Sharing: On* popup modal.
+2. Select **Generate public URL**, which opens up a *Sharing: On* popup modal.
 3. Under **Time & Variable Settings**, configure your desired options for the time frame and whether users can change it, as well as which tags are visible for selectable template variables.
 4. Copy the URL and click **Done**.
 
@@ -44,7 +44,7 @@ To share an entire dashboard publicly, generate a URL:
  To authorize one or more specific email addresses to view a dashboard page:
 
 1. On the dashboard's page, click the export icon in the upper right.
-2. Select **Generate public URL** which opens up a *Sharing: On* popup modal.
+2. Select **Generate public URL**, which opens up a *Sharing: On* popup modal.
 3. Select **Only specified people** for indicating who can access this dashboard.
 4. Input the email addresses for people you would like to share your dashboard with.
 5. Under **Time & Variable Settings**, configure your desired options for the time frame and whether users can change it, as well as which tags are visible for selectable template variables.

--- a/content/en/dashboards/sharing.md
+++ b/content/en/dashboards/sharing.md
@@ -31,8 +31,9 @@ When you share a dashboard by URL or email link, the shared page shows live, rea
 
 To share an entire dashboard publicly, generate a URL:
 
+
 1. On the dashboard's page, click the export icon in the upper right.
-2. Select **Generate public URL**.
+2. Select **Generate public URL** which opens up a *Sharing: On* popup modal.
 3. Under **Time & Variable Settings**, configure your desired options for the time frame and whether users can change it, as well as which tags are visible for selectable template variables.
 4. Copy the URL and click **Done**.
 
@@ -43,7 +44,7 @@ To share an entire dashboard publicly, generate a URL:
  To authorize one or more specific email addresses to view a dashboard page:
 
 1. On the dashboard's page, click the export icon in the upper right.
-2. Select **Generate public URL**.
+2. Select **Generate public URL** which opens up a *Sharing: On* popup modal.
 3. Select **Only specified people** for indicating who can access this dashboard.
 4. Input the email addresses for people you would like to share your dashboard with.
 5. Under **Time & Variable Settings**, configure your desired options for the time frame and whether users can change it, as well as which tags are visible for selectable template variables.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Add clarification on the sharing modal that opens up when users want to share a dashboard.

### Motivation
[DOCS-4775](https://datadoghq.atlassian.net/browse/DOCS-4775)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4775]: https://datadoghq.atlassian.net/browse/DOCS-4775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ