### PR TITLE
[Tracing][Logs][.NET] Change order of instructions 

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/dotnet.md
@@ -32,7 +32,13 @@ The .NET Tracer supports the following logging libraries:
 - [NLog][4]
 - [Microsoft.Extensions.Logging][5] (added in v1.28.6)
 
-## Getting started
+## Configure log collection
+
+Ensure that log collection is configured in the Datadog Agent and that the [Logs Agent configuration][15] for the specified files to tail is set to `source: csharp` so log pipelines can parse the log files. For more information, see [C# Log Collection][7]. If the `source` is set to a value other than `csharp`, you may need to add a [trace remapper][8] to the appropriate log processing pipeline for the correlation to work correctly.
+
+<div class="alert alert-warning"><strong>Note:</strong> Automatic log collection only works for logs formatted as JSON. Alternatively, use custom parsing rules.</div>
+
+## Configure injection in logs
 
 To inject correlation identifiers into your log messages, follow the instructions for your logging library.
 
@@ -324,12 +330,6 @@ You can read more about using BeginScope to create structured log messages for t
 - Serilog: [The semantics of ILogger.BeginScope()][12]
 - NLog: [NLog properties with Microsoft Extension Logging][13]
 - log4net: [Using BeginScope][14]
-
-## Configure log collection
-
-Ensure that log collection is configured in the Datadog Agent and that the [Logs Agent configuration][15] for the specified files to tail is set to `source: csharp` so log pipelines can parse the log files. For more information, see [C# Log Collection][7]. If the `source` is set to a value other than `csharp`, you may need to add a [trace remapper][8] to the appropriate log processing pipeline for the correlation to work correctly.
-
-<div class="alert alert-warning"><strong>Note:</strong> Automatic log collection only works for logs formatted as JSON. Alternatively, use custom parsing rules.</div>
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Change the layout of the doc to have instructions appear in chronological order

### Motivation
It's more logical and also allows to show a warning panel early in the page as we had an escalation about that use case, where this information was missed.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
