### PR TITLE
Update Ruby profiler requirements

### DIFF
--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -25,7 +25,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 ## Requirements
 
-The Datadog Profiler requires MRI Ruby 2.2+.
+The Datadog Profiler requires Ruby 2.3+ (JRuby and TruffleRuby are not supported).
 
 The following operating systems and architectures are supported:
 - Linux (GNU libc) x86-64, aarch64


### PR DESCRIPTION
### What does this PR do?

This PR updates the requirements listed for Ruby profiling to mention that Ruby 2.3+ is required.

Also, rather than saying "you need MRI Ruby" -- not all Rubyists may know what MRI means -- I've changed it to explicitly say we don't support JRuby or TruffleRuby, which hopefully is clearer.

### Motivation

Make sure documentation is up-to-date with the library support.

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
(N/A)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
