### PR TITLE
Clarify which Okta setup doc to use

### DIFF
--- a/content/en/account_management/saml/okta.md
+++ b/content/en/account_management/saml/okta.md
@@ -14,11 +14,11 @@ further_reading:
 
 ## Setup
 
-Follow [Create SAML app integrations][6] docs to configure Okta as a SAML IdP.
+Follow Okta's [Create SAML app integrations][6] docs to configure Okta as a SAML IdP.
 
 **Note**: It's recommended that you set up Datadog as an Okta application manually, as opposed to using a `pre-configured` configuration.
 
-**Note**: For `US1` customers, there's a `pre-configured` configuration [How to Configure SAML 2.0 for Datadog][1] docs to configure Okta as a SAML IdP.
+**Note**: US1 customers can use the preset configuration in Okta's [How to Configure SAML 2.0 for Datadog][1] docs to configure Okta as a SAML IdP.
 
 ## General details
 

--- a/content/en/account_management/saml/okta.md
+++ b/content/en/account_management/saml/okta.md
@@ -14,9 +14,11 @@ further_reading:
 
 ## Setup
 
-Follow the [How to Configure SAML 2.0 for Datadog][1] docs to configure Okta as a SAML IdP.
+Follow [Create SAML app integrations][6] docs to configure Okta as a SAML IdP.
 
 **Note**: It's recommended that you set up Datadog as an Okta application manually, as opposed to using a `pre-configured` configuration.
+
+**Note**: For `US1` customers, there's a `pre-configured` configuration [How to Configure SAML 2.0 for Datadog][1] docs to configure Okta as a SAML IdP.
 
 ## General details
 
@@ -66,3 +68,4 @@ In the event that you need to upload an `IDP.XML` file to Datadog before being a
 [3]: /account_management/saml/#mapping-saml-attributes-to-datadog-roles
 [4]: /account_management/saml/
 [5]: https://support.okta.com/help/s/article/How-do-we-download-the-IDP-XML-metadata-file-from-a-SAML-Template-App
+[6]: https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm?cshid=ext_Apps_App_Integration_Wizard-saml


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update the order of mentioning which Okta doc to refer to.

### Motivation
<!-- What inspired you to submit this pull request?-->
Support Case Ticket Number 1057108. Documentation was not clear that the recommended way is actually to setup Okta manually instead of pre-configured.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs.datadoghq.com/account_management/saml/okta/

https://docs-staging.datadoghq.com/mecsantos/propose-change-okta-docs/account_management/saml/okta/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Kindly check have AAA product team to review.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
