### PR TITLE
[WEB-3032] adds `device_id` cookie logic

### DIFF
--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -15,6 +15,24 @@ function getConfig() {
 
 const Config = getConfig();
 
+const generateRumDeviceId = () => Math.floor(Math.random() * (2 ** 53)).toString(36)
+
+const getRumDeviceId = () => {
+    const matches = /_dd_device_id=(\w+)/.exec(document.cookie)
+    return matches ? matches[1] : generateRumDeviceId()
+}
+
+// Temporary solution attributing website page views w. dd app user
+const setRumDeviceId = () => {
+    const deviceId = getRumDeviceId()
+    const domain = window.location.hostname.split('.').slice(-2).join('.')
+    const maxAge = 60 * 60 * 24 * 365
+
+    document.cookie = `_dd_device_id=${deviceId}; Domain=.${domain}; Max-Age=${maxAge}; Path=/; SameSite=None; Secure`
+
+    window.DD_RUM.setUserProperty('device_id', deviceId)
+}
+
 if (window.DD_RUM) {
     if (env === 'preview' || env === 'live') {
         window.DD_RUM.init({
@@ -37,6 +55,8 @@ if (window.DD_RUM) {
         if (branch) {
             window.DD_RUM.addRumGlobalContext('branch', branch);
         }
+
+        setRumDeviceId()
     }
 }
 

--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -56,7 +56,9 @@ if (window.DD_RUM) {
             window.DD_RUM.addRumGlobalContext('branch', branch);
         }
 
-        setRumDeviceId()
+        if (env === 'live') {
+            setRumDeviceId()
+        }
     }
 }
 


### PR DESCRIPTION
### What does this PR do?
generates a `device_id` cookie and connects it with RUM

### Motivation
https://datadoghq.atlassian.net/browse/WEB-3032

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/rum-device-id/

- [x] check that a cookie named `_dd_device_id` was created.   confirm the `domain`, `path`, and `expires / max-age` values.   this can be confirmed in chrome in the dev tools under `application` and `cookies` in the left hand menu.
- [x] find your session in RUM and click `attributes`.   there should be a `user` dropdown that contains a `@usr.device_id` value matching that of the generated cookie.   [it should look something like this](https://dd-corpsite.datadoghq.com/rum/explorer?query=%40application.id%3A3493b4e7-ab12-4852-8836-ba96af7bc745%20%40type%3Asession%20env%3Apreview&cols=&event=AgAAAYYSq8TFyvcpYgAAAAAAAAAYAAAAAEFZWVNxOFRGQUFBcDFta3pWcEdiQVFnTAAAACQAAAAAMDE4NjEyYmUtOWViMS00ZTU0LTk3ZTktMjBiNGMwMTE0ZTkw&p_tab=attributes&viz=stream&from_ts=1675265559198&to_ts=1675351959198&live=true)
- [x] open a new window, revisit the preview site and make sure the cookie value is still present (and didnt change).

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
