### PR TITLE
Update HPA doc to include more HPA examples

### DIFF
--- a/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
+++ b/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
@@ -142,8 +142,8 @@ spec:
             <TAG_KEY>: <TAG_VALUE>
 ```
 
-### Example HPA
-An HPA manifest to autoscale off an NGINX deployment based off of the `nginx.net.request_per_s` Datadog metric:
+### Example HPAs
+An HPA manifest to autoscale off an NGINX deployment based off of the `nginx.net.request_per_s` Datadog metric using `apiVersion: autoscaling/v2beta1`:
 
 ```yaml
 apiVersion: autoscaling/v2beta1
@@ -172,6 +172,30 @@ spec:
 - The HPA is configured to autoscale the deployment called `nginx`.
 - The maximum number of replicas created is `3`, and the minimum is `1`.
 - The metric used is `nginx.net.request_per_s`, and the scope is `kube_container_name: nginx`. This metric format corresponds to the Datadog one.
+
+The following is the same HPA manifest as above using `apiVersion: autoscaling/v2`:
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: nginxext
+spec:
+  minReplicas: 1
+  maxReplicas: 3
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx
+  metrics:
+  - type: External
+    external:
+      metric:
+        name: nginx.net.request_per_s
+      target:
+        type: AverageValue
+        averageValue: 9
+```
 
 Every 30 seconds, Kubernetes queries the Datadog Cluster Agent to get the value of this metric and autoscales proportionally if necessary. For advanced use cases, it is possible to have several metrics in the same HPA. As noted in [Kubernetes horizontal pod autoscaling][5], the largest of the proposed values is the one chosen.
 
@@ -298,8 +322,10 @@ spec:
         metricName: "datadogmetric@<namespace>:<datadogmetric_name>"
 ```
 
-##### Example HPA
-An HPA using the `DatadogMetric` named `nginx-requests`, assuming both objects are in namespace `nginx-demo`:
+##### Example HPAs
+An HPA using the `DatadogMetric` named `nginx-requests`, assuming both objects are in namespace `nginx-demo`.
+
+Using `apiVersion: autoscaling/v2beta1`:
 
 ```yaml
 apiVersion: autoscaling/v2beta1
@@ -318,6 +344,30 @@ spec:
     external:
       metricName: datadogmetric@nginx-demo:nginx-requests
       targetAverageValue: 9
+```
+
+Using `apiVersion: autoscaling/v2`:
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: nginxext
+spec:
+  minReplicas: 1
+  maxReplicas: 3
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx
+  metrics:
+  - type: External
+    external:
+      metric:
+        name: datadogmetric@nginx-demo:nginx-requests
+      target:
+        type: AverageValue
+        averageValue: 9
 ```
 
 Once you've linked your HPA to a `DatadogMetric`, the Datadog Cluster Agent uses your custom query to provide values to your HPA.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Include some additional HPA examples using a more recent apiVersion.

### Motivation
Customer reached out on a ticket requesting this update.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Provided the new examples based off of the examples provided in the Kubernetes documentation:
https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-metrics-not-related-to-kubernetes-objects

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
