### PR TITLE
Update node.js info / version with mysql support

### DIFF
--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -19,7 +19,7 @@ This guide assumes that you have configured [Datadog Monitoring][1] and are usin
 Supported tracers
 : [dd-trace-go][3] >= 1.44.0 (support for [database/sql][4] and [sqlx][5] packages)<br />
 [dd-trace-rb][6] >= 1.6.0 (support for [mysql2][7] and [pg][8] gems)<br />
-[dd-trace-js][9] >= 3.9.0 or >= 2.22.0 (support for [postgres client][10])<br />
+[dd-trace-js][9] >= 3.13.0 or >= 2.26.0 (support for [postgres][10] and [mysql][13] clients)<br />
 [dd-trace-py][11] >= 1.7.0 (support for [psycopg2][12])
 
 Supported databases
@@ -261,3 +261,4 @@ client.query('SELECT $1::text as message', ['Hello world!'], (err, result) => {
 [10]: https://node-postgres.com/
 [11]: https://github.com/DataDog/dd-trace-py
 [12]: https://www.psycopg.org/docs/index.html
+[13]: https://github.com/mysqljs/mysql

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -19,7 +19,7 @@ This guide assumes that you have configured [Datadog Monitoring][1] and are usin
 Supported tracers
 : [dd-trace-go][3] >= 1.44.0 (support for [database/sql][4] and [sqlx][5] packages)<br />
 [dd-trace-rb][6] >= 1.6.0 (support for [mysql2][7] and [pg][8] gems)<br />
-[dd-trace-js][9] >= 3.13.0 or >= 2.26.0 (support for [postgres][10] and [mysql][13] clients)<br />
+[dd-trace-js][9] >= 3.13.0 or >= 2.26.0 (support for [postgres][10], [mysql][13] and [mysql2][14] clients)<br />
 [dd-trace-py][11] >= 1.7.0 (support for [psycopg2][12])
 
 Supported databases
@@ -262,3 +262,4 @@ client.query('SELECT $1::text as message', ['Hello world!'], (err, result) => {
 [11]: https://github.com/DataDog/dd-trace-py
 [12]: https://www.psycopg.org/docs/index.html
 [13]: https://github.com/mysqljs/mysql
+[14]: https://github.com/sidorares/node-mysql2


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The [last release](https://github.com/DataDog/dd-trace-js/releases/tag/v3.13.0) of the node tracer includes support for mysql so this change updates the version and how mysql is now also currently supported. 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
