### PR TITLE
Output warning during process

### DIFF
--- a/local/bin/py/build/github_connect.py
+++ b/local/bin/py/build/github_connect.py
@@ -173,3 +173,5 @@ class GitHub:
             makedirs(dirname(file_out), exist_ok=True)
             with open(file_out, mode="wb+") as f:
                 f.write(raw_response.content)
+        else:
+            print(f"\x1b[33mWARNING\x1b[0m: Github request returned an unexpected response {raw_response.status_code} {raw_response.reason} for {path_to_file}")


### PR DESCRIPTION
### What does this PR do?

Outputs to the CI an indication of non 200 status codes when processing.

### Motivation

Until its improved, output a better notice for debugging issues

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
