### PR TITLE
Add retry to live job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -241,6 +241,7 @@ build_live:
   cache:
     - *yarn_cache_pull_push
   environment: "live"
+  retry: 1
   variables:
     CONFIG: ${LIVE_CONFIG}
     URL: ${LIVE_DOMAIN}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a single retry to the live build job. 
### Motivation
<!-- What inspired you to submit this pull request?-->
Due to heavy usage, it seems like we believe we are periodically hitting a rate-limit with our git token, and it's causing integrations to not get pulled and builds to fail. 

Since they usually work when we manually rerun the job a second time, adding this flag will automatically rerun the job one time in the event of  failure. 

This is a temporary solution while we investigate if we are in fact hitting a rate limit, or if it's something else related to how we source integrations.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Docs for the CI retry flag: https://docs.gitlab.com/ee/ci/yaml/#retry

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
