### PR TITLE
Added info on declaring an incident from monitor

### DIFF
--- a/content/en/monitors/manage/status.md
+++ b/content/en/monitors/manage/status.md
@@ -46,6 +46,9 @@ Manually resolving a monitor is appropriate for cases where data is reported int
 
 **Typical use case**: A monitor based on error metrics that are not generated when there are no errors (`aws.elb.httpcode_elb_5xx`, or any DogStatsD counter in your code reporting an error _only when there is an error_).
 
+### Create an incident
+Create an incident from a monitor by selecting **Declare incident**. Configure the *Declare Incident* popup modal with the severity level, notifications, and additional notes. For more information, see the [Incident Management][3] documentation.
+
 ### Settings
 
 Click the settings cog to display the options available:
@@ -65,12 +68,12 @@ The properties section is the overview of your monitor's:
 |--------------|---------------------------------------------------------------------------------------|
 | Status       | Alert, Warn, No Data, or OK                                                           |
 | Type         | Learn more about [monitor types][1].                                                  |
-| ID           | Used for the [monitor API][3].                                                        |
+| ID           | Used for the [monitor API][4].                                                        |
 | Date created | The date the monitor was created.                                                     |
 | Author       | The person who created the monitor.                                                   |
 | Tags         | The tags attached at the monitor level. Edit the tags by clicking on the pencil icon. |
-| Query        | Learn more about [querying][4].                                                       |
-| Message      | The message specified in the [notification][5] section of the monitor.                |
+| Query        | Learn more about [querying][5].                                                       |
+| Message      | The message specified in the [notification][6] section of the monitor.                |
 
 ## Status and history
 
@@ -93,7 +96,7 @@ The evaluation graph represents the exact query behavior within the timeframe br
 
 {{< img src="monitors/monitor_status/status_monitor_history.mp4" alt="status monitor history" video="true"  width="80%" >}}
 
-For further investigation into your metrics evolution, click **Open in a notebook** by the status graph. This generates an investigation [notebook][6] with a formatted graph of the monitor query.
+For further investigation into your metrics evolution, click **Open in a notebook** by the status graph. This generates an investigation [notebook][7] with a formatted graph of the monitor query.
 
 {{< img src="monitors/monitor_status/notebook-button.png" alt="Open in notebook button"  style="width:60%;">}}
 
@@ -103,11 +106,11 @@ The notebook matches the monitor evaluation period time range and includes relat
 
 ## Events
 
-Events generated from your monitor (alerts, warnings, recoveries, etc.) are shown in this section based on the time selector above the **Status & History** section. The events are also displayed in your [event explorer][7].
+Events generated from your monitor (alerts, warnings, recoveries, etc.) are shown in this section based on the time selector above the **Status & History** section. The events are also displayed in your [event explorer][8].
 
 ### Audit events
 
-For all monitor types, monitor changes (monitor edits for instance) create an event in the [event explorer][7]. This event explains the change and displays the user that made the change.
+For all monitor types, monitor changes (monitor edits for instance) create an event in the [event explorer][8]. This event explains the change and displays the user that made the change.
 
 If you made changes to a monitor, you can see examples with the following event search:
 
@@ -117,13 +120,13 @@ https://app.datadoghq.com/event/stream?per_page=30&query=tags%3Aaudit%20status%3
 
 Datadog also provides a notification option for changes to monitors you create. At the bottom of the monitor editor, under **Notify your team**, choose **Notify** in the drop-down next to: *alert recipients and monitor creator when this alert is modified*.
 
-The notify setting sends an email with the monitor audit event to all people who are alerted in the specific monitor as well as to the monitor creator. The monitor audit event also appears in the [event explorer][8].
+The notify setting sends an email with the monitor audit event to all people who are alerted in the specific monitor as well as to the monitor creator. The monitor audit event also appears in the [event explorer][9].
 
 ## Export and import
 
 You can obtain a JSON export of any monitor from the monitor's status page. Click the settings cog (top right) and choose **Export** from the menu.
 
-[Import a monitor][9] to Datadog with JSON using the main navigation: *Monitors --> New Monitor --> Import*.
+[Import a monitor][10] to Datadog with JSON using the main navigation: *Monitors --> New Monitor --> Import*.
 
 ## Further Reading
 
@@ -131,10 +134,11 @@ You can obtain a JSON export of any monitor from the monitor's status page. Clic
 
 [1]: /monitors/
 [2]: /monitors/notify/downtimes/
-[3]: /api/v1/monitors/
-[4]: /dashboards/querying/
-[5]: /monitors/notify/
-[6]: /notebooks
-[7]: /events/
-[8]: https://app.datadoghq.com/event/explorer
-[9]: https://app.datadoghq.com/monitors#create/import
+[3]: /monitors/incident_management/#from-a-monitor
+[4]: /api/v1/monitors/
+[5]: /dashboards/querying/
+[6]: /monitors/notify/
+[7]: /notebooks
+[8]: /events/
+[9]: https://app.datadoghq.com/event/explorer
+[10]: https://app.datadoghq.com/monitors#create/import


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Add information on the Declare incident option in a Monitor header to match the UI descriptions that already exist
![image](https://user-images.githubusercontent.com/41168354/216672402-8c929b25-f199-464d-b79c-20cc678851af.png)

### Motivation
[DOCS-4809](https://datadoghq.atlassian.net/browse/DOCS-4809)
 
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
The UI might be changing again, between the Sandbox and Demo accounts, the Declare Incident might be shifting to another button.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4809]: https://datadoghq.atlassian.net/browse/DOCS-4809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ