### PR TITLE
Update to use new env variable for enabling system-probe

### DIFF
--- a/content/en/containers/amazon_ecs/_index.md
+++ b/content/en/containers/amazon_ecs/_index.md
@@ -176,7 +176,7 @@ Live Container data is automatically collected by the Datadog Agent container. T
        "environment": [
          (...)
          {
-           "name": "DD_SYSTEM_PROBE_ENABLED",
+           "name": "DD_SYSTEM_PROBE_NETWORK_ENABLED",
            "value": "true"
          }
        ],

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -387,7 +387,7 @@ To enable Network Performance Monitoring in Docker, use the following configurat
 $ docker run --cgroupns host \
 --pid host \
 -e DD_API_KEY="<DATADOG_API_KEY>" \
--e DD_SYSTEM_PROBE_ENABLED=true \
+-e DD_SYSTEM_PROBE_NETWORK_ENABLED=true \
 -e DD_PROCESS_AGENT_ENABLED=true \
 -v /var/run/docker.sock:/var/run/docker.sock:ro \
 -v /proc/:/host/proc/:ro \
@@ -416,7 +416,7 @@ services:
   datadog:
     image: "gcr.io/datadoghq/agent:latest"
     environment:
-       DD_SYSTEM_PROBE_ENABLED: 'true'
+       DD_SYSTEM_PROBE_NETWORK_ENABLED: 'true'
        DD_PROCESS_AGENT_ENABLED: 'true'
        DD_API_KEY: '<DATADOG_API_KEY>'
     volumes:

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -90,7 +90,7 @@ Network Performance Monitoring supports use of the following provisioning system
 
 ## Setup
 
-Given this tool's focus and strength is in analyzing traffic _between_ network endpoints and mapping network dependencies, it is recommended to install it on a meaningful subset of your infrastructure and a **_minimum of 2 hosts_** to maximize value. 
+Given this tool's focus and strength is in analyzing traffic _between_ network endpoints and mapping network dependencies, it is recommended to install it on a meaningful subset of your infrastructure and a **_minimum of 2 hosts_** to maximize value.
 
 {{< tabs >}}
 {{% tab "Agent (Linux)" %}}
@@ -206,7 +206,7 @@ To enable Network Performance Monitoring for Windows hosts:
     ```shell
     net /y stop datadogagent && net start datadogagent
     ```
-**Note**: Network Performance Monitoring monitors Windows hosts only, and not Windows containers. 
+**Note**: Network Performance Monitoring monitors Windows hosts only, and not Windows containers.
 
 
 [1]: /agent/basic_agent_usage/windows/?tab=commandline

--- a/content/fr/containers/amazon_ecs/_index.md
+++ b/content/fr/containers/amazon_ecs/_index.md
@@ -52,7 +52,7 @@ L'exemple suivant montre comment effectuer une surveillance générale de l'infr
 
 1. Pour les conteneurs Linux, téléchargez le fichier [datadog-agent-ecs.json][20]
     1. Si vous utilisez une AMI Amazon Linux 1 d'origine, utilisez [datadog-agent-ecs1.json][21]
-    2. Si vous êtes sous Windows, utilisez [datadog-agent-ecs-win.json][22] 
+    2. Si vous êtes sous Windows, utilisez [datadog-agent-ecs-win.json][22]
 
 2. Modifiez votre fichier de définition de tâche de départ
     1. Remplacez `<YOUR_DATADOG_API_KEY>` par la [clé d'API Datadog][14] de votre compte.
@@ -174,7 +174,7 @@ Le conteneur de l'Agent Datadog recueille automatiquement les données des live 
        "environment": [
          (...)
          {
-           "name": "DD_SYSTEM_PROBE_ENABLED",
+           "name": "DD_SYSTEM_PROBE_NETWORK_ENABLED",
            "value": "true"
          }
        ],

--- a/content/fr/network_monitoring/performance/setup.md
+++ b/content/fr/network_monitoring/performance/setup.md
@@ -57,7 +57,7 @@ La solution NPM Datadog ne prend pas en charge les plateformes macOS.
 
 ### Containers
 
-NPM vous aide à visualiser l'architecture et les performances de vos environnements orchestrés et conteneurisés, avec la prise en charge de [Docker][5], [Kubernetes][6], [ECS][7], et d'autres technologies de conteneur. Les intégrations pour conteneurs de Datadog vous permettent d'agréger le trafic en fonction d'entités pertinentes (conteneurs, tâches, pods, clusters, déploiements, etc.) grâce à des tags prêts à l'emploi (tels que `container_name`, `task_name` et `kube_service`). 
+NPM vous aide à visualiser l'architecture et les performances de vos environnements orchestrés et conteneurisés, avec la prise en charge de [Docker][5], [Kubernetes][6], [ECS][7], et d'autres technologies de conteneur. Les intégrations pour conteneurs de Datadog vous permettent d'agréger le trafic en fonction d'entités pertinentes (conteneurs, tâches, pods, clusters, déploiements, etc.) grâce à des tags prêts à l'emploi (tels que `container_name`, `task_name` et `kube_service`).
 
 ### Outils de routage réseau
 
@@ -179,7 +179,7 @@ Si ces utilitaires ne sont pas disponibles pour votre distribution, suivez les m
 
 La collecte de logs réseau pour Windows repose sur un pilote de filtre.
 
-Pour activer NPM pour des hosts Windows, procédez comme suit 
+Pour activer NPM pour des hosts Windows, procédez comme suit
 
 1. Installez l'[Agent Datadog][1 (version 7.27.1+) en prenant soin d'activer le composant du pilote de filtre.
 
@@ -201,7 +201,7 @@ Pour activer NPM pour des hosts Windows, procédez comme suit 
     ```shell
     net /y stop datadogagent && net start datadogagent
     ```
-**Remarque** : NPM surveille uniquement des hosts Windows, et non des conteneurs Windows. 
+**Remarque** : NPM surveille uniquement des hosts Windows, et non des conteneurs Windows.
 
 
 [1]: /fr/agent/basic_agent_usage/windows/?tab=commandline
@@ -255,7 +255,7 @@ Si l'[Agent est déjà exécuté avec un manifeste][4] :
                       # (...)
                           - name: DD_PROCESS_AGENT_ENABLED
                             value: 'true'
-                          - name: DD_SYSTEM_PROBE_ENABLED
+                          - name: DD_SYSTEM_PROBE_NETWORK_ENABLED
                             value: 'true'
                           - name: DD_SYSTEM_PROBE_EXTERNAL
                             value: 'true'
@@ -382,7 +382,7 @@ Pour configurer la fonctionnalité Network Performance Monitoring dans Docker, u
 $ docker run --cgroupns host \
 --pid host \
 -e DD_API_KEY="<CLÉ_API_DATADPG>" \
--e DD_SYSTEM_PROBE_ENABLED=true \
+-e DD_SYSTEM_PROBE_NETWORK_ENABLED=true \
 -e DD_PROCESS_AGENT_ENABLED=true \
 -v /var/run/docker.sock:/var/run/docker.sock:ro \
 -v /proc/:/host/proc/:ro \
@@ -411,7 +411,7 @@ services:
   datadog:
     image: "gcr.io/datadoghq/agent:latest"
     environment:
-       DD_SYSTEM_PROBE_ENABLED: 'true'
+       DD_SYSTEM_PROBE_NETWORK_ENABLED: 'true'
        DD_PROCESS_AGENT_ENABLED: 'true'
        DD_API_KEY: '<CLÉ_API_DATADOG>'
     volumes:

--- a/content/ja/containers/amazon_ecs/_index.md
+++ b/content/ja/containers/amazon_ecs/_index.md
@@ -171,7 +171,7 @@ Live Container のデータは、Datadog Agent コンテナによって自動的
        "environment": [
          (...)
          {
-           "name": "DD_SYSTEM_PROBE_ENABLED",
+           "name": "DD_SYSTEM_PROBE_NETWORK_ENABLED",
            "value": "true"
          }
        ],

--- a/content/ja/network_monitoring/performance/setup.md
+++ b/content/ja/network_monitoring/performance/setup.md
@@ -192,7 +192,7 @@ Windows ホストのネットワークパフォーマンスモニタリングを
     ```
 3. [Agent を再起動します][2]。
 
-   PowerShell (`powershell.exe`) の場合: 
+   PowerShell (`powershell.exe`) の場合:
     ```shell
     restart-service -f datadogagent
     ```
@@ -381,7 +381,7 @@ Docker でネットワークパフォーマンスのモニタリングを有効�
 $ docker run --cgroupns host \
 --pid host \
 -e DD_API_KEY="<DATADOG_API_KEY>" \
--e DD_SYSTEM_PROBE_ENABLED=true \
+-e DD_SYSTEM_PROBE_NETWORK_ENABLED=true \
 -e DD_PROCESS_AGENT_ENABLED=true \
 -v /var/run/docker.sock:/var/run/docker.sock:ro \
 -v /proc/:/host/proc/:ro \
@@ -410,7 +410,7 @@ services:
   datadog:
     image: "gcr.io/datadoghq/agent:latest"
     environment:
-       DD_SYSTEM_PROBE_ENABLED: 'true'
+       DD_SYSTEM_PROBE_NETWORK_ENABLED: 'true'
        DD_PROCESS_AGENT_ENABLED: 'true'
        DD_API_KEY: '<DATADOG_API_KEY>'
     volumes:

--- a/static/resources/json/datadog-agent-sysprobe-ecs.json
+++ b/static/resources/json/datadog-agent-sysprobe-ecs.json
@@ -12,7 +12,7 @@
             "value": "datadoghq.com"
         },
         {
-          "name": "DD_SYSTEM_PROBE_ENABLED",
+          "name": "DD_SYSTEM_PROBE_NETWORK_ENABLED",
           "value": "true"
         }
       ],

--- a/static/resources/json/datadog-agent-sysprobe-ecs1.json
+++ b/static/resources/json/datadog-agent-sysprobe-ecs1.json
@@ -12,7 +12,7 @@
             "value": "datadoghq.com"
         },
         {
-          "name": "DD_SYSTEM_PROBE_ENABLED",
+          "name": "DD_SYSTEM_PROBE_NETWORK_ENABLED",
           "value": "true"
         }
       ],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The older env variable, `DD_SYSTEM_PROBE_ENABLED` has been deprecated for a while now and this env variable (`DD_SYSTEM_PROBE_NETWORK_ENABLED`) will actually correspond to the config used on the other tabs.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
