### PR TITLE
Update datadog_operator docs

### DIFF
--- a/content/en/containers/datadog_operator.md
+++ b/content/en/containers/datadog_operator.md
@@ -11,7 +11,7 @@ further_reading:
   - link: 'https://github.com/DataDog/datadog-operator/blob/main/docs/installation.md'
     tag: 'GitHub'
     text: 'Datadog Operator: Advanced Installation'
-  - link: 'https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md'
+  - link: 'https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v1alpha1.md'
     tag: 'GitHub'
     text: 'Datadog Operator: Configuration'
 ---
@@ -58,4 +58,4 @@ For all installation and configuration options, see the detailed [installation][
 [5]: https://github.com/DataDog/extendeddaemonset
 [6]: /getting_started/containers/datadog_operator
 [7]: https://github.com/DataDog/datadog-operator/blob/main/docs/installation.md
-[8]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+[8]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v1alpha1.md


### PR DESCRIPTION
Changing links on Further Reading section: `Datadog Operator: Configuration` should go to the v1alpha1 page

reasoning:
datadog-operator repo uses v1alpha1, 
Helm by default installs version with v1alpha1
v2alpha1 is reserved for GA, TBD.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Changing links on Datadog Operator: Configuration to go to the v1alpha1 page


<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
