### PR TITLE
changed the delimiter for DD__TAGS

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -71,7 +71,7 @@ The `git.commit.sha` and `git.repository_url` are tagged in your telemetry.
 To tag your traces, spans, and profiles with `git.commit.sha` and `git.repository_url`, configure the tracer with the `DD_TAGS` environment variable:
 
 ```
-export DD_TAGS="git.commit.sha:<FULL_GIT_COMMIT_SHA> git.repository_url:git-provider.example/me/my-repo"
+export DD_TAGS="git.commit.sha:<FULL_GIT_COMMIT_SHA>,git.repository_url:git-provider.example/me/my-repo"
 ./my-application start
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The delimiter for DD_TAGS is changed from "space" to "comma"

### Motivation
<!-- What inspired you to submit this pull request?-->
https://dd.slack.com/archives/C04MFJ05CSH/p1675361333229209 for details

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
