### PR TITLE
Add version information for PHP allocation profiling

### DIFF
--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -194,10 +194,10 @@ Wall Time
 CPU
 : Shows the time each function spent running on the CPU.
 
-Allocations
+Allocations (beta, v0.84+)
 : The number of allocations by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.
 
-Allocated memory
+Allocated memory (beta, v0.84+)
 : The amount of heap memory allocated by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.
 
 [1]: /profiler/enabling/php/#requirements
@@ -209,10 +209,10 @@ Once profiling is enabled, the following profile types are collected for [suppor
 CPU
 : The time each function spent running on the CPU.
 
-Allocations (beta, v0.84+)
+Allocations
 : The number of allocations by each function during the profiling period (default: 59s), including allocations which were subsequently freed. Stack allocations are not tracked. 
 
-Allocated memory (beta, v0.84+)
+Allocated memory
 : The amount of heap memory allocated by each function during the profiling period (default: 59s), including allocations which were subsequently freed. Stack allocations are not tracked. 
 
 [1]: /profiler/enabling/ddprof/

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -209,10 +209,10 @@ Once profiling is enabled, the following profile types are collected for [suppor
 CPU
 : The time each function spent running on the CPU.
 
-Allocations
+Allocations (beta, v0.84+)
 : The number of allocations by each function during the profiling period (default: 59s), including allocations which were subsequently freed. Stack allocations are not tracked. 
 
-Allocated memory
+Allocated memory (beta, v0.84+)
 : The amount of heap memory allocated by each function during the profiling period (default: 59s), including allocations which were subsequently freed. Stack allocations are not tracked. 
 
 [1]: /profiler/enabling/ddprof/


### PR DESCRIPTION
### What does this PR do?

Add version information to the PHP allocation profiling types.

### Motivation

Make sure that folks to not assume that this feature is existing in older version.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
