### PR TITLE
Add Security Notification Category with token leak event

### DIFF
--- a/content/en/account_management/audit_trail/events.md
+++ b/content/en/account_management/audit_trail/events.md
@@ -23,6 +23,7 @@ further_reading:
 - [Notebook](#notebook-events)
 - [OAuth](#oauth-events)
 - [Organization management](#organization-management-events)
+- [Security Notifications](#security-notification-events)
 
 #### Product-Specific Events
 - [Application Performance Monitoring (APM)](#apm-events)

--- a/content/en/account_management/audit_trail/events.md
+++ b/content/en/account_management/audit_trail/events.md
@@ -187,7 +187,7 @@ See the [Audit Trail documentation][2] for more information on setting up and co
 ### Security Notification events
 | Name                 | Description of audit event                                                       | Query in audit explorer                                           |
 | -------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------|
-| [Token leaked][80] | A user's API or Application Key has leaked online and been detected. | `@evt.name:"Security Notification" @asset.type:(api_key OR application_key) @action:notification` |
+| [Token leaked][80] | Datadog has detected leaked Datadog API or Application Key that should be revoked| `@evt.name:"Security Notification" @asset.type:(api_key OR application_key) @action:notification` |
 
 ### Sensitive Data Scanner events
 | Name | Description of audit event                                          | Query in audit explorer                           |

--- a/content/en/account_management/audit_trail/events.md
+++ b/content/en/account_management/audit_trail/events.md
@@ -184,6 +184,11 @@ See the [Audit Trail documentation][2] for more information on setting up and co
 | [RUM application created][68] | A user created or deleted an application in RUM and the type of the application (Browser, Flutter, IOS, React Native, Android). | `@evt.name:"Real User Monitoring" @asset.type:real_user_monitoring_application @action:(created OR deleted)` |
 | [RUM application modified][69] | A user modified an application in RUM, the new value of the application, and the type of the application (Browser, Flutter, IOS, React Native, Android). | `@evt.name:"Real User Monitoring" @asset.type:real_user_monitoring_application @action:modified` |
 
+### Security Notification events
+| Name                 | Description of audit event                                                       | Query in audit explorer                                           |
+| -------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------|
+| [Token leaked][80] | A user's API or Application Key has leaked online and been detected. | `@evt.name:"Security Notification" @asset.type:(api_key OR application_key) @action:notification` |
+
 ### Sensitive Data Scanner events
 | Name | Description of audit event                                          | Query in audit explorer                           |
 | ---- | ------------------------------------------------------------------- | --------------------------------------------------|
@@ -296,3 +301,4 @@ See the [Audit Trail documentation][2] for more information on setting up and co
 [77]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Synthetics%20Monitoring%22%20%40asset.type%3Asynthetics_variable
 [78]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Synthetics%20Monitoring%22%20%40asset.type%3Asynthetics_settings%20%40action%3Amodified
 [79]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Reference%20Tables%22%20%40asset.type%3Areference_table%20%40action%3A%28created%20OR%20deleted%20OR%20modified%29
+[80]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Security%20Notification%22%20%40asset.type%3A%28api_key%20OR%20application_key%29


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Added the Security Notification AuditCategory as well as added an Audit event for when a token leaks

### Motivation
<!-- What inspired you to submit this pull request?-->
See above

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
