### PR TITLE
update filters to use all categories

### DIFF
--- a/layouts/shortcodes/integrations.html
+++ b/layouts/shortcodes/integrations.html
@@ -11,20 +11,6 @@
 
 <!-- build filters -->
 {{ $.Scratch.Set "filters" (slice)}}
-{{ range $index, $element := $integration_list }}
-    {{ $urlname := $element.File.TranslationBaseName }}
-    {{ $src := (print "images/integrations_logos/" ($urlname | lower) ".png")}}
-    {{ $indx :=  $src }}
-    {{ range $e := $element.Params.categories }}
-        {{ if and $indx (fileExists (print "static/" $src)) }}
-          {{ with $e }}
-            {{ if not (in ($.Scratch.Get "filters") (. | lower)) }}
-                {{ $.Scratch.Add "filters" (. | lower) }}
-            {{ end }}
-          {{ end }}
-        {{ end }}
-    {{ end }}
-{{ end }}
 
 <!-- build tiles -->
 {{- $s := newScratch -}}
@@ -49,6 +35,7 @@
   {{- $curr_categories := slice -}}
   {{- range $i, $e := $v.Params.categories -}}
     {{- $curr_categories = $curr_categories | append (print "cat-" (replace $e "/" "" | urlize)) -}}
+
   {{- end -}}
   {{- $s.SetInMap $path "tags" ($curr_categories | default slice) -}}
   {{- $basename := $v.Params.integration_id | default ($v.Params.name | lower) | default ($v.File.TranslationBaseName | lower) }}
@@ -60,6 +47,12 @@
   {{- $s.SetInMap $path "int_logo" $int_logo -}}
   {{ if $int_logo }}
     {{- $s.SetInMap "hits" $path ($s.Get $path) -}}
+    <!-- add to filters, only if image exists (aka tile exists) -->
+    {{- range $i, $e := $v.Params.categories -}}
+      {{ if not (in ($.Scratch.Get "filters") (. | lower)) }}
+        {{ $.Scratch.Add "filters" (. | lower) }}
+      {{ end }}
+    {{- end -}}
   {{ end }}
 {{- end -}}
 {{- $integrationData := ($s.GetSortedMapValues "hits") -}}


### PR DESCRIPTION
### What does this PR do?

There was a bug where we weren't including all filter categories on docs this PR corrects this.

### Motivation

Discussing differences in integrations filters

### Preview

https://docs-staging.datadoghq.com/david.jones/missing-categories/integrations/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
