### PR TITLE
feat: remove images from previews

### DIFF
--- a/assets/styles/base/_variables.scss
+++ b/assets/styles/base/_variables.scss
@@ -57,5 +57,5 @@ $shadow-tile-default: 0px 4px 10px rgba(0,0,0,0.2);
 $shadow-tile-hover: 0px 8px 20px rgba(0,0,0,0.25);
 $shadow-card-large: 0 2px 30px 0 rgba(0,0,0,.3);
 
-// Breakpointés 
+// Breakpointés
 $screen-md: 992px !default;

--- a/assets/styles/base/_variables.scss
+++ b/assets/styles/base/_variables.scss
@@ -57,5 +57,5 @@ $shadow-tile-default: 0px 4px 10px rgba(0,0,0,0.2);
 $shadow-tile-hover: 0px 8px 20px rgba(0,0,0,0.25);
 $shadow-card-large: 0 2px 30px 0 rgba(0,0,0,.3);
 
-// Breakpointés
+// Breakpointés 
 $screen-md: 992px !default;

--- a/assets/styles/pages/_home.scss
+++ b/assets/styles/pages/_home.scss
@@ -13,7 +13,7 @@
         }
         @media (min-width: 768px) {
             height: 346px;
-            background-image: url('../images/home-hero.png');
+            background-image: url('#{$baseImgURL}/images/home-hero.png');
         }
         .docssearch {
             transform: none;

--- a/assets/styles/pages/_home.scss
+++ b/assets/styles/pages/_home.scss
@@ -13,7 +13,7 @@
         }
         @media (min-width: 768px) {
             height: 346px;
-            background-image: url('#{$baseImgURL}/images/home-hero.png');
+            background-image: url('#{$baseImgURL}images/home-hero.png');
         }
         .docssearch {
             transform: none;

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -14,6 +14,7 @@
 @import 'base/typography';
 @import 'base/spacing';
 @import 'base/helpers';
+$baseImgURL: '{{.Site.Params.img_url}}';
 
 // vendor
 @import 'vendor/chroma-styles';

--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -17,7 +17,7 @@ deployment:
     targets:
     - name: "preview"
       URL: "s3://datadog-docs-preview?region=us-east-1&prefix=$CI_COMMIT_REF_NAME/"
-      exclude: "**.{go,java,py,rb}"
+      exclude: "**.{go,java,py,rb,jpg,jpeg,png,gif,mp4,svg,json}"
       cloudFrontDistributionID: E3EYIYXXL26MK1
     - name: "previewAssets"
       URL: "s3://dd-staging-static-assets?region=us-east-1&prefix=documentation/"

--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -17,7 +17,7 @@ deployment:
     targets:
     - name: "preview"
       URL: "s3://datadog-docs-preview?region=us-east-1&prefix=$CI_COMMIT_REF_NAME/"
-      exclude: "**.{go,java,py,rb,jpg,jpeg,png,gif,mp4,svg,json}"
+      exclude: "**.{go,java,py,rb,jpg,jpeg,png,gif,mp4,svg}"
       cloudFrontDistributionID: E3EYIYXXL26MK1
     - name: "previewAssets"
       URL: "s3://dd-staging-static-assets?region=us-east-1&prefix=documentation/"

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -4,9 +4,9 @@
 {{- $outputStyles := "" -}}
 
 {{- if $isLocalServer -}}
-    {{- $outputStyles = resources.Get $inputStyleFile | toCSS $options -}}
+    {{- $outputStyles = resources.Get $inputStyleFile | resources.ExecuteAsTemplate $inputStyleFile . | toCSS $options -}}
 {{- else -}}
-    {{- $outputStyles = resources.Get $inputStyleFile | toCSS $options | minify | fingerprint -}}
+    {{- $outputStyles = resources.Get $inputStyleFile | resources.ExecuteAsTemplate $inputStyleFile . | toCSS $options | minify | fingerprint -}}
     {{ if ne (path.Ext $outputStyles.Permalink) ".css" }}
         {{ errorf "ERROR CSS File Not Found! %q" .Path }}
     {{ end }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

- Updates the config for previews to no longer upload assets to the bucket
- Adds the img url as an SCSS variable
- Updates the CSS to execute as a template (so we can use the hugo param in the scss files) https://gohugo.io/hugo-pipes/resource-from-template/

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/browse/WEB-3175

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/devin.ford/config-adjustment/


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---




### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
