### PR TITLE
Renzo.renteria/hash scroll bug

### DIFF
--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -68,12 +68,6 @@ $(document).ready(function () {
 
     updateMainContentAnchors();
 
-    // disable lazy load
-    const images = document.querySelectorAll("img");
-    images.forEach(img => {
-        img.loading = "eager";
-    });
-
     // add targer-blank to external links
     const newLinks = document.getElementsByTagName('a');
     for (let i = 0; i < newLinks.length; i++) {

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -68,6 +68,12 @@ $(document).ready(function () {
 
     updateMainContentAnchors();
 
+    // disable lazy load
+    const images = document.querySelectorAll("img");
+    images.forEach(img => {
+        img.loading = "eager";
+    });
+
     // add targer-blank to external links
     const newLinks = document.getElementsByTagName('a');
     for (let i = 0; i < newLinks.length; i++) {

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -69,7 +69,7 @@
     <img class="img-fluid" src="{{ (print $img_resource | safeURL) }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}" {{ end }} {{ if .Get "alt" }} alt="{{ with .Get "alt"}}{{ . }}{{ end }}" {{ end }} />
   {{- else -}}
     <picture {{ if .Get "style" }} style="{{- with .Get "style" -}}{{- . | safeCSS -}}{{- end -}}" {{ end }}>
-      <img loading="lazy" class="img-fluid" srcset="{{ $e }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}" {{ end }} {{ if .Get "alt" }} alt="{{ with .Get "alt"}}{{ . }}{{ end }}" {{ end }} />
+      <img class="img-fluid" srcset="{{ $e }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}" {{ end }} {{ if .Get "alt" }} alt="{{ with .Get "alt"}}{{ . }}{{ end }}" {{ end }} />
     </picture>
   {{- end -}}
 {{- else -}}
@@ -78,7 +78,7 @@
         <img class="img-fluid" src="{{ (print $img_resource | safeURL) }}" {{ if .Get "style" }} style="{{- with .Get "style" -}}{{ . | safeCSS }}{{- end -}}" {{ end }} {{ if .Get "alt" }} alt="{{- with .Get "alt" -}}{{.}}{{- end -}}" {{ end }} />
     {{- else -}}
       <picture class="" {{ if .Get "style" }} style="{{- with .Get "style" -}}{{- . | safeCSS -}}{{- end -}}" {{ end }} >
-        <img loading="lazy" 
+        <img 
             class="img-fluid" 
             srcset="{{ $e }}" 
             {{ if .Get "style" }}style="{{ with .Get "style" }}{{ . | safeCSS }}{{ end }}" {{ end }} 


### PR DESCRIPTION
### What does this PR do?
remove lazy loading from img shortcode as temporary scroll issue fix

 ### Preview 
https://docs-staging.datadoghq.com/renzo.renteria/hash-scroll-bug/integrations/guide/pivotal-cloud-foundry-manual-setup/#deploy-the-datadog-firehose-nozzle

### Additional Notes
tested on chrome, firefox, and safari

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
