### PR TITLE
[serverless] recommend extension over forwarder

### DIFF
--- a/content/en/serverless/guide/extension_motivation.md
+++ b/content/en/serverless/guide/extension_motivation.md
@@ -13,7 +13,7 @@ AWS Lambda extensions run within the Lambda execution environment, alongside you
 
 If you configured [Datadog Serverless][2] before the introduction of the Datadog Lambda extension, you are likely using the [Datadog Forwarder][3] to submit custom metrics, enhanced metrics, traces, and logs.
 
-There are some key differences between the Lambda extension and the Forwarder, as well as certain situations where you may find it advantageous to use one over the other. This page describes the various reasons you may or may not choose to migrate from the Forwarder to the Lambda extension.
+There are some key differences between the Lambda extension and the Forwarder. This page describes the various reasons you may or may not choose to migrate from the Forwarder to the Lambda extension. 
 
 ### Differences in functionality
 
@@ -25,12 +25,16 @@ Although the Lambda Extension replaces the Forwarder as the recommended way to c
 
 The Datadog Lambda Extension offers the following advantages over the Datadog Forwarder:
 
-- **Skip CloudWatch Logs**: The Forwarder extracts telemetry from logs, which are then sent to Datadog. The Datadog Lambda Extension sends telemetry directly to Datadog, enabling you to reduce the cost associated with CloudWatch Logs.
+- **Skip CloudWatch Logs**: The Forwarder extracts telemetry from logs, which are then sent to Datadog. The Datadog Lambda Extension sends telemetry directly to Datadog, enabling you to reduce the cost associated with CloudWatch Logs and the Forwarder Lambda function itself.
 - **Simple to set up**: The Datadog Lambda extension can be added as a Lambda layer and sends telemetry directly to Datadog, so you do not need to set up a subscription filter for every new Lambda function's CloudWatch log group.
 
 ### Trade-offs
 
-The extension [adds overhead to your Lambda functions][4], compared to functions that have zero instrumentation. The added overhead affects your AWS bill and Lambda concurrency, and could cause worse cold starts. The majority of the added duration **does not** affect your function's performance. Based on Datadog's latest benchmarking results, the cost overhead is always lower (or about the same when reporting data from remote regions) when using the Lambda extension versus the Forwarder.
+The extension [adds additional overhead to your Lambda functions][4] due to loading the extension on cold starts and flushing telemetry to Datadog. The majority of the added duration **does not** affect your function's performance. Based on Datadog's latest benchmarking results, the cost overhead is always lower when using the Lambda extension versus the Forwarder.
+
+### Conclusion
+
+If you only want to collect logs, especially from many Lambda functions, it makes sense to continue using the Datadog Forwarder. If you are also collecting metrics and traces from your Lambda functions, we recommend migrating to the Datadog Lambda Extension.
 
 ## Migrate to the Datadog Lambda Extension
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Recommend using the extension over the forwarder for serverless monitoring, while the forwarder may still make sense for centralized log collection.

### Motivation
This doc was written while the Extension was in beta with lots of uncertainties. Given the growing adoption and confidence, it makes sense to recommend the extension over forwarder for serverless monitoring.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
