### PR TITLE
Fixed a typo in Dynamic Instrumentation docs

### DIFF
--- a/content/en/dynamic_instrumentation/_index.md
+++ b/content/en/dynamic_instrumentation/_index.md
@@ -28,7 +28,7 @@ further_reading:
   access it.
 {{< /callout >}}
 
-Dynamic Instrumentation lets you capture data from your live applications without needing to do any code changes or redployment.
+Dynamic Instrumentation lets you capture data from your live applications without needing to do any code changes or redeployment.
 
 ## Getting started
 


### PR DESCRIPTION
### What does this PR do?
Fixed a small typo: redployment -> redeployment.
https://docs.datadoghq.com/dynamic_instrumentation/