### PR TITLE
Add GCP CIS compliance report to CSPM docs

### DIFF
--- a/content/en/security/cspm/frameworks_and_benchmarks.md
+++ b/content/en/security/cspm/frameworks_and_benchmarks.md
@@ -25,6 +25,7 @@ Cloud Security Posture Management (CSPM) comes with more than 400 out-of-the-box
 
 - [CIS AWS Foundations Benchmark v1.3.0*][2]
 - [CIS Azure Foundations Benchmark v1.3.0][3]
+- [CIS GCP Foundations Benchmark v1.3.0][22]
 - [CIS Docker Benchmark v1.2.0][4]
 - [CIS Kubernetes Benchmark v1.5.1**][5]
 - [PCI DSS v3.2.1][6]
@@ -90,3 +91,4 @@ Select a rule to view details about the misconfigured resources, the rule descri
 [19]: /integrations/webhooks/
 [20]: https://app.datadoghq.com/security/compliance/homepage
 [21]: /security/cspm/detection_rules
+[22]: https://www.cisecurity.org/benchmark/google_cloud_computing_platform


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds GCP CIS compliance report to the list of compliance reports in public docs

### Motivation
<!-- What inspired you to submit this pull request?-->
We have the GCP CIS report on the app but not on the docs, so it's misleading to customers.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
