### PR TITLE
Reorganize OTel information

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1526,11 +1526,16 @@ main:
     parent: tracing_custom_inst
     identifier: tracing_custom_inst_dotnet
     weight: 108
-  - name: Instrumenting with OpenStandards
-    url: opentelemetry/otel_tracing/
+  - name: OpenStandards
+    url: tracing/trace_collection/open_standards
     parent: tracing_trace_collection
     identifier: tracing_open_standards
-    weight: 105
+    weight: 105  
+  - name: OpenTelemetry
+    url: opentelemetry/otel_tracing/
+    parent: tracing_trace_collection
+    identifier: tracing_open_telemetry
+    weight: 106
   - name: Java
     url: tracing/trace_collection/open_standards/java/
     parent: tracing_open_standards
@@ -1570,22 +1575,22 @@ main:
     url: serverless/distributed_tracing/
     parent: tracing_trace_collection
     identifier: tracing_serverless
-    weight: 106
+    weight: 107
   - name: Admission Controller Injection
     url: tracing/trace_collection/admission_controller/
     parent: tracing_trace_collection
     identifier: tracing_admission_controller
-    weight: 107
+    weight: 108
   - name: Tracing Proxies
     url: tracing/trace_collection/proxy_setup/
     parent: tracing_trace_collection
     identifier: tracing_proxies
-    weight: 108
+    weight: 109
   - name: Span Tags Semantics
     url: tracing/trace_collection/tracing_naming_convention
     parent: tracing_trace_collection
     identifier: tracing_naming_convention
-    weight: 109
+    weight: 110
   - name: APM Metrics Collection
     url: tracing/metrics/
     parent: tracing

--- a/content/en/opentelemetry/_index.md
+++ b/content/en/opentelemetry/_index.md
@@ -34,18 +34,6 @@ If your applications and services are instrumented with OpenTelemetry libraries,
 
 {{< img src="tracing/setup/open_standards/otel-flow.png" alt="Map options for generating telemetry data and sending it to observability products.">}}
 
-## Setup
-
-For additional information about sending OpenTelemetry data to Datadog, configuring it, and using Datadog's observability platform to gain actionable insights into your service performance, see:
-
-{{< whatsnext desc=" " >}}
-    {{< nextlink href="/opentelemetry/otel_tracing/" >}}Trace collection through OpenTelemetry{{< /nextlink >}}
-    {{< nextlink href="/opentelemetry/otel_metrics/" >}}Metrics collection through OpenTelemetry{{< /nextlink >}}
-    {{< nextlink href="/opentelemetry/otel_logs/" >}}Logs collection through OpenTelemetry{{< /nextlink >}}
-{{< /whatsnext >}}
-
-
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/opentelemetry/otel_collector_datadog_exporter.md
+++ b/content/en/opentelemetry/otel_collector_datadog_exporter.md
@@ -15,6 +15,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/hivemq-opentelemetry-monitor-iot-applications/"
   tag: "Blog"
   text: "Use HiveMQ and OpenTelemetry to monitor IoT applications in Datadog"
+- link: "/metrics/open_telemetry/otlp_metric_types"
+  tag: "Documentation"
+  text: "OTLP Metrics Types"
 ---
 
 The OpenTelemetry Collector is a vendor-agnostic agent process for collecting and exporting telemetry data emitted by many processes. The [Datadog Exporter][1] for the OpenTelemetry Collector allows you to forward trace, metric, and logs data from OpenTelemetry SDKs on to Datadog (without the Datadog Agent). It works with all supported languages, and you can [connect those OpenTelemetry trace data with application logs][2].
@@ -99,22 +102,131 @@ The above configuration enables the receiving of OTLP data from OpenTelemetry in
 
 The exact configuration of the batch processor depends on your specific workload as well as the signal types. Datadog intake has different payload size limits for the 3 signal types:
 - Trace intake: 3.2MB
-- Log intake: [5MB uncompressed][15]
-- Metrics V2 intake: [500KB or 5MB after decompression][16]
+- Log intake: [5MB uncompressed][6]
+- Metrics V2 intake: [500KB or 5MB after decompression][7]
 
 #### Advanced configuration
 
-[This fully documented example configuration file][6] illustrates all possible configuration options for the Datadog Exporter. There may be other options relevant to your deployment, such as `api::site` or the ones on the `host_metadata` section.
+[This fully documented example configuration file][8] illustrates all possible configuration options for the Datadog Exporter. There may be other options relevant to your deployment, such as `api::site` or the ones on the `host_metadata` section.
 
 ### 3. Configure your application
 
 To get better metadata for traces and for smooth integration with Datadog:
 
-- **Use resource detectors**: If they are provided by the language SDK, attach container information as resource attributes. For example, in Go, use the [`WithContainer()`][7] resource option.
+- **Use resource detectors**: If they are provided by the language SDK, attach container information as resource attributes. For example, in Go, use the [`WithContainer()`][9] resource option.
 
-- **Apply [Unified Service Tagging][8]**: Make sure you’ve configured your application with the appropriate resource attributes for unified service tagging. This ties Datadog telemetry together with tags for service name, deployment environment, and service version. The application should set these tags using the OpenTelemetry semantic conventions: `service.name`, `deployment.environment`, and `service.version`.
+- **Apply [Unified Service Tagging][10]**: Make sure you’ve configured your application with the appropriate resource attributes for unified service tagging. This ties Datadog telemetry together with tags for service name, deployment environment, and service version. The application should set these tags using the OpenTelemetry semantic conventions: `service.name`, `deployment.environment`, and `service.version`.
 
-### 4. Run the collector
+### 4. Configure the logger for your application
+
+{{< img src="logs/log_collection/otel_collector_logs.png" alt="A diagram showing the host, container, or application sending data the filelog receiver in the collector and the Datadog Exporter in the collector sending the data to the Datadog backend" style="width:100%;">}}
+
+Since the OpenTelemetry SDKs' logging functionality is not fully supported (see your specific language in the [OpenTelemetry documentation][11] for more information), Datadog recommends using a standard logging library for your application. Follow the language-specific [Log Collection documentation][12] to set up the appropriate logger in your application. Datadog strongly encourages setting up your logging library to output your logs in JSON to avoid the need for [custom parsing rules][13]. 
+
+#### Configure the filelog receiver
+
+Configure the filelog receiver using [operators][14]. For example, if there is a service `checkoutservice` that is writing logs to `/var/log/pods/services/checkout/0.log`, a sample log might look like this:
+
+```
+{"level":"info","message":"order confirmation email sent to \"jack@example.com\"","service":"checkoutservice","span_id":"197492ff2b4e1c65","timestamp":"2022-10-10T22:17:14.841359661Z","trace_id":"e12c408e028299900d48a9dd29b0dc4c"}
+```
+
+Example filelog configuration:
+
+```
+filelog:
+   include:
+     - /var/log/pods/**/*checkout*/*.log
+   start_at: end
+   poll_interval: 500ms
+   operators:
+     - id: parse_log
+       type: json_parser
+       parse_from: body
+     - id: trace
+       type: trace_parser
+       trace_id:
+         parse_from: attributes.trace_id
+       span_id:
+         parse_from: attributes.span_id
+   attributes:
+     ddtags: env:staging
+```
+
+- `include`: The list of files the receiver tails 
+- `start_at: end`: Indicates to read new content that is being written 
+- `poll_internal`: Sets the poll frequency 
+- Operators:
+    - `json_parser`: Parses JSON logs. By default, the filelog receiver converts each log line into a log record, which is the `body` of the logs' [data model][15]. Then, the `json_parser` converts the JSON body into attributes in the data model.
+    - `trace_parser`: Extract the `trace_id` and `span_id` from the log to correlate logs and traces in Datadog. 
+
+#### Using Kubernetes
+
+There are multiple ways to deploy the OpenTelemetry Collector and Datadog Exporter in a Kubernetes infrastructure. For the filelog receiver to work, the [Agent/DaemonSet deployment][16] is the recommended deployment method.
+
+In containerized environments, applications write logs to `stdout` or `stderr`. Kubernetes collects the logs and writes them to a standard location. You need to mount the location on the host node into the Collector for the filelog receiver. Below is an [extension example][17] with the mounts required for sending logs. 
+
+```
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: otel-agent
+  labels:
+    app: opentelemetry
+    component: otel-collector
+spec:
+  template:
+    metadata:
+      labels:
+        app: opentelemetry
+        component: otel-collector
+    spec:
+      containers:
+        - name: collector
+          command:
+            - "/otelcol-contrib"
+            - "--config=/conf/otel-agent-config.yaml"
+          image: otel/opentelemetry-collector-contrib:0.61.0
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # The k8s.pod.ip is used to associate pods for k8sattributes
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.ip=$(POD_IP)"
+          ports:
+            - containerPort: 4318 # default port for OpenTelemetry HTTP receiver.
+              hostPort: 4318
+            - containerPort: 4317 # default port for OpenTelemetry gRPC receiver.
+              hostPort: 4317
+            - containerPort: 8888 # Default endpoint for querying metrics.
+          volumeMounts:
+            - name: otel-agent-config-vol
+              mountPath: /conf
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+      volumes:
+        - name: otel-agent-config-vol
+          configMap:
+            name: otel-agent-conf
+            items:
+              - key: otel-agent-config
+                path: otel-agent-config.yaml
+        # Mount nodes log file location.
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+```
+
+### 5. Run the collector
 
 {{< tabs >}}
 {{% tab "On a host" %}}
@@ -509,11 +621,16 @@ To use the OpenTelemetry Collector alongside the Datadog Agent:
 {{% /tab %}}
 {{< /tabs >}}
 
+### Logs and traces correlation
+
+If you are using the Datadog Exporter to also send OpenTelemetry traces to Datadog, use the `trace_parser` operator to extract the `trace_id` from each trace and add it to the associated logs. Datadog automatically correlates the related logs and traces. See [Connect OpenTelemetry Traces and Logs][18] for more information.
+
+{{< img src="logs/log_collection/logs_traces_correlation.png" alt="The trace panel showing a list of logs correlated with the trace" style="width:70%;">}}
 ### Host name resolution
 
 The host name that OpenTelemetry signals are tagged with is obtained based on the following sources in order, falling back to the next one if the current one is unavailable or invalid:
 
-1. From [resource attributes][9], for example `host.name` (many others are supported).
+1. From [resource attributes][19], for example `host.name` (many others are supported).
 2. The `hostname` field in the exporter configuration.
 3. Cloud provider API.
 4. Kubernetes host name.
@@ -522,29 +639,44 @@ The host name that OpenTelemetry signals are tagged with is obtained based on th
 
 ## Deployment-based limitations
 
-The OpenTelemetry Collector has [two primary deployment methods][14]: Agent and Gateway. Depending on your deployment method, some components are not available.
+The OpenTelemetry Collector has [two primary deployment methods][20]: Agent and Gateway. Depending on your deployment method, some components are not available.
 
 | Deployment mode | Host metrics | Kubernetes orchestration metrics | Traces | Logs auto-ingestion |
 | --- | --- | --- | --- | --- |
 | as Gateway | | {{< X >}} | {{< X >}} | |
 | as Agent | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
 
+## Out-of-the-box dashboards
+
+Datadog provides out-of-the-box dashboards that you can copy and customize. To use Datadog's out-of-the-box OpenTelemetry dashboards, go to **Dashboards** > **Dashboards list** and search for `opentelemetry`:
+
+{{< img src="metrics/otel/dashboard.png" alt="The Dashboards list, showing two OpenTelemetry out-of-the-box dashboards: Host Metrics and Collector Metrics." style="width:80%;">}}
+
+The **Host Metrics** dashboard is for data collected from the [host metrics receiver][21]. The **Collector Metrics** dashboard is for any other types of metrics collected, depending on which [metrics receiver][22] you choose to enable.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-
-
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter
 [2]: /tracing/other_telemetry/connect_logs_and_traces/opentelemetry
 [3]: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/latest
 [4]: https://opentelemetry.io/docs/collector/configuration/
 [5]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md
-[6]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/collector.yaml
-[7]: https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#WithContainer
-[8]: /getting_started/tagging/unified_service_tagging/
-[9]: https://opentelemetry.io/docs/reference/specification/resource/sdk/#sdk-provided-resource-attributes
-[14]: https://opentelemetry.io/docs/collector/deployment/
-[15]: https://docs.datadoghq.com/api/latest/logs/
-[16]: https://docs.datadoghq.com/api/latest/metrics/#submit-metrics
+[6]: https://docs.datadoghq.com/api/latest/logs/
+[7]: https://docs.datadoghq.com/api/latest/metrics/#submit-metrics
+[8]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/collector.yaml
+[9]: https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#WithContainer
+[10]: /getting_started/tagging/unified_service_tagging/
+[11]: https://opentelemetry.io/docs/instrumentation/
+[12]: /logs/log_collection/?tab=host
+[13]: /logs/log_configuration/parsing/
+[14]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/stanza/docs/operators
+[15]: https://opentelemetry.io/docs/reference/specification/logs/data-model/
+[16]: https://opentelemetry.io/docs/collector/deployment/#agent
+[17]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/k8s-chart/daemonset.yaml
+[18]: /tracing/other_telemetry/connect_logs_and_traces/opentelemetry/?tab=python
+[19]: https://opentelemetry.io/docs/reference/specification/resource/sdk/#sdk-provided-resource-attributes
+[20]: https://opentelemetry.io/docs/collector/deployment/
+[21]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver
+[22]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver

--- a/content/en/opentelemetry/otel_logs.md
+++ b/content/en/opentelemetry/otel_logs.md
@@ -3,6 +3,16 @@ title: Send Logs from OpenTelemetry to Datadog
 kind: documentation
 aliases:
 - /logs/log_collection/opentelemetry/
+further_reading:
+- link: "https://opentelemetry.io/docs/collector/"
+  tag: "OpenTelemetry"
+  text: "Collector documentation"
+- link: "https://www.datadoghq.com/blog/ingest-opentelemetry-traces-metrics-with-datadog-exporter/"
+  tag: "Blog"
+  text: "Send metrics, traces, and logs from OpenTelemetry Collector to Datadog using Datadog Exporter"
+- link: "/tracing/other_telemetry/connect_logs_and_traces/opentelemetry/?tab=python"
+  tag: "Documentation"
+  text: "Connect OpenTelemetry Traces and Logs"
 ---
 
 <div class="alert alert-warning"><a href="https://opentelemetry.io/docs/reference/specification/logs/">OpenTelemetry logging</a> and Datadog Exporter's feature for sending logs to Datadog are in alpha.</div>
@@ -13,138 +23,25 @@ aliases:
 
 The OpenTelemetry Collector is a vendor-agnostic agent process for collecting and exporting telemetry data emitted by many processes. Datadog has an [Exporter][3] available for the OpenTelemetry Collector which allows you to forward traces, metrics, and logs data from OpenTelemetry to Datadog. 
 
-For collecting logs, Datadog recommends using the Collector’s [filelog receiver][4]. The filelog receiver tails the log files that you specify. Then the Datadog Exporter (set up in the Collector) sends the log data to Datadog. 
+For collecting logs, Datadog recommends using the Collector's [filelog receiver][4]. The filelog receiver tails the log files that you specify. Then the Datadog Exporter (set up in the Collector) sends the log data to Datadog. 
 
 {{< img src="logs/log_collection/otel_collector_logs.png" alt="A diagram showing the host, container, or application sending data the filelog receiver in the collector and the Datadog Exporter in the collector sending the data to the Datadog backend" style="width:100%;">}}
 
-## Set up the Collector and Datadog Exporter
+## Setup
 
-See [Running the Collector][5] and [Configuring the Datadog Exporter][6].
+If your applications and services are instrumented with [OpenTelemetry][4] libraries, send the logs data to the Datadog backend by using the OTel Collector with the Datadog Exporter.
 
-#### Logs and traces correlation
+[Send logs to the OpenTelemetry collector, and use the Datadog exporter to forward them to Datadog][5]
 
-If you are using the Datadog Exporter to also send OpenTelemetry traces to Datadog, use the `trace_parser` operator to extract the `trace_id` from each trace and add it to the associated logs. Datadog automatically correlates the related logs and traces. See [Connect OpenTelemetry Traces and Logs][7] for more information.
+Read [OpenTelemetry][6] for more information.
 
-{{< img src="logs/log_collection/logs_traces_correlation.png" alt="The trace panel showing a list of logs correlated with the trace" style="width:70%;">}}
+## Further reading
 
-## Configure the logger for your application
-
-Since the OpenTelemetry SDKs’ logging functionality is not fully supported (see your specific language in the [OpenTelemetry documentation][8] for more information), Datadog recommends using a standard logging library for your application. Follow the language-specific [Log Collection documentation][9] to set up the appropriate logger in your application. Datadog strongly encourages setting up your logging library to output your logs in JSON to avoid the need for [custom parsing rules][10]. 
-
-## Configure the filelog receiver
-
-Configure the filelog receiver using [operators][11]. For example, if there is a service `checkoutservice` that is writing logs to `/var/log/pods/services/checkout/0.log`, a sample log might look like this:
-
-```
-{"level":"info","message":"order confirmation email sent to \"jack@example.com\"","service":"checkoutservice","span_id":"197492ff2b4e1c65","timestamp":"2022-10-10T22:17:14.841359661Z","trace_id":"e12c408e028299900d48a9dd29b0dc4c"}
-```
-
-Example filelog configuration:
-
-```
-filelog:
-   include:
-     - /var/log/pods/**/*checkout*/*.log
-   start_at: end
-   poll_interval: 500ms
-   operators:
-     - id: parse_log
-       type: json_parser
-       parse_from: body
-     - id: trace
-       type: trace_parser
-       trace_id:
-         parse_from: attributes.trace_id
-       span_id:
-         parse_from: attributes.span_id
-   attributes:
-     ddtags: env:staging
-```
-
-- `include`: The list of files the receiver tails 
-- `start_at: end`: Indicates to read new content that is being written 
-- `poll_internal`: Sets the poll frequency 
-- Operators:
-    - `json_parser`: Parses JSON logs. By default, the filelog receiver converts each log line into a log record, which is the `body` of the logs’ [data model][12]. Then, the `json_parser` converts the JSON body into attributes in the data model.
-    - `trace_parser`: Extract the `trace_id` and `span_id` from the log to correlate logs and traces in Datadog. 
-
-## Using Kubernetes
-
-There are multiple ways to deploy the OpenTelemetry Collector and Datadog Exporter in a Kubernetes infrastructure. For the filelog receiver to work, the [Agent/DaemonSet deployment][13] is the recommended deployment method.
-
-In containerized environments, applications write logs to `stdout` or `stderr`. Kubernetes collects the logs and writes them to a standard location. You need to mount the location on the host node into the Collector for the filelog receiver. Below is an [extension example][14] with the mounts required for sending logs. 
-
-```
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: otel-agent
-  labels:
-    app: opentelemetry
-    component: otel-collector
-spec:
-  template:
-    metadata:
-      labels:
-        app: opentelemetry
-        component: otel-collector
-    spec:
-      containers:
-        - name: collector
-          command:
-            - "/otelcol-contrib"
-            - "--config=/conf/otel-agent-config.yaml"
-          image: otel/opentelemetry-collector-contrib:0.61.0
-          env:
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            # The k8s.pod.ip is used to associate pods for k8sattributes
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "k8s.pod.ip=$(POD_IP)"
-          ports:
-            - containerPort: 4318 # default port for OpenTelemetry HTTP receiver.
-              hostPort: 4318
-            - containerPort: 4317 # default port for OpenTelemetry gRPC receiver.
-              hostPort: 4317
-            - containerPort: 8888 # Default endpoint for querying metrics.
-          volumeMounts:
-            - name: otel-agent-config-vol
-              mountPath: /conf
-            - name: varlogpods
-              mountPath: /var/log/pods
-              readOnly: true
-            - name: varlibdockercontainers
-              mountPath: /var/lib/docker/containers
-              readOnly: true
-      volumes:
-        - name: otel-agent-config-vol
-          configMap:
-            name: otel-agent-conf
-            items:
-              - key: otel-agent-config
-                path: otel-agent-config.yaml
-        # Mount nodes log file location.
-        - name: varlogpods
-          hostPath:
-            path: /var/log/pods
-        - name: varlibdockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
-```
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://opentelemetry.io/
 [2]: https://www.cncf.io/
 [3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter
 [4]: https://opentelemetry.io/docs/reference/specification/logs/overview/#third-party-application-logs
-[5]: /opentelemetry/otel_collector_datadog_exporter/#running-the-collector
-[6]: /opentelemetry/otel_collector_datadog_exporter/#configuring-the-datadog-exporter
-[7]: /tracing/other_telemetry/connect_logs_and_traces/opentelemetry/?tab=python
-[8]: https://opentelemetry.io/docs/instrumentation/
-[9]: /logs/log_collection/?tab=host
-[10]: /logs/log_configuration/parsing/
-[11]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/stanza/docs/operators
-[12]: https://opentelemetry.io/docs/reference/specification/logs/data-model/
-[13]: https://opentelemetry.io/docs/collector/deployment/#agent
-[14]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/k8s-chart/daemonset.yaml
+[5]: /opentelemetry/otel_collector_datadog_exporter/?tab=onahost#4-configure-the-logger-for-your-application
+[6]: /tracing/other_telemetry/connect_logs_and_traces/opentelemetry/?tab=python

--- a/content/en/opentelemetry/otel_metrics.md
+++ b/content/en/opentelemetry/otel_metrics.md
@@ -20,116 +20,13 @@ further_reading:
 
 To send OTel metrics to Datadog, you have two options: the Datadog Agent, or the OTel Collector. Using the Datadog Agent enables you to keep using all [Agent functionalities][3]. For a more vendor-agnostic setup, use the OTel Collector.
 
-### Datadog Agent setup
+If your applications and services are instrumented with [OpenTelemetry][4] libraries, you can choose between two paths for getting the metrics data to the Datadog backend:
 
-{{< img src="metrics/otel/otlp_ingestion_update.png" alt="OTel SDKs/Libraries, Datadog Trace Library, Datadog Integrations -> Datadog Agent -> Datadog" style="width:100%;">}}
+1. [Send traces to the OpenTelemetry collector, and use the Datadog exporter to forward them to Datadog][5], or
 
+2. [Ingest traces with the Datadog Agent, which collects them for Datadog][6].
 
-
-#### Configuration
-
-1. [Instrument your applications with OpenTelemetry SDKs][4].
-2. [Enable OTLP ingestion][5] on the Datadog Agent.
-3. [Send OTLP telemetry][6] from your system to Datadog.
-
-### OTel Collector setup
-
-{{< img src="metrics/otel/datadog_exporter.png" alt="Application Instrumented Library, Cloud Integrations, and Other Monitoring Solutions (e.g. Prometheus) -> Datadog Exporter inside OTel Collector -> Datadog" style="width:100%;">}}
-
-Using this setup facilitates collecting telemetry data from sources besides OTel SDKs (for example, other libraries, Prometheus, etc.), as well as routing data to multiple vendors. 
-
-#### Configuration
-
-1. [Instrument your system with OpenTelemetry][4].
-2. Follow the [OTel Collector documentation][7] to install the `opentelemetry-collector-contrib` distribution, or any other distribution that includes the Datadog Exporter.
-3. Add a `datadog` exporter to your [OTel configuration YAML file][8]. The following is a minimum configuration file to retrieve system metrics:
-   ```yaml
-   receivers:
-     hostmetrics:
-       scrapers:
-         load:
-         cpu:
-         disk:
-         filesystem:
-         memory:
-         network:
-         paging:
-         process:
-
-   processors:
-     batch:
-       timeout: 10s
-
-   exporters:
-     datadog:
-       api:
-         key: "<API key>"
-         site: "<Datadog site>"
-        
-   service:
-     pipelines:
-       metrics:
-         receivers: [hostmetrics]
-         processors: [batch]
-         exporters: [datadog]
-   ```
-   Add your [Datadog API key][9] and [site][10] (defaults to `datadoghq.com`).
-   See the [sample configuration file][11] for other available options.
-
-##### Using the OTel Collector with the Datadog Agent
-
-If you want to use the OTel Collector, but you also want to keep a full range of Datadog capabilities, use the following setup:
-
-**OTel SDKs/Libraries** -> **OTel Collector** with the OTLP Exporter -> **Datadog Agent** -> **Datadog**
-
-#### Configuration
-
-1. [Instrument your system with OpenTelemetry][4].
-2. [Enable OTLP ingestion through gRPC][5] on the Datadog Agent.
-3. Add an OTLP exporter to your [OTel configuration YAML file][8]. Point the exporter to the Datadog Agent endpoint. For example, if your Datadog Agent is listening on port 4317 and you are running the OTel Collector on the same host, you may define the exporter as:
-   ```yaml
-   receivers:
-     otlp:
-         protocols:
-             grpc:
-               # Set to different port from Datadog Agent OTLP ingest 
-               # Point your instrumented application to port '5317' if using gRPC.
-               endpoint: "0.0.0.0:5317" 
-             http:
-               # Set to different port from Datadog Agent OTLP ingest 
-               # Point your instrumented application to port '5318' if using HTTP.
-               endpoint: "0.0.0.0:5318"
-
-     hostmetrics:
-       scrapers:
-         load:
-         cpu:
-         disk:
-         filesystem:
-         memory:
-         network:
-         paging:
-         process:
-
-   processors:
-     batch:
-       timeout: 10s
-
-   exporters:
-     otlp:
-       endpoint:
-         key: "0.0.0.0:4317"
-         tls:
-           insecure: true
-        
-   service:
-     pipelines:
-       metrics:
-         receivers: [hostmetrics]
-         processors: [batch]
-         exporters: [otlp]
-   ```
-   If you are using a containerized environment, ensure the `endpoint` setting is configured to use the approprate hostname for the Datadog Agent.
+Read [OpenTelemetry][7] for more information.
 
 ## Out-of-the-box dashboards
 
@@ -137,10 +34,7 @@ Datadog provides out-of-the-box dashboards that you can copy and customize. To u
 
 {{< img src="metrics/otel/dashboard.png" alt="The Dashboards list, showing two OpenTelemetry out-of-the-box dashboards: Host Metrics and Collector Metrics." style="width:80%;">}}
 
-The **Host Metrics** dashboard is for data collected from the [host metrics receiver][12]. The **Collector Metrics** dashboard is for any other types of metrics collected, depending on which [metrics receiver][13] you choose to enable.
-
-
-
+The **Host Metrics** dashboard is for data collected from the [host metrics receiver][8]. The **Collector Metrics** dashboard is for any other types of metrics collected, depending on which [metrics receiver][9] you choose to enable.
 
 ## Further reading
 
@@ -149,14 +43,9 @@ The **Host Metrics** dashboard is for data collected from the [host metrics rece
 [1]: https://opentelemetry.io/
 [2]: https://www.cncf.io/
 [3]: https://www.datadoghq.com/pricing/?product=infrastructure#infrastructure
-[4]: https://opentelemetry.io/docs/instrumentation/
-[5]: /opentelemetry/otlp_ingest_in_the_agent/?tab=host#enabling-otlp-ingestion-on-the-datadog-agent
-[6]: /opentelemetry/otlp_ingest_in_the_agent/?tab=host#sending-otlp-traces-from-the-application-to-datadog-agent
-[7]: https://opentelemetry.io/docs/collector/getting-started/#deployment
-[8]: https://opentelemetry.io/docs/collector/configuration/
-[9]: https://app.datadoghq.com/organization-settings/api-keys
-[10]: /getting_started/site/
-[11]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter/examples
-[12]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver
-[13]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver
-
+[4]: https://opentelemetry.io/docs/
+[5]: /opentelemetry/otel_collector_datadog_exporter/
+[6]: /opentelemetry/otlp_ingest_in_the_agent/
+[7]: /opentelemetry/
+[8]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver
+[9]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver

--- a/content/en/opentelemetry/otel_tracing.md
+++ b/content/en/opentelemetry/otel_tracing.md
@@ -9,6 +9,9 @@ further_reading:
 - link: "/tracing/other_telemetry/connect_logs_and_traces/opentelemetry"
   tag: "Documentation"
   text: "Connect OpenTelemetry Traces and Logs"
+- link: "https://www.datadoghq.com/blog/ingest-opentelemetry-traces-metrics-with-datadog-exporter/"
+  tag: "Blog"
+  text: "Send metrics, traces, and logs from OpenTelemetry Collector to Datadog using Datadog Exporter"
 aliases:
 - /tracing/setup_overview/open_standards/
 - /tracing/trace_collection/open_standards/
@@ -28,7 +31,7 @@ Read [OpenTelemetry][4] for more information.
 
 You can correlate OpenTelemetry traces and logs so that your application logs monitoring and analysis has the additional context provided by the OpenTelemetry traces. See [Connect OpenTelemetry Traces and Logs][5] for language specific instructions and example code.
 
-## OpenTracing
+## OpenStandards
 
 Datadog recommends you use the OpenTelemetry Collector Datadog exporter or the OTLP Ingest in the Datadog Agent in conjunction with OpenTelemetry tracing clients. However, if that doesn't work for you, each of the supported languages also has support for sending [OpenTracing][6] data to Datadog. Read more about [setting up OpenTracing for each supported language][7]. 
 

--- a/content/en/opentelemetry/otlp_ingest_in_the_agent.md
+++ b/content/en/opentelemetry/otlp_ingest_in_the_agent.md
@@ -9,6 +9,9 @@ further_reading:
 - link: "https://www.datadoghq.com/about/latest-news/press-releases/datadog-announces-opentelemetry-protocol-support/"
   tag: "Blog"
   text: "OTLP ingestion in the Agent"
+- link: "/metrics/open_telemetry/otlp_metric_types"
+  tag: "Documentation"
+  text: "OTLP Metrics Types"
 ---
 
 
@@ -164,7 +167,7 @@ This enables each protocol in the default port (`4317` for OTLP/gRPC and `4318` 
 
 There are many other environment variables and settings supported in the Datadog Agent. To get an overview of them all, see [the configuration template][6].
 
-## Sending OTLP traces from the application to Datadog Agent
+## Sending OpenTelemetry traces and metrics to Datadog Agent
 
 {{< tabs >}}
 {{% tab "Docker" %}}
@@ -208,6 +211,13 @@ There are many other environment variables and settings supported in the Datadog
 
 <div class="alert alert-info">Check the documentation of your OTLP Library. Some of them must send traces to <code>/v1/traces</code> instead of the <code>/</code> root path.</div>
 
+## Out-of-the-box dashboards
+
+Datadog provides out-of-the-box dashboards that you can copy and customize. To use Datadog's out-of-the-box OpenTelemetry dashboards, go to **Dashboards** > **Dashboards list** and search for `opentelemetry`:
+
+{{< img src="metrics/otel/dashboard.png" alt="The Dashboards list, showing two OpenTelemetry out-of-the-box dashboards: Host Metrics and Collector Metrics." style="width:80%;">}}
+
+The **Host Metrics** dashboard is for data collected from the [host metrics receiver][12]. The **Collector Metrics** dashboard is for any other types of metrics collected, depending on which [metrics receiver][13] you choose to enable.
 
 ## Further Reading
 
@@ -219,3 +229,5 @@ There are many other environment variables and settings supported in the Datadog
 [4]: https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst
 [5]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/config.md
 [6]: https://github.com/DataDog/datadog-agent/blob/7.35.0/pkg/config/config_template.yaml
+[12]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver
+[13]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver

--- a/content/en/tracing/trace_collection/open_standards/_index.md
+++ b/content/en/tracing/trace_collection/open_standards/_index.md
@@ -4,7 +4,9 @@ kind: documentation
 type: multi-code-lang
 ---
 
+## Overview
 
+Datadog recommends you use the OpenTelemetry Collector Datadog exporter or the OTLP Ingest in the Datadog Agent in conjunction with OpenTelemetry tracing clients. However, if that doesn't work for you, each of the supported languages also has support for sending [OpenTracing][1] data to Datadog. 
 
 {{< whatsnext desc="Set up your application to send traces using OpenTracing." >}}
     {{< nextlink href="/tracing/trace_collection/open_standards/java" >}}Java{{< /nextlink >}}
@@ -18,3 +20,5 @@ type: multi-code-lang
 
 <br>
 
+
+[1]: https://opentracing.io/docs/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
    - Moved metrics, and logs info into Exporter page.
    - Added dashboard info to both Exporter and Agent pages.
    - Removed configuration info from individual metric and logs pages.
    - Remove setup from Otel parent page, only points to ingestion methods.
    - Added OpenStandards alongside OpenTelemetry to APM menu.

### Motivation
[DOCS-4530](https://datadoghq.atlassian.net/browse/DOCS-4530)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
