### PR TITLE
[web-3172] async loading: reload page to allow redirect

### DIFF
--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -54,7 +54,8 @@ function loadPage(newUrl) {
             const newSidebar = httpRequest.responseXML.querySelector('.sidebar');
 
             if (newContent === null) {
-                return;
+                // If we got a document in the response but there's no main content, its likely a redirect.
+                location.reload()
             }
 
             document.title = newDocument.title;


### PR DESCRIPTION
### What does this PR do?
in the `async loading` script, reload the page if we didnt get content back from the response xml.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-3172

when pages/directories are re-organized we often put an `alias` in the new markdown so the previous URL will redirect to the new one.   the `async-loading` script doesnt understand the redirect and does nothing, so if the `menu` files arent updated, left-side nav links wont work.

for example loading this page will cause a redirect: https://docs.datadoghq.com/monitors/create/types/apm

but if you [go here](https://docs.datadoghq.com/tracing/services/) and then click `APM Monitors` in the side-nav, nothing happens.

this is more apparent in the translated sites, which may be due to our approach to the translation which is to update the english source and allow translated pages to go through the translation pipeline.   i'm not quite sure if the translators update the `url` field in the menu config files.

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/left-nav-catch-404/

try out some left side nav links that should redirect.   the `APM Monitors` example from above is a good one, there are also quite a few under `tracing` on the `fr` site.

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
