### PR TITLE
DOCS-4579 AD v2 syntax for Docker docs

### DIFF
--- a/content/en/containers/docker/integrations.md
+++ b/content/en/containers/docker/integrations.md
@@ -63,14 +63,14 @@ Integrations templates can be stored as Docker labels. With Autodiscovery, the A
 **Dockerfile**:
 
 ```yaml
-LABEL "com.datadoghq.ad.checks"="{\"<INTEGRATION_NAME>\": {\"instances\": [<INSTANCE_CONFIG>]}}"
+LABEL "com.datadoghq.ad.checks"='{"<INTEGRATION_NAME>": {"instances": [<INSTANCE_CONFIG>]}}'
 ```
 
 **docker-compose.yaml**:
 
 ```yaml
 labels:
-  com.datadoghq.ad.checks: "{\"<INTEGRATION_NAME>\": {\"instances\": [<INSTANCE_CONFIG>]}}"
+  com.datadoghq.ad.checks: '{"<INTEGRATION_NAME>": {"instances": [<INSTANCE_CONFIG>]}}'
 ```
 
 **Using `docker run`, `nerdctl run`, or `podman run` commands**:
@@ -95,7 +95,7 @@ services:
   project:
     image: '<IMAGE_NAME>'
     labels:
-      com.datadoghq.ad.checchecksk_names: "{\"<INTEGRATION_NAME>\": {\"instances\": [<INSTANCE_CONFIG>]}}"
+      com.datadoghq.ad.checchecksk_names: '{"<INTEGRATION_NAME>": {"instances": [<INSTANCE_CONFIG>]}}'
 
 ```
 

--- a/content/en/containers/docker/integrations.md
+++ b/content/en/containers/docker/integrations.md
@@ -37,6 +37,8 @@ To configure an integration with Autodiscovery, use the following parameters:
 | `<INIT_CONFIG>`      | Yes      | Configuration for the `init_config:` section for the given Datadog-`<INTEGRATION_NAME>`           |
 | `<INSTANCE_CONFIG>`  | Yes      | Configuration for the `instances:` section for the given Datadog-`<INTEGRATION_NAME>`             |
 
+**Note**: `<INIT_CONFIG>` is not required for Autodiscovery v2, introduced in Datadog Agent 7.36.
+
 [**Discover the full list of Agent integrations that are Autodiscovery ready with examples for those parameters**][3]
 
 Each tab in sections below shows a different way to apply integration templates to a given container. The available methods are:
@@ -50,7 +52,59 @@ Each tab in sections below shows a different way to apply integration templates 
 ## Configuration
 
 {{< tabs >}}
-{{% tab "Docker" %}}
+{{% tab "Docker (AD v2)" %}}
+
+**Note**: AD Annotations v2 was introduced in Datadog Agent 7.36 to simplify integration configuration. For previous versions of the Datadog Agent, use AD Annotations v1.
+
+To automatically enable Autodiscovery over Docker containers, mount `/var/run/docker.sock` into the containerized Agent. On Windows, mount `\\.\pipe\docker_engine`.
+
+Integrations templates can be stored as Docker labels. With Autodiscovery, the Agent detects if it's running on Docker and automatically searches all labels for integration templates. Autodiscovery expects labels to look like the following examples:
+
+**Dockerfile**:
+
+```yaml
+LABEL "com.datadoghq.ad.checks"="{\"<INTEGRATION_NAME>\": {\"instances\": [<INSTANCE_CONFIG>]}}"
+```
+
+**docker-compose.yaml**:
+
+```yaml
+labels:
+  com.datadoghq.ad.checks: "{\"<INTEGRATION_NAME>\": {\"instances\": [<INSTANCE_CONFIG>]}}"
+```
+
+**Using `docker run`, `nerdctl run`, or `podman run` commands**:
+
+```shell
+-l com.datadoghq.ad.checks="{\"<INTEGRATION_NAME>\": {\"instances\": [<INSTANCE_CONFIG>]}}"
+```
+
+**Note**: You can escape JSON while configuring these labels. For example:
+```shell
+docker run --label "com.datadoghq.ad.checks="{\"apache\": {\"instances\": [{\"apache_status_url\":\"http://%%host%%/server-status?auto2\"}]}}"
+```
+
+**Docker Swarm**:
+
+When using Swarm mode for Docker Cloud, labels must be applied to the image:
+
+```yaml
+version: "1.0"
+services:
+...
+  project:
+    image: '<IMAGE_NAME>'
+    labels:
+      com.datadoghq.ad.checchecksk_names: "{\"<INTEGRATION_NAME>\": {\"instances\": [<INSTANCE_CONFIG>]}}"
+
+```
+
+**Note**: When configuring Autodiscovery, Datadog recommends using Docker labels to unify telemetry across your containerized environment. Read the [unified service tagging][1] documentation for more information.
+
+
+[1]: /getting_started/tagging/unified_service_tagging/?tab=docker
+{{% /tab %}}
+{{% tab "Docker (AD v1)" %}}
 
 To automatically enable Autodiscovery over Docker containers, mount `/var/run/docker.sock` into the Containerized Agent. On Windows, mount `\\.\pipe\docker_engine`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds ADv2 syntax for Docker, bringing it up to parity with the Kubernetes docs. ready to merge

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
