### PR TITLE
quicker redirect

### DIFF
--- a/content/en/observability_pipelines/reference/_index.md
+++ b/content/en/observability_pipelines/reference/_index.md
@@ -3,7 +3,8 @@ title: Reference
 disable_toc: true
 disable_sidebar: true
 type: reference
-external_redirect: /observability_pipelines/reference/sources/
+_build:
+  render: false
 cascade:
   disable_toc: false
   disable_sidebar: false

--- a/content/en/observability_pipelines/reference/sources.md
+++ b/content/en/observability_pipelines/reference/sources.md
@@ -3,6 +3,7 @@ title: Sources
 aliases:
     - /integrations/observability_pipelines/guide/
     - /observability_pipelines/integrations/
+    - /observability_pipelines/reference/
 ---
 
 A source is where data is collected and sent to Observability Pipelines. The source component in a configuration defines how Observability Pipelines collects or receives data from the source.


### PR DESCRIPTION
### What does this PR do?
external redirect can be slow, this pr keeps the same redirect but switches it to an alias instead

### Motivation

Slow redirect `/observability_pipelines/reference/` from to `/observability_pipelines/reference/sources/`

### Preview

https://docs-staging.datadoghq.com/david.jones/faster-redirect/observability_pipelines/reference/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
