### PR TITLE
delete-shadow-DOM-callout

### DIFF
--- a/content/en/real_user_monitoring/session_replay/troubleshooting.md
+++ b/content/en/real_user_monitoring/session_replay/troubleshooting.md
@@ -19,11 +19,7 @@ If you experience unexpected behavior with Datadog Session Replay, use this page
 
 ### Some HTML elements are not visible at replay
 
-Session Replay does not support the following HTML elements: `iframe`, `video`, `audio`, or `canvas`. Session Replay does not support Web Components nor Shadow DOM.
-
-{{< callout url="#" btn_hidden="true" >}}
-Shadow DOM support is in beta. To request access, contact Datadog support at support@datadoghq.com.
-{{< /callout >}}
+Session Replay does not support the following HTML elements: `iframe`, `video`, `audio`, or `canvas`. 
 
 Session Replay requires you to use an HTTPS connection. If you aren't using a secure connection, the resources time out and you can't see images and some page elements.
 


### PR DESCRIPTION
deleted reference that shadow DOM is not supported

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
