### PR TITLE
Separate alert grouping from monitor query grouping

### DIFF
--- a/content/en/monitors/configuration/_index.md
+++ b/content/en/monitors/configuration/_index.md
@@ -4,6 +4,16 @@ kind: documentation
 description: Describes the monitor creation page.
 aliases:
   - /monitors/create/configuration
+further_reading:
+- link: "/monitors/notify/"
+  tag: "Documentation"
+  text: "Monitor Notifications"
+- link: "/monitors/manage/"
+  tag: "Documentation"
+  text: "Manage monitors"
+- link: "/monitors/manage/status/"
+  tag: "Documentation"
+  text: "Monitor Status"
 ---
 
 ## Overview
@@ -275,6 +285,10 @@ If you configure tags or dimensions in your query, these values are available fo
 |-------------------------------------|------------------------|-----------------------|
 | _(everything)_                      | One single group triggering one notification | N/A |
 | 1&nbsp;or&nbsp;more&nbsp;dimensions | One notification if one or more groups meet the alert conditions | One notification per group meeting the alert conditions |
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /monitors/types
 [2]: /monitors/notify/variables/?tab=is_alert#tag-variables

--- a/content/en/monitors/configuration/_index.md
+++ b/content/en/monitors/configuration/_index.md
@@ -257,7 +257,7 @@ Configure your notification messages to include the information you are most int
 
 ### Message
 
-Use this section to configure notifications to your team and configure how to send these alerts
+Use this section to configure notifications to your team and configure how to send these alerts:
   - [Configure your notification with Template Variables][8]
   - [Send notifications to your team through email, Slack, PagerDuty, etc.][6]
 
@@ -275,7 +275,7 @@ Alerts are grouped automatically based on your selection of the `group by` step 
 
 `Multi Alert` mode applies the alert to each source according to your group parameters. You receive an alert for **each group** that meets the set conditions. For example, you could group a query looking at a capacity metric by `host` and `device` to receive a separate alert for each host device that is running out of space.  
 
-Customize which dimensions trigger alerts to reduce the noise and focus on the queries that matter most to you. If you group your query by `host` and `device` but only want alerts to be sent when the `host` attribute meets the threshold, remove the `device` attribute from your multi alert options and reduce the amount of notifications that are sent.
+Customize which dimensions trigger alerts to reduce the noise and focus on the queries that matter most to you. If you group your query by `host` and `device` but only want alerts to be sent when the `host` attribute meets the threshold, remove the `device` attribute from your multi alert options and reduce the number of notifications that are sent.
 
 **Note**: If your metric is only reporting by `host` with no `device` tag, it is not detected by the monitor. Metrics with both `host` and `device` tags are detected by the monitor. 
 

--- a/content/en/monitors/configuration/_index.md
+++ b/content/en/monitors/configuration/_index.md
@@ -275,7 +275,7 @@ Alerts are grouped automatically based on your selection of the `group by` step 
 
 `Multi Alert` mode applies the alert to each source according to your group parameters. You receive an alert for **each group** that meets the set conditions. For example, you could group a query looking at a capacity metric by `host` and `device` to receive a separate alert for each host device that is running out of space.  
 
-Customize which dimensions that trigger alerts to reduce the noise and focus on the queries that matter most to you. For example, if you group your query by `host` and `device` but only want alerts triggered by the `host` attribute, you can remove the `device` attribute from your Multi-alert options and reduce the amount of notifications that are sent.
+Customize which dimensions trigger alerts to reduce the noise and focus on the queries that matter most to you. If you group your query by `host` and `device` but only want alerts to be sent when the `host` attribute meets the threshold, remove the `device` attribute from your multi alert options and reduce the amount of notifications that are sent.
 
 **Note**: If your metric is only reporting by `host` with no `device` tag, it is not detected by the monitor. Metrics with both `host` and `device` tags are detected by the monitor. 
 

--- a/content/en/monitors/configuration/_index.md
+++ b/content/en/monitors/configuration/_index.md
@@ -21,24 +21,6 @@ To learn how to construct the search query, see the individual [monitor types][1
 
 {{< img src="/monitors/create/preview_graph_monitor.mp4" alt="Preview Graph" video=true style="width:90%;">}}
 
-### Alert grouping
-
-Alerts are grouped automatically based on your selection of the `group by` step when defining your query. Grouping defaults to `Simple Alert`. If the query is grouped by any dimension, grouping changes to `Multi Alert`.
-
-#### Simple alert
-`Simple Alert` mode aggregates over all reporting sources. You receive **one alert** when the aggregated value meets the set conditions.
-
-#### Multi alert
-`Multi Alert` mode applies the alert to each source according to your group parameters. You receive an alert for **each group** that meets the set conditions. For example, you could group a query looking at a capacity metric by `host` and `device` to receive a separate alert for each host device that is running out of space.  
-**Note**: If your metric is only reporting by `host` with no `device` tag, it is not detected by the monitor. Metrics with both `host` and `device` tags are detected by the monitor. 
-
-If you configure tags or dimensions, these values are available for every group evaluated in the multi alert to dynamically fill in notifications with useful context. See [Tag Variables][2] to learn how to reference tag values in the notification message.
-
-| Group by                       | Simple alert mode | Multi alert mode |
-|-------------------------------------|------------------------|-----------------------|
-| _(everything)_                      | One single group triggering one notification | N/A |
-| 1&nbsp;or&nbsp;more&nbsp;dimensions | One notification if one or more groups meet the alert conditions | One notification per group meeting the alert conditions |
-
 ## Set alert conditions
 
 The alert conditions vary based on the [monitor type][1]. Configure monitors to trigger if the query value crosses a threshold, or if a certain number of consecutive checks failed.
@@ -259,9 +241,46 @@ The time (in seconds) to delay evaluation. This should be a non-negative integer
 
 **Note**: A 15 minute delay is recommended for cloud metrics which are backfilled by service providers. Additionally, when using a division formula, a 60 second delay is helpful to ensure your monitor evaluates on complete values.
 
+## Notify your team
+
+Configure your notification messages to include the information you are most interested in. Specify which teams to send these alerts to as well as which attributes to trigger alerts for.
+
+### Message
+
+Use this section to configure notifications to your team and configure how to send these alerts
+  - [Configure your notification with Template Variables][8]
+  - [Send notifications to your team through email, Slack, PagerDuty, etc.][6]
+
+  For more information on the configuration options for the Notification message, see  [Alerting Notifications][7].
+
+### Notification aggregation
+
+Alerts are grouped automatically based on your selection of the `group by` step when defining your query. If the query has no grouping, it defaults to `Simple Alert`. If the query is grouped by any dimension, grouping changes to `Multi Alert`.
+
+#### Simple alert
+
+`Simple Alert` mode aggregates over all reporting sources. You receive **one alert** when the aggregated value meets the set conditions.
+
+#### Multi alert
+
+`Multi Alert` mode applies the alert to each source according to your group parameters. You receive an alert for **each group** that meets the set conditions. For example, you could group a query looking at a capacity metric by `host` and `device` to receive a separate alert for each host device that is running out of space.  
+
+Customize which dimensions that trigger alerts to reduce the noise and focus on the queries that matter most to you. For example, if you group your query by `host` and `device` but only want alerts triggered by the `host` attribute, you can remove the `device` attribute from your Multi-alert options and reduce the amount of notifications that are sent.
+
+**Note**: If your metric is only reporting by `host` with no `device` tag, it is not detected by the monitor. Metrics with both `host` and `device` tags are detected by the monitor. 
+
+If you configure tags or dimensions in your query, these values are available for every group evaluated in the multi alert to dynamically fill in notifications with useful context. See [Tag Variables][2] to learn how to reference tag values in the notification message.
+
+| Group by                       | Simple alert mode | Multi alert mode |
+|-------------------------------------|------------------------|-----------------------|
+| _(everything)_                      | One single group triggering one notification | N/A |
+| 1&nbsp;or&nbsp;more&nbsp;dimensions | One notification if one or more groups meet the alert conditions | One notification per group meeting the alert conditions |
 
 [1]: /monitors/types
 [2]: /monitors/notify/variables/?tab=is_alert#tag-variables
 [3]: /monitors/notify/#renotify
 [4]: /monitors/create/configuration#auto-resolve
 [5]: /monitors/create/configuration/?tabs=othermonitortypes#no-data
+[6]: /monitors/notify/#notify-your-team
+[7]: /monitors/notify/#say-whats-happening
+[8]: /monitors/notify/variables/

--- a/content/en/monitors/configuration/_index.md
+++ b/content/en/monitors/configuration/_index.md
@@ -261,7 +261,7 @@ Use this section to configure notifications to your team and configure how to se
   - [Configure your notification with Template Variables][8]
   - [Send notifications to your team through email, Slack, PagerDuty, etc.][6]
 
-  For more information on the configuration options for the Notification message, see  [Alerting Notifications][7].
+  For more information on the configuration options for the notification message, see [Alerting Notifications][7].
 
 ### Notification aggregation
 

--- a/content/en/monitors/manage/status.md
+++ b/content/en/monitors/manage/status.md
@@ -86,7 +86,7 @@ The status graph shows your monitor's status over time, broken out by group. **N
 * The monitor's timeframe is too short for a metric that provides data infrequently.
 * A host's name previously included in the query has changed. Hostname changes age out of the UI within 2 hours.
 
-The status graph shows you the dimensions you configured your alerts, not the dimensions in your monitor query. For example, your monitor query is grouped by `host` and `device`, however you only want to receive alerts for the `host`. The status graph shows the monitor's status grouped by `host`. You can see the `device` subgroups by clicking **View all 1** which opens a panel showing status graphs for each device. For more information on alert groupings, see [Configure Monitors][13].
+The status graph shows you the dimensions you configured for your alerts, not the dimensions in your monitor query. For example: your monitor query is grouped by `host` and `device`, but you only want to receive alerts for the `host`. The status graph shows the monitor's status grouped by `host`. You can see the `device` subgroups by clicking **View all 1** which opens a panel showing status graphs for each device. For more information on alert groupings, see [Configure Monitors][13].
 
 #### Investigate a Monitor in a Notebook
 

--- a/content/en/monitors/manage/status.md
+++ b/content/en/monitors/manage/status.md
@@ -86,6 +86,8 @@ The status graph shows your monitor's status over time, broken out by group. **N
 * The monitor's timeframe is too short for a metric that provides data infrequently.
 * A host's name previously included in the query has changed. Hostname changes age out of the UI within 2 hours.
 
+The status graph shows you the dimensions you configured your alerts, not the dimensions in your monitor query. For example, your monitor query is grouped by `host` and `device`, however you only want to receive alerts for the `host`. The status graph shows the monitor's status grouped by `host`. You can see the `device` subgroups by clicking **View all 1** which opens a panel showing status graphs for each device. For more information on alert groupings, see [Configure Monitors][13].
+
 #### Investigate a Monitor in a Notebook
 
 For further investigation into your metrics evolution, click **Open in a notebook** by the status graph. This generates an investigation [notebook][8] with a formatted graph of the monitor query.
@@ -147,3 +149,4 @@ You can obtain a JSON export of any monitor from the monitor's status page. Clic
 [10]: https://app.datadoghq.com/event/explorer
 [11]: /events/
 [12]: https://app.datadoghq.com/monitors#create/import
+[13]: /monitors/configuration/?tab=thresholdalert#notification-aggregation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Moved alert grouping to Notify your team section
- Add Further Reading section to Monitor Configure page
- Added blurb about new status group UI change to the Monitor Status page

Ready to merge after review

### Motivation
[DOCS-4601](https://datadoghq.atlassian.net/browse/DOCS-4601)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
- Plan to add UI images once the feature is available in the demo org
- Ready to merge after review

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.

[DOCS-4601]: https://datadoghq.atlassian.net/browse/DOCS-4601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ