### PR TITLE
fix envar config

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/go.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go.md
@@ -219,7 +219,7 @@ To disable trace context propagation, set the value of the environment variables
 - Disable all trace context propagation (both inject and extract) using the `DD_PROPAGATION_STYLE=none` environment variable.
 
 If multiple environment variables are set, `DD_PROPAGATION_STYLE_INJECT` and `DD_PROPAGATION_STYLE_EXTRACT`
-override any value provided in `DD_PROPAGATION_STYLE`.
+override any value provided in `DD_TRACE_PROPAGATION_STYLE`.
 
 If multiple extraction styles are enabled, extraction attempts are made
 in the order that those styles are specified. The first successfully


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
It looks like the Go docs originally had the incorrect envar name. If we look at their code base they never have `DD_PROPAGATION_STYLE` as an envar, only `DD_TRACE_PROPAGATION_STYLE` https://github.com/DataDog/dd-trace-go/search?q=DD_TRACE_PROPAGATION_STYLE

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
