### PR TITLE
DOCS-4866 Configuring the .NET Core Tracing Library Edit

### DIFF
--- a/content/en/tracing/trace_collection/library_config/dotnet-core.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-core.md
@@ -73,6 +73,23 @@ Tracer.Configure(settings);
 
 {{% /tab %}}
 
+{{% tab "web.config" %}}
+
+To configure the Tracer using an `app.config` or `web.config` file, use the `<appSettings>` section. For example:
+
+```xml
+<configuration>
+  <appSettings>
+    <add key="DD_TRACE_AGENT_URL" value="http://localhost:8126"/>
+    <add key="DD_ENV" value="prod"/>
+    <add key="DD_SERVICE" value="MyService"/>
+    <add key="DD_VERSION" value="abc123"/>
+  </appSettings>
+</configuration>
+```
+
+{{% /tab %}}
+
 {{% tab "JSON file" %}}
 
 To configure the tracer using a JSON file, create `datadog.json` in the instrumented application's directory. The root JSON object must be an object with a key-value pair for each setting. For example:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds web.config tab in the .NET Core doc page.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-4866

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
