### PR TITLE
Fitzage/glossary scroll

### DIFF
--- a/assets/scripts/components/glossary.js
+++ b/assets/scripts/components/glossary.js
@@ -1,0 +1,14 @@
+let menuSection = document.querySelectorAll('a.nav-link');
+
+window.onscroll = (()=> {
+  let mainSection = document.querySelectorAll('#mainContent h2');
+
+  mainSection.forEach((v,i)=> {
+    // let rect = v.getBoundingClientRect().y
+    let distanceFromTop = v.getBoundingClientRect().top
+    if(distanceFromTop < 100){
+      menuSection.forEach(v=> v.classList.remove('active'))
+      menuSection[i].classList.add('active')
+    }
+  })
+})

--- a/assets/styles/pages/_glossary.scss
+++ b/assets/styles/pages/_glossary.scss
@@ -1,4 +1,8 @@
 .glossary-main {
+  h2:before {
+    margin-top: -140px !important;
+    height: 140px !important;
+  }
     h4 {
         text-transform: none;
 
@@ -10,7 +14,7 @@
             scroll-margin-top: 40px;
         }
     }
-    
+
     #glossary-nav {
         position: sticky;
         top: 128px;
@@ -41,17 +45,17 @@
 
         .btn {
             padding: 0 5px;
-    
+
             &.active {
                 background: $brand-primary;
                 color: white;
             }
-    
+
             &:hover:not(.active) {
                 box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.15);
                 color: $brand-primary;
             }
-    
+
             @include media-breakpoint-up(md) {
                 @include font-size-line-height(18px, 24px);
                 padding: 0px 8px 2px 8px;
@@ -60,7 +64,7 @@
 
         ul {
             flex-direction: column;
-            
+
             @include media-breakpoint-up(md) {
                 padding-left: 15px;
                 flex-direction: row;

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -31,7 +31,7 @@
 {{ $ctx := . }}
 
 <body
-  class="{{ .Site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }} {{ $customClass }} {{ if .Site.Params.announcement_banner }}announcement{{ end }}" {{ with .Params.scrollspy }}data-bs-spy="scroll" data-bs-target="{{ .target }}" data-bs-offset="{{ .offset | default 0 }}" {{ end }}>
+  class="{{ .Site.Language.Lang }} {{ if .Kind }}kind-{{.Kind}}{{ end }} {{ if .IsPage }} {{ replace $.Type "/" "-" }} {{ else }} {{ .Section }} {{ end }} {{ $bodyClass }} {{ $customClass }} {{ if .Site.Params.announcement_banner }}announcement{{ end }}">
 
   <div class="greyside">
     <div class="container container__content h-100">

--- a/layouts/partials/footer-scripts.html
+++ b/layouts/partials/footer-scripts.html
@@ -30,6 +30,15 @@ hugo defaults to environment development with hugo server
     <script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }}></script>
 {{ end }}
 
+{{ if eq .Section "glossary" }}
+    {{ $opts := dict "targetPath" "static/glossary.js" "defines" $defines "inject" $inject "sourceMap" $sourcemap "minify" $isProd }}
+    {{ $js := resources.Get "scripts/components/glossary.js" | js.Build $opts }}
+    {{ if $isProd }}
+        {{ $js = $js | fingerprint "sha512" }}
+    {{ end }}
+    <script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }}></script>
+{{ end }}
+
 {{ if .Params.footer_scripts }}
     {{ range $k, $v := .Params.footer_scripts }}
 


### PR DESCRIPTION
### What does this PR do?

1. Fixes active nav on scrolling for glossary, which was apparently broken with Bootstrap 5.
2. Fixes active nav on scrolling on Japanese language glossary, which was broken before Bootstrap 5.
3. Updates the offset of the in-page links on glossary so the headers no longer fall under the nav.

### Motivation

https://datadoghq.atlassian.net/browse/WEB-2904

 ### Preview
https://docs-staging.datadoghq.com/fitzage/glossary-scroll/glossary/
https://docs-staging.datadoghq.com/fitzage/glossary-scroll/ja/glossary/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
