### PR TITLE
Remove notes about INI-Settings as this is not true anymore

### DIFF
--- a/content/en/profiler/enabling/php.md
+++ b/content/en/profiler/enabling/php.md
@@ -64,8 +64,6 @@ To begin profiling applications:
 
 3. Run the installer to install both the tracer and profiler, for example `php datadog-setup.php --enable-profiling`. This script is interactive and asks which of the detected PHP locations it should install to. At the end of the script, it outputs the non-interactive version of the command arguments for future use.
 
-4. Configure the profiler with environment variables. Unlike the tracer the profiler does not support INI settings.
-
    {{< tabs >}}
 {{% tab "CLI" %}}
 
@@ -115,7 +113,7 @@ SetEnv DD_VERSION 1.3.2
 
    See the [configuration docs][4] for more environment variables.
 
-5. A minute or two after receiving a request, profiles appear on the [APM > Profiler page][5].
+4. A minute or two after receiving a request, profiles appear on the [APM > Profiler page][5].
 
 ## Not sure what to do next?
 


### PR DESCRIPTION
### What does this PR do?

Remove the note about the PHP Profiler not supporting INI settings, as this is not true anymore.

### Motivation

Having an up to date documentation 🚀 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
