### PR TITLE
Fix typo on PHP ASM user login examples

### DIFF
--- a/content/en/security/application_security/threats/add-user-info.md
+++ b/content/en/security/application_security/threats/add-user-info.md
@@ -532,7 +532,7 @@ The following examples show how to track login events or custom events (using si
 {{% tab "Login success" %}}
 ```php
 <?php
-\datadog\appsec\track_user_login_success_event($id, $exists, ['email' => $email])
+\datadog\appsec\track_user_login_success_event($id, ['email' => $email])
 ?>
 ```
 {{% /tab %}}
@@ -540,7 +540,7 @@ The following examples show how to track login events or custom events (using si
 {{% tab "Login failure" %}}
 ```php
 <?php
-\datadog\appsec\track_user_login_failure_event($id, ['email' => $email])
+\datadog\appsec\track_user_login_failure_event($id, $exists, ['email' => $email])
 ?>
 ```
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR fixes a typo on the application security management user login examples.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
