### PR TITLE
[DOCS-4863] Remove regions for Online Archives

### DIFF
--- a/content/en/logs/log_configuration/online_archives.md
+++ b/content/en/logs/log_configuration/online_archives.md
@@ -16,14 +16,6 @@ further_reading:
   text: "Historical log analysis and investigation with Online Archives"
 ---
 
-{{< site-region region="us3,us5,eu,gov" >}}
-
-Online Archives is only available for AWS hosted Datadog customers (US1) site.
-
-{{< /site-region >}}
-
-{{< site-region region="us" >}}
-
 <div class="alert alert-warning">
 Online Archives is in limited availability. To request access, contact <a href="/help/">Datadog Support</a>.
 </div>
@@ -103,4 +95,3 @@ Select the index where you want to turn off Online Archives and then switch the 
 [3]: https://app.datadoghq.com/logs/pipelines/indexes
 [4]: https://app.datadoghq.com/logs
 
-{{< /site-region >}}


### PR DESCRIPTION
### What does this PR do?

Removes region shortcode. Online Archives is available for all regions. Ready to merge.

### Motivation

[DOCS-4863](https://datadoghq.atlassian.net/browse/DOCS-4863), PM and SE request.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4863]: https://datadoghq.atlassian.net/browse/DOCS-4863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ