### PR TITLE
[OPW] Add placeholders for env vars required to start the OP Worker

### DIFF
--- a/content/en/observability_pipelines/installation.md
+++ b/content/en/observability_pipelines/installation.md
@@ -64,7 +64,7 @@ $ DD_API_KEY=<DD_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.
 4. Start the Worker:
 
     ```
-    DD_API_KEY= DD_OP_CONFIG_KEY= observability-pipelines-worker 
+    DD_API_KEY="<DD_API_KEY>" DD_OP_CONFIG_KEY="<DD_OP_CONFIG_KEY>" observability-pipelines-worker 
     ```
 
 <!--

--- a/content/en/observability_pipelines/installation.md
+++ b/content/en/observability_pipelines/installation.md
@@ -64,7 +64,7 @@ $ DD_API_KEY=<DD_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.
 4. Start the Worker:
 
     ```
-    DD_API_KEY="<DD_API_KEY>" DD_OP_CONFIG_KEY="<DD_OP_CONFIG_KEY>" observability-pipelines-worker 
+    DD_API_KEY=<DD_API_KEY> DD_OP_CONFIG_KEY=<DD_OP_CONFIG_KEY> observability-pipelines-worker 
     ```
 
 <!--


### PR DESCRIPTION
Small change to add placeholders for the env vars required to start the Observability Pipelines Worker.