### PR TITLE
Add note about signals explorer

### DIFF
--- a/content/en/security/cspm/detection_rules.md
+++ b/content/en/security/cspm/detection_rules.md
@@ -59,6 +59,8 @@ On the [Rules][13] page, select a rule to open its details page. In the **Set se
 
 Alternatively, create [notification rules][21] that span across multiple detection rules based on parameters such as severities, rule types, rule tags, signal attributes, and signal tags. This allows you to avoid having to manually edit notification preferences for individual detection rules.
 
+**Note**: If a misconfiguration is detected for a rule with notifications enabled, the failed finding also appears on the [Signals Explorer][22].
+
 {{< img src="security/cspm/frameworks_and_benchmarks/notification-2.png" alt="The Set severity and notifications section of the rule details page" >}}
 
 ## Create custom rules
@@ -87,3 +89,4 @@ You can create custom rules to extend the rules being applied to your environmen
 [19]: /integrations/webhooks/
 [20]: /security/cspm/custom_rules/
 [21]: /security/notifications/rules/
+[22]: /security/cspm/signals_explorer/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a note to clarify that rules with notifications enabled appear in the Signals Explorer. Ready to merge.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
