### PR TITLE
Update ruby tracer version requirement to 1.8.0

### DIFF
--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -18,7 +18,7 @@ This guide assumes that you have configured [Datadog Monitoring][1] and are usin
 
 Supported tracers
 : [dd-trace-go][3] >= 1.44.0 (support for [database/sql][4] and [sqlx][5] packages)<br />
-[dd-trace-rb][6] >= 1.6.0 (support for [mysql2][7] and [pg][8] gems)<br />
+[dd-trace-rb][6] >= 1.8.0 (support for [mysql2][7] and [pg][8] gems)<br />
 [dd-trace-js][9] >= 3.13.0 or >= 2.26.0 (support for [postgres][10], [mysql][13], and [mysql2][14] clients)<br />
 [dd-trace-py][11] >= 1.7.0 (support for [psycopg2][12])
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
We updated the ruby version in the detailed instructions to version 1.8.0 but forgot to update the minimum required version in the _before you being_ section.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
