### PR TITLE
Add docs for Node.js W3C Trace Context header configs

### DIFF
--- a/content/en/tracing/trace_collection/library_config/nodejs.md
+++ b/content/en/tracing/trace_collection/library_config/nodejs.md
@@ -231,7 +231,7 @@ Remote configuration polling interval in seconds.
 
 ### Headers extraction and injection
 
-The Datadog APM Tracer supports [B3][5] and [W3C (TraceParent)][6] headers extraction and injection for distributed tracing.
+The Datadog APM Tracer supports [B3][5] and [W3C (TraceParent)][6] header extraction and injection for distributed tracing.
 
 You can configure injection and extraction styles for distributed headers.
 

--- a/content/en/tracing/trace_collection/library_config/nodejs.md
+++ b/content/en/tracing/trace_collection/library_config/nodejs.md
@@ -250,12 +250,12 @@ A comma-separated list of header formats to include to propagate distributed tra
 `DD_TRACE_PROPAGATION_STYLE_EXTRACT`
 : **Configuration**: `tracePropagationStyle.extract`<br>
 **Default**: `Datadog,tracecontext`<br>
-A comma-separated list of header formats from which to attempt to extract distributed tracing propagation data. The first format found with complete and valid headers will be used to define the trace to continue.
+A comma-separated list of header formats from which to attempt to extract distributed tracing propagation data. The first format found with complete and valid headers is used to define the trace to continue.
 
 `DD_TRACE_PROPAGATION_STYLE`
 : **Configuration**: `tracePropagationStyle`<br>
 **Default**: `Datadog,tracecontext`<br>
-A comma-separated list of header formats from which to attempt to inject and extract distributed tracing propagation data. The first format found with complete and valid headers will be used to define the trace to continue. The more specific `DD_TRACE_PROPAGATION_STYLE_INJECT` and `DD_TRACE_PROPAGATION_STYLE_EXTRACT` configurations will take priority when present.
+A comma-separated list of header formats from which to attempt to inject and extract distributed tracing propagation data. The first format found with complete and valid headers is used to define the trace to continue. The more specific `DD_TRACE_PROPAGATION_STYLE_INJECT` and `DD_TRACE_PROPAGATION_STYLE_EXTRACT` configurations take priority when present.
 
 
 For more examples of how to work with the library see [API documentation][2].

--- a/content/en/tracing/trace_collection/library_config/nodejs.md
+++ b/content/en/tracing/trace_collection/library_config/nodejs.md
@@ -229,6 +229,34 @@ A regex string to redact sensitive data by its value in attack reports.
 **Default**: 5<br>
 Remote configuration polling interval in seconds.
 
+### Headers extraction and injection
+
+The Datadog APM Tracer supports [B3][5] and [W3C (TraceParent)][6] headers extraction and injection for distributed tracing.
+
+You can configure injection and extraction styles for distributed headers.
+
+The Node.js Tracer supports the following styles:
+
+- Datadog: `Datadog`
+- B3 Multi Header: `b3multi` (`B3` is deprecated)
+- W3C Trace Context: `tracecontext`
+- B3 Single Header: `B3 single header`
+
+`DD_TRACE_PROPAGATION_STYLE_INJECT`
+: **Configuration**: `tracePropagationStyle.inject`<br>
+**Default**: `Datadog,tracecontext`<br>
+A comma-separated list of header formats to include to propagate distributed traces between services.
+
+`DD_TRACE_PROPAGATION_STYLE_EXTRACT`
+: **Configuration**: `tracePropagationStyle.extract`<br>
+**Default**: `Datadog,tracecontext`<br>
+A comma-separated list of header formats from which to attempt to extract distributed tracing propagation data. The first format found with complete and valid headers will be used to define the trace to continue.
+
+`DD_TRACE_PROPAGATION_STYLE`
+: **Configuration**: `tracePropagationStyle`<br>
+**Default**: `Datadog,tracecontext`<br>
+A comma-separated list of header formats from which to attempt to inject and extract distributed tracing propagation data. The first format found with complete and valid headers will be used to define the trace to continue. The more specific `DD_TRACE_PROPAGATION_STYLE_INJECT` and `DD_TRACE_PROPAGATION_STYLE_EXTRACT` configurations will take priority when present.
+
 
 For more examples of how to work with the library see [API documentation][2].
 
@@ -240,4 +268,6 @@ For more examples of how to work with the library see [API documentation][2].
 [2]: https://datadog.github.io/dd-trace-js/
 [3]: /tracing/trace_pipeline/ingestion_mechanisms/
 [4]: /help/
+[5]: https://github.com/openzipkin/b3-propagation
+[6]: https://www.w3.org/TR/trace-context/#trace-context-http-headers-format
 [13]: /agent/guide/network/#configure-ports


### PR DESCRIPTION
### What does this PR do?

Documents trace propagation style configs for W3C Trace Context support.

### Motivation

Header extraction priority has been made configurable and W3C Trace Context support has been added.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
