### PR TITLE
[RQ3110] Add new field session_count_flutter as part of the v2 API

### DIFF
--- a/content/en/account_management/guide/hourly-usage-migration.md
+++ b/content/en/account_management/guide/hourly-usage-migration.md
@@ -146,6 +146,7 @@ The families and usage types:
     * `session_count_android`
     * `session_count_ios`
     * `session_count_reactnative`
+    * `session_count_flutter`
 - **sds**
     * `logs_scanned_bytes`
     * `total_scanned_bytes`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds the new field session_count_flutter as part of the product taxonomy in the hourly-usage v2

### Motivation
Document the new field for v2 migration

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
n/a

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
