### PR TITLE
Fix transifex string bug

### DIFF
--- a/content/en/getting_started/integrations/_index.md
+++ b/content/en/getting_started/integrations/_index.md
@@ -72,7 +72,7 @@ logs:
       sourcecategory: http_web_access
 ```
 
-To create multiple instances in the same Agent check to monitor two Apache services, add additional instances to the `instances` section:
+To monitor multiple Apache instances in the same Agent check, add additional instances to the `instances` section:
 
 ```yaml
 init_config:

--- a/content/en/getting_started/integrations/_index.md
+++ b/content/en/getting_started/integrations/_index.md
@@ -72,7 +72,7 @@ logs:
       sourcecategory: http_web_access
 ```
 
-To create multiple instances in the same Agent check to monitor two Apache services, create a new instance with a `-` in the `instances` section:
+To create multiple instances in the same Agent check to monitor two Apache services, add additional instances to the `instances` section:
 
 ```yaml
 init_config:


### PR DESCRIPTION
The hyphen is causing a placeholder bug in Transifex and isn't necessary anyway.