### PR TITLE
Clarify `SubscriptionFilter` will not be created by DatadogForwarder CloudFormation

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -68,7 +68,7 @@ Datadog can automatically configure triggers on the Datadog Forwarder Lambda fun
 | Redshift Logs                   | S3             |
 | S3 Access Logs                  | S3             |
 
-**Note**: SubscriptionFilter will not be created automatically.
+**Note**: `SubscriptionFilter` is not created automatically.
 
 1. If you haven't already, set up the [Datadog log collection AWS Lambda function][1].
 2. Ensure the policy of the IAM role used for [Datadog-AWS integration][40] has the following permissions. Information on how these permissions are used can be found in the descriptions below:

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -68,6 +68,8 @@ Datadog can automatically configure triggers on the Datadog Forwarder Lambda fun
 | Redshift Logs                   | S3             |
 | S3 Access Logs                  | S3             |
 
+**Note**: SubscriptionFilter will not be created automatically.
+
 1. If you haven't already, set up the [Datadog log collection AWS Lambda function][1].
 2. Ensure the policy of the IAM role used for [Datadog-AWS integration][40] has the following permissions. Information on how these permissions are used can be found in the descriptions below:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Clarify [SubscriptionFilter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html#LambdaFunctionExample) will not be created by [DatadogForwarder](https://docs.datadoghq.com/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/?tab=awsconsole#automatically-set-up-triggers) CloudFormation. `SubscriptionFilter` needs for people using DatadogForwarder and CloudWatch Log Group. But, it is not created by this CloudFormation template.

### Motivation
<!-- What inspired you to submit this pull request?-->

Some users mistakenly believe that a SubscriptionFilter is created.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Cannot find the definition of [AWS::Logs::SubscriptionFilter](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-subscriptionfilter.html) in https://github.com/DataDog/datadog-serverless-functions/blob/master/aws/logs_monitoring/template.yaml, it means the template will not create `SubscriptionFilter`.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
