### PR TITLE
[CI Visibility] - Add new section for BenchmarkDotnet support.

### DIFF
--- a/content/en/continuous_integration/tests/dotnet.md
+++ b/content/en/continuous_integration/tests/dotnet.md
@@ -207,7 +207,7 @@ using BenchmarkDotNet.Running;
 using Datadog.Trace.BenchmarkDotNet;
 
 var config = DefaultConfig.Instance
-    .WithDatadog();
+              .WithDatadog();
 
 BenchmarkRunner.Run<OperationBenchmark>(config);
 {{< /code-block >}}

--- a/content/en/continuous_integration/tests/dotnet.md
+++ b/content/en/continuous_integration/tests/dotnet.md
@@ -182,7 +182,7 @@ To instrument your benchmark tests you need to:
 
 {{< tabs >}}
 
-{{% tab "Using the `[DatadogDiagnoser]` Attribute" %}}
+{{% tab "Using the [DatadogDiagnoser] Attribute" %}}
 {{< code-block lang="csharp" >}}
 using BenchmarkDotNet.Attributes;
 using Datadog.Trace.BenchmarkDotNet;

--- a/content/en/continuous_integration/tests/dotnet.md
+++ b/content/en/continuous_integration/tests/dotnet.md
@@ -215,7 +215,7 @@ BenchmarkRunner.Run<OperationBenchmark>(config);
 
 {{< /tabs >}}
 
-3. [Configure your CI provider to report via the Datadog Agent or agentless.][13]
+3. Configure the reporting method as [explained above][13]
 4. Run the benchmark project as you normally do, all benchmark tests will be automatically instrumented.
 
 ### Collecting Git metadata

--- a/content/en/continuous_integration/tests/dotnet.md
+++ b/content/en/continuous_integration/tests/dotnet.md
@@ -182,7 +182,7 @@ To instrument your benchmark tests you need to:
 
 {{< tabs >}}
 
-{{% tab "Using the Attribute" %}}
+{{% tab "Using the `[DatadogDiagnoser]` Attribute" %}}
 {{< code-block lang="csharp" >}}
 using BenchmarkDotNet.Attributes;
 using Datadog.Trace.BenchmarkDotNet;

--- a/content/en/continuous_integration/tests/dotnet.md
+++ b/content/en/continuous_integration/tests/dotnet.md
@@ -177,7 +177,7 @@ To create filters or `group by` fields for these tags, you must first create fac
 
 To instrument your benchmark tests you need to:
 
-1. Add the [`Datadog.Trace.BenchmarkDotNet` NuGet package][12] to your project (eg. using `dotnet add package Datadog.Trace.BenchmarkDotNet`).
+1. Add the [`Datadog.Trace.BenchmarkDotNet` NuGet package][12] to your project (for example, using `dotnet add package Datadog.Trace.BenchmarkDotNet`).
 2. Configure your project to use the `Datadog.Trace.BenchmarkDotNet` exporter using the `DatadogDiagnoser` attribute or the `WithDatadog()` extension method. For example:
 
 {{< tabs >}}
@@ -215,7 +215,7 @@ BenchmarkRunner.Run<OperationBenchmark>(config);
 
 {{< /tabs >}}
 
-3. Configure the reporting method as [explained above][13]
+3. [Configure the reporting method][13].
 4. Run the benchmark project as you normally do, all benchmark tests will be automatically instrumented.
 
 ### Collecting Git metadata

--- a/content/en/continuous_integration/tests/dotnet.md
+++ b/content/en/continuous_integration/tests/dotnet.md
@@ -29,6 +29,7 @@ Supported test frameworks:
 * xUnit 2.2 and above
 * NUnit 3.0 and above
 * MsTestV2 14 and above
+* [BenchmarkDotNet 0.13.2][11] and above
 
 ### Test suite level visibility compatibility
 [Test suite level visibility][1] is supported from `dd-trace-dotnet>=2.16.0`.
@@ -96,6 +97,8 @@ Install or update the `dd-trace` command using one of the following ways:
 - Or by downloading [from the github release page][5].
 
 ## Instrumenting tests
+
+<div class="alert alert-warning"><strong>Note</strong>: For BenchmarkDotNet follow <a href="#instrumenting-benchmarkdotnet-tests">these instructions</a>.</div>
 
 To instrument your test suite, prefix your test command with `dd-trace ci run`, providing the name of the service or library under test as the `--dd-service` parameter, and the environment where tests are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) as the `--dd-env` parameter. For example:
 
@@ -169,6 +172,51 @@ if (scope != null) {
 ```
 
 To create filters or `group by` fields for these tags, you must first create facets. For more information about adding tags, see the [Adding Tags][7] section of the .NET custom instrumentation documentation.
+
+### Instrumenting BenchmarkDotNet tests
+
+To instrument your benchmark tests you need to:
+
+1. Add the [`Datadog.Trace.BenchmarkDotNet` NuGet package][12] to your project (eg. using `dotnet add package Datadog.Trace.BenchmarkDotNet`).
+2. Configure your project to use the `Datadog.Trace.BenchmarkDotNet` exporter using the `DatadogDiagnoser` attribute or the `WithDatadog()` extension method. For example:
+
+{{< tabs >}}
+
+{{% tab "Using the Attribute" %}}
+{{< code-block lang="csharp" >}}
+using BenchmarkDotNet.Attributes;
+using Datadog.Trace.BenchmarkDotNet;
+
+[DatadogDiagnoser]
+[MemoryDiagnoser]
+public class OperationBenchmark
+{
+    [Benchmark]
+    public void Operation()
+    {
+        // ...
+    }
+}
+{{< /code-block >}}
+{{% /tab %}}
+
+{{% tab "Using the Configuration" %}}
+{{< code-block lang="csharp" >}}
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Running;
+using Datadog.Trace.BenchmarkDotNet;
+
+var config = DefaultConfig.Instance
+    .WithDatadog();
+
+BenchmarkRunner.Run<OperationBenchmark>(config);
+{{< /code-block >}}
+{{% /tab %}}
+
+{{< /tabs >}}
+
+3. [Configure your CI provider to report via the Datadog Agent or agentless.][13]
+4. Run the benchmark project as you normally do, all benchmark tests will be automatically instrumented.
 
 ### Collecting Git metadata
 
@@ -263,3 +311,6 @@ In addition to that, if [Intelligent Test Runner][10] is enabled, the following 
 [8]: https://www.nuget.org/packages/Datadog.Trace
 [9]: /tracing/trace_collection/custom_instrumentation/dotnet/
 [10]: /continuous_integration/intelligent_test_runner/
+[11]: /continuous_integration/tests/dotnet/#instrumenting-benchmarkdotnet-tests
+[12]: https://www.nuget.org/packages/Datadog.Trace.BenchmarkDotNet
+[13]: /continuous_integration/tests/dotnet/#configuring-reporting-method


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a new section to include the support of a new testing framework to CI Visibility.

### Motivation
We added support to a benchmark testing framework for .NET in CI Visibility.

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
https://docs-staging.datadoghq.com/tony/ci-visibility-tests-benchmarkdotnet/continuous_integration/tests/dotnet

### Additional Notes
<!-- Anything else we should know when reviewing?-->


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
