### PR TITLE
Add supplemental explanation of cli-input-json arguments

### DIFF
--- a/content/en/containers/amazon_ecs/_index.md
+++ b/content/en/containers/amazon_ecs/_index.md
@@ -85,7 +85,7 @@ For all of these examples the `DD_API_KEY` environment variable can alternativel
 Once you have your Task Definition file created you can execute the following command to register this in AWS.
 
 ```bash
-aws ecs register-task-definition --cli-input-json <path to datadog-agent-ecs.json>
+aws ecs register-task-definition --cli-input-json file://<path to datadog-agent-ecs.json>
 ```
 {{% /tab %}}
 {{% tab "Web UI" %}}

--- a/content/fr/containers/amazon_ecs/_index.md
+++ b/content/fr/containers/amazon_ecs/_index.md
@@ -85,7 +85,7 @@ Pour tous ces exemples, la variable d'environnement `DD_API_KEY` peut également
 Une fois votre fichier de définition de tâche créé, vous pouvez exécuter la commande suivante pour l'enregistrer dans AWS.
 
 ```bash
-aws ecs register-task-definition --cli-input-json <chemin vers datadog-agent-ecs.json>
+aws ecs register-task-definition --cli-input-json file://<chemin vers datadog-agent-ecs.json>
 ```
 {{% /tab %}}
 {{% tab "Interface utilisateur Web" %}}

--- a/content/ja/containers/amazon_ecs/_index.md
+++ b/content/ja/containers/amazon_ecs/_index.md
@@ -85,7 +85,7 @@ ECS の Datadog Agent は、ECS クラスター内の各 EC2 インスタンス�
 タスク定義ファイルを作成したら、以下のコマンドを実行して、これを AWS に登録します。
 
 ```bash
-aws ecs register-task-definition --cli-input-json <path to datadog-agent-ecs.json>
+aws ecs register-task-definition --cli-input-json file://<path to datadog-agent-ecs.json>
 ```
 {{% /tab %}}
 {{% tab "Web UI" %}}

--- a/content/kr/containers/amazon_ecs/_index.md
+++ b/content/kr/containers/amazon_ecs/_index.md
@@ -85,7 +85,7 @@ EC2 컨테이너 서비스 클러스터가 설정되어 있지 않은 경우 [EC
 작업 정의 파일이 생성되면 다음 명령을 실행하여 AWS에 등록할 수 있습니다.
 
 ```bash
-aws ecs register-task-definition --cli-input-json <path to datadog-agent-ecs.json>
+aws ecs register-task-definition --cli-input-json file://<path to datadog-agent-ecs.json>
 ```
 {{% /tab %}}
 {{% tab "Web UI" %}}


### PR DESCRIPTION
### What does this PR do?
Add `file://` before `<path to datadog-agent-ecs.json>` in "aws ecs register-task-definition" command.

Before:
`aws ecs register-task-definition --cli-input-json <path to datadog-agent-ecs.json>`
After:
`aws ecs register-task-definition --cli-input-json file://<path to datadog-agent-ecs.json>`

### Motivation
A user who is unfamiliar with aws command may run the command incorrectly.

### Additional Notes
Without `file://` aws command will fail.
```
$ aws ecs register-task-definition --cli-input-json datadog-agent-ecs.json
Error parsing parameter 'cli-input-json': Invalid JSON received.

$ aws ecs register-task-definition --cli-input-json file://datadog-agent-ecs.json
{
    "taskDefinition": {
        "taskDefinitionArn": "arn:aws:ecs:ap-northeast-1:601427279990:task-definition/datadog-agent-task:24",
... snip ...
        "registeredAt": "2023-02-20T16:45:36.859000+09:00",
        "registeredBy": "arn:aws:sts::601427279990:assumed-role/account-admin/masafumi.kashiwagi"
    }
}
```

This is documented in AWS document too.
https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-skeleton.html

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
