### PR TITLE
[DOCS-4919] Remove Aggregating Agents from nav

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3776,11 +3776,6 @@ main:
     identifier: help_top_level
     parent: administration_heading
     weight: 240000
-  - name: Aggregating Agents
-    url: observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker/
-    parent: agent
-    identifier: vector_aggregation
-    weight: 13
 api:
   - name: Overview
     url: /api/latest/


### PR DESCRIPTION
### What does this PR do?

Removes Aggregating Agents from the nav.

Ready to merge.

### Motivation

[DOCS-4919](https://datadoghq.atlassian.net/browse/DOCS-4919)

The associated doc, Integrate Datadog with OPW, was removed because it had incorrect info and links and is currently going through an overhaul. I'll add Aggregating Agents back once the new doc is ready.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4919]: https://datadoghq.atlassian.net/browse/DOCS-4919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ