### PR TITLE
Updates to Container Apps Docs

### DIFF
--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -206,7 +206,7 @@ az containerapp up \
 
 ### 3. Results
 
-Once the deployment is completed, your metrics and traces are sent to Datadog. In Datadog, navigate to the [APM Trace Explorer] and search for your Container App by service name, or filter using the facet `origin:containerapp` to see your Azure Container App traces.
+Once the deployment is completed, your metrics and traces are sent to Datadog. In Datadog, navigate to the [APM Trace Explorer][11] and search for your Container App by service name, or filter using the facet `origin:containerapp` to see your Azure Container App traces.
 
 ## Additional configurations
 

--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -206,13 +206,13 @@ az containerapp up \
 
 ### 3. Results
 
-Once the deployment is completed, your metrics and traces are sent to Datadog. In Datadog, navigate to **Infrastructure->Serverless** to see your serverless metrics and traces.
+Once the deployment is completed, your metrics and traces are sent to Datadog. In Datadog, navigate to the [APM Trace Explorer] and search for your Container App by service name, or filter using the facet `origin:containerapp` to see your Azure Container App traces.
 
 ## Additional configurations
 
 - **Advanced Tracing:** The Datadog Agent already provides some basic tracing for popular frameworks. Follow the [advanced tracing guide][2] for more information.
 
-- **Logs:** If you use the [Azure integration][1], your logs are already being collected. Alternatively, you can set the `DD_LOGS_ENABLED` environment variable to `true` to capture application logs through the serverless instrumentation directly.
+- **Logs:** You can set the `DD_LOGS_ENABLED` environment variable to `true` to capture application logs and dispatch them to Datadog through the serverless instrumentation directly. To send logs without direct instrumentation, you can set up central [log collection via the Azure Integration][1], then use the [Diagnostic Settings on the Container App Environment][] to direct the logs to the configured logs pipeline. 
 
 - **Custom Metrics:** You can submit custom metrics using a [DogStatsd client][3]. For monitoring Cloud Run and other serverless applications, use [distribution][8] metrics. Distributions provide `avg`, `sum`, `max`, `min`, and `count` aggregations by default. On the Metric Summary page, you can enable percentile aggregations (p50, p75, p90, p95, p99) and also manage tags. To monitor a distribution for a gauge metric type, use `avg` for both the [time and space aggregations][9]. To monitor a distribution for a count metric type, use `sum` for both the time and space aggregations.
 
@@ -251,3 +251,4 @@ RUN apt-get update && apt-get install -y ca-certificates
 [7]: https://learn.microsoft.com/en-us/azure/container-apps/manage-secrets
 [8]: /metrics/distributions/
 [9]: /metrics/#time-and-space-aggregation
+[10]: https://learn.microsoft.com/en-us/azure/container-apps/log-options#diagnostic-settings

--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -252,3 +252,4 @@ RUN apt-get update && apt-get install -y ca-certificates
 [8]: /metrics/distributions/
 [9]: /metrics/#time-and-space-aggregation
 [10]: https://learn.microsoft.com/en-us/azure/container-apps/log-options#diagnostic-settings
+[11]: https://app.datadoghq.com/apm/traces

--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -212,7 +212,7 @@ Once the deployment is completed, your metrics and traces are sent to Datadog. I
 
 - **Advanced Tracing:** The Datadog Agent already provides some basic tracing for popular frameworks. Follow the [advanced tracing guide][2] for more information.
 
-- **Logs:** You can set the `DD_LOGS_ENABLED` environment variable to `true` to capture application logs and dispatch them to Datadog through the serverless instrumentation directly. To send logs without direct instrumentation, you can set up central [log collection via the Azure Integration][1], then use the [Diagnostic Settings on the Container App Environment][] to direct the logs to the configured logs pipeline. 
+- **Logs:** You can set the `DD_LOGS_ENABLED` environment variable to `true` to capture application logs and send them to Datadog through the serverless instrumentation directly. To send logs without direct instrumentation, set up central [log collection through the Azure Integration][1], then use the [Diagnostic Settings on the Container App Environment][10] to direct the logs to the configured logs pipeline. 
 
 - **Custom Metrics:** You can submit custom metrics using a [DogStatsd client][3]. For monitoring Cloud Run and other serverless applications, use [distribution][8] metrics. Distributions provide `avg`, `sum`, `max`, `min`, and `count` aggregations by default. On the Metric Summary page, you can enable percentile aggregations (p50, p75, p90, p95, p99) and also manage tags. To monitor a distribution for a gauge metric type, use `avg` for both the [time and space aggregations][9]. To monitor a distribution for a count metric type, use `sum` for both the time and space aggregations.
 


### PR DESCRIPTION
2 small expansions in Container Apps docs:
1. Direct customers to our standard APM pages instead of Azure Serverless view to interact with traces until Azure view is complete
2. Add more detail to how to set up logs without direct instrumentation

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
