### PR TITLE
Updated montior template variable description

### DIFF
--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -390,7 +390,7 @@ Use template variables to customize your monitor notifications. The built-in var
 | `{{value}}`                    | The value that breached the alert for metric based query monitors.            |
 | `{{threshold}}`                | The value of the alert threshold set in the monitor's alert conditions.       |
 | `{{warn_threshold}}`           | The value of the warning threshold set in the monitor's alert conditions.     |
-| `{{ok_threshold}}`             | The value that recovered the monitor.                                         |
+| `{{ok_threshold}}`             | The value that recovered the Service Check monitor.                            |
 | `{{comparator}}`               | The relational value set in the monitor's alert conditions.                   |
 | `{{first_triggered_at}}`       | The UTC date and time when the monitor first triggered.                       |
 | `{{first_triggered_at_epoch}}` | The UTC date and time when the monitor first triggered in epoch milliseconds. |


### PR DESCRIPTION
Update Monitor Template Variable Description
- There is currently no description of which monitors can reference the `{{ok_threshold}}` template variable.
- Added a description to the monitor template variable `{{ok_threshold}}` that this template variable can only be used for ServiceCheck monitors.

### Motivation
Customer reached out to us why `{{ok_threshold}}` is not working for metric alerts.
- https://datadog.zendesk.com/agent/tickets/1106640 
Escalation:
- https://datadoghq.atlassian.net/browse/MNTS-89602

### Additional Notes
Waiting review from the monitor team to merge.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
