### PR TITLE
[ci-visibility] Add note about git upload

### DIFF
--- a/content/en/continuous_integration/intelligent_test_runner/_index.md
+++ b/content/en/continuous_integration/intelligent_test_runner/_index.md
@@ -45,7 +45,7 @@ Prior to setting up Intelligent Test Runner, you must have finished setting up [
 
 To enable Intelligent Test Runner, the following environment variables need to be set:
 
-`DD_CIVISIBILITY_AGENTLESS_ENABLED`
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required only if you're using `dd-trace<2.23.0` or `dd-trace<3.10`)
 : Enables or disables Agentless mode.<br/>
 **Default**: `false`<br/>
 
@@ -61,11 +61,6 @@ To enable Intelligent Test Runner, the following environment variables need to b
 : The [Datadog site][4] to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
 **Selected site**: {{< region-param key="dd_site" code="true" >}}
-
-`DD_CIVISIBILITY_GIT_UPLOAD_ENABLED=true` (Required)
-: Flag to enable git metadata upload.<br/>
-**Default**: `false`<br/>
-**Note**: Required only during Beta
 
 `DD_CIVISIBILITY_ITR_ENABLED=true` (Required)
 : Flag to enable test skipping. <br/>

--- a/content/en/continuous_integration/tests/javascript.md
+++ b/content/en/continuous_integration/tests/javascript.md
@@ -369,7 +369,7 @@ All other [Datadog Tracer configuration][7] options can also be used.
 
 Datadog uses Git information for visualizing your test results and grouping them by repository, branch, and commit. Git metadata is automatically collected by the test instrumentation from CI provider environment variables and the local `.git` folder in the project path, if available.
 
-From `dd-trace>=3.15.0` and `dd-trace>=2.28.0`, CI Visibility will automatically upload git metadata information (commit history). This metadata will contain file names but no file contents. If you want to opt out of this behavior, you can do so by setting `DD_CIVISIBILITY_GIT_UPLOAD_ENABLED` to `false`.
+From `dd-trace>=3.15.0` and `dd-trace>=2.28.0`, CI Visibility will automatically upload git metadata information (commit history). This metadata will contain file names but no file contents. If you want to opt out of this behavior, you can do so by setting `DD_CIVISIBILITY_GIT_UPLOAD_ENABLED` to `false`. This is not recommended, as features like Intelligent Test Runner and others will not work.
 
 If you are running tests in non-supported CI providers or with no `.git` folder, you can set the Git information manually using environment variables. These environment variables take precedence over any auto-detected information. Set the following environment variables to provide Git information:
 

--- a/content/en/continuous_integration/tests/javascript.md
+++ b/content/en/continuous_integration/tests/javascript.md
@@ -369,8 +369,6 @@ All other [Datadog Tracer configuration][7] options can also be used.
 
 Datadog uses Git information for visualizing your test results and grouping them by repository, branch, and commit. Git metadata is automatically collected by the test instrumentation from CI provider environment variables and the local `.git` folder in the project path, if available.
 
-From `dd-trace>=3.15.0` and `dd-trace>=2.28.0`, CI Visibility will automatically upload git metadata information (commit history). This metadata will contain file names but no file contents. If you want to opt out of this behavior, you can do so by setting `DD_CIVISIBILITY_GIT_UPLOAD_ENABLED` to `false`. This is not recommended, as features like Intelligent Test Runner and others will not work.
-
 If you are running tests in non-supported CI providers or with no `.git` folder, you can set the Git information manually using environment variables. These environment variables take precedence over any auto-detected information. Set the following environment variables to provide Git information:
 
 `DD_GIT_REPOSITORY_URL`
@@ -416,6 +414,10 @@ If you are running tests in non-supported CI providers or with no `.git` folder,
 `DD_GIT_COMMIT_COMMITTER_DATE`
 : Commit committer date in ISO 8601 format.<br/>
 **Example**: `2021-03-12T16:00:28Z`
+
+## Git metadata upload
+
+From `dd-trace>=3.15.0` and `dd-trace>=2.28.0`, CI Visibility automatically uploads git metadata information (commit history). This metadata contains file names but no file contents. If you want to opt out of this behavior, you can do so by setting `DD_CIVISIBILITY_GIT_UPLOAD_ENABLED` to `false`. However, this is not recommended, as features like Intelligent Test Runner and others do not work without it.
 
 ## Known limitations
 

--- a/content/en/continuous_integration/tests/javascript.md
+++ b/content/en/continuous_integration/tests/javascript.md
@@ -369,6 +369,8 @@ All other [Datadog Tracer configuration][7] options can also be used.
 
 Datadog uses Git information for visualizing your test results and grouping them by repository, branch, and commit. Git metadata is automatically collected by the test instrumentation from CI provider environment variables and the local `.git` folder in the project path, if available.
 
+From `dd-trace>=3.15.0` and `dd-trace>=2.28.0`, CI Visibility will automatically upload git metadata information (commit history). This metadata will contain file names but no file contents. If you want to opt out of this behavior, you can do so by setting `DD_CIVISIBILITY_GIT_UPLOAD_ENABLED` to `false`.
+
 If you are running tests in non-supported CI providers or with no `.git` folder, you can set the Git information manually using environment variables. These environment variables take precedence over any auto-detected information. Set the following environment variables to provide Git information:
 
 `DD_GIT_REPOSITORY_URL`


### PR DESCRIPTION
### What does this PR do?

* Remove `DD_CIVISIBILITY_GIT_UPLOAD_ENABLED` as a necessary parameter to intelligent test runner initialization.
* Add informative `Git metadata upload` section and explain how users can opt out of it.

### Motivation

* Now that git upload is an opt out in CI Visibility, we need to update the necessary configuration for intelligent test runner.
* We also want to be clear to users that we're uploading git information.

### Preview

* [Changes to configuration parameters](https://docs-staging.datadoghq.com/juan-fernandez/change-git-upload-info/continuous_integration/intelligent_test_runner/?tab=dotnettest#javascript)
* [Git upload section](https://docs-staging.datadoghq.com/juan-fernandez/change-git-upload-info/continuous_integration/tests/javascript/?tab=onpremisesciproviderdatadogagent#git-metadata-upload)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
