### PR TITLE
Update GCP instance requirements for DBM

### DIFF
--- a/content/en/database_monitoring/setup_mysql/troubleshooting.md
+++ b/content/en/database_monitoring/setup_mysql/troubleshooting.md
@@ -160,7 +160,7 @@ Before following these steps to diagnose missing query metric data, ensure the A
 The Agent requires the `performance_schema` option to be enabled. It is enabled by default by MySQL, but may be disabled in configuration or by your cloud provider. Follow the [setup instructions][1] for enabling it.
 
 #### Google Cloud SQL limitation
-The host is managed by Google Cloud SQL and does not support `performance_schema`. Due to limitations with Google Cloud SQL, Datadog Database Monitoring is [not supported on instances with less than 26GB of RAM][6].
+The host is managed by Google Cloud SQL and does not support `performance_schema`. Due to limitations with Google Cloud SQL, Datadog Database Monitoring is [not supported on instances with less than 16GB of RAM][6].
 
 ### Certain queries are missing
 


### PR DESCRIPTION
This change updates our documentation to match updates GCP has made to their docs. [Previously](https://web.archive.org/web/20220125094341/https://cloud.google.com/sql/docs/mysql/flags#tips) 26gb RAM was required to enable the `performance_schema` flag on GCP Cloud SQL instances for MySQL. This requirement changed to 16gb RAM in [March 2022](https://web.archive.org/web/20220318025316/https://cloud.google.com/sql/docs/mysql/flags#tips).