### PR TITLE
Clean up monitor references

### DIFF
--- a/content/en/account_management/audit_trail/_index.md
+++ b/content/en/account_management/audit_trail/_index.md
@@ -173,7 +173,7 @@ Datadog Audit Trail comes with an [out-of-the-box dashboard][12] that shows vari
 [3]: https://app.datadoghq.com/event/explorer
 [4]: /logs/explorer/
 [5]: https://docs.datadoghq.com/account_management/rbac/permissions/?tab=ui#general-permissions
-[6]: /monitors/create/types/audit_trail/
+[6]: /monitors/types/audit_trail/
 [7]: /dashboards/
 [8]: /dashboards/widgets/top_list/
 [9]: /dashboards/widgets/timeseries/

--- a/content/en/account_management/billing/usage_monitor_apm.md
+++ b/content/en/account_management/billing/usage_monitor_apm.md
@@ -44,6 +44,6 @@ Learn more about [retention filters][7].
 [2]: /account_management/billing/apm_distributed_tracing/
 [3]: https://app.datadoghq.com/account/usage
 [4]: https://app.datadoghq.com/monitors#create/metric
-[5]: /monitors/create/types/apm/?tab=traceanalytics#monitor-creation
+[5]: /monitors/types/apm/?tab=traceanalytics#monitor-creation
 [6]: https://app.datadoghq.com/apm/analytics
 [7]: /tracing/trace_pipeline/trace_retention/

--- a/content/en/dashboards/functions/algorithms.md
+++ b/content/en/dashboards/functions/algorithms.md
@@ -66,6 +66,6 @@ The `forecast()` function has two parameters:
     {{< nextlink href="/dashboards/functions/timeshift" >}}Timeshift: Shift your metric data point along the timeline. {{< /nextlink >}}
 {{< /whatsnext >}}
 
-[1]: /monitors/create/types/anomaly/
-[2]: /monitors/create/types/outlier/
-[3]: /monitors/create/types/forecasts/#forecast-algorithms
+[1]: /monitors/types/anomaly/
+[2]: /monitors/types/outlier/
+[3]: /monitors/types/forecasts/#forecast-algorithms

--- a/content/en/dashboards/functions/rollup.md
+++ b/content/en/dashboards/functions/rollup.md
@@ -82,4 +82,4 @@ Rollups should usually be avoided in [monitor][5] queries, because of the possib
 [2]: /metrics/faq/rollup-for-distributions-with-percentiles/
 [3]: https://www.datadoghq.com/blog/visualize-statsd-metrics-counts-graphing
 [4]: /metrics/custom_metrics/type_modifiers/
-[5]: /monitors/create/types/metric/
+[5]: /monitors/types/metric/

--- a/content/en/getting_started/monitors/_index.md
+++ b/content/en/getting_started/monitors/_index.md
@@ -97,13 +97,13 @@ You can view Monitor Saved Views from your mobile home screen or view and mute m
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /monitors/create/types/metric/
+[1]: /monitors/types/metric/
 [2]: https://www.datadoghq.com
 [3]: https://app.datadoghq.com/account/settings#agent
 [4]: https://app.datadoghq.com/infrastructure
 [5]: https://app.datadoghq.com/monitors#create/metric
 [6]: /integrations/disk/
-[7]: /monitors/create/types/metric/?tab=threshold#set-alert-conditions
+[7]: /monitors/types/metric/?tab=threshold#set-alert-conditions
 [8]: /monitors/notify/#conditional-variables
 [9]: /account_management/rbac/
 [10]: /mobile/

--- a/content/en/glossary/terms/delay.md
+++ b/content/en/glossary/terms/delay.md
@@ -2,4 +2,4 @@
 title: delay
 ---
 An evaluation delay tells the monitor to wait a specified number of seconds before it begins evaluation.
-For more information, <a href="https://docs.datadoghq.com/monitors/create/configuration/?tab=thresholdalert#new-group-delay">see the documentation</a>.
+For more information, <a href="https://docs.datadoghq.com/monitors/configuration/?tab=thresholdalert#advanced-alert-conditions">see the Advanced alert conditions</a>.

--- a/content/en/glossary/terms/evaluation_window.md
+++ b/content/en/glossary/terms/evaluation_window.md
@@ -2,4 +2,4 @@
 title: evaluation window
 ---
 The evaluation window is the look back timeframe of the data that the monitor aggregates and uses to compare against the defined thresholds.
-For more information, <a href="https://docs.datadoghq.com/monitors/create/configuration/?tab=thresholdalert#evaluation-window">see the documentation</a>.
+For more information, <a href="https://docs.datadoghq.com/monitors/configuration/?tab=thresholdalert#evaluation-window">see the documentation</a>.

--- a/content/en/glossary/terms/multi-alert.md
+++ b/content/en/glossary/terms/multi-alert.md
@@ -2,4 +2,4 @@
 title: multi alert
 ---
 A multi alert applies the alert to each source according to the monitor's group parameter. An alert notification is sent for each group that meets the set conditions.
-For more information, <a href="https://docs.datadoghq.com/monitors/create/configuration/?tab=thresholdalert#alert-grouping">see the documentation</a>.
+For more information, <a href="https://docs.datadoghq.com/monitors/configuration/?tab=thresholdalert#alert-grouping">see the documentation</a>.

--- a/content/en/infrastructure/process.md
+++ b/content/en/infrastructure/process.md
@@ -368,7 +368,7 @@ While actively working with the Live Processes, metrics are collected at 2s reso
 [3]: /getting_started/tagging/
 [4]: /getting_started/tagging/unified_service_tagging
 [5]: https://app.datadoghq.com/process
-[6]: /monitors/create/types/process/
+[6]: /monitors/types/process/
 [7]: https://app.datadoghq.com/monitors#create/live_process
 [8]: /dashboards/widgets/timeseries/#pagetitle
 [9]: /infrastructure/livecontainers/

--- a/content/en/integrations/faq/windows-status-based-check.md
+++ b/content/en/integrations/faq/windows-status-based-check.md
@@ -31,4 +31,4 @@ You should now have a monitor based on your Windows Service Integration.
 
 [1]: /agent/guide/agent-commands/#start-stop-restart-the-agent
 [2]: https://app.datadoghq.com/account/settings#integrations/windows_service
-[3]: /monitors/create/types/integration/
+[3]: /monitors/types/integration/

--- a/content/en/integrations/guide/reference-tables.md
+++ b/content/en/integrations/guide/reference-tables.md
@@ -166,4 +166,4 @@ You can create monitors from the **Monitors** tab, or click on the Settings icon
 [1]: /logs/log_configuration/processors/#lookup-processor
 [2]: /account_management/audit_trail/
 [3]: /events/
-[4]: /monitors/create/types/event/
+[4]: /monitors/types/event/

--- a/content/en/logs/explorer/export.md
+++ b/content/en/logs/explorer/export.md
@@ -37,7 +37,7 @@ To retrieve a log list longer than the maximum 1000 logs limit returned by the L
 
 [1]: /logs/explorer/saved_views/
 [2]: /dashboards/
-[3]: /monitors/create/types/log/
+[3]: /monitors/types/log/
 [4]: /logs/logs_to_metrics
 [5]: /api/latest/logs/
 [6]: /integrations/#cat-notification

--- a/content/en/logs/explorer/facets.md
+++ b/content/en/logs/explorer/facets.md
@@ -270,7 +270,7 @@ To delete a facet, follow these steps:
 [1]: /logs/search_syntax/
 [2]: /logs/explorer/patterns/
 [3]: /logs/explorer/analytics/
-[4]: /monitors/create/types/log/
+[4]: /monitors/types/log/
 [5]: /dashboards/widgets/
 [6]: /notebooks/
 [15]: /logs/log_configuration/rehydrating

--- a/content/en/logs/guide/best-practices-for-log-management.md
+++ b/content/en/logs/guide/best-practices-for-log-management.md
@@ -197,7 +197,7 @@ If you want to see user activities, such as who changed the retention of an inde
 [8]: /account_management/rbac/permissions/?tab=ui#log-management
 [9]: /logs/guide/logs-rbac/
 [10]: /logs/logs_to_metrics/#logs-usage-metrics
-[11]: /monitors/create/types/anomaly/
+[11]: /monitors/types/anomaly/
 [12]: https://app.datadoghq.com/metric/summary?filter=datadog.estimated_usage.logs.ingested_bytes&metric=datadog.estimated_usage.logs.ingested_bytes
 [13]: https://app.datadoghq.com/monitors/create
 [14]: https://app.datadoghq.com/logs

--- a/content/en/logs/guide/control-sensitive-logs-data.md
+++ b/content/en/logs/guide/control-sensitive-logs-data.md
@@ -129,8 +129,8 @@ If you have a specific compliance questions or need help, contact Datadog [suppo
 [7]: /logs/indexes#exclusion-filters
 [8]: /logs/archives
 [9]: /logs/logs_to_metrics/
-[10]: /monitors/create/types/log/
-[11]: /monitors/create/types/log/#notifications
+[10]: /monitors/types/log/
+[11]: /monitors/types/log/#notifications
 [12]: /logs/explorer/live_tail/
 [13]: /agent/
 [14]: /agent/logs/advanced_log_collection/?tab=configurationfile#scrub-sensitive-data-from-your-logs

--- a/content/en/logs/guide/detect-unparsed-logs.md
+++ b/content/en/logs/guide/detect-unparsed-logs.md
@@ -69,5 +69,5 @@ To monitor the volume of unparsed logs:
 [5]: /logs/archives/?tab=awss3
 [6]: /logs/logs_to_metrics/
 [7]: /logs/indexes#set-daily-quota
-[8]: /monitors/create/types/metric/?tab=threshold#overview
-[9]: /monitors/create/types/metric/?tab=threshold#set-alert-conditions
+[8]: /monitors/types/metric/?tab=threshold#overview
+[9]: /monitors/types/metric/?tab=threshold#set-alert-conditions

--- a/content/en/logs/guide/getting-started-lwl.md
+++ b/content/en/logs/guide/getting-started-lwl.md
@@ -130,5 +130,5 @@ To learn more about Logging Without Limits™ and how to better utilize features
 [6]: /logs/archives/
 [7]: /metrics/
 [8]: /logs/logs_to_metrics/
-[9]: /monitors/create/types/anomaly/
+[9]: /monitors/types/anomaly/
 [10]: https://app.datadoghq.com/monitors#/triggered

--- a/content/en/logs/log_configuration/indexes.md
+++ b/content/en/logs/log_configuration/indexes.md
@@ -168,7 +168,7 @@ See [Monitor log usage][20] on how to monitor and alert on your usage.
 [2]: /logs/explorer/#visualization
 [3]: /logs/explorer/patterns/
 [4]: /logs/explorer/analytics/
-[6]: /monitors/create/types/log/
+[6]: /monitors/types/log/
 [7]: /logs/explorer/facets/#the-index-facet
 [8]: /logs/live_tail/
 [9]: /logs/logs_to_metrics/

--- a/content/en/monitors/configuration/_index.md
+++ b/content/en/monitors/configuration/_index.md
@@ -136,9 +136,9 @@ See the documentation for [process check][1], [integration check][2], and [custo
 
 
 
-[1]: /monitors/create/types/process_check/
-[2]: /monitors/create/types/integration/?tab=checkalert#integration-status
-[3]: /monitors/create/types/custom_check/
+[1]: /monitors/types/process_check/
+[2]: /monitors/types/integration/?tab=checkalert#integration-status
+[3]: /monitors/types/custom_check/
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -293,8 +293,8 @@ If you configure tags or dimensions in your query, these values are available fo
 [1]: /monitors/types
 [2]: /monitors/notify/variables/?tab=is_alert#tag-variables
 [3]: /monitors/notify/#renotify
-[4]: /monitors/create/configuration#auto-resolve
-[5]: /monitors/create/configuration/?tabs=othermonitortypes#no-data
+[4]: /monitors/configuration/?tab=thresholdalert#auto-resolve
+[5]: /monitors/configuration/?tabs=othermonitortypes#no-data
 [6]: /monitors/notify/#notify-your-team
 [7]: /monitors/notify/#say-whats-happening
 [8]: /monitors/notify/variables/

--- a/content/en/monitors/guide/adjusting-no-data-alerts-for-metric-monitors.md
+++ b/content/en/monitors/guide/adjusting-no-data-alerts-for-metric-monitors.md
@@ -35,9 +35,9 @@ Contact [us][6] should you experience any issues.
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /monitors/create/types/metric/
+[1]: /monitors/types/metric/
 [2]: /integrations/amazon_web_services/
-[3]: /monitors/create/types/metric/?tab=threshold#advanced-alert-conditions
+[3]: /monitors/types/metric/?tab=threshold#advanced-alert-conditions
 [4]: /integrations/guide/cloud-metric-delay/
 [5]: /agent/faq/why-should-i-install-the-agent-on-my-cloud-instances/
 [6]: /help/

--- a/content/en/monitors/guide/alert-on-no-change-in-value.md
+++ b/content/en/monitors/guide/alert-on-no-change-in-value.md
@@ -41,4 +41,4 @@ Other [alert conditions/options][2] can be set to preference. Your monitor's UI 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /api/
-[2]: /monitors/create/configuration/
+[2]: /monitors/configuration/

--- a/content/en/monitors/guide/anomaly-monitor.md
+++ b/content/en/monitors/guide/anomaly-monitor.md
@@ -89,7 +89,7 @@ Datadog monitors use UTC time and by default are agnostic to local time zones. U
 Datadog allows you to configure a timezone for each anomaly detection monitor that automatically corrects for the time shift. For more details, see [How to update an anomaly detection monitor to account for local timezone][5].
 
 [1]: https://www.datadoghq.com/blog/anti-patterns-metric-graphs-101
-[2]: /monitors/create/types/metric/
-[3]: /monitors/create/types/composite/
+[2]: /monitors/types/metric/
+[3]: /monitors/types/composite/
 [4]: /monitors/guide/recovery-thresholds/
 [5]: /monitors/guide/how-to-update-anomaly-monitor-timezone/

--- a/content/en/monitors/guide/create-monitor-dependencies.md
+++ b/content/en/monitors/guide/create-monitor-dependencies.md
@@ -64,7 +64,7 @@ That's alot of missing data - check first to see if there is an AWS outage?
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /monitors/create/types/composite/
+[1]: /monitors/types/composite/
 [2]: /api/v1/downtimes/
 [3]: /api/v1/downtimes/#cancel-downtimes-by-scope
 [4]: https://app.datadoghq.com/account/settings#integrations/webhooks

--- a/content/en/monitors/guide/integrate-monitors-with-statuspage.md
+++ b/content/en/monitors/guide/integrate-monitors-with-statuspage.md
@@ -65,5 +65,5 @@ To create a [metric monitor][8] that triggers on Statuspage alerts:
 [5]: https://app.datadoghq.com/event/explorer
 [6]: /dashboards/guide/custom_time_frames/
 [7]: https://support.atlassian.com/statuspage/docs/get-started-with-email-automation/
-[8]: /monitors/create/types/metric/
+[8]: /monitors/types/metric/
 [9]: https://app.datadoghq.com/monitors/create/metric

--- a/content/en/monitors/guide/reduce-alert-flapping.md
+++ b/content/en/monitors/guide/reduce-alert-flapping.md
@@ -38,7 +38,7 @@ If the issue is alert routing, [template variables][4] and the separation of **w
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://www.datadoghq.com/blog/alert-rollup
-[2]: /monitors/create/types/anomaly/
-[3]: /monitors/create/types/outlier/
+[2]: /monitors/types/anomaly/
+[3]: /monitors/types/outlier/
 [4]: /monitors/notify/variables/?tab=is_alert#template-variables
 [5]: /monitors/notify/variables/?tab=is_alert#conditional-variables

--- a/content/en/monitors/guide/set-up-an-alert-for-when-a-specific-tag-stops-reporting.md
+++ b/content/en/monitors/guide/set-up-an-alert-for-when-a-specific-tag-stops-reporting.md
@@ -25,4 +25,4 @@ Your alert triggers if the tag stops reporting.
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /monitors/
-[2]: /monitors/create/types/metric/
+[2]: /monitors/types/metric/

--- a/content/en/monitors/guide/troubleshooting-monitor-alerts.md
+++ b/content/en/monitors/guide/troubleshooting-monitor-alerts.md
@@ -84,17 +84,17 @@ Due to an [Opsgenie feature][19], Opsgenie will discard what is seen as a duplic
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /monitors/create/configuration/?tabs=thresholdalert#no-data
+[1]: /monitors/configuration/?tabs=thresholdalert#no-data
 [2]: /monitors/manage/status/#history
 [3]: /monitors/guide/monitor-arithmetic-and-sparse-metrics/
-[4]: /monitors/create/configuration/?tabs=thresholdalert#auto-resolve
-[5]: /monitors/create/configuration/?tabs=thresholdalert#set-alert-conditions
+[4]: /monitors/configuration/?tabs=thresholdalert#auto-resolve
+[5]: /monitors/configuration/?tabs=thresholdalert#set-alert-conditions
 [6]: /monitors/types
 [7]: /monitors/guide/as-count-in-monitor-evaluations/
 [8]: /monitors/guide/recovery-thresholds/#behavior
 [9]: /monitors/guide/why-did-my-monitor-settings-change-not-take-effect
-[10]: /monitors/create/configuration/?tabs=thresholdalert#new-group-delay
-[11]: /monitors/create/configuration/?tabs=thresholdalert#evaluation-delay
+[10]: /monitors/configuration/?tabs=thresholdalert#new-group-delay
+[11]: /monitors/configuration/?tabs=thresholdalert#evaluation-delay
 [12]: /integrations/faq/cloud-metric-delay/
 [13]: /monitors/guide/reduce-alert-flapping/
 [14]: /monitors/guide/suppress-alert-with-downtimes/

--- a/content/en/monitors/notify/_index.md
+++ b/content/en/monitors/notify/_index.md
@@ -184,7 +184,7 @@ Message variables auto-populate with a randomly selected group based on the scop
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /monitors/create/configuration
+[1]: /monitors/configuration
 [2]: /monitors/notify/variables/#tag-variables
 [3]: http://daringfireball.net/projects/markdown/syntax
 [4]: /monitors/notify/variables/

--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -563,10 +563,10 @@ If your alert message includes information that needs to be encoded in a URL (fo
 https://app.datadoghq.com/apm/services/{{urlencode "service.name"}}
 ```
 
-[1]: /monitors/create/configuration/#alert-grouping
-[2]: /monitors/create/types/log/
-[3]: /monitors/create/types/apm/?tab=analytics
-[4]: /monitors/create/types/real_user_monitoring/
-[5]: /monitors/create/types/ci/
+[1]: /monitors/configuration/#alert-grouping
+[2]: /monitors/types/log/
+[3]: /monitors/types/apm/?tab=analytics
+[4]: /monitors/types/real_user_monitoring/
+[5]: /monitors/types/ci/
 [6]: /monitors/guide/template-variable-evaluation/
 [7]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

--- a/content/en/monitors/service_level_objectives/_index.md
+++ b/content/en/monitors/service_level_objectives/_index.md
@@ -229,7 +229,7 @@ To view, edit, and delete existing status corrections, click on the **Correction
 [2]: /dashboards/widgets/slo/
 [3]: /monitors/service_level_objectives/metric/
 [4]: /monitors/service_level_objectives/monitor/
-[5]: /monitors/create/types/metric/?tab=threshold#alert-grouping
+[5]: /monitors/types/metric/?tab=threshold#alert-grouping
 [6]: /monitors/service_level_objectives/metric/#define-queries
 [7]: /monitors/service_level_objectives/monitor/#set-your-slo-targets
 [8]: /monitors/service_level_objectives/metric/#set-your-slo-targets
@@ -238,7 +238,7 @@ To view, edit, and delete existing status corrections, click on the **Correction
 [11]: https://play.google.com/store/apps/details?id=com.datadog.app
 [12]: /monitors/service_level_objectives/#saved-views
 [13]: /api/v1/events/#query-the-event-stream
-[14]: /monitors/create/types/event/
+[14]: /monitors/types/event/
 [15]: https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html
 [16]: /api/latest/service-level-objective-corrections/
 [17]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/slo_correction

--- a/content/en/monitors/types/anomaly.md
+++ b/content/en/monitors/types/anomaly.md
@@ -231,14 +231,14 @@ A standard configuration of thresholds and threshold window looks like:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/monitors#create/anomaly
-[2]: /monitors/create/types/metric/#define-the-metric
+[2]: /monitors/types/metric/#define-the-metric
 [3]: /dashboards/functions/algorithms/#anomalies
 [4]: /monitors/guide/how-to-update-anomaly-monitor-timezone/
 [5]: /dashboards/functions/rollup/
 [6]: https://en.wikipedia.org/wiki/Autoregressive_integrated_moving_average
 [7]: https://en.wikipedia.org/wiki/Decomposition_of_time_series
-[8]: /monitors/create/configuration/#advanced-alert-conditions
-[9]: /monitors/create/types/metric/#data-window
+[8]: /monitors/configuration/#advanced-alert-conditions
+[9]: /monitors/types/metric/#data-window
 [10]: /monitors/notify/
 [11]: /api/v1/monitors/#create-a-monitor
 [12]: /monitors/manage/status/#settings

--- a/content/en/monitors/types/apm.md
+++ b/content/en/monitors/types/apm.md
@@ -69,12 +69,12 @@ For detailed instructions on the advanced alert options (no data, evaluation del
 [1]: /tracing/guide/setting_primary_tags_to_scope/#environment
 [2]: /tracing/services/service_page/
 [3]: /tracing/services/resource_page/
-[4]: /monitors/create/configuration/#advanced-alert-conditions
-[5]: /monitors/create/types/metric/#data-window
+[4]: /monitors/configuration/#advanced-alert-conditions
+[5]: /monitors/types/metric/#data-window
 {{% /tab %}}
 {{% tab "Trace Analytics" %}}
 
-<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 Trace Analytics monitors per account. If you are encountering this limit, consider using <a href="/monitors/create/configuration/?tab=thresholdalert#alert-grouping">multi alerts</a>, or <a href="/help/">Contact Support</a>.</div>
+<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 Trace Analytics monitors per account. If you are encountering this limit, consider using <a href="/monitors/configuration/?tab=thresholdalert#alert-grouping">multi alerts</a>, or <a href="/help/">Contact Support</a>.</div>
 
 ### Define the search query
 
@@ -112,7 +112,7 @@ For detailed instructions on the advanced alert options (evaluation delay, etc.)
 [2]: /tracing/trace_explorer/query_syntax/#facet-search
 [3]: /tracing/trace_explorer/query_syntax/#numerical-values
 [4]: /tracing/glossary/#indexed-span
-[5]: /monitors/create/configuration/#advanced-alert-conditions
+[5]: /monitors/configuration/#advanced-alert-conditions
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -126,7 +126,7 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /monitors/create/types/metric/
+[1]: /monitors/types/metric/
 [2]: https://app.datadoghq.com/monitors#create/apm
 [3]: /monitors/notify/
 [4]: https://app.datadoghq.com/apm/services

--- a/content/en/monitors/types/ci.md
+++ b/content/en/monitors/types/ci.md
@@ -211,7 +211,7 @@ For more information on flaky tests, see the [flaky test management guide][6].
 
 [1]: /continuous_integration/
 [2]: https://app.datadoghq.com/monitors/create/ci-pipelines
-[3]: /monitors/create/configuration/#advanced-alert-conditions
+[3]: /monitors/configuration/#advanced-alert-conditions
 [4]: /monitors/notify/
 [5]: https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/?tab=linux
 [6]: https://docs.datadoghq.com/continuous_integration/guides/flaky_test_management/

--- a/content/en/monitors/types/composite.md
+++ b/content/en/monitors/types/composite.md
@@ -222,7 +222,7 @@ Setting [new_group_delay][4] is possible in composite monitors and if set and bi
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/monitors#create/composite
-[2]: /monitors/create/configuration/#advanced-alert-conditions
+[2]: /monitors/configuration/#advanced-alert-conditions
 [3]: /monitors/notify/
-[4]: /monitors/create/configuration/?tab=thresholdalert#new-group-delay
+[4]: /monitors/configuration/?tab=thresholdalert#new-group-delay
 [5]: /monitors/notify/variables/?tab=is_alert#composite-monitor-variables

--- a/content/en/monitors/types/custom_check.md
+++ b/content/en/monitors/types/custom_check.md
@@ -99,8 +99,8 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 [4]: /api/v1/service-checks/
 [5]: /developers/service_checks/#overview
 [6]: https://app.datadoghq.com/monitors/create/custom
-[7]: /monitors/create/configuration/#advanced-alert-conditions
-[8]: /monitors/create/configuration/#no-data
-[9]: /monitors/create/configuration/#auto-resolve
-[10]: /monitors/create/configuration/#new-group-delay
+[7]: /monitors/configuration/#advanced-alert-conditions
+[8]: /monitors/configuration/#no-data
+[9]: /monitors/configuration/#auto-resolve
+[10]: /monitors/configuration/#new-group-delay
 [11]: /monitors/notify/

--- a/content/en/monitors/types/error_tracking.md
+++ b/content/en/monitors/types/error_tracking.md
@@ -66,7 +66,7 @@ Select **Web and Mobile Apps** from the dropdown menu. If you select **Backend S
 Triggers when the error count is `above` or `above or equal to`. An alert is triggered whenever a metric crosses a threshold.
 
 [1]: /real_user_monitoring/explorer/search/
-[2]: /monitors/create/configuration/#alert-grouping/
+[2]: /monitors/configuration/#alert-grouping/
 [3]: /tracing/trace_explorer/?tab=listview#filtering
 [4]: /logs/explorer/search/
 {{% /tab %}}
@@ -93,7 +93,7 @@ The monitor triggers when the number of errors is `above` or `above or equal to`
 [1]: /real_user_monitoring/explorer/?tab=measures#setup-facets-measures
 [2]: /real_user_monitoring/explorer/search/
 [3]: /tracing/trace_explorer/?tab=listview#filtering
-[4]: /monitors/create/configuration/#alert-grouping/
+[4]: /monitors/configuration/#alert-grouping/
 [5]: /logs/explorer/search/
 {{% /tab %}}
 {{< /tabs >}}
@@ -115,6 +115,6 @@ For more information about the **Notify your team** and **Say what’s happening
 [1]: /real_user_monitoring/
 [2]: /tracing/
 [3]: https://app.datadoghq.com/monitors/create/error-tracking
-[4]: /monitors/create/configuration/#advanced-alert-conditions
+[4]: /monitors/configuration/#advanced-alert-conditions
 [5]: /monitors/notify/
 [6]: /logs/

--- a/content/en/monitors/types/event.md
+++ b/content/en/monitors/types/event.md
@@ -25,7 +25,7 @@ Event monitors allow you to alert on events matching a search query.
 
 To create an [event monitor][1] in Datadog, navigate to **Monitors** > **New Monitor** > **Event**.
 
-<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 Event monitors per account. If you are encountering this limit, consider using <a href="/monitors/create/configuration/?tab=thresholdalert#alert-grouping">multi alerts</a>, or <a href="/help/">Contact Support</a>.</div>
+<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 Event monitors per account. If you are encountering this limit, consider using <a href="/monitors/configuration/?tab=thresholdalert#alert-grouping">multi alerts</a>, or <a href="/help/">Contact Support</a>.</div>
 
 ### Define the search query
 
@@ -85,5 +85,5 @@ The template variable is `{{event.tags.env}}`. The result of using this template
 [1]: https://app.datadoghq.com/monitors#create/event
 [2]: /events/explorer/#search-syntax
 [3]: /help/
-[4]: /monitors/create/configuration/#advanced-alert-conditions
+[4]: /monitors/configuration/#advanced-alert-conditions
 [5]: /monitors/notify/

--- a/content/en/monitors/types/forecasts.md
+++ b/content/en/monitors/types/forecasts.md
@@ -138,12 +138,12 @@ The following functions cannot be nested inside calls to the `forecast()` functi
 {{< partial name="whats-next/whats-next.html"  >}}
 
 [1]: https://app.datadoghq.com/monitors#create/forecast
-[2]: /monitors/create/types/metric/#define-the-metric
+[2]: /monitors/types/metric/#define-the-metric
 [3]: /monitors/guide/recovery-thresholds/
 [4]: /monitors/guide/how-to-update-anomaly-monitor-timezone/
 [5]: /dashboards/functions/rollup/
-[6]: /monitors/create/configuration/#advanced-alert-conditions
-[7]: /monitors/create/types/metric/#data-window
+[6]: /monitors/configuration/#advanced-alert-conditions
+[7]: /monitors/types/metric/#data-window
 [8]: /monitors/notify/
 [9]: /api/v1/monitors/#create-a-monitor
 [10]: /monitors/manage/status/#settings

--- a/content/en/monitors/types/host.md
+++ b/content/en/monitors/types/host.md
@@ -81,5 +81,5 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/monitors#create/host
-[2]: /monitors/create/configuration/#advanced-alert-conditions
+[2]: /monitors/configuration/#advanced-alert-conditions
 [3]: /monitors/notify/

--- a/content/en/monitors/types/integration.md
+++ b/content/en/monitors/types/integration.md
@@ -113,10 +113,10 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 
 [1]: /integrations/
 [2]: https://app.datadoghq.com/monitors#create/integration
-[3]: /monitors/create/types/metric/
+[3]: /monitors/types/metric/
 [4]: https://app.datadoghq.com/monitors/manage
-[5]: /monitors/create/configuration/#advanced-alert-conditions
-[6]: /monitors/create/configuration/#no-data
-[7]: /monitors/create/configuration/#auto-resolve
-[8]: /monitors/create/configuration/#new-group-delay
+[5]: /monitors/configuration/#advanced-alert-conditions
+[6]: /monitors/configuration/#no-data
+[7]: /monitors/configuration/#auto-resolve
+[8]: /monitors/configuration/#new-group-delay
 [9]: /monitors/notify/

--- a/content/en/monitors/types/log.md
+++ b/content/en/monitors/types/log.md
@@ -24,7 +24,7 @@ Once [log management is enabled][1] for your organization, you can create a logs
 
 To create a [logs monitor][3] in Datadog, use the main navigation: *Monitors --> New Monitor --> Logs*.
 
-<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 Log monitors per account. If you are encountering this limit, consider using <a href="/monitors/create/configuration/?tab=thresholdalert#alert-grouping">multi alerts</a>, or <a href="/help/">Contact Support</a>.</div>
+<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 Log monitors per account. If you are encountering this limit, consider using <a href="/monitors/configuration/?tab=thresholdalert#alert-grouping">multi alerts</a>, or <a href="/help/">Contact Support</a>.</div>
 
 ### Define the search query
 
@@ -111,5 +111,5 @@ Include a sample of 10 logs in the alert notification:
 [4]: /logs/explorer/search/
 [5]: /logs/explorer/facets/
 [6]: /logs/explorer/facets/#measures
-[7]: /monitors/create/configuration/#advanced-alert-conditions
+[7]: /monitors/configuration/#advanced-alert-conditions
 [8]: /monitors/notify/

--- a/content/en/monitors/types/metric.md
+++ b/content/en/monitors/types/metric.md
@@ -54,7 +54,7 @@ On each alert evaluation, Datadog calculates the percentage of the series that f
 
 For more detailed information, see the [Anomaly Monitor][1] page.
 
-[1]: /monitors/create/types/anomaly/
+[1]: /monitors/types/anomaly/
 {{% /tab %}}
 {{% tab "Outliers" %}}
 
@@ -64,7 +64,7 @@ On each alert evaluation, Datadog checks whether or not all groups are clustered
 
 For more detailed information, see the [Outlier Monitor][1] page.
 
-[1]: /monitors/create/types/outlier/
+[1]: /monitors/types/outlier/
 {{% /tab %}}
 {{% tab "Forecast" %}}
 
@@ -74,7 +74,7 @@ On each alert evaluation, a forecast alert predicts the future values of the met
 
 For more detailed information, see the [Forecast Monitor][1] page.
 
-[1]: /monitors/create/types/forecasts/
+[1]: /monitors/types/forecasts/
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -215,7 +215,7 @@ Note that if your metric is only reporting by `host` with no `device` tag, it wo
 [2]: /dashboards/querying/#advanced-graphing
 [3]: /monitors/guide/as-count-in-monitor-evaluations/
 [4]: /monitors/notify/?tab=is_alert#tag-variables
-[5]: /monitors/create/configuration/?tab=thresholdalert#evaluation-window
-[6]: /monitors/create/configuration/#advanced-alert-conditions
+[5]: /monitors/configuration/?tab=thresholdalert#evaluation-window
+[6]: /monitors/configuration/#advanced-alert-conditions
 [7]: /monitors/notify/
 [8]: /monitors/configuration/?tab=thresholdalert#notify-your-team

--- a/content/en/monitors/types/network.md
+++ b/content/en/monitors/types/network.md
@@ -95,9 +95,9 @@ Create a network metric monitor by following the instructions in the [metric mon
 [1]: /integrations/http_check/
 [2]: /integrations/tcp_check/
 [3]: https://app.datadoghq.com/monitors#create/network
-[4]: /monitors/create/configuration/#advanced-alert-conditions
-[5]: /monitors/create/configuration/#no-data
-[6]: /monitors/create/configuration/#auto-resolve
-[7]: /monitors/create/configuration/#new-group-delay
+[4]: /monitors/configuration/#advanced-alert-conditions
+[5]: /monitors/configuration/#no-data
+[6]: /monitors/configuration/#auto-resolve
+[7]: /monitors/configuration/#new-group-delay
 [8]: /monitors/notify/
 [9]: https://app.datadoghq.com/monitors/manage

--- a/content/en/monitors/types/outlier.md
+++ b/content/en/monitors/types/outlier.md
@@ -118,8 +118,8 @@ The outlier algorithms are set up to identify groups that are behaving different
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/monitors#create/outlier
-[2]: /monitors/create/types/metric/#define-the-metric
-[3]: /monitors/create/configuration/#advanced-alert-conditions
+[2]: /monitors/types/metric/#define-the-metric
+[3]: /monitors/configuration/#advanced-alert-conditions
 [4]: /monitors/notify/
 [5]: /api/v1/monitors/#create-a-monitor
 [6]: /monitors/manage/status/#settings

--- a/content/en/monitors/types/process.md
+++ b/content/en/monitors/types/process.md
@@ -64,5 +64,5 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 [2]: https://app.datadoghq.com/monitors#create/live_process
 [3]: /infrastructure/process/#search-syntax
 [4]: https://app.datadoghq.com/process
-[5]: /monitors/create/configuration/#advanced-alert-conditions
+[5]: /monitors/configuration/#advanced-alert-conditions
 [6]: /monitors/notify/

--- a/content/en/monitors/types/process_check.md
+++ b/content/en/monitors/types/process_check.md
@@ -86,8 +86,8 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 
 [1]: /integrations/process/
 [2]: https://app.datadoghq.com/monitors#create/process
-[3]: /monitors/create/configuration/#advanced-alert-conditions
-[4]: /monitors/create/configuration/#no-data
-[5]: /monitors/create/configuration/#auto-resolve
-[6]: /monitors/create/configuration/#new-group-delay
+[3]: /monitors/configuration/#advanced-alert-conditions
+[4]: /monitors/configuration/#no-data
+[5]: /monitors/configuration/#auto-resolve
+[6]: /monitors/configuration/#new-group-delay
 [7]: /monitors/notify/

--- a/content/en/monitors/types/real_user_monitoring.md
+++ b/content/en/monitors/types/real_user_monitoring.md
@@ -27,7 +27,7 @@ Once [Real User Monitoring (RUM) is enabled][1] for your organization, you can c
 
 To create a RUM monitor in Datadog, first navigate to [**Monitors** > **New Monitor** > **Real User Monitoring**][2].
 
-<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 RUM monitors per account. If you are encountering this limit, consider using <a href="/monitors/create/configuration/?tab=thresholdalert#alert-grouping">multi alerts</a>, or <a href="/help/">Contact Support</a>.</div>
+<div class="alert alert-info"><strong>Note</strong>: There is a default limit of 1000 RUM monitors per account. If you are encountering this limit, consider using <a href="/monitors/configuration/?tab=thresholdalert#alert-grouping">multi alerts</a>, or <a href="/help/">Contact Support</a>.</div>
 
 ### Define the search query
 
@@ -94,5 +94,5 @@ For more information about the **Say what's happening** and **Notify your team**
 [3]: /real_user_monitoring/explorer/search/
 [4]: /real_user_monitoring/explorer/?tab=facets#setup-facets-measures
 [5]: /real_user_monitoring/explorer/?tab=measures#setup-facets-measures
-[6]: /monitors/create/configuration/#advanced-alert-conditions
+[6]: /monitors/configuration/#advanced-alert-conditions
 [7]: /monitors/notify/

--- a/content/en/monitors/types/service_check.md
+++ b/content/en/monitors/types/service_check.md
@@ -100,8 +100,8 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 [4]: /api/v1/service-checks/
 [5]: /developers/service_checks/#overview
 [6]: https://app.datadoghq.com/monitors/create/custom
-[7]: /monitors/create/configuration/#advanced-alert-conditions
-[8]: /monitors/create/configuration/#no-data
-[9]: /monitors/create/configuration/#auto-resolve
-[10]: /monitors/create/configuration/#new-group-delay
+[7]: /monitors/configuration/#advanced-alert-conditions
+[8]: /monitors/configuration/#no-data
+[9]: /monitors/configuration/#auto-resolve
+[10]: /monitors/configuration/#new-group-delay
 [11]: /monitors/notify/

--- a/content/en/network_monitoring/devices/_index.md
+++ b/content/en/network_monitoring/devices/_index.md
@@ -88,5 +88,5 @@ The following vendor devices are supported with dedicated profiles. If a vendor/
 [2]: /network_monitoring/devices/snmp_metrics/#autodiscovery
 [3]: https://app.datadoghq.com/dash/integration/30409/datacenter-overview
 [4]: https://app.datadoghq.com/dash/integration/30417/interface-performance
-[5]: /monitors/create/types/metric/
+[5]: /monitors/types/metric/
 [6]: /network_monitoring/devices/troubleshooting#what-do-i-do-if-datadog-supports-a-vendor-or-device-type-but-my-specific-model-isnt-supported

--- a/content/en/real_user_monitoring/_index.md
+++ b/content/en/real_user_monitoring/_index.md
@@ -120,7 +120,7 @@ Access triggered logs, errors, and performance information when troubleshooting 
 
 [1]: /real_user_monitoring/dashboards/
 [2]: /real_user_monitoring/explorer/visualize/
-[3]: /monitors/create/types/real_user_monitoring/
+[3]: /monitors/types/real_user_monitoring/
 [4]: /real_user_monitoring/connect_rum_and_traces/
 [5]: /real_user_monitoring/error_tracking/
 [6]: /real_user_monitoring/browser/monitoring_page_performance/#core-web-vitals

--- a/content/en/real_user_monitoring/error_tracking/explorer.md
+++ b/content/en/real_user_monitoring/error_tracking/explorer.md
@@ -58,4 +58,4 @@ Each event generated is tagged with the version, the service, and the environmen
 
 
 [1]: /events
-[2]: /monitors/create/types/event/
+[2]: /monitors/types/event/

--- a/content/en/real_user_monitoring/explorer/export.md
+++ b/content/en/real_user_monitoring/explorer/export.md
@@ -45,5 +45,5 @@ Options available for some visualization types are not supported in others. For 
 [3]: /real_user_monitoring/explorer/
 [4]: https://docs.datadoghq.com/api/latest/rum/
 [5]: /dashboards/
-[6]: /monitors/create/types/real_user_monitoring/
+[6]: /monitors/types/real_user_monitoring/
 [7]: /notebooks/

--- a/content/en/real_user_monitoring/frustration_signals/_index.md
+++ b/content/en/real_user_monitoring/frustration_signals/_index.md
@@ -147,8 +147,8 @@ To provide feedback or submit a feature request, contact <a href="/help/">Datado
 [3]: /real_user_monitoring/dashboards/frustration_signals_dashboard/
 [4]: https://app.datadoghq.com/rum/explorer
 [5]: /dashboards/
-[6]: /monitors/create/
+[6]: /monitors/
 [7]: https://app.datadoghq.com/rum/replay/sessions/
 [8]: /real_user_monitoring/session_replay/
-[9]: /monitors/create/types/real_user_monitoring/
+[9]: /monitors/types/real_user_monitoring/
 [10]: mailto:success@datadoghq.com

--- a/content/en/real_user_monitoring/generate_metrics/_index.md
+++ b/content/en/real_user_monitoring/generate_metrics/_index.md
@@ -117,6 +117,6 @@ You can use RUM-based custom metrics for the following actions:
 [10]: /monitors/
 [11]: /metrics/distributions/
 [12]: /dashboards/querying/#configuring-a-graph
-[13]: /monitors/create/types/anomaly/
-[14]: /monitors/create/types/forecasts/
+[13]: /monitors/types/anomaly/
+[14]: /monitors/types/forecasts/
 [15]: /monitors/service_level_objectives/metric/

--- a/content/en/real_user_monitoring/guide/alerting-with-conversion-rates.md
+++ b/content/en/real_user_monitoring/guide/alerting-with-conversion-rates.md
@@ -55,4 +55,4 @@ With the applied query, you can customize alert conditions and set up notificati
 [1]: /real_user_monitoring/explorer/visualize/#funnel
 [2]: https://app.datadoghq.com/rum/explorer?viz=timeseries
 [3]: https://app.datadoghq.com/monitors/create/rum
-[4]: /monitors/create/types/real_user_monitoring/
+[4]: /monitors/types/real_user_monitoring/

--- a/content/en/real_user_monitoring/guide/alerting-with-rum.md
+++ b/content/en/real_user_monitoring/guide/alerting-with-rum.md
@@ -80,7 +80,7 @@ This example monitor warns when the LCP takes 2 seconds to load and alerts when 
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /monitors/create/types/real_user_monitoring/#create-a-rum-monitor
+[1]: /monitors/types/real_user_monitoring/#create-a-rum-monitor
 [2]: https://app.datadoghq.com/rum/explorer
 [3]: /real_user_monitoring/guide/send-rum-custom-actions/#create-facets-and-measures-on-your-new-attributes
 [4]: /real_user_monitoring/explorer/export/

--- a/content/en/real_user_monitoring/guide/monitor-your-rum-usage.md
+++ b/content/en/real_user_monitoring/guide/monitor-your-rum-usage.md
@@ -118,6 +118,6 @@ You are notified about the amount of sessions captured in any scope (such as the
 
 [1]: /account_management/billing/usage_metrics/
 [2]: https://app.datadoghq.com/dashboard/lists
-[3]: /monitors/create/types/anomaly/
+[3]: /monitors/types/anomaly/
 [4]: https://app.datadoghq.com/monitors#create/anomaly
 [5]: https://app.datadoghq.com/rum/explorer?query=%40type%3Asession

--- a/content/en/serverless/guide/datadog_forwarder_java.md
+++ b/content/en/serverless/guide/datadog_forwarder_java.md
@@ -200,20 +200,15 @@ If you are upgrading from 0.3.x to 1.4.x and you wish to use the `dd-trace-java`
 
 ```
 arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-java:4
-````
+```
 
-
-
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
 
 [2]: /serverless/forwarder/
 [3]: /serverless/enhanced_lambda_metrics
 [4]: https://img.shields.io/maven-central/v/com.datadoghq/datadog-lambda-java
 [5]: /logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/#collecting-logs-from-cloudwatch-log-group
 [6]: /serverless/insights#cold-starts
-[7]: /monitors/create/types/metric/?tab=threshold#overview
+[7]: /monitors/types/metric/?tab=threshold#overview
 [8]: /getting_started/tagging/unified_service_tagging/#aws-lambda-functions
 [9]: https://app.datadoghq.com/functions
 [10]: /serverless/custom_metrics?tab=java

--- a/content/en/synthetics/guide/monitor-usage.md
+++ b/content/en/synthetics/guide/monitor-usage.md
@@ -43,5 +43,5 @@ You can graph and monitor these metrics against static thresholds as well as use
 [2]: /synthetics/api_tests
 [3]: /synthetics/multistep
 [4]: /synthetics/browser_tests
-[5]: /monitors/create/types/anomaly/
-[6]: /monitors/create/types/forecasts
+[5]: /monitors/types/anomaly/
+[6]: /monitors/types/forecasts

--- a/content/en/synthetics/guide/using-synthetic-metrics.md
+++ b/content/en/synthetics/guide/using-synthetic-metrics.md
@@ -63,6 +63,6 @@ This guide demonstrates how to set up a metric monitor using a general metric su
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /synthetics/metrics/
-[2]: /monitors/create/types/metric/
+[2]: /monitors/types/metric/
 [3]: /synthetics/guide/synthetic-test-monitors/
 [4]: https://app.datadoghq.com/monitors/create/metric

--- a/content/en/tracing/glossary/_index.md
+++ b/content/en/tracing/glossary/_index.md
@@ -200,7 +200,7 @@ When child spans are concurrent, execution time is calculated by dividing the ov
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /monitors/create/types/apm/
+[1]: /monitors/types/apm/
 [2]: /developers/guide/data-collection-resolution-retention/
 [3]: /tracing/setup/
 [4]: /tracing/services/services_list/

--- a/content/en/tracing/guide/alert_anomalies_p99_database.md
+++ b/content/en/tracing/guide/alert_anomalies_p99_database.md
@@ -77,12 +77,12 @@ Datadog allows you to set monitors to keep track of the health of your services 
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /monitors/create/types/anomaly/
+[1]: /monitors/types/anomaly/
 [2]: https://app.datadoghq.com/monitors#/create
 [3]: https://app.datadoghq.com/monitors#create/apm
 [4]: /tracing/glossary/#resources
 [5]: /tracing/glossary/#services
-[6]: /monitors/create/types/anomaly/#faq
+[6]: /monitors/types/anomaly/#faq
 [7]: /monitors/notify/?tab=is_alertis_warning
 [8]: https://app.datadoghq.com/apm/services
 [9]: https://app.datadoghq.com/service/map

--- a/content/en/tracing/guide/trace_ingestion_volume_control.md
+++ b/content/en/tracing/guide/trace_ingestion_volume_control.md
@@ -143,7 +143,7 @@ Read more about ingestion reasons in the [Ingestion Mechanisms documentation][2]
 [3]: /tracing/metrics/metrics_namespace/
 [4]: /opentelemetry/guide/ingestion_sampling_with_opentelemetry/
 [5]: /tracing/trace_pipeline/generate_metrics/
-[6]: /monitors/create/types/apm/?tab=analytics
+[6]: /monitors/types/apm/?tab=analytics
 [7]: /tracing/trace_pipeline/ingestion_mechanisms/#head-based-sampling
 [8]: /tracing/trace_pipeline/metrics/
 [9]: /tracing/trace_pipeline/ingestion_mechanisms/#error-traces

--- a/content/en/tracing/services/service_page.md
+++ b/content/en/tracing/services/service_page.md
@@ -198,7 +198,7 @@ View common patterns in your service’s logs, and use facets like status in the
 
 [1]: /tracing/glossary/
 [2]: /tracing/services/resource_page/
-[3]: /monitors/create/types/apm/
+[3]: /monitors/types/apm/
 [4]: /tracing/error_tracking/
 [5]: /monitors/service_level_objectives/
 [6]: /monitors/incident_management/

--- a/content/en/tracing/trace_explorer/_index.md
+++ b/content/en/tracing/trace_explorer/_index.md
@@ -132,7 +132,7 @@ All spans indexed by custom retention filters (*not* the intelligent retention f
 From the timeseries view, export your query to a [dashboard][1], a [monitor][2] or a [notebook][3] to investigate further or to alert automatically when an aggregate number of spans crosses a specific threshold.
 
 [1]: /dashboards/widgets/timeseries/
-[2]: /monitors/create/types/apm/?tab=analytics
+[2]: /monitors/types/apm/?tab=analytics
 [3]: /notebooks
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/tracing/trace_explorer/facets.md
+++ b/content/en/tracing/trace_explorer/facets.md
@@ -126,7 +126,7 @@ Autocomplete based on the content in spans of the current views helps you to def
 
 [1]: /tracing/trace_explorer/query_syntax/
 [2]: /tracing/trace_explorer/group/
-[3]: /monitors/create/types/apm/?tab=analytics
+[3]: /monitors/types/apm/?tab=analytics
 [4]: /dashboards/widgets/
 [5]: /notebooks/
 [6]: /tracing/trace_explorer/

--- a/content/en/tracing/trace_explorer/query_syntax.md
+++ b/content/en/tracing/trace_explorer/query_syntax.md
@@ -307,7 +307,7 @@ Export [Analytics][4] from the trace search or build them directly in your [Dash
 [8]: /tracing/trace_search_and_analytics/query_syntax/#facets
 [9]: /tracing/trace_search_and_analytics/query_syntax/#measures
 [10]: /tracing/glossary/#trace
-[11]: /monitors/create/types/apm/
+[11]: /monitors/types/apm/
 [12]: /dashboards/#timeboards
 [13]: /help/
 [14]: /tracing/glossary/#indexed-span

--- a/content/en/tracing/trace_pipeline/generate_metrics.md
+++ b/content/en/tracing/trace_pipeline/generate_metrics.md
@@ -76,10 +76,10 @@ After a metric is created, only two fields can be updated:
 [1]: /tracing/trace_pipeline/trace_retention
 [2]: /account_management/billing/custom_metrics/
 [3]: https://docs.datadoghq.com/metrics/#overview
-[4]: /monitors/create/types/anomaly/#overview
+[4]: /monitors/types/anomaly/#overview
 [5]: /tracing/trace_explorer/
 [6]: /tracing/trace_explorer/query_syntax/#analytics-query
-[7]: /monitors/create/types/forecasts/
+[7]: /monitors/types/forecasts/
 [8]: https://app.datadoghq.com/apm/getting-started
 [9]: https://app.datadoghq.com/apm/traces/generate-metrics
 [10]: /tracing/trace_explorer/query_syntax/

--- a/content/en/universal_service_monitoring/_index.md
+++ b/content/en/universal_service_monitoring/_index.md
@@ -792,6 +792,6 @@ DD_SYSTEM_PROBE_NETWORK_HTTP_REPLACE_RULES=[{"pattern":"<drop regex>","repl":""}
 [1]: /getting_started/tagging/unified_service_tagging
 [2]: /tracing/services/deployment_tracking/
 [3]: /tracing/service_catalog/
-[4]: /monitors/create/types/apm/?tab=apmmetrics
+[4]: /monitors/types/apm/?tab=apmmetrics
 [5]: /dashboards/
 [6]: /monitors/service_level_objectives/metric/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- This is a follow up to the Monitor menu reorganization
- Cleaned up reference links within the docs to show the new monitor urls.

### Motivation
[DOCS-4503](https://datadoghq.atlassian.net/browse/DOCS-4503)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Ready to merge after review

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4503]: https://datadoghq.atlassian.net/browse/DOCS-4503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ