### PR TITLE
Update restrictions for HIPAA enabled customers

### DIFF
--- a/content/en/data_security/logs.md
+++ b/content/en/data_security/logs.md
@@ -39,7 +39,6 @@ Datadog will sign a Business Associate Agreement (BAA) with customers that trans
 These features are not available to customers who have signed Datadog's BAA:
 
 * Users cannot request support through chat.
-* Group-by dimensions are limited to host tags, source, service, and status for [Log-based Metrics][5].
 * Notifications from Log Monitors cannot include log samples.
 * You cannot configure Log Monitors with a `group-by` clause.
 * You cannot [share][6] logs, security signals, or traces from the explorer through web integrations.

--- a/content/en/data_security/logs.md
+++ b/content/en/data_security/logs.md
@@ -41,7 +41,7 @@ These features are not available to customers who have signed Datadog's BAA:
 * Users cannot request support through chat.
 * Notifications from Log Monitors cannot include log samples.
 * You cannot configure Log Monitors with a `group-by` clause.
-* You cannot [share][6] logs, security signals, or traces from the explorer through web integrations.
+* You cannot [share][5] logs, security signals, or traces from the explorer through web integrations.
 * Security rules cannot include triggering group-by values in notification title.
 * Security rules cannot include message template variables.
 * Security rules cannot be notified by webhooks.
@@ -97,5 +97,4 @@ All log submission endpoints are encrypted. These legacy endpoints are still sup
 [2]: /agent/logs/log_transport
 [3]: /agent/logs/advanced_log_collection/#filter-logs
 [4]: /agent/logs/advanced_log_collection/#scrub-sensitive-data-from-your-logs
-[5]: /logs/logs_to_metrics/
-[6]: /logs/explorer/#share-views
+[5]: /logs/explorer/#share-views


### PR DESCRIPTION
We have signed a new Business Associate Agreement that allows us to remove the restrictions on group-bys for Logs to Metrics

Changes to support this have been made in this [PR](https://github.com/DataDog/logs-backend/pull/46357)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes a restriction for HIPAA-enabled customers

### Motivation
Changes have been made to enable HIPAA-enabled customers to use any dimensions for group-by in Log-based Metrics. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
