### PR TITLE
Add documentation for DD_TRACE_CLIENT_IP_ENABLED

### DIFF
--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -115,7 +115,7 @@ Datadog may collect [environmental and diagnostic information about your system]
 
 `DD_TRACE_CLIENT_IP_ENABLED`
 : **Default**: `false` <br>
-Enables client IP collection from relevant IP headers in HTTP request spans.
+Enable client IP collection from relevant IP headers in HTTP request spans.
 Added in version 1.47.0 
 
 ## Configure APM environment name

--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -113,6 +113,10 @@ Dynamically rename services through configuration. Services can be separated by 
 : **Default**: `false` <br>
 Datadog may collect [environmental and diagnostic information about your system][6] to improve the product. When false, this telemetry data will not be collected.
 
+`DD_TRACE_CLIENT_IP_ENABLED`
+: **Default**: `false` <br>
+Enables client IP collection from relevant IP headers in HTTP request spans.
+Added in version 1.47.0 
 
 ## Configure APM environment name
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->


### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds documentation for `DD_TRACE_CLIENT_IP_ENABLED `environment variable for the Go Tracer

### Motivation
<!-- What inspired you to submit this pull request?-->

This flag should be documented for all tracers

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
