### PR TITLE
DOCS-4348 Cleanup Legacy Analytics Link

### DIFF
--- a/content/en/account_management/billing/usage_monitor_apm.md
+++ b/content/en/account_management/billing/usage_monitor_apm.md
@@ -45,5 +45,5 @@ Learn more about [retention filters][7].
 [3]: https://app.datadoghq.com/account/usage
 [4]: https://app.datadoghq.com/monitors#create/metric
 [5]: /monitors/types/apm/?tab=traceanalytics#monitor-creation
-[6]: https://app.datadoghq.com/apm/analytics
+[6]: https://app.datadoghq.com/apm/traces
 [7]: /tracing/trace_pipeline/trace_retention/

--- a/content/en/account_management/billing/usage_monitor_apm.md
+++ b/content/en/account_management/billing/usage_monitor_apm.md
@@ -45,5 +45,5 @@ Learn more about [retention filters][7].
 [3]: https://app.datadoghq.com/account/usage
 [4]: https://app.datadoghq.com/monitors#create/metric
 [5]: /monitors/types/apm/?tab=traceanalytics#monitor-creation
-[6]: https://app.datadoghq.com/apm/traces
+[6]: https://app.datadoghq.com/apm/traces?viz=timeseries
 [7]: /tracing/trace_pipeline/trace_retention/

--- a/content/en/tracing/guide/add_span_md_and_graph_it.md
+++ b/content/en/tracing/guide/add_span_md_and_graph_it.md
@@ -286,6 +286,6 @@ Finally, you can also see all the traces relevant to your query by clicking the 
 [5]: /tracing/glossary/#services
 [6]: https://app.datadoghq.com/apm/traces
 [7]: /tracing/trace_explorer/#live-search-for-15-minutes
-[8]: https://app.datadoghq.com/apm/traces
+[8]: https://app.datadoghq.com/apm/traces?viz=timeseries
 [9]: /tracing/trace_explorer/query_syntax/
 [10]: /tracing/guide/alert_anomalies_p99_database/

--- a/content/en/tracing/guide/add_span_md_and_graph_it.md
+++ b/content/en/tracing/guide/add_span_md_and_graph_it.md
@@ -286,6 +286,6 @@ Finally, you can also see all the traces relevant to your query by clicking the 
 [5]: /tracing/glossary/#services
 [6]: https://app.datadoghq.com/apm/traces
 [7]: /tracing/trace_explorer/#live-search-for-15-minutes
-[8]: https://app.datadoghq.com/apm/analytics
+[8]: https://app.datadoghq.com/apm/traces
 [9]: /tracing/trace_explorer/query_syntax/
 [10]: /tracing/guide/alert_anomalies_p99_database/

--- a/content/en/tracing/guide/apm_dashboard.md
+++ b/content/en/tracing/guide/apm_dashboard.md
@@ -130,5 +130,5 @@ This guides walks you through adding trace metrics to a dashboard, correlating t
 [1]: https://app.datadoghq.com/apm/services
 [2]: /dashboards/widgets/timeseries/
 [3]: /tracing/metrics/metrics_namespace/
-[4]: https://app.datadoghq.com/apm/analytics
+[4]: https://app.datadoghq.com/apm/traces
 [5]: /events/

--- a/content/en/tracing/guide/apm_dashboard.md
+++ b/content/en/tracing/guide/apm_dashboard.md
@@ -130,5 +130,5 @@ This guides walks you through adding trace metrics to a dashboard, correlating t
 [1]: https://app.datadoghq.com/apm/services
 [2]: /dashboards/widgets/timeseries/
 [3]: /tracing/metrics/metrics_namespace/
-[4]: https://app.datadoghq.com/apm/traces
+[4]: https://app.datadoghq.com/apm/traces?viz=timeseries
 [5]: /events/

--- a/content/en/tracing/guide/instrument_custom_method.md
+++ b/content/en/tracing/guide/instrument_custom_method.md
@@ -369,5 +369,5 @@ You've now successfully added custom spans to your codebase, making them availab
 
 [1]: https://app.datadoghq.com/apm/services
 [2]: https://bojanv91.github.io/posts/2018/06/select-n-1-problem
-[3]: https://app.datadoghq.com/apm/traces
+[3]: https://app.datadoghq.com/apm/traces?viz=timeseries
 [4]: /tracing/guide/add_span_md_and_graph_it/

--- a/content/en/tracing/guide/instrument_custom_method.md
+++ b/content/en/tracing/guide/instrument_custom_method.md
@@ -369,5 +369,5 @@ You've now successfully added custom spans to your codebase, making them availab
 
 [1]: https://app.datadoghq.com/apm/services
 [2]: https://bojanv91.github.io/posts/2018/06/select-n-1-problem
-[3]: https://app.datadoghq.com/apm/analytics
+[3]: https://app.datadoghq.com/apm/traces
 [4]: /tracing/guide/add_span_md_and_graph_it/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates links from the deprecated Analytics view to the Trace Explorer page.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-4348

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

[If you give a mouse a cookie...](https://www.youtube.com/watch?v=QCDPkGjMBro) 🍪

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
