### PR TITLE
adds new build artifact upload

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,7 +89,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-brian.deutsch_new_docs_artifact
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:brian.deutsch_new-docs-artifact
   tags:
     - "arch:amd64"
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,7 +89,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-brian.deutsch/new-docs-artifact
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-brian.deutsch_new-docs-artifact
   tags:
     - "arch:amd64"
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,7 +89,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-brian.deutsch/new_docs_artifact
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-brian.deutsch_new_docs_artifact
   tags:
     - "arch:amd64"
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,7 +89,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-brian.deutsch_new-docs-artifact
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-brian.deutsch/new-docs-artifact
   tags:
     - "arch:amd64"
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,7 +89,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-12899749
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-brian.deutsch_new-docs-artifact
   tags:
     - "arch:amd64"
   rules:
@@ -122,6 +122,7 @@ build_preview:
     - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
     - yarn run prebuild
     - build_site
+    - in-isolation create_artifact_cached
     # remove service_checks json as we don't need to s3 push that..
     - rm -rf data/service_checks
     - in-isolation deploy_site > logs/deploy.txt
@@ -259,6 +260,7 @@ build_live:
     - in-isolation deploy_site
     - in-isolation create_artifact
     - in-isolation create_artifact_ignored
+    - in-isolation create_artifact_cached
     - remove_static_from_repo
   artifacts:
     when: on_success

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,7 +122,6 @@ build_preview:
     - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
     - yarn run prebuild
     - build_site
-    - in-isolation create_artifact_cached
     # remove service_checks json as we don't need to s3 push that..
     - rm -rf data/service_checks
     - in-isolation deploy_site > logs/deploy.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,7 +89,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:brian.deutsch_new-docs-artifact
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-13672312
   tags:
     - "arch:amd64"
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,7 +89,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-brian.deutsch_new-docs-artifact
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-brian.deutsch/new_docs_artifact
   tags:
     - "arch:amd64"
   rules:


### PR DESCRIPTION
### What does this PR do?
- points gitlab to latest build image
- adds `create_artifact_cached` to live build process

`create_artifact_cached` is needed for the build caching we intend to test out in preview soon.

### Motivation
making the preview build more performant

### Preview
no UI changes here

verifying changes:
- latest build ran the job without issues: https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/234349582#L810

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
