### PR TITLE
add section on faulty deployment notification

### DIFF
--- a/content/en/tracing/services/deployment_tracking.md
+++ b/content/en/tracing/services/deployment_tracking.md
@@ -38,6 +38,13 @@ You can scope the errors widget to:
 
 Requests and Errors widgets can both be exported to dashboards and monitors.
 
+## Using version tags for automatic faulty deployment detection
+
+Configuring your services with `version` tag enables [Automatic Faulty Deployment Detection][4]. 
+
+You can set up a monitor to get automatically notified on all potentially faulty deployments. To do so, navigate to the New Monitors page and choose Events, and include `tags:deployment_analysis` in the search query defining the monitor.
+
+
 ## Versions deployed
 
 A service configured with `version` tags has a version section on its Service page, below the main service health graphs. The version section shows all versions of the service that were active during the selected time interval, with active services at the top.
@@ -224,3 +231,4 @@ Max time between deployments:
 [1]: /getting_started/tagging/unified_service_tagging/
 [2]: /metrics/types/?tab=distribution#metric-types
 [3]: /tracing/guide/setting_primary_tags_to_scope/#add-a-second-primary-tag-in-datadog
+[4]: /watchdog/faulty_deployment_detection/

--- a/content/en/tracing/services/deployment_tracking.md
+++ b/content/en/tracing/services/deployment_tracking.md
@@ -40,7 +40,7 @@ Requests and Errors widgets can both be exported to dashboards and monitors.
 
 ## Using version tags for automatic faulty deployment detection
 
-Configuring your services with `version` tag enables [Automatic Faulty Deployment Detection][4]. 
+Configuring your services with the `version` tag enables [Automatic Faulty Deployment Detection][4]. 
 
 You can set up a monitor to get automatically notified on all potentially faulty deployments. To do so, navigate to the New Monitors page and choose Events, and include `tags:deployment_analysis` in the search query defining the monitor.
 


### PR DESCRIPTION
added mentions of automatic faulty deployment notification and linking watchdog documentation.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
