### PR TITLE
Add a note about hostname aliases to the FAQ

### DIFF
--- a/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
+++ b/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
@@ -54,6 +54,8 @@ See the list of all hosts in your account from the [Infrastructure List][4]. The
 
 {{< img src="agent/faq/host_aliases.png" alt="Host aliases"  >}}
 
+**Note:** it's NOT possible to search or filter using these aliases, they are only available in the inspect panel mentioned above.
+
 ## Agent versions
 
 There are differences in hostname resolution between Agent v5 and Agent v6.

--- a/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
+++ b/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
@@ -54,7 +54,7 @@ See the list of all hosts in your account from the [Infrastructure List][4]. The
 
 {{< img src="agent/faq/host_aliases.png" alt="Host aliases"  >}}
 
-**Note:** it's NOT possible to search or filter using these aliases, they are only available in the inspect panel mentioned above.
+**Note**: These aliases are not available for searching or filtering. They are available only in the inspect panel mentioned above.
 
 ## Agent versions
 


### PR DESCRIPTION
### What does this PR do?

Add a note clarifying that it's not possible to search or filter using hostname aliases.

### Motivation

I'm in the process of setting up the Datadog agent for some EC2 instances, and I wasted some time because I was searching for a host by using one of its hostname aliases and couldn't find it. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
