### PR TITLE
Add link to Event Mapper APIs for React Native

### DIFF
--- a/content/en/data_security/real_user_monitoring.md
+++ b/content/en/data_security/real_user_monitoring.md
@@ -51,6 +51,7 @@ The data we track automatically contains primarily technical information, much o
 - [iOS][2]
 - [Android][3]
 - [Flutter][4]
+- [React Native][16]
 
 ### Transmit RUM events through a proxy server
 You can transmit all RUM events through your own [proxy server][15] so that end user devices never directly communicate with Datadog.
@@ -123,3 +124,4 @@ See [privacy options specific to Session Replay][12].
 [13]: https://www.datadoghq.com/privacy/
 [14]: /real_user_monitoring/explorer/search/
 [15]: /real_user_monitoring/guide/proxy-rum-data/?tab=npm
+[16]: /real_user_monitoring/reactnative/advanced_configuration/#modify-or-drop-rum-events


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
