### PR TITLE
[WEB-3124] Flaky anchors on Chrome

### DIFF
--- a/assets/scripts/components/table-of-contents.js
+++ b/assets/scripts/components/table-of-contents.js
@@ -2,7 +2,7 @@ let sidenavMapping = [];
 // let apiNavMapping = [];
 
 // fixes Chrome issue where pages with hash params are not scrolling to anchor
-document.addEventListener('DOMContentLoaded', function () {
+window.addEventListener('load', function () {
     const isChrome = /Chrome/.test(navigator.userAgent);
     if (window.location.hash && isChrome) {
         setTimeout(function () {


### PR DESCRIPTION
### What does this PR do?
Anchor links often aren't scrolling to the appropriate position on Chrome browser on first page load. While a fix had been implemented previously, it doesn't seem to be consistent. 

### Motivation
https://datadoghq.atlassian.net/browse/WEB-3124

### Preview 
https://docs-staging.datadoghq.com/nsollecito/web-3124/tracing/trace_collection/compatibility/nodejs/#web-framework-compatibility

vs: 
https://docs.datadoghq.com/tracing/trace_collection/compatibility/nodejs/#web-framework-compatibility

### Additional Notes
Make sure functionality is working in all major browsers and mobile. Not 100% this is going to work because I'm seeing different behavior in the dev environment vs the live site and it's difficult to reproduce outside of the live environment. It does seem more susceptible on links to the site in a new session/window/tab

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
