### PR TITLE
Updated tracer version to 1.10.0

### DIFF
--- a/content/en/tracing/trace_collection/library_injection.md
+++ b/content/en/tracing/trace_collection/library_injection.md
@@ -115,8 +115,7 @@ template:
   -  ...
 ```
 
-To find a list of tracer versions for each language, check the releases page in the tracer source repositories:
-
+To find a list of tracer versions for each language, check the releases in the source repositories:
 - [Java][17]
 - [Javascript][18]
 - [Python][19]

--- a/content/en/tracing/trace_collection/library_injection.md
+++ b/content/en/tracing/trace_collection/library_injection.md
@@ -93,6 +93,8 @@ The available library versions are listed in each container registry.
 
 **Note**: If you already have an application instrumented using version X of the library, and then use library injection to instrument using version Y of the same tracer library, the tracer does not break. Rather, the library version loaded first is used. Because library injection happens at the admission controller level prior to runtime, it takes precedent over manually configured libraries.
 
+INSERT LINK TO VARIOUS REPOS FOR TRACING CLIENT
+
 <div class="alert alert-warning"><strong>Note</strong>: Using the <code>latest</code> tag is supported, but use it with caution because major library releases can introduce breaking changes.</div>
 
 For example:
@@ -109,7 +111,7 @@ template:
     labels:
         admission.datadoghq.com/enabled: "true" # Enable Admission Controller to mutate new pods in this deployment
     annotations:
-        admission.datadoghq.com/java-lib.version: "v0.114.0" # Enable Java instrumentation (version 0.114.0) injection
+        admission.datadoghq.com/java-lib.version: "v1.10.0" # Enable Java instrumentation (version 1.10.0) injection
   containers:
   -  ...
 ```
@@ -150,7 +152,7 @@ template:
         tags.datadoghq.com/version: "1.1" # Unified service tag - Pod Version tag
         admission.datadoghq.com/enabled: "true" # Enable Admission Controller to mutate new pods part of this deployment
     annotations:
-        admission.datadoghq.com/java-lib.version: "v0.114.0" # Enable Java instrumentation (version 0.114.0) injection
+        admission.datadoghq.com/java-lib.version: "v1.10.0" # Enable Java instrumentation (version 1.10.0) injection
   containers:
   -  ...
 ```

--- a/content/en/tracing/trace_collection/library_injection.md
+++ b/content/en/tracing/trace_collection/library_injection.md
@@ -93,8 +93,6 @@ The available library versions are listed in each container registry.
 
 **Note**: If you already have an application instrumented using version X of the library, and then use library injection to instrument using version Y of the same tracer library, the tracer does not break. Rather, the library version loaded first is used. Because library injection happens at the admission controller level prior to runtime, it takes precedent over manually configured libraries.
 
-INSERT LINK TO VARIOUS REPOS FOR TRACING CLIENT
-
 <div class="alert alert-warning"><strong>Note</strong>: Using the <code>latest</code> tag is supported, but use it with caution because major library releases can introduce breaking changes.</div>
 
 For example:
@@ -111,7 +109,7 @@ template:
     labels:
         admission.datadoghq.com/enabled: "true" # Enable Admission Controller to mutate new pods in this deployment
     annotations:
-        admission.datadoghq.com/java-lib.version: "v1.10.0" # Enable Java instrumentation (version 1.10.0) injection
+        admission.datadoghq.com/java-lib.version: "v{{< tracer-version >}}" # Enable Java instrumentation (version {{< tracer-version >}}) injection
   containers:
   -  ...
 ```
@@ -152,7 +150,7 @@ template:
         tags.datadoghq.com/version: "1.1" # Unified service tag - Pod Version tag
         admission.datadoghq.com/enabled: "true" # Enable Admission Controller to mutate new pods part of this deployment
     annotations:
-        admission.datadoghq.com/java-lib.version: "v1.10.0" # Enable Java instrumentation (version 1.10.0) injection
+        admission.datadoghq.com/java-lib.version: "{{< tracer-version >}}" # Enable Java instrumentation (version {{< tracer-version >}}) injection
   containers:
   -  ...
 ```
@@ -270,7 +268,7 @@ For more information about configuring `BLOB` or `LOCAL` settings, see [Supplyin
 
 <a id="supplying-configuration-source-host"></a>
 
-### Supplying configuration source 
+### Supplying configuration source
 
 If you specify `BLOB` or `LOCAL` configuration source, create a JSON or YAML file at `etc/<APP_NAME>/config.json` or `.yaml`, and provide the configuration either as JSON:
 
@@ -311,8 +309,8 @@ health_metrics_enabled: true
 runtime_metrics_enabled: true
 tracing_sampling_rate: 1.0
 tracing_rate_limit: 1
-tracing_tags: 
-- a=b 
+tracing_tags:
+- a=b
 - foo
 tracing_service_mapping:
 - from_key: mysql
@@ -399,7 +397,7 @@ Any newly started processes are intercepted and the specified instrumentation li
 
 ## Requirements
 
-- A recent [Datadog Agent v7][1] installation 
+- A recent [Datadog Agent v7][1] installation
 - [Docker Engine][2]
 
 **Note**: Injection on arm64, and injection with `musl` on Alpine Linux container images are not supported.
@@ -446,7 +444,7 @@ output_paths:
 For more information about configuring `BLOB` or `LOCAL` settings, see [Supplying configuration source](#supplying-configuration-source-hc).
 
 `library_inject`
-: Set to `false` to disable library injection altogether.<br> 
+: Set to `false` to disable library injection altogether.<br>
 **Default**: `true`
 
 `log_level`
@@ -503,8 +501,8 @@ health_metrics_enabled: true
 runtime_metrics_enabled: true
 tracing_sampling_rate: 1.0
 tracing_rate_limit: 1
-tracing_tags: 
-- a=b 
+tracing_tags:
+- a=b
 - foo
 tracing_service_mapping:
 - from_key: mysql
@@ -651,7 +649,7 @@ config_sources: BASIC
 For more information about configuring `BLOB` or `LOCAL` settings, see [Supplying configuration source](#supplying-configuration-source-c).
 
 `library_inject`
-: Set to `false` to disable library injection altogether.<br> 
+: Set to `false` to disable library injection altogether.<br>
 **Default**: `true`
 
 `log_level`
@@ -667,7 +665,7 @@ Optional: `env`
 
 <a id="supplying-configuration-source-c"></a>
 
-### Supplying configuration source 
+### Supplying configuration source
 
 If you specify `BLOB` or `LOCAL` configuration source, create a JSON or YAML file there, and provide the configuration either as JSON:
 
@@ -708,8 +706,8 @@ health_metrics_enabled: true
 runtime_metrics_enabled: true
 tracing_sampling_rate: 1.0
 tracing_rate_limit: 1
-tracing_tags: 
-- a=b 
+tracing_tags:
+- a=b
 - foo
 tracing_service_mapping:
 - from_key: mysql

--- a/content/en/tracing/trace_collection/library_injection.md
+++ b/content/en/tracing/trace_collection/library_injection.md
@@ -89,8 +89,10 @@ To select your pods for library injection, annotate them with the following, cor
 | JavaScript | `admission.datadoghq.com/js-lib.version: "<lib-version>"`     |
 | Python     | `admission.datadoghq.com/python-lib.version: "<lib-version>"` |
 
-The available library versions are listed in each container registry:
-
+The available library versions are listed in each container registry, as well as in the tracer source repositories for each language:
+- [Java][17]
+- [Javascript][18]
+- [Python][19]
 
 **Note**: If you already have an application instrumented using version X of the library, and then use library injection to instrument using version Y of the same tracer library, the tracer does not break. Rather, the library version loaded first is used. Because library injection happens at the admission controller level prior to runtime, it takes precedent over manually configured libraries.
 
@@ -114,11 +116,6 @@ template:
   containers:
   -  ...
 ```
-
-To find a list of tracer versions for each language, check the releases in the source repositories:
-- [Java][17]
-- [Javascript][18]
-- [Python][19]
 
 ### Step 3 - Tag your pods with Unified Service Tags
 

--- a/content/en/tracing/trace_collection/library_injection.md
+++ b/content/en/tracing/trace_collection/library_injection.md
@@ -89,13 +89,14 @@ To select your pods for library injection, annotate them with the following, cor
 | JavaScript | `admission.datadoghq.com/js-lib.version: "<lib-version>"`     |
 | Python     | `admission.datadoghq.com/python-lib.version: "<lib-version>"` |
 
-The available library versions are listed in each container registry.
+The available library versions are listed in each container registry:
+
 
 **Note**: If you already have an application instrumented using version X of the library, and then use library injection to instrument using version Y of the same tracer library, the tracer does not break. Rather, the library version loaded first is used. Because library injection happens at the admission controller level prior to runtime, it takes precedent over manually configured libraries.
 
 <div class="alert alert-warning"><strong>Note</strong>: Using the <code>latest</code> tag is supported, but use it with caution because major library releases can introduce breaking changes.</div>
 
-For example:
+For example, to inject a Java library:
 
 ```yaml
 apiVersion: apps/v1
@@ -109,10 +110,16 @@ template:
     labels:
         admission.datadoghq.com/enabled: "true" # Enable Admission Controller to mutate new pods in this deployment
     annotations:
-        admission.datadoghq.com/java-lib.version: "v{{< tracer-version >}}" # Enable Java instrumentation (version {{< tracer-version >}}) injection
+        admission.datadoghq.com/java-lib.version: "<TRACER VERSION>"
   containers:
   -  ...
 ```
+
+To find a list of tracer versions for each language, check the releases page in the tracer source repositories:
+
+- [Java][17]
+- [Javascript][18]
+- [Python][19]
 
 ### Step 3 - Tag your pods with Unified Service Tags
 
@@ -150,7 +157,7 @@ template:
         tags.datadoghq.com/version: "1.1" # Unified service tag - Pod Version tag
         admission.datadoghq.com/enabled: "true" # Enable Admission Controller to mutate new pods part of this deployment
     annotations:
-        admission.datadoghq.com/java-lib.version: "{{< tracer-version >}}" # Enable Java instrumentation (version {{< tracer-version >}}) injection
+        admission.datadoghq.com/java-lib.version: "<TRACER VERSION>"
   containers:
   -  ...
 ```
@@ -172,8 +179,6 @@ Or run `kubectl describe pod <my-pod>` to see the `datadog-lib-init` init contai
 
 The instrumentation also starts sending telemetry to Datadog (for example, traces to [APM][15]).
 
-
-
 [1]: /containers/cluster_agent/admission_controller/
 [2]: /tracing/trace_collection/
 [3]: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/
@@ -190,6 +195,9 @@ The instrumentation also starts sending telemetry to Datadog (for example, trace
 [14]: /getting_started/tagging/unified_service_tagging/
 [15]: https://app.datadoghq.com/apm/traces
 [16]: /tracing/trace_collection/library_config/
+[17]: https://github.com/DataDog/dd-trace-java/releases
+[18]: https://github.com/DataDog/dd-trace-js/releases
+[19]: https://github.com/DataDog/dd-trace-py/releases
 
 {{% /tab %}}
 

--- a/layouts/shortcodes/tracer-version.html
+++ b/layouts/shortcodes/tracer-version.html
@@ -1,0 +1,5 @@
+<!--
+    Output the latest tracer version.
+    These version numbers are updated by the ____ team.
+-->
+{{- "1.10.0" -}}

--- a/layouts/shortcodes/tracer-version.html
+++ b/layouts/shortcodes/tracer-version.html
@@ -1,5 +1,0 @@
-<!--
-    Output the latest tracer version.
-    These version numbers are updated by the ____ team.
--->
-{{- "1.10.0" -}}


### PR DESCRIPTION
Docs were written a while back and were referencing a version of the tracing client that was released Oct 2022. I've updated to the latest version of the java tracer. This however is only a short term measure. The prospect should always be using the latest/greatest of the tracing clients for better support/performance etc. 

I also added - INSERT LINK TO VARIOUS REPOS FOR TRACING CLIENT. It would be good to have a clear link to the dd-trace-java or the other repos so the customer can go look at the versions they may be most interested in.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
