### PR TITLE
Update library_injection.md

### DIFF
--- a/content/en/tracing/trace_collection/library_injection.md
+++ b/content/en/tracing/trace_collection/library_injection.md
@@ -614,7 +614,7 @@ Any newly started processes are intercepted and the specified instrumentation li
    enabled=1
    gpgcheck=1
    repo_gpgcheck=1
-   gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.publichttps://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.publichttps://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+   gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
    ```
    **Note**: Due to a [bug in dnf][5], on RedHat/CentOS 8.1 set `repo_gpgcheck=0` instead of `1`.
 


### PR DESCRIPTION
Fix small type in configuration for centos container-only

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

It fixes the value assigned to gpgkey when adding the datadog repository manually on Centos/RedHat/Fedora.

### Motivation

Was duplicating steps for a customer who is using Fedora and ran into this.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
