### PR TITLE
Update CI to report more granular metrics

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,7 +90,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-devin.ford_ci-pass-step
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-13808246
   tags:
     - "arch:amd64"
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,7 @@ before_script:
   - export BRANCH=${CI_COMMIT_REF_NAME}
   - git config --global url."https://${GITHUB_TOKEN}@github.com/DataDog".insteadOf https://github.com/DataDog
   - type build_dogrc &>/dev/null && build_dogrc || echo "build_dogrc not found." # create .dogrc for metrics, events submission
+  - export job_start=$(date +%s) # we need the start of each job recorded for the ci reporting
 
 
 # set policy for the common case
@@ -89,7 +90,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-13791412
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-devin.ford_ci-pass-step
   tags:
     - "arch:amd64"
   rules:
@@ -128,6 +129,7 @@ build_preview:
     # remove static images so we can skip from artifact passed in gitlab
     - remove_static_from_repo
     - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_REF_NAME}> is ready for preview. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." "#31b834"
+    - ci_pass_step "${CI_PROJECT_NAME}-${CI_JOB_NAME}" # run at completion of job, if job fails at any point prior this won't run
   artifacts:
     paths:
       - ${ARTIFACT_RESOURCE}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -263,6 +263,7 @@ build_live:
     - in-isolation create_artifact_ignored
     - in-isolation create_artifact_cached
     - remove_static_from_repo
+    - ci_pass_step "${CI_PROJECT_NAME}-${CI_JOB_NAME}" # run at completion of job, if job fails at any point prior this won't run
   artifacts:
     when: on_success
     paths:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a new function to the CI to allow better metrics in the app to get insight into the average time
### Motivation
<!-- What inspired you to submit this pull request?-->
We want to keep more granular track of how long things are taking
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Not really much to test on the site it's self

[Docs Preview Job](https://gitlab.ddbuild.io/DataDog/documentation/-/pipelines/13808474)
[Metrics Dashboard](https://dd-corpsite.datadoghq.com/dashboard/4jg-n7c-9kt/pipeline-durations?from_ts=1677783347223&to_ts=1677786947223&live=true) - depending on when you check this, you may need to update the time. The Function times will be a bit messy since the old metric definitions are running on all other branches, but you should look for any function listed that ends with _preview

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
