### PR TITLE
[NET-3053] update docs to include npm domain discovery for azure

### DIFF
--- a/content/en/network_monitoring/performance/guide/_index.md
+++ b/content/en/network_monitoring/performance/guide/_index.md
@@ -12,4 +12,5 @@ disable_toc: true
     {{< nextlink href="network_monitoring/performance/guide/detecting_a_network_outage" >}}Detecting a Network Outage{{< /nextlink >}}
     {{< nextlink href="network_monitoring/performance/guide/aws_supported_services/" >}}NPM AWS Supported Services{{< /nextlink >}}
     {{< nextlink href="network_monitoring/performance/guide/gcp_supported_services/" >}}NPM GCP Supported Services{{< /nextlink >}}
+    {{< nextlink href="network_monitoring/performance/guide/azure_supported_services/" >}}NPM Azure Supported Services{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/network_monitoring/performance/guide/azure_supported_services.md
+++ b/content/en/network_monitoring/performance/guide/azure_supported_services.md
@@ -1,0 +1,20 @@
+---
+title: NPM Azure Supported Services
+kind: guide
+npm_provider: azure
+further_reading:
+  - link: 'https://www.datadoghq.com/blog/network-performance-monitoring'
+    tag: 'Blog'
+    text: 'Network Performance Monitoring'
+  - link: '/network_monitoring/devices'
+    tag: 'Documentation'
+    text: 'Network Device Monitoring'
+---
+
+Datadog Network Performance Monitoring (NPM) automatically detects API calls to Azure Blob Storage, Cosmos, Postgres and other Azure services listed below:
+
+{{< get-npm-integrations "azure" >}}
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -471,7 +471,7 @@ class Integrations:
 
             new_file_name = "{}aws.json".format(self.data_npm_dir)
 
-        elif file_name.endswith("gcp_services.go"):
+        elif file_name.endswith("gcp_services.go") or file_name.endswith("azure_services.go"):
 
             with open(file_name) as fh:
 
@@ -482,7 +482,10 @@ class Integrations:
                         integration = line.split('"')[3]
                         dict_npm[integration] = {"name": integration}
 
-            new_file_name = "{}gcp.json".format(self.data_npm_dir)
+            if file_name.endswith("gcp_services.go"):
+                new_file_name = "{}gcp.json".format(self.data_npm_dir)
+            elif file_name.endswith("azure_services.go"):
+                new_file_name = "{}azure.json".format(self.data_npm_dir)
 
         if new_file_name != "":
             with open(
@@ -774,7 +777,7 @@ class Integrations:
                 self.regex_partial_close, "", result, 0
             )
             result = re.sub(
-                self.regex_site_region, r"{{% \1 %}}", result, 0   
+                self.regex_site_region, r"{{% \1 %}}", result, 0
             )
 
         # if __init__.py exists lets grab the integration id

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -53,6 +53,8 @@
       globs:
       # https://github.com/DataDog/dd-go/blob/prod/networks/model/domain/gcp_services.go
       - networks/model/domain/gcp_services.go
+      # https://github.com/DataDog/dd-go/blob/prod/networks/model/domain/azure_services.go
+      - networks/model/domain/azure_services.go
 
   - repo_name: dogweb
 

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -54,6 +54,8 @@
       globs:
       # https://github.com/DataDog/dd-go/blob/prod/networks/model/domain/gcp_services.go
       - networks/model/domain/gcp_services.go
+      # https://github.com/DataDog/dd-go/blob/prod/networks/model/domain/azure_services.go
+      - networks/model/domain/azure_services.go
 
   - repo_name: dogweb
 

--- a/local/bin/py/build/update_pre_build.py
+++ b/local/bin/py/build/update_pre_build.py
@@ -52,18 +52,18 @@ class Build:
     # Build the documentation by injecting content from other repository.
     def build_documentation(self, list_of_contents):
 
-        # Instanciation of the integrations class since it's needed for content management below.
+        # Instantiation of the integrations class since it's needed for content management below.
         Int = Integrations(self.options.source, self.tempdir,
                            self.integration_mutations)
 
-        # Depending of the action attached to the content the proper function is called
+        # Depending on the action attached to the content the proper function is called
         for content in list_of_contents:
             try:
                 if content["action"] == "integrations":
                     Int.process_integrations(content)
                 elif content["action"] == "marketplace-integrations":
                     Int.process_integrations(content, marketplace=True)
-                elif (content["action"] == "pull-and-push-folder"):
+                elif content["action"] == "pull-and-push-folder":
                     pull_and_push_folder(content, self.content_dir)
                 elif content["action"] == "npm-integrations":
                     Int.process_integrations(content)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds a page describing NPMs support for automatic service tagging from domain for **Azure**. It was already supported/documented for GCP/AWS

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/browse/NET-3053

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
