### PR TITLE
[CIAPP-5990] Removing pull_request trigger limitation for test summaries

### DIFF
--- a/content/en/continuous_integration/guides/pull_request_comments.md
+++ b/content/en/continuous_integration/guides/pull_request_comments.md
@@ -27,8 +27,6 @@ This integration is only available for test services hosted on `github.com`.
 
 ## Install the GitHub integration
 
-<div class="alert alert-info">The integration is not available for GitHub Actions when triggered by the <code>pull_request*</code> event. </div>
-
 To install the [GitHub integration][1]:
 
 1. Navigate to the **Configuration** tab on the [GitHub integration tile][2] and click **+ Create GitHub App**.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Removes pull_request trigger limitation for test summaries

### Motivation
<!-- What inspired you to submit this pull request?-->
We now added support for pull_request triggers

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
