### PR TITLE
[content/en/opentelemetry] Guide on how to use delta temporality

### DIFF
--- a/content/en/metrics/open_telemetry/otlp_metric_types.md
+++ b/content/en/metrics/open_telemetry/otlp_metric_types.md
@@ -8,6 +8,9 @@ further_reading:
     - link: 'tracing/trace_collection/open_standards/'
       tag: 'Documentation'
       text: 'Learn more about OpenTelemetry'
+    - link: '/opentelemetry/guide/otlp_delta_temporality/'
+      tag: 'Guide'
+      text: 'Producing delta temporality metrics with OpenTelemetry'
 aliases:
   - /metrics/otlp
 ---
@@ -32,7 +35,7 @@ A single OTLP metric may be mapped to several Datadog metrics with a suffix indi
 
 **Note**: OpenTelemetry provides metric API instruments (`Gauge`, `Counter`, `UpDownCounter`, `Histogram`, and so on), whose measurements can be exported as OTLP metrics (Sum, Gauge, Histogram). Other sources for OTLP metrics are possible. Applications and libraries may provide customization into the OTLP metrics they produce. Read the documentation of your OpenTelemetry SDK or OTLP-producing application to understand the OTLP metrics produced and how to customize them.
 
-**Note**: OpenTelemetry protocol supports two ways of representing metrics in time: [Cumulative and Delta temporality][2], affecting the metrics described below. Set the temporality preference of the OTel implementation to **DELTA**, because setting it to CUMULATIVE may discard some data points during application (or collector) startup.  
+**Note**: OpenTelemetry protocol supports two ways of representing metrics in time: [Cumulative and Delta temporality][2], affecting the metrics described below. Set the temporality preference of the OTel implementation to **DELTA**, because setting it to CUMULATIVE may discard some data points during application (or collector) startup. For more information, read [Producing Delta Temporality Metrics with OpenTelemetry][3].
 
 ## Metric types
 
@@ -217,3 +220,4 @@ Suppose you are submitting a legacy OTLP Summary metric, `request.response_time.
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#resource-detection-processor
 [2]: https://opentelemetry.io/docs/reference/specification/metrics/data-model/#temporality
+[3]: /opentelemetry/guide/otlp_delta_temporality/

--- a/content/en/opentelemetry/guide/_index.md
+++ b/content/en/opentelemetry/guide/_index.md
@@ -10,4 +10,5 @@ aliases:
 
 {{< whatsnext desc="OpenTelemetry Guides" >}}
     {{< nextlink href="/opentelemetry/guide/ingestion_sampling_with_opentelemetry/" >}}Ingestion Sampling with OpenTelemetry{{< /nextlink >}}
+    {{< nextlink href="/opentelemetry/guide/otlp_delta_temporality/" >}}Producing Delta Temporality Metrics with OpenTelemetry{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/opentelemetry/guide/otlp_delta_temporality.md
+++ b/content/en/opentelemetry/guide/otlp_delta_temporality.md
@@ -1,5 +1,5 @@
 ---
-title: Producing delta temporality metrics with OpenTelemetry
+title: Producing Delta Temporality Metrics with OpenTelemetry
 kind: guide
 further_reading:
 - link: "/metrics/open_telemetry/otlp_metric_types"
@@ -12,20 +12,22 @@ further_reading:
 
 ## Overview
 
-The OpenTelemetry protocol (OTLP) can send [several metric types][1] some of which can have *delta* of *cumulative* [aggregation temporality][2]. Datadog products work best with delta aggregation temporality for monotonic sums, histograms, and exponential histograms. You can select which aggregation temporality to export your metrics with on your OpenTelemetry SDK or use the [OpenTelemetry Collector `cumulativetodelta` processor][3].
+The OpenTelemetry protocol (OTLP) sends [several metric types][1], some of which can have either *delta* or *cumulative* [aggregation temporality][2]. Datadog works best with delta aggregation temporality for monotonic sums, histograms, and exponential histograms. 
+
+This guide describes the implications of using cumulative aggregation temporality instead, and how to select which aggregation temporality to export your metrics with, either in the OpenTelemetry SDK or by using the [OpenTelemetry Collector `cumulativetodelta` processor][3].
 
 ## Implications of using cumulative aggregation temporality
 
-If you send OTLP monotonic sums, histograms, or exponential histograms with cumulative aggregation temporality, Datadog products take the difference between consecutive points on a timeseries. This means that:
+If you send OTLP monotonic sums, histograms, or exponential histograms with cumulative aggregation temporality, Datadog takes the difference between consecutive points on a timeseries. This means that:
 
 - Your deployment is stateful, so you need to send all points on a timeseries to the same Datadog Agent or Datadog exporter. This affects how you scale your OpenTelemetry Collector deployments.
-- Datadog products may not send the first point they receive from a given timeseries if they cannot ensure this point is the 'true' start of the timeseries. This may lead to missing points upon restarts.
+- Datadog might not send the first point it receives from a given timeseries if it cannot ensure this point is the true start of the timeseries. This may lead to missing points upon restarts.
 
 ## Configuring your OpenTelemetry SDK
 
-If you are producing OTLP metrics from an OpenTelemetry SDK, you can configure your OTLP exporter to produce these metric types with delta aggregation temporality. In some languages you can use the recommended configuration by setting the `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable with the (case-insensitive) `Delta` value. The list of languages with support for this environment variable can be found on the [specification compliance matrix][4].
+If you produce OTLP metrics from an OpenTelemetry SDK, you can configure your OTLP exporter to produce these metric types with delta aggregation temporality. In some languages you can use the recommended configuration by setting the `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable to `Delta` (case-insensitive). For a list of languages with support for this environment variable, read [the specification compliance matrix][4].
 
-If your SDK does not support this environment variable you can configure this in code. The following example configures an OTLP HTTP exporter and adds 1 to a counter every 2 seconds for a total of 5 minutes:
+If your SDK does not support this environment variable you can configure delta temporality in code. The following example configures an OTLP HTTP exporter and adds `1` to a counter every two seconds for a total of five minutes:
 
 {{< programming-lang-wrapper langs="python,go,java" >}}
 
@@ -177,13 +179,13 @@ public final class Main {
 
 {{< /programming-lang-wrapper >}}
 
-OTLP gRPC exporters can be configured in a similar fashion.
+You can configure OTLP gRPC exporters in a similar fashion.
 
 ## Converting to delta temporality on the Collector
 
-When your metrics do not come from an OpenTelemetry language library, it may be infeasible to configure them to use delta aggregation temporality. This may be the case e.g. when producing metric with other open source libraries such as Prometheus. In this situation, you may want to use the [cumulative to delta processor][3] to map your metrics to delta aggregation temporality. Your deployment will still be stateful: if your deployment has multiple Collectors, you need to use the processor on a first layer of stateful Collectors, ensuring that all points of a metric are sent to the same Collector instance.
+When your metrics do not come from an OpenTelemetry language library, it may be infeasible to configure them to use delta aggregation temporality. This may be the case, for example, when producing metrics with other open source libraries such as Prometheus. In this situation, you can use the [cumulative to delta processor][3] to map your metrics to delta aggregation temporality. Your deployment is still stateful, so if your deployment has multiple Collectors, you need to use the processor on a first layer of stateful Collectors to ensure that all points of a metric are sent to the same Collector instance.
 
-To enable the cumulative to delta processor so that it applies to all your metrics, define it with an empty configuration on the `processors` section:
+To enable the cumulative-to-delta processor so that it applies to all your metrics, define it with an empty configuration on the `processors` section:
 
 ```yaml
 processors:
@@ -192,7 +194,7 @@ processors:
 
 Finally, add it to the `processors` list on your metrics pipelines.
 
-Note that the cumulative to delta processor does not support exponential histograms, and that some fields such as the minimum and maximum can't be recovered with this approach. Prefer using the OpenTelemetry SDK approach whenever possible.
+**Note**: The cumulative-to-delta processor does not support exponential histograms. Also, some fields, such as the minimum and maximum, can't be recovered with this approach. Instead, use the OpenTelemetry SDK approach whenever possible.
 
 [1]: /metrics/open_telemetry/otlp_metric_types
 [2]: https://opentelemetry.io/docs/reference/specification/metrics/data-model/#sums

--- a/content/en/opentelemetry/guide/otlp_delta_temporality.md
+++ b/content/en/opentelemetry/guide/otlp_delta_temporality.md
@@ -1,0 +1,153 @@
+---
+title: Producing delta temporality metrics with OpenTelemetry
+kind: guide
+further_reading:
+- link: "/metrics/open_telemetry/otlp_metric_types"
+  tag: "Documentation"
+  text: "OTLP Metric Types"
+- link: "/opentelemetry/"
+  tag: "Documentation"
+  text: "OpenTelemetry Support in Datadog"
+---
+
+## Overview
+
+The OpenTelemetry protocol (OTLP) can send [several metric types][1] some of which can have *delta* of *cumulative* [aggregation temporality][2]. You can select which aggregation temporality to export your metrics with on your OpenTelemetry SDK. Datadog products work best with delta aggregation temporality for OTLP monotonic sums, OTLP histograms and OTLP exponential histograms, which can be configured at the OpenTelemetry SDK level or by using the [OpenTelemetry Collector cumulative to delta processor][3].
+
+## Implications of using cumulative aggregation temporality
+
+If you send OTLP monotonic sums, OTLP histograms or OTLP exponential histograms with cumulative aggregation temporality, Datadog products take the difference between consecutive points on a timeseries. This means that:
+
+- Your deployment will be stateful, so you need to send all points on a timeseries to the same Datadog Agent or Datadog exporter. This affects how you scale your OpenTelemetry Collector deployments.
+- Datadog products may not send the first point they receive from a given timeseries if they cannot ensure this point is the 'true' start of the timeseries. This may lead to missing points upon restarts.
+
+## Configuring your OpenTelemetry SDK
+
+If you are producing OTLP metrics from an OpenTelemetry SDK, you can configure your OTLP exporter to produce these metric types with delta aggregation temporality. In some languages you can use the recommended configuration by setting the `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable with the (case-insensitive) `Delta` value. The list of languages with support for this environment variable can be found on the [specification compliance matrix][4].
+
+If your SDK does not support this environment variable you can configure this in code. The following example configures an OTLP HTTP exporter and adds 1 to a counter every 2 seconds for a total of 5 minutes:
+
+{{< programming-lang-wrapper langs="python,go,java" >}}
+
+{{< programming-lang lang="python" >}}
+```python
+import time
+
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+    OTLPMetricExporter,
+)
+from opentelemetry.sdk.metrics import (
+    Counter,
+    Histogram,
+    MeterProvider,
+    ObservableCounter,
+    ObservableGauge,
+    ObservableUpDownCounter,
+    UpDownCounter,
+)
+from opentelemetry.sdk.metrics.export import (
+    AggregationTemporality,
+    PeriodicExportingMetricReader,
+)
+
+deltaTemporality = {
+    Counter: AggregationTemporality.DELTA,
+    UpDownCounter: AggregationTemporality.CUMULATIVE,
+    Histogram: AggregationTemporality.DELTA,
+    ObservableCounter: AggregationTemporality.DELTA,
+    ObservableUpDownCounter: AggregationTemporality.CUMULATIVE,
+    ObservableGauge: AggregationTemporality.CUMULATIVE,
+}
+
+exporter = OTLPMetricExporter(preferred_temporality=deltaTemporality)
+reader = PeriodicExportingMetricReader(exporter)
+provider = MeterProvider(metric_readers=[reader])
+
+meter = provider.get_meter("my-meter")
+
+counter = meter.create_counter("example.counter")
+
+for i in range(150):
+    counter.add(1)
+    time.sleep(2)
+```
+{{< /programming-lang >}}
+
+
+{{< programming-lang lang="go" >}}
+```go
+package main
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func deltaSelector(kind metric.InstrumentKind) metricdata.Temporality {
+	switch kind {
+	case metric.InstrumentKindCounter,
+		metric.InstrumentKindHistogram,
+		metric.InstrumentKindObservableGauge,
+		metric.InstrumentKindObservableCounter:
+		return metricdata.DeltaTemporality
+	case metric.InstrumentKindUpDownCounter,
+		metric.InstrumentKindObservableUpDownCounter:
+		return metricdata.CumulativeTemporality
+	}
+	panic("unknown instrument kind")
+}
+
+func main() {
+	ctx := context.Background()
+	exporter, err := otlpmetrichttp.New(ctx,
+		otlpmetrichttp.WithTemporalitySelector(deltaSelector),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	reader := metric.NewPeriodicReader(exporter)
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	defer func() {
+		if err := meterProvider.Shutdown(ctx); err != nil {
+			panic(err)
+		}
+	}()
+
+	meter := provider.Meter("my-meter")
+	counter, err := meter.Int64Counter("example.counter")
+	if err != nil {
+		panic(err)
+	}
+
+	for i := 0; i < 150; i++ {
+		counter.Add(ctx, 1)
+		time.Sleep(2 * time.Second)
+	}
+}
+```
+{{< /programming-lang >}}
+
+
+{{< programming-lang lang="java" >}}
+```java
+/* TBD */
+```
+{{< /programming-lang >}}
+
+{{< /programming-lang-wrapper >}}
+
+OTLP gRPC exporters can be configured in a similar fashion.
+
+## Converting to delta temporality on the Collector
+
+TODO: fill this section.
+
+[1]: /metrics/open_telemetry/otlp_metric_types
+[2]: https://opentelemetry.io/docs/reference/specification/metrics/data-model/#sums
+[3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor
+[4]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#environment-variables

--- a/content/en/opentelemetry/guide/otlp_delta_temporality.md
+++ b/content/en/opentelemetry/guide/otlp_delta_temporality.md
@@ -18,7 +18,7 @@ This guide describes the implications of using cumulative aggregation temporalit
 
 ## Implications of using cumulative aggregation temporality
 
-If you send OTLP monotonic sums, histograms, or exponential histograms with cumulative aggregation temporality, Datadog takes the difference between consecutive points on a timeseries. This means that:
+If you opt to send OTLP monotonic sums, histograms, or exponential histograms with cumulative aggregation temporality, Datadog takes the difference between consecutive points on a timeseries. This means that:
 
 - Your deployment is stateful, so you need to send all points on a timeseries to the same Datadog Agent or Datadog exporter. This affects how you scale your OpenTelemetry Collector deployments.
 - Datadog might not send the first point it receives from a given timeseries if it cannot ensure this point is the true start of the timeseries. This may lead to missing points upon restarts.
@@ -195,6 +195,10 @@ processors:
 Finally, add it to the `processors` list on your metrics pipelines.
 
 **Note**: The cumulative-to-delta processor does not support exponential histograms. Also, some fields, such as the minimum and maximum, can't be recovered with this approach. Instead, use the OpenTelemetry SDK approach whenever possible.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /metrics/open_telemetry/otlp_metric_types
 [2]: https://opentelemetry.io/docs/reference/specification/metrics/data-model/#sums

--- a/content/en/opentelemetry/guide/otlp_delta_temporality.md
+++ b/content/en/opentelemetry/guide/otlp_delta_temporality.md
@@ -12,11 +12,11 @@ further_reading:
 
 ## Overview
 
-The OpenTelemetry protocol (OTLP) can send [several metric types][1] some of which can have *delta* of *cumulative* [aggregation temporality][2]. You can select which aggregation temporality to export your metrics with on your OpenTelemetry SDK. Datadog products work best with delta aggregation temporality for monotonic sums, histograms and exponential histograms, which can be configured at the SDK level or by using the [OpenTelemetry Collector `cumulativetodelta` processor][3].
+The OpenTelemetry protocol (OTLP) can send [several metric types][1] some of which can have *delta* of *cumulative* [aggregation temporality][2]. Datadog products work best with delta aggregation temporality for monotonic sums, histograms, and exponential histograms. You can select which aggregation temporality to export your metrics with on your OpenTelemetry SDK or use the [OpenTelemetry Collector `cumulativetodelta` processor][3].
 
 ## Implications of using cumulative aggregation temporality
 
-If you send OTLP monotonic sums, histograms or exponential histograms with cumulative aggregation temporality, Datadog products take the difference between consecutive points on a timeseries. This means that:
+If you send OTLP monotonic sums, histograms, or exponential histograms with cumulative aggregation temporality, Datadog products take the difference between consecutive points on a timeseries. This means that:
 
 - Your deployment is stateful, so you need to send all points on a timeseries to the same Datadog Agent or Datadog exporter. This affects how you scale your OpenTelemetry Collector deployments.
 - Datadog products may not send the first point they receive from a given timeseries if they cannot ensure this point is the 'true' start of the timeseries. This may lead to missing points upon restarts.
@@ -181,7 +181,7 @@ OTLP gRPC exporters can be configured in a similar fashion.
 
 ## Converting to delta temporality on the Collector
 
-When your metrics do not come from an OpenTelemetry language library, it may be infeasible to configure them to use delta aggregation temporality. This may be the case e.g. when producing metric with other open source libraries such as Prometheus. In this situation, you may want to use the [cumulative to delta processor][3] to map your metrics to delta aggregation temporality. If your deployment has multiple Collectors, you need to use the processor on a first layer of stateful Collectors, ensuring that all points of a metric are sent to the same Collector instance.
+When your metrics do not come from an OpenTelemetry language library, it may be infeasible to configure them to use delta aggregation temporality. This may be the case e.g. when producing metric with other open source libraries such as Prometheus. In this situation, you may want to use the [cumulative to delta processor][3] to map your metrics to delta aggregation temporality. Your deployment will still be stateful: if your deployment has multiple Collectors, you need to use the processor on a first layer of stateful Collectors, ensuring that all points of a metric are sent to the same Collector instance.
 
 To enable the cumulative to delta processor so that it applies to all your metrics, define it with an empty configuration on the `processors` section:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds guidelines on how to export OTLP metrics using delta aggregation temporality.

### Motivation
<!-- What inspired you to submit this pull request?-->

As described on the Overview section, the choice of aggregation temporality has implications on the statefulness of the Collector/Agent deployments.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
