### PR TITLE
Remove group by clause on log monitors for hipaa

### DIFF
--- a/content/en/data_security/logs.md
+++ b/content/en/data_security/logs.md
@@ -40,7 +40,6 @@ These features are not available to customers who have signed Datadog's BAA:
 
 * Users cannot request support through chat.
 * Notifications from Log Monitors cannot include log samples.
-* You cannot configure Log Monitors with a `group-by` clause.
 * You cannot [share][5] logs, security signals, or traces from the explorer through web integrations.
 * Security rules cannot include triggering group-by values in notification title.
 * Security rules cannot include message template variables.


### PR DESCRIPTION
The restriction is now removed.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
