### PR TITLE
minor docs correction to infra list

### DIFF
--- a/content/en/infrastructure/list.md
+++ b/content/en/infrastructure/list.md
@@ -34,7 +34,7 @@ Instance ID
 : A hostname [alias](#aliases).
 
 Status
-: Displays `UP` when the expected metrics are received and displays `???` if no metrics are received.
+: Displays `ACTIVE` when the expected metrics are received and displays `INACTIVE` if no metrics are received.
 
 CPU
 : The percent of CPU used (everything but idle).


### PR DESCRIPTION
### What does this PR do?
Updates docs for current UI labels for the "Status" field in the Infrastructure List

### Motivation
Let's call it a "personality quirk", and noticed it while reading some docs

![Screenshot 2023-03-03 at 16 05 16](https://user-images.githubusercontent.com/215667/222829983-532587df-fb35-4678-a7fd-039c63d87e0f.png)



