### PR TITLE
added $ to beginning of shell language code blocks

### DIFF
--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -175,6 +175,14 @@ code {
     white-space: normal;
     /*font-family: 'Source Code Pro', monospace;*/
     font-family: $font-family-monospace;
+  &.language-shell {
+    .line {
+      &:before {
+        content: '$ ';
+        display: inline;
+      }
+    }
+  }
 }
 
 h2 code {


### PR DESCRIPTION
### What does this PR do?

Styles shell code blocks with dollar signs at the beginning of each line to indicate they are commands to be run, without affecting the copy button.

### Motivation

https://datadoghq.atlassian.net/browse/WEB-3254

### Preview

https://docs-staging.datadoghq.com/fitzage/code-styling/developers/integrations/api_integration/

### Additional Notes

1. Using `lang=“bash”` allows for shell syntax highlighting, but disables the dollar signs. This could be useful for blocks of code that also include shell command output.
2. I will write up documentation for this to make that capability clear.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
