### PR TITLE
[prod]mike-dessailly/custom-retention-filter-note

### DIFF
--- a/content/en/monitors/types/apm.md
+++ b/content/en/monitors/types/apm.md
@@ -91,7 +91,7 @@ For detailed instructions on the advanced alert options (no data, evaluation del
 
 {{< img src="monitors/monitor_types/apm/define-the-search-query.png" alt="Define the search query" style="width:80%;" >}}
 
-**Note:** Analytics monitors can only be created based on [Indexed Spans][4].
+**Note:** Analytics monitors can only be created based on [Indexed Spans][4]. All spans indexed by custom retention filters (not spans indexed from the intelligent retention filter) are available to be monitored by a trace analytics monitor.
 
 ### Select alert conditions
 


### PR DESCRIPTION
Update note that trace analytics monitors only monitor spans from custom retention filters, and not the intelligent retention filter.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
