### PR TITLE
WEB-3284 - remove invalid integration categorization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,10 @@ placeholders:
 
 # create the virtual environment
 hugpython: local/etc/requirements3.txt
-	@${PY3} -m venv --clear $@ && . $@/bin/activate && $@/bin/pip install --upgrade pip wheel && $@/bin/pip install -r $<
+	@${PY3} -m venv --clear $@ && . $@/bin/activate && $@/bin/pip install --upgrade pip wheel && $@/bin/pip install -r $<;\
+	if [[ "$(CI_COMMIT_REF_NAME)" != "" ]]; then \
+		$@/bin/pip install https://binaries.ddbuild.io/dd-source/python/assetlib-0.0.13488267-py2.py3-none-any.whl; \
+	fi
 
 update_pre_build:
 	@. hugpython/bin/activate && GITHUB_TOKEN=$(GITHUB_TOKEN) CONFIGURATION_FILE=$(CONFIGURATION_FILE) ./local/bin/py/build/update_pre_build.py

--- a/layouts/shortcodes/integration_categories.md
+++ b/layouts/shortcodes/integration_categories.md
@@ -1,0 +1,71 @@
+- Category::Alerting
+- Category::Automation
+- Category::AWS
+- Category::Azure
+- Category::Caching
+- Category::Cloud
+- Category::Collaboration
+- Category::Compliance
+- Category::Configuration & Deployment
+- Category::Containers
+- Category::Cost Management
+- Category::Data Store
+- Category::Developer Tools
+- Category::Event Management
+- Category::Exceptions
+- Category::Google Cloud
+- Category::Incidents
+- Category::IOT
+- Category::ISP
+- Category::Issue Tracking
+- Category::Kubernetes
+- Category::Languages
+- Category::Log Collection
+- Category::Mainframe
+- Category::Marketplace
+- Category::Messaging
+- Category::Metrics
+- Category::Mobile
+- Category::Monitoring
+- Category::Network
+- Category::Notification
+- Category::Oracle
+- Category::Orchestration
+- Category::OS & System
+- Category::Processing
+- Category::Profiling
+- Category::Provisioning
+- Category::SAP
+- Category::Security
+- Category::SNMP
+- Category::Source Control
+- Category::Testing
+- Category::Tracing
+- Category::Web
+- Offering::Integration
+- Offering::Professional Service
+- Offering::Software License
+- Offering::UI Extension
+- Queried Data Type::Metrics
+- Queried Data Type::Logs
+- Queried Data Type::Traces
+- Queried Data Type::Events
+- Queried Data Type::Incidents
+- Submitted Data Type::Metrics
+- Submitted Data Type::Logs
+- Submitted Data Type::Traces
+- Submitted Data Type::Events
+- Submitted Data Type::Incidents
+- Supported OS::Android
+- Supported OS::Any
+- Supported OS::HP-UX
+- Supported OS::IBM i/OS
+- Supported OS::IBM z/OS
+- Supported OS::iOS
+- Supported OS::Linux
+- Supported OS::macOS
+- Supported OS::Solaris
+- Supported OS::Windows
+- Supported OS::Mac OS
+- Category::OS System
+

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -37,6 +37,11 @@ except ImportError:
 finally:
     if not CLASSIFIER_TAGS:
         print(f'\x1b[33mWARNING\x1b[0m: CLASSIFIER_TAGS empty continuing without validation')
+    else:
+        with open('layouts/shortcodes/integration_categories.md', 'w') as file:
+            for tag in CLASSIFIER_TAGS:
+                file.write(f'- {tag}\n')
+            file.write("\n")
 
 
 class Integrations:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: true
+    cache_enabled: false
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: false
+    cache_enabled: true
 
 - data:
     - org_name: jenkinsci


### PR DESCRIPTION
### What does this PR do?

This PR:
- Uses the classifiers in the assetlib as a reference to only allow valid categorization of integrations
- Write to the `layouts/shortcodes/integration_categories.md` file with the classifiers so that they can be used by the `https://docs.datadoghq.com/developers/integrations/check_references/` page

### Motivation

https://datadoghq.atlassian.net/browse/WEB-3284

### Preview

- Test https://docs-staging.datadoghq.com/david.jones/validate-categories/integrations/ loads the same integrations.
- Test local build still works despite installing lib that isn't always available

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
