### PR TITLE
Add Vertical Pod Autoscalers to docs

### DIFF
--- a/content/en/infrastructure/livecontainers/configuration.md
+++ b/content/en/infrastructure/livecontainers/configuration.md
@@ -177,6 +177,7 @@ The following table presents the list of collected resources and the minimal Age
 | ServiceAccounts | 7.27.0 | 1.19.0 | 2.30.9 |
 | Services | 7.27.0 | 1.11.0 | 2.10.0 |
 | Statefulsets | 7.27.0 | 1.15.0 | 2.20.1 |
+| VerticalPodAutoscalers | 7.27.0 | 7.43.0 | 3.6.8 |
 
 **Note**: For Kubernetes version 1.25 and above, the minimal Cluster Agent version required is 7.40.0.
 


### PR DESCRIPTION
Add Vertical Pod Autoscalers to the configuration docs

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update our docs to include vertical pod autoscalers

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
