### PR TITLE
Update ZF1 v1.21 support

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/php.md
+++ b/content/en/tracing/trace_collection/compatibility/php.md
@@ -110,7 +110,7 @@ The following table enumerates some of the frameworks and versions Datadog succe
 | Symfony        | 3.3, 3.4, 4.x, 5.x, 6.x | All supported PHP versions | Framework-level instrumentation |
 | WordPress      | 4.x, 5.x             | PHP 7+                     | Framework-level instrumentation |
 | Yii            | 1.1, 2.0             | All supported PHP versions | Framework-level instrumentation |
-| Zend Framework | 1.12                 | All supported PHP versions | Framework-level instrumentation |
+| Zend Framework | 1.12, 1.21           | All supported PHP versions | Framework-level instrumentation |
 | Zend Framework | 2.x                  | All supported PHP versions | Generic web tracing             |
 
 Note that even if you don't see your web framework in this list, it is supported out of the box with the latest release of the tracer.


### PR DESCRIPTION
### What does this PR do?
This version is now officially supported (web integration test added in ddtrace-php)
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
