### PR TITLE
[DOCS-5027] Remove bithuas google analytics integration

### DIFF
--- a/content/en/developers/community/libraries.md
+++ b/content/en/developers/community/libraries.md
@@ -187,7 +187,6 @@ If you've written a Datadog library and would like to add it to this page, send 
 [29]: https://github.com/cvent/dogscaler
 [30]: https://github.com/wimactel/FreeSwitch-DataDog-Metrics
 [31]: https://github.com/wimactel
-[32]: https://github.com/bithauschile/datadog-ga
 [34]: /logs/guide/collect-heroku-logs/
 [35]: https://github.com/ozinc/heroku-datadog-drain
 [36]: https://web.oz.com/

--- a/content/en/developers/community/libraries.md
+++ b/content/en/developers/community/libraries.md
@@ -82,10 +82,6 @@ Scale up auto-scale groups based on the results of a Datadog query with [Dogscal
 
 This is for a [FreeSwitch ESL][30] application to export statistics to Datadog using the DogStatsD API and is written by [WiMacTel][31].
 
-### Google Analytics
-
-You can get data into Datadog from Google Analytics using the Datadog API with the [Google Analytics library][32] from [Bithaus][33].
-
 ### Heroku
 
 Heroku emits dyno metrics through logs. To convert these logs into metrics and send them to Datadog, use one of the following log drains. To send your Heroku logs to Datadog, see [Collect Heroku logs][34].

--- a/content/en/developers/community/libraries.md
+++ b/content/en/developers/community/libraries.md
@@ -188,7 +188,6 @@ If you've written a Datadog library and would like to add it to this page, send 
 [30]: https://github.com/wimactel/FreeSwitch-DataDog-Metrics
 [31]: https://github.com/wimactel
 [32]: https://github.com/bithauschile/datadog-ga
-[33]: https://blog.bithaus.cl/2016/04/20/realtime-google-analytics-metrics-in-datadog
 [34]: /logs/guide/collect-heroku-logs/
 [35]: https://github.com/ozinc/heroku-datadog-drain
 [36]: https://web.oz.com/


### PR DESCRIPTION
This integration is no longer working with current agent versions as per ticket: https://datadog.zendesk.com/agent/tickets/1082256 

Last update was about 4 years ago: https://github.com/bithauschile/datadog-ga 

Because of these two points, we shouldn't advertise this community integration anymore

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Remove bithaus google analytics integration from our list as it is no longer working

### Motivation
Ticket 1082256

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
