### PR TITLE
Changed image to be dotnet_text.png

### DIFF
--- a/layouts/partials/apm/apm-manual-instrumentation.html
+++ b/layouts/partials/apm/apm-manual-instrumentation.html
@@ -54,7 +54,7 @@
       <div class="col">
         <a class="card h-100" href="dotnet">
           <div class="card-body text-center py-2 px-1">
-            {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet-framework.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
+            {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>


### PR DESCRIPTION
### What does this PR do?
Changes the current logo for .NET used in the Custom Instrumentation main page.
https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/#pagetitle

### Motivation
This way it simply says .NET instead of .NET Framework or .NET Core since the steps for both live in the same page.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
