### PR TITLE
WEB-3203 | Add redirect metadata job to Docs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,7 @@ before_script:
   - export DATADOG_API_KEY=$(get_secret 'dd-api-key')
   - export DATADOG_APP_KEY=$(get_secret 'dd-app-key')
   - export BRANCH=${CI_COMMIT_REF_NAME}
+  - export SLACK_URL=$(get_secret 'slack_url')
   - git config --global url."https://${GITHUB_TOKEN}@github.com/DataDog".insteadOf https://github.com/DataDog
   - type build_dogrc &>/dev/null && build_dogrc || echo "build_dogrc not found." # create .dogrc for metrics, events submission
   - export job_start=$(date +%s) # we need the start of each job recorded for the ci reporting
@@ -90,7 +91,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-13808246
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-13890255
   tags:
     - "arch:amd64"
   rules:
@@ -138,6 +139,7 @@ build_preview:
       - .vale.ini
       - .htmltest.yml
       - ./logs
+      - ./public/redirects.txt
   interruptible: true
 
 link_checks_preview:
@@ -271,6 +273,7 @@ build_live:
       - ./integrations_data
       - content/en
       - .htmltest.yml
+      - ./public/redirects.txt
     expire_in: 1 week
 
 test_live_link_checks:
@@ -432,3 +435,18 @@ post_failure_event_to_dd_live:
   rules:
     - if: $CI_COMMIT_REF_NAME == "master"
       when: on_failure
+
+set_redirect_metadata_preview:
+  <<: *base_template
+  <<: *preview_rules
+  variables:
+    BUCKET: "datadog-docs-preview"
+    IS_REDIRECT_JOB: "true" 
+  stage: post-deploy
+  cache: []
+  environment: "preview"
+  dependencies:
+    - build_preview
+  script:
+    - in-isolation update_redirect_metadata
+  interruptible: true

--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -104,3 +104,11 @@ security:
     osEnv:
       # as suggested here https://github.com/gohugoio/hugo/issues/9333#issuecomment-1022435616
       - (?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM|HOME|SSH_AUTH_SOCK|USERPROFILE|XDG_CONFIG_HOME)$
+
+# Output Format for Redirects
+outputFormats:
+  Redirects:
+    baseName: "redirects"
+    isPlainText: true
+    mediaType: "text/plain"
+    notAlternative: true

--- a/config/_default/languages.yaml
+++ b/config/_default/languages.yaml
@@ -3,6 +3,14 @@ en:
   #languageCode: "en-US"
   weight: 1
   #contentDir: content/en
+  outputs:
+    home:
+      - HTML
+      - RSS
+      - Redirects
+    page:
+      - HTML
+      
 fr:
   languageName: "Français"
   weight: 2

--- a/content/en/containers/cluster_agent/_index.md
+++ b/content/en/containers/cluster_agent/_index.md
@@ -4,7 +4,6 @@ kind: documentation
 aliases:
 - /agent/kubernetes/cluster/
 - /agent/cluster_agent/
-- /containers/cluster_agent/
 - /containers/cluster_agent/event_collection
 - /containers/cluster_agent/metadata_provider
 further_reading:

--- a/content/en/developers/guide/unified-tagging-advanced-usage.md
+++ b/content/en/developers/guide/unified-tagging-advanced-usage.md
@@ -1,8 +1,6 @@
 ---
 title: Unified Tagging Advanced Usage Guide
 kind: guide
-aliases:
-  - /developers/guide/unified-tagging-advanced-usage
 ---
 
 ## Overview

--- a/content/en/getting_started/agent/_index.md
+++ b/content/en/getting_started/agent/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Getting Started with the Agent
 kind: documentation
-aliases:
-    - /getting_started/agent
 further_reading:
     - link: '/agent/basic_agent_usage/'
       tag: 'Documentation'

--- a/content/en/getting_started/integrations/_index.md
+++ b/content/en/getting_started/integrations/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Introduction to Integrations
 kind: documentation
-aliases:
-    - /getting_started/integrations
 further_reading:
   - link: 'https://learn.datadoghq.com/courses/intro-to-integrations'
     tag: 'Learning Center'

--- a/content/en/getting_started/tagging/assigning_tags.md
+++ b/content/en/getting_started/tagging/assigning_tags.md
@@ -4,7 +4,6 @@ kind: documentation
 description: 'Learn how to assign tags in Datadog.'
 aliases:
     - /agent/tagging
-    - /getting_started/tagging/assigning_tags
     - /tagging/assigning_tags/
 further_reading:
 - link: "/getting_started/tagging/"

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -1,8 +1,6 @@
 ---
 title: Unified Service Tagging
 kind: documentation
-aliases:
-- /getting_started/tagging/unified_service_tagging
 further_reading:
 - link: "/getting_started/tagging/using_tags"
   tag: "Documentation"

--- a/content/en/integrations/guide/jmx_integrations.md
+++ b/content/en/integrations/guide/jmx_integrations.md
@@ -1,8 +1,6 @@
 ---
 title: Which Integrations use Jmxfetch?
 kind: guide
-aliases:
-  - /integrations/guide/jmx_integrations/
 further_reading:
 - link: "/agent/faq/log4j_mitigation/"
   tag: "Documentation"

--- a/content/en/logs/explorer/export.md
+++ b/content/en/logs/explorer/export.md
@@ -3,7 +3,6 @@ title: Export Logs
 kind: documentation
 description: 'Export your Log Explorer view to reuse it later or in different contexts.'
 aliases:
-    - /logs/explorer/export
     - /logs/export
 further_reading:
     - link: 'logs/explorer/search'

--- a/content/en/logs/explorer/search.md
+++ b/content/en/logs/explorer/search.md
@@ -3,7 +3,6 @@ title: Search Logs
 kind: documentation
 description: 'Filter logs; to narrow down, broaden, or shift your focus on the subset of logs of current interest.'
 aliases:
-    - /logs/explorer/search
     - /logs/search
 further_reading:
     - link: 'logs/explorer/group'

--- a/content/en/logs/explorer/visualize.md
+++ b/content/en/logs/explorer/visualize.md
@@ -3,7 +3,6 @@ title: Log Visualizations
 kind: documentation
 description: 'Visualize the outcome of filters and aggregations to put your logs into the right perspective and bubble up decisive information.'
 aliases:
-    - /logs/explorer/visualize
     - /logs/visualize
 further_reading:
     - link: 'logs/explorer/search'

--- a/content/en/monitors/guide/monitor-arithmetic-and-sparse-metrics.md
+++ b/content/en/monitors/guide/monitor-arithmetic-and-sparse-metrics.md
@@ -1,8 +1,6 @@
 ---
 title: Monitor Arithmetic and Sparse Metrics
 kind: guide
-aliases:
-  - /monitors/guide/monitor-arithmetic-and-sparse-metrics
 ---
 
 ## Overview

--- a/content/en/profiler/compare_profiles.md
+++ b/content/en/profiler/compare_profiles.md
@@ -17,8 +17,6 @@ further_reading:
     - link: 'https://www.datadoghq.com/blog/engineering/how-we-optimized-our-akka-application-using-datadogs-continuous-profiler/'
       tag: 'Blog'
       text: 'How we optimized our Akka application using Datadog’s Continuous Profiler'
-aliases:
-  - /profiler/compare_profiles/
 ---
 
 The Continuous Profiler can compare two profiles or profile aggregations with each other to help you identify code performance improvements, regressions, and structural changes. You can compare a profile with:

--- a/content/en/synthetics/apm/_index.md
+++ b/content/en/synthetics/apm/_index.md
@@ -2,8 +2,6 @@
 title: Synthetic APM
 kind: documentation
 description: APM and Distributed Tracing with Synthetic Monitoring
-aliases:
-  - "/synthetics/apm"
 further_reading:
   - link: "https://www.datadoghq.com/blog/introducing-synthetic-monitoring/"
     tag: "Blog"

--- a/layouts/_default/list.redirects.txt
+++ b/layouts/_default/list.redirects.txt
@@ -1,0 +1,8 @@
+{{- range $p := .Site.Pages -}}
+    {{- range .Aliases -}}
+        {{- $temp := strings.TrimPrefix "/" . -}}
+        {{- $alias := strings.TrimSuffix "/" $temp -}}
+        {{- $target := strings.TrimSuffix "/" $p.RelPermalink -}}
+        {{- printf "%s/ %s\n" $alias $p.RelPermalink -}}
+    {{- end -}}
+{{- end -}}

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -903,6 +903,19 @@ class Integrations:
                 item["draft"] = not item.get("is_public", False)
                 item["integration_id"] = item.get("integration_id", integration_id)
                 item["integration_version"] = item.get("integration_version", integration_version)
+                # remove aliases that point to the page they're located on
+                # get the current slug from the doc_link
+                if item.get('name'):
+                    current_slug = 'integrations/{}'.format(item.get('name'))
+                # If there are aliases and the current slug value, check to see if they match and if they do, remove it
+                if (item.get('aliases')) and current_slug:
+                    # loop over the aliases
+                    for single_alias in item['aliases']:
+                        # strip any tailing and leading / and see if the alias matches the page slug
+                        if current_slug == single_alias.strip('/'):
+                            # add the alias from the list
+                            item['aliases'].remove(single_alias)
+                            print(f"\033[94mALIAS REMOVAL\x1b[0m: Removed redundant alias: {single_alias}")
                 fm = yaml.safe_dump(
                     item, width=float("inf"), default_style='"', default_flow_style=False, allow_unicode=True
                 ).rstrip()

--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -125,8 +125,8 @@ def security_rules(content, content_dir):
                 "type": "security_rules",
                 "disable_edit": True,
                 "aliases": [
-                    f"{data.get('defaultRuleId', '').strip()}",
-                    f"/security_monitoring/default_rules/{data.get('defaultRuleId', '').strip()}",
+                    # f"{data.get('defaultRuleId', '').strip()}",
+                    # f"/security_monitoring/default_rules/{data.get('defaultRuleId', '').strip()}",
                     f"/security_monitoring/default_rules/{p.stem}"
                 ],
                 "rule_category": [],

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -353,7 +353,6 @@
               kind: documentation
               aliases:
                 - /serverless/datadog_lambda_library/extension
-                - /serverless/libraries_integrations/extension
 
       - repo_name: datadog-ci-azure-devops
         contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -353,7 +353,6 @@
               kind: documentation
               aliases:
                 - /serverless/datadog_lambda_library/extension
-                - /serverless/libraries_integrations/extension
 
       - repo_name: datadog-ci-azure-devops
         contents:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

- Adds redirect logic to documentation
- Removes redundant redirects
- Adds logic for integrations to remove redundant redirects that may exist 
- Removes logic that was creating approx 1500 redirects for OOTB security rules that were not in used (verified via logs that the redirects have not been hit)

I'm open to input, but would like to just roll the CI job out on previews for the time being to ensure we are not missing anything before we push this to live (maybe Monday?)

### Motivation
<!-- What inspired you to submit this pull request?-->

In an effort to get the correct status code of `301` for redirects from aliases. Hugo handles it with data in a temporary page that redirects to the alias, but gives a status code of `200`

### Preview
https://docs-staging.datadoghq.com/devin.ford/WEB-3203/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

 Check different areas of the site and ensure redirects are behaving as we expect

The pipeline output during an integrations build will notify what aliases have been removed from integrations on intatke

<img width="1088" alt="Screenshot 2023-03-07 at 9 38 53 AM" src="https://user-images.githubusercontent.com/63879468/223454566-efe79075-1c16-49d7-9d62-cafca13add9f.png">

This most recent "failing" [job](https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/239309153) is working as intended. If there is a redundant redirect, the pipeline will complete adding the rest of the redirects to S3, but will not add the redundant ones identified, and instead will output them at the end of the job and have a failure status in order to have them addressed. In this case specifically, it is happening because the cache of integrations comes from the latest master branch, which does **NOT** have the new integrations logic ran to exclude these, but will be fixed once the master deploy runs and runs the new integrations code. 

You can see what that will look like in this [old job](https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/239017332) where the cache was disabled, and the subsequent [passing job](https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/239017346) for redirects.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
