### PR TITLE
Rebrand event rules to In-App WAF rules

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2795,8 +2795,8 @@ main:
     parent: appsec_threats
     identifier: threats_custom_rules
     weight: 504
-  - name: Event Rules
-    url: security/application_security/threats/event_rules/
+  - name: In-App WAF Rules
+    url: security/application_security/threats/inapp_waf_rules/
     parent: appsec_threats
     identifier: threats_event_rules
     weight: 505

--- a/content/en/security/application_security/terms.md
+++ b/content/en/security/application_security/terms.md
@@ -29,19 +29,19 @@ detection rule
 : A conditional logic definition that is applied to ingested data and cloud configurations. When at least one case defined in a rule is matched over a given period of time, Datadog generates a _security signal_.
 : See [Detection rules][10].
 
-exclusion filter
-: A mechanism for discarding suspicious requests flagged through the ASM library and the event rules. Exclusion filters are applied as requests are ingested into Datadog (intake). Exclusion filters help you manage false positives and intake costs.
+passlist (formerly exclusion filter)
+: A mechanism for discarding suspicious requests flagged through the ASM library and the In-App WAF rules. Passlist is applied as requests are ingested into Datadog (intake). Passlist helps manage false positives and intake costs.
 : See [Exclusion filters][11] in the app.
 
-event rules
+In-App WAF rules (formerly event rules)
 : A set of rules executed in the Datadog libraries to catch security activity. These include Web Application Firewall (WAF) patterns that monitor for attempts to exploit known vulnerabilities.
-: See [Event rules][12].
+: See [In-App WAF rules][12].
 
 interactive application security testing (IAST)
 : An application security testing method that proactively detects vulnerabilities while the app is run by an automated test, human tester, or any activity interacting with the application functionality.
 
 Remote Configuration
-: A Datadog platform mechanism that enables the Agent configuration to be updated remotely. Used by ASM to update event rules, activate the product, and block attackers.
+: A Datadog platform mechanism that enables the Agent configuration to be updated remotely. Used by ASM to update In-App WAF rules, activate the product, and block attackers.
 : See [How Remote Configuration Works][8].
 
 service
@@ -58,7 +58,7 @@ severity
 : An indicator of how quickly an attack attempt should be triaged and addressed. Based on a combination of factors, including the attack's potential impact and risk. Values are Critical, High, Medium, Low, Info.
 
 suspicious request 
-: A distributed trace for which security activity has been flagged by event rules. The underlying trace is shared with APM, allowing deeper and faster investigations. 
+: A distributed trace for which security activity has been flagged by In-App WAF rules. The underlying trace is shared with APM, allowing deeper and faster investigations. 
 
 user attribution
 : A mechanism that maps suspicious requests to known users in your systems. 
@@ -115,6 +115,6 @@ Object-Graph Navigation Language Injection (OGNLi)
 [8]: /agent/guide/how_remote_config_works/
 [10]: /security/detection_rules/
 [11]: https://app.datadoghq.com/security/appsec/exclusions
-[12]: /security/application_security/event_rules/#overview
+[12]: /security/application_security/threats/inapp_waf_rules
 [13]: https://app.datadoghq.com/security?query=%40workflow.rule.type%3A%22Application%20Security%22&product=appsec&view=signal
 [14]: /security/application_security/threats/add-user-info/

--- a/content/en/security/application_security/threats/_index.md
+++ b/content/en/security/application_security/threats/_index.md
@@ -36,11 +36,11 @@ From this page you can block and unblock users and IPs, or investigate what infr
 {{< img src="security/application_security/appsec-threat-overview.mp4" alt="Overview of investigating threats in signals explorer" video="true" >}}
 
 
-## Create event rules for identifying attack patterns
+## Create In-App WAF rules for identifying attack patterns
 
-You can [create event rules][5] that define what suspicious behavior looks like in your application, augmenting the default rules that come with ASM. Then [specify custom rules][6] to generate security signals from these events, raising them in the Threat Monitoring views for your investigation. 
+You can [create In-App WAF rules][5] that define what suspicious behavior looks like in your application, augmenting the default rules that come with ASM. Then [specify custom rules][6] to generate security signals from the attack attempts triggered from these rules, raising them in the Threat Monitoring views for your investigation. 
 
-## Slow down attacks
+## Slow down attacks and attackers with ASM Protect
 
 <div class="alert alert-info"><strong>Beta: IP and user blocking</strong><br>
 If your service is running <a href="/agent/guide/how_remote_config_works/#enabling-remote-configuration">an Agent with Remote Configuration enabled and a tracing library version that supports it</a>, you can block attackers from the Datadog UI without additional configuration of the Agent or tracing libraries.</div>
@@ -67,7 +67,7 @@ From there, all services already protected by ASM block incoming requests perfor
 [1]: https://app.datadoghq.com/services?lens=Security
 [2]: /security/explorer
 [4]: /security/application_security/how-appsec-works/
-[5]: /security/application_security/threats/event_rules/
+[5]: /security/application_security/threats/inapp_waf_rules/
 [6]: /security/application_security/threats/custom_rules/
 [7]: /tracing/trace_collection/dd_libraries/
 [8]: /agent/guide/how_remote_config_works/

--- a/content/en/security/application_security/threats/inapp_waf_rules.md
+++ b/content/en/security/application_security/threats/inapp_waf_rules.md
@@ -110,5 +110,5 @@ Next, [configure detection rules to create security signals][1] based on those s
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /security/application_security/custom_rules/
-[2]: https://app.datadoghq.com/security/configuration/asm/in-app-waf?group_by=NONE
+[2]: https://app.datadoghq.com/security/appsec/in-app-waf
 [3]: /security/application_security/getting_started/

--- a/content/en/security/application_security/threats/inapp_waf_rules.md
+++ b/content/en/security/application_security/threats/inapp_waf_rules.md
@@ -110,5 +110,5 @@ Next, [configure detection rules to create security signals][1] based on those s
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /security/application_security/custom_rules/
-[2]: https://app.datadoghq.com/security/appsec/in-app-waf
+[2]: https://app.datadoghq.com/security/appsec/in-app-waf?group_by=NONE
 [3]: /security/application_security/getting_started/

--- a/content/en/security/application_security/threats/inapp_waf_rules.md
+++ b/content/en/security/application_security/threats/inapp_waf_rules.md
@@ -1,9 +1,10 @@
 ---
-title: Event Rules
+title: In-App WAF Rules
 kind: documentation
 aliases:
   - /security_platform/application_security/event_rules
   - /security/application_security/event_rules
+  - /security/application_security/threats/event_rules
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"
@@ -20,19 +21,19 @@ further_reading:
 
 With Application Security Management (ASM) enabled, the Datadog tracing library actively monitors all web services and API requests for suspicious security activity.
 
-An _event rule_ specifies conditions on the incoming request to define what the library considers suspicious. The Datadog tracing library includes hundreds of out-of-the-box ASM event rules, which are used to display suspicious requests in the trace explorer and in the default signal rules. 
+An _In-App WAF rule_ specifies conditions on the incoming request to define what the library considers suspicious. The Datadog tracing library includes hundreds of out-of-the-box ASM In-App WAF rules, which are used to display suspicious requests in the trace explorer and in the default signal rules. 
 
-You can add to the event rules without upgrading the tracing library. 
+You can add to the In-App WAF rules without upgrading the tracing library. 
 
-## Structure of an ASM event rule
+## Structure of an ASM In-App WAF rule
 
-An event rule is a JSON object composed of a category, a name, tags, and conditions. When a suspicious request is detected, tags from the rules are propagated onto the suspicious request, and can be used to build [detection rules][1].
+An In-App WAF rule is a JSON object composed of a category, a name, tags, and conditions. When a suspicious request is detected, tags from the rules are propagated onto the suspicious request, and can be used to build [detection rules][1].
 
 ### Conditions
 Conditions define when the rule tags an incoming request. The conditions are composed of _inputs_ and _operators_.
 
 #### Inputs
-An input represents which part of the request the operator is applied to. The following inputs are used in the event rules:
+An input represents which part of the request the operator is applied to. The following inputs are used in the In-App WAF rules:
 
 | Name | Description | Example |
 |------|-------------|---------|
@@ -53,18 +54,18 @@ An input represents which part of the request the operator is applied to. The fo
 | `is_xss` | Special operator to check for cross-site scripting (XSS) payloads |
 | `is_sqli` | Special operator to check for SQL injection (SQLI) payloads |
 
-## Configure an ASM event rule in your service
+## Configure an ASM In-App WAF rule in your service
 
-1. In Datadog, navigate to the [Event Rules page under ASM Configuration][2].
+1. In Datadog, navigate to the [In-App WAF page under ASM Configuration][2].
 
-2. Click **Download Configuration** in the top right corner to download the configuration file, `appsec-rules.json`, to your local machine.
+2. Click **Download Configuration** to download the configuration file, `appsec-rules.json`, to your local machine.
 
 3. Update the file to include the JSON definition of your new rule, following the specification above. For example:
 
    {{< code-block lang="json" collapsible="true" >}}
     {
         "id": "id-123",
-        "name": "My event rule",
+        "name": "My In-App WAF rule",
         "tags": {
             "category": "attack_attempt",
             "crs_id": "920260",
@@ -102,12 +103,12 @@ An input represents which part of the request the operator is applied to. The fo
 
 ## What to do next
 
-Next, [configure detection rules to create security signals][1] based on those suspicious requests defined by the event rules you created. You can modify the provided out-of-the-box ASM detection rules or create new ones. 
+Next, [configure detection rules to create security signals][1] based on those suspicious requests defined by the In-App WAF rules you created. You can modify the provided out-of-the-box ASM detection rules or create new ones. 
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /security/application_security/custom_rules/
-[2]: https://app.datadoghq.com/security/appsec/event-rules
+[2]: https://app.datadoghq.com/security/configuration/asm/in-app-waf?group_by=NONE
 [3]: /security/application_security/getting_started/


### PR DESCRIPTION
rebranding event rules to In-App WAF rules

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
