### PR TITLE
[DOCS-4912] Move C# TCP info to specific sites

### DIFF
--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -523,10 +523,9 @@ using (var log = new LoggerConfiguration()
 
 {{< /site-region >}}
 
-
-You can also override the default behavior and forward logs in TCP by manually specifying the following required properties: `url`, `port`, `useSSL`, and `useTCP`. Optionally, [specify the `source`, `service`, `host`, and custom tags.][20]
-
 {{< site-region region="us" >}}
+
+You can also override the default behavior and forward logs in TCP by manually specifying the following required properties: `url`, `port`, `useSSL`, and `useTCP`. Optionally, [specify the `source`, `service`, `host`, and custom tags.][1]
 
 For instance to forward logs to the Datadog US region in TCP you would use the following sink configuration:
 
@@ -547,8 +546,12 @@ using (var log = new LoggerConfiguration()
 }
 ```
 
+[1]: /logs/log_configuration/attributes_naming_convention/#reserved-attributes
+
 {{< /site-region >}}
 {{< site-region region="eu" >}}
+
+You can also override the default behavior and forward logs in TCP by manually specifying the following required properties: `url`, `port`, `useSSL`, and `useTCP`. Optionally, [specify the `source`, `service`, `host`, and custom tags.][1]
 
 For instance to forward logs to the Datadog EU region in TCP you would use the following sink configuration:
 
@@ -568,6 +571,7 @@ using (var log = new LoggerConfiguration()
     // Some code
 }
 ```
+[1]: /logs/log_configuration/attributes_naming_convention/#reserved-attributes
 
 {{< /site-region >}}
 
@@ -623,4 +627,3 @@ In the `Serilog.WriteTo` array, add an entry for `DatadogLogs`. An example is sh
 [17]: /logs/log_configuration/pipelines/?tab=source
 [18]: /api/latest/logs/#send-logs
 [19]: https://www.nuget.org/packages/Serilog.Sinks.Datadog.Logs
-[20]: /logs/log_configuration/attributes_naming_convention/#reserved-attributes


### PR DESCRIPTION
### What does this PR do?

Moves C# TCP info to specific sites.

### Motivation

[DOCS-4912](https://datadoghq.atlassian.net/browse/DOCS-4912)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4912]: https://datadoghq.atlassian.net/browse/DOCS-4912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ