### PR TITLE
DOCS-4908 APM Library injection: add info about enabling ASM or Profiler

### DIFF
--- a/content/en/tracing/trace_collection/library_injection.md
+++ b/content/en/tracing/trace_collection/library_injection.md
@@ -867,11 +867,11 @@ Exercise your application to start generating telemetry data, which you can see 
 
 The supported features and configuration options for the tracing library are the same for library injection as for other installation methods, and can be set with environment variables. Read the [Datadog Library configuration page][16] for your language for more details.
 
-For example, to turn on [Application Security Monitoring][4] or [Continuous Profiler][3], each of which may have billing impact:
+For example, you can turn on [Application Security Monitoring][4] or [Continuous Profiler][3], each of which may have billing impact:
 
-- For **Kubernetes**, set the container environment variables `DD_APPSEC_ENABLED` or `DD_PROFILING_ENABLED` to `true`.
+- For **Kubernetes**, set the `DD_APPSEC_ENABLED` or `DD_PROFILING_ENABLED` container environment variables to `true`.
 
-- For **hosts and containers**, set the container environment variables `DD_APPSEC_ENABLED` or `DD_PROFILING_ENABLED` to `true`, or in the [injection configuration](#supplying-configuration-source) specify an `additional_environment_variables` section like the following YAML example: 
+- For **hosts and containers**, set the `DD_APPSEC_ENABLED` or `DD_PROFILING_ENABLED` container environment variables to `true`, or in the [injection configuration](#supplying-configuration-source), specify an `additional_environment_variables` section like the following YAML example: 
 
   ```yaml
   additional_environment_variables:

--- a/content/en/tracing/trace_collection/library_injection.md
+++ b/content/en/tracing/trace_collection/library_injection.md
@@ -867,6 +867,24 @@ Exercise your application to start generating telemetry data, which you can see 
 
 The supported features and configuration options for the tracing library are the same for library injection as for other installation methods, and can be set with environment variables. Read the [Datadog Library configuration page][16] for your language for more details.
 
+For example, to turn on [Application Security Monitoring][4] or [Continuous Profiler][3], each of which may have billing impact:
+
+- For **Kubernetes**, set the container environment variables `DD_APPSEC_ENABLED` or `DD_PROFILING_ENABLED` to `true`.
+
+- For **hosts and containers**, set the container environment variables `DD_APPSEC_ENABLED` or `DD_PROFILING_ENABLED` to `true`, or in the [injection configuration](#supplying-configuration-source) specify an `additional_environment_variables` section like the following YAML example: 
+
+  ```yaml
+  additional_environment_variables:
+  - key: DD_PROFILING_ENABLED
+    value: true
+  - key: DD_APPSEC_ENABLED
+    value: true 
+  ```
+
+  Only configuration keys that start with `DD_` can be set in the injection config source `additional_environment_variables` section.
+
 
 [2]: /tracing/trace_collection/
+[3]: /profiler/enabling/java/?tab=environmentvariables#installation
+[4]: /security/application_security/getting_started/java/?tab=kubernetes#get-started
 [16]: /tracing/trace_collection/library_config/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Describes how to enable ASM and Profiler using library injection config

### Motivation
Suggestion from evangelism team

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
