### PR TITLE
Fix trace agent metric name (ratelimit)

### DIFF
--- a/content/en/tracing/troubleshooting/agent_apm_metrics.md
+++ b/content/en/tracing/troubleshooting/agent_apm_metrics.md
@@ -54,10 +54,6 @@ Increment by one on every code panic.
 : **Type**: Count<br>
 Increment by one every time a reverse proxy of profile endpoints is created.
 
-`datadog.trace_agent.ratelimit`
-: **Type**: Gauge<br>
-If lower than `1`, it means payloads are being refused due to high resource usage (cpu or memory).
-
 `datadog.trace_agent.receiver.error`
 : **Type**: Count<br>
 Number of times that the API rejected a payload due to an error in either decoding, formatting or other.
@@ -85,6 +81,10 @@ Number of payloads accepted by the Agent.
 `datadog.trace_agent.receiver.payload_refused`
 : **Type**: Count<br>
 Number of payloads rejected by the receiver because of the sampling.
+
+`datadog.trace_agent.receiver.ratelimit`
+: **Type**: Gauge<br>
+If lower than `1`, it means payloads are being refused due to high resource usage (cpu or memory).
 
 `datadog.trace_agent.receiver.spans_dropped`
 : **Type**: Count<br>


### PR DESCRIPTION
### What does this PR do?
`datadog.trace_agent.ratelimit` is actually `datadog.trace_agent.receiver.ratelimit`
see https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/api.go#L676


### Motivation
Having a correct doc

<!-- ### Preview -->


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
