### PR TITLE
[DOCS-4903] Add aliases and links to Getting Started with Obs Pipelines  

### DIFF
--- a/content/en/agent/_index.md
+++ b/content/en/agent/_index.md
@@ -64,7 +64,8 @@ Datadog Agent release numbering follows <a href="https://semver.org/">SemVer</a>
   {{< nextlink href="/agent/versions/">}}<u>Versions</u>: Agent 7 is the latest major version of the Datadog Agent. Learn about changes between major Agent versions and how to upgrade.{{< /nextlink >}}
   {{< nextlink href="/agent/troubleshooting">}}<u>Troubleshooting</u>: Find troubleshooting information for the Datadog Agent.{{< /nextlink >}}
   {{< nextlink href="/agent/guide">}}<u>Guides</u>: These are in-depth, step-by-step tutorials for using the Agent.{{< /nextlink >}}
-  {{< nextlink href="/agent/security">}}<u>Security</u>: Information on the main security capabilities and features available to customers to ensure their environment is secure.{{< /nextlink >}}
+  {{< nextlink href="/agent/security">}}<u></u>: Information on the main security capabilities and features available to customers to ensure their environment is secure.{{< /nextlink >}}
+  {{< nextlink href="/getting_started/observability_pipelines">}}<u>Configure Observability Pipelines and Datadog</u>: Deploy the Observability Pipelines Worker as an aggregator to collect, transform, and route all of your logs and metrics to any destination.{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ## Further Reading

--- a/content/en/agent/_index.md
+++ b/content/en/agent/_index.md
@@ -64,7 +64,7 @@ Datadog Agent release numbering follows <a href="https://semver.org/">SemVer</a>
   {{< nextlink href="/agent/versions/">}}<u>Versions</u>: Agent 7 is the latest major version of the Datadog Agent. Learn about changes between major Agent versions and how to upgrade.{{< /nextlink >}}
   {{< nextlink href="/agent/troubleshooting">}}<u>Troubleshooting</u>: Find troubleshooting information for the Datadog Agent.{{< /nextlink >}}
   {{< nextlink href="/agent/guide">}}<u>Guides</u>: These are in-depth, step-by-step tutorials for using the Agent.{{< /nextlink >}}
-  {{< nextlink href="/agent/security">}}<u></u>: Information on the main security capabilities and features available to customers to ensure their environment is secure.{{< /nextlink >}}
+  {{< nextlink href="/agent/security">}}<u>Security</u>: Information on the main security capabilities and features available to customers to ensure their environment is secure.{{< /nextlink >}}
   {{< nextlink href="/getting_started/observability_pipelines">}}<u>Configure Observability Pipelines and Datadog</u>: Deploy the Observability Pipelines Worker as an aggregator to collect, transform, and route all of your logs and metrics to any destination.{{< /nextlink >}}
 {{< /whatsnext >}}
 

--- a/content/en/getting_started/observability_pipelines/_index.md
+++ b/content/en/getting_started/observability_pipelines/_index.md
@@ -2,7 +2,11 @@
 title: Getting Started with Observability Pipelines
 kind: Documentation
 aliases:
-    - /observability_pipelines/quickstart/
+  - /agent/vector_aggregation/
+  - /integrations/observability_pipelines/integrate_vector_with_datadog/
+  - /observability_pipelines/integrate_vector_with_datadog/
+  - /observability_pipelines/integrations/integrate_vector_with_datadog/
+  - /observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker/
 further_reading:
   - link: "/observability_pipelines/production_deployment_overview/"
     tag: "Documentation"

--- a/content/en/observability_pipelines/_index.md
+++ b/content/en/observability_pipelines/_index.md
@@ -4,9 +4,12 @@ kind: Documentation
 aliases:
   - /integrations/observability_pipelines/
 further_reading:
-  - link: /observability_pipelines/installation/
+  - link: /getting_started/observability_pipelines/
     tag: Documentation
-    text: Set up Observability Pipelines 
+    text: Install the Observability Pipelines Worker
+  - link: /getting_started/observability_pipelines/
+    tag: Documentation
+    text: Get started with Observability Pipelines and Datadog
   - link: https://www.datadoghq.com/blog/datadog-observability-pipelines/
     tag: Blog
     text: Take control of your telemetry data with Observability Pipelines

--- a/content/en/observability_pipelines/configurations.md
+++ b/content/en/observability_pipelines/configurations.md
@@ -9,6 +9,9 @@ further_reading:
   - link: /observability_pipelines/working_with_data/
     tag: Documentation
     text: Working with data using Observability Pipelines
+  - link: /getting_started/observability_pipelines/
+    tag: Documentation
+    text: Get started with Observability Pipelines and Datadog
 ---
 
 ## Overview

--- a/content/en/observability_pipelines/installation.md
+++ b/content/en/observability_pipelines/installation.md
@@ -3,18 +3,13 @@ title: Installation
 kind: Documentation
 aliases:
     - /observability_pipelines/setup/
-    - /agent/vector_aggregation/
-    - /integrations/observability_pipelines/integrate_vector_with_datadog/
-    - /observability_pipelines/integrate_vector_with_datadog/
-    - /observability_pipelines/integrations/integrate_vector_with_datadog/
-    - /observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker/
 further_reading:
-  - link: /observability_pipelines/production_deployment_overview/
-    tag: Documentation
-    text: Taking the Worker to production environments
-  - link: /getting_started/observability_pipelines
-    tag: Documentation
-    text: Get started with the Observability Pipelines Worker and Datadog Agent
+    - link: /getting_started/observability_pipelines/
+      tag: Documentation
+      text: Get started with Observability Pipelines and Datadog
+    - link: /observability_pipelines/production_deployment_overview/
+      tag: Documentation
+      text: Taking the Worker to production environments
 ---
 
 {{< tabs >}}
@@ -30,7 +25,7 @@ Before installing, make sure you:
 
 1. Are using one of the supported Linux architectures: x86_64 or AMD64
 2. Have a valid [Datadog API key][5].
-3. Have an [Observability Pipelines Configuration][7].
+3. Have an [Observability Pipelines Configuration][6].
 
 ## Installation
 
@@ -75,7 +70,7 @@ $ DD_API_KEY=<DD_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.
     echo "<DD_OP_CONFIG>" > /var/lib/observability-pipelines-worker/observability-pipelines-worker.yaml
     ```
 
-    Where `DD_OP_CONFIG` is the content of your Observability Pipeline configuration that you created in the [Observability Pipelines UI][7].
+    Where `DD_OP_CONFIG` is the content of your Observability Pipeline configuration that you created in the [Observability Pipelines UI][6].
 
 
 5. Start the Worker:
@@ -103,17 +98,18 @@ $ DD_API_KEY=<DD_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.
 ## Configuration
 
 - The configuration file for the Worker is located at `/etc/observability-pipelines-worker/observability-pipelines-worker.yaml`.
-- See Configuration Reference for all configuration options.
-- See [Working with Data][6] and Configuration Reference for configuration examples.
+- See [Configuration Reference][7] for all configuration options.
+- See [Working with Data][8] and Configuration Reference for configuration examples.
+
 
 [1]: https://en.wikipedia.org/wiki/APT_%28software%29
 [2]: https://debian.org/
 [3]: https://ubuntu.com/
 [4]: https://linux.org/
 [5]: /account_management/api-app-keys/#api-keys
-[6]: /observability_pipelines/working_with_data/
-[7]: https://app.datadoghq.com/observability-pipelines
-
+[6]: https://app.datadoghq.com/observability-pipelines
+[7]: /observability_pipelines/configurations/
+[8]: /observability_pipelines/working_with_data/
 {{% /tab %}}
 {{% tab "Helm" %}}
 
@@ -194,12 +190,12 @@ Before installing, make sure you have:
 
 See [this table][5] for the the list of values.
 
-[1]: https://helm.sh/ 
+
+[1]: https://helm.sh/
 [2]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [3]: /account_management/api-app-keys/#api-keys
 [4]: https://artifacthub.io/packages/helm/datadog/observability-pipelines-worker
 [5]: https://github.com/DataDog/helm-charts/tree/main/charts/observability-pipelines-worker#values
-
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/observability_pipelines/installation.md
+++ b/content/en/observability_pipelines/installation.md
@@ -189,7 +189,6 @@ Before installing, make sure you have:
 
 See [this table][5] for the the list of values.
 
-
 [1]: https://helm.sh/
 [2]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [3]: /account_management/api-app-keys/#api-keys

--- a/content/en/observability_pipelines/installation.md
+++ b/content/en/observability_pipelines/installation.md
@@ -101,7 +101,6 @@ $ DD_API_KEY=<DD_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.
 - See [Configuration Reference][7] for all configuration options.
 - See [Working with Data][8] and Configuration Reference for configuration examples.
 
-
 [1]: https://en.wikipedia.org/wiki/APT_%28software%29
 [2]: https://debian.org/
 [3]: https://ubuntu.com/

--- a/content/en/observability_pipelines/working_with_data.md
+++ b/content/en/observability_pipelines/working_with_data.md
@@ -4,7 +4,7 @@ kind: Documentation
 aliases:
   - /integrations/observability_pipelines/working_with_data/
 further_reading:
-  - link: /observability_pipelines/installation/
+  - link: /getting_started/observability_pipelines/
     tag: Documentation
     text: Get started with Observability Pipelines and Datadog
   - link: /observability_pipelines/reference/transforms/#awsec2metadata

--- a/content/en/observability_pipelines/working_with_data.md
+++ b/content/en/observability_pipelines/working_with_data.md
@@ -4,6 +4,9 @@ kind: Documentation
 aliases:
   - /integrations/observability_pipelines/working_with_data/
 further_reading:
+  - link: /observability_pipelines/installation/
+    tag: Documentation
+    text: Get started with Observability Pipelines and Datadog
   - link: /observability_pipelines/reference/transforms/#awsec2metadata
     tag: Documentation
     text: Parsing metadata emitted by AWS EC2 instance


### PR DESCRIPTION
### What does this PR do?

- Adds previous aliases in Integrate Observability Pipelines Worker and Datadog to the new Getting Started with Obs Pipelines.
- Add links to Getting Started with Obs Pipelines in further reading sections.

Ready to merge.

### Motivation

[Docs-4903](https://datadoghq.atlassian.net/browse/DOCS-4903)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
