### PR TITLE
Fix wrong env variable to enable dbm propagation in python instructions

### DIFF
--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -180,7 +180,7 @@ pip install psycopg2
 ```
 
 Enable the database monitoring propagation feature by setting the following environment variable:
-   - `DD_TRACE_SQL_COMMENT_INJECTION_MODE=full`
+   - `DD_DBM_PROPAGATION_MODE=full`
 
 For the best user experience ensure the following environment variables are set in your application:
    - `DD_SERVICE=(application name)`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This fixes the python trace instructions that were referring to an earlier iteration that was never used/committed when the python tracer implementation was in development. 

The correct env variable is `DD_DBM_PROPAGATION_MODE`.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
