### PR TITLE
apm_dbm: bump minimum supported version of the python tracer

### DIFF
--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -40,7 +40,7 @@ Data privacy
 |          | [postgres][10]                 | {{< X >}}   |             |
 |          | [mysql][13]                    |             | {{< X >}}   |
 |          | [mysql2][14]                   |             | {{< X >}}   |
-| **Python:** [dd-trace-py][11] >= 1.7.0 |  |             |             |
+| **Python:** [dd-trace-py][11] >= 1.9.0 |  |             |             |
 |          | [psycopg2][12]                 | {{< X >}}   |             |
 | **Java**     |                            |             |             |
 |          | jdbc                           | Coming soon | Coming soon |


### PR DESCRIPTION
[dd-trace-py v1.9.0](https://ddtrace.readthedocs.io/en/stable/release_notes.html#v1-9-0) introduced support for appending dbm comments to queries with the type byte. Previously we would only append DBM comments to unicode strings. Although this is an edge case that should not impact most customers it's worth calling out.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
