### PR TITLE
(hackathon) integration finder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,11 @@ start-docker: clean  ## Build and run docs including external content via docker
 stop-docker: ## Stop the running docker container.
 	@docker-compose -f ./docker-compose-docs.yml down
 
+find-int: hugpython ## Find the source for an integration (downloads/updates integrations repos first)
+	@. hugpython/bin/activate && \
+	export GITHUB_TOKEN=$(GITHUB_TOKEN) && \
+	./local/bin/py/integration-finder.py $(int)
+
 # install the root level node modules
 node_modules: package.json yarn.lock
 	@yarn install --immutable

--- a/local/bin/py/integration-finder.py
+++ b/local/bin/py/integration-finder.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import yaml
+from pprint import pprint
+import os
+from os.path import isdir
+import git
+import argparse
+import re
+
+'''
+Find the source repo for a given integration.
+'''
+def filter_out_dots(array):
+    for dir in array:
+        if dir[0] == '.':
+            array.remove(dir)
+    return array
+
+# Grab DataDog repos data from pull_config
+def grab_repos_data():
+    with open('local/bin/py/build/configurations/pull_config.yaml', 'r') as file:
+        repo_data = yaml.safe_load(file)
+    for item in repo_data:
+        for child in item:
+            if child == 'data':
+                for org in item[child]:
+                    if org['org_name'] == 'DataDog':
+                        dd_org_repos = org['repos']
+
+    # collect source repos and primary branches for integrations
+    integrations_repos = []
+    for repo in dd_org_repos:
+        for item in repo['contents']:
+            if item['action'] == 'integrations' or item['action'] == 'marketplace-integrations':
+                integrations_repos.append({repo['repo_name']: item['branch']})
+    return integrations_repos
+
+# Check if the repos are present locally. If not, clone them. If so, update them
+def update_repos(integrations_repos):
+    for repo in integrations_repos:
+        for k in repo:
+            local_repo_path = os.path.join('..', k)
+            if isdir(local_repo_path):
+                print(f'Updating {k}: {repo[k]}')
+                local_repo = git.Repo(local_repo_path)
+                local_repo.remotes.origin.pull(repo[k])
+            else:
+                print(f'{k}: {repo[k]} not found. Cloning to {local_repo_path}')
+                git.Repo.clone_from(url=f'git@github.com:DataDog/{k}.git', to_path=local_repo_path)
+
+# Find the given integration in the integrations repos
+def find_integration(integrations_repos, integration_name):
+    integration_dict = {}
+    found = []
+    for repo in integrations_repos:
+        for k in repo:
+            integration_list = []
+            location = os.path.join('..', k)
+            if k == 'dogweb':
+                location = location + '/integration/'
+                url = f'- https://github.com/DataDog/{k}/blob/{repo[k]}/integration/{integration_name}/README.md'
+            url = f'- https://github.com/DataDog/{k}/blob/{repo[k]}/{integration_name}/README.md'
+            integration_list = [f.name for f in os.scandir(location) if f.is_dir()]
+            integration_list = filter_out_dots(integration_list)
+            if integration_name in integration_list:
+                found.append(f'{location}/{integration_name}/README.md\n{url}')
+    if len(found) == 0:
+        print(f'\nIntegration "{integration_name}" not found. Check the spelling and try again.')
+    elif len(found) == 1:
+        print(f'\nYou can find {integration_name} here:\n- {"".join(found)}')
+    else:
+        print('\nMore than one integration with that name was found. Check the following:')
+        for entry in found:
+            print(f'{entry}\n')
+
+
+parser = argparse.ArgumentParser(description="Find an integration")
+parser.add_argument('integration', help="The name of the integration to search for", type=str)
+args = parser.parse_args()
+
+integrations_repos = grab_repos_data()
+integrations = update_repos(integrations_repos)
+find_integration(integrations_repos, args.integration)

--- a/local/bin/py/integration-finder.py
+++ b/local/bin/py/integration-finder.py
@@ -10,7 +10,13 @@ import re
 
 '''
 Find the source repo for a given integration.
+
+TODO:
+- Remove from make. Add to dedicated CLI
+- Make repo + branch finder a separate module
+- Make branch updater a separate module / command
 '''
+
 def filter_out_dots(array):
     for dir in array:
         if dir[0] == '.':
@@ -51,16 +57,15 @@ def update_repos(integrations_repos):
 
 # Find the given integration in the integrations repos
 def find_integration(integrations_repos, integration_name):
-    integration_dict = {}
     found = []
     for repo in integrations_repos:
         for k in repo:
             integration_list = []
             location = os.path.join('..', k)
+            url = f'- https://github.com/DataDog/{k}/blob/{repo[k]}/{integration_name}/README.md'
             if k == 'dogweb':
                 location = location + '/integration/'
                 url = f'- https://github.com/DataDog/{k}/blob/{repo[k]}/integration/{integration_name}/README.md'
-            url = f'- https://github.com/DataDog/{k}/blob/{repo[k]}/{integration_name}/README.md'
             integration_list = [f.name for f in os.scandir(location) if f.is_dir()]
             integration_list = filter_out_dots(integration_list)
             if integration_name in integration_list:

--- a/local/etc/requirements3.txt
+++ b/local/etc/requirements3.txt
@@ -14,3 +14,4 @@ Pygments==2.7.4
 datadog==0.35.0
 markdown2==2.3.8
 Jinja2==3.0.1
+GitPython


### PR DESCRIPTION
Integration finder:
- looks for local copies of all integrations repos and either updates them or clones them
- searches for a given integration (use the integration spelling from the docs url)

I have some TODOs listed. I'm planning on eventually building a little docs CLI tool in a different repo. For now, I'd like to get this merged in though, cos I don't know when I'll get to the CLI stuff (maybe next hackathon).

To test:
```shell
make find-int int=<integration_name>
```

For example:
```shell
make find-int int=btrfs
Updating dogweb: prod
Updating integrations-core: master
Updating integrations-extras: master
Updating integrations-internal-core: main
Updating marketplace: master

More than one integration with that name was found. Check the following:
../dogweb/integration//btrfs/README.md
- https://github.com/DataDog/dogweb/blob/prod/btrfs/README.md

../integrations-core/btrfs/README.md
- https://github.com/DataDog/integrations-core/blob/master/btrfs/README.md
```

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
