### PR TITLE
WEB-3342 - update api md table style to be similar to generated tables

### DIFF
--- a/assets/styles/pages/_api.scss
+++ b/assets/styles/pages/_api.scss
@@ -256,4 +256,21 @@ $ddpurple: #632ca6;
       opacity:1;
     }
 
+
+    // Style api tables from markdown to be purple similar to generated api examples
+    table,
+    .table {
+        background-color: #fdfcff;
+        border: 1px solid #ebebeb;
+        & > thead > tr > th {
+            background: #f3edff;
+        }
+        & > thead > tr > th,
+        & > tbody > tr > td {
+            border-left: 1px solid #ebebeb !important;
+        }
+        & > tbody tr:nth-child(2n) {
+            background: #fdfcff;
+        }
+    }
 }


### PR DESCRIPTION
### What does this PR do?

When using table syntax in markdown on api generated pages we use the regular docs style tables however it looks out of place on the api where all the generated tables are using a purple color scheme.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-3342

### Preview

There isn't currently any usage of this to show on the preview site but it ends up looking like this (from my testing)
![Screenshot 2023-03-14 at 12 36 26](https://user-images.githubusercontent.com/871552/225003388-ed56c207-d966-49d9-85de-a0f394b4395b.png)

https://docs-staging.datadoghq.com/david.jones/md-table-style/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
