### PR TITLE
vertically align footer download icons

### DIFF
--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -47,7 +47,7 @@
                     </a>
                 </div>
 
-                <div class="stef d-none d-lg-flex justify-content-lg-start align-items-lg-center">
+                <div class="d-none d-lg-flex justify-content-lg-start align-items-lg-end">
                     <a href="https://apps.apple.com/app/datadog/id1391380318" class="me-2" aria-label="Apple Store Link">
                         {{ partial "svg" (dict "context" $dot "src" "apple.svg" )}}
                     </a>

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -38,7 +38,7 @@
                 </a>
                 <p class="fw-semibold text-center text-lg-start mb-0">Download mobile app</p>
 
-                <div class="d-flex d-lg-none justify-content-center ">
+                <div class="d-flex d-lg-none justify-content-center">
                     <a href="https://apps.apple.com/app/datadog/id1391380318" class="me-1" aria-label="Apple Store Link">
                         {{ partial "svg" (dict "context" $dot "src" "app-store-badge.svg" )}}
                     </a>
@@ -47,7 +47,7 @@
                     </a>
                 </div>
 
-                <div class="d-none d-lg-flex justify-content-lg-start">
+                <div class="stef d-none d-lg-flex justify-content-lg-start align-items-lg-center">
                     <a href="https://apps.apple.com/app/datadog/id1391380318" class="me-2" aria-label="Apple Store Link">
                         {{ partial "svg" (dict "context" $dot "src" "apple.svg" )}}
                     </a>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->



### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

vertically  align google play and apple store footer icons on large screens

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/browse/WEB-3231?focusedCommentId=994816

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/stefon.simmons/vertically-align-footer-icons/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
