### PR TITLE
CI Visibility: Add Codefresh env vars

### DIFF
--- a/content/en/continuous_integration/tests/containers.md
+++ b/content/en/continuous_integration/tests/containers.md
@@ -148,6 +148,20 @@ Additionally, you need to pass in the environment variables required to configur
 
 [1]: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
 {{% /tab %}}
+{{% tab "Codefresh" %}}
+
+- `CF_BUILD_ID`
+- `CF_PIPELINE_NAME`
+- `CF_BUILD_URL`
+- `CF_STEP_NAME`
+- `CF_BRANCH`
+- `CF_REVISION`
+
+[Full list of build environment variables provided by CircleCI][1]
+
+
+[1]: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+{{% /tab %}}
 {{% tab "GitHub Actions" %}}
 
 - `GITHUB_ACTION`

--- a/content/en/continuous_integration/tests/containers.md
+++ b/content/en/continuous_integration/tests/containers.md
@@ -160,7 +160,7 @@ Additionally, you need to pass in the environment variables required to configur
 [Full list of build environment variables provided by Codefresh][1]
 
 
-[1]: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+[1]: https://codefresh.io/docs/docs/pipelines/variables/
 {{% /tab %}}
 {{% tab "GitHub Actions" %}}
 

--- a/content/en/continuous_integration/tests/containers.md
+++ b/content/en/continuous_integration/tests/containers.md
@@ -157,7 +157,7 @@ Additionally, you need to pass in the environment variables required to configur
 - `CF_BRANCH`
 - `CF_REVISION`
 
-[Full list of build environment variables provided by CircleCI][1]
+[Full list of build environment variables provided by Codefresh][1]
 
 
 [1]: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables


### PR DESCRIPTION
### What does this PR do?
Document the env vars from Codefresh that are used for CI Visibility.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
