### PR TITLE
[ci-visibility] Update cypress instructions to warn about `cypress open`

### DIFF
--- a/content/en/continuous_integration/tests/javascript.md
+++ b/content/en/continuous_integration/tests/javascript.md
@@ -316,6 +316,12 @@ To create filters or `group by` fields for these tags, you must first create fac
 
 If the browser application being tested is instrumented using [RUM][6], your Cypress test results and their generated RUM browser sessions and session replays are automatically linked. Learn more in the [RUM integration][7] guide.
 
+
+### Cypress interactive mode
+
+Cypress interactive mode (that is, when cypress is run via `cypress open`) is not supported by CI Visibility, because some events CI Visibility relies on are not fired by default, such as [`before:run`][8]. If you want to try it anyway, we suggest that you pass `experimentalInteractiveRunEvents: true` to the [cypress configuration file][9].
+
+
 [1]: https://docs.cypress.io/api/plugins/writing-a-plugin#Plugins-API
 [2]: https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Plugins-file
 [3]: https://docs.cypress.io/guides/references/configuration#cypress-json
@@ -323,6 +329,8 @@ If the browser application being tested is instrumented using [RUM][6], your Cyp
 [5]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
 [6]: /real_user_monitoring/browser/#setup
 [7]: /continuous_integration/guides/rum_integration/
+[8]: https://docs.cypress.io/api/plugins/before-run-api
+[9]: https://docs.cypress.io/guides/references/configuration#Configuration-File
 {{% /tab %}}
 
 {{< /tabs >}}

--- a/content/en/continuous_integration/tests/javascript.md
+++ b/content/en/continuous_integration/tests/javascript.md
@@ -432,7 +432,7 @@ If you want visibility into the browser process, consider using [RUM & Session R
 
 ### Cypress interactive mode
 
-Cypress interactive mode (cypress is run through `cypress open`) is not supported by CI Visibility, because some cypress events are not fired, such as [`before:run`][12]. If you want to try it anyway, pass `experimentalInteractiveRunEvents: true` to the [cypress configuration file][13].
+Cypress interactive mode (which you can enter by running `cypress open`) is not supported by CI Visibility because some cypress events, such as [`before:run`][12], are not fired. If you want to try it anyway, pass `experimentalInteractiveRunEvents: true` to the [cypress configuration file][13].
 
 
 ## Best practices

--- a/content/en/continuous_integration/tests/javascript.md
+++ b/content/en/continuous_integration/tests/javascript.md
@@ -317,11 +317,6 @@ To create filters or `group by` fields for these tags, you must first create fac
 If the browser application being tested is instrumented using [RUM][6], your Cypress test results and their generated RUM browser sessions and session replays are automatically linked. Learn more in the [RUM integration][7] guide.
 
 
-### Cypress interactive mode
-
-Cypress interactive mode (that is, when cypress is run via `cypress open`) is not supported by CI Visibility, because some events CI Visibility relies on are not fired by default, such as [`before:run`][8]. If you want to try it anyway, we suggest that you pass `experimentalInteractiveRunEvents: true` to the [cypress configuration file][9].
-
-
 [1]: https://docs.cypress.io/api/plugins/writing-a-plugin#Plugins-API
 [2]: https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Plugins-file
 [3]: https://docs.cypress.io/guides/references/configuration#cypress-json
@@ -329,8 +324,6 @@ Cypress interactive mode (that is, when cypress is run via `cypress open`) is no
 [5]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
 [6]: /real_user_monitoring/browser/#setup
 [7]: /continuous_integration/guides/rum_integration/
-[8]: https://docs.cypress.io/api/plugins/before-run-api
-[9]: https://docs.cypress.io/guides/references/configuration#Configuration-File
 {{% /tab %}}
 
 {{< /tabs >}}
@@ -437,6 +430,9 @@ Browser tests executed with `mocha`, `jest`, `cucumber`, `cypress`, and `playwri
 
 If you want visibility into the browser process, consider using [RUM & Session Replay][10]. When using Cypress, test results and their generated RUM browser sessions and session replays are automatically linked. Learn more in the [RUM integration][11] guide.
 
+### Cypress interactive mode
+
+Cypress interactive mode (cypress is run through `cypress open`) is not supported by CI Visibility, because some cypress events are not fired, such as [`before:run`][12]. If you want to try it anyway, pass `experimentalInteractiveRunEvents: true` to the [cypress configuration file][13].
 
 
 ## Best practices
@@ -456,14 +452,14 @@ Avoid this:
 })
 {{< /code-block >}}
 
-And use [`test.each`][12] instead:
+And use [`test.each`][14] instead:
 {{< code-block lang="javascript" >}}
 test.each([[1,2,3], [3,4,7]])('sums correctly %i and %i', (a,b,expected) => {
   expect(a+b).toEqual(expected)
 })
 {{< /code-block >}}
 
-For `mocha`, use [`mocha-each`][13]:
+For `mocha`, use [`mocha-each`][15]:
 {{< code-block lang="javascript" >}}
 const forEach = require('mocha-each');
 forEach([
@@ -486,13 +482,14 @@ When CI Visibility is enabled, the following data is collected from your project
 * Git commit history including the hash, message, author information, and files changed (without file contents).
 * Information from the CODEOWNERS file.
 
-In addition to that, if [Intelligent Test Runner][14] is enabled, the following data is collected from your project:
+In addition to that, if [Intelligent Test Runner][16] is enabled, the following data is collected from your project:
 
 * Code coverage information, including file names and line numbers covered by each test.
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
 
 
 [1]: https://github.com/facebook/jest/tree/main/packages/jest-circus
@@ -506,6 +503,8 @@ In addition to that, if [Intelligent Test Runner][14] is enabled, the following 
 [9]: https://nodejs.org/api/packages.html#packages_determining_module_system
 [10]: /real_user_monitoring/browser/
 [11]: /continuous_integration/guides/rum_integration/
-[12]: https://jestjs.io/docs/api#testeachtablename-fn-timeout
-[13]: https://www.npmjs.com/package/mocha-each
-[14]: /continuous_integration/intelligent_test_runner/
+[12]: https://docs.cypress.io/api/plugins/before-run-api
+[13]: https://docs.cypress.io/guides/references/configuration#Configuration-File
+[14]: https://jestjs.io/docs/api#testeachtablename-fn-timeout
+[15]: https://www.npmjs.com/package/mocha-each
+[16]: /continuous_integration/intelligent_test_runner/


### PR DESCRIPTION
### What does this PR do?
Warn about usage of `cypress open`

### Motivation
Do not confuse customers that are trying cypress interactive mode with CI Visibility.

### Preview
https://docs-staging.datadoghq.com/juan-fernandez/update-cypress-instructions/continuous_integration/tests/javascript/?tab=onpremisesciproviderdatadogagent#known-limitations

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
