### PR TITLE
WEB-3346 | Add redirect CI job for live

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -450,3 +450,18 @@ set_redirect_metadata_preview:
   script:
     - in-isolation update_redirect_metadata
   interruptible: true
+
+set_redirect_metadata_live:
+  <<: *base_template
+  <<: *live_rules
+  variables:
+    BUCKET: "datadog-docs-live-hugo"
+    IS_REDIRECT_JOB: "true" 
+  stage: post-deploy
+  cache: []
+  environment: "live"
+  dependencies:
+    - build_live
+  script:
+    - in-isolation update_redirect_metadata
+  interruptible: true


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add the redirect meta job to the live site in CI

### Motivation
<!-- What inspired you to submit this pull request?-->
Now that we have been running the redirect meta job in preview for a few days, and haven't seen odd behavior on redirects, we want to roll it out to the live site. 

For context:
This job runs post deploy, hugo will use the current alias pages while this job is still working to make sure redirects are always live on site. As the job works, it replaces the redirects in the bucket with metadata that will redirect as the link is hit and serve the proper `301` code. This job has built in logic to not allow redirects to the same page (causing redirect loops, hugo bypasses these for alias pages to avoid the same) and will inform the user at the end of the job what aliases should be removed since they are redundant. If you have any questions or want further clarification please feel free to slack me.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
