### PR TITLE
WEB-3353 - adjust styles of reference docs schema table

### DIFF
--- a/assets/styles/components/_schema-table.scss
+++ b/assets/styles/components/_schema-table.scss
@@ -3,35 +3,13 @@
     background-color: #fdfcff;
     position: relative;
     border-left: 0.5px solid #ebebeb;
-    overflow-x: scroll;
 
     .table-header {
         background-color: #f3edff;
         text-transform: uppercase;
-        width: 880px;
-
-        @include media-breakpoint-up(lg) {
-            width: 706px;
-        }
-
-        @include media-breakpoint-up(xl) {
-            width: 880px;
-        }
 
         .column {
             border: none;
-        }
-    }
-
-    .table-header + div {
-        width: 850px;
-
-        @include media-breakpoint-up(lg) {
-            width: 676px;
-        }
-
-        @include media-breakpoint-up(xl) {
-            width: 850px;
         }
     }
 
@@ -50,17 +28,13 @@
         border-right: 0.5px solid #ebebeb;
         padding: 0 15px 0 15px;
         @media (min-width: 992px) {
-            padding: 0 10px;
+            padding: 0 15px 0 30px;
         }
-    }
-
-    .column:last-of-type p {
-        overflow-wrap: break-word;
     }
 
     .key {
         position: relative;
-        word-break: normal;
+        word-break: break-all;
         .toggle-arrow {
             font-size: 18px;
             position: absolute;
@@ -78,13 +52,20 @@
                 left: -20px;
             }
         }
+
+        @media (min-width: 768px) {
+            word-break: normal;
+        }
     }
 
     p {
         margin: 4px 0;
         font-size: 16px;
         line-height: 22px;
-        overflow-wrap: normal;
+        overflow-wrap: break-word;
+        @media (min-width: 768px) {
+            overflow-wrap: normal;
+        }
     }
 
     code {

--- a/assets/styles/pages/_reference.scss
+++ b/assets/styles/pages/_reference.scss
@@ -1,61 +1,118 @@
-.announcement .main h5 {
-  pointer-events:all;
-}
-.main h5:before {
-  display: none;
-}
-.main .chroma {
-  max-height: 350px;
-  overflow-wrap: break-word;
-  white-space: inherit;
-}
+.reference {
+  .announcement .main h5 {
+    pointer-events: all;
+  }
 
-.main .code-snippet-wrapper {
-  margin-right: 0;
-}
-.code-snippet-wrapper {
-  padding-right: 0 !important;
-  position: relative;
-  margin-bottom: 24px;
-}
+  .main h5:before {
+    display: none;
+  }
 
-#accordion .btn,
-.example-accordion .btn,
-.code-snippet-wrapper button:disabled,
-.code-snippet-wrapper button[disabled] {
-  font-weight: bold;
-  color: #632ca6;
-}
-#accordion .btn.collapsed,
-.example-accordion .btn.collapsed {
-  color: #666;
-}
-#accordion pre,
-.example-accordion pre {
-  border-bottom: 3px solid rgba(119,0,255,.3);
-  margin:0;
-}
-.code-snippet-wrapper button:disabled,
-.code-snippet-wrapper button[disabled], {
-  opacity:1;
-}
-.code-snippet-wrapper .code-snippet pre {
-  padding-top:10px;
-}
+  .main .chroma {
+    max-height: 350px;
+    overflow-wrap: break-word;
+    white-space: inherit;
+  }
 
-.schema-table .column {
-  padding:0px 8px 0 8px;
-}
-.schema-table .first-row .column:first-of-type {
-  padding-left: 30px;
-}
-.schema-table .table-header .column:first-of-type {
-  padding-left: 30px;
-}
+  .main .code-snippet-wrapper {
+    margin-right: 0;
+  }
 
-.col-1-5 {
-  flex: 0 0 12.5%;
-  max-width: 12.5%;
-  position: relative;
-  width: 100%;
+  .code-snippet-wrapper {
+    padding-right: 0 !important;
+    position: relative;
+    margin-bottom: 24px;
+  }
+
+  #accordion .btn,
+  .example-accordion .btn,
+  .code-snippet-wrapper button:disabled,
+  .code-snippet-wrapper button[disabled] {
+    font-weight: bold;
+    color: #632ca6;
+  }
+
+  #accordion .btn.collapsed,
+  .example-accordion .btn.collapsed {
+    color: #666;
+  }
+
+  #accordion pre,
+  .example-accordion pre {
+    border-bottom: 3px solid rgba(119, 0, 255, .3);
+    margin: 0;
+  }
+
+  .code-snippet-wrapper button:disabled,
+  .code-snippet-wrapper button[disabled], {
+    opacity: 1;
+  }
+
+  .code-snippet-wrapper .code-snippet pre {
+    padding-top: 10px;
+  }
+
+  .schema-table .column {
+    padding: 0px 8px 0 8px;
+  }
+
+  .schema-table .first-row .column:first-of-type {
+    padding-left: 30px;
+  }
+
+  .schema-table .table-header .column:first-of-type {
+    padding-left: 30px;
+  }
+
+  .schema-table {
+    overflow-x: scroll;
+
+    .table-header {
+      width: 880px;
+
+      @include media-breakpoint-up(lg) {
+        width: 706px;
+      }
+
+      @include media-breakpoint-up(xl) {
+        width: 880px;
+      }
+    }
+
+    .table-header + div {
+      width: 850px;
+
+      @include media-breakpoint-up(lg) {
+        width: 676px;
+      }
+
+      @include media-breakpoint-up(xl) {
+        width: 850px;
+      }
+    }
+
+    .expand-all {
+      @media (min-width: 992px) {
+        padding: 0 10px;
+      }
+    }
+
+    .column:last-of-type p {
+      overflow-wrap: break-word;
+    }
+
+    .key {
+      word-break: normal;
+    }
+
+    p {
+      overflow-wrap: normal;
+    }
+  }
+
+  .col-1-5 {
+    flex: 0 0 12.5%;
+    max-width: 12.5%;
+    position: relative;
+    width: 100%;
+  }
 }


### PR DESCRIPTION
### What does this PR do?

Corrects some api table style bug that was introduced in
https://github.com/DataDog/documentation/pull/17288

### Motivation

https://datadoghq.atlassian.net/browse/WEB-3353

### Preview

Check ref docs has horizontal scroll
https://docs-staging.datadoghq.com/david.jones/schema-table-update/observability_pipelines/reference/sinks/#awscloudwatchmetrics

Check api tables look normal
https://docs-staging.datadoghq.com/david.jones/schema-table-update/[api/latest/dashboards/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
