### PR TITLE
Change config option name to DD_TRACE_SAMPLING_RULES

### DIFF
--- a/content/ja/tracing/trace_collection/dd_libraries/java.md
+++ b/content/ja/tracing/trace_collection/dd_libraries/java.md
@@ -129,7 +129,7 @@ Agent のインストール後、アプリケーションをトレースする�
 | `DD_PROFILING_ENABLED`      | `dd.profiling.enabled`          | [継続的プロファイラー][5]を有効化 |
 | `DD_LOGS_INJECTION`   | `dd.logs.injection`     | Datadog トレース ID とスパン ID に対する自動 MDC キー挿入を有効にします。詳しくは、[高度な使用方法][6]を参照してください。 |
 | `DD_TRACE_SAMPLE_RATE` | `dd.trace.sample.rate` |   全サービスのトレースのルートでサンプリングレートを設定します。     |
-| `DD_TRACE_SAMPLING_SERVICE_RULES` | `dd.trace.sampling.service.rules` |   指定したルールに合致するサービスのトレースのルートでのサンプリングレートを設定します。    |
+| `DD_TRACE_SAMPLING_RULES` | `dd.trace.sampling.rules` |   指定したルールに合致するサービスのトレースのルートでのサンプリングレートを設定します。    |
 
 追加の[コンフィギュレーションオプション](#configuration) は以下で説明されています。
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Change DD_TRACE_SAMPLING_SERVICE_RULES to DD_TRACE_SAMPLING_RULES in the Japanese documentation.

Same as https://github.com/DataDog/documentation/pull/16820

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
