### PR TITLE
Remove Podman Log Note

### DIFF
--- a/content/en/agent/guide/podman-support-with-docker-integration.md
+++ b/content/en/agent/guide/podman-support-with-docker-integration.md
@@ -37,7 +37,6 @@ When running Podman in daemonless mode, instead of these options, you must mount
 
 ## Known limitations
 
-* Container logs aggregation is not supported.
 * The activation of the Podman socket can be optional depending on your setup. It may need to be enabled.
 
 


### PR DESCRIPTION
@kennonkwok 

Removed note about Podman not being able to collect logs:

"Container logs aggregation is not supported"

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Removes note about Podman not being able to collect logs.

### Motivation
<!-- What inspired you to submit this pull request?-->

Tested a Podman deployment with log collection. Showed that logs were being collected. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
