### PR TITLE
APM > .NET > Add initial DBM configuration key to APM configuration page.

### DIFF
--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -280,7 +280,7 @@ Ensure that you are using a supported client library (e.g. `Npgsql`).
 Enable the database monitoring propagation feature by setting the following environment variable:
    - `DD_DBM_PROPAGATION_MODE=full`
 
-For the best user experience ensure the following environment variables are set in your application:
+For the best user experience, ensure the following environment variables are set in your application:
    - `DD_SERVICE=(application name)`
    - `DD_ENV=(application environment)`
    - `DD_VERSION=(application version)`

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -42,12 +42,12 @@ Data privacy
 |          | [mysql2][14]                   |             | {{< X >}}   |
 | **Python:** [dd-trace-py][11] >= 1.9.0 |  |             |             |
 |          | [psycopg2][12]                 | {{< X >}}   |             |
-| **Java**     |                            |             |             |
-|          | jdbc                           | Coming soon | Coming soon |
 | **.NET** [dd-trace-dotnet][15] >= 2.26.0 ||             |             |
 |          | [Npgsql][16]                   | {{< X >}}   |             |
 |          | [MySql.Data][17]               |             | {{< X >}}   |
 |          | [MySqlConnector][18]           |             | {{< X >}}   |
+| **Java**     |                            |             |             |
+|          | jdbc                           | Coming soon | Coming soon |
 
 
 

--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -44,8 +44,11 @@ Data privacy
 |          | [psycopg2][12]                 | {{< X >}}   |             |
 | **Java**     |                            |             |             |
 |          | jdbc                           | Coming soon | Coming soon |
-| **.NET**     |                            |             |             |
-|          |                                | Coming soon | Coming soon |
+| **.NET** [dd-trace-dotnet][15] >= 2.26.0 ||             |             |
+|          | [Npgsql][16]                   | {{< X >}}   |             |
+|          | [MySql.Data][17]               |             | {{< X >}}   |
+|          | [MySqlConnector][18]           |             | {{< X >}}   |
+
 
 
 
@@ -264,6 +267,29 @@ client.query('SELECT $1::text as message', ['Hello world!'], (err, result) => {
 
 {{% /tab %}}
 
+{{% tab ".NET" %}}
+
+<div class="alert alert-warning">
+This features requires automatic instrumentation to be enabled for your .NET service.
+</div>
+
+Follow the [.NET Framework tracing instructions][1] or the [.NET Core tracing instructions][2] to install the automatic instrumentation package and enable tracing for your service.
+
+Ensure that you are using a supported client library (e.g. `Npgsql`).
+
+Enable the database monitoring propagation feature by setting the following environment variable:
+   - `DD_DBM_PROPAGATION_MODE=full`
+
+For the best user experience ensure the following environment variables are set in your application:
+   - `DD_SERVICE=(application name)`
+   - `DD_ENV=(application environment)`
+   - `DD_VERSION=(application version)`
+
+[1]: /tracing/trace_collection/dd_libraries/dotnet-framework
+[2]: /tracing/trace_collection/dd_libraries/dotnet-core
+
+{{% /tab %}}
+
 {{< /tabs >}}
 
 ## Explore the APM Connection
@@ -278,13 +304,13 @@ Break down active connections for a given host by the upstream APM services maki
 
 {{< img src="database_monitoring/dbm_query_sample_trace_preview.png" alt="Preview the sampled APM trace that the query sample being inspected was generated from.">}}
 
-When viewing a Query Sample in Database Monitoring, if the associated trace has been sampled by APM, you can view the DBM Sample in the context of the APM Trace. This allows you to combine DBM telemetry, including the explain plan and historical performance of the query, alongside the lineage of the span within your infrastructure to understand if a change on the database is responsible for poor application performance.  
+When viewing a Query Sample in Database Monitoring, if the associated trace has been sampled by APM, you can view the DBM Sample in the context of the APM Trace. This allows you to combine DBM telemetry, including the explain plan and historical performance of the query, alongside the lineage of the span within your infrastructure to understand if a change on the database is responsible for poor application performance.
 
-### Identify the downstream database hosts of APM services 
+### Identify the downstream database hosts of APM services
 
 {{< img src="database_monitoring/dbm_apm_service_page_db_host_list.png" alt="Visualize the downstream database hosts that your APM Services depend on from the Service Page.">}}
 
-On the APM Service Page, view the direct downstream database dependencies of the service as identified by Database Monitoring. Quickly determine if any hosts have disproportionate load that may be caused by noisy neighbors.  
+On the APM Service Page, view the direct downstream database dependencies of the service as identified by Database Monitoring. Quickly determine if any hosts have disproportionate load that may be caused by noisy neighbors.
 
 
 [1]: /database_monitoring/#getting-started
@@ -301,3 +327,7 @@ On the APM Service Page, view the direct downstream database dependencies of the
 [12]: https://www.psycopg.org/docs/index.html
 [13]: https://github.com/mysqljs/mysql
 [14]: https://github.com/sidorares/node-mysql2
+[15]: https://github.com/DataDog/dd-trace-dotnet
+[16]: https://www.nuget.org/packages/npgsql
+[17]: https://www.nuget.org/packages/MySql.Data
+[18]: https://www.nuget.org/packages/MySqlConnector

--- a/content/en/tracing/trace_collection/library_config/dotnet-core.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-core.md
@@ -210,6 +210,10 @@ The following configuration variables are available **only** when using automati
 Enables or disables all automatic instrumentation. Setting the environment variable to `false` completely disables the CLR profiler. For other configuration methods, the CLR profiler is still loaded, but traces will not be generated. Valid values are: `true` or `false`.<br>
 **Default**: `true`
 
+`DD_DBM_PROPAGATION_MODE`
+: Enables DBM to APM link when set to `'service'` or `'full'`. The `'service'` option enables the connection between DBM and APM services. The `'full'` option enables connection between database spans with database query events. Available for Postgres and MySql.<br>
+**Default**: `'disabled'`
+
 `DD_HTTP_CLIENT_ERROR_STATUSES`
 : Sets status code ranges that will cause HTTP client spans to be marked as errors. <br>
 **Default**: `400-499`

--- a/content/en/tracing/trace_collection/library_config/dotnet-core.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-core.md
@@ -211,7 +211,7 @@ Enables or disables all automatic instrumentation. Setting the environment varia
 **Default**: `true`
 
 `DD_DBM_PROPAGATION_MODE`
-: Enables DBM to APM link when set to `'service'` or `'full'`. The `'service'` option enables the connection between DBM and APM services. The `'full'` option enables connection between database spans with database query events. Available for Postgres and MySql.<br>
+: Enables linking between data sent from APM and the Database Monitoring product when set to `'service'` or `'full'`. The `'service'` option enables the connection between DBM and APM services. The `'full'` option enables connection between database spans with database query events. Available for Postgres and MySQL.<br>
 **Default**: `'disabled'`
 
 `DD_HTTP_CLIENT_ERROR_STATUSES`

--- a/content/en/tracing/trace_collection/library_config/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-framework.md
@@ -227,7 +227,7 @@ Enables or disables all automatic instrumentation. Setting the environment varia
 **Default**: `true`
 
 `DD_DBM_PROPAGATION_MODE`
-: Enables DBM to APM link when set to `'service'` or `'full'`. The `'service'` option enables the connection between DBM and APM services. The `'full'` option enables connection between database spans with database query events. Available for Postgres and MySql.<br>
+: Enables linking between data sent from APM and the Database Monitoring product when set to `'service'` or `'full'`. The `'service'` option enables the connection between DBM and APM services. The `'full'` option enables connection between database spans with database query events. Available for Postgres and MySQL.<br>
 **Default**: `'disabled'`
 
 `DD_HTTP_CLIENT_ERROR_STATUSES`

--- a/content/en/tracing/trace_collection/library_config/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-framework.md
@@ -226,6 +226,10 @@ The following configuration variables are available **only** when using automati
 Enables or disables all automatic instrumentation. Setting the environment variable to `false` completely disables the CLR profiler. For other configuration methods, the CLR profiler is still loaded, but traces will not be generated. Valid values are: `true` or `false`.<br>
 **Default**: `true`
 
+`DD_DBM_PROPAGATION_MODE`
+: Enables DBM to APM link when set to `'service'` or `'full'`. The `'service'` option enables the connection between DBM and APM services. The `'full'` option enables connection between database spans with database query events. Available for Postgres and MySql.<br>
+**Default**: `'disabled'`
+
 `DD_HTTP_CLIENT_ERROR_STATUSES`
 : Sets status code ranges that will cause HTTP client spans to be marked as errors. <br>
 **Default**: `400-499`


### PR DESCRIPTION
### What does this PR do?
1. Adds setup instructions to the DBM <-> APM link guide for compatibility with .NET
2. Adds the DBM configuration setting `DD_DBM_PROPAGATION_MODE` to the .NET tracing configuration pages

### Motivation
.NET has recently implemented the ability to link spans to DBM.

### Preview
DBM guide page: https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-configuration-dbm/database_monitoring/guide/connect_dbm_and_apm/?tab=net#setup

.NET Framework APM configuration page: https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-configuration-dbm/tracing/trace_collection/library_config/dotnet-framework/?tab=environmentvariables#automatic-instrumentation-optional-configuration

.NET Core APM configuration page: https://docs-staging.datadoghq.com/zach.montoya/apm-dotnet-configuration-dbm/tracing/trace_collection/library_config/dotnet-core/?tab=environmentvariables#automatic-instrumentation-optional-configuration

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
