### PR TITLE
APM availability for supported Istio releases

### DIFF
--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -587,6 +587,7 @@ variable. To define sampling rules in the Ingress Controller:
 [12]: https://github.com/DataDog/dd-opentracing-cpp/blob/master/doc/sampling.md
 [13]: https://github.com/kubernetes/ingress-nginx
 [14]: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#main-snippet
+[15]: https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases
 {{% /tab %}}
 {{% tab "Istio" %}}
 
@@ -598,7 +599,7 @@ Datadog monitors every aspect of your Istio environment, so you can:
 
 To learn more about monitoring your Istio environment with Datadog, [see the Istio blog][3].
 
-Datadog APM is available for Istio v1.1.3+ on Kubernetes clusters.
+Datadog APM is available for [supported Istio releases][15].
 
 ## Datadog Agent installation
 


### PR DESCRIPTION
Switched the following statement  - Datadog APM is available for Istio v1.1.3+ on Kubernetes clusters. To a more generalized statement - Datadog APM is available for supported Istio releases. 

Link to original doc - https://docs.datadoghq.com/tracing/trace_collection/proxy_setup/?tab=istio#ingress-controller-sampling

This was discussed in the following slack thread https://dd.slack.com/archives/G016KHR5TTL/p1677280714908719

This needs PM review @yoannrobin

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
