### PR TITLE
use public definition classifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ placeholders:
 hugpython: local/etc/requirements3.txt
 	@${PY3} -m venv --clear $@ && . $@/bin/activate && $@/bin/pip install --upgrade pip wheel && $@/bin/pip install -r $<;\
 	if [[ "$(CI_COMMIT_REF_NAME)" != "" ]]; then \
-		$@/bin/pip install https://binaries.ddbuild.io/dd-source/python/assetlib-0.0.14231163-py2.py3-none-any.whl; \
+		$@/bin/pip install https://binaries.ddbuild.io/dd-source/python/assetlib-0.0.14246916-py2.py3-none-any.whl; \
 	fi
 
 update_pre_build:

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ placeholders:
 hugpython: local/etc/requirements3.txt
 	@${PY3} -m venv --clear $@ && . $@/bin/activate && $@/bin/pip install --upgrade pip wheel && $@/bin/pip install -r $<;\
 	if [[ "$(CI_COMMIT_REF_NAME)" != "" ]]; then \
-		$@/bin/pip install https://binaries.ddbuild.io/dd-source/python/assetlib-0.0.13488267-py2.py3-none-any.whl; \
+		$@/bin/pip install https://binaries.ddbuild.io/dd-source/python/assetlib-0.0.14231163-py2.py3-none-any.whl; \
 	fi
 
 update_pre_build:

--- a/layouts/shortcodes/integration_categories.md
+++ b/layouts/shortcodes/integration_categories.md
@@ -12,11 +12,9 @@
 - Category::Data Store
 - Category::Developer Tools
 - Category::Event Management
-- Category::Exceptions
 - Category::Google Cloud
 - Category::Incidents
 - Category::IOT
-- Category::ISP
 - Category::Issue Tracking
 - Category::Kubernetes
 - Category::Languages
@@ -26,14 +24,11 @@
 - Category::Messaging
 - Category::Metrics
 - Category::Mobile
-- Category::Monitoring
 - Category::Network
 - Category::Notification
 - Category::Oracle
 - Category::Orchestration
 - Category::OS & System
-- Category::Processing
-- Category::Profiling
 - Category::Provisioning
 - Category::SAP
 - Category::Security
@@ -41,7 +36,6 @@
 - Category::Source Control
 - Category::Testing
 - Category::Tracing
-- Category::Web
 - Offering::Integration
 - Offering::Professional Service
 - Offering::Software License
@@ -66,6 +60,4 @@
 - Supported OS::macOS
 - Supported OS::Solaris
 - Supported OS::Windows
-- Supported OS::Mac OS
-- Category::OS System
 

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -28,7 +28,7 @@ from os.path import (
 from actions.format_link import format_link_file
 
 try:
-    from assetlib.constants import CLASSIFIER_TAGS
+    from assetlib.constants import CLASSIFIER_TAGS, get_public_classifiers
 except ImportError:
     CLASSIFIER_TAGS = []
     if getenv("CI_COMMIT_REF_NAME"):
@@ -39,7 +39,7 @@ finally:
         print(f'\x1b[33mWARNING\x1b[0m: CLASSIFIER_TAGS empty continuing without validation')
     else:
         with open('layouts/shortcodes/integration_categories.md', 'w') as file:
-            for tag in CLASSIFIER_TAGS:
+            for tag in get_public_classifiers():
                 file.write(f'- {tag}\n')
             file.write("\n")
 

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -28,7 +28,8 @@ from os.path import (
 from actions.format_link import format_link_file
 
 try:
-    from assetlib.constants import CLASSIFIER_TAGS, get_public_classifiers
+    from assetlib.classifiers import get_all_classifier_names, get_non_deprecated_classifier_names
+    CLASSIFIER_TAGS = get_all_classifier_names()
 except ImportError:
     CLASSIFIER_TAGS = []
     if getenv("CI_COMMIT_REF_NAME"):
@@ -39,7 +40,7 @@ finally:
         print(f'\x1b[33mWARNING\x1b[0m: CLASSIFIER_TAGS empty continuing without validation')
     else:
         with open('layouts/shortcodes/integration_categories.md', 'w') as file:
-            for tag in get_public_classifiers():
+            for tag in get_non_deprecated_classifier_names():
                 file.write(f'- {tag}\n')
             file.write("\n")
 


### PR DESCRIPTION
### What does this PR do?

Use `get_non_deprecated_classifier_names` data instead when writing to shortcode

### Motivation

Currently we are outputting all our classifiers in the shortcode however some of these exist temporarily while we transition off them. We don't want them to appear in the docs and perpetuate its usage so switching to this different dataset should only include the items we want to publically display.

### Preview

Nothing to preview as this shortcode isn't used yet. 

### Additional Notes

Prerequisite to merging:
- [This PR is merged ](https://github.com/DataDog/dd-source/pull/28235)
- The assetlib version used in this pr is bumped to the version including above changes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
