### PR TITLE
revert integrations site region changes

### DIFF
--- a/layouts/shortcodes/site-region.html
+++ b/layouts/shortcodes/site-region.html
@@ -6,7 +6,7 @@
 {{ end }}
 
 {{ $region := .Get "region" }}
-{{ $listOfPages := slice "account_management" "integrations" }}
+{{ $listOfPages := slice "account_management" }}
 {{ if in $listOfPages .Page.Type}}
   <div class="d-none site-region-container" data-region="{{ $region }}">
     {{.Inner}}

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -795,9 +795,9 @@ class Integrations:
             result = re.sub(
                 self.regex_partial_close, "", result, 0
             )
-            result = re.sub(
-                self.regex_site_region, r"{{% \1 %}}", result, 0
-            )
+            # result = re.sub(
+            #     self.regex_site_region, r"{{% \1 %}}", result, 0
+            # )
 
         # if __init__.py exists lets grab the integration id
         integration_id = manifest_json.get("integration_id", "") or ""

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: true
+    cache_enabled: false
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: false
+    cache_enabled: true
 
 - data:
     - org_name: jenkinsci


### PR DESCRIPTION
### What does this PR do?
Revert integrations page `site-region` shortcode updates as they were causing issues with the link formatting script.

### Motivation
https://dd.slack.com/archives/C3CT8QA11/p1678986335840829

### Preview
links are correct: https://docs-staging.datadoghq.com/brian.deutsch/integrations-site-region-format/integrations/azure

check some other pages for sanity: links/site region shortcode should still work
https://docs-staging.datadoghq.com/brian.deutsch/integrations-site-region-format/integrations/vmware_tanzu_application_service/

https://docs-staging.datadoghq.com/brian.deutsch/integrations-site-region-format/integrations/syslog_ng

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
