### PR TITLE
Fixed broken link in how-datadog-agent-determines-the-hostname file

### DIFF
--- a/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
+++ b/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
@@ -125,6 +125,6 @@ If you're upgrading from Agent v5 with `gce_updated_hostname` unset or set to fa
 {{< /tabs >}}
 
 [1]: /agent/guide/agent-commands/#agent-status-and-information
-[2]: /agent/guide/agent-configuration-files/#agent-main-configuration-file
+[2]: /content/en/agent/guide/agent-configuration-files/#agent-main-configuration-file
 [3]: /api/v1/hosts/
 [4]: https://app.datadoghq.com/infrastructure

--- a/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
+++ b/content/en/agent/faq/how-datadog-agent-determines-the-hostname.md
@@ -125,6 +125,6 @@ If you're upgrading from Agent v5 with `gce_updated_hostname` unset or set to fa
 {{< /tabs >}}
 
 [1]: /agent/guide/agent-commands/#agent-status-and-information
-[2]: /content/en/agent/guide/agent-configuration-files/#agent-main-configuration-file
+[2]: /content/en/agent/guide/agent-configuration-files.md
 [3]: /api/v1/hosts/
 [4]: https://app.datadoghq.com/infrastructure

--- a/content/es/agent/faq/how-datadog-agent-determines-the-hostname.md
+++ b/content/es/agent/faq/how-datadog-agent-determines-the-hostname.md
@@ -126,6 +126,6 @@ Si vas a actualizar el Agent v5 con el parámetro `gce_updated_hostname` sin co
 {{< /tabs >}}
 
 [1]: /es/agent/guide/agent-commands/#agent-status-and-information
-[2]: /content/es/agent/guide/agent-configuration-files/#agent-main-configuration-file
+[2]: /content/es/agent/guide/agent-configuration-files.md
 [3]: /es/api/v1/hosts/
 [4]: https://app.datadoghq.com/infrastructure

--- a/content/es/agent/faq/how-datadog-agent-determines-the-hostname.md
+++ b/content/es/agent/faq/how-datadog-agent-determines-the-hostname.md
@@ -126,6 +126,6 @@ Si vas a actualizar el Agent v5 con el parámetro `gce_updated_hostname` sin co
 {{< /tabs >}}
 
 [1]: /es/agent/guide/agent-commands/#agent-status-and-information
-[2]: /es/agent/guide/agent-configuration-files/#agent-main-configuration-file
+[2]: /content/es/agent/guide/agent-configuration-files/#agent-main-configuration-file
 [3]: /es/api/v1/hosts/
 [4]: https://app.datadoghq.com/infrastructure

--- a/content/fr/agent/faq/how-datadog-agent-determines-the-hostname.md
+++ b/content/fr/agent/faq/how-datadog-agent-determines-the-hostname.md
@@ -124,6 +124,6 @@ Si vous mettez à niveau l'Agent depuis la v5 alors que `gce_updated_hostname` n
 {{< /tabs >}}
 
 [1]: /fr/agent/guide/agent-commands/#agent-status-and-information
-[2]: /content/fr/agent/guide/agent-configuration-files
+[2]: /content/fr/agent/guide/agent-configuration-files.md
 [3]: /fr/api/v1/hosts/
 [4]: https://app.datadoghq.com/infrastructure

--- a/content/fr/agent/faq/how-datadog-agent-determines-the-hostname.md
+++ b/content/fr/agent/faq/how-datadog-agent-determines-the-hostname.md
@@ -124,6 +124,6 @@ Si vous mettez à niveau l'Agent depuis la v5 alors que `gce_updated_hostname` n
 {{< /tabs >}}
 
 [1]: /fr/agent/guide/agent-commands/#agent-status-and-information
-[2]: /fr/agent/guide/agent-configuration-files/#agent-main-configuration-file
+[2]: /content/fr/agent/guide/agent-configuration-files
 [3]: /fr/api/v1/hosts/
 [4]: https://app.datadoghq.com/infrastructure

--- a/content/ja/agent/faq/how-datadog-agent-determines-the-hostname.md
+++ b/content/ja/agent/faq/how-datadog-agent-determines-the-hostname.md
@@ -124,6 +124,6 @@ Agent v5 で `gce_updated_hostname` が未設定または false に設定され�
 {{< /tabs >}}
 
 [1]: /ja/agent/guide/agent-commands/#agent-status-and-information
-[2]: /ja/agent/guide/agent-configuration-files/#agent-main-configuration-file
+[2]: /content/ja/agent/guide/agent-configuration-files.md
 [3]: /ja/api/v1/hosts/
 [4]: https://app.datadoghq.com/infrastructure


### PR DESCRIPTION
### What does this PR do?
Fixed broken link to agent-configuration-files.md file, in how-datadog-agent-determines-the-hostname.md

### Motivation
Unable to locate agent-configuration-files.md from how-datadog-agent-determines-the-hostname.md

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
