### PR TITLE
Add beta alert box to Teams page because the launch was delayed

### DIFF
--- a/content/en/account_management/teams.md
+++ b/content/en/account_management/teams.md
@@ -3,6 +3,8 @@ title: Teams
 kind: documentation
 ---
 
+<div class="alert alert-warning">The Teams feature is in beta and is not yet generally available.</div>
+
 ## Overview
 Datadog Teams allow groups of users to organize their team assets within Datadog and automatically filter their Datadog-wide experience to prioritize these assets.
 


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Support reported that a customer was confused because the Teams feature is documented, but does not appear in their org.

The Teams launch was delayed by the recent Datadog outage and subsequent freeze. Adding a beta notice to the docs to inform customers that the product has not yet launched. I used a regular info box instead of the special callout because we don't want people to contact Support or attempt to sign up.

I'll remove the beta notice once Teams becomes generally available. 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
