### PR TITLE
Correcting syntax for musl download link

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/dd_libraries/dotnet-core.md
@@ -163,7 +163,7 @@ To install the .NET Tracer machine-wide:
    : `sudo rpm -Uvh datadog-dotnet-apm<TRACER_VERSION>-1.x86_64.rpm && /opt/datadog/createLogPath.sh`
 
    Alpine or other musl-based distributions
-   : `sudo tar -C /opt/datadog -xzf datadog-dotnet-apm<TRACER_VERSION>-musl.tar.gz && sh /opt/datadog/createLogPath.sh`
+   : `sudo tar -C /opt/datadog -xzf datadog-dotnet-apm-<TRACER_VERSION>-musl.tar.gz && sh /opt/datadog/createLogPath.sh`
 
    Other distributions
    : `sudo tar -C /opt/datadog -xzf datadog-dotnet-apm<TRACER_VERSION>-tar.gz && /opt/datadog/createLogPath.sh`


### PR DESCRIPTION
Customer in this ticket (https://datadog.zendesk.com/agent/tickets/1129215) pointed out that the link in the docs is missing a `-` before the <TRACER_VERSION>

https://a.cl.ly/wbuDWnAr

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add a dash before <TRACER_VERSION> for musl download link

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer in this ticket (https://datadog.zendesk.com/agent/tickets/1129215) pointed out that the link in the docs was incorrect. https://a.cl.ly/wbuDWnAr

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
