### PR TITLE
Snooze Vale Linter Rule About Documentation Links

### DIFF
--- a/.github/styles/Datadog/links.yml
+++ b/.github/styles/Datadog/links.yml
@@ -6,6 +6,5 @@ scope: link
 level: warning
 tokens:
   - here
-  - documentation
   - this
   - ^page$


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

The "Documentation" rule was popping up for instances of "See the [Company] documentation" or "the Service Level Objectives documentation", when both instances of using the word "documentation" in the link were appropriate.

### Motivation
<!-- What inspired you to submit this pull request?-->

Docs Style Council

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
