### PR TITLE
Standardize the capitalization of Datadog library

### DIFF
--- a/content/en/opentelemetry/otlp_ingest_in_the_agent.md
+++ b/content/en/opentelemetry/otlp_ingest_in_the_agent.md
@@ -17,7 +17,7 @@ further_reading:
 
 OTLP Ingest in the Agent is a way to send telemetry data directly from applications instrumented with [OpenTelemetry SDKs][1] to Datadog Agent. Since versions 6.32.0 and 7.32.0, the Datadog Agent can ingest OTLP traces and [OTLP metrics][2] through gRPC or HTTP.
 
-OTLP Ingest in the Agent allows you to use observability features in the Datadog Agent. Because the application is instrumented with OpenTelemetry SDK, some Datadog Library specific features aren't available for the ingested data including Application Security Management, Continuous Profiler, Runtime Metrics, and Ingestion Rules.
+OTLP Ingest in the Agent allows you to use observability features in the Datadog Agent. Because the application is instrumented with OpenTelemetry SDK, some Datadog library specific features aren't available for the ingested data including Application Security Management, Continuous Profiler, Runtime Metrics, and Ingestion Rules.
 
 To get started, you first [instrument your application][3] with OpenTelemetry SDKs. Then, export the telemetry data in OTLP format to the Datadog Agent. Configuring this varies depending on the kind of infrastructure your service is deployed on, as described on the page below. Although the aim is to be compatible with the latest OTLP version, the OTLP Ingest in the Agent is not compatible with all OTLP versions. Verify OTLP version compatibility through the [Agent changelog][4]. 
 
@@ -217,7 +217,7 @@ Datadog provides out-of-the-box dashboards that you can copy and customize. To u
 
 {{< img src="metrics/otel/dashboard.png" alt="The Dashboards list, showing two OpenTelemetry out-of-the-box dashboards: Host Metrics and Collector Metrics." style="width:80%;">}}
 
-The **Host Metrics** dashboard is for data collected from the [host metrics receiver][12]. The **Collector Metrics** dashboard is for any other types of metrics collected, depending on which [metrics receiver][13] you choose to enable.
+The **Host Metrics** dashboard is for data collected from the [host metrics receiver][7]. The **Collector Metrics** dashboard is for any other types of metrics collected, depending on which [metrics receiver][8] you choose to enable.
 
 ## Further Reading
 
@@ -229,5 +229,5 @@ The **Host Metrics** dashboard is for data collected from the [host metrics rece
 [4]: https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst
 [5]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/config.md
 [6]: https://github.com/DataDog/datadog-agent/blob/7.35.0/pkg/config/config_template.yaml
-[12]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver
-[13]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver
+[7]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver
+[8]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver

--- a/content/en/security/application_security/enabling/dotnet.md
+++ b/content/en/security/application_security/enabling/dotnet.md
@@ -13,7 +13,7 @@ further_reading:
       text: "Adding user information to traces"
     - link: 'https://github.com/DataDog/dd-trace-dotnet'
       tag: 'GitHub'
-      text: '.NET Datadog Library source code'
+      text: '.NET Datadog library source code'
     - link: "/security/default_rules/#cat-application-security"
       tag: "Documentation"
       text: "OOTB Application Security Management Rules"

--- a/content/en/security/application_security/enabling/go.md
+++ b/content/en/security/application_security/enabling/go.md
@@ -13,7 +13,7 @@ further_reading:
       text: "Adding user information to traces"
     - link: 'https://github.com/DataDog/dd-trace-go/tree/v1'
       tag: 'GitHub'
-      text: 'Go Datadog Library source code'
+      text: 'Go Datadog library source code'
     - link: "/security/default_rules/#cat-application-security"
       tag: "Documentation"
       text: "OOTB Application Security Management Rules"

--- a/content/en/security/application_security/enabling/java.md
+++ b/content/en/security/application_security/enabling/java.md
@@ -13,7 +13,7 @@ further_reading:
   text: "Adding user information to traces"
 - link: 'https://github.com/DataDog/dd-trace-java'
   tag: 'GitHub'
-  text: 'Java Datadog Library source code'
+  text: 'Java Datadog library source code'
 - link: "/security/default_rules/#cat-application-security"
   tag: "Documentation"
   text: "OOTB Application Security Management Rules"

--- a/content/en/security/application_security/enabling/nodejs.md
+++ b/content/en/security/application_security/enabling/nodejs.md
@@ -13,7 +13,7 @@ further_reading:
       text: "Adding user information to traces"
     - link: 'https://github.com/DataDog/dd-trace-js'
       tag: 'GitHub'
-      text: 'Node.js Datadog Library source code'
+      text: 'Node.js Datadog library source code'
     - link: "/security/default_rules/#cat-application-security"
       tag: "Documentation"
       text: "OOTB Application Security Management Rules"

--- a/content/en/security/application_security/enabling/python.md
+++ b/content/en/security/application_security/enabling/python.md
@@ -13,7 +13,7 @@ further_reading:
       text: "Adding user information to traces"
     - link: 'https://github.com/DataDog/dd-trace-py'
       tag: 'GitHub'
-      text: 'Python Datadog Library source code'
+      text: 'Python Datadog library source code'
     - link: "/security/default_rules/#cat-application-security"
       tag: "Documentation"
       text: "OOTB Application Security Management Rules"

--- a/content/en/security/application_security/enabling/ruby.md
+++ b/content/en/security/application_security/enabling/ruby.md
@@ -13,7 +13,7 @@ further_reading:
       text: "Adding user information to traces"
     - link: 'https://github.com/DataDog/dd-trace-rb'
       tag: 'GitHub'
-      text: 'Ruby Datadog Library source code'
+      text: 'Ruby Datadog library source code'
     - link: "/security/default_rules/#cat-application-security"
       tag: "Documentation"
       text: "OOTB Application Security Management Rules"

--- a/content/en/security/application_security/how-appsec-works.md
+++ b/content/en/security/application_security/how-appsec-works.md
@@ -87,26 +87,7 @@ Security Signals are automatically created when Datadog detects meaningful attac
 
 ## Built-in protection
 
-<div class="alert alert-info"><strong>Beta: IP and user blocking</strong><br>
-If your service is running with <a href="/agent/guide/how_remote_config_works/#enabling-remote-configuration">an Agent with Remote Configuration enabled and a tracing library version that supports it</a>, you can block attackers from the Datadog UI without additional configuration of the Agent or tracing libraries.</div>
-
-Datadog ASM offers built-in protection capabilities to slow down attacks and attackers. 
-
-IP and user blocking actions are implemented through the [tracing libraries][11], not introducing any new dependencies in your stack.
-Blocks are saved in the Datadog platform, automatically and securely fetched by the [Datadog Agent][14], deployed in your infrastructure, and applied to your application. For details, read [How Remote Configuration Works][14].
-
-You can block attackers that are flagged in ASM Security Signals temporarily or permanently. In the Signals Explorer, click into a signal to see what users and IP addresses are generating the signal, and optionally block them.
-
-{{< img src="/security/application_security/appsec-block-user-ip.png" alt="A security signal panel in Datadog ASM, allowing to block the attackers' IPs" width="75%">}}
-
-
-From there, all ASM-protected services block incoming requests performed by the blocked IP or user, for the specified duration. All blocked traces are tagged with `security_response.block_ip` and displayed in the [Trace Explorer][15]. Services where ASM is disabled aren't protected.
-
-{{% asm-protection-page-configuration %}}
-
-{{< img src="/security/application_security/asm-blocking-page-html.png" alt="The page displayed as ASM blocks requests originating from blocked IPs" width="75%" >}}
-
-For more information, read [Threat Monitoring and Protection][1].
+{{% asm-protect %}}
 
 
 ## Threat monitoring coverage
@@ -117,7 +98,7 @@ Datadog ASM categorizes attack attempts into different threat types:
 * **Contextualized attacks** correlate the attack attempts performed on the service with a matching business-logic. For example, SQL injection patterns on a service performing SQL statements.
 * A **Vulnerability is triggered** when an attack attempt gives evidence that a vulnerability has been successfully exploited, after matching known attack patterns.
 
-Datadog ASM includes over 100 attack patterns that help protect against [many different kinds of attacks][16], including the following vulnerabilities:
+Datadog ASM includes over 100 attack patterns that help protect against [many different kinds of attacks][14], including the following vulnerabilities:
 
 * SQL injections
 * Code injections
@@ -130,13 +111,13 @@ Datadog ASM includes over 100 attack patterns that help protect against [many di
 
 <div class="alert alert-info">Risk Management through vulnerability detection is in beta.</a></div>
 
-Datadog ASM offers built-in detection capabilities that warn you about the vulnerabilities detected in your open source dependencies. Details of that information are shown in the [Vulnerability Explorer][17], identifying the severity, affected services, potentially vulnerable infrastructure, and remediation instructions to solve the surfaced risks.
+Datadog ASM offers built-in detection capabilities that warn you about the vulnerabilities detected in your open source dependencies. Details of that information are shown in the [Vulnerability Explorer][15], identifying the severity, affected services, potentially vulnerable infrastructure, and remediation instructions to solve the surfaced risks.
 
 For more information, read [Risk Management][5].
 
 ## How Datadog ASM protects against Log4Shell
 
-Datadog ASM identifies Log4j Log4Shell attack payloads and provides visibility into vulnerable apps that attempt to remotely load malicious code. When used in tandem with the rest of [Datadog's Cloud SIEM][18], you can investigate to identify common post-exploitation activity, and proactively remediate potentially vulnerable Java web services acting as an attack vector.
+Datadog ASM identifies Log4j Log4Shell attack payloads and provides visibility into vulnerable apps that attempt to remotely load malicious code. When used in tandem with the rest of [Datadog's Cloud SIEM][16], you can investigate to identify common post-exploitation activity, and proactively remediate potentially vulnerable Java web services acting as an attack vector.
 
 ## Further Reading
 
@@ -155,8 +136,6 @@ Datadog ASM identifies Log4j Log4Shell attack payloads and provides visibility i
 [11]: /security/application_security/threats/setup_and_configure/#exclude-specific-parameters-from-triggering-detections
 [12]: https://owasp.org/www-project-modsecurity-core-rule-set/
 [13]: /security/default_rules/#cat-application-security
-[14]: /agent/guide/how_remote_config_works/
-[15]: https://app.datadoghq.com/security/appsec/traces?query=%40appsec.blocked%3Atrue
-[16]: https://app.datadoghq.com/security/appsec/event-rules
-[17]: https://app.datadoghq.com/security/appsec/vm
-[18]: /security/cloud_siem/
+[14]: https://app.datadoghq.com/security/appsec/event-rules
+[15]: https://app.datadoghq.com/security/appsec/vm
+[16]: /security/cloud_siem/

--- a/content/en/security/application_security/how-appsec-works.md
+++ b/content/en/security/application_security/how-appsec-works.md
@@ -28,7 +28,7 @@ Traditional Web Application Firewalls (WAFs) are usually deployed at the perimet
 
 ### Identify services exposed to application attacks
 
-Datadog ASM [Threat Monitoring and Protection][22] uses the information APM is already collecting, and flags traces containing attack attempts. Services exposed to application attacks are highlighted directly in the security views embedded in APM ([Service Catalog][1], [Service Page][2], [Traces][3]).
+Datadog ASM [Threat Monitoring and Protection][1] uses the information APM is already collecting, and flags traces containing attack attempts. Services exposed to application attacks are highlighted directly in the security views embedded in APM ([Service Catalog][2], [Service Page][3], [Traces][4]).
 
 Because APM collects a sample of your application traffic, enabling ASM in the tracing library is necessary to effectively monitor and protect your services.
 
@@ -41,11 +41,11 @@ If your service is running with <a href="/agent/guide/how_remote_config_works/#e
 
 <div class="alert alert-info">Risk Management vulnerability detection is in beta.</a></div>
 
-Datadog ASM [Risk Management][21] uses various known vulnerability data sources related to open source software libraries, plus information provided by the Datadog security research team, to match the libraries your application depends on at runtime with their potential vulnerabilities, and to make remediation recommendations.
+Datadog ASM [Risk Management][5] uses various known vulnerability data sources related to open source software libraries, plus information provided by the Datadog security research team, to match the libraries your application depends on at runtime with their potential vulnerabilities, and to make remediation recommendations.
 
 ## Compatibility
 
-For Datadog ASM to be compatible with your Datadog configuration, you must have APM enabled, and [send traces to Datadog][4]. ASM uses the same libraries used by APM, so you don't need to deploy and maintain another library. Steps to enable Datadog ASM are specific to runtime language. Check to see if your language is supported in the [ASM prerequisites][5].
+For Datadog ASM to be compatible with your Datadog configuration, you must have APM enabled, and [send traces to Datadog][6]. ASM uses the same libraries used by APM, so you don't need to deploy and maintain another library. Steps to enable Datadog ASM are specific to runtime language. Check to see if your language is supported in the [ASM prerequisites][7].
 
 ### Serverless monitoring
 
@@ -53,32 +53,32 @@ For Datadog ASM to be compatible with your Datadog configuration, you must have 
  
 Datadog ASM for AWS Lambda provides deep visibility into attackers targeting your functions. With distributed tracing providing a context-rich picture of the attack, you can assess the impact and remediate the threat effectively. 
 
-Read [Enabling ASM for Serverless][24] for information on setting it up.
+Read [Enabling ASM for Serverless][8] for information on setting it up.
 
 ## Performance
 
-Datadog ASM uses processes already contained in the Agent and APM, so there are negligible performance implications when using it. When APM is enabled, the Datadog Library generates distributed traces. Datadog ASM flags security activity in traces by using known attack patterns. Correlation between the attack patterns and the execution context provided by the distributed trace triggers security signals based on detection rules.
+Datadog ASM uses processes already contained in the Agent and APM, so there are negligible performance implications when using it. When APM is enabled, the Datadog library generates distributed traces. Datadog ASM flags security activity in traces by using known attack patterns. Correlation between the attack patterns and the execution context provided by the distributed trace triggers security signals based on detection rules.
 
 {{< img src="security/application_security/How_Application_Security_Works_d1.png" alt="A diagram illustrates that the Datadog tracer library operates at the application service level and sends traces to the Datadog backend. The Datadog backend flags actionable security signals and sends a notification to the relevant application, such as PagerDuty, Jira or Slack." >}}
 
 ## Data sampling and retention
 
-In the tracing library, Datadog ASM collects all traces that include security data. A default [retention filter][7] ensures the retention of all security-related traces in the Datadog platform.
+In the tracing library, Datadog ASM collects all traces that include security data. A default [retention filter][9] ensures the retention of all security-related traces in the Datadog platform.
 
 Data for suspicious requests is kept for 90 days. The underlying trace data is kept for 15 days.
 
 ## Data privacy
 
-There are multiple methods used to avoid your sensitive information being indexed. To take further action, you can set up [custom and static scrubbers][8], and use the [passlist][9].
+There are multiple methods used to avoid your sensitive information being indexed. To take further action, you can set up [custom and static scrubbers][10], and use the [passlist][11].
 
 
-**Note:** Datadog ASM does not automatically obfuscate sensitive information or PII. To keep this sensitive data from being sent to Datadog, [configure the Datadog Agent or Tracer for data security][8].
+**Note:** Datadog ASM does not automatically obfuscate sensitive information or PII. To keep this sensitive data from being sent to Datadog, [configure the Datadog Agent or Tracer for data security][10].
 
 Contact Support to delete sensitive data that may have been indexed.
 
 ## Threat detection methods
 
-Datadog uses multiple pattern sources, including the [OWASP ModSecurity Core Rule Set][10] to detect known threats and vulnerabilities in HTTP requests. When an HTTP request matches one of [the OOTB detection rules][11], a security signal is generated in Datadog.
+Datadog uses multiple pattern sources, including the [OWASP ModSecurity Core Rule Set][12] to detect known threats and vulnerabilities in HTTP requests. When an HTTP request matches one of [the OOTB detection rules][13], a security signal is generated in Datadog.
 
 <div class="alert alert-info"><strong>Beta: Automatic Threat Patterns Updates</strong><br>
 If your service is running with <a href="/agent/guide/how_remote_config_works/#enabling-remote-configuration">an Agent with Remote Configuration enabled and a tracing library version that supports it</a>, the threat patterns being used to monitor your service is automatically updated whenever Datadog publishes updates.</div>
@@ -87,7 +87,26 @@ Security Signals are automatically created when Datadog detects meaningful attac
 
 ## Built-in protection
 
-{{% asm-protect %}}
+<div class="alert alert-info"><strong>Beta: IP and user blocking</strong><br>
+If your service is running with <a href="/agent/guide/how_remote_config_works/#enabling-remote-configuration">an Agent with Remote Configuration enabled and a tracing library version that supports it</a>, you can block attackers from the Datadog UI without additional configuration of the Agent or tracing libraries.</div>
+
+Datadog ASM offers built-in protection capabilities to slow down attacks and attackers. 
+
+IP and user blocking actions are implemented through the [tracing libraries][11], not introducing any new dependencies in your stack.
+Blocks are saved in the Datadog platform, automatically and securely fetched by the [Datadog Agent][14], deployed in your infrastructure, and applied to your application. For details, read [How Remote Configuration Works][14].
+
+You can block attackers that are flagged in ASM Security Signals temporarily or permanently. In the Signals Explorer, click into a signal to see what users and IP addresses are generating the signal, and optionally block them.
+
+{{< img src="/security/application_security/appsec-block-user-ip.png" alt="A security signal panel in Datadog ASM, allowing to block the attackers' IPs" width="75%">}}
+
+
+From there, all ASM-protected services block incoming requests performed by the blocked IP or user, for the specified duration. All blocked traces are tagged with `security_response.block_ip` and displayed in the [Trace Explorer][15]. Services where ASM is disabled aren't protected.
+
+{{% asm-protection-page-configuration %}}
+
+{{< img src="/security/application_security/asm-blocking-page-html.png" alt="The page displayed as ASM blocks requests originating from blocked IPs" width="75%" >}}
+
+For more information, read [Threat Monitoring and Protection][1].
 
 
 ## Threat monitoring coverage
@@ -98,7 +117,7 @@ Datadog ASM categorizes attack attempts into different threat types:
 * **Contextualized attacks** correlate the attack attempts performed on the service with a matching business-logic. For example, SQL injection patterns on a service performing SQL statements.
 * A **Vulnerability is triggered** when an attack attempt gives evidence that a vulnerability has been successfully exploited, after matching known attack patterns.
 
-Datadog ASM includes over 100 attack patterns that help protect against [many different kinds of attacks][15], including the following vulnerabilities:
+Datadog ASM includes over 100 attack patterns that help protect against [many different kinds of attacks][16], including the following vulnerabilities:
 
 * SQL injections
 * Code injections
@@ -111,39 +130,33 @@ Datadog ASM includes over 100 attack patterns that help protect against [many di
 
 <div class="alert alert-info">Risk Management through vulnerability detection is in beta.</a></div>
 
-Datadog ASM offers built-in detection capabilities that warn you about the vulnerabilities detected in your open source dependencies. Details of that information are shown in the [Vulnerability Explorer][20], identifying the severity, affected services, potentially vulnerable infrastructure, and remediation instructions to solve the surfaced risks.
+Datadog ASM offers built-in detection capabilities that warn you about the vulnerabilities detected in your open source dependencies. Details of that information are shown in the [Vulnerability Explorer][17], identifying the severity, affected services, potentially vulnerable infrastructure, and remediation instructions to solve the surfaced risks.
 
-For more information, read [Risk Management][21].
+For more information, read [Risk Management][5].
 
 ## How Datadog ASM protects against Log4Shell
 
-Datadog ASM identifies Log4j Log4Shell attack payloads and provides visibility into vulnerable apps that attempt to remotely load malicious code. When used in tandem with the rest of [Datadog's Cloud SIEM][16], you can investigate to identify common post-exploitation activity, and proactively remediate potentially vulnerable Java web services acting as an attack vector.
+Datadog ASM identifies Log4j Log4Shell attack payloads and provides visibility into vulnerable apps that attempt to remotely load malicious code. When used in tandem with the rest of [Datadog's Cloud SIEM][18], you can investigate to identify common post-exploitation activity, and proactively remediate potentially vulnerable Java web services acting as an attack vector.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/service_catalog/#security-view
-[2]: /tracing/services/service_page/#security
-[3]: /tracing/trace_explorer/trace_view/?tab=security#more-information
-[4]: /tracing/trace_collection/
-[5]: /security/application_security/enabling/#prerequisites
-[6]: /serverless/installation/java/?tab=serverlessframework
-[7]: /tracing/trace_pipeline/trace_retention/
-[8]: /tracing/configure_data_security/?tab=http
-[9]: /security/application_security/threats/setup_and_configure/#exclude-specific-parameters-from-triggering-detections
-[10]: https://owasp.org/www-project-modsecurity-core-rule-set/
-[11]: /security/default_rules/#cat-application-security
-[12]: /tracing/
-[13]: /agent/guide/how_remote_config_works/
-[14]: https://app.datadoghq.com/security/appsec/traces?query=%40appsec.blocked%3Atrue
-[15]: https://app.datadoghq.com/security/appsec/event-rules
-[16]: /security/cloud_siem/
-[17]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/resources/datadog/trace/bootstrap/blocking/template.html
-[18]: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/resources/datadog/trace/bootstrap/blocking/template.json
-[19]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
-[20]: https://app.datadoghq.com/security/appsec/vm
-[21]: /security/application_security/risk_management/
-[22]: /security/application_security/threats/
-[23]: /agent/guide/how_remote_config_works/
-[24]: /security/application_security/enabling/serverless/
+[1]: /security/application_security/threats/
+[2]: /tracing/service_catalog/#security-view
+[3]: /tracing/services/service_page/#security
+[4]: /tracing/trace_explorer/trace_view/?tab=security#more-information
+[5]: /security/application_security/risk_management/
+[6]: /tracing/trace_collection/
+[7]: /security/application_security/enabling/#prerequisites
+[8]: /security/application_security/enabling/serverless/
+[9]: /tracing/trace_pipeline/trace_retention/
+[10]: /tracing/configure_data_security/?tab=http
+[11]: /security/application_security/threats/setup_and_configure/#exclude-specific-parameters-from-triggering-detections
+[12]: https://owasp.org/www-project-modsecurity-core-rule-set/
+[13]: /security/default_rules/#cat-application-security
+[14]: /agent/guide/how_remote_config_works/
+[15]: https://app.datadoghq.com/security/appsec/traces?query=%40appsec.blocked%3Atrue
+[16]: https://app.datadoghq.com/security/appsec/event-rules
+[17]: https://app.datadoghq.com/security/appsec/vm
+[18]: /security/cloud_siem/

--- a/content/en/tracing/trace_collection/library_injection.md
+++ b/content/en/tracing/trace_collection/library_injection.md
@@ -10,7 +10,7 @@ aliases:
 
 There are two ways to instrument your application:
 * Injecting the instrumentation library, as described on this page; or
-* [Manually adding the instrumentation library in the application][2].
+* [Manually adding the instrumentation library in the application][1].
 
 How to inject the library, without touching the application code at all, varies depending on where and how your Agent and application are installed. Select the scenario that represents your environment:
 
@@ -21,12 +21,12 @@ With the [Admission Controller][1] approach, the Agent uses the Kubernetes Admis
 
 <div class="alert alert-warning">Library injection is applied on new pods only and does not have any impact on running pods.</div>
 
-To learn more about Kubernetes Admission Controller, read [Kubernetes Admission Controllers Reference][3].
+To learn more about Kubernetes Admission Controller, read [Kubernetes Admission Controllers Reference][2].
 
 ## Requirements
 
 * Kubernetes v1.14+
-* Datadog [Cluster Agent v7.40+][4] with Datadog Admission Controller enabled. **Note**: In Helm chart v2.35.0 and later, Datadog Admission Controller is activated by default in the Cluster Agent.
+* Datadog [Cluster Agent v7.40+][3] with Datadog Admission Controller enabled. **Note**: In Helm chart v2.35.0 and later, Datadog Admission Controller is activated by default in the Cluster Agent.
 * Applications in Java, JavaScript, or Python deployed on Linux with a supported architecture. Check the [corresponding container registry](#container-registries) for the complete list of supported architectures by language.
 
 
@@ -35,9 +35,9 @@ To learn more about Kubernetes Admission Controller, read [Kubernetes Admission 
 Datadog publishes instrumentation libraries images on gcr.io, Docker Hub, and AWS ECR:
 | Language   | gcr.io                              | hub.docker.com                              | gallery.ecr.aws                            |
 |------------|-------------------------------------|---------------------------------------------|-------------------------------------------|
-| Java       | [gcr.io/datadoghq/dd-lib-java-init][5]   | [hub.docker.com/r/datadog/dd-lib-java-init][6]   | [gallery.ecr.aws/datadog/dd-lib-java-init][7]   |
-| JavaScript | [gcr.io/datadoghq/dd-lib-js-init][8]     | [hub.docker.com/r/datadog/dd-lib-js-init][9]     | [gallery.ecr.aws/datadog/dd-lib-js-init][10]     |
-| Python     | [gcr.io/datadoghq/dd-lib-python-init][11] | [hub.docker.com/r/datadog/dd-lib-python-init][12] | [gallery.ecr.aws/datadog/dd-lib-python-init][13] |
+| Java       | [gcr.io/datadoghq/dd-lib-java-init][4]   | [hub.docker.com/r/datadog/dd-lib-java-init][5]   | [gallery.ecr.aws/datadog/dd-lib-java-init][6]   |
+| JavaScript | [gcr.io/datadoghq/dd-lib-js-init][7]     | [hub.docker.com/r/datadog/dd-lib-js-init][8]     | [gallery.ecr.aws/datadog/dd-lib-js-init][9]     |
+| Python     | [gcr.io/datadoghq/dd-lib-python-init][10] | [hub.docker.com/r/datadog/dd-lib-python-init][11] | [gallery.ecr.aws/datadog/dd-lib-python-init][12] |
 
 The `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY` environment variable in the Datadog Cluster Agent configuration specifies the registry used by the Admission Controller. The default value is `gcr.io/datadoghq`.
 
@@ -90,9 +90,9 @@ To select your pods for library injection, annotate them with the following, cor
 | Python     | `admission.datadoghq.com/python-lib.version: "<lib-version>"` |
 
 The available library versions are listed in each container registry, as well as in the tracer source repositories for each language:
-- [Java][17]
-- [Javascript][18]
-- [Python][19]
+- [Java][13]
+- [Javascript][14]
+- [Python][15]
 
 **Note**: If you already have an application instrumented using version X of the library, and then use library injection to instrument using version Y of the same tracer library, the tracer does not break. Rather, the library version loaded first is used. Because library injection happens at the admission controller level prior to runtime, it takes precedent over manually configured libraries.
 
@@ -119,7 +119,7 @@ template:
 
 ### Step 3 - Tag your pods with Unified Service Tags
 
-With [Unified Service Tags][14], you can tie Datadog telemetry together and navigate seamlessly across traces, metrics, and logs with consistent tags. Set the Unified Service Tagging on both the deployment object and the pod template specs.
+With [Unified Service Tags][16], you can tie Datadog telemetry together and navigate seamlessly across traces, metrics, and logs with consistent tags. Set the Unified Service Tagging on both the deployment object and the pod template specs.
 Set Unified Service tags by using the following labels:
 
 ```yaml
@@ -173,28 +173,26 @@ If the injection was successful you can see an `init` container called `datadog-
 
 Or run `kubectl describe pod <my-pod>` to see the `datadog-lib-init` init container listed.
 
-The instrumentation also starts sending telemetry to Datadog (for example, traces to [APM][15]).
+The instrumentation also starts sending telemetry to Datadog (for example, traces to [APM][17]).
+
 
 [1]: /containers/cluster_agent/admission_controller/
-[2]: /tracing/trace_collection/
-[3]: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/
-[4]: /containers/kubernetes/installation/?tab=helm
-[5]: http://gcr.io/datadoghq/dd-lib-java-init
-[6]: http://hub.docker.com/r/datadog/dd-lib-java-init
-[7]: http://gallery.ecr.aws/datadog/dd-lib-java-init
-[8]: http://gcr.io/datadoghq/dd-lib-js-init
-[9]: http://hub.docker.com/r/datadog/dd-lib-js-init
-[10]: http://gallery.ecr.aws/datadog/dd-lib-js-init
-[11]: http://gcr.io/datadoghq/dd-lib-python-init
-[12]: http://hub.docker.com/r/datadog/dd-lib-python-init
-[13]: http://gallery.ecr.aws/datadog/dd-lib-python-init
-[14]: /getting_started/tagging/unified_service_tagging/
-[15]: https://app.datadoghq.com/apm/traces
-[16]: /tracing/trace_collection/library_config/
-[17]: https://github.com/DataDog/dd-trace-java/releases
-[18]: https://github.com/DataDog/dd-trace-js/releases
-[19]: https://github.com/DataDog/dd-trace-py/releases
-
+[2]: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/
+[3]: /containers/kubernetes/installation/?tab=helm
+[4]: http://gcr.io/datadoghq/dd-lib-java-init
+[5]: http://hub.docker.com/r/datadog/dd-lib-java-init
+[6]: http://gallery.ecr.aws/datadog/dd-lib-java-init
+[7]: http://gcr.io/datadoghq/dd-lib-js-init
+[8]: http://hub.docker.com/r/datadog/dd-lib-js-init
+[9]: http://gallery.ecr.aws/datadog/dd-lib-js-init
+[10]: http://gcr.io/datadoghq/dd-lib-python-init
+[11]: http://hub.docker.com/r/datadog/dd-lib-python-init
+[12]: http://gallery.ecr.aws/datadog/dd-lib-python-init
+[13]: https://github.com/DataDog/dd-trace-java/releases
+[14]: https://github.com/DataDog/dd-trace-js/releases
+[15]: https://github.com/DataDog/dd-trace-py/releases
+[16]: /getting_started/tagging/unified_service_tagging/
+[17]: https://app.datadoghq.com/apm/traces
 {{% /tab %}}
 
 {{% tab "Host" %}}
@@ -210,7 +208,7 @@ When both the Agent and your services are running on a host, real or virtual, Da
 **Note**: Injection on arm64, and injection with `musl` on Alpine Linux container images are not supported.
 ## Install the preload library
 
-1. Ensure your [Agent is running][6].
+1. Ensure your [Agent is running][2].
 
 2. Install the library with one of the following sets of commands, where `<LANG>` is one of `java`, `js`, `dotnet`, or `all`:
 
@@ -337,7 +335,7 @@ Set `service_language` to one of the following values:
 
 In this configuration file, the value of `version` is always `1`. This refers to the configuration schema version in use, not the version of the content.
 
-The following table shows how the injection configuration values map to the corresponding [tracing library configuration options][2]:
+The following table shows how the injection configuration values map to the corresponding [tracing library configuration options][4]:
 
 | Injection | Java tracer | NodeJS tracer | .NET tracer |
 | --------- | ----------- | ------------- | ----------- |
@@ -394,15 +392,14 @@ DD_CONFIG_SOURCES=BASIC dotnet <SERVICE_1>.dll &
 DD_CONFIG_SOURCES=LOCAL:/etc/<SERVICE_2>/config.yaml;BASIC dotnet <SERVICE_2>.dll &
 ```
 
-Exercise your application to start generating telemetry data, which you can see as [traces in APM][4].
+Exercise your application to start generating telemetry data, which you can see as [traces in APM][5].
+
 
 [1]: https://app.datadoghq.com/account/settings#agent/overview
-[2]: /tracing/trace_collection/library_config/
+[2]: /agent/guide/agent-commands/?tab=agentv6v7#start-the-agent
 [3]: https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu
-[4]: https://app.datadoghq.com/apm/traces
-[5]: https://bugzilla.redhat.com/show_bug.cgi?id=1792506
-[6]: /agent/guide/agent-commands/?tab=agentv6v7#start-the-agent
-
+[4]: /tracing/trace_collection/library_config/
+[5]: https://app.datadoghq.com/apm/traces
 {{% /tab %}}
 
 {{% tab "Agent on host, app in containers" %}}
@@ -423,7 +420,7 @@ Any newly started processes are intercepted and the specified instrumentation li
 
 ## Install the preload library
 
-1. Ensure your [Agent is running][6].
+1. Ensure your [Agent is running][3].
 
 2. Install the library with one of the following sets of commands, where `<LANG>` is one of `java`, `js`, `dotnet`, or `all`:
 
@@ -544,7 +541,7 @@ Set `service_language` to one of the following values:
 
 In this configuration file, the value of `version` is always `1`. This refers to the configuration schema version in use, not the version of the content.
 
-The following table shows how the injection configuration values map to the corresponding [tracing library configuration options][3]:
+The following table shows how the injection configuration values map to the corresponding [tracing library configuration options][4]:
 
 | Injection | Java tracer | NodeJS tracer | .NET tracer |
 | --------- | ----------- | ------------- | ----------- |
@@ -589,16 +586,15 @@ If they are not specified, `DD_ENV` uses the `env` value set in the `/etc/datado
 
 Start your Agent and launch your containerized services as usual.
 
-Exercise your application to start generating telemetry data, which you can see as [traces in APM][4].
+Exercise your application to start generating telemetry data, which you can see as [traces in APM][5].
+
 
 
 [1]: https://app.datadoghq.com/account/settings#agent/overview
 [2]: https://docs.docker.com/engine/install/ubuntu/
-[3]: /tracing/trace_collection/library_config/
-[4]: https://app.datadoghq.com/apm/traces
-[5]: https://bugzilla.redhat.com/show_bug.cgi?id=1792506
-[6]: /agent/guide/agent-commands/?tab=agentv6v7#start-the-agent
-
+[3]: /agent/guide/agent-commands/?tab=agentv6v7#start-the-agent
+[4]: /tracing/trace_collection/library_config/
+[5]: https://app.datadoghq.com/apm/traces
 {{% /tab %}}
 
 {{% tab "Agent and app in separate containers" %}}
@@ -611,7 +607,7 @@ Any newly started processes are intercepted and the specified instrumentation li
 
 ## Requirements
 
-- [Docker Engine][2]
+- [Docker Engine][1]
 
 **Note**: Injection on arm64, and injection with `musl` on Alpine Linux container images are not supported.
 
@@ -650,7 +646,7 @@ Any newly started processes are intercepted and the specified instrumentation li
    repo_gpgcheck=1
    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
    ```
-   **Note**: Due to a [bug in dnf][5], on RedHat/CentOS 8.1 set `repo_gpgcheck=0` instead of `1`.
+   **Note**: Due to a [bug in dnf][2], on RedHat/CentOS 8.1 set `repo_gpgcheck=0` instead of `1`.
 
 2. Update the yum cache and install the library:
    ```sh
@@ -856,11 +852,11 @@ Launch your containerized services as usual.
 Exercise your application to start generating telemetry data, which you can see as [traces in APM][4].
 
 
-[2]: https://docs.docker.com/engine/install/ubuntu/
+
+[1]: https://docs.docker.com/engine/install/ubuntu/
+[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1792506
 [3]: /tracing/trace_collection/library_config/
 [4]: https://app.datadoghq.com/apm/traces
-[5]: https://bugzilla.redhat.com/show_bug.cgi?id=1792506
-
 {{% /tab %}}
 
 
@@ -869,9 +865,9 @@ Exercise your application to start generating telemetry data, which you can see 
 
 ## Configuring the library
 
-The supported features and configuration options for the tracing library are the same for library injection as for other installation methods, and can be set with environment variables. Read the [Datadog Library configuration page][16] for your language for more details.
+The supported features and configuration options for the tracing library are the same for library injection as for other installation methods, and can be set with environment variables. Read the [Datadog library configuration page][2] for your language for more details.
 
-For example, you can turn on [Application Security Monitoring][4] or [Continuous Profiler][3], each of which may have billing impact:
+For example, you can turn on [Application Security Monitoring][3] or [Continuous Profiler][4], each of which may have billing impact:
 
 - For **Kubernetes**, set the `DD_APPSEC_ENABLED` or `DD_PROFILING_ENABLED` container environment variables to `true`.
 
@@ -888,7 +884,7 @@ For example, you can turn on [Application Security Monitoring][4] or [Continuous
   Only configuration keys that start with `DD_` can be set in the injection config source `additional_environment_variables` section.
 
 
-[2]: /tracing/trace_collection/
-[3]: /profiler/enabling/java/?tab=environmentvariables#installation
-[4]: /security/application_security/enabling/java/?tab=kubernetes#get-started
-[16]: /tracing/trace_collection/library_config/
+[1]: /tracing/trace_collection/
+[2]: /tracing/trace_collection/library_config/
+[3]: /security/application_security/enabling/java/?tab=kubernetes#get-started
+[4]: /profiler/enabling/java/?tab=environmentvariables#installation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Standardizes "Datadog library" to have a capital D, lowercase l.

### Motivation
When I corrected the capitalization on an unrelated pull request, the author mentioned that "Datadog Library" exists in several other places in the codebase.

### Additional Notes

Sorry about all the link renumbering! I glanced at them and thought they looked okay. Some of the pages do have tabs. I can back them out if you prefer.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
