### PR TITLE
[Tracing] [.NET] Update default injection style

### DIFF
--- a/content/en/tracing/trace_collection/library_config/dotnet-core.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-core.md
@@ -299,9 +299,9 @@ You can use the following environment variables to configure injection and extra
 - `DD_TRACE_PROPAGATION_STYLE_INJECT=Datadog, b3multi, tracecontext`
 - `DD_TRACE_PROPAGATION_STYLE_EXTRACT=Datadog, b3multi, tracecontext`
 
-The environment variable values are comma-separated lists of header styles enabled for injection or extraction. By default, only the `Datadog` injection style is enabled.
-
 If multiple extraction styles are enabled, the extraction attempt is completed in order of configured styles, and uses the first successful extracted value.
+
+The environment variable values are comma-separated lists of header styles enabled for injection or extraction. From verion 2.22.0, the default injection style is `tracecontext, Datadog`, so the W3C context is used preferentially, followed by the Datadog headers. Prior to version 2.22.0, only the `Datadog` injection style is enabled.
 
 ## Further reading
 

--- a/content/en/tracing/trace_collection/library_config/dotnet-core.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-core.md
@@ -299,9 +299,9 @@ You can use the following environment variables to configure injection and extra
 - `DD_TRACE_PROPAGATION_STYLE_INJECT=Datadog, b3multi, tracecontext`
 - `DD_TRACE_PROPAGATION_STYLE_EXTRACT=Datadog, b3multi, tracecontext`
 
-The environment variable values are comma-separated lists of header styles enabled for injection or extraction. If multiple extraction styles are enabled, the extraction attempt is completed in order of configured styles, and uses the first successful extracted value.
+The environment variable values are comma-separated lists of header styles enabled for injection or extraction. If multiple extraction styles are enabled, the extraction attempt is completed in the order of configured styles, and uses the first successful extracted value.
 
-From verion 2.22.0, the default injection style is `tracecontext, Datadog`, so the W3C context is used preferentially, followed by the Datadog headers. Prior to version 2.22.0, only the `Datadog` injection style is enabled.
+Starting from version 2.22.0, the default injection style is `tracecontext, Datadog`, so the W3C context is used, followed by the Datadog headers. Prior to version 2.22.0, only the `Datadog` injection style is enabled.
 
 ## Further reading
 

--- a/content/en/tracing/trace_collection/library_config/dotnet-core.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-core.md
@@ -289,15 +289,15 @@ You can configure injection and extraction styles for distributed headers.
 
 The .NET Tracer supports the following styles:
 
+- W3C: `tracecontext` (`W3C` is deprecated)
 - Datadog: `Datadog`
 - B3 Multi Header: `b3multi` (`B3` is deprecated)
-- W3C: `tracecontext` (`W3C` is deprecated)
 - B3 Single Header: `B3 single header` (`B3SingleHeader` is deprecated)
 
 You can use the following environment variables to configure injection and extraction styles:
 
-- `DD_TRACE_PROPAGATION_STYLE_INJECT=Datadog, b3multi, tracecontext`
-- `DD_TRACE_PROPAGATION_STYLE_EXTRACT=Datadog, b3multi, tracecontext`
+- `DD_TRACE_PROPAGATION_STYLE_INJECT=tracecontext, Datadog, b3multi`
+- `DD_TRACE_PROPAGATION_STYLE_EXTRACT=tracecontext, Datadog, b3multi`
 
 The environment variable values are comma-separated lists of header styles enabled for injection or extraction. If multiple extraction styles are enabled, the extraction attempt is completed in the order of configured styles, and uses the first successful extracted value.
 

--- a/content/en/tracing/trace_collection/library_config/dotnet-core.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-core.md
@@ -299,9 +299,9 @@ You can use the following environment variables to configure injection and extra
 - `DD_TRACE_PROPAGATION_STYLE_INJECT=Datadog, b3multi, tracecontext`
 - `DD_TRACE_PROPAGATION_STYLE_EXTRACT=Datadog, b3multi, tracecontext`
 
-If multiple extraction styles are enabled, the extraction attempt is completed in order of configured styles, and uses the first successful extracted value.
+The environment variable values are comma-separated lists of header styles enabled for injection or extraction. If multiple extraction styles are enabled, the extraction attempt is completed in order of configured styles, and uses the first successful extracted value.
 
-The environment variable values are comma-separated lists of header styles enabled for injection or extraction. From verion 2.22.0, the default injection style is `tracecontext, Datadog`, so the W3C context is used preferentially, followed by the Datadog headers. Prior to version 2.22.0, only the `Datadog` injection style is enabled.
+From verion 2.22.0, the default injection style is `tracecontext, Datadog`, so the W3C context is used preferentially, followed by the Datadog headers. Prior to version 2.22.0, only the `Datadog` injection style is enabled.
 
 ## Further reading
 

--- a/content/en/tracing/trace_collection/library_config/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-framework.md
@@ -315,9 +315,9 @@ You can use the following environment variables to configure injection and extra
 - `DD_TRACE_PROPAGATION_STYLE_INJECT=Datadog, b3multi, tracecontext`
 - `DD_TRACE_PROPAGATION_STYLE_EXTRACT=Datadog, b3multi, tracecontext`
 
-The environment variable values are comma-separated lists of header styles enabled for injection or extraction. By default, only the `Datadog` injection style is enabled.
-
 If multiple extraction styles are enabled, the extraction attempt is completed in order of configured styles, and uses the first successful extracted value.
+
+The environment variable values are comma-separated lists of header styles enabled for injection or extraction. From verion 2.22.0, the default injection style is `tracecontext, Datadog`, so the W3C context is used preferentially, followed by the Datadog headers. Prior to version 2.22.0, only the `Datadog` injection style is enabled.
 
 
 ## Further reading

--- a/content/en/tracing/trace_collection/library_config/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-framework.md
@@ -305,15 +305,15 @@ You can configure injection and extraction styles for distributed headers.
 
 The .NET Tracer supports the following styles:
 
-- Datadog: `Datadog`
 - W3C: `tracecontext` (`W3C` is deprecated)
+- Datadog: `Datadog`
 - B3 Multi Header: `b3multi` (`B3` is deprecated)
 - B3 Single Header: `B3 single header` (`B3SingleHeader` is deprecated)
 
 You can use the following environment variables to configure injection and extraction styles:
 
-- `DD_TRACE_PROPAGATION_STYLE_INJECT=Datadog, b3multi, tracecontext`
-- `DD_TRACE_PROPAGATION_STYLE_EXTRACT=Datadog, b3multi, tracecontext`
+- `DD_TRACE_PROPAGATION_STYLE_INJECT=tracecontext, Datadog, b3multi`
+- `DD_TRACE_PROPAGATION_STYLE_EXTRACT=tracecontext, Datadog, b3multi`
 
 The environment variable values are comma-separated lists of header styles enabled for injection or extraction. If multiple extraction styles are enabled, the extraction attempt is completed in the order of configured styles, and uses the first successful extracted value.
 

--- a/content/en/tracing/trace_collection/library_config/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-framework.md
@@ -315,9 +315,9 @@ You can use the following environment variables to configure injection and extra
 - `DD_TRACE_PROPAGATION_STYLE_INJECT=Datadog, b3multi, tracecontext`
 - `DD_TRACE_PROPAGATION_STYLE_EXTRACT=Datadog, b3multi, tracecontext`
 
-If multiple extraction styles are enabled, the extraction attempt is completed in order of configured styles, and uses the first successful extracted value.
+The environment variable values are comma-separated lists of header styles enabled for injection or extraction. If multiple extraction styles are enabled, the extraction attempt is completed in order of configured styles, and uses the first successful extracted value.
 
-The environment variable values are comma-separated lists of header styles enabled for injection or extraction. From verion 2.22.0, the default injection style is `tracecontext, Datadog`, so the W3C context is used preferentially, followed by the Datadog headers. Prior to version 2.22.0, only the `Datadog` injection style is enabled.
+From verion 2.22.0, the default injection style is `tracecontext, Datadog`, so the W3C context is used preferentially, followed by the Datadog headers. Prior to version 2.22.0, only the `Datadog` injection style is enabled.
 
 
 ## Further reading

--- a/content/en/tracing/trace_collection/library_config/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-framework.md
@@ -315,9 +315,9 @@ You can use the following environment variables to configure injection and extra
 - `DD_TRACE_PROPAGATION_STYLE_INJECT=Datadog, b3multi, tracecontext`
 - `DD_TRACE_PROPAGATION_STYLE_EXTRACT=Datadog, b3multi, tracecontext`
 
-The environment variable values are comma-separated lists of header styles enabled for injection or extraction. If multiple extraction styles are enabled, the extraction attempt is completed in order of configured styles, and uses the first successful extracted value.
+The environment variable values are comma-separated lists of header styles enabled for injection or extraction. If multiple extraction styles are enabled, the extraction attempt is completed in the order of configured styles, and uses the first successful extracted value.
 
-From verion 2.22.0, the default injection style is `tracecontext, Datadog`, so the W3C context is used preferentially, followed by the Datadog headers. Prior to version 2.22.0, only the `Datadog` injection style is enabled.
+Starting from version 2.22.0, the default injection style is `tracecontext, Datadog`, so the W3C context is used, followed by the Datadog headers. Prior to version 2.22.0, only the `Datadog` injection style is enabled.
 
 
 ## Further reading


### PR DESCRIPTION
### What does this PR do?
Updates the .NET tracing documentation about the default injected distributed headers..-->

### Motivation
In v2.22.0, we changed which header styles we injected by default

### Additional Notes
Related to https://github.com/DataDog/dd-trace-dotnet/issues/3832

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
