### PR TITLE
Cleanup the left nav menu for Dashboards

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -661,205 +661,100 @@ main:
     url: dashboards/widgets/
     parent: dashboards
     identifier: dashboards_widgets
-    weight: 4
-  - name: Alert Graph
-    url: dashboards/widgets/alert_graph/
-    parent: dashboards_widgets
-    weight: 10
-  - name: Alert Value
-    url: dashboards/widgets/alert_value/
-    parent: dashboards_widgets
-    weight: 11
-  - name: Change
-    url: dashboards/widgets/change/
-    parent: dashboards_widgets
-    weight: 12
-  - name: Check Status
-    url: dashboards/widgets/check_status/
-    parent: dashboards_widgets
-    weight: 13
-  - name: Distribution
-    url: dashboards/widgets/distribution/
-    parent: dashboards_widgets
-    weight: 14
-  - name: Event Stream
-    url: dashboards/widgets/event_stream/
-    parent: dashboards_widgets
-    weight: 15
-  - name: Event Timeline
-    url: dashboards/widgets/event_timeline/
-    parent: dashboards_widgets
-    weight: 16
-  - name: Free Text
-    url: dashboards/widgets/free_text/
-    parent: dashboards_widgets
-    weight: 17
-  - name: Funnel
-    url: dashboards/widgets/funnel/
-    parent: dashboards_widgets
-    weight: 18
-  - name: Geomap
-    url: dashboards/widgets/geomap/
-    parent: dashboards_widgets
-    weight: 19
-  - name: Group
-    url: dashboards/widgets/group/
-    parent: dashboards_widgets
-    weight: 20
-  - name: Heat Map
-    url: dashboards/widgets/heat_map/
-    parent: dashboards_widgets
-    weight: 21
-  - name: Host Map
-    url: dashboards/widgets/hostmap/
-    parent: dashboards_widgets
-    weight: 22
-    identifier: widgets_host_map
-  - name: Iframe
-    url: dashboards/widgets/iframe/
-    parent: dashboards_widgets
-    weight: 23
-  - name: Image
-    url: dashboards/widgets/image/
-    parent: dashboards_widgets
-    weight: 24
-  - name: Log Stream
-    url: dashboards/widgets/log_stream/
-    parent: dashboards_widgets
-    weight: 25
-  - name: Monitor Summary
-    url: dashboards/widgets/monitor_summary/
-    parent: dashboards_widgets
-    weight: 26
-  - name: Notes and Links
-    url: dashboards/widgets/note/
-    parent: dashboards_widgets
-    weight: 27
-  - name: Query Value
-    url: dashboards/widgets/query_value/
-    parent: dashboards_widgets
-    weight: 28
-  - name: Scatter Plot
-    url: dashboards/widgets/scatter_plot/
-    parent: dashboards_widgets
-    weight: 29
-  - name: SLO Summary
-    url: dashboards/widgets/slo/
-    parent: dashboards_widgets
-    weight: 30
-  - name: Service Summary
-    url: dashboards/widgets/service_summary/
-    parent: dashboards_widgets
-    weight: 31
-  - name: Table
-    url: dashboards/widgets/table/
-    parent: dashboards_widgets
-    weight: 32
-  - name: Timeseries
-    url: dashboards/widgets/timeseries/
-    parent: dashboards_widgets
-    weight: 33
-  - name: Top List
-    url: dashboards/widgets/top_list/
-    parent: dashboards_widgets
-    weight: 34
-  - name: Topology Map
-    url: dashboards/widgets/topology_map/
-    parent: dashboards_widgets
-    weight: 35
+    weight: 1
   - name: Querying
     url: dashboards/querying/
     parent: dashboards
-    weight: 5
+    weight: 2
   - name: Functions
     url: dashboards/functions/
     parent: dashboards
     identifier: dashboards_functions
-    weight: 6
+    weight: 3
   - name: Algorithms
     url: dashboards/functions/algorithms/
     parent: dashboards_functions
-    weight: 601
+    weight: 301
   - name: Arithmetic
     url: dashboards/functions/arithmetic/
     parent: dashboards_functions
-    weight: 602
+    weight: 302
   - name: Count
     url: dashboards/functions/count/
     parent: dashboards_functions
-    weight: 603
+    weight: 303
   - name: Exclusion
     url: dashboards/functions/exclusion/
     parent: dashboards_functions
-    weight: 603
+    weight: 303
   - name: Interpolation
     url: dashboards/functions/interpolation/
     parent: dashboards_functions
-    weight: 604
+    weight: 304
   - name: Rank
     url: dashboards/functions/rank/
     parent: dashboards_functions
-    weight: 605
+    weight: 305
   - name: Rate
     url: dashboards/functions/rate/
     parent: dashboards_functions
-    weight: 606
+    weight: 306
   - name: Regression
     url: dashboards/functions/regression/
     parent: dashboards_functions
-    weight: 607
+    weight: 307
   - name: Rollup
     url: dashboards/functions/rollup/
     parent: dashboards_functions
-    weight: 608
+    weight: 308
   - name: Smoothing
     url: dashboards/functions/smoothing/
     parent: dashboards_functions
-    weight: 609
+    weight: 309
   - name: Timeshift
     url: dashboards/functions/timeshift/
     parent: dashboards_functions
-    weight: 610
+    weight: 310
   - name: Beta
     url: dashboards/functions/beta/
     parent: dashboards_functions
-    weight: 611
+    weight: 311
   - name: Correlations
     url: dashboards/correlations/
     parent: dashboards
-    weight: 7
+    weight: 4
   - name: Scheduled Reports
     url: dashboards/scheduled_reports/
     parent: dashboards
-    weight: 8
+    weight: 5
     identifier: dashboards_reporting
   - name: Template Variables
     url: dashboards/template_variables/
     parent: dashboards
-    weight: 9
+    weight: 6
     identifier: dashboards_temp_variables
   - name: Sharing
     url: dashboards/sharing/
     parent: dashboards
-    weight: 10
+    weight: 7
   - name: Graphing with JSON
     url: dashboards/graphing_json/
     parent: dashboards
     identifier: graphing_json
-    weight: 11
+    weight: 8
   - name: Widget JSON schema
     url: dashboards/graphing_json/widget_json/
     parent: graphing_json
-    weight: 1001
+    weight: 801
   - name: Request JSON schema
     url: dashboards/graphing_json/request_json/
     parent: graphing_json
-    weight: 1002
+    weight: 802
   - name: Guides
     url: dashboards/guide/
     parent: dashboards
     identifier: guides
-    weight: 12
+    weight: 9
   - name: Mobile Application
     url: mobile/
     identifier: mobile


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Remove the individual widgets from the menu (these aren't visible from the left nav currently)
- Renumber the Dashboard child menu items starting from 1 instead of 4

### Motivation
<!-- What inspired you to submit this pull request?-->
- [DOCS-5054](https://datadoghq.atlassian.net/browse/DOCS-5054)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
- Ready for release after review

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5054]: https://datadoghq.atlassian.net/browse/DOCS-5054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ