### PR TITLE
[SC] Fix filename for service definition file

### DIFF
--- a/content/en/tracing/service_catalog/service_definition_api.md
+++ b/content/en/tracing/service_catalog/service_definition_api.md
@@ -27,7 +27,7 @@ The Service Definition Schema is a structure that contains basic information abo
 
 
 #### Example
-{{< code-block lang="yaml" filename="service.definition.yaml" collapsible="true" >}}
+{{< code-block lang="yaml" filename="service.datadog.yaml" collapsible="true" >}}
 schema-version: v2
 dd-service: web-store
 team: shopist
@@ -63,6 +63,7 @@ docs:
     url: https://docs.datadoghq.com/
 tags: []
 integrations:
+    pagerduty: https://example.pagerduty.com/service-directory/XYZYX
 External Resources (Optional)
 {{< /code-block >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix the file naming for service definition file, 
This is what we recommend: https://docs.datadoghq.com/tracing/service_catalog/setup/#service-definition-yaml-files

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
