### PR TITLE
DOCS-4924 Add Supported OS for the Kubernetes State Metrics Core Integration Documentation

### DIFF
--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -16,6 +16,10 @@ has_logo: true
 integration_title: Kubernetes State Metrics Core
 is_public: true
 public_title: Datadog-Kubernetes State Metrics Core Integration
+supported_os:
+    - linux
+    - mac_os
+    - windows
 # forcing integration_id to kube-state-metrics so it loads kubernetes svg
 integration_id: "kube-state-metrics"
 further_reading:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Resolves the merge conflict in https://github.com/DataDog/integrations-core/pull/14154.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-4924

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

This is a hardcoded integration in the `documentation` repo.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
