### PR TITLE
Remove the S3 bucket mention as it's misleading

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -18,7 +18,7 @@ further_reading:
 
 ## Overview
 
-AWS service logs are usually stored in S3 buckets or CloudWatch Log groups. It is possible to subscribe to these logs and forward them to an Amazon Kinesis stream to then forward them to one or multiple destinations. Datadog is one of the default destinations for Amazon Kinesis Delivery streams. 
+It is possible to subscribe to AWS service logs stored in CloudWatch Log groups and forward them to an Amazon Kinesis stream to then forward them to one or multiple destinations. Datadog is one of the default destinations for Amazon Kinesis Delivery streams. 
 
 AWS fully manages Amazon Kinesis Data Firehose, so you don't need to maintain any additional infrastructure or forwarding configurations for streaming logs. You can set up a Kinesis Firehose Delivery Stream in the AWS Firehose console, or automatically set up the destination using a CloudFormation template.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
After discussing this with Ryan internally, it's better to remove the S3 bucket mention in the doc as it can be misleading for customers. 

### Motivation
We had one customer asking clarification about this: he was not sure he could use the kinesis firehose to forward his S3 bucket objects to datadog. Only CW is supported. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
(https://a.cl.ly/llu72vKp)
This should be reviewed by Bryce Eadie as asked by Ryan 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
