### PR TITLE
[PROF-7359] Document workaround for Ruby profiler signal usage

### DIFF
--- a/content/en/profiler/profiler_troubleshooting.md
+++ b/content/en/profiler/profiler_troubleshooting.md
@@ -237,15 +237,13 @@ end
 
 Starting from `dd-trace-rb` 1.11.0, the "CPU Profiling 2.0" profiler gathers data by sending `SIGPROF` unix signals to Ruby applications, enabling finer-grained data gathering.
 
-Sending `SIGPROF` is a common profiling approach, and may cause system calls from native extensions/libraries to be interrupted [with a system `EINTR` error code](https://man7.org/linux/man-pages/man7/signal.7.html#:~:text=Interruption%20of%20system%20calls%20and%20library%20functions%20by%20signal%20handlers).
+Sending `SIGPROF` is a common profiling approach, and may cause system calls from native extensions/libraries to be interrupted with a system [`EINTR` error code][4].
 Rarely, native extensions or libraries called by them may be have missing or incorrect error handling for the `EINTR` error code.
 
-One known instance of this issue is when using the `mysql2` gem together with versions of libmysqlclient [older than 8.0.0](https://bugs.mysql.com/bug.php?id=83109). The affected libmysqlclient version is known to be present on Ubuntu 18.04, but not 20.04 and later releases.
+One known instance of this issue is when using the `mysql2` gem together with versions of libmysqlclient [older than 8.0.0][5]. The affected libmysqlclient version is known to be present on Ubuntu 18.04, but not 20.04 and later releases.
 **Note**: For this case, the profiler auto-detects when the `mysql2` gem is in use and auto-applies the solution described below.
 
-If you run into run-time failures and/or errors from Ruby gems that use native extensions, you can revert back to the legacy profiler.
-The legacy profiler does not use `SIGPROF` signals.
-You can do this by setting the `DD_PROFILING_FORCE_ENABLE_LEGACY` environment variable to `true`, or in code:
+If you encounter run-time failures or errors from Ruby gems that use native extensions, you can revert back to the legacy profiler which does not use `SIGPROF` signals. To revert to the legacy profiler, set the `DD_PROFILING_FORCE_ENABLE_LEGACY` environment variable to `true`, or in code:
 
 ```ruby
 Datadog.configure do |c|
@@ -253,12 +251,14 @@ Datadog.configure do |c|
 end
 ```
 
-Let our team know if you find (or suspect) any such incompatibilities [by opening a support ticket][2].
+Let our team know if you find or suspect any such incompatibilities [by opening a support ticket][2].
 Doing this enables Datadog to add them to the auto-detection list, and to work with the gem/library authors to fix the issue.
 
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/
 [3]: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.54.0
+[4]: https://man7.org/linux/man-pages/man7/signal.7.html#:~:text=Interruption%20of%20system%20calls%20and%20library%20functions%20by%20signal%20handlers
+[5]: https://bugs.mysql.com/bug.php?id=83109
 [4]: https://github.com/resque/resque
 [5]: https://github.com/resque/resque/blob/v2.0.0/docs/HOOKS.md#worker-hooks
 [6]: https://bugs.ruby-lang.org/issues/18073

--- a/content/en/profiler/profiler_troubleshooting.md
+++ b/content/en/profiler/profiler_troubleshooting.md
@@ -237,10 +237,10 @@ end
 
 Starting from `dd-trace-rb` 1.11.0, the "CPU Profiling 2.0" profiler gathers data by sending `SIGPROF` unix signals to Ruby applications, enabling finer-grained data gathering.
 
-Sending `SIGPROF` is a common profiling approach, and may cause system calls from native extensions/libraries to be interrupted with a system [`EINTR` error code][4].
+Sending `SIGPROF` is a common profiling approach, and may cause system calls from native extensions/libraries to be interrupted with a system [`EINTR` error code][8].
 Rarely, native extensions or libraries called by them may be have missing or incorrect error handling for the `EINTR` error code.
 
-One known instance of this issue is when using the `mysql2` gem together with versions of libmysqlclient [older than 8.0.0][5]. The affected libmysqlclient version is known to be present on Ubuntu 18.04, but not 20.04 and later releases.
+One known instance of this issue is when using the `mysql2` gem together with versions of libmysqlclient [older than 8.0.0][9]. The affected libmysqlclient version is known to be present on Ubuntu 18.04, but not 20.04 and later releases.
 **Note**: For this case, the profiler auto-detects when the `mysql2` gem is in use and auto-applies the solution described below.
 
 If you encounter run-time failures or errors from Ruby gems that use native extensions, you can revert back to the legacy profiler which does not use `SIGPROF` signals. To revert to the legacy profiler, set the `DD_PROFILING_FORCE_ENABLE_LEGACY` environment variable to `true`, or in code:
@@ -257,12 +257,12 @@ Doing this enables Datadog to add them to the auto-detection list, and to work w
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/
 [3]: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.54.0
-[4]: https://man7.org/linux/man-pages/man7/signal.7.html#:~:text=Interruption%20of%20system%20calls%20and%20library%20functions%20by%20signal%20handlers
-[5]: https://bugs.mysql.com/bug.php?id=83109
 [4]: https://github.com/resque/resque
 [5]: https://github.com/resque/resque/blob/v2.0.0/docs/HOOKS.md#worker-hooks
 [6]: https://bugs.ruby-lang.org/issues/18073
 [7]: https://github.com/DataDog/dd-trace-rb/issues/1799
+[8]: https://man7.org/linux/man-pages/man7/signal.7.html#:~:text=Interruption%20of%20system%20calls%20and%20library%20functions%20by%20signal%20handlers
+[9]: https://bugs.mysql.com/bug.php?id=83109
 {{< /programming-lang >}}
 {{< programming-lang lang="dotnet" >}}
 

--- a/content/en/profiler/profiler_troubleshooting.md
+++ b/content/en/profiler/profiler_troubleshooting.md
@@ -235,14 +235,17 @@ end
 
 ## Unexpected run-time failures and errors from Ruby gems that use native extensions in `dd-trace-rb` 1.11.0+
 
-Starting from `dd-trace-rb` 1.11.0, the "CPU Profiling 2.0" profiler now gathers profiling data by sending `SIGPROF` unix signals to Ruby applications, enabling finer-grained data gathering.
+Starting from `dd-trace-rb` 1.11.0, the "CPU Profiling 2.0" profiler gathers data by sending `SIGPROF` unix signals to Ruby applications, enabling finer-grained data gathering.
 
-Sending `SIGPROF` unix signals is a common profiling approach, and it may cause system calls performed by native extensions/libraries to be interrupted [with a system `EINTR` error code](https://man7.org/linux/man-pages/man7/signal.7.html#:~:text=Interruption%20of%20system%20calls%20and%20library%20functions%20by%20signal%20handlers).
+Sending `SIGPROF` is a common profiling approach, and may cause system calls from native extensions/libraries to be interrupted [with a system `EINTR` error code](https://man7.org/linux/man-pages/man7/signal.7.html#:~:text=Interruption%20of%20system%20calls%20and%20library%20functions%20by%20signal%20handlers).
 Rarely, native extensions or libraries called by them may be have missing or incorrect error handling for the `EINTR` error code.
 
-One known instance of this issue is when using the `mysql2` gem together with versions of libmysqlclient [older than 8.0.0](https://bugs.mysql.com/bug.php?id=83109). The affected libmysqlclient version is known to be present on Ubuntu 18.04, but not 20.04 and later releases. Note that for this specific case, the profiler auto-detects when the `mysql2` gem is in use and auto-applies the solution described below.
+One known instance of this issue is when using the `mysql2` gem together with versions of libmysqlclient [older than 8.0.0](https://bugs.mysql.com/bug.php?id=83109). The affected libmysqlclient version is known to be present on Ubuntu 18.04, but not 20.04 and later releases.
+**Note**: For this case, the profiler auto-detects when the `mysql2` gem is in use and auto-applies the solution described below.
 
-If you run into run-time failures and/or errors from Ruby gems that use native extensions when the profiler is enabled, you can fall back to the legacy profiler, which does not use `SIGPROF` signals to work. You can do this by setting the `DD_PROFILING_FORCE_ENABLE_LEGACY` environment variable to `true`, or via code:
+If you run into run-time failures and/or errors from Ruby gems that use native extensions, we suggest reverting back to the legacy profiler.
+The legacy profiler does not use `SIGPROF` signals.
+You can do this by setting the `DD_PROFILING_FORCE_ENABLE_LEGACY` environment variable to `true`, or in code:
 
 ```ruby
 Datadog.configure do |c|
@@ -250,7 +253,8 @@ Datadog.configure do |c|
 end
 ```
 
-Please [open a support ticket][2] if you find any such incompatibilities: We will add those to the auto-detection list, and will work with the gem authors to fix the issue.
+[Let us know via a support ticket][2] if you find (or suspect) any such incompatibilities.
+Doing this enables Datadog to add them to the auto-detection list, and to work with the gem/library authors to fix the issue.
 
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/

--- a/content/en/profiler/profiler_troubleshooting.md
+++ b/content/en/profiler/profiler_troubleshooting.md
@@ -238,10 +238,9 @@ end
 Starting from `dd-trace-rb` 1.11.0, the "CPU Profiling 2.0" profiler gathers data by sending `SIGPROF` unix signals to Ruby applications, enabling finer-grained data gathering.
 
 Sending `SIGPROF` is a common profiling approach, and may cause system calls from native extensions/libraries to be interrupted with a system [`EINTR` error code][8].
-Rarely, native extensions or libraries called by them may be have missing or incorrect error handling for the `EINTR` error code.
+Rarely, native extensions or libraries called by them may have missing or incorrect error handling for the `EINTR` error code.
 
-One known instance of this issue is when using the `mysql2` gem together with versions of libmysqlclient [older than 8.0.0][9]. The affected libmysqlclient version is known to be present on Ubuntu 18.04, but not 20.04 and later releases.
-**Note**: For this case, the profiler auto-detects when the `mysql2` gem is in use and auto-applies the solution described below.
+One known instance of this issue is when using the `mysql2` gem together with versions of libmysqlclient [older than 8.0.0][9]. The affected libmysqlclient version is known to be present on Ubuntu 18.04, but not 20.04 and later releases. For this case, the profiler auto-detects when the `mysql2` gem is in use and auto-applies the solution described below.
 
 If you encounter run-time failures or errors from Ruby gems that use native extensions, you can revert back to the legacy profiler which does not use `SIGPROF` signals. To revert to the legacy profiler, set the `DD_PROFILING_FORCE_ENABLE_LEGACY` environment variable to `true`, or in code:
 

--- a/content/en/profiler/profiler_troubleshooting.md
+++ b/content/en/profiler/profiler_troubleshooting.md
@@ -243,7 +243,7 @@ Rarely, native extensions or libraries called by them may be have missing or inc
 One known instance of this issue is when using the `mysql2` gem together with versions of libmysqlclient [older than 8.0.0](https://bugs.mysql.com/bug.php?id=83109). The affected libmysqlclient version is known to be present on Ubuntu 18.04, but not 20.04 and later releases.
 **Note**: For this case, the profiler auto-detects when the `mysql2` gem is in use and auto-applies the solution described below.
 
-If you run into run-time failures and/or errors from Ruby gems that use native extensions, we suggest reverting back to the legacy profiler.
+If you run into run-time failures and/or errors from Ruby gems that use native extensions, you can revert back to the legacy profiler.
 The legacy profiler does not use `SIGPROF` signals.
 You can do this by setting the `DD_PROFILING_FORCE_ENABLE_LEGACY` environment variable to `true`, or in code:
 
@@ -253,7 +253,7 @@ Datadog.configure do |c|
 end
 ```
 
-[Let us know via a support ticket][2] if you find (or suspect) any such incompatibilities.
+Let our team know if you find (or suspect) any such incompatibilities [by opening a support ticket][2].
 Doing this enables Datadog to add them to the auto-detection list, and to work with the gem/library authors to fix the issue.
 
 [1]: /tracing/troubleshooting/#tracer-debug-logs


### PR DESCRIPTION
### What does this PR do?
This PR documents, in the "Profiler Troubleshooting" page, what to do if customers run into issues due to the new Ruby profiler using `SIGPROF` signals for working.

We currently don't know of any cases where this may be needed (other than `mysql2`, which is already autodetected and worked around in the library), so I've also added a note asking for customers to report any such cases.

### Motivation

From dd-trace-rb 1.11.0+, the new profiler will be the default so it's important to document this caveat and its workaround, in the rare case that customers run into it.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
N/A
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
