### PR TITLE
Add codeowners on articles related to browser

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,3 +42,11 @@ docker-compose-docs.yml                                 @DataDog/corpweb
 
 # Cloud Cost Management
 documentation/content/en/cloud_cost_management/_index.md         @DataDog/cloud-cost-management-visibility
+
+# Browser SDK
+content/en/real_user_monitoring/browser/                       @Datadog/rum-browser @DataDog/documentation
+content/en/real_user_monitoring/guide/                         @Datadog/rum-browser @DataDog/documentation
+content/en/real_user_monitoring/session_replay/                @Datadog/rum-browser @DataDog/documentation
+content/en/logs/log_collection/javascript.md                   @Datadog/rum-browser @DataDog/documentation
+content/en/logs/error_tracking/browser_and_mobile.md           @Datadog/rum-browser @DataDog/documentation
+content/en/real_user_monitoring/error_tracking/browser.md      @Datadog/rum-browser @DataDog/documentation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add @Datadog/rum-browser as owner of browser related files

### Motivation
<!-- What inspired you to submit this pull request?-->

Be notified when those files are updated to have a chance to review the edits

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
