### PR TITLE
Update SQL Server adoprovider to use MSOLEDBSQL19 instead

### DIFF
--- a/content/en/database_monitoring/setup_sql_server/azure.md
+++ b/content/en/database_monitoring/setup_sql_server/azure.md
@@ -158,7 +158,7 @@ Use the `service` and `env` tags to link your database telemetry to other teleme
 The recommended [ADO][6] provider is [Microsoft OLE DB Driver][7]. Ensure the driver is installed on the host where the agent is running.
 ```yaml
 connector: adodbapi
-adoprovider: MSOLEDBSQL
+adoprovider: MSOLEDBSQL19  # Replace with MSOLEDBSQL for versions 18 and lower
 ```
 
 The other two providers, `SQLOLEDB` and `SQLNCLI`, are considered deprecated by Microsoft and should no longer be used.

--- a/content/en/database_monitoring/setup_sql_server/gcsql.md
+++ b/content/en/database_monitoring/setup_sql_server/gcsql.md
@@ -92,7 +92,7 @@ Use the `service` and `env` tags to link your database telemetry to other teleme
 The recommended [ADO][6] provider is [Microsoft OLE DB Driver][7]. Ensure the driver is installed on the host where the agent is running.
 ```yaml
 connector: adodbapi
-provider: MSOLEDBSQL
+adoprovider: MSOLEDBSQL19  # Replace with MSOLEDBSQL for versions 18 and lower
 ```
 
 The other two providers, `SQLOLEDB` and `SQLNCLI`, are considered deprecated by Microsoft and should no longer be used.

--- a/layouts/shortcodes/dbm-sqlserver-agent-setup-windows.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-setup-windows.md
@@ -30,7 +30,7 @@ Use the `service` and `env` tags to link your database telemetry to other teleme
 The recommended [ADO][9] provider is [Microsoft OLE DB Driver][2]. Ensure the driver is installed on the host where the agent is running.
 ```yaml
 connector: adodbapi
-adoprovider: MSOLEDBSQL
+adoprovider: MSOLEDBSQL19  # Replace with MSOLEDBSQL for versions 18 and lower
 ```
 
 The other two providers, `SQLOLEDB` and `SQLNCLI`, are considered deprecated by Microsoft and should no longer be used.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update adoprovider parameter to use MSOLEDBSQL19 instead of MSOLEDBSQL.

### Motivation
Microsoft OLE DB Driver for SQL Server 19 is now the default download on the linked [Microsoft ODBC Driver](https://docs.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server) page, meaning that without this change Datadog's SQL Server integration will always fail with an error "Provider cannot be found. It may not be properly installed". This follows the same changes made to spec.yaml and conf.yaml.example in https://github.com/DataDog/integrations-core/pull/12916

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
