### PR TITLE
WEB-3368 | Allow redirect preview job to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -450,6 +450,7 @@ set_redirect_metadata_preview:
   script:
     - in-isolation update_redirect_metadata
   interruptible: true
+  allow_failure: true
 
 set_redirect_metadata_live:
   <<: *base_template


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds `allow_faulure: true` to `set_redirect_metadata_preview`

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/browse/WEB-3368

This job is not (technically) required to consider a build pipeline successful, since we rely on the aliases as a backup to redirect metadata, and any redirect loops from redundant aliases are bypassed and not uploaded to S3 and just outputted to the console. With that in mind if the job did fail, it would not block a deployment, and the redundant alias could be cleaned up in a follow up PR.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
