### PR TITLE
Add Heroku dyno to the hosts section

### DIFF
--- a/content/en/account_management/billing/_index.md
+++ b/content/en/account_management/billing/_index.md
@@ -11,7 +11,7 @@ Datadog meters the count of hosts and custom metrics hourly. The billable count 
 
 ### Hosts
 
-A host is any physical or virtual OS instance that you monitor with Datadog. It could be a server, VM, node (in the case of Kubernetes), or App Service Plan instance (in the case of Azure App Service). Hosts can be instances with the Datadog Agent installed plus any AWS EC2s, GCP, Azure, or vSphere VMs monitored with Datadog integrations. Any EC2s or VMs with the Agent installed count as a single instance (no double-billing).
+A host is any physical or virtual OS instance that you monitor with Datadog. It could be a server, VM, node (in the case of Kubernetes), App Service Plan instance (in the case of Azure App Service), or Heroku dyno (in the case of the Heroku platform). Hosts can be instances with the Datadog Agent installed plus any AWS EC2s, GCP, Azure, or vSphere VMs monitored with Datadog integrations. Any EC2s or VMs with the Agent installed count as a single instance (no double-billing).
 
 Non-reporting hosts (status `???` in your [Infrastructure list][2]) do not count towards billing. It could take up to 2 hours for these hosts to drop out of the [Infrastructure List][2]. Datadog retains the historical data for these hosts (paid accounts). Metrics can be graphed on a dashboard by knowing the specific host name or tags.
 


### PR DESCRIPTION
### What does this PR do?
Adds Heroku dyno as a unit for hosts counting for billing

### Motivation
A lot of people coming to Heroku is confused on how we count hosts when it comes to Heroku. This PR makes it clear in the Billing page.

### Preview

https://docs-staging.datadoghq.com/arapulido/heroku-dynos-billing-docs/account_management/billing/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
