### PR TITLE
Add a partial for links in dashboard overview

### DIFF
--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -49,6 +49,14 @@ A dashboard is Datadog's tool for visually tracking, analyzing, and displaying k
 
 **Note**: View Dashboards with the [Datadog Mobile App][1], available on the [Apple App Store][2] and [Google Play Store][3].
 
+{{< whatsnext desc="Dashboard features:">}}
+    {{< nextlink href="/dashboards/widgets" >}}Widgets: Learn the configuration for different visualizations{{< /nextlink >}}
+    {{< nextlink href="/dashboards/querying" >}}Querying: See the formatting options for graph queries{{< /nextlink >}}
+    {{< nextlink href="/dashboards/functions" >}}Functions: Modify metric queries and resulting graphs{{< /nextlink >}}
+    {{< nextlink href="/dashboards/template_variables" >}}Template Variable: Dynamically filter widgets in a dashboard{{< /nextlink >}}
+    {{< nextlink href="/api/latest/dashboards" >}}API: Manage dashboards programmatically{{< /nextlink >}}
+{{< /whatsnext >}}
+
 ## New dashboard
 
 To create a dashboard, click **+New Dashboard** on the [Dashboard List][4] page or **New Dashboard** from the navigation menu. Enter a dashboard name and choose a layout option.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- Add a quick start section with links to docs pages customers frequently look for, similar to the [Metrics page](https://docs.datadoghq.com/metrics/#what-are-metrics)

### Motivation
<!-- What inspired you to submit this pull request?-->
[DOCS-5102](https://datadoghq.atlassian.net/browse/DOCS-5102)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Ready for release after review


[DOCS-5102]: https://datadoghq.atlassian.net/browse/DOCS-5102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ