### PR TITLE
APM > Library Injection > Add .NET instructions

### DIFF
--- a/content/en/tracing/trace_collection/library_injection_local.md
+++ b/content/en/tracing/trace_collection/library_injection_local.md
@@ -105,10 +105,9 @@ The available library versions are listed in each container registry, as well as
 - [.NET][19]
   - **Note**: For .NET library injection, if the application container uses a musl-based Linux distribution (such as Alpine), you must specify a tag with the the `-musl` suffix for the pod annotation. For example, to use library version `v2.29.0`, specify container tag `v2.29.0-musl`.
 - [Ruby][20]
+  - **Note**: For Ruby, instrumenting only Ruby on Rails or Hanami applications is supported.
 
 **Note**: If you already have an application instrumented using version X of the library, and then use library injection to instrument using version Y of the same tracer library, the tracer does not break. Rather, the library version loaded first is used. Because library injection happens at the admission controller level prior to runtime, it takes precedent over manually configured libraries.
-
-**Note**: For Ruby, only support instrumenting Ruby on Rails or Hanami application.
 
 <div class="alert alert-warning"><strong>Note</strong>: Using the <code>latest</code> tag is supported, but use it with caution because major library releases can introduce breaking changes.</div>
 

--- a/content/en/tracing/trace_collection/library_injection_local.md
+++ b/content/en/tracing/trace_collection/library_injection_local.md
@@ -30,7 +30,7 @@ To learn more about Kubernetes Admission Controller, read [Kubernetes Admission 
 * Kubernetes v1.14+
 * Datadog [Cluster Agent v7.40+][3]
 * Datadog Admission Controller enabled. **Note**: In Helm chart v2.35.0 and later, Datadog Admission Controller is activated by default in the Cluster Agent.
-* Applications in Java, JavaScript, or Python deployed on Linux with a supported architecture. Check the [corresponding container registry](#container-registries) for the complete list of supported architectures by language.
+* Applications in Java, JavaScript, Python, or .NET deployed on Linux with a supported architecture. Check the [corresponding container registry](#container-registries) for the complete list of supported architectures by language.
 
 **Note:** Python uWSGI applications are not supported.
 
@@ -43,6 +43,7 @@ Datadog publishes instrumentation libraries images on gcr.io, Docker Hub, and AW
 | Java       | [gcr.io/datadoghq/dd-lib-java-init][4]   | [hub.docker.com/r/datadog/dd-lib-java-init][5]   | [gallery.ecr.aws/datadog/dd-lib-java-init][6]   |
 | JavaScript | [gcr.io/datadoghq/dd-lib-js-init][7]     | [hub.docker.com/r/datadog/dd-lib-js-init][8]     | [gallery.ecr.aws/datadog/dd-lib-js-init][9]     |
 | Python     | [gcr.io/datadoghq/dd-lib-python-init][10] | [hub.docker.com/r/datadog/dd-lib-python-init][11] | [gallery.ecr.aws/datadog/dd-lib-python-init][12] |
+| .NET       | [gcr.io/datadoghq/dd-lib-dotnet-init][13] | [hub.docker.com/r/datadog/dd-lib-dotnet-init][14] | [gallery.ecr.aws/datadog/dd-lib-dotnet-init][15] |
 
 The `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY` environment variable in the Datadog Cluster Agent configuration specifies the registry used by the Admission Controller. The default value is `gcr.io/datadoghq`.
 
@@ -50,7 +51,7 @@ You can pull the tracing library from a different registry by changing it to `do
 
 ## Configure instrumentation libraries injection
 
-For your Kubernetes applications whose traces you want to send to Datadog, configure the Datadog Admission Controller to inject Java, JavaScript, or Python instrumentation libraries automatically. From a high level, this involves the following steps, described in detail below:
+For your Kubernetes applications whose traces you want to send to Datadog, configure the Datadog Admission Controller to inject Java, JavaScript, Python, or .NET instrumentation libraries automatically. From a high level, this involves the following steps, described in detail below:
 
 1. Enable Datadog Admission Controller to mutate your pods.
 2. Annotate your pods to select which instrumentation library to inject.
@@ -93,11 +94,13 @@ To select your pods for library injection, annotate them with the following, cor
 | Java       | `admission.datadoghq.com/java-lib.version: "<CONTAINER IMAGE TAG>"`   |
 | JavaScript | `admission.datadoghq.com/js-lib.version: "<CONTAINER IMAGE TAG>"`     |
 | Python     | `admission.datadoghq.com/python-lib.version: "<CONTAINER IMAGE TAG>"` |
+| .NET       | `admission.datadoghq.com/dotnet-lib.version: "<CONTAINER IMAGE TAG>"` |
 
 The available library versions are listed in each container registry, as well as in the tracer source repositories for each language:
-- [Java][13]
-- [Javascript][14]
-- [Python][15]
+- [Java][16]
+- [Javascript][17]
+- [Python][18]
+- [.NET][19]
 
 **Note**: If you already have an application instrumented using version X of the library, and then use library injection to instrument using version Y of the same tracer library, the tracer does not break. Rather, the library version loaded first is used. Because library injection happens at the admission controller level prior to runtime, it takes precedent over manually configured libraries.
 
@@ -124,7 +127,7 @@ template:
 
 ### Step 3 - Tag your pods with Unified Service Tags
 
-With [Unified Service Tags][16], you can tie Datadog telemetry together and navigate seamlessly across traces, metrics, and logs with consistent tags. Set the Unified Service Tagging on both the deployment object and the pod template specs.
+With [Unified Service Tags][20], you can tie Datadog telemetry together and navigate seamlessly across traces, metrics, and logs with consistent tags. Set the Unified Service Tagging on both the deployment object and the pod template specs.
 Set Unified Service tags by using the following labels:
 
 ```yaml
@@ -178,7 +181,7 @@ If the injection was successful you can see an `init` container called `datadog-
 
 Or run `kubectl describe pod <my-pod>` to see the `datadog-lib-init` init container listed.
 
-The instrumentation also starts sending telemetry to Datadog (for example, traces to [APM][17]).
+The instrumentation also starts sending telemetry to Datadog (for example, traces to [APM][21]).
 
 
 [1]: /containers/cluster_agent/admission_controller/
@@ -193,11 +196,15 @@ The instrumentation also starts sending telemetry to Datadog (for example, trace
 [10]: http://gcr.io/datadoghq/dd-lib-python-init
 [11]: http://hub.docker.com/r/datadog/dd-lib-python-init
 [12]: http://gallery.ecr.aws/datadog/dd-lib-python-init
-[13]: https://github.com/DataDog/dd-trace-java/releases
-[14]: https://github.com/DataDog/dd-trace-js/releases
-[15]: https://github.com/DataDog/dd-trace-py/releases
-[16]: /getting_started/tagging/unified_service_tagging/
-[17]: https://app.datadoghq.com/apm/traces
+[13]: http://gcr.io/datadoghq/dd-lib-dotnet-init
+[14]: http://hub.docker.com/r/datadog/dd-lib-dotnet-init
+[15]: http://gallery.ecr.aws/datadog/dd-lib-dotnet-init
+[16]: https://github.com/DataDog/dd-trace-java/releases
+[17]: https://github.com/DataDog/dd-trace-js/releases
+[18]: https://github.com/DataDog/dd-trace-py/releases
+[19]: https://github.com/DataDog/dd-trace-dotnet/releases
+[20]: /getting_started/tagging/unified_service_tagging/
+[21]: https://app.datadoghq.com/apm/traces
 {{% /tab %}}
 
 {{% tab "Host" %}}
@@ -245,7 +252,7 @@ When both the Agent and your services are running on a host, real or virtual, Da
    sudo apt install nodejs -y
    ```
    For .NET applications, ensure you have the [.NET runtime installed][3].
-   
+
    For Python applications, ensure you have Python installed, for example:
    ```sh
    sudo apt install python -y
@@ -889,14 +896,14 @@ For example, you can turn on [Application Security Monitoring][3] or [Continuous
 
 - For **Kubernetes**, set the `DD_APPSEC_ENABLED` or `DD_PROFILING_ENABLED` container environment variables to `true`.
 
-- For **hosts and containers**, set the `DD_APPSEC_ENABLED` or `DD_PROFILING_ENABLED` container environment variables to `true`, or in the [injection configuration](#supplying-configuration-source), specify an `additional_environment_variables` section like the following YAML example: 
+- For **hosts and containers**, set the `DD_APPSEC_ENABLED` or `DD_PROFILING_ENABLED` container environment variables to `true`, or in the [injection configuration](#supplying-configuration-source), specify an `additional_environment_variables` section like the following YAML example:
 
   ```yaml
   additional_environment_variables:
   - key: DD_PROFILING_ENABLED
     value: true
   - key: DD_APPSEC_ENABLED
-    value: true 
+    value: true
   ```
 
   Only configuration keys that start with `DD_` can be set in the injection config source `additional_environment_variables` section.

--- a/content/en/tracing/trace_collection/library_injection_local.md
+++ b/content/en/tracing/trace_collection/library_injection_local.md
@@ -101,7 +101,7 @@ The available library versions are listed in each container registry, as well as
 - [Javascript][17]
 - [Python][18]
 - [.NET][19]
-  - Note: If the application container uses a musl-based Linux distribution (for example, Alpine), you must specify a tag with the the `-musl` suffix for the pod annotation.
+  - Note: If the application container uses a musl-based Linux distribution (such as Alpine), you must specify a tag with the the `-musl` suffix for the pod annotation. For example, if you would like to use library version `v2.29.0`, specify container tag `v2.29.0-musl`.
 
 **Note**: If you already have an application instrumented using version X of the library, and then use library injection to instrument using version Y of the same tracer library, the tracer does not break. Rather, the library version loaded first is used. Because library injection happens at the admission controller level prior to runtime, it takes precedent over manually configured libraries.
 

--- a/content/en/tracing/trace_collection/library_injection_local.md
+++ b/content/en/tracing/trace_collection/library_injection_local.md
@@ -103,8 +103,8 @@ The available library versions are listed in each container registry, as well as
 - [Javascript][17]
 - [Python][18]
 - [.NET][19]
+  - **Note**: For .NET library injection, if the application container uses a musl-based Linux distribution (such as Alpine), you must specify a tag with the the `-musl` suffix for the pod annotation. For example, to use library version `v2.29.0`, specify container tag `v2.29.0-musl`.
 - [Ruby][20]
-  - Note: If the application container uses a musl-based Linux distribution (such as Alpine), you must specify a tag with the the `-musl` suffix for the pod annotation. For example, if you would like to use library version `v2.29.0`, specify container tag `v2.29.0-musl`.
 
 **Note**: If you already have an application instrumented using version X of the library, and then use library injection to instrument using version Y of the same tracer library, the tracer does not break. Rather, the library version loaded first is used. Because library injection happens at the admission controller level prior to runtime, it takes precedent over manually configured libraries.
 

--- a/content/en/tracing/trace_collection/library_injection_local.md
+++ b/content/en/tracing/trace_collection/library_injection_local.md
@@ -44,7 +44,7 @@ Datadog publishes instrumentation libraries images on gcr.io, Docker Hub, and AW
 | JavaScript | [gcr.io/datadoghq/dd-lib-js-init][7]     | [hub.docker.com/r/datadog/dd-lib-js-init][8]     | [gallery.ecr.aws/datadog/dd-lib-js-init][9]     |
 | Python     | [gcr.io/datadoghq/dd-lib-python-init][10] | [hub.docker.com/r/datadog/dd-lib-python-init][11] | [gallery.ecr.aws/datadog/dd-lib-python-init][12] |
 | .NET       | [gcr.io/datadoghq/dd-lib-dotnet-init][13] | [hub.docker.com/r/datadog/dd-lib-dotnet-init][14] | [gallery.ecr.aws/datadog/dd-lib-dotnet-init][15] |
-| Ruby       | [gcr.io/datadoghq/dd-lib-ruby-init][13] | [hub.docker.com/r/datadog/dd-lib-ruby-init][14] | [gallery.ecr.aws/datadog/dd-lib-dotnet-init][15] |
+| Ruby       | [gcr.io/datadoghq/dd-lib-ruby-init][23] | [hub.docker.com/r/datadog/dd-lib-ruby-init][24] | [gallery.ecr.aws/datadog/dd-lib-ruby-init][25] |
 
 The `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY` environment variable in the Datadog Cluster Agent configuration specifies the registry used by the Admission Controller. The default value is `gcr.io/datadoghq`.
 
@@ -212,6 +212,9 @@ The instrumentation also starts sending telemetry to Datadog (for example, trace
 [20]: https://github.com/DataDog/dd-trace-rb/releases
 [21]: /getting_started/tagging/unified_service_tagging/
 [22]: https://app.datadoghq.com/apm/traces
+[23]: http://gcr.io/datadoghq/dd-lib-ruby-init
+[24]: http://hub.docker.com/r/datadog/dd-lib-ruby-init
+[25]: http://gallery.ecr.aws/datadog/dd-lib-ruby-init
 {{% /tab %}}
 
 {{% tab "Host" %}}

--- a/content/en/tracing/trace_collection/library_injection_local.md
+++ b/content/en/tracing/trace_collection/library_injection_local.md
@@ -30,7 +30,7 @@ To learn more about Kubernetes Admission Controller, read [Kubernetes Admission 
 * Kubernetes v1.14+
 * Datadog [Cluster Agent v7.40+][3]
 * Datadog Admission Controller enabled. **Note**: In Helm chart v2.35.0 and later, Datadog Admission Controller is activated by default in the Cluster Agent.
-* Applications in Java, JavaScript, Python, or .NET deployed on Linux with a supported architecture. Check the [corresponding container registry](#container-registries) for the complete list of supported architectures by language.
+* Applications in Java, JavaScript, Python, .NET, or Ruby deployed on Linux with a supported architecture. Check the [corresponding container registry](#container-registries) for the complete list of supported architectures by language.
 
 **Note:** Python uWSGI applications are not supported.
 
@@ -44,6 +44,7 @@ Datadog publishes instrumentation libraries images on gcr.io, Docker Hub, and AW
 | JavaScript | [gcr.io/datadoghq/dd-lib-js-init][7]     | [hub.docker.com/r/datadog/dd-lib-js-init][8]     | [gallery.ecr.aws/datadog/dd-lib-js-init][9]     |
 | Python     | [gcr.io/datadoghq/dd-lib-python-init][10] | [hub.docker.com/r/datadog/dd-lib-python-init][11] | [gallery.ecr.aws/datadog/dd-lib-python-init][12] |
 | .NET       | [gcr.io/datadoghq/dd-lib-dotnet-init][13] | [hub.docker.com/r/datadog/dd-lib-dotnet-init][14] | [gallery.ecr.aws/datadog/dd-lib-dotnet-init][15] |
+| Ruby       | [gcr.io/datadoghq/dd-lib-ruby-init][13] | [hub.docker.com/r/datadog/dd-lib-ruby-init][14] | [gallery.ecr.aws/datadog/dd-lib-dotnet-init][15] |
 
 The `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY` environment variable in the Datadog Cluster Agent configuration specifies the registry used by the Admission Controller. The default value is `gcr.io/datadoghq`.
 
@@ -51,7 +52,7 @@ You can pull the tracing library from a different registry by changing it to `do
 
 ## Configure instrumentation libraries injection
 
-For your Kubernetes applications whose traces you want to send to Datadog, configure the Datadog Admission Controller to inject Java, JavaScript, Python, or .NET instrumentation libraries automatically. From a high level, this involves the following steps, described in detail below:
+For your Kubernetes applications whose traces you want to send to Datadog, configure the Datadog Admission Controller to inject Java, JavaScript, Python, .NET or Ruby instrumentation libraries automatically. From a high level, this involves the following steps, described in detail below:
 
 1. Enable Datadog Admission Controller to mutate your pods.
 2. Annotate your pods to select which instrumentation library to inject.
@@ -95,12 +96,14 @@ To select your pods for library injection, annotate them with the following, cor
 | JavaScript | `admission.datadoghq.com/js-lib.version: "<CONTAINER IMAGE TAG>"`     |
 | Python     | `admission.datadoghq.com/python-lib.version: "<CONTAINER IMAGE TAG>"` |
 | .NET       | `admission.datadoghq.com/dotnet-lib.version: "<CONTAINER IMAGE TAG>"` |
+| Ruby       | `admission.datadoghq.com/ruby-lib.version: "<CONTAINER IMAGE TAG>"` |
 
 The available library versions are listed in each container registry, as well as in the tracer source repositories for each language:
 - [Java][16]
 - [Javascript][17]
 - [Python][18]
 - [.NET][19]
+- [Ruby][20]
   - Note: If the application container uses a musl-based Linux distribution (such as Alpine), you must specify a tag with the the `-musl` suffix for the pod annotation. For example, if you would like to use library version `v2.29.0`, specify container tag `v2.29.0-musl`.
 
 **Note**: If you already have an application instrumented using version X of the library, and then use library injection to instrument using version Y of the same tracer library, the tracer does not break. Rather, the library version loaded first is used. Because library injection happens at the admission controller level prior to runtime, it takes precedent over manually configured libraries.
@@ -128,7 +131,7 @@ template:
 
 ### Step 3 - Tag your pods with Unified Service Tags
 
-With [Unified Service Tags][20], you can tie Datadog telemetry together and navigate seamlessly across traces, metrics, and logs with consistent tags. Set the Unified Service Tagging on both the deployment object and the pod template specs.
+With [Unified Service Tags][21], you can tie Datadog telemetry together and navigate seamlessly across traces, metrics, and logs with consistent tags. Set the Unified Service Tagging on both the deployment object and the pod template specs.
 Set Unified Service tags by using the following labels:
 
 ```yaml
@@ -182,7 +185,7 @@ If the injection was successful you can see an `init` container called `datadog-
 
 Or run `kubectl describe pod <my-pod>` to see the `datadog-lib-init` init container listed.
 
-The instrumentation also starts sending telemetry to Datadog (for example, traces to [APM][21]).
+The instrumentation also starts sending telemetry to Datadog (for example, traces to [APM][22]).
 
 
 [1]: /containers/cluster_agent/admission_controller/
@@ -204,8 +207,9 @@ The instrumentation also starts sending telemetry to Datadog (for example, trace
 [17]: https://github.com/DataDog/dd-trace-js/releases
 [18]: https://github.com/DataDog/dd-trace-py/releases
 [19]: https://github.com/DataDog/dd-trace-dotnet/releases
-[20]: /getting_started/tagging/unified_service_tagging/
-[21]: https://app.datadoghq.com/apm/traces
+[20]: https://github.com/DataDog/dd-trace-rb/releases
+[21]: /getting_started/tagging/unified_service_tagging/
+[22]: https://app.datadoghq.com/apm/traces
 {{% /tab %}}
 
 {{% tab "Host" %}}

--- a/content/en/tracing/trace_collection/library_injection_local.md
+++ b/content/en/tracing/trace_collection/library_injection_local.md
@@ -101,6 +101,7 @@ The available library versions are listed in each container registry, as well as
 - [Javascript][17]
 - [Python][18]
 - [.NET][19]
+  - Note: If the application container uses a musl-based Linux distribution (e.g. Alpine), you must specify a tag with the the `-musl` suffix for the pod annotation.
 
 **Note**: If you already have an application instrumented using version X of the library, and then use library injection to instrument using version Y of the same tracer library, the tracer does not break. Rather, the library version loaded first is used. Because library injection happens at the admission controller level prior to runtime, it takes precedent over manually configured libraries.
 

--- a/content/en/tracing/trace_collection/library_injection_local.md
+++ b/content/en/tracing/trace_collection/library_injection_local.md
@@ -101,7 +101,7 @@ The available library versions are listed in each container registry, as well as
 - [Javascript][17]
 - [Python][18]
 - [.NET][19]
-  - Note: If the application container uses a musl-based Linux distribution (e.g. Alpine), you must specify a tag with the the `-musl` suffix for the pod annotation.
+  - Note: If the application container uses a musl-based Linux distribution (for example, Alpine), you must specify a tag with the the `-musl` suffix for the pod annotation.
 
 **Note**: If you already have an application instrumented using version X of the library, and then use library injection to instrument using version Y of the same tracer library, the tracer does not break. Rather, the library version loaded first is used. Because library injection happens at the admission controller level prior to runtime, it takes precedent over manually configured libraries.
 

--- a/content/en/tracing/trace_collection/library_injection_local.md
+++ b/content/en/tracing/trace_collection/library_injection_local.md
@@ -108,6 +108,8 @@ The available library versions are listed in each container registry, as well as
 
 **Note**: If you already have an application instrumented using version X of the library, and then use library injection to instrument using version Y of the same tracer library, the tracer does not break. Rather, the library version loaded first is used. Because library injection happens at the admission controller level prior to runtime, it takes precedent over manually configured libraries.
 
+**Note**: For Ruby, only support instrumenting Ruby on Rails or Hanami application.
+
 <div class="alert alert-warning"><strong>Note</strong>: Using the <code>latest</code> tag is supported, but use it with caution because major library releases can introduce breaking changes.</div>
 
 For example, to inject a Java library:

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -167,23 +167,24 @@ GlobalSettings.SetDebugEnabled(true);
 
 Logs files are saved in the following directories by default. Use the `DD_TRACE_LOG_DIRECTORY` setting to change these paths.
 
-| Platform | Path                                      |
-|----------|-------------------------------------------|
-| Windows  | `%ProgramData%\Datadog .NET Tracer\logs\` |
-| Linux    | `/var/log/datadog/dotnet/`                |
-| Azure App Service | `%AzureAppServiceHomeDirectory%\LogFiles\datadog`|
+| Platform                                             | Path                                             |
+|------------------------------------------------------|--------------------------------------------------|
+| Windows                                              | `%ProgramData%\Datadog .NET Tracer\logs\`        |
+| Linux                                                | `/var/log/datadog/dotnet/`                       |
+| Linux (when using [Kubernetes library injection][1]) | `/datadog-lib/logs`                              |
+| Azure App Service                                    | `%AzureAppServiceHomeDirectory%\LogFiles\datadog`|
 
 **Note:**: On Linux, you must create the logs directory before you enabled debug mode.
 
-For more details on how to configure the .NET Tracer, see the [Configuration][1] section.
+For more details on how to configure the .NET Tracer, see the [Configuration][2] section.
 
 There are two types of logs that are created in these paths:
 1. **Logs from native code:** In 1.26.0 and higher, these logs are saved as `dotnet-tracer-native-<processname>-<processid>.log`. From version 1.21.0 to 1.25.x, these logs were saved as `dotnet-tracer-native.log`. In 1.20.x and older versions, this was stored as `dotnet-profiler.log`.
 2. **Logs from managed code:** In 1.21.0 and higher, these logs are saved `dotnet-tracer-managed-<processname>-<date>.log`. In 1.20.x and older versions, this was stored as `dotnet-tracer-<processname>-<date>.log`.
 
 
-
-[1]: /tracing/setup/dotnet/#configuration
+[1]: /tracing/trace_collection/library_injection/?tab=kubernetes
+[2]: /tracing/setup/dotnet/#configuration
 {{< /programming-lang >}}
 
 {{< programming-lang lang="php" >}}

--- a/content/en/tracing/troubleshooting/tracer_startup_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_startup_logs.md
@@ -8,13 +8,13 @@ further_reading:
 ---
 ## Startup logs
 
-Tracer startup logs capture all obtainable information at startup and log it as `DATADOG TRACER CONFIGURATION`, `DATADOG TRACER DIAGNOSTICS`, or `DATADOG CONFIGURATION` to simplify searching within your logs. 
+Tracer startup logs capture all obtainable information at startup and log it as `DATADOG TRACER CONFIGURATION`, `DATADOG TRACER DIAGNOSTICS`, or `DATADOG CONFIGURATION` to simplify searching within your logs.
 
-Some languages log to a separate file depending on language conventions and the safety of accessing `Stdout` or equivalent. In those cases, the location of logs are noted in the language tab below. Some languages don't log diagnostics entries, also noted below. 
+Some languages log to a separate file depending on language conventions and the safety of accessing `Stdout` or equivalent. In those cases, the location of logs are noted in the language tab below. Some languages don't log diagnostics entries, also noted below.
 
 `CONFIGURATION` logs are a JSON formatted representation of settings applied to your tracer. In languages where an Agent connectivity check is performed, the configuration JSON will also include an `agent_error` key, which indicates whether the Agent is reachable.
 
-`DIAGNOSTICS` log entries, in the languages that produce them, happen when the tracer encounters an error during application startup. If you see `DIAGNOSTICS` log lines, confirm from the indicated log that settings and configurations are applied correctly. 
+`DIAGNOSTICS` log entries, in the languages that produce them, happen when the tracer encounters an error during application startup. If you see `DIAGNOSTICS` log lines, confirm from the indicated log that settings and configurations are applied correctly.
 
 If you do not see logs at all, ensure that your application logs are not silenced and that your log level is at least `INFO` where applicable.
 
@@ -40,10 +40,12 @@ The Java tracer does not output Diagnostics logs.  For this check, run the trace
 
 Log files are saved in the following directories by default. Use the `DD_TRACE_LOG_DIRECTORY` setting to change these paths.
 
-| Platform | Path                                      |
-|----------|-------------------------------------------|
-| Windows  | `%ProgramData%\Datadog .NET Tracer\logs\` |
-| Linux    | `/var/log/datadog/dotnet/`                |
+| Platform                                             | Path                                             |
+|------------------------------------------------------|--------------------------------------------------|
+| Windows                                              | `%ProgramData%\Datadog .NET Tracer\logs\`        |
+| Linux                                                | `/var/log/datadog/dotnet/`                       |
+| Linux (when using [Kubernetes library injection][1]) | `/datadog-lib/logs`                              |
+| Azure App Service                                    | `%AzureAppServiceHomeDirectory%\LogFiles\datadog`|
 
 **Note:** On Linux, you must create the logs directory before you enable debug mode.
 
@@ -81,6 +83,7 @@ DATADOG TRACER DIAGNOSTICS - Failed to attach profiler: unable to set event mask
 DATADOG TRACER DIAGNOSTICS - Error fetching configuration {exception}
 ```
 
+[1]: /tracing/trace_collection/library_injection/?tab=kubernetes
 {{< /programming-lang >}}
 {{< programming-lang lang="php" >}}
 
@@ -198,7 +201,7 @@ DATADOG TRACER DIAGNOSTIC - Agent Error: Network error trying to reach the agent
 
 The Python tracer logs configuration information as INFO-level. It logs diagnostics information, if found, as ERROR.
 
-If there is no logging configuration, only Diagnostics will be output to `Stderr`. 
+If there is no logging configuration, only Diagnostics will be output to `Stderr`.
 
 To see tracer startup logs, either add a logger, or set `DD_TRACE_DEBUG=true` in your configuration and run your application with `ddtrace-run`. This adds a logger, and exposes both debug and startup tracer logs.
 

--- a/content/en/tracing/troubleshooting/tracer_startup_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_startup_logs.md
@@ -29,7 +29,7 @@ If you do not see logs at all, ensure that your application logs are not silence
 
 **Diagnostics:**
 
-The Java tracer does not output Diagnostics logs.  For this check, run the tracer in [debug mode][1].
+The Java tracer does not output Diagnostics logs. For this check, run the tracer in [debug mode][1].
 
 
 [1]: /tracing/troubleshooting/tracer_debug_logs/


### PR DESCRIPTION
### What does this PR do?
Adds the information for users to set up library injection for their .NET containers in Kubernetes

### Motivation
In the next release of the Datadog agent (7.44.0), .NET will be a supported language for library injection, so this updates the documentation to allow customers to use it.

### Additional Notes
@elee0625 I would like your input on how we differentiate between the two different containers that cover our Linux support. The main `musl` distribution is Alpine. For reference, you can see how we have previously described the .NET Tracer setup for different separate Linux distributions [here](https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-core?tab=linux#install-the-tracer).

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
