### PR TITLE
update live deploy workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
         "build:live": "yarn run build:hugo:live",
         "deploy:previewAssets": "./node_modules/.bin/hugo deploy --target previewAssets -e preview --maxDeletes 0 --workers 100 --log --verbose",
         "deploy:preview": "./node_modules/.bin/hugo deploy --target preview -e preview --maxDeletes -1 --workers 100 --invalidateCDN --log --verbose",
-        "deploy:liveAssets": "./node_modules/.bin/hugo deploy --target liveAssets -e live --maxDeletes 0 --log --verbose --debug",
-        "deploy:live": "./node_modules/.bin/hugo deploy --target live -e live --maxDeletes -1 --log --verbose --debug",
+        "deploy:liveAssets": "./node_modules/.bin/hugo deploy --target liveAssets -e live --maxDeletes 0 --workers 100 --log --verbose --debug",
+        "deploy:live": "./node_modules/.bin/hugo deploy --target live -e live --maxDeletes -1 --workers 100 --log --verbose --debug",
         "build:apiPages": "node -e 'require(\"./assets/scripts/build-api-pages.js\").init()'",
         "dereference": "node ./assets/scripts/dereference.js",
         "jest-test": "./node_modules/.bin/jest ./assets/scripts/tests"


### PR DESCRIPTION
### What does this PR do?

Hugo deploys in preview environments have workers set to 100 with no issues.
This PR uses the same setting for live deploys with an impact of a faster deploy time.

### Motivation

No card but the motivation is consistency with other environments and some improved performance

### Additional Notes

There isn't really anything to preview, operations will continue as normal but with more concurrency

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
