### PR TITLE
Update lib injection with lack of uWSGI support

### DIFF
--- a/content/en/tracing/trace_collection/library_injection.md
+++ b/content/en/tracing/trace_collection/library_injection.md
@@ -29,7 +29,7 @@ To learn more about Kubernetes Admission Controller, read [Kubernetes Admission 
 * Datadog [Cluster Agent v7.40+][3] with Datadog Admission Controller enabled. **Note**: In Helm chart v2.35.0 and later, Datadog Admission Controller is activated by default in the Cluster Agent.
 * Applications in Java, JavaScript, or Python deployed on Linux with a supported architecture. Check the [corresponding container registry](#container-registries) for the complete list of supported architectures by language.
 
-<div class="alert alert-warning">Python uWSGI applications are currently not supported.</div>
+**Note:** Python uWSGI applications are not supported.
 
 
 ## Container registries

--- a/content/en/tracing/trace_collection/library_injection.md
+++ b/content/en/tracing/trace_collection/library_injection.md
@@ -29,6 +29,8 @@ To learn more about Kubernetes Admission Controller, read [Kubernetes Admission 
 * Datadog [Cluster Agent v7.40+][3] with Datadog Admission Controller enabled. **Note**: In Helm chart v2.35.0 and later, Datadog Admission Controller is activated by default in the Cluster Agent.
 * Applications in Java, JavaScript, or Python deployed on Linux with a supported architecture. Check the [corresponding container registry](#container-registries) for the complete list of supported architectures by language.
 
+<div class="alert alert-warning">Python uWSGI applications are currently not supported.</div>
+
 
 ## Container registries
 


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update the lib injection docs about uWSGI.

### Motivation
<!-- What inspired you to submit this pull request?-->
The Python injection mechanism does not currently support uWSGI so we should call it out to avoid confusion.


<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
