### PR TITLE
CI env vars: Add vars for node name/labels

### DIFF
--- a/content/en/continuous_integration/tests/containers.md
+++ b/content/en/continuous_integration/tests/containers.md
@@ -192,6 +192,8 @@ Additionally, you need to pass in the environment variables required to configur
 - `CI_JOB_STAGE`
 - `CI_JOB_NAME`
 - `CI_JOB_URL`
+- `CI_RUNNER_ID`
+- `CI_RUNNER_TAGS`
 - `CI_REPOSITORY_URL`
 - `CI_COMMIT_SHA`
 - `CI_COMMIT_REF_NAME`
@@ -219,6 +221,8 @@ Additionally, you need to pass in the environment variables required to configur
 - `GIT_URL_1`
 - `GIT_COMMIT`
 - `GIT_BRANCH`
+- `NODE_NAME`
+- `NODE_LABELS`
 - `DD_CUSTOM_TRACE_ID` (custom variable set by the [Jenkins Datadog Plugin][2])
 - `DD_CUSTOM_PARENT_ID` (idem)
 


### PR DESCRIPTION
### What does this PR do?
Adds a new env vars to the list of env vars that need to be forwarded for CI Visibility when running in a container.

### Motivation
We want to tag the node name and labels based on those env vars.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
