### PR TITLE
[DRAFT] Library Injection Setup: Update how to reference the container image

### DIFF
--- a/content/en/tracing/trace_collection/library_injection.md
+++ b/content/en/tracing/trace_collection/library_injection.md
@@ -85,9 +85,9 @@ To select your pods for library injection, annotate them with the following, cor
 
 | Language   | Pod annotation                                              |
 |------------|-------------------------------------------------------------|
-| Java       | `admission.datadoghq.com/java-lib.version: "<lib-version>"`   |
-| JavaScript | `admission.datadoghq.com/js-lib.version: "<lib-version>"`     |
-| Python     | `admission.datadoghq.com/python-lib.version: "<lib-version>"` |
+| Java       | `admission.datadoghq.com/java-lib.version: "<CONTAINER IMAGE TAG>"`   |
+| JavaScript | `admission.datadoghq.com/js-lib.version: "<CONTAINER IMAGE TAG>"`     |
+| Python     | `admission.datadoghq.com/python-lib.version: "<CONTAINER IMAGE TAG>"` |
 
 The available library versions are listed in each container registry, as well as in the tracer source repositories for each language:
 - [Java][13]
@@ -112,7 +112,7 @@ template:
     labels:
         admission.datadoghq.com/enabled: "true" # Enable Admission Controller to mutate new pods in this deployment
     annotations:
-        admission.datadoghq.com/java-lib.version: "<TRACER VERSION>"
+        admission.datadoghq.com/java-lib.version: "<CONTAINER IMAGE TAG>"
   containers:
   -  ...
 ```
@@ -153,7 +153,7 @@ template:
         tags.datadoghq.com/version: "1.1" # Unified service tag - Pod Version tag
         admission.datadoghq.com/enabled: "true" # Enable Admission Controller to mutate new pods part of this deployment
     annotations:
-        admission.datadoghq.com/java-lib.version: "<TRACER VERSION>"
+        admission.datadoghq.com/java-lib.version: "<CONTAINER IMAGE TAG>"
   containers:
   -  ...
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Clarifies that we need to look at the container image tag when referencing the image the init container pulls from.

### Motivation
<!-- What inspired you to submit this pull request?-->

Pulling the "tracer version" when trying to pull images isn't correct because the container image tags start with `v`. This PR aims to clarify that the value of the tracing library version used depends on the container image tags available.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/wantsui/lib-injection-container-image/tracing/trace_collection/library_injection

### Additional Notes
<!-- Anything else we should know when reviewing?-->

This should be reviewed by the APM team.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
