### PR TITLE
[DOCS-5126] Remove site regions from logs docs

### DIFF
--- a/content/en/logs/explorer/search.md
+++ b/content/en/logs/explorer/search.md
@@ -26,28 +26,19 @@ For example, to filter on logs produced by a specific service, with a specific s
 
 {{< img src="logs/explorer/search_filter.jpg" alt="Search Filter" style="width:100%;" >}}
 
-[Indexed Logs][3] support both full-text search and `key:value` search queries.
+[Indexed Logs][1] support both full-text search and `key:value` search queries.
 
-{{< site-region region="gov,us3,us5" >}}
-**Note**: `key:value` queries require that you [declare a facet][1] beforehand.
-
-[1]: /logs/explorer/facets/
-{{< /site-region >}}
-
-{{< site-region region="us,eu" >}}
-**Note**: `key:value` queries **do not** require that you [declare a facet][1] beforehand.
-
-[1]: /logs/explorer/facets/
-{{< /site-region >}}
+**Note**: `key:value` queries **do not** require that you [declare a facet][2] beforehand.
 
 ### Search syntax
 
-To begin searching for logs in Log Explorer, see the [Log Search Syntax documentation][1] and read the [time frame documentation][2] for more details on custom time frames.
+To begin searching for logs in Log Explorer, see the [Log Search Syntax documentation][3] and read the [time frame documentation][4] for more details on custom time frames.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /logs/search-syntax
-[2]: /dashboards/guide/custom_time_frames
-[3]: /logs/indexes
+[1]: /logs/indexes
+[2]: /logs/explorer/facets/
+[3]: /logs/search-syntax
+[4]: /dashboards/guide/custom_time_frames

--- a/content/en/logs/explorer/search_syntax.md
+++ b/content/en/logs/explorer/search_syntax.md
@@ -59,27 +59,6 @@ The following characters are considered special: `+` `-` `=` `&&` `||` `>` `<` `
 
 ## Attributes search
 
-{{< site-region region="gov,us3,us5" >}}
-To search on a specific attribute, first [add it as a facet][1] and then add `@` to specify you are searching on a facet.
-
-For instance, if your attribute name is **url** and you want to filter on the **url** value `www.datadoghq.com`, enter:
-
-```
-@url:www.datadoghq.com
-```
-
-**Notes**:
-
-1. Facet searches are case sensitive. Use free text search to get case insensitive results. Another option is to use the lowercase filter with your Grok parser while parsing to get case insensitive results during search.
-
-2. Searching for a facet value that contains special characters requires escaping or double quotes.
-    - For example, for a facet `my_facet` with the value `hello:world`, search using: `@my_facet:hello\:world` or `@my_facet:"hello:world"`.
-    - To match a single special character or space, use the `?` wildcard. For example, for a facet `my_facet` with the value `hello world`, search using: `@my_facet:hello?world`.
-
-[1]: /logs/explorer/facets/
-
-{{< /site-region >}}
-{{< site-region region="us,eu" >}}
 To search on a specific attribute, add `@` to specify you are searching on an attribute.
 
 For instance, if your attribute name is **url** and you want to filter on the **url** value `www.datadoghq.com`, enter:
@@ -98,7 +77,6 @@ For instance, if your attribute name is **url** and you want to filter on the **
 3. Searching for an attribute value that contains special characters requires escaping or double quotes.
     - For example, for an attribute `my_attribute` with the value `hello:world`, search using: `@my_attribute:hello\:world` or `@my_attribute:"hello:world"`.
     - To match a single special character or space, use the `?` wildcard. For example, for an attribute `my_attribute` with the value `hello world`, search using: `@my_attribute:hello?world`.
-{{< /site-region >}}
 
 Examples:
 
@@ -118,17 +96,10 @@ To perform a multi-character wildcard search, use the `*` symbol as follows:
 * `web*` matches all log messages starting with `web`
 * `*web` matches all log messages that end with `web`
 
-**Note**: Wildcards only work as wildcards outside of double quotes. For example, `”*test*”` matches a log which has the string `*test*` in its message. `*test*` matches a log which has the string test anywhere in its message.
+**Note**: Wildcards only work as wildcards outside of double quotes. For example, `"*test*"` matches a log which has the string `*test*` in its message. `*test*` matches a log which has the string test anywhere in its message.
 
-{{< site-region region="gov,us3,us5" >}}
-Wildcard searches work within facets with this syntax. This query returns all the services that end with the string `mongo`:
-<p> </p>
-{{< /site-region >}}
-
-{{< site-region region="us,eu" >}}
 Wildcard searches work within tags and attributes (faceted or not) with this syntax. This query returns all the services that end with the string `mongo`:
 <p> </p>
-{{< /site-region >}}
 <p></p>
 
 ```
@@ -145,15 +116,8 @@ However, this search term does not return logs that contain the string `NETWORK`
 
 ### Search wildcard
 
-{{< site-region region="gov,us3,us5" >}}
-When searching for a facet value that contains special characters or requires escaping or double quotes, use the `?` wildcard to match a single special character or space. For example, to search for a facet `my_facet` with the value `hello world`: `@my_facet:hello?world`.
-<p> </p>
-{{< /site-region >}}
-
-{{< site-region region="us,eu" >}}
 When searching for an attribute or tag value that contains special characters or requires escaping or double quotes, use the `?` wildcard to match a single special character or space. For example, to search for an attribute `my_attribute` with the value `hello world`: `@my_attribute:hello?world`.
 <p> </p>
-{{< /site-region >}}
 
 ## Numerical values
 
@@ -189,8 +153,6 @@ In the below example, clicking on the `Peter` value in the facet returns all the
 
 {{< img src="logs/explorer/search/array_search.png" alt="Array and Facets" style="width:80%;">}}
 
-{{< site-region region="us,eu" >}}
-
 **Note**: Search can also be used on non-faceted array attributes using an equivalent syntax.
 
 In the following example, CloudWatch logs for Windows contain an array of JSON objects under `@Event.EventData.Data`. You cannot create a facet on array of JSON objects, but you can search using the following syntax.
@@ -199,7 +161,6 @@ In the following example, CloudWatch logs for Windows contain an array of JSON o
 
 {{< img src="logs/explorer/search/facetless_query_json_arrray2.png" alt="Facetless query on array of JSON objects" style="width:80%;">}}
 <p> </p>
-{{< /site-region >}}
 
 ## Saved searches
 

--- a/content/en/logs/explorer/visualize.md
+++ b/content/en/logs/explorer/visualize.md
@@ -37,21 +37,9 @@ With the **Options** button, control the **number of lines** displayed in the ta
 
 {{< img src="logs/explorer/table_controls.mp4" alt="Configuring the display table" video=true style="width:80%;">}}
 
-{{< site-region region="gov,us3,us5" >}}
 The default **sort** for logs in the list visualization is by timestamp, with the most recent logs on top. This is the fastest and therefore recommended sorting method for general purposes. Surface logs with lowest or highest value for a measure first, or sort your logs lexicographically for the unique value of facet, ordering a column according to that facet.
 
-**Note**: Sorting your table according to a specific field requires that you [declare a facet][1] beforehand.
-
-[1]: /logs/explorer/facets/
-{{< /site-region >}}
-
-{{< site-region region="us,eu" >}}
-The default **sort** for logs in the list visualization is by timestamp, with the most recent logs on top. This is the fastest and therefore recommended sorting method for general purposes. Surface logs with lowest or highest value for a measure first, or sort your logs lexicographically for the unique value of facet, ordering a column according to that facet.
-
-**Note**: Although any attributes or tags can be added as a column, sorting your table is most reliable if you [declare a facet][1] beforehand. Non-faceted attributes can be added as columns, but it does not produce reliable sorting.
-
-[1]: /logs/explorer/facets/
-{{< /site-region >}}
+**Note**: Although any attributes or tags can be added as a column, sorting your table is most reliable if you [declare a facet][3] beforehand. Non-faceted attributes can be added as columns, but it does not produce reliable sorting.
 
 The configuration of the log table is stored alongside other elements of your troubleshooting context in [Saved Views][1].
 
@@ -113,6 +101,6 @@ The following tree map shows the percentage breakdown by **service**.
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-
 [1]: /logs/explorer/saved_views/
 [2]: /logs/search-syntax
+[3]: /logs/explorer/facets/


### PR DESCRIPTION
### What does this PR do?

- Remove site regions from log docs because the information should be the same for all regions.

### Motivation

[DOCS-5126](https://datadoghq.atlassian.net/browse/DOCS-5126)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5126]: https://datadoghq.atlassian.net/browse/DOCS-5126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ