### PR TITLE
Add a link to the Custom metrics page from the Serverless main page

### DIFF
--- a/content/en/serverless/_index.md
+++ b/content/en/serverless/_index.md
@@ -39,15 +39,17 @@ Datadog provides solutions for monitoring [AWS Lambda](#aws-lambda), [Azure App 
 
 [Enhanced Lambda metrics][3], which appear in Datadog with the prefix `aws.lambda.enhanced`, are available at second granularity and in near real time. You can use enhanced Lambda metrics for alerts or SLOs on cold starts, estimated AWS costs, timeouts, out-of-memory errors, and memory usage across all of your Lambda functions.
 
-With [Distributed Tracing][4], you can connect your serverless traces to metrics for a context-rich picture of your application's performance. The Datadog Python, Node.js, Ruby, Go, Java, and .NET tracing libraries support distributed tracing for AWS Lambda.
+Send [Custom metrics][4] from a Lambda function through several methods such as generating metrics from logs and traces, the Datadog Lambda Extension, and the Datadog Forward Lambda.
 
-[Deployment Tracking][5] helps you to correlate serverless code, configuration, and deployment changes with metrics, traces, and logs from your functions for real-time insight into how these changes may affect the health and performance of your applications.
+With [Distributed Tracing][5], you can connect your serverless traces to metrics for a context-rich picture of your application's performance. The Datadog Python, Node.js, Ruby, Go, Java, and .NET tracing libraries support distributed tracing for AWS Lambda.
+
+[Deployment Tracking][6] helps you to correlate serverless code, configuration, and deployment changes with metrics, traces, and logs from your functions for real-time insight into how these changes may affect the health and performance of your applications.
 
 ### Azure App Service
 
-The [Datadog extension for Azure App Service][6] provides tracing capabilities for Azure Web Apps. 
+The [Datadog extension for Azure App Service][7] provides tracing capabilities for Azure Web Apps. 
 
-Use the [Azure App Service view][7] to:
+Use the [Azure App Service view][8] to:
 
 - Quickly identify apps with high latency or errors
 
@@ -57,19 +59,19 @@ Use the [Azure App Service view][7] to:
 
 - Map the apps running on your App Service Plans to identify apps that may be impacting costs or performance
 
-The Datadog extension for Azure App Service provides tracing capabilities for Azure Web Apps. For more information about setting up tracing in Azure, see [Azure App Service][6].
+The Datadog extension for Azure App Service provides tracing capabilities for Azure Web Apps. For more information about setting up tracing in Azure, see [Azure App Service][7].
 
 ### Azure Container Apps
 
-Azure Container Apps is a fully managed serverless platform for deploying and scaling container-based applications. Datadog provides monitoring and log collection for Container Apps through the [Azure integration][8]. 
+Azure Container Apps is a fully managed serverless platform for deploying and scaling container-based applications. Datadog provides monitoring and log collection for Container Apps through the [Azure integration][9]. 
 
-Datadog also provides a solution, now in beta, for [instrumenting your Container Apps applications][9] with a purpose-built Agent to enable tracing, custom metrics, and direct log collection.
+Datadog also provides a solution, now in beta, for [instrumenting your Container Apps applications][10] with a purpose-built Agent to enable tracing, custom metrics, and direct log collection.
 
 ### Google Cloud Run
 
-Google Cloud Run is a lightweight, event-based, asynchronous compute solution that allows you to create small, single-purpose functions. To monitor serverless functions running on Google Cloud Platform, enable the [Google Cloud Platform integration][10].
+Google Cloud Run is a lightweight, event-based, asynchronous compute solution that allows you to create small, single-purpose functions. To monitor serverless functions running on Google Cloud Platform, enable the [Google Cloud Platform integration][11].
 
-Datadog also provides a solution, now in public beta, for [instrumenting your Cloud Run applications][11] with a purpose-built Agent to enable tracing, custom metrics, and direct log collection.
+Datadog also provides a solution, now in public beta, for [instrumenting your Cloud Run applications][12] with a purpose-built Agent to enable tracing, custom metrics, and direct log collection.
 
 ## Further Reading
 
@@ -78,11 +80,12 @@ Datadog also provides a solution, now in public beta, for [instrumenting your Cl
 [1]: http://app.datadoghq.com/functions
 [2]: /serverless/aws_lambda
 [3]: /serverless/enhanced_lambda_metrics
-[4]: /serverless/distributed_tracing
-[5]: /serverless/deployment_tracking
-[6]: /infrastructure/serverless/azure_app_services/#overview
-[7]: https://app.datadoghq.com/functions?cloud=azure&config_serverless-azure-app=true&group=service
-[8]: /integrations/azure/#log-collection
-[9]: /serverless/azure_container_apps
-[10]: /integrations/google_cloud_platform/
-[11]: /serverless/google_cloud_run
+[4]: /serverless/custom_metrics
+[5]: /serverless/distributed_tracing
+[6]: /serverless/deployment_tracking
+[7]: /infrastructure/serverless/azure_app_services/#overview
+[8]: https://app.datadoghq.com/functions?cloud=azure&config_serverless-azure-app=true&group=service
+[9]: /integrations/azure/#log-collection
+[10]: /serverless/azure_container_apps
+[11]: /integrations/google_cloud_platform/
+[12]: /serverless/google_cloud_run

--- a/content/en/serverless/_index.md
+++ b/content/en/serverless/_index.md
@@ -39,7 +39,7 @@ Datadog provides solutions for monitoring [AWS Lambda](#aws-lambda), [Azure App 
 
 [Enhanced Lambda metrics][3], which appear in Datadog with the prefix `aws.lambda.enhanced`, are available at second granularity and in near real time. You can use enhanced Lambda metrics for alerts or SLOs on cold starts, estimated AWS costs, timeouts, out-of-memory errors, and memory usage across all of your Lambda functions.
 
-Send [Custom metrics][4] from a Lambda function through several methods such as generating metrics from logs and traces, the Datadog Lambda Extension, and the Datadog Forward Lambda.
+You can send [custom metrics][4] from a Lambda function by generating metrics from logs and traces, using the Datadog Lambda Extension, or using the Datadog Forwarder Lambda.
 
 With [Distributed Tracing][5], you can connect your serverless traces to metrics for a context-rich picture of your application's performance. The Datadog Python, Node.js, Ruby, Go, Java, and .NET tracing libraries support distributed tracing for AWS Lambda.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- Add a reference link to the AWS Lambda Custom metrics page from the main Serverless page.

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/jira/software/projects/DOCS/boards/199?selectedIssue=DOCS-5115

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Ready to merge after review.

