### PR TITLE
Update AKS Connection Setup for TLS Verification

### DIFF
--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -94,7 +94,7 @@ spec:
 
 ## Azure Kubernetes Service (AKS) {#AKS}
 
-AKS requires specific configuration for the `Kubelet` integration due to AKS certificates setup.
+AKS requires a specific configuration for the `Kubelet` integration due to how AKS has setup the SSL Certificates. Additionally the optional [Admission Controller][3] feature requires a specific configuration to prevent an error when reconciling the webhook.
 
 {{< tabs >}}
 {{% tab "Helm" %}}
@@ -105,8 +105,76 @@ Custom `values.yaml`:
 datadog:
   apiKey: <DATADOG_API_KEY>
   appKey: <DATADOG_APP_KEY>
+  # Required as of Agent 7.35. See Kubelet Certificate note below.
   kubelet:
-    tlsVerify: false # Required as of Agent 7.35. See Notes.
+    tlsVerify: false
+
+providers:
+  aks:
+    enabled: true
+```
+
+The `providers.aks.enabled` option sets the necessary environment variable `DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS=true` for you.
+
+{{% /tab %}}
+{{% tab "Operator" %}}
+
+DatadogAgent Kubernetes Resource:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  credentials:
+    apiKey: <DATADOG_API_KEY>
+    appKey: <DATADOG_APP_KEY>
+  agent:
+    config:
+      # Required as of Agent 7.35. See Kubelet Certificate note below.
+      kubelet:
+        tlsVerify: false
+  clusterAgent:
+    config:
+      admissionController:
+        enabled: true
+      env:
+        - name: DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS
+          value: true
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+The `kubelet.tlsVerify=false` sets the environment variable `DD_KUBELET_TLS_VERIFY=false` for you to deactivate verification of the server certificate.
+
+### AKS Kubelet certificate
+
+There is a known issue with the format of the AKS Kubelet certificate in older node image versions. As of Agent 7.35 it became required to use `tlsVerify: false` as the certificates did not contain a valid Subject Alternative Name (SAN).
+
+If all the nodes within your AKS cluster are using a supported node image version, you can use Kubelet TLS Verification. Your version must be at or above the [versions listed here for the 2022-10-30 release][4]. As well as update your Kubelet configuration to use the node name for the address and map in the custom certificate path.
+
+{{< tabs >}}
+{{% tab "Helm" %}}
+
+Custom `values.yaml`:
+
+```yaml
+datadog:
+  apiKey: <DATADOG_API_KEY>
+  appKey: <DATADOG_APP_KEY>
+  # Requires supported node image version
+  kubelet:
+    host:
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
+
+providers:
+  aks:
+    enabled: true
 ```
 
 {{% /tab %}}
@@ -125,40 +193,25 @@ spec:
     appKey: <DATADOG_APP_KEY>
   agent:
     config:
+      # Requires supported node image version
       kubelet:
-        tlsVerify: false # Required as of Agent 7.35. See Notes.
+        host:
+          fieldRef:
+            fieldPath: spec.nodeName
+        hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
   clusterAgent:
-    image:
-      name: "gcr.io/datadoghq/cluster-agent:latest"
     config:
-      externalMetrics:
-        enabled: false
       admissionController:
-        enabled: false
+        enabled: true
+      env:
+        - name: DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS
+          value: true
 ```
 
 {{% /tab %}}
 {{< /tabs >}}
 
-**Notes**:
-
-- As of Agent 7.35, `tlsVerify: false` is required because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
-
-- In some setups, DNS resolution for `spec.nodeName` inside Pods may not work in AKS. This has been reported on all AKS Windows nodes and when cluster is setup in a Virtual Network using custom DNS on Linux nodes. In this case, removing the `agent.config.kubelet.host` field (defaults to `status.hostIP`) and using `tlsVerify: false` is **required**. Using the `DD_KUBELET_TLS_VERIFY=false` environment variable also resolves this issue. Both of these options deactivate verification of the server certificate.
-
-  ```yaml
-  env:
-    - name: DD_KUBELET_TLS_VERIFY
-      value: "false"
-  ```
-- Admission Controller functionality on AKS requires configuring the add selectors to prevent an error on reconciling the webhook: 
-
-```yaml
-clusterAgent:
-  env:
-    - name: "DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS"
-      value: "true"
-```
+In some setups, DNS resolution for `spec.nodeName` inside Pods may not work in AKS. This has been reported on all AKS Windows nodes and when the cluster is setup in a Virtual Network using custom DNS on Linux nodes. In this case use the first AKS configuration provided. Remove any settings for the Kubelet host path (defaults to `status.hostIP`) and use `tlsVerify: false`. This setting is **required**.
 
 ## Google Kubernetes Engine (GKE) {#GKE}
 
@@ -561,3 +614,5 @@ spec:
 
 [1]: https://github.com/DataDog/helm-charts/tree/master/examples/datadog
 [2]: https://github.com/DataDog/datadog-operator/tree/master/examples/datadogagent
+[3]: /containers/cluster_agent/admission_controller
+[4]: https://github.com/Azure/AKS/releases/tag/2022-10-30

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -94,7 +94,7 @@ spec:
 
 ## Azure Kubernetes Service (AKS) {#AKS}
 
-AKS requires a specific configuration for the `Kubelet` integration due to how AKS has setup the SSL Certificates. Additionally the optional [Admission Controller][3] feature requires a specific configuration to prevent an error when reconciling the webhook.
+AKS requires a specific configuration for the `Kubelet` integration due to how AKS has setup the SSL Certificates. Additionally, the optional [Admission Controller][3] feature requires a specific configuration to prevent an error when reconciling the webhook.
 
 {{< tabs >}}
 {{% tab "Helm" %}}
@@ -151,9 +151,9 @@ The `kubelet.tlsVerify=false` sets the environment variable `DD_KUBELET_TLS_VERI
 
 ### AKS Kubelet certificate
 
-There is a known issue with the format of the AKS Kubelet certificate in older node image versions. As of Agent 7.35 it became required to use `tlsVerify: false` as the certificates did not contain a valid Subject Alternative Name (SAN).
+There is a known issue with the format of the AKS Kubelet certificate in older node image versions. As of Agent 7.35, it is required to use `tlsVerify: false` as the certificates did not contain a valid Subject Alternative Name (SAN).
 
-If all the nodes within your AKS cluster are using a supported node image version, you can use Kubelet TLS Verification. Your version must be at or above the [versions listed here for the 2022-10-30 release][4]. As well as update your Kubelet configuration to use the node name for the address and map in the custom certificate path.
+If all the nodes within your AKS cluster are using a supported node image version, you can use Kubelet TLS Verification. Your version must be at or above the [versions listed here for the 2022-10-30 release][4]. You must also update your Kubelet configuration to use the node name for the address and map in the custom certificate path.
 
 {{< tabs >}}
 {{% tab "Helm" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add back in the steps to use Kubelet TLS Verification. This wasn't possible for awhile due to the format of the certificates. However, was fixed by AKS in late October. Adding as (ideally) customer's have been able to upgrade their Node Pools by now. 

Tried to adjust it to add more context so it's less multiple bullets of, "if this then do this". 

### Motivation
<!-- What inspired you to submit this pull request?-->
Provide steps for TLS Verification now that it's possible again. As well as provide a little more context.

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
Preview: TBD

Current: https://docs.datadoghq.com/containers/kubernetes/distributions/?tab=helm#AKS

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
