### PR TITLE
telemetry: now enabled by default

### DIFF
--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -110,7 +110,7 @@ Enable web framework and library instrumentation. When false, the application co
 Dynamically rename services through configuration. Services can be separated by commas or spaces, for example: `mysql:mysql-service-name,postgres:postgres-service-name`, `mysql:mysql-service-name postgres:postgres-service-name`.
 
 `DD_INSTRUMENTATION_TELEMETRY_ENABLED`
-: **Default**: `false` <br>
+: **Default**: `true` <br>
 Datadog may collect [environmental and diagnostic information about your system][6] to improve the product. When false, this telemetry data will not be collected.
 
 `DD_TRACE_CLIENT_IP_ENABLED`


### PR DESCRIPTION
latest version of dd-trace-go(v1.49.0) will change the default value here to true

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
