### PR TITLE
Add new pictures of SDS to align with new UI

### DIFF
--- a/content/en/account_management/org_settings/sensitive_data_detection.md
+++ b/content/en/account_management/org_settings/sensitive_data_detection.md
@@ -30,7 +30,7 @@ Sensitive Data Scanner is a stream-based, pattern matching service that you can 
 
 Sensitive Data Scanner can be found under [Organization Settings][1].
 
-{{< img src="logs/sensitive_data_scanner/sds_main_apr_22.png" alt="Sensitive Data Scanner in Organization Settings" style="width:90%;">}}
+{{< img src="logs/sensitive_data_scanner/sds_main_28_03_23.png" alt="Sensitive Data Scanner in Organization Settings" style="width:90%;">}}
 
 ### Setup
 
@@ -62,12 +62,12 @@ Sensitive Data Scanner supports Perl Compatible RegEx (PCRE), but the following 
 - **Process matching values:** Optionally, specify whether you want to redact, partially redact, or hash matching values. When redacting, specify placeholder text to replace the matching values with. When partially redacting, specify the position (start/end) and length (# of characters) to redact within matching values. Redaction, partial redaction, and hashing are all irreversible actions.
 - **Name the rule:** Provide a human-readable name for the rule.
 
-{{< img src="logs/sensitive_data_scanner/sds_rule_apr_22.png" alt="A Sensitive Data Scanner custom rule" style="width:90%;">}}
+{{< img src="logs/sensitive_data_scanner/sds_rules_28_03_23.png" alt="A Sensitive Data Scanner custom rule" style="width:90%;">}}
 
 ### Out-of-the-box Scanning Rules
 
 The Scanning Rule Library contains an evergrowing collection of predefined rules maintained by Datadog for detecting common patterns such as email addresses, credit card numbers, API keys, authorization tokens, and more.
-{{< img src="logs/sensitive_data_scanner/sds_library_apr_22.png" alt="Scanning Rule Library"  style="width:90%;">}}
+{{< img src="logs/sensitive_data_scanner/sds_library_28_03_23.png" alt="Scanning Rule Library"  style="width:90%;">}}
 
 ### Permissions
 


### PR DESCRIPTION
Hi ! We just released a new UI for sensitive data scanner, and we need the pictures to align with the new UI. This change is dependent on this commit: https://github.com/DataDog/documentation/pull/17450, which adds the pictures to our images repo.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

It changes the link to the pictures of SDS to align with the new SDS UI.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
