### PR TITLE
fixed banner overlap on 404

### DIFF
--- a/layouts/_default/404-baseof.html
+++ b/layouts/_default/404-baseof.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang='{{ if eq .Site.Language.Lang "en" }}en-US{{ else }}{{ .Site.Language.Lang }}{{ end }}' data-type="{{.Type}}" data-relpermalink="{{.RelPermalink}}"
   data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0"
-  class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner{{ end }}">
+  class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner announcement{{ end }}">
 
 <head>
   {{ partial "header-scripts.html" . }}
@@ -40,7 +40,7 @@
   </div>
   {{ partial "header/header.html" . }}
 
-  <div class="container container__content h-100">
+  <div class="container container__content h-100 pt-1">
     <div class="row h-100">
       <div class="d-none d-lg-flex col-12 col-sm-3 side">
         {{ partial "sidenav/main-sidenav.html" . }}


### PR DESCRIPTION
### What does this PR do?
Fixed announcement banner overlap on nav for 404 page

### Motivation
https://datadoghq.atlassian.net/browse/WEB-3403

 ### Preview
https://docs-staging.datadoghq.com/renzo.renteria/404-banner-overlap/404.html

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
