### PR TITLE
Remove deprecation alerts and naming convention refs

### DIFF
--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -599,6 +599,45 @@ window.DD_RUM && window.DD_RUM.setGlobalContextProperty('activity', {
 
 You can remove a previously defined global context property.
 
+{{< tabs >}}
+{{% tab "NPM" %}}
+
+```javascript
+import { datadogRum } from '@datadog/browser-rum';
+datadogRum.removeGlobalContextProperty('<CONTEXT_KEY>');
+
+// Code example
+datadogRum.removeGlobalContextProperty('codeVersion');
+```
+
+{{% /tab %}}
+{{% tab "CDN async" %}}
+```javascript
+DD_RUM.onReady(function() {
+    DD_RUM.removeGlobalContextProperty('<CONTEXT_KEY>');
+})
+
+// Code example
+DD_RUM.onReady(function() {
+    DD_RUM.removeGlobalContextProperty('codeVersion');
+})
+```
+{{% /tab %}}
+{{% tab "CDN sync" %}}
+
+```javascript
+window.DD_RUM &&
+    DD_RUM.removeGlobalContextProperty('<CONTEXT_KEY>');
+
+// Code example
+window.DD_RUM &&
+    DD_RUM.removeGlobalContextProperty('codeVersion');;
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+
 ### Replace global context
 
 Replace the default context for all your RUM events with the `setGlobalContext(context: Context)` API.

--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -668,14 +668,14 @@ const context = datadogRum.getRumGlobalContext();
 {{% tab "CDN async" %}}
 ```javascript
 DD_RUM.onReady(function() {
-  var context = DD_RUM.getRumGlobalContext();
+  const context = DD_RUM.getRumGlobalContext();
 });
 ```
 {{% /tab %}}
 {{% tab "CDN sync" %}}
 
 ```javascript
-var context = window.DD_RUM && DD_RUM.getRumGlobalContext();
+const context = window.DD_RUM && DD_RUM.getRumGlobalContext();
 ```
 
 {{% /tab %}}

--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -474,8 +474,6 @@ window.DD_RUM && window.DD_RUM.removeUserProperty('name')
 
 `datadogRum.clearUser()`
 
-<div class="alert alert-info">The RUM Browser SDK v4.17.0 introduced `clearUser` and deprecated `removeUser`</div>
-
 {{< tabs >}}
 {{% tab "NPM" %}}
 ```javascript
@@ -555,8 +553,6 @@ For a sampled out session, all page views and associated telemetry for that sess
 
 After RUM is initialized, add extra context to all RUM events collected from your application with the `setGlobalContextProperty(key: string, value: any)` API:
 
-<div class="alert alert-info">The RUM Browser SDK v4.17.0 introduced `setGlobalContextProperty` and deprecated `addRumGlobalContext`</div>
-
 {{< tabs >}}
 {{% tab "NPM" %}}
 ```javascript
@@ -599,23 +595,13 @@ window.DD_RUM && window.DD_RUM.setGlobalContextProperty('activity', {
 {{% /tab %}}
 {{< /tabs >}}
 
-Follow the [Datadog naming convention][16] for a better correlation of your data across the product.
-
 ### Remove global context property
 
 You can remove a previously defined global context property.
 
-<div class="alert alert-info">The RUM Browser SDK v4.17.0 introduced `removeGlobalContextProperty` and deprecated `removeRumGlobalContext`</div>
-
-Follow the [Datadog naming convention][16] for a better correlation of your data across the product.
-
 ### Replace global context
 
 Replace the default context for all your RUM events with the `setGlobalContext(context: Context)` API:
-
-<div class="alert alert-info">The RUM Browser SDK v4.17.0 introduced `setGlobalContext` and deprecated `setRumGlobalContext`</div>
-
-Follow the [Datadog naming convention][16] for a better correlation of your data across the product.
 
 ### Clear global context
 
@@ -624,8 +610,6 @@ You can clear the global context by using `clearGlobalContext`.
 ### Read global context
 
 Once RUM is initialized, read the global context with the `getGlobalContext()` API:
-
-<div class="alert alert-info">The RUM Browser SDK v4.17.0 introduced `getGlobalContext` and deprecated `getRumGlobalContext`</div>
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -690,6 +690,32 @@ window.DD_RUM &&
 
 You can clear the global context by using `clearGlobalContext`.
 
+{{< tabs >}}
+{{% tab "NPM" %}}
+
+```javascript
+import { datadogRum } from '@datadog/browser-rum';
+
+datadogRum.clearGlobalContext();
+```
+
+{{% /tab %}}
+{{% tab "CDN async" %}}
+```javascript
+DD_RUM.onReady(function() {
+  DD_RUM.clearGlobalContext();
+});
+```
+{{% /tab %}}
+{{% tab "CDN sync" %}}
+
+```javascript
+window.DD_RUM && DD_RUM.clearGlobalContext();
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ### Read global context
 
 Once RUM is initialized, read the global context with the `getGlobalContext()` API.

--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -606,7 +606,7 @@ Replace the default context for all your RUM events with the `setGlobalContext(c
 {{< tabs >}}
 {{% tab "NPM" %}}
 
-```
+```javascript
 import { datadogRum } from '@datadog/browser-rum';
 datadogRum.setGlobalContext({ '<CONTEXT_KEY>': '<CONTEXT_VALUE>' });
 
@@ -618,7 +618,7 @@ datadogRum.setGlobalContext({
 
 {{% /tab %}}
 {{% tab "CDN async" %}}
-```
+```javascript
 DD_RUM.onReady(function() {
     DD_RUM.setGlobalContext({ '<CONTEXT_KEY>': '<CONTEXT_VALUE>' });
 })
@@ -633,7 +633,7 @@ DD_RUM.onReady(function() {
 {{% /tab %}}
 {{% tab "CDN sync" %}}
 
-```
+```javascript
 window.DD_RUM &&
     DD_RUM.setGlobalContext({ '<CONTEXT_KEY>': '<CONTEXT_VALUE>' });
 
@@ -658,7 +658,7 @@ Once RUM is initialized, read the global context with the `getGlobalContext()` A
 {{< tabs >}}
 {{% tab "NPM" %}}
 
-```
+```javascript
 import { datadogRum } from '@datadog/browser-rum';
 
 const context = datadogRum.getRumGlobalContext();
@@ -666,7 +666,7 @@ const context = datadogRum.getRumGlobalContext();
 
 {{% /tab %}}
 {{% tab "CDN async" %}}
-```
+```javascript
 DD_RUM.onReady(function() {
   var context = DD_RUM.getRumGlobalContext();
 });
@@ -674,7 +674,7 @@ DD_RUM.onReady(function() {
 {{% /tab %}}
 {{% tab "CDN sync" %}}
 
-```
+```javascript
 var context = window.DD_RUM && DD_RUM.getRumGlobalContext();
 ```
 

--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -601,7 +601,51 @@ You can remove a previously defined global context property.
 
 ### Replace global context
 
-Replace the default context for all your RUM events with the `setGlobalContext(context: Context)` API:
+Replace the default context for all your RUM events with the `setGlobalContext(context: Context)` API.
+
+{{< tabs >}}
+{{% tab "NPM" %}}
+
+```
+import { datadogRum } from '@datadog/browser-rum';
+datadogRum.setGlobalContext({ '<CONTEXT_KEY>': '<CONTEXT_VALUE>' });
+
+// Code example
+datadogRum.setGlobalContext({
+    codeVersion: 34,
+});
+```
+
+{{% /tab %}}
+{{% tab "CDN async" %}}
+```
+DD_RUM.onReady(function() {
+    DD_RUM.setGlobalContext({ '<CONTEXT_KEY>': '<CONTEXT_VALUE>' });
+})
+
+// Code example
+DD_RUM.onReady(function() {
+    DD_RUM.setGlobalContext({
+        codeVersion: 34,
+    })
+})
+```
+{{% /tab %}}
+{{% tab "CDN sync" %}}
+
+```
+window.DD_RUM &&
+    DD_RUM.setGlobalContext({ '<CONTEXT_KEY>': '<CONTEXT_VALUE>' });
+
+// Code example
+window.DD_RUM &&
+    DD_RUM.setGlobalContext({
+        codeVersion: 34,
+    });
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Clear global context
 
@@ -609,7 +653,33 @@ You can clear the global context by using `clearGlobalContext`.
 
 ### Read global context
 
-Once RUM is initialized, read the global context with the `getGlobalContext()` API:
+Once RUM is initialized, read the global context with the `getGlobalContext()` API.
+
+{{< tabs >}}
+{{% tab "NPM" %}}
+
+```
+import { datadogRum } from '@datadog/browser-rum';
+
+const context = datadogRum.getRumGlobalContext();
+```
+
+{{% /tab %}}
+{{% tab "CDN async" %}}
+```
+DD_RUM.onReady(function() {
+  var context = DD_RUM.getRumGlobalContext();
+});
+```
+{{% /tab %}}
+{{% tab "CDN sync" %}}
+
+```
+var context = window.DD_RUM && DD_RUM.getRumGlobalContext();
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -631,7 +631,7 @@ window.DD_RUM &&
 
 // Code example
 window.DD_RUM &&
-    DD_RUM.removeGlobalContextProperty('codeVersion');;
+    DD_RUM.removeGlobalContextProperty('codeVersion');
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

- Removes alerts about deprecations because they are 7+ months old
- Removes links that refer to the logs naming convention because they are confusing
- Adds back some API examples that were removed
- Updates some other examples that were missing

### Motivation
Internal feedback (see [DOCS-5055](https://datadoghq.atlassian.net/browse/DOCS-5055)).

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5055]: https://datadoghq.atlassian.net/browse/DOCS-5055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ