### PR TITLE
library_config/go: add documention for new 128-bit environment variables

### DIFF
--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -118,6 +118,17 @@ Datadog may collect [environmental and diagnostic information about your system]
 Enable client IP collection from relevant IP headers in HTTP request spans.
 Added in version 1.47.0 
 
+`DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED`
+: **Default**: `false` <br>
+Enable generation of 128-bit trace IDs. By default, only 64-bit IDs are generated.
+
+`DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED`
+: **Default**: `false` <br>
+Enable printing of the full 128-bit ID when formatting a span with '%v'.
+When false (default), only the low 64-bits of the traceID are printed, formatted as an integer. This means if the Trace ID is only 64 bits, the full ID is printed.
+When true, the TraceID is printed as a full 128-bit ID in hexadecimal format. This is the case even if the ID itself is only 64 bits.
+
+
 ## Configure APM environment name
 
 The [APM environment name][7] may be configured [in the Agent][8] or using the [WithEnv][3] start option of the tracer.


### PR DESCRIPTION


### What does this PR do?
Document the new environment variables that control the behavior of 128-bit IDs in dd-trace-go

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
