### PR TITLE
Changed URLs to relative instead of absolute

### DIFF
--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -643,26 +643,24 @@ window.DD_RUM && window.DD_RUM.getInternalContext() // { session_id: "xxxx", app
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-<!-- Note: all URLs should be absolute -->
-
 [1]: https://app.datadoghq.com/rum/list
-[2]: https://docs.datadoghq.com/real_user_monitoring/data_collected/
-[3]: https://docs.datadoghq.com/real_user_monitoring/dashboards/
+[2]: /real_user_monitoring/data_collected/
+[3]: /real_user_monitoring/dashboards/
 [4]: https://www.npmjs.com/package/@datadog/browser-rum
-[5]: https://docs.datadoghq.com/account_management/api-app-keys/#client-tokens
-[6]: https://docs.datadoghq.com/real_user_monitoring/browser/tracking_user_actions
-[7]: https://docs.datadoghq.com/real_user_monitoring/guide/proxy-rum-data/
+[5]: /account_management/api-app-keys/#client-tokens
+[6]: /real_user_monitoring/browser/tracking_user_actions
+[7]: /real_user_monitoring/guide/proxy-rum-data/
 [8]: https://github.com/DataDog/browser-sdk/blob/main/packages/rum/BROWSER_SUPPORT.md
-[9]: https://docs.datadoghq.com/real_user_monitoring/browser/tracking_user_actions/#declare-a-name-for-click-actions
-[10]: https://docs.datadoghq.com/real_user_monitoring/browser/modifying_data_and_context/?tab=npm#override-default-rum-view-names
+[9]: /real_user_monitoring/browser/tracking_user_actions/#declare-a-name-for-click-actions
+[10]: /real_user_monitoring/browser/modifying_data_and_context/?tab=npm#override-default-rum-view-names
 [11]: https://www.datadoghq.com/pricing/?product=real-user-monitoring--session-replay#real-user-monitoring--session-replay
-[12]: https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces?tab=browserrum
-[13]: https://docs.datadoghq.com/real_user_monitoring/session_replay/privacy_options?tab=maskuserinput
-[14]: https://docs.datadoghq.com/getting_started/site/
-[15]: https://docs.datadoghq.com/getting_started/tagging/#defining-tags
-[16]: https://docs.datadoghq.com/real_user_monitoring/browser/monitoring_page_performance/#how-page-activity-is-calculated
-[17]: https://docs.datadoghq.com/real_user_monitoring/session_replay/
-[18]: https://docs.datadoghq.com/real_user_monitoring/session_replay/privacy_options
-[19]: https://docs.datadoghq.com/getting_started/tagging/using_tags
-[20]: https://docs.datadoghq.com/real_user_monitoring/frustration_signals/
-[21]: https://docs.datadoghq.com/real_user_monitoring/guide/sampling-browser-plans/
+[12]: /real_user_monitoring/connect_rum_and_traces?tab=browserrum
+[13]: /real_user_monitoring/session_replay/privacy_options?tab=maskuserinput
+[14]: /getting_started/site/
+[15]: /getting_started/tagging/#defining-tags
+[16]: /real_user_monitoring/browser/monitoring_page_performance/#how-page-activity-is-calculated
+[17]: /real_user_monitoring/session_replay/
+[18]: /real_user_monitoring/session_replay/privacy_options
+[19]: /getting_started/tagging/using_tags
+[20]: /real_user_monitoring/frustration_signals/
+[21]: /real_user_monitoring/guide/sampling-browser-plans/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Changed URLs on the RUM browser index page to relative instead of absolute.

### Motivation
This page was recently moved from a single-sourced repo to the documentation repo, and I realized I had forgotten to do this.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
