### PR TITLE
[CIAPP-6189] Add queue time support for GitHub

### DIFF
--- a/content/en/continuous_integration/pipelines/github.md
+++ b/content/en/continuous_integration/pipelines/github.md
@@ -32,6 +32,8 @@ further_reading:
 
 - **Custom tags and metrics at runtime**: Configure custom tags and metrics at runtime for pipeline spans
 
+- **Queue time**: View amount of time workflow jobs sit in the queue before processing
+
 ## Configuring the Datadog integration
 
 ### Configuring a GitHub App


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds queue time support for GitHub docs

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
