### PR TITLE
Clarify user blocking in PHP

### DIFF
--- a/content/en/security/application_security/threats/add-user-info.md
+++ b/content/en/security/application_security/threats/add-user-info.md
@@ -198,9 +198,9 @@ trace.set_tag('usr.another_tag', 'another_value')
 
 The PHP tracer provides the `\DDTrace\set_user()` function, which allows you to monitor and block authenticated requests.
 
-`\DDTrace\set_user()` adds the relevant user tags and metadata to the the trace and automatically performs user blocking.
+`\DDTrace\set_user()` adds the relevant user tags and metadata to the trace and automatically performs user blocking.
 
-The example below shows how to set user monitoring tags, and enable user blocking capability:
+The following example shows how to set user monitoring tags and enable user blocking:
 
 ```php
 <?php

--- a/content/en/security/application_security/threats/add-user-info.md
+++ b/content/en/security/application_security/threats/add-user-info.md
@@ -196,14 +196,15 @@ trace.set_tag('usr.another_tag', 'another_value')
 
 {{< programming-lang lang="php" >}}
 
-Use the PHP tracer's API for adding custom tags to a root span, and add user information so that you can monitor authenticated requests in the application.
+The PHP tracer provides the `\DDTrace\set_user()` function, which allows you to monitor and block authenticated requests.
 
-User monitoring tags are applied to the `meta` section of the root span and start with the prefix `usr` followed by the name of the field. For example, `usr.name` is a user monitoring tag that tracks the user’s name.
+`\DDTrace\set_user()` adds the relevant user tags and metadata to the the trace and automatically performs user blocking.
 
-The example below shows how to obtain the root span and add the relevant user monitoring tags:
+The example below shows how to set user monitoring tags, and enable user blocking capability:
 
 ```php
 <?php
+// Blocking is performed internally through the set_user call.
 \DDTrace\set_user(
     // A unique identifier of the user is required.
     '123456789',


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Clarify the wording on the PHP user blocking section of application security management.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
