### PR TITLE
fix font variant numeric -[WEB-3371]

### DIFF
--- a/assets/styles/_icons.scss
+++ b/assets/styles/_icons.scss
@@ -11,7 +11,6 @@
 }
 [class^="icon-"], [class*=" icon-"] {
   font-family: 'Glyphter' !important;
-  speak: none;
   font-style: normal;
   font-weight: normal;
   font-variant: normal;

--- a/assets/styles/components/_language-region-select.scss
+++ b/assets/styles/components/_language-region-select.scss
@@ -90,6 +90,7 @@ aside.sidebar {
     font-size: 16px;
     line-height: 20px;
     z-index: 3;
+    font-variant: lining-nums;
 
     &:lang(ja) {
       font-size: 14px;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

fixes the number styling on the region selector button (US1, US3 US5).

Issue seems to be contained to Chrome browsers in a recent Chrome update.

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-3371

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/stefon.simmons/fix-font-variant-numeric/getting_started/agent/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
