### PR TITLE
[Serverless] Add AWS CDK instructions to java installation page

### DIFF
--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -124,6 +124,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 
 The Datadog CDK Construct is only available for AWS CDK apps written in either Node.js or Python.
 
+{{< tabs >}}
 {{% tab "Node.js AWS CDK App" %}}
 
 The [Datadog CDK Construct][1] automatically installs Datadog on your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension.
@@ -207,6 +208,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 [1]: https://github.com/DataDog/datadog-cdk-constructs
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
+{{< /tabs >}}
 {{< /tab >}}
 {{% tab "Container image" %}}
 

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -124,8 +124,12 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 
 The [Datadog CDK Construct][1] automatically installs Datadog on your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension.
 
+The Datadog CDK Construct only supports instrumenting Java Lambda functions for AWS CDK apps written in Node.js and Python.
+
+{{% tab "Node.js AWS CDK App" %}}
 1. Install the Datadog CDK constructs library
 
+    
     ```sh
     # For AWS CDK v1
     npm install datadog-cdk-constructs --save-dev
@@ -155,6 +159,47 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
     To fill in the placeholders:
     - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][2] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob).The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `apiKey` instead and set the Datadog API key in plaintext.
+
+    More information and additional parameters can be found on the [Datadog CDK documentation][1].
+
+[1]: https://github.com/DataDog/datadog-cdk-constructs
+[2]: https://app.datadoghq.com/organization-settings/api-keys
+{{% /tab %}}
+{{% tab "Python AWS CDK App" %}}
+
+The [Datadog CDK Construct][1] automatically installs Datadog on your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension.
+
+1. Install the Datadog CDK constructs library
+
+    ```sh
+    # For AWS CDK v1
+    pip install datadog-cdk-constructs
+
+    # For AWS CDK v2
+    pip install datadog-cdk-constructs-v2
+    ```
+
+2. Instrument your Lambda functions
+
+    ```python
+    # For AWS CDK v1
+    from datadog_cdk_constructs import Datadog
+
+    # For AWS CDK v2
+    from datadog_cdk_constructs_v2 import Datadog
+
+    datadog = Datadog(self, "Datadog",
+        java_layer_version={{< latest-lambda-layer-version layer="dd-trace-java" >}},
+        extension_layer_version={{< latest-lambda-layer-version layer="extension" >}},
+        site="<DATADOG_SITE>",
+        api_key_secret_arn="<DATADOG_API_KEY_SECRET_ARN>",
+      )
+    datadog.add_lambda_functions([<LAMBDA_FUNCTIONS>])
+    ```
+
+    To fill in the placeholders:
+    - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
+    - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][2] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `apiKey` instead and set the Datadog API key in plaintext.
 
     More information and additional parameters can be found on the [Datadog CDK documentation][1].
 

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -120,13 +120,14 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 [2]: https://docs.datadoghq.com/serverless/libraries_integrations/extension
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
-{{< tabs "AWS CDK" >}}
+{{< tab "AWS CDK" >}}
+
+The Datadog CDK Construct is only available for AWS CDK apps written in either Node.js or Python.
+
+{{% tab "Node.js AWS CDK App" %}}
 
 The [Datadog CDK Construct][1] automatically installs Datadog on your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension.
 
-The Datadog CDK Construct only supports instrumenting Java Lambda functions for AWS CDK apps written in Node.js and Python.
-
-{{% tab "Node.js AWS CDK App" %}}
 1. Install the Datadog CDK constructs library
 
     
@@ -206,7 +207,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 [1]: https://github.com/DataDog/datadog-cdk-constructs
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
-{{< /tabs >}}
+{{< /tab >}}
 {{% tab "Container image" %}}
 
 1. Install the Datadog Lambda Extension

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -122,9 +122,9 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 {{% /tab %}}
 {{% tab "AWS CDK" %}}
 
-<div class="alert alert-info">Instrumenting Java functions through the Datadog CDK Construct is only available for AWS CDK apps written in Node.js and Python.</div>
+<div class="alert alert-info">Instrumenting Java functions through the Datadog CDK construct is only available for AWS CDK apps written in Node.js and Python.</div>
 
-The [Datadog CDK Construct][1] automatically installs Datadog on your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension. 
+The [Datadog CDK construct][1] automatically installs Datadog on your functions using Lambda layers. It configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension. 
 
 1. Install the Datadog CDK constructs library
 

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -184,7 +184,7 @@ The [Datadog CDK construct][1] automatically installs Datadog on your functions 
 
     To fill in the placeholders:
     - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
-    - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][2] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob).The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `apiKey` instead and set the Datadog API key in plaintext.
+    - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][2] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). Ensure your Lambda execution role has the `secretsmanager:GetSecretValue` IAM permission in order to read the secret value. For quick testing, you can use `apiKey` instead and set the Datadog API key in plaintext.
 
     More information and additional parameters can be found on the [Datadog CDK documentation][1].
 

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -120,11 +120,6 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 [2]: https://docs.datadoghq.com/serverless/libraries_integrations/extension
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
-{{< tab "AWS CDK" >}}
-
-The Datadog CDK Construct is only available for AWS CDK apps written in either Node.js or Python.
-
-{{< tabs >}}
 {{% tab "Node.js AWS CDK App" %}}
 
 The [Datadog CDK Construct][1] automatically installs Datadog on your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension.
@@ -207,8 +202,6 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 
 [1]: https://github.com/DataDog/datadog-cdk-constructs
 [2]: https://app.datadoghq.com/organization-settings/api-keys
-{{% /tab %}}
-{{< /tabs >}}
 {{< /tab >}}
 {{% tab "Container image" %}}
 

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -120,6 +120,47 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 [2]: https://docs.datadoghq.com/serverless/libraries_integrations/extension
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
+{{% tab "AWS CDK" %}}
+
+The [Datadog CDK Construct][1] automatically installs Datadog on your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension.
+
+1. Install the Datadog CDK constructs library
+
+    ```sh
+    # For AWS CDK v1
+    npm install datadog-cdk-constructs --save-dev
+
+    # For AWS CDK v2
+    npm install datadog-cdk-constructs-v2 --save-dev
+    ```
+
+2. Instrument your Lambda functions
+
+    ```javascript
+    // For AWS CDK v1
+    import { Datadog } from "datadog-cdk-constructs";
+
+    // For AWS CDK v2
+    import { Datadog } from "datadog-cdk-constructs-v2";
+
+    const datadog = new Datadog(this, "Datadog", {
+        javaLayerVersion: {{< latest-lambda-layer-version layer="dd-trace-java" >}},
+        extensionLayerVersion: {{< latest-lambda-layer-version layer="extension" >}},
+        site: "<DATADOG_SITE>",
+        apiKeySecretArn: "<DATADOG_API_KEY_SECRET_ARN>"
+    });
+    datadog.addLambdaFunctions([<LAMBDA_FUNCTIONS>])
+    ```
+
+    To fill in the placeholders:
+    - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
+    - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][2] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob).The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `apiKey` instead and set the Datadog API key in plaintext.
+
+    More information and additional parameters can be found on the [Datadog CDK documentation][1].
+
+[1]: https://github.com/DataDog/datadog-cdk-constructs
+[2]: https://app.datadoghq.com/organization-settings/api-keys
+{{% /tab %}}
 {{% tab "Container image" %}}
 
 1. Install the Datadog Lambda Extension

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -120,13 +120,15 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 [2]: https://docs.datadoghq.com/serverless/libraries_integrations/extension
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
-{{% tab "Node.js AWS CDK App" %}}
+{{% tab "AWS CDK" %}}
 
-The [Datadog CDK Construct][1] automatically installs Datadog on your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension.
+<div class="alert alert-info">Instrumenting Java functions through the Datadog CDK Construct is only available for AWS CDK apps written in Node.js and Python.</div>
+
+The [Datadog CDK Construct][1] automatically installs Datadog on your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension. 
 
 1. Install the Datadog CDK constructs library
 
-    
+    **Node.js**:
     ```sh
     # For AWS CDK v1
     npm install datadog-cdk-constructs --save-dev
@@ -135,8 +137,18 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
     npm install datadog-cdk-constructs-v2 --save-dev
     ```
 
+    **Python**:
+    ```sh
+    # For AWS CDK v1
+    pip install datadog-cdk-constructs
+
+    # For AWS CDK v2
+    pip install datadog-cdk-constructs-v2
+    ```
+
 2. Instrument your Lambda functions
 
+    **Node.js**:
     ```javascript
     // For AWS CDK v1
     import { Datadog } from "datadog-cdk-constructs";
@@ -153,31 +165,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
     datadog.addLambdaFunctions([<LAMBDA_FUNCTIONS>])
     ```
 
-    To fill in the placeholders:
-    - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
-    - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][2] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob).The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `apiKey` instead and set the Datadog API key in plaintext.
-
-    More information and additional parameters can be found on the [Datadog CDK documentation][1].
-
-[1]: https://github.com/DataDog/datadog-cdk-constructs
-[2]: https://app.datadoghq.com/organization-settings/api-keys
-{{% /tab %}}
-{{% tab "Python AWS CDK App" %}}
-
-The [Datadog CDK Construct][1] automatically installs Datadog on your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension.
-
-1. Install the Datadog CDK constructs library
-
-    ```sh
-    # For AWS CDK v1
-    pip install datadog-cdk-constructs
-
-    # For AWS CDK v2
-    pip install datadog-cdk-constructs-v2
-    ```
-
-2. Instrument your Lambda functions
-
+    **Python**:
     ```python
     # For AWS CDK v1
     from datadog_cdk_constructs import Datadog
@@ -196,13 +184,13 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 
     To fill in the placeholders:
     - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
-    - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][2] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `apiKey` instead and set the Datadog API key in plaintext.
+    - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][2] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob).The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can use `apiKey` instead and set the Datadog API key in plaintext.
 
     More information and additional parameters can be found on the [Datadog CDK documentation][1].
 
 [1]: https://github.com/DataDog/datadog-cdk-constructs
 [2]: https://app.datadoghq.com/organization-settings/api-keys
-{{< /tab >}}
+{{% /tab %}}
 {{% tab "Container image" %}}
 
 1. Install the Datadog Lambda Extension

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -120,7 +120,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 [2]: https://docs.datadoghq.com/serverless/libraries_integrations/extension
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
-{{% tab "AWS CDK" %}}
+{{< tab "AWS CDK" >}}
 
 The [Datadog CDK Construct][1] automatically installs Datadog on your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension.
 
@@ -205,7 +205,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 
 [1]: https://github.com/DataDog/datadog-cdk-constructs
 [2]: https://app.datadoghq.com/organization-settings/api-keys
-{{% /tab %}}
+{{< /tab >}}
 {{% tab "Container image" %}}
 
 1. Install the Datadog Lambda Extension

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -120,7 +120,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 [2]: https://docs.datadoghq.com/serverless/libraries_integrations/extension
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
-{{< tab "AWS CDK" >}}
+{{< tabs "AWS CDK" >}}
 
 The [Datadog CDK Construct][1] automatically installs Datadog on your functions using Lambda Layers, and configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension.
 
@@ -205,7 +205,8 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 
 [1]: https://github.com/DataDog/datadog-cdk-constructs
 [2]: https://app.datadoghq.com/organization-settings/api-keys
-{{< /tab >}}
+{{% /tab %}}
+{{< /tabs >}}
 {{% tab "Container image" %}}
 
 1. Install the Datadog Lambda Extension


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds aws cdk installation instructions to the serverless java installation page. Essentially copied over from the [node](https://docs.datadoghq.com/serverless/installation/nodejs/?tab=awscdk) and [python](https://docs.datadoghq.com/serverless/installation/python/?tab=awscdk) installation guides, but with an updated layer version property.

The instructions include a banner note, saying that the Datadog CDK is only available for AWS CDK python and node.js apps.

### Motivation
<!-- What inspired you to submit this pull request?-->

Added java tracing layer support to datadog-cdk-constructs for both v1 and v2.

Customers writing AWS CDK apps in node or python can now use the datadog cdk construct to instrument java functions included in their app.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

I thought it made more sense to include both Node + Python CDK app instructions in a single AWS CDK tab (since nested tabs aren't supported). If anyone thinks separate `AWS CDK - Node App` and `AWS CDK - Python App` make more sense, let me know!

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
