### PR TITLE
[DOCS-4939] Add Aggregating Agents back to nav

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -379,11 +379,16 @@ main:
     identifier: agent_guides
     parent: agent
     weight: 12
+  - name: Aggregating Agents
+    url: getting_started/observability_pipelines/
+    parent: agent
+    identifier: opw_aggregation
+    weight: 13
   - name: Data Security
     identifier: agent_security
     url: data_security/agent/
     parent: agent
-    weight: 13
+    weight: 14
   - name: Containers
     url: containers/
     identifier: containers


### PR DESCRIPTION
### What does this PR do?

Add Aggregating Agents back to nav and link to the new Getting Started with Observability Pipelines

Ready to merge.

### Motivation

Task as part of [DOCS-4939](https://datadoghq.atlassian.net/browse/DOCS-4939)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4939]: https://datadoghq.atlassian.net/browse/DOCS-4939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ