### PR TITLE
Update CI to point at latest image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,7 +91,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-14418551
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-devin.ford_tm-script-testing
   tags:
     - "arch:amd64"
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,7 +91,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-devin.ford_tm-script-testing
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-14529003
   tags:
     - "arch:amd64"
   rules:
@@ -378,8 +378,6 @@ test_missing_tms_live:
   stage: post-deploy
   cache: {}
   environment: "live"
-  variables:
-    GIT_STRATEGY: none
   dependencies:
     - build_live
   script:
@@ -446,7 +444,7 @@ set_redirect_metadata_preview:
   dependencies:
     - build_preview
   script:
-    - run_update_redirect_metadata
+    - in-isolation run_update_redirect_metadata
   interruptible: true
   allow_failure: true
 
@@ -461,5 +459,5 @@ set_redirect_metadata_live:
   dependencies:
     - build_live
   script:
-    - run_update_redirect_metadata
+    - in-isolation run_update_redirect_metadata
   interruptible: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -173,8 +173,6 @@ missing_tms_preview:
   environment: "preview"
   allow_failure: true
   cache: {}
-  variables:
-    GIT_STRATEGY: none
   dependencies:
     - build_preview
   script:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

- Updates the CI to point at the latest image
- Updates the TM test on previews to only run against changed html files (speed it up a ton)
- Update the redirect job to run in isolation (due to an image change)

### Motivation
<!-- What inspired you to submit this pull request?-->
Attempting to speed up post-deploy CI jobs for previews
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Successful pipeline run: https://gitlab.ddbuild.io/DataDog/documentation/-/pipelines/14529457
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
