### PR TITLE
default tab - [WEB-3378]

### DIFF
--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -76,15 +76,17 @@ const initCodeTabs = () => {
     }
 
     const activateTabsOnLoad = () => {
+        const firstTab = document.querySelectorAll('.code-tabs .nav-tabs a').item(0)
         if (tabQueryParameter) {
             const selectedLanguageTab = document.querySelector(`a[data-lang="${tabQueryParameter}"]`);
 
             if (selectedLanguageTab) {
                 selectedLanguageTab.click()
+            }else{
+                activateCodeTab(firstTab)
             }
         } else {
             if (codeTabsList.length > 0) {
-                const firstTab = document.querySelectorAll('.code-tabs .nav-tabs a').item(0)
                 activateCodeTab(firstTab)
             }
         }
@@ -95,7 +97,6 @@ const initCodeTabs = () => {
 
         allTabLinksNodeList.forEach(link => {
             link.addEventListener('click', () => {
-                event.preventDefault()
                 activateCodeTab(link)
             })
         })


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

default to first tab if tab param doesnt exist

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-3378

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

set `tab` param in url to equal the name of a tab that doesn't exist on the page.
page should reset the `tab` param to equal the first tab of the `tabs` section.
https://docs-staging.datadoghq.com/stefon.simmons/default-tab/tracing/trace_collection/dd_libraries/nodejs/?tab=foo


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
