### PR TITLE
Datadog Operator GA documentation update.

### DIFF
--- a/content/en/agent/guide/agent-v6-python-3.md
+++ b/content/en/agent/guide/agent-v6-python-3.md
@@ -108,87 +108,90 @@ If the image information is not specified in the `DatadogAgent` resource, the Op
 If you have previously pinned the image version:
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  override:
+    clusterChecksRunner:
+      image:
+        tag: 6.33.0
+    nodeAgent:
+      image:
+        tag: 6.33.0
+```
+
+or you are using `image.name`:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+      appKey: <DATADOG_APP_KEY>
+  override:
+    # ...
+    nodeAgent:
+      image:
+        name: gcr.io/datadoghq/agent:6.33.0
+    # ...
+    clusterChecksRunner:
+      image:
+        name: gcr.io/datadoghq/agent:6.33.0
+```
+
+Use the `spec.global.registry` if you need to change the default registry. The default is `gcr.io/datadoghq/agent`.
+
+Then, pin the Agent 7 image tag in `spec.override.nodeAgent.image.tag`.
+
+If you have enabled cluster check runners deployment, also pin the Agent 7 image tag in `spec.override.clusterChecksRunner.image.tag`.
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
 kind: DatadogAgent
 metadata:
   name: datadog
 spec:
   # ...
-  agent:
+  global:
+    registry: public.ecr.aws/datadog
+  override:
     # ...
-    imageConfig:
-      tag: 6.33.0
-  clusterChecksRunner:
+    nodeAgent:
+      image:
+        tag: 7.33.0
     # ...
-    imageConfig:
-      tag: 6.33.0
+    clusterChecksRunner:
+      image:
+        tag: 7.33.0
 ```
 
-or you are using `imageConfig.name`:
+**Note**: Datadog recommends that you do not set the `*.image.tag`. Instead, let the Datadog Operator keep the Agent image tag up-to-date with an Agent 7 image.
+
+If you need to use an Agent JMX image, you can set it without specifying the Agent `*.image.tag`:
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogAgent
-metadata:
-  name: datadog
-spec:
-  credentials:
-    apiKey: <DATADOG_API_KEY>
-    appKey: <DATADOG_APP_KEY>
-  agent:
-    # ...
-    imageConfig:
-      name: gcr.io/datadoghq/agent:6.33.0
-  clusterChecksRunner:
-    # ...
-    imageConfig:
-      name: gcr.io/datadoghq/agent:6.33.0
-```
-
-Use the `spec.registry` if you need to change the default registry. The default is `gcr.io/datadoghq/agent`.
-
-Then, pin the Agent 7 image tag in `spec.agents.imageConfig.tag`.
-
-If you have enabled cluster check runners deployment, also pin the Agent 7 image tag in `spec.clusterChecksRunner.imageConfig.tag`.
-
-```yaml
-apiVersion: datadoghq.com/v1alpha1
+apiVersion: datadoghq.com/v2alpha1
 kind: DatadogAgent
 metadata:
   name: datadog
 spec:
   # ...
-  registry: public.ecr.aws/datadog
-  agent:
+  global:
+    registry: public.ecr.aws/datadog
+  override:
     # ...
-    imageConfig:
-      tag: 7.33.0
-  clusterChecksRunner:
-    # ...
-    imageConfig:
-      tag: 7.33.0
-```
-
-**Note**: Datadog recommends that you do not set the `*.imageConfig.tag`. Instead, let the Datadog Operator keep the Agent image tag up-to-date with an Agent 7 image.
-
-If you need to use an Agent JMX image, you can set it without specifying the Agent `*.imageConfig.tag`:
-
-```yaml
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogAgent
-metadata:
-  name: datadog
-spec:
-  # ...
-  registry: public.ecr.aws/datadog
-  agent:
-    # ...
-    imageConfig:
-      jmxEnabled: true
-  clusterChecksRunner:
-    # ...
-    imageConfig:
-      jmxEnabled: true
+    nodeAgent:
+      image:
+        jmxEnabled: true
+    clusterChecksRunner:
+      image:
+        jmxEnabled: true
 ```
 
 [1]: https://github.com/DataDog/datadog-operator

--- a/content/en/agent/guide/changing_container_registry.md
+++ b/content/en/agent/guide/changing_container_registry.md
@@ -64,15 +64,16 @@ To update your registry while deploying the Datadog Agent (or Datadog Cluster Ag
 1. Update the Datadog Agent manifest file to override the default registry (`gcr.io/datadoghq`). For example, with  `public.ecr.aws/datadog`:
 
     ```yaml
-    apiVersion: datadoghq.com/v1alpha1
+    apiVersion: datadoghq.com/v2alpha1
     kind: DatadogAgent
     metadata:
       name: datadog
     spec:
+      global:
+        registry: gcr.io/datadoghq
       // ..
-      registry: gcr.io/datadoghq
     ```
-2. Remove any overrides for the `spec.agents.image.name`, `spec.clusterAgent.image.name`, and `spec.clusterChecksRunner.image.name` fields.
+2. Remove any overrides for the `spec.override.nodeAgent.image.name`, `spec.override.clusterAgent.image.name`, and `sspec.override.clusterChecksRunner.image.name` fields.
 
 For more information about the Datadog Operator, see [Deploying an Agent with the Operator][4].
 

--- a/content/en/agent/guide/changing_container_registry.md
+++ b/content/en/agent/guide/changing_container_registry.md
@@ -63,17 +63,17 @@ To update your registry while deploying the Datadog Agent (or Datadog Cluster Ag
 
 1. Update the Datadog Agent manifest file to override the default registry (`gcr.io/datadoghq`). For example, with  `public.ecr.aws/datadog`:
 
-    ```yaml
-    apiVersion: datadoghq.com/v2alpha1
-    kind: DatadogAgent
-    metadata:
-      name: datadog
-    spec:
-      global:
-        registry: gcr.io/datadoghq
-      // ..
-    ```
-2. Remove any overrides for the `spec.override.nodeAgent.image.name`, `spec.override.clusterAgent.image.name`, and `sspec.override.clusterChecksRunner.image.name` fields.
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    registry: gcr.io/datadoghq
+  // ..
+```
+2. Remove any overrides for the `spec.override.nodeAgent.image.name`, `spec.override.clusterAgent.image.name`, and `spec.override.clusterChecksRunner.image.name` fields.
 
 For more information about the Datadog Operator, see [Deploying an Agent with the Operator][4].
 

--- a/content/en/agent/guide/operator-advanced.md
+++ b/content/en/agent/guide/operator-advanced.md
@@ -91,20 +91,21 @@ helm delete datadog
 Update your `datadog-agent.yaml` file with the following configuration to add the toleration in the `Daemonset.spec.template` of your `DaemonSet` :
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: "<DATADOG_API_KEY>"
-    appKey: "<DATADOG_APP_KEY>"
-  agent:
-    image:
-      name: "gcr.io/datadoghq/agent:latest"
-    config:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+      appKey: <DATADOG_APP_KEY>
+  override:
+    nodeAgent:
+      image:
+        name: gcr.io/datadoghq/agent:latest
       tolerations:
-       - operator: Exists
+        - operator: Exists
 ```
 
 Apply this new configuration:

--- a/content/en/agent/troubleshooting/hostname_containers.md
+++ b/content/en/agent/troubleshooting/hostname_containers.md
@@ -70,15 +70,14 @@ datadog:
 `DatadogAgent` Kubernetes Resource:
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  agent:
-    config:
-      kubelet:
-        tlsVerify: false
+  global:
+    kubelet:
+      tlsVerify: false
 ```
 
 {{% /tab %}}
@@ -139,17 +138,18 @@ datadog:
 `DatadogAgent` Kubernetes Resource:
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  agent:
-    env:
-      - name: DD_HOSTNAME
-        valueFrom:
-          fieldRef:
-            fieldPath: spec.nodeName
+  override:
+    nodeAgent:
+      env:
+        - name: DD_HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
 ```
 
 {{% /tab %}}

--- a/content/en/containers/cluster_agent/clusterchecks.md
+++ b/content/en/containers/cluster_agent/clusterchecks.md
@@ -53,15 +53,14 @@ This enables the cluster check setup in the Cluster Agent and allows it to proce
 {{% tab "Operator" %}}
 Cluster check dispatching is enabled in the Operator deployment of the Cluster Agent by using the `clusterAgent.config.clusterChecksEnabled` configuration key:
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  # (...)
-  clusterAgent:
-    config:
-      clusterChecksEnabled: true
+  features:
+    clusterChecks:
+      enabled: true
 ```
 
 This enables the cluster check setup in the Cluster Agent and allows it to process configurations from the Kubernetes service annotations (`kube_services`).

--- a/content/en/containers/cluster_agent/endpointschecks.md
+++ b/content/en/containers/cluster_agent/endpointschecks.md
@@ -83,7 +83,7 @@ By design, endpoint checks are dispatched to Agents that run on the same node as
 {{< tabs >}}
 {{% tab "Operator" %}}
 
-Endpoint check dispatching is enabled in the Operator deployment of the Cluster Agent by using the `features.config.clusterChecks.enabled` configuration key:
+Endpoint check dispatching is enabled in the Operator deployment of the Cluster Agent by using the `features.clusterChecks.enabled` configuration key:
 ```yaml
 kind: DatadogAgent
 apiVersion: datadoghq.com/v2alpha1

--- a/content/en/containers/cluster_agent/endpointschecks.md
+++ b/content/en/containers/cluster_agent/endpointschecks.md
@@ -83,17 +83,16 @@ By design, endpoint checks are dispatched to Agents that run on the same node as
 {{< tabs >}}
 {{% tab "Operator" %}}
 
-Endpoint check dispatching is enabled in the Operator deployment of the Cluster Agent by using the `clusterAgent.config.clusterChecksEnabled` configuration key:
+Endpoint check dispatching is enabled in the Operator deployment of the Cluster Agent by using the `features.config.clusterChecks.enabled` configuration key:
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  # (...)
-  clusterAgent:
-    config:
-      clusterChecksEnabled: true
+  features:
+    clusterChecks:
+      enabled: true
 ```
 
 This configuration enables both cluster check and endpoint check dispatching between the Cluster Agent and the Agents.

--- a/content/en/containers/datadog_operator.md
+++ b/content/en/containers/datadog_operator.md
@@ -11,7 +11,7 @@ further_reading:
   - link: 'https://github.com/DataDog/datadog-operator/blob/main/docs/installation.md'
     tag: 'GitHub'
     text: 'Datadog Operator: Advanced Installation'
-  - link: 'https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v1alpha1.md'
+  - link: 'https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md'
     tag: 'GitHub'
     text: 'Datadog Operator: Configuration'
 ---
@@ -58,4 +58,4 @@ For all installation and configuration options, see the detailed [installation][
 [5]: https://github.com/DataDog/extendeddaemonset
 [6]: /getting_started/containers/datadog_operator
 [7]: https://github.com/DataDog/datadog-operator/blob/main/docs/installation.md
-[8]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v1alpha1.md
+[8]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md

--- a/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
+++ b/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
@@ -63,21 +63,24 @@ This automatically updates the necessary RBAC configurations and sets up the cor
 {{% /tab %}}
 {{% tab "Operator" %}}
 
-To enable the external metrics server with your Cluster Agent managed by the Datadog Operator, first [set up the Datadog Operator][1]. Then, set `clusterAgent.config.externalMetrics.enabled` to `true` in the `DatadogAgent` custom resource:
+To enable the external metrics server with your Cluster Agent managed by the Datadog Operator, first [set up the Datadog Operator][1]. Then, set `features.externalMetricsServer.enabled` to `true` in the `DatadogAgent` custom resource:
 
   ```yaml
-  apiVersion: datadoghq.com/v1alpha1
-  kind: DatadogAgent
-  metadata:
-    name: datadog
-  spec:
+kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: datadog
+spec:
+  features:
+    externalMetricsServer:
+      enabled: true
+      useDatadogMetrics: false
+  global:
     credentials:
       apiKey: <DATADOG_API_KEY>
-  clusterAgent:
-    config:
-      externalMetrics:
-        enabled: true
-    replicas: 2
+  override:
+    clusterAgent:
+      replicas: 2
   ```
 
 The Operator automatically updates the necessary RBAC configurations and sets the corresponding `Service` and `APIService` for Kubernetes to use.
@@ -177,19 +180,21 @@ This automatically updates the necessary RBAC files and directs the Cluster Agen
 To activate the usage of the `DatadogMetric` CRD update your `DatadogAgent` custom resource and set `clusterAgent.config.externalMetrics.useDatadogMetrics` to `true`.
 
   ```yaml
-  apiVersion: datadoghq.com/v1alpha1
-  kind: DatadogAgent
-  metadata:
-    name: datadog
-  spec:
+kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: datadog
+spec:
+  features:
+    externalMetricsServer:
+      enabled: true
+      useDatadogMetrics: true
+  global:
     credentials:
       apiKey: <DATADOG_API_KEY>
-  clusterAgent:
-    config:
-      externalMetrics:
-        enabled: true
-        useDatadogMetrics: true
-    replicas: 2
+  override:
+    clusterAgent:
+      replicas: 2
   ```
 
 The Operator automatically updates the necessary RBAC configurations and directs the Cluster Agent to manage these HPA queries through these `DatadogMetric` resources.

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -71,7 +71,6 @@ kind: DatadogAgent
 apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
-  creationTimestamp: null
 spec:
   features:
     admissionController:
@@ -127,7 +126,6 @@ kind: DatadogAgent
 apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
-  creationTimestamp: null
 spec:
   features:
     admissionController:
@@ -444,7 +442,6 @@ kind: DatadogAgent
 apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
-  creationTimestamp: null
 spec:
   features:
     logCollection:
@@ -487,9 +484,6 @@ spec:
         - key: node-role.kubernetes.io/etcd
           operator: Exists
           effect: NoExecute
-status:
-  conditions: null
-
 ```
 
 {{% /tab %}}
@@ -589,7 +583,6 @@ kind: DatadogAgent
 apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
-  creationTimestamp: null
 spec:
   features:
     eventCollection:

--- a/content/en/containers/kubernetes/installation.md
+++ b/content/en/containers/kubernetes/installation.md
@@ -50,7 +50,7 @@ Some features related to later Kubernetes versions require a minimum Datadog Age
 {{< tabs >}}
 {{% tab "Operator" %}}
 
-<div class="alert alert-warning">The Datadog Operator is now Generally Available with the `1.0.0` version and it reconciles `v2alpha1.DatadogAgent`. </div>
+<div class="alert alert-warning">The Datadog Operator is now Generally Available with the `1.0.0` version and it reconciles the version `v2alpha1` of the DatadogAgent Custom Resource. </div>
 
 [The Datadog Operator][1] is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options.
 

--- a/content/en/containers/kubernetes/installation.md
+++ b/content/en/containers/kubernetes/installation.md
@@ -50,7 +50,7 @@ Some features related to later Kubernetes versions require a minimum Datadog Age
 {{< tabs >}}
 {{% tab "Operator" %}}
 
-<div class="alert alert-warning">The Datadog Operator is in public beta. If you have any feedback or questions, contact <a href="/help">Datadog support</a>.</div>
+<div class="alert alert-warning">The Datadog Operator is now Generally Available with the `1.0.0` version and it reconciles `v2alpha1.DatadogAgent`. </div>
 
 [The Datadog Operator][1] is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options.
 
@@ -58,7 +58,7 @@ Some features related to later Kubernetes versions require a minimum Datadog Age
 
 Using the Datadog Operator requires the following prerequisites:
 
-- **Kubernetes Cluster version >= v1.14.X**: Tests were done on versions >= `1.14.0`. Still, it should work on versions `>= v1.11.0`. For earlier versions, because of limited CRD support, the Operator may not work as expected.
+- **Kubernetes Cluster version >= v1.20.X**: Tests were done on versions >= `1.20.0`. Still, it should work on versions `>= v1.11.0`. For earlier versions, because of limited CRD support, the Operator may not work as expected.
 - [`Helm`][2] for deploying the `datadog-operator`.
 - [`Kubectl` CLI][3] for installing the `datadog-agent`.
 
@@ -82,26 +82,28 @@ To deploy the Datadog Agent with the operator in the minimum number of steps, se
 
 2. Create a file with the spec of your Datadog Agent deployment configuration. The simplest configuration is as follows:
 
-   ```yaml
-   apiVersion: datadoghq.com/v1alpha1
-   kind: DatadogAgent
-   metadata:
-     name: datadog
-   spec:
-     credentials:
-       apiSecret:
-         secretName: datadog-secret
-         keyName: api-key
-       appSecret:
-         secretName: datadog-secret
-         keyName: app-key
-     agent:
-       image:
-         name: "gcr.io/datadoghq/agent:latest"
-     clusterAgent:
-       image:
-         name: "gcr.io/datadoghq/cluster-agent:latest"
-   ```
+```yaml
+kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: datadog
+spec:
+  global:
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+      appSecret:
+        secretName: datadog-secret
+        keyName: app-key
+  override:
+    clusterAgent:
+      image:
+        name: gcr.io/datadoghq/cluster-agent:latest
+    nodeAgent:
+      image:
+        name: gcr.io/datadoghq/agent:latest
+```
 
 3. Deploy the Datadog Agent with the above configuration file:
    ```shell
@@ -332,11 +334,18 @@ To install the Datadog Agent on your Kubernetes cluster:
 (Optional) To run an unprivileged installation, add the following to your [pod template][19]:
 
 ```yaml
-  spec:
-    securityContext:
-      runAsUser: <USER_ID>
-      supplementalGroups:
-        - <DOCKER_GROUP_ID>
+kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: placeholder
+  namespace: placeholder
+spec:
+  override:
+    nodeAgent:
+      securityContext:
+        runAsUser: 1 # <USER_ID>
+        supplementalGroups:
+          - 123 # "<DOCKER_GROUP_ID>"
 ```
 
 where `<USER_ID>` is the UID to run the agent and `<DOCKER_GROUP_ID>` is the group ID owning the docker or containerd socket.

--- a/content/en/getting_started/containers/datadog_operator.md
+++ b/content/en/getting_started/containers/datadog_operator.md
@@ -8,7 +8,7 @@ further_reading:
   - link: 'https://github.com/DataDog/datadog-operator/blob/main/docs/installation.md'
     tag: 'GitHub'
     text: 'Datadog Operator: Advanced Installation'
-  - link: 'https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v1alpha1.md'
+  - link: 'https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md'
     tag: 'GitHub'
     text: 'Datadog Operator: Configuration'
 ---
@@ -17,7 +17,7 @@ The [Datadog Operator][1] is an open source [Kubernetes Operator][2] that enable
 
 ## Prerequisites
 
-- Kubernetes v1.14.X+
+- Kubernetes v1.20.X+
 - [Helm][3] for deploying the Datadog Operator
 - The Kubernetes command-line tool, [kubectl][4], for installing the Datadog Agent
 
@@ -36,11 +36,16 @@ The [Datadog Operator][1] is an open source [Kubernetes Operator][2] that enable
 
 3. Create a `datadog-agent.yaml` file with the spec of your `DatadogAgent` deployment configuration. The following sample configuration enables metrics, logs, and APM:
   ```yaml
-  apiVersion: datadoghq.com/v1alpha1
+  apiVersion: datadoghq.com/v2alpha1
   kind: DatadogAgent
   metadata:
     name: datadog
   spec:
+    features:
+      apm:
+        enabled: true
+      logCollection:
+        enabled: true
     credentials:
       apiSecret:
         secretName: datadog-secret
@@ -48,11 +53,6 @@ The [Datadog Operator][1] is an open source [Kubernetes Operator][2] that enable
       appSecret:
         secretName: datadog-secret
         keyName: app-key
-    agent:
-      apm:
-        enabled: true
-      log:
-        enabled: true
   ```
 
 4. Deploy the Datadog Agent:

--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -71,18 +71,18 @@ datadog:
 To enable the `kubernetes_state_core` check, the setting `spec.features.kubeStateMetricsCore.enabled` must be set to `true` in the DatadogAgent resource:
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: <DATADOG_API_KEY>
-    appKey: <DATADOG_APP_KEY>
   features:
     kubeStateMetricsCore:
       enabled: true
-  # (...)
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+      appKey: <DATADOG_APP_KEY>
 ```
 
 Note: Datadog Operator v0.7.0 or greater is required.

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -362,22 +362,21 @@ If you already have the [Agent running with a manifest][4]:
 [4]: /agent/kubernetes/
 {{% /tab %}}
 {{% tab "Operator" %}}
-<div class="alert alert-warning">The Datadog Operator is in public beta. If you have any feedback or questions, contact <a href="/help">Datadog support</a>.</div>
+<div class="alert alert-warning">The Datadog Operator is now Generally Available with the `1.0.0` version and it reconciles `v2alpha1.DatadogAgent`. </div>
 
 [The Datadog Operator][1] is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options.
 
 To enable Network Performance Monitoring in Operator, use the following configuration:
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: placeholder
   namespace: placeholder
 spec:
-  # (...)
   features:
-    networkMonitoring:
+    npm:
       enabled: true
 ```
 

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -362,7 +362,7 @@ If you already have the [Agent running with a manifest][4]:
 [4]: /agent/kubernetes/
 {{% /tab %}}
 {{% tab "Operator" %}}
-<div class="alert alert-warning">The Datadog Operator is now Generally Available with the `1.0.0` version and it reconciles `v2alpha1.DatadogAgent`. </div>
+<div class="alert alert-warning">The Datadog Operator is now Generally Available with the `1.0.0` version and it reconciles the version `v2alpha1` of the DatadogAgent Custom Resource. </div>
 
 [The Datadog Operator][1] is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options.
 

--- a/content/es/getting_started/containers/datadog_operator.md
+++ b/content/es/getting_started/containers/datadog_operator.md
@@ -35,12 +35,18 @@ El [Datadog Operator][1] es un [operador de Kubernetes][2] de código abierto qu
   Reemplaza `<DATADOG_API_KEY>` y `<DATADOG_APP_KEY>` por tu [API de Datadog API y las claves de tu aplicación][5].
 
 3. Crea un archivo `datadog-agent.yaml` con las especificaciones de la configuración de despliegue del `DatadogAgent`. La configuración del siguiente ejemplo activa las métricas, los logs y la herramienta APM:
-  ```yaml
-  apiVersion: datadoghq.com/v1alpha1
-  kind: DatadogAgent
-  metadata:
-    name: datadog
-  spec:
+```yaml
+kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: datadog
+spec:
+  features:
+    logCollection:
+      enabled: true
+    apm:
+      enabled: true
+  global:
     credentials:
       apiSecret:
         secretName: datadog-secret
@@ -48,12 +54,7 @@ El [Datadog Operator][1] es un [operador de Kubernetes][2] de código abierto qu
       appSecret:
         secretName: datadog-secret
         keyName: app-key
-    agent:
-      apm:
-        enabled: true
-      log:
-        enabled: true
-  ```
+```
 
 4. Despliega el Datadog Agent:
   ```bash

--- a/content/fr/agent/guide/agent-v6-python-3.md
+++ b/content/fr/agent/guide/agent-v6-python-3.md
@@ -108,87 +108,90 @@ Si les informations de l'image ne sont pas indiquées dans la ressource `Datadog
 Si vous avez précédemment imposé la version d'une image :
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  override:
+    clusterChecksRunner:
+      image:
+        tag: 6.33.0
+    nodeAgent:
+      image:
+        tag: 6.33.0
+```
+
+Ou si vous utilisez `image.name` :
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+      appKey: <DATADOG_APP_KEY>
+  override:
+    # ...
+    nodeAgent:
+      image:
+        name: gcr.io/datadoghq/agent:6.33.0
+    # ...
+    clusterChecksRunner:
+      image:
+        name: gcr.io/datadoghq/agent:6.33.0
+```
+
+Utilisez l'option `spec.global.registry` pour modifier le registre par défaut. Par défaut, le registre `gcr.io/datadoghq/agent` est utilisé.
+
+Imposez ensuite le tag de l'image de l'Agent 7 dans `spec.override.nodeAgent.image.tag`.
+
+Si vous avez activé le déploiement d'exécuteurs de checks de cluster, imposez également le tag de l'image de l'Agent 7 dans `spec.override.clusterChecksRunner.image.tag`.
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
 kind: DatadogAgent
 metadata:
   name: datadog
 spec:
   # ...
-  agent:
+  global:
+    registry: public.ecr.aws/datadog
+  override:
     # ...
-    imageConfig:
-      tag: 6.33.0
-  clusterChecksRunner:
+    nodeAgent:
+      image:
+        tag: 7.33.0
     # ...
-    imageConfig:
-      tag: 6.33.0
+    clusterChecksRunner:
+      image:
+        tag: 7.33.0
 ```
 
-Ou si vous utilisez `imageConfig.name` :
+**Remarque** : Datadog vous recommande de ne pas définir `*.image.tag`. Laissez plutôt l'Operator Datadog mettre automatiquement à jour le tag pour une image de l'Agent 7. 
+
+Si vous devez utiliser une image JMX de l'Agent, vous pouvez la définir sans utiliser `*.image.tag` pour l'Agent :
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogAgent
-metadata:
-  name: datadog
-spec:
-  credentials:
-    apiKey: <CLÉ_API_DATADOG>
-    appKey: <CLÉ_APPLICATION_DATADOG>
-  agent:
-    # ...
-    imageConfig:
-      name: gcr.io/datadoghq/agent:6.33.0
-  clusterChecksRunner:
-    # ...
-    imageConfig:
-      name: gcr.io/datadoghq/agent:6.33.0
-```
-
-Utilisez l'option `spec.registry` pour modifier le registre par défaut. Par défaut, le registre `gcr.io/datadoghq/agent` est utilisé.
-
-Imposez ensuite le tag de l'image de l'Agent 7 dans `spec.agents.imageConfig.tag`.
-
-Si vous avez activé le déploiement d'exécuteurs de checks de cluster, imposez également le tag de l'image de l'Agent 7 dans `spec.clusterChecksRunner.imageConfig.tag`.
-
-```yaml
-apiVersion: datadoghq.com/v1alpha1
+apiVersion: datadoghq.com/v2alpha1
 kind: DatadogAgent
 metadata:
   name: datadog
 spec:
   # ...
-  registry: public.ecr.aws/datadog
-  agent:
+  global:
+    registry: public.ecr.aws/datadog
+  override:
     # ...
-    imageConfig:
-      tag: 7.33.0
-  clusterChecksRunner:
-    # ...
-    imageConfig:
-      tag: 7.33.0
-```
-
-**Remarque** : Datadog vous recommande de ne pas définir `*.imageConfig.tag`. Laissez plutôt l'Operator Datadog mettre automatiquement à jour le tag pour une image de l'Agent 7. 
-
-Si vous devez utiliser une image JMX de l'Agent, vous pouvez la définir sans utiliser `*.imageConfig.tag` pour l'Agent :
-
-```yaml
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogAgent
-metadata:
-  name: datadog
-spec:
-  # ...
-  registry: public.ecr.aws/datadog
-  agent:
-    # ...
-    imageConfig:
-      jmxEnabled: true
-  clusterChecksRunner:
-    # ...
-    imageConfig:
-      jmxEnabled: true
+    nodeAgent:
+      image:
+        jmxEnabled: true
+    clusterChecksRunner:
+      image:
+        jmxEnabled: true
 ```
 
 [1]: https://github.com/DataDog/datadog-operator

--- a/content/fr/agent/guide/changing_container_registry.md
+++ b/content/fr/agent/guide/changing_container_registry.md
@@ -62,16 +62,16 @@ Pour mettre à jour votre registre lorsque vous déployez l'Agent Datadog (ou l'
 
 1. Mettez à jour le fichier manifeste de l'Agent Datadog afin de remplacer le registre par défaut (`gcr.io/datadoghq`). Par exemple, pour `public.ecr.aws/datadog` :
 
-    ```yaml
-    apiVersion: datadoghq.com/v1alpha1
-    kind: DatadogAgent
-    metadata:
-      name: datadog
-    spec:
-      // ..
-      registry: gcr.io/datadoghq
-    ```
-2. Supprimez les éventuelles valeurs personnalisées définies pour les champs `spec.agents.image.name`, `spec.clusterAgent.image.name` et `spec.clusterChecksRunner.image.name`.
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    registry: gcr.io/datadoghq
+```
+2. Supprimez les éventuelles valeurs personnalisées définies pour les champs `spec.override.nodeAgent.image.name`, `spec.override.clusterAgent.image.name` et `spec.override.clusterChecksRunner.image.name`.
 
 Pour en savoir plus sur l'Operator Datadog, consultez [Déployer un Agent avec l'Operator][4].
 

--- a/content/fr/agent/guide/operator-advanced.md
+++ b/content/fr/agent/guide/operator-advanced.md
@@ -90,20 +90,21 @@ helm delete datadog
 Mettez à jour votre fichier `datadog-agent.yaml` avec la configuration suivante pour ajouter la tolérance dans le `Daemonset.spec.template` de votre `DaemonSet` :
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: "<CLÉ_API_DATADOG>"
-    appKey: "<CLÉ_APPLICATION_DATADOG>"
-  agent:
-    image:
-      name: "gcr.io/datadoghq/agent:latest"
-    config:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+      appKey: <DATADOG_APP_KEY>
+  override:
+    nodeAgent:
+      image:
+        name: gcr.io/datadoghq/agent:latest
       tolerations:
-       - operator: Exists
+        - operator: Exists
 ```
 
 Appliquez cette nouvelle configuration :

--- a/content/fr/containers/kubernetes/distributions.md
+++ b/content/fr/containers/kubernetes/distributions.md
@@ -66,26 +66,26 @@ datadog:
 Ressource Kubernetes DatadogAgent :
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: <CLÉ_API_DATADOG>
-    appKey: <CLÉ_APPLICATION_DATADOG>
-  agent:
-    config:
-      criSocket:
-        criSocketPath: /run/dockershim.sock
-  clusterAgent:
-    image:
-      name: "gcr.io/datadoghq/cluster-agent:latest"
-    config:
-      externalMetrics:
-        enabled: false
-      admissionController:
-        enabled: false
+  features:
+    admissionController:
+      enabled: false
+    externalMetricsServer:
+      enabled: false
+      useDatadogMetrics: false
+  global:
+    credentials:
+      apiKey: <CLÉ_API_DATADOG>
+      appKey: <CLÉ_APPLICATION_DATADOG>
+    criSocketPath: /run/dockershim.sock
+  override:
+    clusterAgent:
+      image:
+        name: gcr.io/datadoghq/cluster-agent:latest
 ```
 
 {{% /tab %}}
@@ -114,26 +114,27 @@ datadog:
 Ressource Kubernetes DatadogAgent :
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: <CLÉ_API_DATADOG>
-    appKey: <CLÉ_APPLICATION_DATADOG>
-  agent:
-    config:
-      kubelet:
-        tlsVerify: false # Obligatoire à partir de l'Agent 7.35. Voir la section Remarques.
-  clusterAgent:
-    image:
-      name: "gcr.io/datadoghq/cluster-agent:latest"
-    config:
-      externalMetrics:
-        enabled: false
-      admissionController:
-        enabled: false
+  features:
+    admissionController:
+      enabled: true
+  global:
+    credentials:
+      apiKey: <CLÉ_API_DATADOG>
+      appKey: <CLÉ_APPLICATION_DATADOG>
+    kubelet:
+      tlsVerify: false # Obligatoire à partir de l'Agent 7.35. Voir la section Remarques.
+  override:
+    clusterAgent:
+      containers:
+        cluster-agent:
+          env:
+            - name: DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS
+              value: "true"
 ```
 
 {{% /tab %}}
@@ -292,56 +293,55 @@ kube-state-metrics:
 Si vous utilisez l'Operator Datadog dans OpenShift, il est conseillé de l'installer par l'intermédiaire d'OperatorHub ou du Marketplace Redhat. La configuration ci-dessous a été conçue pour un environnement où l'Agent est installé dans le même espace de nommage que l'Operator Datadog (en raison des paramètres SCC/ServiceAccount).
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: <CLÉ_API_DATADOG>
-    appKey: <CLÉ_APPLICATION_DATADOG>
-  clusterName: <NOM_CLUSTER>
-  agent:
-    image:
-      name: "gcr.io/datadoghq/agent:latest"
+  features:
+    logCollection:
+      enabled: false
+    liveProcessCollection:
+      enabled: false
+    liveContainerCollection:
+      enabled: true
     apm:
       enabled: false
-    process:
-      enabled: true
-      processCollectionEnabled: false
-    log:
+    cspm:
       enabled: false
-    systemProbe:
+    cws:
       enabled: false
-    security:
-      compliance:
-        enabled: false
-      runtime:
-        enabled: false
-    rbac:
+    npm:
+      enabled: false
+    admissionController:
+      enabled: false
+    externalMetricsServer:
+      enabled: false
+      useDatadogMetrics: false
+      port: 8443
+  global:
+    credentials:
+      apiKey: <CLÉ_API_DATADOG>
+      appKey: <CLÉ_APPLICATION_DATADOG>
+    clusterName: <NOM_CLUSTER>
+    kubelet:
+      tlsVerify: false
+    criSocketPath: /var/run/crio/crio.sock
+  override:
+    clusterAgent:
+      image:
+        name: gcr.io/datadoghq/cluster-agent:latest
+    nodeAgent:
       serviceAccountName: datadog-agent-scc
-    config:
-      kubelet:
-        tlsVerify: false
-      criSocket:
-        criSocketPath: /var/run/crio/crio.sock
-        useCriSocketVolume: true
+      image:
+        name: gcr.io/datadoghq/agent:latest
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/infra
-        operator: Exists
-  clusterAgent:
-    image:
-      name: "gcr.io/datadoghq/cluster-agent:latest"
-    config:
-      externalMetrics:
-        enabled: false
-        port: 8443
-      admissionController:
-        enabled: false
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/infra
+          operator: Exists
+          effect: NoSchedule
 ```
 
 {{% /tab %}}
@@ -381,50 +381,52 @@ agents:
 Ressource Kubernetes DatadogAgent :
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: <CLÉ_API_DATADOG>
-    appKey: <CLÉ_APPLICATION_DATADOG>
-  clusterName: <NOM_CLUSTER>
-  agent:
-    image:
-      name: "gcr.io/datadoghq/agent:latest"
+  features:
+    logCollection:
+      enabled: false
+    liveProcessCollection:
+      enabled: false
+    liveContainerCollection:
+      enabled: true
     apm:
       enabled: false
-    process:
-      enabled: true
-      processCollectionEnabled: false
-    log:
+    cspm:
       enabled: false
-    systemProbe:
+    cws:
       enabled: false
-    security:
-      compliance:
-        enabled: false
-      runtime:
-        enabled: false
-    config:
-      kubelet:
-        tlsVerify: false
+    npm:
+      enabled: false
+    admissionController:
+      enabled: false
+    externalMetricsServer:
+      enabled: false
+      useDatadogMetrics: false
+  global:
+    credentials:
+      apiKey: <CLÉ_API_DATADOG>
+      appKey: <CLÉ_APPLICATION_DATADOG>
+    clusterName: <NOM_CLUSTER>
+    kubelet:
+      tlsVerify: false
+  override:
+    clusterAgent:
+      image:
+        name: gcr.io/datadoghq/cluster-agent:latest
+    nodeAgent:
+      image:
+        name: gcr.io/datadoghq/agent:latest
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/controlplane
-        operator: Exists
-      - effect: NoExecute
-        key: node-role.kubernetes.io/etcd
-        operator: Exists
-  clusterAgent:
-    image:
-      name: "gcr.io/datadoghq/cluster-agent:latest"
-    config:
-      externalMetrics:
-        enabled: false
-      admissionController:
-        enabled: false
+        - key: node-role.kubernetes.io/controlplane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/etcd
+          operator: Exists
+          effect: NoExecute
 ```
 
 {{% /tab %}}
@@ -457,26 +459,26 @@ datadog:
 Ressource Kubernetes DatadogAgent :
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: <CLÉ_API_DATADOG>
-    appKey: <CLÉ_APPLICATION_DATADOG>
-  agent:
-    config:
-      criSocket:
-        criSocketPath: /run/dockershim.sock
-  clusterAgent:
-    image:
-      name: "gcr.io/datadoghq/cluster-agent:latest"
-    config:
-      externalMetrics:
-        enabled: false
-      admissionController:
-        enabled: false
+  features:
+    admissionController:
+      enabled: false
+    externalMetricsServer:
+      enabled: false
+      useDatadogMetrics: false
+  global:
+    credentials:
+      apiKey: <CLÉ_API_DATADOG>
+      appKey: <CLÉ_APPLICATION_DATADOG>
+    criSocketPath: /run/dockershim.sock
+  override:
+    clusterAgent:
+      image:
+        name: gcr.io/datadoghq/cluster-agent:latest
 ```
 
 {{% /tab %}}
@@ -519,34 +521,34 @@ agents:
 Ressource Kubernetes DatadogAgent :
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiSecret:
-      secretName: datadog-secret
-      keyName: api-key
-    appSecret:
-      secretName: datadog-secret
-      keyName: app-key
   features:
-    # Activer le nouveau check `kubernetes_state_core`.
+    eventCollection:
+      collectKubernetesEvents: true
     kubeStateMetricsCore:
+      # Activer le nouveau check `kubernetes_state_core`.
       enabled: true
-  agent:
-    config:
-      kubelet:
-        # Définir tlsVerify sur false étant donné que les certificats Kubelet sont autosignés
-        tlsVerify: false
+  global:
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+      appSecret:
+        secretName: datadog-secret
+        keyName: app-key
+    kubelet:
+      # Définir tlsVerify sur false étant donné que les certificats Kubelet sont autosignés
+      tlsVerify: false
+  override:
+    nodeAgent:
       # Ajouter une tolérance pour que l'Agent puisse être planifié sur les nœuds du plan de contrôle.
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-  clusterAgent:
-    config:
-      collectEvents: true
 ```
 
 {{% /tab %}}
@@ -555,5 +557,5 @@ spec:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/helm-charts/tree/master/examples/datadog
-[2]: https://github.com/DataDog/datadog-operator/tree/master/examples/datadogagent
+[1]: https://github.com/DataDog/helm-charts/tree/main/examples/datadog
+[2]: https://github.com/DataDog/datadog-operator/tree/main/examples/datadogagent

--- a/content/fr/containers/kubernetes/installation.md
+++ b/content/fr/containers/kubernetes/installation.md
@@ -51,7 +51,7 @@ Pour utiliser certaines fonctionnalités des versions récentes de Kubernetes, v
 {{< tabs >}}
 {{% tab "Operator" %}}
 
-<div class="alert alert-warning">L'Operator Datadog est en bêta publique. Si vous souhaitez nous faire part de vos remarques ou de vos questions, contactez l'<a href="/help">assistance Datadog</a>.</div>
+<div class="alert alert-warning">L'Operator Datadog est disponible pour le grand public depuis la version `1.0.0`, il prend en charge la version `v2alpha1` du `DatadogAgent` .</div>
 
 [L'Operator Datadog][1] est une fonctionnalité permettant de déployer l'Agent Datadog sur Kubernetes et OpenShift. L'Operator transmet des données sur le statut, la santé et les erreurs du déploiement dans le statut de sa ressource personnalisée. Ses paramètres de niveau supérieur permettent également de réduire les erreurs de configuration.
 
@@ -59,7 +59,7 @@ Pour utiliser certaines fonctionnalités des versions récentes de Kubernetes, v
 
 L'utilisation de l'Operator Datadog nécessite les prérequis suivants :
 
-- **Cluster Kubernetes version >= v1.14.X** : les tests ont été réalisés sur les versions >= `1.14.0`. Néanmoins, les versions `>= v1.11.0` devraient également fonctionner. Pour les versions plus anciennes, en raison de la prise en charge limitée de la CRD, il se peut que l'Operator ne fonctionne pas comme prévu.
+- **Cluster Kubernetes version >= v1.20.X** : les tests ont été réalisés sur les versions >= `1.20.0`. Néanmoins, les versions `>= v1.11.0` devraient également fonctionner. Pour les versions plus anciennes, en raison de la prise en charge limitée de la CRD, il se peut que l'Operator ne fonctionne pas comme prévu.
 - [`Helm`][2] pour le déploiement de `datadog-operator`.
 - [Interface de ligne de commande `Kubectl`][3] pour l'installation de `datadog-agent`.
 
@@ -83,26 +83,28 @@ Pour déployer l'Agent Datadog avec l'Operator le plus rapidement possible, cons
 
 2. Créez un fichier avec les spécifications de la configuration de déploiement de votre Agent Datadog. Voici la configuration la plus simple :
 
-   ```yaml
-   apiVersion: datadoghq.com/v1alpha1
-   kind: DatadogAgent
-   metadata:
-     name: datadog
-   spec:
-     credentials:
-       apiSecret:
-         secretName: datadog-secret
-         keyName: api-key
-       appSecret:
-         secretName: datadog-secret
-         keyName: app-key
-     agent:
-       image:
-         name: "gcr.io/datadoghq/agent:latest"
-     clusterAgent:
-       image:
-         name: "gcr.io/datadoghq/cluster-agent:latest"
-   ```
+```yaml
+kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: datadog
+spec:
+  global:
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+      appSecret:
+        secretName: datadog-secret
+        keyName: app-key
+  override:
+    clusterAgent:
+      image:
+        name: gcr.io/datadoghq/cluster-agent:latest
+    nodeAgent:
+      image:
+        name: gcr.io/datadoghq/agent:latest
+```
 
 3. Déployez l'Agent Datadog avec le fichier de configuration ci-dessus :
    ```shell
@@ -125,15 +127,21 @@ Pour en savoir plus sur la configuration de l'Operator, notamment sur l'utilisat
 (Facultatif) Pour exécuter une installation sans privilèges, ajoutez le bloc suivant à la [ressource personnalisée Datadog][8] :
 
 ```yaml
-agent:
-  config:
-    securityContext:
-      runAsUser: <ID_UTILISATEUR>
-      supplementalGroups:
-        - <ID_GROUPE_DOCKER>
+kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: placeholder
+  namespace: placeholder
+spec:
+  override:
+    nodeAgent:
+      securityContext:
+        runAsUser: 1 # <ID_UTILISATEUR>
+        supplementalGroups:
+          - 123 # <ID_GROUPE_DOCKER>
 ```
 
-`<USER_ID>` correspond à l'UID utilisé pour exécuter l'agent et `<DOCKER_GROUP_ID>` à l'ID du groupe auquel appartient le socket containerd ou Docker.
+`<ID_UTILISATEUR>` correspond à l'UID utilisé pour exécuter l'agent et `<ID_GROUPE_DOCKER>` à l'ID du groupe auquel appartient le socket containerd ou Docker.
 
 ## Registres de conteneurs
 
@@ -237,7 +245,7 @@ datadog:
         - <ID_GROUPE_DOCKER>
 ```
 
-`<USER_ID>` correspond à l'UID utilisé pour exécuter l'agent et `<DOCKER_GROUP_ID>` à l'ID du groupe auquel appartient le socket containerd ou docker.
+`<ID_UTILISATEUR>` correspond à l'UID utilisé pour exécuter l'agent et `<ID_GROUPE_DOCKER>` à l'ID du groupe auquel appartient le socket containerd ou docker.
 
 [1]: https://v3.helm.sh/docs/intro/install/
 [2]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
@@ -340,7 +348,7 @@ Pour installer l'Agent Datadog sur votre cluster Kubernetes :
         - <ID_GROUPE_DOCKER>
 ```
 
-`<USER_ID>` correspond à l'UID utilisé pour exécuter l'agent et `<DOCKER_GROUP_ID>` à l'ID du groupe auquel appartient le socket containerd ou docker.
+`<ID_UTILISATEUR>` correspond à l'UID utilisé pour exécuter l'agent et `<ID_GROUPE_DOCKER>` à l'ID du groupe auquel appartient le socket containerd ou docker.
 
 [1]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 [2]: /resources/yaml/datadog-agent-all-features.yaml

--- a/content/fr/integrations/kubernetes_state_core.md
+++ b/content/fr/integrations/kubernetes_state_core.md
@@ -69,18 +69,18 @@ datadog:
 Pour activer le check `kubernetes_state_core`, le paramètre `spec.features.kubeStateMetricsCore.enabled` doit être défini sur `true` dans la ressource DatadogAgent :
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: <CLÉ_API_DATADOG>
-    appKey: <CLÉ_APPLICATION_DATADOG>
   features:
     kubeStateMetricsCore:
       enabled: true
-  # (...)
+  global:
+    credentials:
+      apiKey: <CLÉ_API_DATADOG>
+      appKey: <CLÉ_APPLICATION_DATADOG>
 ```
 
 Remarque : l'Operator Datadog 0.7.0 ou ultérieur est requis.

--- a/content/fr/network_monitoring/performance/setup.md
+++ b/content/fr/network_monitoring/performance/setup.md
@@ -353,22 +353,21 @@ Si l'[Agent est déjà exécuté avec un manifeste][4] :
 [4]: /fr/agent/kubernetes/
 {{% /tab %}}
 {{% tab "Operator" %}}
-<div class="alert alert-warning">L'Operator Datadog est en bêta publique. Si vous souhaitez nous faire part de vos remarques ou de vos questions, contactez l'<a href="/help">assistance Datadog</a>.</div>
+<div class="alert alert-warning">L'Operator Datadog est disponible pour le grand public depuis la version `1.0.0`, il prend en charge la version `v2alpha1` du `DatadogAgent` .</div>
 
 [L'Operator Datadog][1] est une fonctionnalité permettant de déployer l'Agent Datadog sur Kubernetes et OpenShift. L'Operator transmet des données sur le statut, la santé et les erreurs du déploiement dans le statut de sa ressource personnalisée. Ses paramètres de niveau supérieur permettent également de réduire les erreurs de configuration.
 
 Pour activer NPM dans l'Operator, appliquez la configuration suivante :
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: placeholder
   namespace: placeholder
 spec:
-  # (...)
   features:
-    networkMonitoring:
+    npm:
       enabled: true
 ```
 

--- a/content/ja/agent/guide/changing_container_registry.md
+++ b/content/ja/agent/guide/changing_container_registry.md
@@ -63,16 +63,17 @@ Datadog Operator で Datadog Agent (または Datadog Cluster Agent) をデプ�
 
 1. Datadog Agent のマニフェストファイルを更新し、デフォルトのレジストリ (`gcr.io/datadoghq`) をオーバーライドします。例えば、`public.ecr.aws/datadog` の場合:
 
-    ```yaml
-    apiVersion: datadoghq.com/v1alpha1
-    kind: DatadogAgent
-    metadata:
-      name: datadog
-    spec:
-      // ..
-      registry: gcr.io/datadoghq
-    ```
-2. `spec.agents.image.name`、`spec.clusterAgent.image.name` および `spec.clusterChecksRunner.image.name` フィールドに対するすべてのオーバーライドを削除します。
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    registry: gcr.io/datadoghq
+  // ..
+```
+2. `spec.override.nodeAgent.image.name`、``spec.override.clusterAgent.image.name` および `spec.override.clusterChecksRunner.image.name` フィールドに対するすべてのオーバーライドを削除します。
 
 Datadog Operator の詳細については、[Operator を使用して Agent をデプロイする][4]を参照してください。
 

--- a/content/ja/agent/guide/operator-advanced.md
+++ b/content/ja/agent/guide/operator-advanced.md
@@ -90,20 +90,21 @@ helm delete datadog
 `datadog-agent.yaml` ファイルを次のコンフィギュレーションで更新して、`DaemonSet` の `Daemonset.spec.template` に許容範囲を追加します。
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: "<DATADOG_API_KEY>"
-    appKey: "<DATADOG_APP_KEY>"
-  agent:
-    image:
-      name: "gcr.io/datadoghq/agent:latest"
-    config:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+      appKey: <DATADOG_APP_KEY>
+  override:
+    nodeAgent:
+      image:
+        name: gcr.io/datadoghq/agent:latest
       tolerations:
-       - operator: Exists
+        - operator: Exists
 ```
 
 この新しいコンフィギュレーションを適用します。

--- a/content/ja/agent/troubleshooting/hostname_containers.md
+++ b/content/ja/agent/troubleshooting/hostname_containers.md
@@ -70,15 +70,14 @@ datadog:
 `DatadogAgent` Kubernetes Resource:
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  agent:
-    config:
-      kubelet:
-        tlsVerify: false
+  global:
+    kubelet:
+      tlsVerify: false
 ```
 
 {{% /tab %}}
@@ -139,17 +138,18 @@ datadog:
 `DatadogAgent` Kubernetes Resource:
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  agent:
-    env:
-      - name: DD_HOSTNAME
-        valueFrom:
-          fieldRef:
-            fieldPath: spec.nodeName
+  override:
+    nodeAgent:
+      env:
+        - name: DD_HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
 ```
 
 {{% /tab %}}

--- a/content/ja/containers/cluster_agent/endpointschecks.md
+++ b/content/ja/containers/cluster_agent/endpointschecks.md
@@ -82,17 +82,16 @@ nginx   ClusterIP   10.3.253.165   <none>        80/TCP    1h    app=nginx
 {{< tabs >}}
 {{% tab "Operator" %}}
 
-エンドポイントチェックのディスパッチは、Cluster Agent の Operator デプロイメントで `clusterAgent.config.clusterChecksEnabled` 構成キーを使用して有効にします。
+エンドポイントチェックのディスパッチは、Cluster Agent の Operator デプロイメントで `features.clusterChecks.enabled` 構成キーを使用して有効にします。
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  # (...)
-  clusterAgent:
-    config:
-      clusterChecksEnabled: true
+  features:
+    clusterChecks:
+      enabled: true
 ```
 
 この構成では、Cluster Agent と ノードベースの Agent との間で、クラスターチェックとエンドポイントチェックの両方のディスパッチが可能です。

--- a/content/ja/containers/guide/cluster_agent_autoscaling_metrics.md
+++ b/content/ja/containers/guide/cluster_agent_autoscaling_metrics.md
@@ -66,18 +66,21 @@ Helm の Cluster Agent で外部メトリクスサーバーを有効にするに
 Datadog Operator で管理する Cluster Agent で外部メトリクスサーバーを有効にするには、まず [Datadog Operator をセットアップします][1]。次に、`DatadogAgent` カスタムリソースで `clusterAgent.config.externalMetrics.enabled` を `true` に設定します。
 
   ```yaml
-  apiVersion: datadoghq.com/v1alpha1
-  kind: DatadogAgent
-  metadata:
-    name: datadog
-  spec:
+kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: datadog
+spec:
+  features:
+    externalMetricsServer:
+      enabled: true
+      useDatadogMetrics: false
+  global:
     credentials:
       apiKey: <DATADOG_API_KEY>
-  clusterAgent:
-    config:
-      externalMetrics:
-        enabled: true
-    replicas: 2
+  override:
+    clusterAgent:
+      replicas: 2
   ```
 
 Operator により必要な RBAC コンフィギュレーションが自動的に更新され、Kubernetes が利用可能な `Service` と `APIService` がそれぞれ設定されます。
@@ -221,21 +224,23 @@ Helm、Datadog Operator または Daemonset を使用して `DatadogMetric` を�
 
 `DatadogMetric` CRD の使用をアクティブにするには、`DatadogAgent` カスタムリソースを更新し、`clusterAgent.config.externalMetrics.useDatadogMetrics` を ` true` に設定します。
 
-  ```yaml
-  apiVersion: datadoghq.com/v1alpha1
-  kind: DatadogAgent
-  metadata:
-    name: datadog
-  spec:
+```yaml
+kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: datadog
+spec:
+  features:
+    externalMetricsServer:
+      enabled: true
+      useDatadogMetrics: true
+  global:
     credentials:
       apiKey: <DATADOG_API_KEY>
-  clusterAgent:
-    config:
-      externalMetrics:
-        enabled: true
-        useDatadogMetrics: true
-    replicas: 2
-  ```
+  override:
+    clusterAgent:
+      replicas: 2
+```
 
 Operator により必要な RBAC コンフィギュレーションが自動的に更新され、Cluster Agent に `DatadogMetric` リソースを介してこれらの HPA クエリを管理するよう指示します。
 

--- a/content/ja/containers/kubernetes/control_plane.md
+++ b/content/ja/containers/kubernetes/control_plane.md
@@ -55,7 +55,7 @@ API サーバーインテグレーションは自動的に構成されます。D
 
 カスタム `values.yaml`:
 
-```
+```yaml
 datadog:
   apiKey: <DATADOG_API_KEY>
   appKey: <DATADOG_APP_KEY>
@@ -93,43 +93,47 @@ agents:
 
 DatadogAgent Kubernetes Resource:
 
-```
-apiVersion: datadoghq.com/v1alpha1
+```yaml
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: <DATADOG_API_KEY>
-    appKey: <DATADOG_APP_KEY>
-  clusterName: <CLUSTER_NAME>
-  agent:
-    image:
-      name: "gcr.io/datadoghq/agent:latest"
-    config:
-      confd:
-        configMapName: datadog-checks
-      kubelet:
-        tlsVerify: false
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+      appKey: <DATADOG_APP_KEY>
+    clusterName: <CLUSTER_NAME>
+    kubelet:
+      tlsVerify: false
+  override:
+    clusterAgent:
+      image:
+        name: gcr.io/datadoghq/cluster-agent:latest
+    nodeAgent:
+      image:
+        name: gcr.io/datadoghq/agent:latest
+      extraConfd:
+        configMap:
+          name: datadog-checks
+      containers:
+        agent:
+          volumeMounts:
+            - name: etcd-certs
+              readOnly: true
+              mountPath: /host/etc/kubernetes/pki/etcd
+            - name: disable-etcd-autoconf
+              mountPath: /etc/datadog-agent/conf.d/etcd.d
       volumes:
-        - hostPath:
+        - name: etcd-certs
+          hostPath:
             path: /etc/kubernetes/pki/etcd
-          name: etcd-certs
         - name: disable-etcd-autoconf
           emptyDir: {}
-      volumeMounts:
-        - name: etcd-certs
-          mountPath: /host/etc/kubernetes/pki/etcd
-          readOnly: true
-        - name: disable-etcd-autoconf
-          mountPath: /etc/datadog-agent/conf.d/etcd.d
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-  clusterAgent:
-    image:
-      name: "gcr.io/datadoghq/cluster-agent:latest"
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -165,7 +169,7 @@ Controller Manager インスタンスと Scheduler インスタンスの安全�
 
 カスタム `values.yaml`:
 
-```
+```yaml
 datadog:
   apiKey: <DATADOG_API_KEY>
   appKey: <DATADOG_APP_KEY>
@@ -219,51 +223,55 @@ agents:
 
 DatadogAgent Kubernetes Resource:
 
-```
-apiVersion: datadoghq.com/v1alpha1
+```yaml
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: <DATADOG_API_KEY>
-    appKey: <DATADOG_APP_KEY>
-  clusterName: <CLUSTER_NAME>
-  agent:
-    image:
-      name: "gcr.io/datadoghq/agent:latest"
-    config:
-      confd:
-        configMapName: datadog-checks
-      kubelet:
-        tlsVerify: false
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+      appKey: <DATADOG_APP_KEY>
+    clusterName: <CLUSTER_NAME>
+    kubelet:
+      tlsVerify: false
+  override:
+    clusterAgent:
+      image:
+        name: gcr.io/datadoghq/cluster-agent:latest
+    nodeAgent:
+      image:
+        name: gcr.io/datadoghq/agent:latest
+      extraConfd:
+        configMap:
+          name: datadog-checks
+      containers:
+        agent:
+          volumeMounts:
+            - name: etcd-certs
+              readOnly: true
+              mountPath: /host/etc/kubernetes/pki/etcd
+            - name: disable-etcd-autoconf
+              mountPath: /etc/datadog-agent/conf.d/etcd.d
+            - name: disable-scheduler-autoconf
+              mountPath: /etc/datadog-agent/conf.d/kube_scheduler.d
+            - name: disable-controller-manager-autoconf
+              mountPath: /etc/datadog-agent/conf.d/kube_controller_manager.d
       volumes:
-        - hostPath:
-            path: /etc/kubernetes/pki/etcd
-          name: etcd-certs
-        - name: disable-etcd-autoconf
-          emptyDir: {}
-        - name: disable-scheduler-autoconf
-          emptyDir: {}
-        - name: disable-controller-manager-autoconf
-          emptyDir: {}
-      volumeMounts:
         - name: etcd-certs
-          mountPath: /host/etc/kubernetes/pki/etcd
-          readOnly: true
+          hostPath:
+            path: /etc/kubernetes/pki/etcd
         - name: disable-etcd-autoconf
-          mountPath: /etc/datadog-agent/conf.d/etcd.d
+          emptyDir: {}
         - name: disable-scheduler-autoconf
-          mountPath: /etc/datadog-agent/conf.d/kube_scheduler.d
+          emptyDir: {}
         - name: disable-controller-manager-autoconf
-          mountPath: /etc/datadog-agent/conf.d/kube_controller_manager.d
+          emptyDir: {}
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-  clusterAgent:
-    image:
-      name: "gcr.io/datadoghq/cluster-agent:latest"
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -397,25 +405,27 @@ clusterChecksRunner:
 {{% tab "Operator" %}}
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
-...
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: datadog
 spec:
-  agent:
+  override:
     clusterChecksRunner:
-      config:
-        volumes:
+      containers:
+        agent:
+          volumeMounts:
+            - name: etcd-certs
+              readOnly: true
+              mountPath: /etc/etcd-certs
+            - name: disable-etcd-autoconf
+              mountPath: /etc/datadog-agent/conf.d/etcd.d
+      volumes:
         - name: etcd-certs
           secret:
             secretName: kube-etcd-client-certs
         - name: disable-etcd-autoconf
           emptyDir: {}
-        volumeMounts:
-        - name: etcd-certs
-          mountPath: /etc/etcd-certs
-          readOnly: true
-        - name: disable-etcd-autoconf
-          mountPath: /etc/datadog-agent/conf.d/etcd.d
 ```
 
 {{% /tab %}}
@@ -529,25 +539,27 @@ clusterChecksRunner:
 {{% tab "Operator" %}}
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
-...
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: datadog
 spec:
-  agent:
+  override:
     clusterChecksRunner:
-      config:
-        volumes:
-          - name: etcd-certs
-            hostPath:
-              path: /etc/etcd
-          - name: disable-etcd-autoconf
-            emptyDir: {}
-        volumeMounts:
-          - name: etcd-certs
-            mountPath: /host/etc/etcd
-            readOnly: true
-          - name: disable-etcd-autoconf
-            mountPath: /etc/datadog-agent/conf.d/etcd.d
+      containers:
+        agent:
+          volumeMounts:
+            - name: etcd-certs
+              readOnly: true
+              mountPath: /host/etc/etcd
+            - name: disable-etcd-autoconf
+              mountPath: /etc/datadog-agent/conf.d/etcd.d
+      volumes:
+        - name: etcd-certs
+          hostPath:
+            path: /etc/etcd
+        - name: disable-etcd-autoconf
+          emptyDir: {}
 ```
 
 {{% /tab %}}
@@ -703,7 +715,7 @@ spec:
 
 カスタム `values.yaml`:
 
-```
+```yaml
 datadog:
   apiKey: <DATADOG_API_KEY>
   appKey: <DATADOG_APP_KEY>
@@ -733,38 +745,41 @@ agents:
 
 DatadogAgent Kubernetes Resource:
 
-```
-apiVersion: datadoghq.com/v1alpha1
+```yaml
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: <DATADOG_API_KEY>
-    appKey: <DATADOG_APP_KEY>
-  clusterName: <CLUSTER_NAME>
-  agent:
-    config:
-      kubelet:
-        tlsVerify: false
+  features:
+    clusterChecks:
+      enabled: true
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+      appKey: <DATADOG_APP_KEY>
+    clusterName: <CLUSTER_NAME>
+    kubelet:
+      tlsVerify: false
+  override:
+    nodeAgent:
+      containers:
+        agent:
+          volumeMounts:
+            - name: etcd-certs
+              readOnly: true
+              mountPath: /host/opt/rke/etc/kubernetes/ssl
       volumes:
-        - hostPath:
-            path: /opt/rke/etc/kubernetes/ssl
-          name: etcd-certs
-      volumeMounts:
         - name: etcd-certs
-          mountPath: /host/opt/rke/etc/kubernetes/ssl
-          readOnly: true
+          hostPath:
+            path: /opt/rke/etc/kubernetes/ssl
       tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/controlplane
+        - key: node-role.kubernetes.io/controlplane
           operator: Exists
-        - effect: NoExecute
-          key: node-role.kubernetes.io/etcd
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/etcd
           operator: Exists
-  clusterAgent:
-    config:
-      clusterChecksEnabled: true
+          effect: NoExecute
 ```
 
 {{% /tab %}}
@@ -820,7 +835,7 @@ Etcd は Kubernetes 外の Docker で実行され、Etcd サービスとの通�
 
 カスタム `values.yaml`:
 
-```
+```yaml
 datadog:
   apiKey: <DATADOG_API_KEY>
   appKey: <DATADOG_APP_KEY>
@@ -850,38 +865,41 @@ agents:
 
 DatadogAgent Kubernetes Resource:
 
-```
-apiVersion: datadoghq.com/v1alpha1
+```yaml
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: <DATADOG_API_KEY>
-    appKey: <DATADOG_APP_KEY>
-  clusterName: <CLUSTER_NAME>
-  agent:
-    config:
-      kubelet:
-        tlsVerify: false
+  features:
+    clusterChecks:
+      enabled: true
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+      appKey: <DATADOG_APP_KEY>
+    clusterName: <CLUSTER_NAME>
+    kubelet:
+      tlsVerify: false
+  override:
+    nodeAgent:
+      containers:
+        agent:
+          volumeMounts:
+            - name: etcd-certs
+              readOnly: true
+              mountPath: /host/opt/rke/etc/kubernetes/ssl
       volumes:
-        - hostPath:
-            path: /opt/rke/etc/kubernetes/ssl
-          name: etcd-certs
-      volumeMounts:
         - name: etcd-certs
-          mountPath: /host/opt/rke/etc/kubernetes/ssl
-          readOnly: true
+          hostPath:
+            path: /opt/rke/etc/kubernetes/ssl
       tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/controlplane
+        - key: node-role.kubernetes.io/controlplane
           operator: Exists
-        - effect: NoExecute
-          key: node-role.kubernetes.io/etcd
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/etcd
           operator: Exists
-  clusterAgent:
-    config:
-      clusterChecksEnabled: true
+          effect: NoExecute
 ```
 
 {{% /tab %}}

--- a/content/ja/containers/kubernetes/installation.md
+++ b/content/ja/containers/kubernetes/installation.md
@@ -82,26 +82,28 @@ Datadog Operator を使用するには、次の前提条件が必要です。
 
 2. Datadog Agent のデプロイコンフィギュレーションを使用してファイルを作成します。最も単純なコンフィギュレーションは次のとおりです。
 
-   ```yaml
-   apiVersion: datadoghq.com/v1alpha1
-   kind: DatadogAgent
-   metadata:
-     name: datadog
-   spec:
-     credentials:
-       apiSecret:
-         secretName: datadog-secret
-         keyName: api-key
-       appSecret:
-         secretName: datadog-secret
-         keyName: app-key
-     agent:
-       image:
-         name: "gcr.io/datadoghq/agent:latest"
-     clusterAgent:
-       image:
-         name: "gcr.io/datadoghq/cluster-agent:latest"
-   ```
+```yaml
+kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: datadog
+spec:
+  global:
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+      appSecret:
+        secretName: datadog-secret
+        keyName: app-key
+  override:
+    clusterAgent:
+      image:
+        name: gcr.io/datadoghq/cluster-agent:latest
+    nodeAgent:
+      image:
+        name: gcr.io/datadoghq/agent:latest
+```
 
 3. 上記のコンフィギュレーションファイルを使用して Datadog Agent をデプロイします。
    ```shell
@@ -124,12 +126,18 @@ helm delete my-datadog-operator
 (オプション) 非特権インストールを実行するには、[Datadog カスタムリソース (CR)][8] に以下を追加します。
 
 ```yaml
-agent:
-  config:
-    securityContext:
-      runAsUser: <USER_ID>
-      supplementalGroups:
-        - <DOCKER_GROUP_ID>
+kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: placeholder
+  namespace: placeholder
+spec:
+  override:
+    nodeAgent:
+      securityContext:
+        runAsUser: 1 # <USER_ID>
+        supplementalGroups:
+          - 123 # "<DOCKER_GROUP_ID>"
 ```
 
 `<USER_ID>` が、Agent を実行する UID で、`<DOCKER_GROUP_ID>` が、Docker または Containerd ソケットを所有するグループ ID の場合。

--- a/content/ja/getting_started/containers/datadog_operator.md
+++ b/content/ja/getting_started/containers/datadog_operator.md
@@ -36,11 +36,16 @@ title: Datadog Operator の概要
 
 3. `DatadogAgent` のデプロイメント構成の仕様を記述した `datadog-agent.yaml` ファイルを作成します。以下のサンプル構成では、メトリクス、ログ、APM を有効にしています。
   ```yaml
-  apiVersion: datadoghq.com/v1alpha1
+  apiVersion: datadoghq.com/v2alpha1
   kind: DatadogAgent
   metadata:
     name: datadog
   spec:
+    features:
+      apm:
+        enabled: true
+      logCollection:
+        enabled: true
     credentials:
       apiSecret:
         secretName: datadog-secret
@@ -48,11 +53,6 @@ title: Datadog Operator の概要
       appSecret:
         secretName: datadog-secret
         keyName: app-key
-    agent:
-      apm:
-        enabled: true
-      log:
-        enabled: true
   ```
 
 4. Datadog Agent をデプロイします。

--- a/content/ja/integrations/kubernetes_state_core.md
+++ b/content/ja/integrations/kubernetes_state_core.md
@@ -70,18 +70,18 @@ datadog:
 `kubernetes_state_core` のチェックを有効にするには、DatadogAgent リソースの設定 `spec.features.kubeStateMetricsCore.enabled` を `true` に設定する必要があります。
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: <DATADOG_API_KEY>
-    appKey: <DATADOG_APP_KEY>
   features:
     kubeStateMetricsCore:
       enabled: true
-  # (...)
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+      appKey: <DATADOG_APP_KEY>
 ```
 
 注: Datadog Operator v0.7.0 以降が必要です。

--- a/content/ja/network_monitoring/performance/setup.md
+++ b/content/ja/network_monitoring/performance/setup.md
@@ -369,15 +369,14 @@ Helm をお使いでない場合は、Kubernetes を使用してネットワー�
 Operator でネットワークパフォーマンスのモニタリングを有効化するには、次のコンフィギュレーションを使用します。
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: placeholder
   namespace: placeholder
 spec:
-  # (...)
   features:
-    networkMonitoring:
+    npm:
       enabled: true
 ```
 

--- a/content/kr/agent/guide/operator-advanced.md
+++ b/content/kr/agent/guide/operator-advanced.md
@@ -90,20 +90,21 @@ helm delete datadog
 `datadog-agent.yaml` 파일을 다음의 설정으로 업데이트하여 `DaemonSet`의 `Daemonset.spec.template`에 톨러레이션을 추가할 수 있습니다.
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiKey: "<DATADOG_API_KEY>"
-    appKey: "<DATADOG_APP_KEY>"
-  agent:
-    image:
-      name: "gcr.io/datadoghq/agent:latest"
-    config:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+      appKey: <DATADOG_APP_KEY>
+  override:
+    nodeAgent:
+      image:
+        name: gcr.io/datadoghq/agent:latest
       tolerations:
-       - operator: Exists
+        - operator: Exists
 ```
 
 다음의 새 설정을 적용하세요.

--- a/content/kr/containers/cluster_agent/endpointschecks.md
+++ b/content/kr/containers/cluster_agent/endpointschecks.md
@@ -82,18 +82,17 @@ name: nginx-66d557f4cf-x2wzq
 {{< tabs >}}
 {{% tab "Operator" %}}
 
-`clusterAgent.config.clusterChecksEnabled` 설정 키를 사용하여 클러스터 에이전트의 책임자(Operator) 배포에서 엔드포인트 점검 디스패칭을 사용할 수 있습니다.
+`features.clusterChecks.enabled` 설정 키를 사용하여 클러스터 에이전트의 책임자(Operator) 배포에서 엔드포인트 점검 디스패칭을 사용할 수 있습니다.
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
 metadata:
-name: datadog
+  name: datadog
 spec:
-# (...)
-clusterAgent:
-config:
-clusterChecksEnabled: true
-
+  features:
+    clusterChecks:
+      enabled: true
+```
 이 설정으로 클러스터 에이전트와 에이전트 사이에 클러스터 점검 및 엔드포인트 점검 디스패칭을 모두 사용할 수 있습니다.
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Updating the references to the v2alpha1 version of the Datadog Agent in the Public documentation to prepare for the GA of the Datadog Operator.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

I was not able to translate the:
> <div class="alert alert-warning">The Datadog Operator is now Generally Available with the `1.0.0` version and it reconciles the version `v2alpha1` of the DatadogAgent Custom Resource. </div>

in ja and kr. French one might need approval too.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
