### PR TITLE
Node.js: add instruction for bundlers/esbuild

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -131,7 +131,7 @@ After the Agent is installed, follow these steps to add the Datadog tracing libr
 
 #### JavaScript
 
-```js
+```javascript
 // This line must come before importing any instrumented module.
 const tracer = require('dd-trace').init();
 ```
@@ -170,6 +170,41 @@ node --require dd-trace/init app.js
 
 **Note:** This approach requires using environment variables for all
 configuration of the tracer.
+
+### Bundling
+
+Generally, `dd-trace` works by intercepting `require()` calls that a Node.js application makes when loading modules. This includes modules that are built-in to Node.js, like the `fs` module for accessing the filesystem, as well as modules installed from the npm registry, like the `pg` database module.
+
+Also generally, bundlers work by crawling all of the `require()` calls that an application makes to files on disk, replacing the `require()` calls with custom code, and then concatenating all of the resulting JavaScript into one "bundled" file. When a built-in module is loaded, like `require('fs')`, that call can then remain the same in the resulting bundle.
+
+Fundamentally APM tools like `dd-trace` stop working at this point. Perhaps they continue to intercept the calls for built-in modules but don't intercept calls to third party libraries. This means that by default when you bundle a `dd-trace` app with a bundler it is likely to capture information about disk access (via `fs`) and outbound HTTP requests (via `http`), but will otherwise omit calls to third party libraries (like extracting incoming request route information for the `express` framework or showing which query is run for the `mysql` database client).
+
+To get around this, one can treat all third party modules, or at least third party modules that the APM needs to instrument, as being "external" to the bundler. With this setting the instrumented modules remain on disk and continue to be loaded via `require()` while the non-instrumented modules are bundled. Sadly this results in a build with many extraneous files and starts to defeat the purpose of bundling.
+
+For these reasons it's necessary to have custom-built bundler plugins. Such plugins are able to instruct the bundler on how to behave, injecting intermediary code and otherwise intercepting the "translated" `require()` calls. The result is that many more packages are then included in the bundled JavaScript file. Some applications can have 100% of modules bundled, however native modules still need to remain external to the bundle.
+
+#### Esbuild Support
+
+This library provides experimental esbuild support in the form of an esbuild plugin, and requires at least Node.js v14.17. To use the plugin, make sure you have `dd-trace@3+` installed, and then require the `dd-trace/esbuild` module when building your bundle.
+
+Here's an example of how one might use `dd-trace` with esbuild:
+
+```javascript
+const ddPlugin = require('dd-trace/esbuild')
+const esbuild = require('esbuild')
+
+esbuild.build({
+  entryPoints: ['app.js'],
+  bundle: true,
+  outfile: 'out.js',
+  plugins: [ddPlugin],
+  platform: 'node', // allows built-in modules to be required
+  target: ['node16']
+}).catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+```
 
 ## Configuration
 

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -179,13 +179,13 @@ Also generally, bundlers work by crawling all of the `require()` calls that an a
 
 Fundamentally APM tools like `dd-trace` stop working at this point. Perhaps they continue to intercept the calls for built-in modules but don't intercept calls to third party libraries. This means that by default when you bundle a `dd-trace` app with a bundler it is likely to capture information about disk access (via `fs`) and outbound HTTP requests (via `http`), but will otherwise omit calls to third party libraries (like extracting incoming request route information for the `express` framework or showing which query is run for the `mysql` database client).
 
-To get around this, one can treat all third party modules, or at least third party modules that the APM needs to instrument, as being "external" to the bundler. With this setting the instrumented modules remain on disk and continue to be loaded via `require()` while the non-instrumented modules are bundled. Sadly this results in a build with many extraneous files and starts to defeat the purpose of bundling.
+To get around this, one can treat all third party modules, or at least third party modules that the APM needs to instrument, as being "external" to the bundler. With this setting the instrumented modules remain on disk and continue to be loaded with `require()` while the non-instrumented modules are bundled. Sadly this results in a build with many extraneous files and starts to defeat the purpose of bundling.
 
 For these reasons it's necessary to have custom-built bundler plugins. Such plugins are able to instruct the bundler on how to behave, injecting intermediary code and otherwise intercepting the "translated" `require()` calls. The result is that many more packages are then included in the bundled JavaScript file. Some applications can have 100% of modules bundled, however native modules still need to remain external to the bundle.
 
-#### Esbuild Support
+#### Esbuild support
 
-This library provides experimental esbuild support in the form of an esbuild plugin, and requires at least Node.js v14.17. To use the plugin, make sure you have `dd-trace@3+` installed, and then require the `dd-trace/esbuild` module when building your bundle.
+This library provides experimental esbuild support in the form of an esbuild plugin, and currently requires at least Node.js v16.17 or v18.7. To use the plugin, make sure you have `dd-trace@3+` installed, and then require the `dd-trace/esbuild` module when building your bundle.
 
 Here's an example of how one might use `dd-trace` with esbuild:
 

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -177,7 +177,9 @@ configuration of the tracer.
 
 Bundlers crawl all of the `require()` calls that an application makes to files on disk. It replaces the `require()` calls with custom code and combines all of the resulting JavaScript into one "bundled" file. When a built-in module is loaded, such as `require('fs')`, that call can then remain the same in the resulting bundle.
 
-Fundamentally APM tools like `dd-trace` stop working at this point. Perhaps they continue to intercept the calls for built-in modules but don't intercept calls to third party libraries. This means that by default when you bundle a `dd-trace` app with a bundler it is likely to capture information about disk access (via `fs`) and outbound HTTP requests (via `http`), but will otherwise omit calls to third party libraries (like extracting incoming request route information for the `express` framework or showing which query is run for the `mysql` database client).
+APM tools like `dd-trace` stop working at this point. They can continue to intercept the calls for built-in modules but don't intercept calls to third party libraries. This means that when you bundle a `dd-trace` app with a bundler it is likely to capture information about disk access (through `fs`) and outbound HTTP requests (through `http`), but omit calls to third party libraries. For example:
+- Extracting incoming request route information for the `express` framework. 
+- Showing which query is run for the `mysql` database client.
 
 To get around this, one can treat all third party modules, or at least third party modules that the APM needs to instrument, as being "external" to the bundler. With this setting the instrumented modules remain on disk and continue to be loaded with `require()` while the non-instrumented modules are bundled. Sadly this results in a build with many extraneous files and starts to defeat the purpose of bundling.
 

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -181,7 +181,7 @@ APM tools like `dd-trace` stop working at this point. They can continue to inter
 - Extracting incoming request route information for the `express` framework. 
 - Showing which query is run for the `mysql` database client.
 
-To get around this, one can treat all third party modules, or at least third party modules that the APM needs to instrument, as being "external" to the bundler. With this setting the instrumented modules remain on disk and continue to be loaded with `require()` while the non-instrumented modules are bundled. Sadly this results in a build with many extraneous files and starts to defeat the purpose of bundling.
+A common workaround is to treat all third party modules that the APM needs to instrument as being "external" to the bundler. With this setting the instrumented modules remain on disk and continue to be loaded with `require()` while the non-instrumented modules are bundled. However, this results in a build with many extraneous files and starts to defeat the purpose of bundling.
 
 For these reasons it's necessary to have custom-built bundler plugins. Such plugins are able to instruct the bundler on how to behave, injecting intermediary code and otherwise intercepting the "translated" `require()` calls. The result is that many more packages are then included in the bundled JavaScript file. Some applications can have 100% of modules bundled, however native modules still need to remain external to the bundle.
 

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -175,7 +175,7 @@ configuration of the tracer.
 
 `dd-trace` works by intercepting `require()` calls that a Node.js application makes when loading modules. This includes modules that are built-in to Node.js, like the `fs` module for accessing the filesystem, as well as modules installed from the NPM registry, like the `pg` database module.
 
-Also generally, bundlers work by crawling all of the `require()` calls that an application makes to files on disk, replacing the `require()` calls with custom code, and then concatenating all of the resulting JavaScript into one "bundled" file. When a built-in module is loaded, like `require('fs')`, that call can then remain the same in the resulting bundle.
+Bundlers crawl all of the `require()` calls that an application makes to files on disk. It replaces the `require()` calls with custom code and combines all of the resulting JavaScript into one "bundled" file. When a built-in module is loaded, such as `require('fs')`, that call can then remain the same in the resulting bundle.
 
 Fundamentally APM tools like `dd-trace` stop working at this point. Perhaps they continue to intercept the calls for built-in modules but don't intercept calls to third party libraries. This means that by default when you bundle a `dd-trace` app with a bundler it is likely to capture information about disk access (via `fs`) and outbound HTTP requests (via `http`), but will otherwise omit calls to third party libraries (like extracting incoming request route information for the `express` framework or showing which query is run for the `mysql` database client).
 

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -173,7 +173,7 @@ configuration of the tracer.
 
 ### Bundling
 
-Generally, `dd-trace` works by intercepting `require()` calls that a Node.js application makes when loading modules. This includes modules that are built-in to Node.js, like the `fs` module for accessing the filesystem, as well as modules installed from the npm registry, like the `pg` database module.
+`dd-trace` works by intercepting `require()` calls that a Node.js application makes when loading modules. This includes modules that are built-in to Node.js, like the `fs` module for accessing the filesystem, as well as modules installed from the NPM registry, like the `pg` database module.
 
 Also generally, bundlers work by crawling all of the `require()` calls that an application makes to files on disk, replacing the `require()` calls with custom code, and then concatenating all of the resulting JavaScript into one "bundled" file. When a built-in module is loaded, like `require('fs')`, that call can then remain the same in the resulting bundle.
 

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -185,7 +185,7 @@ A common workaround is to treat all third party modules that the APM needs to in
 
 Datadog recommends you have custom-built bundler plugins. These plugins are able to instruct the bundler on how to behave, inject intermediary code and intercept the "translated" `require()` calls. As a result, more packages are included in the bundled JavaScript file. 
 
-**Note**: Some applications can have 100% of modules bundled, however native modules still need to remain external to the bundle.` 
+**Note**: Some applications can have 100% of modules bundled, however native modules still need to remain external to the bundle.
 
 #### Esbuild support
 

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -183,7 +183,7 @@ APM tools like `dd-trace` stop working at this point. They can continue to inter
 
 A common workaround is to treat all third party modules that the APM needs to instrument as being "external" to the bundler. With this setting the instrumented modules remain on disk and continue to be loaded with `require()` while the non-instrumented modules are bundled. However, this results in a build with many extraneous files and starts to defeat the purpose of bundling.
 
-Datadog recommends you have custom-built bundler plugins. These plugins are able to instruct the bundler on how to behave, inject intermediary code and intercept the "translated" `require() calls. As a result, more packages are included in the bundled JavaScript file. 
+Datadog recommends you have custom-built bundler plugins. These plugins are able to instruct the bundler on how to behave, inject intermediary code and intercept the "translated" `require()` calls. As a result, more packages are included in the bundled JavaScript file. 
 
 **Note**: Some applications can have 100% of modules bundled, however native modules still need to remain external to the bundle.` 
 

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -183,7 +183,9 @@ APM tools like `dd-trace` stop working at this point. They can continue to inter
 
 A common workaround is to treat all third party modules that the APM needs to instrument as being "external" to the bundler. With this setting the instrumented modules remain on disk and continue to be loaded with `require()` while the non-instrumented modules are bundled. However, this results in a build with many extraneous files and starts to defeat the purpose of bundling.
 
-For these reasons it's necessary to have custom-built bundler plugins. Such plugins are able to instruct the bundler on how to behave, injecting intermediary code and otherwise intercepting the "translated" `require()` calls. The result is that many more packages are then included in the bundled JavaScript file. Some applications can have 100% of modules bundled, however native modules still need to remain external to the bundle.
+Datadog recommends you have custom-built bundler plugins. These plugins are able to instruct the bundler on how to behave, inject intermediary code and intercept the "translated" `require() calls. As a result, more packages are included in the bundled JavaScript file. 
+
+**Note**: Some applications can have 100% of modules bundled, however native modules still need to remain external to the bundle.` 
 
 #### Esbuild support
 

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -187,7 +187,7 @@ For these reasons it's necessary to have custom-built bundler plugins. Such plug
 
 #### Esbuild support
 
-This library provides experimental esbuild support in the form of an esbuild plugin, and currently requires at least Node.js v16.17 or v18.7. To use the plugin, make sure you have `dd-trace@3+` installed, and then require the `dd-trace/esbuild` module when building your bundle.
+This library provides experimental esbuild support in the form of an esbuild plugin, and requires at least Node.js v16.17 or v18.7. To use the plugin, make sure you have `dd-trace@3+` installed, and then require the `dd-trace/esbuild` module when building your bundle.
 
 Here's an example of how one might use `dd-trace` with esbuild:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- adds a section to a Node.js page with instructions regarding bundling

### Motivation
- this is a new feature that users will likely have questions about using

### Preview
- https://docs-staging.datadoghq.com/tlhunter/nodejs-bundlers/tracing/trace_collection/dd_libraries/nodejs/?tab=containers#bundling

### Additional Notes
- these docs are copied from the dd-trace-js README
- probably shouldn't land until dd-trace-js cuts a new release
- should the documentation mention the library version number that introduces the feature?

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
