### PR TITLE
(asm) Fix python user SDK documentation

### DIFF
--- a/content/en/security/application_security/threats/add-user-info.md
+++ b/content/en/security/application_security/threats/add-user-info.md
@@ -269,21 +269,12 @@ Monitor authenticated requests by adding user information to the trace with the 
 This example shows how to set user monitoring tags and enable user blocking capability:
 
 ```python
-from ddtrace.appsec.trace_utils import should_block_user
-from ddtrace.appsec.trace_utils import block_request
-from ddtrace.appsec.trace_utils import block_request_if_user_blocked
 from ddtrace.contrib.trace_utils import set_user
 from ddtrace import tracer
 # Call set_user() to trace the currently authenticated user id
 user_id = "some_user_id"
 set_user(tracer, user_id, name="John", email="test@test.com", scope="some_scope",
          role="manager", session_id="session_id", propagate=True)
-# Call is_user_blocked() to possibly block the authenticated user when in the denylist
-if should_block_user(user_id):
-    block_request()
-# Also the utility function that checks and blocks if needed:
-block_request_if_user_blocked(tracer, user_id)
-    block_request()
 ```
 
 {{< /programming-lang >}}

--- a/content/ja/security/application_security/threats/add-user-info.md
+++ b/content/ja/security/application_security/threats/add-user-info.md
@@ -266,21 +266,12 @@ Python トレーサーパッケージが提供する `set_user` 関数を用い�
 この例では、ユーザー監視タグを設定し、ユーザーブロック機能を有効にする方法を示します。
 
 ```python
-from ddtrace.appsec.trace_utils import should_block_user
-from ddtrace.appsec.trace_utils import block_request
-from ddtrace.appsec.trace_utils import block_request_if_user_blocked
 from ddtrace.contrib.trace_utils import set_user
 from ddtrace import tracer
 # set_user() を呼び出し、現在認証されているユーザー ID をトレースします
 user_id = "some_user_id"
 set_user(tracer, user_id, name="John", email="test@test.com", scope="some_scope",
          role="manager", session_id="session_id", propagate=True)
-# is_user_blocked() を呼び出し、denylist にあるときに認証ユーザーをブロックする可能性があります
-if should_block_user(user_id):
-    block_request()
-# また、チェックし、必要であればブロックするユーティリティ関数:
-block_request_if_user_blocked(tracer, user_id)
-    block_request()
 ```
 
 {{< /programming-lang >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fix documentation of the ASM user SDK for python. Ther code snippet was
broken and wrong. The call to is_user_block is not needed as part of the set_user function: 
https://github.com/DataDog/dd-trace-py/blob/1.x/ddtrace/contrib/trace_utils.py#L644
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.