### PR TITLE
Add documentation about connecting logs and traces

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -82,6 +82,21 @@ For monolog v2:
   ?>
 ```
 
+For monolog v3:
+
+```php
+<?php
+  $logger->pushProcessor(function ($record) {
+        $context = \DDTrace\current_context();
+        $record->extra['dd'] = [
+            'trace_id' => $context['trace_id'],
+            'span_id'  => $context['span_id'],
+        ];
+        return $record;
+    });
+?>
+```
+
 If your application uses json logs format instead of appending trace_id and span_id to the log message you can add first-level key "dd" containing these ids:
 
 ```php


### PR DESCRIPTION
### What does this PR do?
Add an updated code snippet on how to connect logs and traces together when using monolog v3. 

In this version, the manual injection should make use of the [`extra`](https://github.com/Seldaek/monolog/blob/main/src/Monolog/LogRecord.php#L24) field accessible from the `LogRecord` class.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
