### PR TITLE
[Serverless] update outdated python/node.js installation note

### DIFF
--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -257,7 +257,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 {{% /tab %}}
 {{% tab "Custom" %}}
 
-<div class="alert alert-info">If you are not using a serverless development tool that Datadog supports, such as the Serverless Framework or AWS CDK, Datadog strongly encourages you instrument your serverless applications with the <a href="./?tab=datadogcli">Datadog CLI</a>.</div>
+<div class="alert alert-info">If you are not using a serverless development tool that Datadog supports, Datadog strongly encourages you instrument your serverless applications with the <a href="./?tab=datadogcli">Datadog CLI</a>.</div>
 
 1. Install the Datadog Lambda library
 

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -246,7 +246,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 {{% /tab %}}
 {{% tab "Custom" %}}
 
-<div class="alert alert-info">If you are not using a serverless development tool that Datadog supports, such as the Serverless Framework or AWS CDK, Datadog strongly encourages you instrument your serverless applications with the <a href="./?tab=datadogcli">Datadog CLI</a>.</div>
+<div class="alert alert-info">If you are not using a serverless development tool that Datadog supports, Datadog strongly encourages you instrument your serverless applications with the <a href="./?tab=datadogcli">Datadog CLI</a>.</div>
 
 1. Install the Datadog Lambda library
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Fixes an outdated banner in the node/python serverless instrumentation installation pages

previous note: 
`If you are not using a serverless development tool that Datadog supports, such as the Serverless Framework or AWS CDK, Datadog strongly encourages you instrument your serverless applications with the Datadog CLI`

new note: 
`If you are not using a serverless development tool that Datadog supports, Datadog strongly encourages you instrument your serverless applications with the Datadog CLI`

### Motivation
<!-- What inspired you to submit this pull request?-->

We support both the Serverless Framework and AWS CDK.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
