### PR TITLE
as_count/aggregation cleanup

### DIFF
--- a/content/en/monitors/guide/as-count-in-monitor-evaluations.md
+++ b/content/en/monitors/guide/as-count-in-monitor-evaluations.md
@@ -74,9 +74,7 @@ sum(last_5m):error
 sum(last_5m):total
 ```
 
-In general, **`avg`** time aggregation with **`.as_rate()`** is reasonable, but **`sum`** aggregation with **`.as_count()`** is recommended for error rates. Aggregation methods other than **`sum`** (shown as _in total_ in-app) do not make sense to use with **`.as_count()`**.
-
-**Note**: Aggregation methods other than sum (shown as in total in-app) cannot be used with `.as_count()`.
+In general, **`avg`** time aggregation with **`.as_rate()`** is reasonable, but **`sum`** aggregation with **`.as_count()`** is recommended for error rates. Aggregation methods other than **`sum`** do not make sense to use with (and cannot be used with) **`.as_count()`**.
 
 [Reach out to the Datadog support team][1] if you have any questions.
 


### PR DESCRIPTION
Consolidating "does not make sense" and "cannot be used" into one line, and removing reference to "in total" notation, which is no longer accurate

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Cleaning up the section on using non-sum aggregation with as_count(), and making it more accurate by removing outdated reference to "in total" notation, which has been removed from the UI.

### Motivation
Just happened to look at this doc and it was repetitive and inaccurate.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
