### PR TITLE
david.grashton/evaluate as zero incompatible with default zero

### DIFF
--- a/content/en/monitors/configuration/_index.md
+++ b/content/en/monitors/configuration/_index.md
@@ -202,8 +202,8 @@ The selected behavior is applied when a monitor's query does not return any data
 
 The `Evaluate as zero` and `Show last known status` options are displayed based on the query type:
 
-- **Evaluate as zero:** This option is available for monitors using `Count` queries.
-- **Show last known status:** This option is available for monitors using any other query type than `Count`, for example `Gauge`, `Rate`, and `Distribution`.
+- **Evaluate as zero:** This option is available for monitors using `Count` queries without the `default_zero()` function.
+- **Show last known status:** This option is available for monitors using any other query type than `Count`, for example `Gauge`, `Rate`, and `Distribution`, as well as for `Count` queries with `default_zero()`.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
Clarifying that "Evaluate as zero" does not work with default_zero. Including quotes for formatting.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- Clarifies that defaulat_zero() and "Evaluate as zero" cannot coexist on the same monitor.-->

### Motivation
<!-- Customer confusion.-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Second attempt. First attempt was sent back for inclusion of quotes for formatting-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
