### PR TITLE
[OTLP] Update mapping for OTLP Histograms

### DIFF
--- a/content/en/metrics/open_telemetry/otlp_metric_types.md
+++ b/content/en/metrics/open_telemetry/otlp_metric_types.md
@@ -83,7 +83,7 @@ The Datadog Agent and the OpenTelemetry Collector Datadog exporter allow changin
 : Bucket count in the time window for the bucket with the specified lower and upper bounds.<br>
 **Datadog In-App Type**: COUNT
 
-- If the `send_count_sum_metrics` flag is enabled, the following metrics are produced:
+- If the `send_aggregation_metrics` flag is enabled, the following metrics are produced:
 
 `<METRIC_NAME>.sum`
 : Sum of the values submitted during the time window.<br>
@@ -93,7 +93,15 @@ The Datadog Agent and the OpenTelemetry Collector Datadog exporter allow changin
 : Number of values submitted during the time window.<br>
 **Datadog In-App Type**: COUNT
 
-**Note**: `send_count_sum_metrics` is useful only when not using the distributions mode.
+`<METRIC_NAME>.min`
+: Minimum of values submitted during the time window. Only available for delta OTLP Histograms. Available since: Datadog exporter v0.75.0 and Datadog Agent v6.45.0 and v7.45.0. <br>
+**Datadog In-App Type**: GAUGE
+
+`<METRIC_NAME>.max`
+: Maximum of values submitted during the time window. Only available for delta OTLP Histograms. Available since: Datadog exporter v0.75.0 and Datadog Agent v6.45.0 and v7.45.0.<br>
+**Datadog In-App Type**: GAUGE
+
+**Note**: `send_aggregation_metrics` is useful only when not using the distributions mode. Before the Datadog exporter v0.75.0 and the Datadog Agent v6.45.0 and v7.45.0 use `send_count_sum_metrics` instead.
 
 [1]: /metrics/distributions
 [2]: /dashboards/functions/arithmetic/#cumulative-sum

--- a/content/en/metrics/open_telemetry/otlp_metric_types.md
+++ b/content/en/metrics/open_telemetry/otlp_metric_types.md
@@ -194,7 +194,7 @@ Suppose you are using an OpenTelemetry Histogram instrument, `request.response_t
 
 [Read more about distributions][1] to understand how to configure further aggregations.
 
-Alternatively, if you are using the `counters` mode and enabling the `send_aggregation_metrics` flag, the following metrics would be reported if the histogram bucket boundaries are set to `[-inf, 2, inf]`:
+Alternatively, if you are using the `counters` mode, the `send_aggregation_metrics` flag is enabled, and the histogram bucket boundaries are set to `[-inf, 2, inf]`, the following metrics are reported:
 
 | Metric Name                                 | Value  | Tags                                | Datadog In-App Type |
 | ------------------------------------------- | ------ | ------------------------------------| ------------------- |

--- a/content/en/metrics/open_telemetry/otlp_metric_types.md
+++ b/content/en/metrics/open_telemetry/otlp_metric_types.md
@@ -194,12 +194,14 @@ Suppose you are using an OpenTelemetry Histogram instrument, `request.response_t
 
 [Read more about distributions][1] to understand how to configure further aggregations.
 
-Alternatively, if you are using the `counters` mode and enabling the `send_count_sum_metrics` flag, the following metrics would be reported if the histogram bucket boundaries are set to `[-inf, 2, inf]`:
+Alternatively, if you are using the `counters` mode and enabling the `send_aggregation_metrics` flag, the following metrics would be reported if the histogram bucket boundaries are set to `[-inf, 2, inf]`:
 
 | Metric Name                                 | Value  | Tags                                | Datadog In-App Type |
 | ------------------------------------------- | ------ | ------------------------------------| ------------------- |
 | `request.response_time.distribution.count`  | `8`    | n/a                                 | COUNT               |
 | `request.response_time.distribution.sum`    | `15`   | n/a                                 | COUNT               |
+| `request.response_time.distribution.max`    | `3`    | n/a                                 | GAUGE               |
+| `request.response_time.distribution.min `   | `1`    | n/a                                 | GAUGE               |
 | `request.response_time.distribution.bucket` | `6`    | `lower_bound:-inf`, `upper_bound:2` | GAUGE               |
 | `request.response_time.distribution.bucket` | `2`    | `lower_bound:2`, `upper_bound:inf`  | GAUGE               |
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates documented mapping for OTLP Histograms.

### Motivation
<!-- What inspired you to submit this pull request?-->

In DataDog/opentelemetry-mapping-go/pull/23 we 
- Updated the mapping to support sending `.min` and `.max` metrics on delta OTLP Histograms that have these fields set.
- Renamed `send_count_sum_metrics` to `send_aggregation_metrics`.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
