### PR TITLE
[PROF-7409] Document Ruby profiler incompatibility with rugged gem

### DIFF
--- a/content/en/profiler/profiler_troubleshooting.md
+++ b/content/en/profiler/profiler_troubleshooting.md
@@ -240,9 +240,11 @@ Starting from `dd-trace-rb` 1.11.0, the "CPU Profiling 2.0" profiler gathers dat
 Sending `SIGPROF` is a common profiling approach, and may cause system calls from native extensions/libraries to be interrupted with a system [`EINTR` error code][8].
 Rarely, native extensions or libraries called by them may have missing or incorrect error handling for the `EINTR` error code.
 
-There are a few known instances of this issue. For these gems, the auto-detects the incompatibility and automatically applies the workaround documented below:
-* Using the `mysql2` gem together with versions of libmysqlclient [older than 8.0.0][9]. The affected libmysqlclient version is known to be present on Ubuntu 18.04, but not 20.04 and later releases.
+The following incompatibilities are known:
+* Using the `mysql2` gem together with versions of `libmysqlclient` [older than 8.0.0][9]. The affected `libmysqlclient` version is known to be present on Ubuntu 18.04, but not 20.04 or later releases.
 * [Using the `rugged` gem.][10]
+
+In these cases, the profiler automatically detects the incompatibility and applies a workaround.
 
 If you encounter run-time failures or errors from Ruby gems that use native extensions, you can revert back to the legacy profiler which does not use `SIGPROF` signals. To revert to the legacy profiler, set the `DD_PROFILING_FORCE_ENABLE_LEGACY` environment variable to `true`, or in code:
 

--- a/content/en/profiler/profiler_troubleshooting.md
+++ b/content/en/profiler/profiler_troubleshooting.md
@@ -240,7 +240,9 @@ Starting from `dd-trace-rb` 1.11.0, the "CPU Profiling 2.0" profiler gathers dat
 Sending `SIGPROF` is a common profiling approach, and may cause system calls from native extensions/libraries to be interrupted with a system [`EINTR` error code][8].
 Rarely, native extensions or libraries called by them may have missing or incorrect error handling for the `EINTR` error code.
 
-One known instance of this issue is when using the `mysql2` gem together with versions of libmysqlclient [older than 8.0.0][9]. The affected libmysqlclient version is known to be present on Ubuntu 18.04, but not 20.04 and later releases. For this case, the profiler auto-detects when the `mysql2` gem is in use and auto-applies the solution described below.
+There are a few known instances of this issue. For these gems, the auto-detects the incompatibility and automatically applies the workaround documented below:
+* Using the `mysql2` gem together with versions of libmysqlclient [older than 8.0.0][9]. The affected libmysqlclient version is known to be present on Ubuntu 18.04, but not 20.04 and later releases.
+* [Using the `rugged` gem.][10]
 
 If you encounter run-time failures or errors from Ruby gems that use native extensions, you can revert back to the legacy profiler which does not use `SIGPROF` signals. To revert to the legacy profiler, set the `DD_PROFILING_FORCE_ENABLE_LEGACY` environment variable to `true`, or in code:
 
@@ -262,6 +264,7 @@ Doing this enables Datadog to add them to the auto-detection list, and to work w
 [7]: https://github.com/DataDog/dd-trace-rb/issues/1799
 [8]: https://man7.org/linux/man-pages/man7/signal.7.html#:~:text=Interruption%20of%20system%20calls%20and%20library%20functions%20by%20signal%20handlers
 [9]: https://bugs.mysql.com/bug.php?id=83109
+[10]: https://github.com/DataDog/dd-trace-rb/issues/2721
 {{< /programming-lang >}}
 {{< programming-lang lang="dotnet" >}}
 


### PR DESCRIPTION
 ### What does this PR do?

This PR extends the troubleshooting steps added in #17370 with a new known incompatiblity with the `rugged` gem.

(Originally reported in
https://github.com/DataDog/dd-trace-rb/issues/2721 )

 ### Motivation

Document the known incompatibility.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
