### PR TITLE
[WEB-3418]Brooklyne.finni/obs pipelines redir

### DIFF
--- a/assets/scripts/components/mobile-nav.js
+++ b/assets/scripts/components/mobile-nav.js
@@ -76,16 +76,6 @@ export function closeMobileNav(){
 export function setMobileNav () {
     const dataPath = window.location.pathname.slice(1,-1)
     const mobileSelection = document.querySelector(`#mobile-nav a[data-path="${dataPath}"]`) || false
-    // redirect the AGENT/aggregating agent path to observability_pipelines/integrations/... on mobile nav
-    // if(dataPath.includes('observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker')){
-    //     const observabilityPipelineMobile = document.querySelector('#mobile-nav a[data-path$="observability_pipelines"]');
-    // 
-    //    mobileSelection = observabilityPipelineMobile.nextElementSibling.querySelector(
-    //        'a[data-path*="observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker"]'
-    //     );
-    // }else{
-    //     mobileSelection = document.querySelector(`#mobile-nav a[data-path="${dataPath}"]`) || false
-    // }
     const subMenu = document.querySelector(`#mobile-nav a[data-path="${dataPath}"] + ul.d-none`)
 
     if (mobileSelection) {

--- a/assets/scripts/components/mobile-nav.js
+++ b/assets/scripts/components/mobile-nav.js
@@ -77,15 +77,15 @@ export function setMobileNav () {
     const dataPath = window.location.pathname.slice(1,-1)
     let mobileSelection = ''
     // redirect the AGENT/aggregating agent path to observability_pipelines/integrations/... on mobile nav
-    if(dataPath.includes('observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker')){
-        const observabilityPipelineMobile = document.querySelector('#mobile-nav a[data-path$="observability_pipelines"]');
+    // if(dataPath.includes('observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker')){
+    //     const observabilityPipelineMobile = document.querySelector('#mobile-nav a[data-path$="observability_pipelines"]');
 
-        mobileSelection = observabilityPipelineMobile.nextElementSibling.querySelector(
-            'a[data-path*="observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker"]'
-        );
-    }else{
+    //    mobileSelection = observabilityPipelineMobile.nextElementSibling.querySelector(
+    //        'a[data-path*="observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker"]'
+    //     );
+    // }else{
         mobileSelection = document.querySelector(`#mobile-nav a[data-path="${dataPath}"]`) || false
-    }
+    // }
     const subMenu = document.querySelector(`#mobile-nav a[data-path="${dataPath}"] + ul.d-none`)
 
     if (mobileSelection) {

--- a/assets/scripts/components/mobile-nav.js
+++ b/assets/scripts/components/mobile-nav.js
@@ -75,16 +75,16 @@ export function closeMobileNav(){
 
 export function setMobileNav () {
     const dataPath = window.location.pathname.slice(1,-1)
-    let mobileSelection = ''
+    const mobileSelection = document.querySelector(`#mobile-nav a[data-path="${dataPath}"]`) || false
     // redirect the AGENT/aggregating agent path to observability_pipelines/integrations/... on mobile nav
     // if(dataPath.includes('observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker')){
     //     const observabilityPipelineMobile = document.querySelector('#mobile-nav a[data-path$="observability_pipelines"]');
-
+    // 
     //    mobileSelection = observabilityPipelineMobile.nextElementSibling.querySelector(
     //        'a[data-path*="observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker"]'
     //     );
     // }else{
-        mobileSelection = document.querySelector(`#mobile-nav a[data-path="${dataPath}"]`) || false
+    //     mobileSelection = document.querySelector(`#mobile-nav a[data-path="${dataPath}"]`) || false
     // }
     const subMenu = document.querySelector(`#mobile-nav a[data-path="${dataPath}"] + ul.d-none`)
 

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -162,14 +162,14 @@ function getPathElement(event = null) {
         );
     }
 
-    // redirect support. if agent/aggregating agents is selected, highlight `observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker` in the sidenav.
-    if (path.includes('observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker')) {
-        const observabilityPipelineEl = document.querySelector('.side .nav-top-level > [data-path*="observability_pipelines"]');
-        sideNavPathElement = observabilityPipelineEl.nextElementSibling.querySelector(
-            '[data-path*="observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker"]'
-        );
-        mobileNavPathElement = sideNavPathElement;
-    }
+    // // redirect support. if agent/aggregating agents is selected, highlight `observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker` in the sidenav.
+    // if (path.includes('observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker')) {
+    //     const observabilityPipelineEl = document.querySelector('.side .nav-top-level > [data-path*="observability_pipelines"]');
+    //     sideNavPathElement = observabilityPipelineEl.nextElementSibling.querySelector(
+    //         '[data-path*="observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker"]'
+    //     );
+    //     mobileNavPathElement = sideNavPathElement;
+    // }
 
     // if on a detailed integration page then make sure integrations is highlighted in nav
     if (document.getElementsByClassName('integration-labels').length) {

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -162,15 +162,6 @@ function getPathElement(event = null) {
         );
     }
 
-    // // redirect support. if agent/aggregating agents is selected, highlight `observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker` in the sidenav.
-    // if (path.includes('observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker')) {
-    //     const observabilityPipelineEl = document.querySelector('.side .nav-top-level > [data-path*="observability_pipelines"]');
-    //     sideNavPathElement = observabilityPipelineEl.nextElementSibling.querySelector(
-    //         '[data-path*="observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker"]'
-    //     );
-    //     mobileNavPathElement = sideNavPathElement;
-    // }
-
     // if on a detailed integration page then make sure integrations is highlighted in nav
     if (document.getElementsByClassName('integration-labels').length) {
         sideNavPathElement = document.querySelector(


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Removes scripts that highlighted and redirected to `observability_pipelines/production_deployment_overview/integrate_datadog_and_the_observability_pipelines_worker`  when "Aggregating Agents" under "Agent" was selected

Redirects and documentation for observability pipelines configuration has been updated and this scripted behavior is no longer required.

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/browse/WEB-3418

 ### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
https://docs-staging.datadoghq.com/brooklyne.finni/obs_pipelines_redir/

On the preview branch, please select Agent and then Aggregating Agents. You should be redirected to "Getting Started with Observability Pipelines". (This is the same behavior that is on live now- so there should be no change evident on the site)

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
