### PR TITLE
Add proxy variables in DCA

### DIFF
--- a/content/en/containers/cluster_agent/commands.md
+++ b/content/en/containers/cluster_agent/commands.md
@@ -120,10 +120,10 @@ The following environment variables are supported:
 : Adds extra tags to cluster checks metrics.
 
 `DD_PROXY_HTTPS`                
-: Sets a proxy server for https requests.
+: Sets a proxy server for HTTPS requests.
 
 `DD_PROXY_HTTP`                
-: Sets a proxy server for http requests.
+: Sets a proxy server for HTTP requests.
 
 `DD_PROXY_NO_PROXY`                
 : Sets a list of hosts that should bypass the proxy. The list is space-separated.

--- a/content/en/containers/cluster_agent/commands.md
+++ b/content/en/containers/cluster_agent/commands.md
@@ -119,6 +119,15 @@ The following environment variables are supported:
 `DD_CLUSTER_CHECKS_EXTRA_TAGS`                
 : Adds extra tags to cluster checks metrics.
 
+`DD_PROXY_HTTPS`                
+: Sets a proxy server for https requests.
+
+`DD_PROXY_HTTP`                
+: Sets a proxy server for http requests.
+
+`DD_PROXY_NO_PROXY`                
+: Sets a list of hosts that should bypass the proxy. The list is space-separated.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
Adding the proxy variables to the documentation since you may get proxy type errors in the DCA, and adding these variables would address the issue.  These proxy variables were added in the DCA last 2019 but not added to the documentation.

https://github.com/DataDog/datadog-agent/pull/4191

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
