### PR TITLE
add link to index retention organisation setting

### DIFF
--- a/content/en/logs/log_configuration/indexes.md
+++ b/content/en/logs/log_configuration/indexes.md
@@ -185,4 +185,4 @@ See [Monitor log usage][20] on how to monitor and alert on your usage.
 [18]: /logs/live_tail/#overview
 [19]: https://www.timeanddate.com/worldclock/converter.html
 [20]: /logs/guide/best-practices-for-log-management/#monitor-log-usage
-[21]: https://docs.datadoghq.com/account_management/org_settings/#out-of-contract-retention-periods-for-log-indexes
+[21]: /account_management/org_settings/#out-of-contract-retention-periods-for-log-indexes

--- a/content/en/logs/log_configuration/indexes.md
+++ b/content/en/logs/log_configuration/indexes.md
@@ -137,9 +137,11 @@ In the following example:
 ## Update log retention
 
 The index retention setting determines how long logs are stored and searchable in Datadog. You can set the retention to any value allowed in your account configuration.
-To add retentions that are not in your current contract, contact Customer Success at: `success@datadoghq.com`.
+To add retentions that are not in your current contract, contact Customer Success at: `success@datadoghq.com`. 
 
 {{< img src="logs/indexes/log_retention.png" alt="index details"  style="width:70%;">}}
+
+To use retentions which are not in your current contract, [the option][20] must be enabled by an admin in your organisation settings.
 
 ## Set daily quota
 
@@ -183,3 +185,4 @@ See [Monitor log usage][20] on how to monitor and alert on your usage.
 [18]: /logs/live_tail/#overview
 [19]: https://www.timeanddate.com/worldclock/converter.html
 [20]: /logs/guide/best-practices-for-log-management/#monitor-log-usage
+[21]: https://docs.datadoghq.com/account_management/org_settings/#out-of-contract-retention-periods-for-log-indexes

--- a/content/en/logs/log_configuration/indexes.md
+++ b/content/en/logs/log_configuration/indexes.md
@@ -141,7 +141,7 @@ To add retentions that are not in your current contract, contact Customer Succes
 
 {{< img src="logs/indexes/log_retention.png" alt="index details"  style="width:70%;">}}
 
-To use retentions which are not in your current contract, [the option][20] must be enabled by an admin in your organisation settings.
+**Note**: To use retentions which are not in your current contract, [the option][21] must be enabled by an admin in your organisation settings.
 
 ## Set daily quota
 


### PR DESCRIPTION
### What does this PR do?
Add a link to the organisation setting where user can enable the option to use retention outside of their contract

### Motivation
Users look mostly in the index page to learn about the index and how to set the retention and there was no link toward this option

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
