### PR TITLE
Add to product taxonomy the logs_forwarding to logs family

### DIFF
--- a/content/en/account_management/guide/hourly-usage-migration.md
+++ b/content/en/account_management/guide/hourly-usage-migration.md
@@ -119,6 +119,7 @@ The families and usage types:
     * `billable_ingested_bytes`
     * `indexed_events_count`
     * `ingested_events_bytes`
+    * `logs_forwarding_events_bytes`
     * `logs_live_indexed_count`
     * `logs_live_ingested_bytes`
     * `logs_rehydrated_indexed_count`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds to the logs family of product taxonomy the logs_forwarding_events_bytes usage type.
### Motivation
<!-- What inspired you to submit this pull request?-->
New product to be displayed as usage for our customers: https://datadoghq.atlassian.net/browse/RQ-3362
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
