### PR TITLE
[WEB-3432] Update Code Tabs behavior

### DIFF
--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -25,6 +25,7 @@ const initCodeTabs = () => {
                     const lang = tabPane.getAttribute('data-lang')
                     const li = document.createElement('li')
                     const anchor = document.createElement('a')
+                    anchor.addEventListener("click", e => e.preventDefault(), false);
                     anchor.dataset.lang = lang
                     anchor.href = '#'
                     anchor.innerText = title

--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -97,7 +97,8 @@ const initCodeTabs = () => {
         const allTabLinksNodeList = document.querySelectorAll('.code-tabs .nav-tabs li a')
 
         allTabLinksNodeList.forEach(link => {
-            link.addEventListener('click', () => {
+            link.addEventListener('click', e => {
+                e.preventDefault();
                 activateCodeTab(link)
             })
         })


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This makes it so clicking a tab no longer brings you to the top of the screen.
### Motivation
<!-- What inspired you to submit this pull request?-->
JIRA Ticket: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-3432
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
