### PR TITLE
Add azure deployment_type/name section to azure sql db instance config

### DIFF
--- a/content/en/database_monitoring/setup_sql_server/azure.md
+++ b/content/en/database_monitoring/setup_sql_server/azure.md
@@ -65,11 +65,19 @@ instances:
     database: '<DATABASE_1>'
     username: datadog
     password: '<PASSWORD>'
+    # After adding your project and instance, configure the Datadog Azure integration to pull additional cloud data such as CPU, Memory, etc.
+    azure:
+      deployment_type: 'sql_database'
+      name: '<DATABASE_1>'
 
   - host: '<SERVER_NAME>.database.windows.net,1433'
     database: '<DATABASE_2>'
     username: datadog
     password: '<PASSWORD>'
+    # After adding your project and instance, configure the Datadog Azure integration to pull additional cloud data such as CPU, Memory, etc.
+    azure:
+      deployment_type: 'sql_database'
+      name: '<DATABASE_2>'
 ```
 
 See [Install the Agent](#install-the-agent) for more detailed instructions on how to install and configure the Datadog Agent.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds extra section to the example sql database instance config, this is important for us detecting if the instance is an azure host so we can enable resource linking of integration metrics to cloud crawler metrics. The config already existed for managed instance and virtual machines, but was missing for sql database

```yaml
    # After adding your project and instance, configure the Datadog Azure integration to pull additional cloud data such as CPU, Memory, etc.
    azure:
      deployment_type: 'sql_database'
      name: '<DATABASE_2>'
```

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
