### PR TITLE
[DOCS-4935] Update info and remove image in logs archive encryption section

### DIFF
--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -306,9 +306,9 @@ If you wish to rehydrate from archives in another access tier, you must first mo
 
 ##### SSE-S3
 
-The default encryption of an Amazon S3 bucket is automatically enabled and set to server-side encryption with Amazon S3 management keys ([SSE-S3][1]). 
+The default encryption for Amazon S3 buckets is server-side encryption with Amazon S3 management keys ([SSE-S3][1]).
 
-To confirm this:
+To confirm your S3 bucket is encrypted with SSE-S3:
 
 1. Navigate to your S3 bucket.
 1. Click the **Properties** tab.

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -306,15 +306,17 @@ If you wish to rehydrate from archives in another access tier, you must first mo
 
 ##### SSE-S3
 
-The easiest method to add server side encryption to your S3 log archives is with S3's native server side encryption, [SSE-S3][1].
+The default encryption of an Amazon S3 bucket is automatically enabled and set to server-side encryption with Amazon S3 management keys ([SSE-S3][1]). 
 
-To enable it, go to the **Properties** tab in your S3 bucket and select **Default Encryption**. Select the `AES-256` option and **Save**.
+To confirm this:
 
-{{< img src="logs/archives/log_archives_s3_encryption.png" alt="Select the AES-256 option and Save."  style="width:75%;">}}
+1. Navigate to your S3 bucket.
+1. Click the **Properties** tab.
+1. In the **Default Encryption** section, check that the **Encryption key type** is **Amazon S3 managed keys (SSE-S3)**.
 
 ##### SSE-KMS
 
-Alternatively, Datadog supports server side encryption with a CMK from [AWS KMS][2]. To enable it, take the following steps:
+Alternatively, Datadog supports server-side encryption with a CMK from [AWS KMS][2]. To enable it, take the following steps:
 
 1. Create your CMK
 2. Attach a CMK policy to your CMK with the following content, replacing the AWS account number and Datadog IAM role name appropriately:


### PR DESCRIPTION
### What does this PR do?

Updates the info for AWS encryption and removes outdated image.

Ready to merge.

### Motivation

[DOCS-4935](https://datadoghq.atlassian.net/browse/DOCS-4935)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-4935]: https://datadoghq.atlassian.net/browse/DOCS-4935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ