### PR TITLE
[web-3431] fail and exit the build if link formatting fails for integrations

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -739,6 +739,7 @@ class Integrations:
                 result = format_link_file(file_name,regex_skip_sections_start,regex_skip_sections_end)
             except Exception as e:
                 print(e)
+                sys.exit(1)
         else:
             with open(file_name, 'r+') as f:
                 markdown_string = f.read()
@@ -876,9 +877,13 @@ class Integrations:
 
                 ## Reformating all links now that all processing is done
                 if tab_logic:
-                    final_text = format_link_file(out_name, regex_skip_sections_start, regex_skip_sections_end)
-                    with open(out_name, 'w') as final_file:
-                        final_file.write(final_text)
+                    try:
+                        final_text = format_link_file(out_name, regex_skip_sections_start, regex_skip_sections_end)
+                        with open(out_name, 'w') as final_file:
+                            final_file.write(final_text)
+                    except Exception as e:
+                        print(e)
+                        sys.exit(1)
             else:
                 if exists(out_name):
                     print(f"removing {integration_name} due to is_public/display_on_public_websites flag, {out_name}")

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -739,6 +739,7 @@ class Integrations:
                 result = format_link_file(file_name,regex_skip_sections_start,regex_skip_sections_end)
             except Exception as e:
                 print(e)
+                print('An error occurred formatting markdown links from integration readme file(s), exiting the build now...')
                 sys.exit(1)
         else:
             with open(file_name, 'r+') as f:
@@ -883,6 +884,7 @@ class Integrations:
                             final_file.write(final_text)
                     except Exception as e:
                         print(e)
+                        print('An error occurred formatting markdown links from integration readme file(s), exiting the build now...')
                         sys.exit(1)
             else:
                 if exists(out_name):

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: true
+    cache_enabled: false
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: false
+    cache_enabled: true
 
 - data:
     - org_name: jenkinsci


### PR DESCRIPTION
### What does this PR do?
fail and exit the build if the `format_link_file()` function fails when processing links for integration readmes.

### Motivation
https://dd.slack.com/archives/C3CT8QA11/p1680640924358629

azure integrations page deployed as blank due to issues with the link formatting script

### Preview
n/a

### Additional Notes
we have additional work on going to improve the link formatting, this is a more immediate fix to prevent blank integrations pages from being deployed

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
