### PR TITLE
[RUMF-1519] browser sdk: consistent usage of window

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -62,8 +62,8 @@ Load and configure the SDK in the head section of your pages. For **{{<region-pa
         d=o.createElement(u);d.async=1;d.src=n
         n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
       })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v4/datadog-logs.js','DD_LOGS')
-      DD_LOGS.onReady(function() {
-          DD_LOGS.init({
+      window.DD_LOGS.onReady(function() {
+          window.DD_LOGS.init({
             clientToken: '<DATADOG_CLIENT_TOKEN>',
             site: 'datadoghq.com',
             forwardErrorsToLogs: true,
@@ -86,8 +86,8 @@ Load and configure the SDK in the head section of your pages. For **{{<region-pa
         d=o.createElement(u);d.async=1;d.src=n
         n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
       })(window,document,'script','https://www.datadoghq-browser-agent.com/eu1/v4/datadog-logs.js','DD_LOGS')
-      DD_LOGS.onReady(function() {
-          DD_LOGS.init({
+      window.DD_LOGS.onReady(function() {
+          window.DD_LOGS.init({
             clientToken: '<DATADOG_CLIENT_TOKEN>',
             site: 'datadoghq.eu',
             forwardErrorsToLogs: true,
@@ -110,8 +110,8 @@ Load and configure the SDK in the head section of your pages. For **{{<region-pa
         d=o.createElement(u);d.async=1;d.src=n
         n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
       })(window,document,'script','https://www.datadoghq-browser-agent.com/us3/v4/datadog-logs.js','DD_LOGS')
-      DD_LOGS.onReady(function() {
-          DD_LOGS.init({
+      window.DD_LOGS.onReady(function() {
+          window.DD_LOGS.init({
             clientToken: '<DATADOG_CLIENT_TOKEN>',
             site: 'us3.datadoghq.com',
             forwardErrorsToLogs: true,
@@ -134,8 +134,8 @@ Load and configure the SDK in the head section of your pages. For **{{<region-pa
         d=o.createElement(u);d.async=1;d.src=n
         n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
       })(window,document,'script','https://www.datadoghq-browser-agent.com/us5/v4/datadog-logs.js','DD_LOGS')
-      DD_LOGS.onReady(function() {
-          DD_LOGS.init({
+      window.DD_LOGS.onReady(function() {
+          window.DD_LOGS.init({
             clientToken: '<DATADOG_CLIENT_TOKEN>',
             site: 'us5.datadoghq.com',
             forwardErrorsToLogs: true,
@@ -158,8 +158,8 @@ Load and configure the SDK in the head section of your pages. For **{{<region-pa
         d=o.createElement(u);d.async=1;d.src=n
         n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
       })(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-logs-v4.js','DD_LOGS')
-      DD_LOGS.onReady(function() {
-          DD_LOGS.init({
+      window.DD_LOGS.onReady(function() {
+          window.DD_LOGS.init({
             clientToken: '<DATADOG_CLIENT_TOKEN>',
             site: 'ddog-gov.com',
             forwardErrorsToLogs: true,
@@ -173,7 +173,7 @@ Load and configure the SDK in the head section of your pages. For **{{<region-pa
 {{</ site-region>}}
 
 
-**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `window.DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ### CDN sync
 
@@ -187,7 +187,7 @@ To receive all logs and errors, load and configure the SDK at the beginning of t
     <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v4/datadog-logs.js"></script>
     <script>
       window.DD_LOGS &&
-        DD_LOGS.init({
+        window.DD_LOGS.init({
           clientToken: '<DATADOG_CLIENT_TOKEN>',
           site: 'datadoghq.com',
           forwardErrorsToLogs: true,
@@ -206,7 +206,7 @@ To receive all logs and errors, load and configure the SDK at the beginning of t
     <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/eu1/v4/datadog-logs.js"></script>
     <script>
       window.DD_LOGS &&
-        DD_LOGS.init({
+        window.DD_LOGS.init({
           clientToken: '<DATADOG_CLIENT_TOKEN>',
           site: 'datadoghq.eu',
           forwardErrorsToLogs: true,
@@ -225,7 +225,7 @@ To receive all logs and errors, load and configure the SDK at the beginning of t
     <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us3/v4/datadog-logs.js"></script>
     <script>
       window.DD_LOGS &&
-        DD_LOGS.init({
+        window.DD_LOGS.init({
           clientToken: '<DATADOG_CLIENT_TOKEN>',
           site: 'us3.datadoghq.com',
           forwardErrorsToLogs: true,
@@ -244,7 +244,7 @@ To receive all logs and errors, load and configure the SDK at the beginning of t
     <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us5/v4/datadog-logs.js"></script>
     <script>
       window.DD_LOGS &&
-        DD_LOGS.init({
+        window.DD_LOGS.init({
           clientToken: '<DATADOG_CLIENT_TOKEN>',
           site: 'us5.datadoghq.com',
           forwardErrorsToLogs: true,
@@ -263,7 +263,7 @@ To receive all logs and errors, load and configure the SDK at the beginning of t
     <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-v4.js"></script>
     <script>
       window.DD_LOGS &&
-        DD_LOGS.init({
+        window.DD_LOGS.init({
           clientToken: '<DATADOG_CLIENT_TOKEN>',
           site: 'ddog-gov.com',
           forwardErrorsToLogs: true,
@@ -343,17 +343,17 @@ datadogLogs.logger.info('Button clicked', { name: 'buttonName', id: 123 })
 #### CDN async
 
 ```javascript
-DD_LOGS.onReady(function () {
-  DD_LOGS.logger.info('Button clicked', { name: 'buttonName', id: 123 })
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.logger.info('Button clicked', { name: 'buttonName', id: 123 })
 })
 ```
 
-**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `window.DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 #### CDN sync
 
 ```javascript
-window.DD_LOGS && DD_LOGS.logger.info('Button clicked', { name: 'buttonName', id: 123 })
+window.DD_LOGS && window.DD_LOGS.logger.info('Button clicked', { name: 'buttonName', id: 123 })
 ```
 
 **Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
@@ -430,13 +430,13 @@ try {
   throw new Error('Wrong behavior')
   ...
 } catch (ex) {
-  DD_LOGS.onReady(function () {
-    DD_LOGS.logger.error('Error occurred', {}, ex)
+  window.DD_LOGS.onReady(function () {
+    window.DD_LOGS.logger.error('Error occurred', {}, ex)
   })
 }
 ```
 
-**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `window.DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 #### CDN sync
 
@@ -446,7 +446,7 @@ try {
   throw new Error('Wrong behavior')
   ...
 } catch (ex) {
-    window.DD_LOGS && DD_LOGS.logger.error('Error occurred', {}, ex)
+    window.DD_LOGS && window.DD_LOGS.logger.error('Error occurred', {}, ex)
 }
 ```
 
@@ -495,19 +495,19 @@ datadogLogs.logger.log(<MESSAGE>,<JSON_ATTRIBUTES>,<STATUS>,<ERROR>);
 For CDN async, use:
 
 ```javascript
-DD_LOGS.onReady(function() {
-  DD_LOGS.logger.log(<MESSAGE>,<JSON_ATTRIBUTES>,<STATUS>,<ERROR>);
+window.DD_LOGS.onReady(function() {
+  window.DD_LOGS.logger.log(<MESSAGE>,<JSON_ATTRIBUTES>,<STATUS>,<ERROR>);
 })
 ```
 
-**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `window.DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 #### CDN sync
 
 For CDN sync, use:
 
 ```javascript
-window.DD_LOGS && DD_LOGS.logger.log(<MESSAGE>,<JSON_ATTRIBUTES>,<STATUS>,<ERROR>);
+window.DD_LOGS && window.DD_LOGS.logger.log(<MESSAGE>,<JSON_ATTRIBUTES>,<STATUS>,<ERROR>);
 ```
 
 #### Placeholders
@@ -549,8 +549,8 @@ datadogLogs.init({
 #### CDN Async
 
 ```javascript
-DD_LOGS.onReady(function() {
-    DD_LOGS.init({
+window.DD_LOGS.onReady(function() {
+    window.DD_LOGS.init({
         ...,
         beforeSend: (log) => {
             // remove email from view url
@@ -611,8 +611,8 @@ datadogLogs.init({
 #### CDN Async
 
 ```javascript
-DD_LOGS.onReady(function() {
-    DD_LOGS.init({
+window.DD_LOGS.onReady(function() {
+    window.DD_LOGS.init({
         ...,
         beforeSend: (log) => {
           // discard 404 network errors
@@ -691,21 +691,21 @@ signupLogger.info('Test sign up completed')
 For example, assume there is a `signupLogger`, defined with all the other loggers:
 
 ```javascript
-DD_LOGS.onReady(function () {
-  const signupLogger = DD_LOGS.createLogger('signupLogger', 'info', 'http', { env: 'staging' })
+window.DD_LOGS.onReady(function () {
+  const signupLogger = window.DD_LOGS.createLogger('signupLogger', 'info', 'http', { env: 'staging' })
 })
 ```
 
 It can now be used in a different part of the code with:
 
 ```javascript
-DD_LOGS.onReady(function () {
-  const signupLogger = DD_LOGS.getLogger('signupLogger')
+window.DD_LOGS.onReady(function () {
+  const signupLogger = window.DD_LOGS.getLogger('signupLogger')
   signupLogger.info('Test sign up completed')
 })
 ```
 
-**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `window.DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ##### CDN sync
 
@@ -713,7 +713,7 @@ For example, assume there is a `signupLogger`, defined with all the other logger
 
 ```javascript
 if (window.DD_LOGS) {
-  const signupLogger = DD_LOGS.createLogger('signupLogger', 'info', 'http', { env: 'staging' })
+  const signupLogger = window.DD_LOGS.createLogger('signupLogger', 'info', 'http', { env: 'staging' })
 }
 ```
 
@@ -721,7 +721,7 @@ It can now be used in a different part of the code with:
 
 ```javascript
 if (window.DD_LOGS) {
-  const signupLogger = DD_LOGS.getLogger('signupLogger')
+  const signupLogger = window.window.DD_LOGS.getLogger('signupLogger')
   signupLogger.info('Test sign up completed')
 }
 ```
@@ -774,55 +774,55 @@ datadogLogs.getGlobalContext() // => {}
 For CDN async, use:
 
 ```javascript
-DD_LOGS.onReady(function () {
-  DD_LOGS.setGlobalContext({ env: 'staging' })
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.setGlobalContext({ env: 'staging' })
 })
 
-DD_LOGS.onReady(function () {
-  DD_LOGS.setGlobalContextProperty('referrer', document.referrer)
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.setGlobalContextProperty('referrer', document.referrer)
 })
 
-DD_LOGS.onReady(function () {
-  DD_LOGS.getGlobalContext() // => {env: 'staging', referrer: ...}
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.getGlobalContext() // => {env: 'staging', referrer: ...}
 })
 
-DD_LOGS.onReady(function () {
-  DD_LOGS.removeGlobalContextProperty('referrer')
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.removeGlobalContextProperty('referrer')
 })
 
-DD_LOGS.onReady(function () {
-  DD_LOGS.getGlobalContext() // => {env: 'staging'}
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.getGlobalContext() // => {env: 'staging'}
 })
 
-DD_LOGS.onReady(function () {
-  DD_LOGS.clearGlobalContext()
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.clearGlobalContext()
 })
 
-DD_LOGS.onReady(function () {
-  DD_LOGS.getGlobalContext() // => {}
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.getGlobalContext() // => {}
 })
 ```
 
-**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `window.DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ##### CDN sync
 
 For CDN sync, use:
 
 ```javascript
-window.DD_LOGS && DD_LOGS.setGlobalContext({ env: 'staging' })
+window.DD_LOGS && window.DD_LOGS.setGlobalContext({ env: 'staging' })
 
-window.DD_LOGS && DD_LOGS.setGlobalContextProperty('referrer', document.referrer)
+window.DD_LOGS && window.DD_LOGS.setGlobalContextProperty('referrer', document.referrer)
 
-window.DD_LOGS && DD_LOGS.getGlobalContext() // => {env: 'staging', referrer: ...}
+window.DD_LOGS && window.DD_LOGS.getGlobalContext() // => {env: 'staging', referrer: ...}
 
-window.DD_LOGS && DD_LOGS.removeGlobalContextProperty('referrer')
+window.DD_LOGS && window.DD_LOGS.removeGlobalContextProperty('referrer')
 
-window.DD_LOGS && DD_LOGS.getGlobalContext() // => {env: 'staging'}
+window.DD_LOGS && window.DD_LOGS.getGlobalContext() // => {env: 'staging'}
 
-window.DD_LOGS && DD_LOGS.clearGlobalContext()
+window.DD_LOGS && window.DD_LOGS.clearGlobalContext()
 
-window.DD_LOGS && DD_LOGS.getGlobalContext() // => {}
+window.DD_LOGS && window.DD_LOGS.getGlobalContext() // => {}
 ```
 
 **Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
@@ -862,55 +862,55 @@ datadogLogs.getUser() // => {}
 For CDN async, use:
 
 ```javascript
-DD_LOGS.onReady(function () {
-  DD_LOGS.setUser({ id: '1234', name: 'John Doe', email: 'john@doe.com' })
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.setUser({ id: '1234', name: 'John Doe', email: 'john@doe.com' })
 })
 
-DD_LOGS.onReady(function () {
-  DD_LOGS.setUserProperty('type', 'customer')
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.setUserProperty('type', 'customer')
 })
 
-DD_LOGS.onReady(function () {
-  DD_LOGS.getUser() // => {id: '1234', name: 'John Doe', email: 'john@doe.com', type: 'customer'}
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.getUser() // => {id: '1234', name: 'John Doe', email: 'john@doe.com', type: 'customer'}
 })
 
-DD_LOGS.onReady(function () {
-  DD_LOGS.removeUserProperty('type')
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.removeUserProperty('type')
 })
 
-DD_LOGS.onReady(function () {
-  DD_LOGS.getUser() // => {id: '1234', name: 'John Doe', email: 'john@doe.com'}
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.getUser() // => {id: '1234', name: 'John Doe', email: 'john@doe.com'}
 })
 
-DD_LOGS.onReady(function () {
-  DD_LOGS.clearUser()
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.clearUser()
 })
 
-DD_LOGS.onReady(function () {
-  DD_LOGS.getUser() // => {}
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.getUser() // => {}
 })
 ```
 
-**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `window.DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ##### CDN sync
 
 For CDN sync, use:
 
 ```javascript
-window.DD_LOGS && DD_LOGS.setUser({ id: '1234', name: 'John Doe', email: 'john@doe.com' })
+window.DD_LOGS && window.DD_LOGS.setUser({ id: '1234', name: 'John Doe', email: 'john@doe.com' })
 
-window.DD_LOGS && DD_LOGS.setUserProperty('type', 'customer')
+window.DD_LOGS && window.DD_LOGS.setUserProperty('type', 'customer')
 
-window.DD_LOGS && DD_LOGS.getUser() // => {id: '1234', name: 'John Doe', email: 'john@doe.com', type: 'customer'}
+window.DD_LOGS && window.DD_LOGS.getUser() // => {id: '1234', name: 'John Doe', email: 'john@doe.com', type: 'customer'}
 
-window.DD_LOGS && DD_LOGS.removeUserProperty('type')
+window.DD_LOGS && window.DD_LOGS.removeUserProperty('type')
 
-window.DD_LOGS && DD_LOGS.getUser() // => {id: '1234', name: 'John Doe', email: 'john@doe.com'}
+window.DD_LOGS && window.DD_LOGS.getUser() // => {id: '1234', name: 'John Doe', email: 'john@doe.com'}
 
-window.DD_LOGS && DD_LOGS.clearUser()
+window.DD_LOGS && window.DD_LOGS.clearUser()
 
-window.DD_LOGS && DD_LOGS.getUser() // => {}
+window.DD_LOGS && window.DD_LOGS.getUser() // => {}
 ```
 
 **Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
@@ -939,25 +939,25 @@ datadogLogs.addContext('referrer', document.referrer)
 For CDN async, use:
 
 ```javascript
-DD_LOGS.onReady(function () {
-  DD_LOGS.setContext("{'env': 'staging'}")
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.setContext("{'env': 'staging'}")
 })
 
-DD_LOGS.onReady(function () {
-  DD_LOGS.addContext('referrer', document.referrer)
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.addContext('referrer', document.referrer)
 })
 ```
 
-**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `window.DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ##### CDN sync
 
 For CDN sync, use:
 
 ```javascript
-window.DD_LOGS && DD_LOGS.setContext("{'env': 'staging'}")
+window.DD_LOGS && window.DD_LOGS.setContext("{'env': 'staging'}")
 
-window.DD_LOGS && DD_LOGS.addContext('referrer', document.referrer)
+window.DD_LOGS && window.DD_LOGS.addContext('referrer', document.referrer)
 ```
 
 **Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
@@ -987,19 +987,19 @@ datadogLogs.logger.setLevel('<LEVEL>')
 For CDN async, use:
 
 ```javascript
-DD_LOGS.onReady(function () {
-  DD_LOGS.logger.setLevel('<LEVEL>')
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.logger.setLevel('<LEVEL>')
 })
 ```
 
-**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `window.DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ##### CDN sync
 
 For CDN sync, use:
 
 ```javascript
-window.DD_LOGS && DD_LOGS.logger.setLevel('<LEVEL>')
+window.DD_LOGS && window.DD_LOGS.logger.setLevel('<LEVEL>')
 ```
 
 **Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
@@ -1032,21 +1032,21 @@ datadogLogs.logger.setHandler(['<HANDLER1>', '<HANDLER2>'])
 For CDN async, use:
 
 ```javascript
-DD_LOGS.onReady(function () {
-  DD_LOGS.logger.setHandler('<HANDLER>')
-  DD_LOGS.logger.setHandler(['<HANDLER1>', '<HANDLER2>'])
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.logger.setHandler('<HANDLER>')
+  window.DD_LOGS.logger.setHandler(['<HANDLER1>', '<HANDLER2>'])
 })
 ```
 
-**Note**: Early API calls must be wrapped in the `DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+**Note**: Early API calls must be wrapped in the `window.DD_LOGS.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ##### CDN sync
 
 For CDN sync, use:
 
 ```javascript
-window.DD_LOGS && DD_LOGS.logger.setHandler('<HANDLER>')
-window.DD_LOGS && DD_LOGS.logger.setHandler(['<HANDLER1>', '<HANDLER2>'])
+window.DD_LOGS && window.DD_LOGS.logger.setHandler('<HANDLER>')
+window.DD_LOGS && window.DD_LOGS.logger.setHandler(['<HANDLER1>', '<HANDLER2>'])
 ```
 
 **Note**: The `window.DD_LOGS` check prevents issues when a loading failure occurs with the SDK.
@@ -1076,8 +1076,8 @@ datadogLogs.getInternalContext() // { session_id: "xxxx-xxxx-xxxx-xxxx" }
 For CDN async, use:
 
 ```javascript
-DD_LOGS.onReady(function () {
-  DD_LOGS.getInternalContext() // { session_id: "xxxx-xxxx-xxxx-xxxx" }
+window.DD_LOGS.onReady(function () {
+  window.DD_LOGS.getInternalContext() // { session_id: "xxxx-xxxx-xxxx-xxxx" }
 })
 ```
 

--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -154,8 +154,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'datadoghq.com',
@@ -180,8 +180,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/eu1/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'datadoghq.eu',
@@ -206,8 +206,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/us3/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'us3.datadoghq.com',
@@ -232,8 +232,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/us5/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'us5.datadoghq.com',
@@ -258,8 +258,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-rum-v4.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'ddog-gov.com',
@@ -290,8 +290,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'datadoghq.com',
@@ -316,8 +316,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/eu1/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'datadoghq.eu',
@@ -342,8 +342,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/us3/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'us3.datadoghq.com',
@@ -368,8 +368,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/us5/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'us5.datadoghq.com',
@@ -394,8 +394,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-rum-v4.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'ddog-gov.com',
@@ -426,8 +426,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'datadoghq.com',
@@ -450,8 +450,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/eu1/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'datadoghq.eu',
@@ -474,8 +474,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/us3/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'us3.datadoghq.com',
@@ -498,8 +498,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/us5/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'us5.datadoghq.com',
@@ -522,8 +522,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-rum-v4.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'ddog-gov.com',
@@ -552,8 +552,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'datadoghq.com',
@@ -576,8 +576,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/eu1/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'datadoghq.eu',
@@ -600,8 +600,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/us3/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'us3.datadoghq.com',
@@ -624,8 +624,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/us5/v4/datadog-rum.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'us5.datadoghq.com',
@@ -648,8 +648,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
      d=o.createElement(u);d.async=1;d.src=n
      n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-rum-v4.js','DD_RUM')
-  DD_RUM.onReady(function() {
-    DD_RUM.init({
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
       site: 'ddog-gov.com',
@@ -669,7 +669,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
 
 The `trackUserInteractions` and `trackFrustrations` parameters enable the automatic collection of user clicks in your application. **Sensitive and private data** contained in your pages may be included to identify the elements interacted with.
 
-Early RUM API calls must be wrapped in the `DD_RUM.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
+Early RUM API calls must be wrapped in the `window.DD_RUM.onReady()` callback. This ensures the code only gets executed once the SDK is properly loaded.
 
 ### CDN sync
 
@@ -1358,8 +1358,8 @@ datadogRum.getInternalContext() // { session_id: "xxxx", application_id: "xxxx" 
 For CDN async, use:
 
 ```javascript
-DD_RUM.onReady(function () {
-  DD_RUM.getInternalContext() // { session_id: "xxxx", application_id: "xxxx" ... }
+window.DD_RUM.onReady(function () {
+  window.DD_RUM.getInternalContext() // { session_id: "xxxx", application_id: "xxxx" ... }
 })
 ```
 

--- a/content/en/real_user_monitoring/browser/collecting_browser_errors.md
+++ b/content/en/real_user_monitoring/browser/collecting_browser_errors.md
@@ -92,16 +92,16 @@ try {
 // Send a custom error with context
 const error = new Error('Something wrong occurred.');
 
-DD_RUM.onReady(function() {
-    DD_RUM.addError(error, {
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.addError(error, {
         pageStatus: 'beta',
     });
 });
 
 // Send a network error
 fetch('<SOME_URL>').catch(function(error) {
-    DD_RUM.onReady(function() {
-        DD_RUM.addError(error);
+    window.DD_RUM.onReady(function() {
+        window.DD_RUM.addError(error);
     });
 })
 
@@ -109,8 +109,8 @@ fetch('<SOME_URL>').catch(function(error) {
 try {
     //Some code logic
 } catch (error) {
-    DD_RUM.onReady(function() {
-        DD_RUM.addError(error);
+    window.DD_RUM.onReady(function() {
+        window.DD_RUM.addError(error);
     })
 }
 ```
@@ -121,20 +121,20 @@ try {
 // Send a custom error with context
 const error = new Error('Something wrong occurred.');
 
-window.DD_RUM && DD_RUM.addError(error, {
+window.DD_RUM && window.DD_RUM.addError(error, {
     pageStatus: 'beta',
 });
 
 // Send a network error
 fetch('<SOME_URL>').catch(function(error) {
-    window.DD_RUM && DD_RUM.addError(error);
+    window.DD_RUM && window.DD_RUM.addError(error);
 })
 
 // Send a handled exception error
 try {
     //Some code logic
 } catch (error) {
-    window.DD_RUM && DD_RUM.addError(error);
+    window.DD_RUM && window.DD_RUM.addError(error);
 }
 ```
 {{% /tab %}}

--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -57,8 +57,8 @@ datadogRum.init({
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.init({
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
         ...,
         trackViewsManually: true,
         ...
@@ -101,8 +101,8 @@ datadogRum.startView({
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.startView({
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.startView({
       name: 'checkout',
       service: 'purchase',
       version: '1.2.3'
@@ -176,8 +176,8 @@ datadogRum.init({
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.init({
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
         ...,
         beforeSend: (event, context) => {
             // collect a RUM resource's response headers
@@ -235,8 +235,8 @@ datadogRum.init({
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.init({
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
         ...,
         beforeSend: (event) => {
             // remove email from view url
@@ -301,8 +301,8 @@ datadogRum.init({
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.init({
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
         ...,
         beforeSend: (event) => {
             if (shouldDiscard(event)) {
@@ -371,8 +371,8 @@ datadogRum.setUser({
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.setUser({
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.setUser({
         id: '1234',
         name: 'John Doe',
         email: 'john@doe.com',
@@ -408,8 +408,8 @@ datadogRum.getUser()
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.getUser()
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.getUser()
 })
 ```
 {{% /tab %}}
@@ -433,8 +433,8 @@ datadogRum.setUserProperty('name', 'John Doe')
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.setUserProperty('name', 'John Doe')
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.setUserProperty('name', 'John Doe')
 })
 ```
 {{% /tab %}}
@@ -458,8 +458,8 @@ datadogRum.removeUserProperty('name')
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.removeUserProperty('name')
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.removeUserProperty('name')
 })
 ```
 {{% /tab %}}
@@ -482,8 +482,8 @@ datadogRum.clearUser()
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.clearUser()
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.clearUser()
 })
 ```
 {{% /tab %}}
@@ -515,8 +515,8 @@ datadogRum.init({
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.init({
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
         clientToken: '<CLIENT_TOKEN>',
         applicationId: '<APPLICATION_ID>',
         site: '<DATADOG_SITE>',
@@ -562,13 +562,13 @@ datadogRum.setGlobalContextProperty('activity', {
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.setGlobalContextProperty('<CONTEXT_KEY>', '<CONTEXT_VALUE>');
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.setGlobalContextProperty('<CONTEXT_KEY>', '<CONTEXT_VALUE>');
 })
 
 // Code example
-DD_RUM.onReady(function() {
-    DD_RUM.setGlobalContextProperty('activity', {
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.setGlobalContextProperty('activity', {
         hasPaid: true,
         amount: 23.42
     });
@@ -606,13 +606,13 @@ datadogRum.removeGlobalContextProperty('codeVersion');
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.removeGlobalContextProperty('<CONTEXT_KEY>');
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.removeGlobalContextProperty('<CONTEXT_KEY>');
 })
 
 // Code example
-DD_RUM.onReady(function() {
-    DD_RUM.removeGlobalContextProperty('codeVersion');
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.removeGlobalContextProperty('codeVersion');
 })
 ```
 {{% /tab %}}
@@ -620,11 +620,11 @@ DD_RUM.onReady(function() {
 
 ```javascript
 window.DD_RUM &&
-    DD_RUM.removeGlobalContextProperty('<CONTEXT_KEY>');
+    window.DD_RUM.removeGlobalContextProperty('<CONTEXT_KEY>');
 
 // Code example
 window.DD_RUM &&
-    DD_RUM.removeGlobalContextProperty('codeVersion');
+    window.DD_RUM.removeGlobalContextProperty('codeVersion');
 ```
 
 {{% /tab %}}
@@ -651,13 +651,13 @@ datadogRum.setGlobalContext({
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.setGlobalContext({ '<CONTEXT_KEY>': '<CONTEXT_VALUE>' });
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.setGlobalContext({ '<CONTEXT_KEY>': '<CONTEXT_VALUE>' });
 })
 
 // Code example
-DD_RUM.onReady(function() {
-    DD_RUM.setGlobalContext({
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.setGlobalContext({
         codeVersion: 34,
     })
 })
@@ -667,11 +667,11 @@ DD_RUM.onReady(function() {
 
 ```javascript
 window.DD_RUM &&
-    DD_RUM.setGlobalContext({ '<CONTEXT_KEY>': '<CONTEXT_VALUE>' });
+    window.DD_RUM.setGlobalContext({ '<CONTEXT_KEY>': '<CONTEXT_VALUE>' });
 
 // Code example
 window.DD_RUM &&
-    DD_RUM.setGlobalContext({
+    window.DD_RUM.setGlobalContext({
         codeVersion: 34,
     });
 ```
@@ -695,15 +695,15 @@ datadogRum.clearGlobalContext();
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-  DD_RUM.clearGlobalContext();
+window.DD_RUM.onReady(function() {
+  window.DD_RUM.clearGlobalContext();
 });
 ```
 {{% /tab %}}
 {{% tab "CDN sync" %}}
 
 ```javascript
-window.DD_RUM && DD_RUM.clearGlobalContext();
+window.DD_RUM && window.DD_RUM.clearGlobalContext();
 ```
 
 {{% /tab %}}
@@ -725,15 +725,15 @@ const context = datadogRum.getRumGlobalContext();
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-  const context = DD_RUM.getRumGlobalContext();
+window.DD_RUM.onReady(function() {
+  const context = window.DD_RUM.getRumGlobalContext();
 });
 ```
 {{% /tab %}}
 {{% tab "CDN sync" %}}
 
 ```javascript
-const context = window.DD_RUM && DD_RUM.getRumGlobalContext();
+const context = window.DD_RUM && window.DD_RUM.getRumGlobalContext();
 ```
 
 {{% /tab %}}

--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -45,7 +45,7 @@ You can access performance metrics for your views in:
 {{< img src="real_user_monitoring/browser/core-web-vitals.png" alt="Core Web Vitals summary visualization"  >}}
 
 - First Input Delay and Largest Contentful Paint are not collected for pages opened in the background (for example, in a new tab or a window without focus).
-- Metrics collected from your real users' page views may differ from those calculated for pages loaded in a fixed, controlled environment such as a [Synthetic browser test][6]. Synthetic Monitoring displays Largest Contentful Paint and Cumulative Layout Shift as lab metrics, not real metrics.  
+- Metrics collected from your real users' page views may differ from those calculated for pages loaded in a fixed, controlled environment such as a [Synthetic browser test][6]. Synthetic Monitoring displays Largest Contentful Paint and Cumulative Layout Shift as lab metrics, not real metrics.
 
 | Metric                   | Focus            | Description                                                                                           | Target value |
 |--------------------------|------------------|-------------------------------------------------------------------------------------------------------|--------------|
@@ -113,7 +113,7 @@ The criteria of 100ms since last request or DOM mutation might not be an accurat
 To improve the accuracy of activity determination in these cases, specify `excludedActivityUrls`, a list of resources for the RUM Browser SDK to exclude when computing the page activity:
 
 ```javascript
-DD_RUM.init({
+window.DD_RUM.init({
     ...
     excludedActivityUrls: [
         // Exclude exact URLs
@@ -140,7 +140,7 @@ For example, you can add a timing when your hero image has appeared:
 ```html
 <html>
   <body>
-    <img onload="DD_RUM.addTiming('hero_image')" src="/path/to/img.png" />
+    <img onload="window.DD_RUM.addTiming('hero_image')" src="/path/to/img.png" />
   </body>
 </html>
 ```
@@ -151,7 +151,7 @@ Or when users first scroll:
 document.addEventListener("scroll", function handler() {
     //Remove the event listener so that it only triggers once
     document.removeEventListener("scroll", handler);
-    DD_RUM.addTiming('first_scroll');
+    window.DD_RUM.addTiming('first_scroll');
 });
 ```
 
@@ -169,8 +169,8 @@ document.addEventListener("scroll", function handler() {
     document.removeEventListener("scroll", handler);
 
     const timing = Date.now()
-    DD_RUM.onReady(function() {
-      DD_RUM.addTiming('first_scroll', timing);
+    window.DD_RUM.onReady(function() {
+      window.DD_RUM.addTiming('first_scroll', timing);
     });
 });
 

--- a/content/en/real_user_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/browser/tracking_user_actions.md
@@ -86,7 +86,7 @@ For example:
 
 ```html
 <script>
-  DD_RUM.init({
+  window.DD_RUM.init({
     ...
     trackUserInteractions: true,
     actionNameAttribute: 'data-custom-name',

--- a/content/en/real_user_monitoring/frustration_signals/_index.md
+++ b/content/en/real_user_monitoring/frustration_signals/_index.md
@@ -38,7 +38,7 @@ First, you need the Browser RUM SDK version >= 4.14.0.
 To start collecting frustration signals, add the following to your SDK configuration:
 
 ```
-DD_RUM.init({
+window.DD_RUM.init({
   trackUserInteractions: true,
   trackFrustrations: true
 })

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -34,8 +34,8 @@ datadogRum.init({
 {{% /tab %}}
 {{% tab "CDN async" %}}
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.init({
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
         clientToken: '<CLIENT_TOKEN>',
         applicationId: '<APPLICATION_ID>',
         proxy: '<YOUR_PROXY_URL>',

--- a/content/en/real_user_monitoring/guide/send-rum-custom-actions.md
+++ b/content/en/real_user_monitoring/guide/send-rum-custom-actions.md
@@ -13,13 +13,13 @@ further_reading:
 ---
 ## Overview
 
-Real User Monitoring [automatically collects actions][1] on your web application. You can collect additional events and timings such as form completions and business transactions. 
+Real User Monitoring [automatically collects actions][1] on your web application. You can collect additional events and timings such as form completions and business transactions.
 
 Custom RUM actions allow you to monitor interesting events with all the relevant context attached. For example, the Datadog Browser SDK can collect a user's checkout information (such as the number of items within the cart, the list of items, and how much value the cart items are worth) when they click the checkout button on an e-commerce website.
 
 ## Instrument your code
 
-Create a RUM action using the `addAction` API. Give your action a name and attach context attributes in the form of a JavaScript object. 
+Create a RUM action using the `addAction` API. Give your action a name and attach context attributes in the form of a JavaScript object.
 
 The following example creates a `checkout` action with details about the user cart when the user clicks on the checkout button.
 
@@ -44,25 +44,25 @@ Ensure that you wrap the API call with the `onReady` callback:
 
 ```javascript
 function onCheckoutButtonClick(cart) {
-    DD_RUM.onReady(function() {
-        DD_RUM.addAction('checkout', {
+    window.DD_RUM.onReady(function() {
+        window.DD_RUM.addAction('checkout', {
             'value': cart.value, // for example, 42.12
             'items': cart.items, // for example, ['tomato', 'strawberries']
         })
-    })    
+    })
 }
 ```
 
 {{% /tab %}}
 {{% tab "CDN sync" %}}
 
-Ensure that you check for `DD_RUM` before the API call:
+Ensure that you check for `window.DD_RUM` before the API call:
 
 ```javascript
-window.DD_RUM && DD_RUM.addAction('<NAME>', '<JSON_OBJECT>');
+window.DD_RUM && window.DD_RUM.addAction('<NAME>', '<JSON_OBJECT>');
 
 function onCheckoutButtonClick(cart) {
-    window.DD_RUM && DD_RUM.addAction('checkout', {
+    window.DD_RUM && window.DD_RUM.addAction('checkout', {
         'value': cart.value, // for example, 42.12
         'items': cart.items, // for example, ['tomato', 'strawberries']
     })
@@ -78,13 +78,13 @@ All RUM context such as current page view information, geoIP data, and browser i
 
 After deploying the code that creates your custom actions, they appear in the **Actions** tab of the [RUM Explorer][3].
 
-To filter on your custom actions, use the `Action Target Name` attribute: `@action.target.name:<ACTION_NAME>`. 
+To filter on your custom actions, use the `Action Target Name` attribute: `@action.target.name:<ACTION_NAME>`.
 
 The example below uses the following filter: `@action.target.name:checkout`.
 
 {{< img src="real_user_monitoring/guide/send-custom-user-actions/facet-from-user-action.mp4" alt="Create a facet for custom RUM actions" video=true style="width:100%;">}}
 
-After clicking on an action, a side panel with metadata appears. You can find your action attributes in the **Custom Attributes** section and create facets or measures for these attributes by clicking on them. 
+After clicking on an action, a side panel with metadata appears. You can find your action attributes in the **Custom Attributes** section and create facets or measures for these attributes by clicking on them.
 
 Use facets for distinctive values (IDs) and measures for quantitative values such as timings and latency. For example, create a facet for the cart items and a measure for the cart value.
 

--- a/content/en/real_user_monitoring/guide/setup-feature-flag-data-collection.md
+++ b/content/en/real_user_monitoring/guide/setup-feature-flag-data-collection.md
@@ -49,8 +49,8 @@ To start collecting feature flag data, initialize the RUM SDK and configure the 
   <summary>CDN async</summary>
 
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.init({
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       ...
       enableExperimentalFeatures: ["feature_flags"],
       ...

--- a/content/en/real_user_monitoring/guide/setup-rum-deployment-tracking.md
+++ b/content/en/real_user_monitoring/guide/setup-rum-deployment-tracking.md
@@ -47,8 +47,8 @@ datadogRum.init({
 {{% tab "CDN async" %}}
 
 ```javascript
-DD_RUM.onReady(function() {
-    DD_RUM.init({
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
       ...
       version: '1.0.0',
       ...

--- a/content/en/real_user_monitoring/session_replay/_index.md
+++ b/content/en/real_user_monitoring/session_replay/_index.md
@@ -43,7 +43,7 @@ Session Replay is available in the RUM Browser SDK. To start collecting data for
 The Session Replay does not start recording automatically when calling `init()`. To start the recording, call `startSessionReplayRecording()`. This can be useful to conditionally start the recording, for example, to only record authenticated user sessions:
 
 ```javascript
-DD_RUM.init({
+window.DD_RUM.init({
   applicationId: '<DATADOG_APPLICATION_ID>',
   clientToken: '<DATADOG_CLIENT_TOKEN>',
   site: '<DATADOG_SITE>',
@@ -56,7 +56,7 @@ DD_RUM.init({
 });
 
 if (user.isAuthenticated) {
-    DD_RUM.startSessionReplayRecording();
+    window.DD_RUM.startSessionReplayRecording();
 }
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Consistently use `window` for `DD_RUM`/`DD_LOGS` usages

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer request https://github.com/DataDog/browser-sdk/issues/2067
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
