### PR TITLE
Update remaining docs for Operator v2alpha1 spec

### DIFF
--- a/content/en/containers/cluster_agent/admission_controller.md
+++ b/content/en/containers/cluster_agent/admission_controller.md
@@ -28,17 +28,19 @@ Datadog's Admission Controller is `MutatingAdmissionWebhook` type. For more deta
 {{< tabs >}}
 {{% tab "Operator" %}}
 
-To enable the Admission Controller for the Datadog Operator, set the parameter `clusterAgent.config.admissionController.enabled` to `true` in the custom resource:
+To enable the Admission Controller for the Datadog Operator, set the parameter `features.admissionController.enabled` to `true` in your `DatadogAgent` configuration:
 
 {{< code-block lang="yaml" disable_copy="false" >}}
-[...]
- clusterAgent:
-[...]
-    config:
-      admissionController:
-        enabled: true
-        mutateUnlabelled: false
-[...]
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  #(...)
+  features:
+    admissionController:
+      enabled: true
+      mutateUnlabelled: false
 {{< /code-block >}}
 {{% /tab %}}
 {{% tab "Helm" %}}
@@ -47,9 +49,9 @@ Starting from Helm chart v2.35.0, Datadog Admission controller is activated by d
 To enable the Admission Controller for Helm chart v2.34.6 and earlier, set the parameter `clusterAgent.admissionController.enabled` to `true`:
 
 {{< code-block lang="yaml" filename="values.yaml" disable_copy="false" >}}
-[...]
- clusterAgent:
-[...]
+#(...)
+clusterAgent:
+  #(...)
   ## @param admissionController - object - required
   ## Enable the admissionController to automatically inject APM and
   ## DogStatsD config and standard tags (env, service, version) into
@@ -63,7 +65,6 @@ To enable the Admission Controller for Helm chart v2.34.6 and earlier, set the p
     ## admission.datadoghq.com/enabled="true"
     #
     mutateUnlabelled: false
-[...]
 {{< /code-block >}}
 {{% /tab %}}
 {{% tab "DaemonSet" %}}

--- a/content/en/containers/cluster_agent/setup.md
+++ b/content/en/containers/cluster_agent/setup.md
@@ -41,7 +41,9 @@ Then, upgrade your Datadog Helm chart.
 
 This automatically updates the necessary RBAC files for the Cluster Agent and Datadog Agent. Both Agents use the same API key.
 
-This also automatically generates a random token in a `Secret` shared by both the Cluster Agent and the Datadog Agent. You can manually set this by specifying a token in the `clusterAgent.token` configuration. You can also manually set this by specifying an existing `Secret` name containing a `token` value through the `clusterAgent.tokenExistingSecret` configuration. When set manually, this token must be 32 alphanumeric characters.
+This also automatically generates a random token in a `Secret` shared by both the Cluster Agent and the Datadog Agent to secure communication. You can manually specify this token used by setting the `clusterAgent.token` configuration. You can alternatively set this by referencing the name of an existing `Secret` containing a `token` value through the `clusterAgent.tokenExistingSecret` configuration.
+
+When set manually, this token must be 32 alphanumeric characters.
 
 [1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
 {{% /tab %}}
@@ -49,16 +51,42 @@ This also automatically generates a random token in a `Secret` shared by both th
 
 The Cluster Agent is enabled by default since Datadog Operator v0.7.0.
 
-To activate it explicitly, update your `DatadogAgent` object with the following configuration:
+It can be managed explicitly by the `DatadogAgent` configuration:
 
   ```yaml
-spec:
-  clusterAgent:
-    # clusterAgent.enabled -- Set this to false to disable Datadog Cluster Agent
-    enabled: true
+  apiVersion: datadoghq.com/v2alpha1
+  kind: DatadogAgent
+  metadata:
+    name: datadog
+  spec:
+    global:
+      credentials:
+        apiKey: <DATADOG_API_KEY>
+
+    override:
+      clusterAgent:
+        disabled: false
   ```
 
-The Operator then creates the necessary RBACs, deploys the Cluster Agent, and modifies the Agent DaemonSet configuration to use a randomly generated token (to secure communication between Agent and Cluster Agent). You can manually specify this token by setting the `credentials.token` field. When set manually, this token must be 32 alphanumeric characters.
+The Operator creates the necessary RBACs, deploys the Cluster Agent, and modifies the Agent DaemonSet configuration.
+
+This also automatically generates a random token in a `Secret` shared by both the Cluster Agent and the Datadog Agent to secure communication. You can manually specify this token used by setting the `global.clusterAgentToken` field. You can alternatively set this by referencing the name of an existing `Secret` and the data key containg this token.
+
+  ```yaml
+  apiVersion: datadoghq.com/v2alpha1
+  kind: DatadogAgent
+  metadata:
+    name: datadog
+  spec:
+    global:
+      credentials:
+        apiKey: <DATADOG_API_KEY>
+      clusterAgentTokenSecret:
+        secretName: <SECRET_NAME>
+        keyName: <KEY_NAME>
+  ```
+
+When set manually, this token must be 32 alphanumeric characters.
 
 {{% /tab %}}
 {{% tab "DaemonSet" %}}

--- a/content/en/containers/cluster_agent/setup.md
+++ b/content/en/containers/cluster_agent/setup.md
@@ -41,7 +41,7 @@ Then, upgrade your Datadog Helm chart.
 
 This automatically updates the necessary RBAC files for the Cluster Agent and Datadog Agent. Both Agents use the same API key.
 
-This also automatically generates a random token in a `Secret` shared by both the Cluster Agent and the Datadog Agent to secure communication. You can manually specify this token used by setting the `clusterAgent.token` configuration. You can alternatively set this by referencing the name of an existing `Secret` containing a `token` value through the `clusterAgent.tokenExistingSecret` configuration.
+This also automatically generates a random token in a `Secret` shared by both the Cluster Agent and the Datadog Agent to secure communication. You can manually specify this token using the `clusterAgent.token` configuration. You can alternatively set this by referencing the name of an existing `Secret` containing a `token` value through the `clusterAgent.tokenExistingSecret` configuration.
 
 When set manually, this token must be 32 alphanumeric characters.
 
@@ -70,7 +70,7 @@ It can be managed explicitly by the `DatadogAgent` configuration:
 
 The Operator creates the necessary RBACs, deploys the Cluster Agent, and modifies the Agent DaemonSet configuration.
 
-This also automatically generates a random token in a `Secret` shared by both the Cluster Agent and the Datadog Agent to secure communication. You can manually specify this token used by setting the `global.clusterAgentToken` field. You can alternatively set this by referencing the name of an existing `Secret` and the data key containg this token.
+This also automatically generates a random token in a `Secret` shared by both the Cluster Agent and the Datadog Agent to secure communication. You can manually specify this token by setting the `global.clusterAgentToken` field. You can alternatively set this by referencing the name of an existing `Secret` and the data key containing this token.
 
   ```yaml
   apiVersion: datadoghq.com/v2alpha1

--- a/content/en/containers/cluster_agent/setup.md
+++ b/content/en/containers/cluster_agent/setup.md
@@ -49,26 +49,7 @@ When set manually, this token must be 32 alphanumeric characters.
 {{% /tab %}}
 {{% tab "Operator" %}}
 
-The Cluster Agent is enabled by default since Datadog Operator v0.7.0.
-
-It can be managed explicitly by the `DatadogAgent` configuration:
-
-  ```yaml
-  apiVersion: datadoghq.com/v2alpha1
-  kind: DatadogAgent
-  metadata:
-    name: datadog
-  spec:
-    global:
-      credentials:
-        apiKey: <DATADOG_API_KEY>
-
-    override:
-      clusterAgent:
-        disabled: false
-  ```
-
-The Operator creates the necessary RBACs, deploys the Cluster Agent, and modifies the Agent DaemonSet configuration.
+The Cluster Agent is enabled by default since Datadog Operator v0.7.0. The Operator creates the necessary RBACs, deploys the Cluster Agent, and modifies the Agent DaemonSet configuration.
 
 This also automatically generates a random token in a `Secret` shared by both the Cluster Agent and the Datadog Agent to secure communication. You can manually specify this token by setting the `global.clusterAgentToken` field. You can alternatively set this by referencing the name of an existing `Secret` and the data key containing this token.
 
@@ -88,6 +69,7 @@ This also automatically generates a random token in a `Secret` shared by both th
 
 When set manually, this token must be 32 alphanumeric characters.
 
+[1]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md#override
 {{% /tab %}}
 {{% tab "DaemonSet" %}}
 

--- a/content/en/containers/cluster_agent/setup.md
+++ b/content/en/containers/cluster_agent/setup.md
@@ -49,7 +49,7 @@ When set manually, this token must be 32 alphanumeric characters.
 {{% /tab %}}
 {{% tab "Operator" %}}
 
-The Cluster Agent is enabled by default since Datadog Operator v0.7.0. The Operator creates the necessary RBACs, deploys the Cluster Agent, and modifies the Agent DaemonSet configuration.
+The Cluster Agent is enabled by default since Datadog Operator v1.0.0. The Operator creates the necessary RBACs, deploys the Cluster Agent, and modifies the Agent DaemonSet configuration.
 
 This also automatically generates a random token in a `Secret` shared by both the Cluster Agent and the Datadog Agent to secure communication. You can manually specify this token by setting the `global.clusterAgentToken` field. You can alternatively set this by referencing the name of an existing `Secret` and the data key containing this token.
 

--- a/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
+++ b/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
@@ -84,6 +84,7 @@ To enable the external metrics server with your Cluster Agent managed by the Dat
         apiKey: <DATADOG_API_KEY>
         appKey: <DATADOG_API_KEY>
 
+    features:
       externalMetricsServer:
         enabled: true
   ```
@@ -106,6 +107,7 @@ The keys can alternatively be set by referencing the names of pre-created `Secre
           secretName: <SECRET_NAME>
           keyName: <KEY_FOR_DATADOG_APP_KEY>
 
+    features:
       externalMetricsServer:
         enabled: true
   ```
@@ -211,7 +213,9 @@ To activate the usage of the `DatadogMetric` CRD update your `DatadogAgent` cust
     name: datadog
   spec:
     global:
-      #(...)
+      credentials:
+        apiKey: <DATADOG_API_KEY>
+        appKey: <DATADOG_API_KEY>
     features:
       externalMetricsServer:
         enabled: true

--- a/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
+++ b/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
@@ -46,7 +46,7 @@ As of v1.0.0, the Custom Metrics Server in the Datadog Cluster Agent implements 
 {{< tabs >}}
 {{% tab "Helm" %}}
 
-To enable the external metrics server with your Cluster Agent in Helm, update your [values.yaml][1] file with the following configurations. Provide a valid Datadog API Key, Application Key, and set the `clusterAgent.metricsProvider.enabled` to `true`. Once done redeploy your Datadog Helm chart:
+To enable the external metrics server with your Cluster Agent in Helm, update your [values.yaml][1] file with the following configurations. Provide a valid Datadog API Key, Application Key, and set the `clusterAgent.metricsProvider.enabled` to `true`. Then redeploy your Datadog Helm chart:
 
   ```yaml
   datadog:
@@ -65,7 +65,7 @@ To enable the external metrics server with your Cluster Agent in Helm, update yo
 
 This automatically updates the necessary RBAC configurations and sets up the corresponding `Service` and `APIService` for Kubernetes to use.
 
-The keys can alternatively be set by referencing the names of pre-created `Secrets` containing the data keys `api-key` and `app-key`  with the configurations `datadog.apiKeyExistingSecret` and `datadog.appKeyExistingSecret`.
+The keys can alternatively be set by referencing the names of pre-created `Secrets` containing the data keys `api-key` and `app-key` with the configurations `datadog.apiKeyExistingSecret` and `datadog.appKeyExistingSecret`.
 
 [1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
 {{% /tab %}}

--- a/content/en/containers/guide/clustercheckrunners.md
+++ b/content/en/containers/guide/clustercheckrunners.md
@@ -31,7 +31,7 @@ Then, deploy the cluster check runner using either [Datadog Operator][4] or [Hel
 
 Using the Operator, you can launch and manage all of these resources with a single manifest. For example:
 
-```
+```yaml
 apiVersion: datadoghq.com/v2alpha1
 kind: DatadogAgent
 metadata:
@@ -72,15 +72,17 @@ See the [Datadog Operator repo][1] for more information about the Datadog Operat
 
 You can update the relevant sections of the chart to enable cluster checks, the Cluster Agent, and the cluster check runner at the same time. For example:
 
-```
-[...]
+```yaml
+datadog:
   clusterChecks:
     enabled: true
-[...]
- clusterAgent:
+  #(...)
+
+clusterAgent:
   enabled: true
-[...]
- clusterChecksRunner:
+  #(...)
+
+clusterChecksRunner:
   enabled: true
   replicas: 2
 ```

--- a/content/en/containers/kubernetes/apm.md
+++ b/content/en/containers/kubernetes/apm.md
@@ -126,22 +126,30 @@ This configuration creates a directory on the host and mounts it within the Agen
 {{% /tab %}}
 {{% tab "Operator" %}}
 
-The default configuration creates a directory on the host and mounts it within the Agent. The Agent then creates and listens on a socket file `/var/run/datadog/apm.socket`. The application pods can then similarly mount this volume and write to this same socket. You can modify the path and socket with the `agent.apm.hostSocketPath` and `agent.apm.socketPath` configuration values.
+When APM is enabled, the default configuration creates a directory on the host and mounts it within the Agent. The Agent then creates and listens on a socket file `/var/run/datadog/apm/apm.socket`. The application pods can then similarly mount this volume and write to this same socket. You can modify the path and socket with the `features.apm.unixDomainSocketConfig.path` configuration value.
 
 #### Optional - Configure the Datadog Agent to accept traces over TCP
 
 The Datadog Agent can also be configured to receive traces over TCP. To enable this feature:
 
-Update your `datadog-agent.yaml` manifest with the following:
+Update your `DatadogAgent` manifest with the following:
 
 ```yaml
-agent:
-  image:
-    name: "gcr.io/datadoghq/agent:latest"
-  apm:
-    enabled: true
-    hostPort: 8126
-site: <DATADOG_SITE>
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+    site: <DATADOG_SITE>
+
+  features:
+    apm:
+      enabled: true
+      hostPortConfig:
+        enabled: true
 ```
 Where your `<DATADOG_SITE>` is {{< region-param key="dd_site" code="true" >}} (defaults to `datadoghq.com`).
 

--- a/content/en/containers/kubernetes/configuration.md
+++ b/content/en/containers/kubernetes/configuration.md
@@ -22,20 +22,25 @@ See the [Live Containers][4] documentation for configuration instructions and ad
 {{< tabs >}}
 {{% tab "Operator" %}}
 
-To collect the Kubernetes events with the Cluster Agent, set `clusterAgent.config.collectEvents` to true in your `datadog-agent.yaml` manifest.
+Event collection is enabled by default by the Datadog Operator. This can be managed by the configuration `features.eventCollection.collectKubernetesEvents` in your `DatadogAgent` configuration.
 
 ```yaml
-clusterAgent:
-  config:
-    collectEvents: true 
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+    site: <DATADOG_SITE>
+
+  features:
+    eventCollection:
+      collectKubernetesEvents: true
 ```
 
-Alternatively, to collect the Kubernetes events with a Node Agent, set `agent.config.collectEvents` to true in your `datadog-agent.yaml` manifest.
-```yaml
-agent:
-  config:
-    collectEvents: true
-```
+The Cluster Agent collects and reports the Kubernetes events.
 
 
 {{% /tab %}}

--- a/content/en/containers/kubernetes/log.md
+++ b/content/en/containers/kubernetes/log.md
@@ -132,7 +132,7 @@ datadog:
     containerCollectAll: true
 ```
 
-You can set the `datadog.logs.containerCollectAll` to `true` to collect logs from all discovered containers by default. When set to `false` (default) you need to specify Autodiscovery log configurations to enable log collection.
+You can set the `datadog.logs.containerCollectAll` to `true` to collect logs from all discovered containers by default. When set to `false` (default), you need to specify Autodiscovery log configurations to enable log collection.
 
 ### Unprivileged
 
@@ -170,7 +170,7 @@ spec:
       containerCollectAll: true
 ```
 
-See the sample [manifest with logs and metrics collection enabled][1] for a complete example. You can set the `features.logCollection.containerCollectAll` to `true` to collect logs from all discovered containers by default. When set to `false` (default) you need to specify Autodiscovery log configurations to enable log collection.
+See the sample [manifest with logs and metrics collection enabled][1] for a complete example. You can set the `features.logCollection.containerCollectAll` to `true` to collect logs from all discovered containers by default. When set to `false` (default), you need to specify Autodiscovery log configurations to enable log collection.
 
 Then apply the new configuration:
 

--- a/content/en/containers/kubernetes/log.md
+++ b/content/en/containers/kubernetes/log.md
@@ -132,6 +132,8 @@ datadog:
     containerCollectAll: true
 ```
 
+You can set the `datadog.logs.containerCollectAll` to `true` to collect logs from all discovered containers by default. When set to `false` (default) you need to specify Autodiscovery log configurations to enable log collection.
+
 ### Unprivileged
 
 (Optional) To run an unprivileged installation, add the following in the `values.yaml` file:
@@ -152,16 +154,23 @@ where `<USER_ID>` is the UID to run the agent and `<DOCKER_GROUP_ID>` is the gro
 
 Update your `datadog-agent.yaml` manifest with:
 
-```
-agent:
-  image:
-    name: "gcr.io/datadoghq/agent:latest"
-  log:
-    enabled: true
-    logsConfigContainerCollectAll: true
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+
+  features:
+    logCollection:
+      enabled: true
+      containerCollectAll: true
 ```
 
-See the sample [manifest with logs and metrics collection enabled][1] for a complete example.
+See the sample [manifest with logs and metrics collection enabled][1] for a complete example. You can set the `features.logCollection.containerCollectAll` to `true` to collect logs from all discovered containers by default. When set to `false` (default) you need to specify Autodiscovery log configurations to enable log collection.
 
 Then apply the new configuration:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update the remaining Kubernetes docs with the Operator `v2alpha1` spec corresponding to the GA `1.0.0` release of the Datadog Operator. Changing the yaml snippets and the descriptions accordingly.

Some minor additional changes were made to the Helm side too just to ensure consistency in the language surrounding the two.

### Motivation
<!-- What inspired you to submit this pull request?-->
Get docs on the GA release instructions instead of the beta instructions.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
CC: @CharlyF from our discussion

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
