### PR TITLE
Update node.js tracer version required for apm/dbm 🔗

### DIFF
--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -46,7 +46,7 @@ Data privacy
 | **PHP**  [dd-trace-php][19] >= 0.86.0    |                      |           |
 |                                          | [pdo][20]            | {{< X >}} | {{< X >}} |
 |                                          | [MySQLi][21]         |           | {{< X >}} |
-| **Node.js:** [dd-trace-js][9] >= 3.13.0     |                      |           |           |
+| **Node.js:** [dd-trace-js][9] >= 3.17.0  |                      |           |           |
 |                                          | [postgres][10]       |   Alpha   |           |
 |                                          | [mysql][13]          |           |   Alpha   |
 |                                          | [mysql2][14]         |           |   Alpha   |
@@ -302,10 +302,10 @@ Enable the database monitoring propagation feature by setting the following envi
 DBM-APM linking for Node.js is in alpha release and may be unstable.
 </div>
 
-Install or update [dd-trace-js][1] to a version greater than `3.13.0` (or `2.22.0` if using end-of-life Node.js version 12):
+Install or update [dd-trace-js][1] to a version greater than `3.17.0` (or `2.30.0` if using end-of-life Node.js version 12):
 
 ```
-npm install dd-trace@^3.13.0
+npm install dd-trace@^3.17.0
 ```
 
 Update your code to import and initialize the tracer:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This changes the minimum required version of the Node.js tracer. 

There was an issue with the Node.js tracer's initial implementation of dbm propagation which was fixed in [3.17.0](https://github.com/DataDog/dd-trace-js/releases/tag/v3.17.0)/[2.30.0](https://github.com/DataDog/dd-trace-js/releases/tag/v2.30.0). 

Since the bug was preventing the basic dbm propagation functionality, we're setting the minimum required version to the releases with the fix. 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
