### PR TITLE
bump java version

### DIFF
--- a/layouts/shortcodes/latest-lambda-layer-version.html
+++ b/layouts/shortcodes/latest-lambda-layer-version.html
@@ -26,7 +26,7 @@
 
 <!-- dd-trace-java Layer -->
 {{- if eq (.Get "layer") "dd-trace-java" -}}
-    8
+    9
 {{- end -}}
 
 <!-- dd-trace-dotnet Layer -->


### PR DESCRIPTION
### What does this PR do?
Bump serverless java layer version

### Motivation
https://github.com/DataDog/datadog-lambda-java/releases/tag/v1.4.11
