### PR TITLE
[DOCS-4506] Add shortcodes to ASM Custom Detection Rules doc

### DIFF
--- a/content/en/security/application_security/threats/custom_rules.md
+++ b/content/en/security/application_security/threats/custom_rules.md
@@ -91,92 +91,17 @@ You can also create [notification rules][5] to alleviate manual edits to notific
 
 ### Time windows
 
-An `evaluation window` is specified to match when at least one of the cases matches true. This is a sliding window and evaluates in real time.
+{{% security-rule-time-windows %}}
 
-When a signal is generated, it remains "open" if a case is matched at least once within this `keep alive` window. Each time a new event matches any of the cases, the *last updated* timestamp is updated for the signal.
-
-A signal will "close" regardless of the query being matched once the time exceeds the `maximum signal duration`. This time is calculated from the first seen timestamp.
-
-Additional cases can be added by clicking the **Add Case** button.
+Click **Add Case** to add additional cases.
 
 **Note**: The `evaluation window` must be less than or equal to the `keep alive` and `maximum signal duration`.
 
 ### Say what's happening
 
-The **Rule name** section allows you to configure the rule name that appears in the rules list view, as well as the title of the signal.
+{{% security-rule-say-whats-happening %}}
 
-Use [Notification Variables][5] to provide specific details about the signal by referencing its tags and event attributes.
-
-#### Template variables
-
-Use [template variables][6] to inject dynamic context from traces directly into a security signal and its associated notifications.
-
-Template variables also permit deep linking into Datadog or a partner portal for quick access to next steps for investigation. For example:
-
-```text
-* [Investigate service in the services dashboard](https://app.datadoghq.com/example/integration/application-security---service-events?tpl_var_service={{@service}})
-```
-
-Epoch template variables create a human-readable string or math-friendly number within a notification. For example, use values such as `first_seen`, `last_seen`, or `timestamp` (in milliseconds) within a function to receive a readable string in a notification. For example:
-
-```text
-{{eval "first_seen_epoch-15*60*1000"}}
-```
-
-The attributes can be seen on a signal in the JSON dropdown, and you can access the attributes with the following syntax: `{{@attribute}}`. You can access inner keys of the event attributes by using JSON dot notation (for example, `{{@attribute.inner_key}}`).
-
-**Note**: You can copy the raw JSON directly from a security signal. Select any security signal in the Signals Explorer to view its details. Click the export button in the top left corner, and select **Copy raw JSON to clipboard**.
-
-This JSON object is an example of event attributes which may be associated with a security signal:
-
-```json
-{
-  "attributes":{
-    "title":"Security scanner detected",
-    "http":{
-      "url":"http://www.example.com"
-    },
-    "rule":{
-      "detectionMethod":"threshold",
-      "name":"Your rule name"
-    },
-    "events_matched":2,
-    "first_seen":"2022-01-26T13:23:33.000Z",
-    "last_seen":"2022-01-27T04:01:57.000Z"
-  },
-  "groupByPaths":[
-    "service"
-  ]
-}
-```
-
-For this attribute, use the following in the **Say what's happening** section:
-
-```
-Real routes targeted for {{@service}}.
-```
-
-This renders your service name in any notifications you receive.
-
-```
-Real routes targeted for `your_service_name`.
-```
-
-You can also use if-else logic to see if an attribute exists with the notation:
-
-```
-{{#if @network.client.ip}}The attribute IP attribute exists.{{/if}}
-```
-
-Or use if-else logic to see if an attribute matches a value:
-
-```
-{{#is_exact_match "@network.client.ip" "1.2.3.4"}}The ip matched.{{/is_exact_match}}
-```
-
-See [Template Variables][6] for more information.
-
-Use the Tag Resulting Signals dropdown to tag your signals with different tags. For example, `attack:sql-injection-attempt`.
+Use the **Tag resulting signals** dropdown menu to add tags to your signals. For example, `attack:sql-injection-attempt`.
 
 **Note**: The tag `security` is special. This tag is used to classify the security signal. The recommended options are: `attack`, `threat-intel`, `compliance`, `anomaly`, and `data-leak`.
 

--- a/content/en/security/cloud_siem/log_detection_rules.md
+++ b/content/en/security/cloud_siem/log_detection_rules.md
@@ -192,11 +192,11 @@ Provide a **name**, for example "Case 1", for each rule case. This name is appen
 
 ### Severity and notification
 
-{{% cloud-siem-rule-severity-notification %}}
+{{% security-rule-severity-notification %}}
 
 ### Time windows
 
-{{% cloud-siem-rule-time-windows %}}
+{{% security-rule-time-windows %}}
 
 Click **Add Case** to add additional cases.
 
@@ -210,7 +210,7 @@ Click **Add Case** to add additional cases.
 
 ### Severity and notification
 
-{{% cloud-siem-rule-severity-notification %}}
+{{% security-rule-severity-notification %}}
 
 ### Forget value
 
@@ -228,7 +228,7 @@ Set a maximum duration to keep updating a signal if new values are detected with
 
 ### Severity and notification
 
-{{% cloud-siem-rule-severity-notification %}}
+{{% security-rule-severity-notification %}}
 
 ### Time windows
 
@@ -246,11 +246,11 @@ The impossible travel detection method does not require setting a rule case.
 
 ### Severity and notification
 
-{{% cloud-siem-rule-severity-notification %}}
+{{% security-rule-severity-notification %}}
 
 ### Time windows
 
-{{% cloud-siem-rule-time-windows %}}
+{{% security-rule-time-windows %}}
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -270,7 +270,11 @@ The severity decrement is applied to signals with an environment tag starting wi
 
 ## Say what's happening
 
-{{% cloud-siem-rule-say-whats-happening %}}
+{{% security-rule-say-whats-happening %}}
+
+Use the **Tag resulting signals** dropdown menu to add tags to your signals. For example, `security:attack` or `technique:T1110-brute-force`.
+
+**Note**: the tag `security` is special. This tag is used to classify the security signal. The recommended options are: `attack`, `threat-intel`, `compliance`, `anomaly`, and `data-leak`.
 
 ## Rule deprecation
 

--- a/content/en/security/cloud_siem/signal_correlation_rules.md
+++ b/content/en/security/cloud_siem/signal_correlation_rules.md
@@ -51,11 +51,11 @@ Provide a **name**, for example "Case 1", for each rule case. This name is appen
 
 #### Severity and notification
 
-{{% cloud-siem-rule-severity-notification %}}
+{{% security-rule-severity-notification %}}
 
 #### Time windows
 
-{{% cloud-siem-rule-time-windows %}}
+{{% security-rule-time-windows %}}
 
 Click **Add Case** to add additional cases.
 
@@ -63,7 +63,11 @@ Click **Add Case** to add additional cases.
 
 ### Say what's happening
 
-{{% cloud-siem-rule-say-whats-happening %}}
+{{% security-rule-say-whats-happening %}}
+
+Use the **Tag resulting signals** dropdown menu to add tags to your signals. For example, `security:attack` or `technique:T1110-brute-force`.
+
+**Note**: the tag `security` is special. This tag is used to classify the security signal. The recommended options are: `attack`, `threat-intel`, `compliance`, `anomaly`, and `data-leak`.
 
 ## Further reading
 

--- a/layouts/shortcodes/cloud-siem-rule-time-windows.md
+++ b/layouts/shortcodes/cloud-siem-rule-time-windows.md
@@ -1,5 +1,0 @@
-An `evaluation window` is specified to match when at least one of the cases matches true. This is a sliding window and evaluates cases in real-time.
-
-Once a signal is generated, the signal remains "open" if a case is matched at least once within the `keep alive` window. Each time a new event matches any of the cases, the *last updated* timestamp is updated for the signal.
-
-A signal closes once the time exceeds the `maximum signal duration`, regardless of the query being matched. This time is calculated from the first seen timestamp.

--- a/layouts/shortcodes/security-rule-say-whats-happening.md
+++ b/layouts/shortcodes/security-rule-say-whats-happening.md
@@ -2,7 +2,5 @@ Add a **Rule name** to configure the rule name that appears in the detection rul
 
 In the **Rule message** section, use [notification variables][101] and Markdown to customize the notifications sent when a signal is generated. Specifically, use [template variables][102] in the notification to inject dynamic context from triggered logs directly into a security signal and its associated notifications. See the [Notification Variables documentation][101] for more information and examples.
 
-Use the **Tag resulting signals** dropdown menu to add tags to your signals. For example, `security:attack` or `technique:T1110-brute-force`.
-
 [101]: /security_platform/notifications/variables/
 [102]: /security_platform/notifications/variables/#template-variables

--- a/layouts/shortcodes/security-rule-severity-notification.md
+++ b/layouts/shortcodes/security-rule-severity-notification.md
@@ -2,4 +2,7 @@ In the **then set severity to** dropdown menu, select the appropriate severity l
 
 In the **Notify** section, optionally, configure [notification targets][101] for each rule case.
 
+You can also create [notification rules][102] to avoid manual edits to notification preferences for individual detection rules.
+
 [101]: /security_platform/notifications/#notification-channels
+[102]: /security/notifications/rules/

--- a/layouts/shortcodes/security-rule-time-windows.md
+++ b/layouts/shortcodes/security-rule-time-windows.md
@@ -1,0 +1,5 @@
+An `evaluation window` is specified to match when at least one of the cases matches true. This is a sliding window and evaluates cases in real time.
+
+After a signal is generated, the signal remains "open" if a case is matched at least once within the `keep alive` window. Each time a new event matches any of the cases, the *last updated* timestamp is updated for the signal.
+
+A signal closes once the time exceeds the `maximum signal duration`, regardless of the query being matched. This time is calculated from the first seen timestamp.


### PR DESCRIPTION
### What does this PR do?

- Renames the Cloud SIEM shortcodes to the more generic Security shortcodes
- Update current shortcode usages to new name
- Add shortcodes to the ASM Custom Detection Rules doc


### Motivation

[DOCS-4506](https://datadoghq.atlassian.net/browse/DOCS-4506)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
