### PR TITLE
WEB-3407 - update header render to have links

### DIFF
--- a/layouts/api/_markup/render-heading.html
+++ b/layouts/api/_markup/render-heading.html
@@ -1,0 +1,1 @@
+<h{{ .Level }} id="{{ .Anchor | safeURL }}"><a href="#{{ .Anchor | safeURL }}">{{ .Text | safeHTML }}</a></h{{ .Level }}>

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -154,7 +154,7 @@
 
                     <h3 class="mt-2">{{ i18n "overview" }}</h3>
                     <p>
-                      {{ $translate_action.description | default $endpoint.action.description | markdownify }}
+                     {{ $translate_action.description | default $endpoint.action.description | $dot.Page.RenderString }}
                       <!-- required scopes -->
                       {{ partial "api/scopes.html" (dict "context" $dot "endpoint" $endpoint "securitySchemes" $adat.components.securitySchemes "tag" $tag) }}
                     </p>


### PR DESCRIPTION
### What does this PR do?

Allows headers in the api description to link to their anchors.
e.g Monitor types heading is clickable at `api/latest/monitors/`

### Motivation

https://datadoghq.atlassian.net/browse/WEB-3407

### Preview

https://docs-staging.datadoghq.com/david.jones/web-3407/api/latest/monitors/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
