### PR TITLE
[DOCS-5082] Add back 2h in the future for log submission

### DIFF
--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -313,7 +313,7 @@ The TCP endpoint is not supported for this site.
 * The HTTPS API supports logs of sizes up to 1MB. However, for optimal performance, it is recommended that an individual log be no greater than 25K bytes. If you use the Datadog Agent for logging, it is configured to split a log at 256kB (256000 bytes).
 * A log event should not have more than 100 tags, and each tag should not exceed 256 characters for a maximum of 10 million unique tags per day.
 * A log event converted to JSON format should contain less than 256 attributes. Each of those attribute's keys should be less than 50 characters, nested in less than 10 successive levels, and their respective value should be less than 1024 characters if promoted as a facet.
-* Log events can be submitted with a [timestamp][14] that is up to 18h in the past.
+* Log events can be submitted with a [timestamp][14] that is up to 18h in the past and 2h in the future.
 
 Log events that do not comply with these limits might be transformed or truncated by the system or not indexed if outside the provided time range. However, Datadog tries to preserve as much user data as possible.
 


### PR DESCRIPTION
### What does this PR do?

Adds back previous info.

### Motivation

[DOCS-5082](https://datadoghq.atlassian.net/browse/DOCS-5082)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
