### PR TITLE
APM > Custom Instrumentation > .NET > Add SQS header extraction logic

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/dotnet.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/dotnet.md
@@ -263,10 +263,10 @@ public static IEnumerable<string> GetHeaderValues(IDictionary<string, MessageAtt
     if (headers.TryGetValue("_datadog", out var messageAttributeValue)
         && messageAttributeValue.StringValue is string jsonString)
     {
-        var datadogHeaderDictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(jsonString);
-        if (datadogHeaderDictionary.TryGetValue(name, out string datadogHeaderValue))
+        var datadogDictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(jsonString);
+        if (datadogDictionary.TryGetValue(name, out string value))
         {
-            return new[] { datadogHeaderValue };
+            return new[] { value };
         }
     }
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/dotnet.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/dotnet.md
@@ -199,7 +199,7 @@ catch(Exception e)
 }
 ```
 
-This sets the following tags on the span: 
+This sets the following tags on the span:
 - `"error.msg":exception.Message`
 - `"error.stack":exception.ToString()`
 - `"error.type":exception.GetType().ToString()`
@@ -246,6 +246,28 @@ IEnumerable<string> GetHeaderValues(IDictionary<string, object> headers, string 
     if (headers.TryGetValue(name, out object value) && value is byte[] bytes)
     {
         return new[] { Encoding.UTF8.GetString(bytes) };
+    }
+
+    return Enumerable.Empty<string>();
+}
+
+// SQS
+public static IEnumerable<string> GetHeaderValues(IDictionary<string, MessageAttributeValue> headers, string name)
+{
+    // For SQS, there are a maximum of 10 message attribute headers,
+    // so the Datadog headers are combined into one header with the following properties:
+    // - Key: "_datadog"
+    // - Value:
+    //   - DataType: "String"
+    //   - StringValue: <JSON map with key-value headers>
+    if (headers.TryGetValue("_datadog", out var messageAttributeValue)
+        && messageAttributeValue.StringValue is string jsonString)
+    {
+        var datadogHeaderDictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(jsonString);
+        if (datadogHeaderDictionary.TryGetValue(name, out string datadogHeaderValue))
+        {
+            return new[] { datadogHeaderValue };
+        }
     }
 
     return Enumerable.Empty<string>();

--- a/content/en/tracing/trace_collection/custom_instrumentation/dotnet.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/dotnet.md
@@ -257,7 +257,7 @@ public static IEnumerable<string> GetHeaderValues(IDictionary<string, MessageAtt
     // For SQS, there are a maximum of 10 message attribute headers,
     // so the Datadog headers are combined into one header with the following properties:
     // - Key: "_datadog"
-    // - Value:
+    // - Value: MessageAttributeValue object
     //   - DataType: "String"
     //   - StringValue: <JSON map with key-value headers>
     if (headers.TryGetValue("_datadog", out var messageAttributeValue)


### PR DESCRIPTION
### What does this PR do?
Adds the logic to extract the propagated span context from SQS messages. This is needed because we can't automatically connect the spans between SQS send/receive for .NET automatic instrumentation (and likely other languages) because the SQS API doesn't give us the right hooks to close the receive spans correctly and reliably 100% of the time.

### Motivation
We have header extraction logic for Kafka and RabbitMQ, so we should also have one for SQS.

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
