### PR TITLE
[web-3471] make corpweb required to approve changes inside assets folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 *                         @DataDog/documentation
 
+/assets/                  @DataDog/corpweb @DataDog/documentation
 /data/                    @DataDog/corpweb @DataDog/documentation
 /local/                   @DataDog/corpweb @DataDog/documentation
 /layouts/                 @DataDog/corpweb @DataDog/documentation


### PR DESCRIPTION
### What does this PR do?
Make CorpWeb required to approve PRs that have changes to anything within the `/assets/` directory.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-3471

### Preview
n/a

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
