### PR TITLE
DOCS-4738: Change GCP to Google Cloud in Security docs

### DIFF
--- a/content/en/security/cloud_siem/guide/how-to-setup-security-filters-using-cloud-siem-api.md
+++ b/content/en/security/cloud_siem/guide/how-to-setup-security-filters-using-cloud-siem-api.md
@@ -229,7 +229,7 @@ If you aim to only analyze explicitly specified categories of logs, be cautious 
 | --------------------- |--------------------------------------------------|
 | AWS Security Logs     | `source:(cloudtrail OR guardduty OR route53)`    |
 | AWS Network Logs      | `source:(vpc OR waf OR elb OR alb)`              |
-| GCP Logs              | `source:gcp*`                                    |
+| Google Cloud Logs     | `source:gcp*`                                    |
 | Azure Logs            | `source:azure*`                                  |
 | Kubernetes Audit Logs | `source:kubernetes.audit`                        |
 | Identity Provider Logs| `source:(okta OR gsuite OR auth0)`               |

--- a/content/en/security/cspm/custom_rules/schema.md
+++ b/content/en/security/cspm/custom_rules/schema.md
@@ -9,7 +9,7 @@ aliases:
 list_section:
   AWS: Review detailed information about AWS resource types in the following pages.
   Azure: Review detailed information about Azure resource types in the following pages.
-  GCP: Review detailed information about GCP resource types in the following pages.
+  Google Cloud: Review detailed information about Google Cloud resource types in the following pages.
 
 ---
 When you [write custom rules for CSPM][1], you specify the resource types that are referenced by the rules.

--- a/content/en/security/cspm/detection_rules.md
+++ b/content/en/security/cspm/detection_rules.md
@@ -65,7 +65,7 @@ Alternatively, create [notification rules][21] that span across multiple detecti
 
 ## Create custom rules
 
-You can create custom rules to extend the rules being applied to your environment to evaluate your security posture. You can also clone the default detection rules and edit the copies (GCP only). See [Custom Rules][20] for more information.
+You can create custom rules to extend the rules being applied to your environment to evaluate your security posture. You can also clone the default detection rules and edit the copies (Google Cloud only). See [Custom Rules][20] for more information.
 
 ## Rule deprecation
 

--- a/content/en/security/cspm/setup.md
+++ b/content/en/security/cspm/setup.md
@@ -29,7 +29,7 @@ Cloud Security Posture Management (CSPM) makes it easier to assess and visualize
 
 ## Enable CSPM for your cloud resources
 
-CSPM provides agentless onboarding using existing Datadog integrations with cloud providers such as AWS, Azure, GCP, Docker, and Kubernetes. For details on how to configure CSPM, select your cloud provider and follow the instructions:
+CSPM provides agentless onboarding using existing Datadog integrations with cloud providers such as AWS, Azure, Google Cloud, Docker, and Kubernetes. For details on how to configure CSPM, select your cloud provider and follow the instructions:
 
 {{< tabs >}}
 {{% tab "AWS" %}}
@@ -91,28 +91,28 @@ Use one of the following methods to enable CSPM for your Azure subscriptions:
 
 {{% /tab %}}
 
-{{% tab "GCP" %}}
+{{% tab "Google Cloud" %}}
 
-### Set up the Datadog GCP integration
+### Set up the Datadog Google Cloud integration
 
 If you haven't already, set up the [Google Cloud Platform integration][1] and make sure that you have successfully completed the steps for enabling [metric collection][2].
 
-### Enable CSPM for GCP
+### Enable CSPM for Google Cloud
 
-Use one of the following methods to enable CSPM for your GCP projects:
+Use one of the following methods to enable CSPM for your Google Cloud projects:
 
 ### Security Setup
 
 1. Navigate to **Security** > **Setup**.
 2. Follow the [in-app instructions][3] to activate CSPM for your account.
-3. On the **Setup** > **Cloud Providers** tab, click the **[GCP][4]** tile.
-4. Enable CSPM for your GCP projects by turning on the **CSPM Enabled** toggle.
+3. On the **Setup** > **Cloud Providers** tab, click the **[Google Cloud Platform][4]** tile.
+4. Enable CSPM for your Google Cloud projects by turning on the **CSPM Enabled** toggle.
 
-**Note**: If you do not see any data on the CSPM overview page, you may not have set up your GCP integration correctly. See the [GCP metric collection][2] instructions for more information.
+**Note**: If you do not see any data on the CSPM overview page, you may not have set up your Google Cloud integration correctly. See the [Google Cloud metric collection][2] instructions for more information.
 
-### GCP integration tile
+### Google Cloud integration tile
 
-1. On the GCP integration tile, select a GCP project.
+1. On the Google Cloud integration tile, select a Google Cloud project.
 2. Under **Enable resource collection for Cloud Security Posture Management**, select the **Resource collection** checkbox.
 3. Click **Update Configuration**.
 
@@ -185,7 +185,7 @@ To filter the default detection rules by cloud provider:
 2. Choose one of the following values from the **Tag** facet.
     - **AWS**: cloud_provider:aws
     - **Azure**: cloud_provider:azure
-    - **GCP**: cloud_provider:gcp
+    - **Google Cloud**: cloud_provider:gcp
     - **Docker**: framework:cis-docker
     - **Kubernetes**: framework:cis-kubernetes
 
@@ -199,7 +199,7 @@ To disable CSPM for your cloud providers:
 
 - **AWS**: On the **Setup** > **Cloud Providers** tab, click the **AWS** tile, and turn off the **Collect Resources** toggle for your AWS accounts. 
 - **Azure**: On the **Setup** > **Cloud Providers** tab, click the **Azure** tile, and turn off the **CSPM Enabled** toggle for your Azure subscriptions.
-- **GCP**: On the **Setup** > **Cloud Providers** tab, click the **GCP** tile, and turn off the **CSPM Enabled** toggle for your GCP projects.
+- **Google Cloud**: On the **Setup** > **Cloud Providers** tab, click the **Google Cloud Platform** tile, and turn off the **CSPM Enabled** toggle for your Google Cloud projects.
 - **Docker**: Set `DD_COMPLIANCE_CONFIG_ENABLED` to `false` in your Docker configuration.
 - **Kubernetes**: In the `datadog` section of the `values.yaml` file, set `compliance` > `enabled` to `false`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Changes GCP to Google Cloud in 4 security docs.

### Motivation
DOCS-4738

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
