### PR TITLE
Rtrieu/docs 5236 add service metadata structure page

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1726,21 +1726,26 @@ main:
     parent: service_catalog
     identifier: service_catalog_api
     weight: 902
+  - name: Service Catalog API
+    url: tracing/service_catalog/service_metadata_structure
+    parent: service_catalog
+    identifier: service_metadata_structure
+    weight: 903
   - name: Integrations
     url: tracing/service_catalog/integrations
     parent: service_catalog
     identifier: service_catalog_integrations
-    weight: 903
+    weight: 904
   - name: Troubleshooting
     url: tracing/service_catalog/troubleshooting
     parent: service_catalog
     identifier: service_catalog_troubleshooting
-    weight: 904
+    weight: 905
   - name: Guides
     url: tracing/service_catalog/guides
     parent: service_catalog
     identifier: service_catalog_guides
-    weight: 905
+    weight: 906
   - name: Error Tracking
     url: tracing/error_tracking/
     parent: tracing

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1726,7 +1726,7 @@ main:
     parent: service_catalog
     identifier: service_catalog_api
     weight: 902
-  - name: Service Catalog API
+  - name: Service Metadata Structure
     url: tracing/service_catalog/service_metadata_structure
     parent: service_catalog
     identifier: service_metadata_structure

--- a/content/en/tracing/service_catalog/service_definition_api.md
+++ b/content/en/tracing/service_catalog/service_definition_api.md
@@ -21,53 +21,7 @@ A service is an independent, deployable unit of software. Datadog [Unified Servi
 
 For more details about creating, getting, and deleting service definitions, see the [Service Definitions API reference][8].
 
-## Service Definition Schema (v2)
-
-The Service Definition Schema is a structure that contains basic information about a service. See the [full schema on GitHub][4].
-
-
-#### Example
-{{< code-block lang="yaml" filename="service.datadog.yaml" collapsible="true" >}}
-schema-version: v2
-dd-service: web-store
-team: shopist
-contacts:
   - type: slack
-    contact: https://exampleincidents.slack.com/archives/C01EWN6319S
-links:
-  - name: Demo Dashboard
-    type: dashboard
-    url: https://app.examplehq.com/dashboard/krp-bq6-362
-  - name: Common Operations
-    type: runbook
-    url: https://examplehq.atlassian.net/wiki/
-  - name: Disabling Deployments
-    type: runbook
-    url: https://examplehq.atlassian.net/wiki/
-  - name: Rolling Back Deployments
-    type: runbook
-    url: https://examplehq.atlassian.net/wiki/
-repos:
-  - name: Source
-    provider: github
-    url: https://github.com/Example/shopist/tree/prod/rails-storefront
-  - name: Deployment
-    provider: github
-    url: https://github.com/Example/shopist/blob/prod/k8s/dd-trace-demo/templates/rails-storefront-deployment.yaml
-docs:
-  - name: Deployment Information
-    provider: link
-    url: https://docs.datadoghq.com/
-  - name: Service Documentation
-    provider: link
-    url: https://docs.datadoghq.com/
-tags: []
-integrations:
-    pagerduty: https://example.pagerduty.com/service-directory/XYZYX
-External Resources (Optional)
-{{< /code-block >}}
-
-
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/tracing/service_catalog/service_metadata_structure.md
+++ b/content/en/tracing/service_catalog/service_metadata_structure.md
@@ -1,0 +1,91 @@
+---
+title: Service Metadata Structure (JSON Schemas)
+kind: documentation
+further_reading:
+- link: "/tracing/service_catalog/"
+  tag: "Documentation"
+  text: "Datadog Service Catalog"
+- link: "/api/latest/service-definition/"
+  tag: "Documentation"
+  text: "Service Definition API"
+- link: "https://github.com/DataDog/schema/blob/main/service-catalog/v2/schema.json"
+  tag: "GitHub"
+  text: "Service Definition Schema"
+---
+
+## Overview
+
+Service Catalog uses Service Definition Schemas to store and display relevant metadata about your services. The schemas have built-in validation rules that ensure that only valid values are accepted and you can view warnings in the 'Definition tab in the side panel for any selected services. 
+
+There are two supported versions of the schema. 
+
+- V2 is the earliest version, and contains some experimental features such as dd-team (this is removed from v2.1).
+- V2.1 supports additional UI elements like service groupings as well as fields like application, tier, lifecycle to make it easier to preserve context for your service ownership information. 
+
+You can find the latest updates and additional information about the schemas on GitHub.
+
+## Service Definition Schema (v2.1)
+
+The Service Definition Schema is a structure that contains basic information about a service. See the [full schema on GitHub][4].
+
+#### Example
+{{< code-block lang="yaml" filename="service.datadog.yaml" collapsible="true" >}}
+
+{{< /code-block >}}
+
+## Service Definition Schema (v2)
+
+The Service Definition Schema is a structure that contains basic information about a service. See the [full schema on GitHub][4].
+
+#### Example
+{{< code-block lang="yaml" filename="service.datadog.yaml" collapsible="true" >}}
+schema-version: v2
+dd-service: web-store
+team: shopist
+contacts:
+  - type: slack
+    contact: https://exampleincidents.slack.com/archives/C01EWN6319S
+links:
+  - name: Demo Dashboard
+    type: dashboard
+    url: https://app.examplehq.com/dashboard/krp-bq6-362
+  - name: Common Operations
+    type: runbook
+    url: https://examplehq.atlassian.net/wiki/
+  - name: Disabling Deployments
+    type: runbook
+    url: https://examplehq.atlassian.net/wiki/
+  - name: Rolling Back Deployments
+    type: runbook
+    url: https://examplehq.atlassian.net/wiki/
+repos:
+  - name: Source
+    provider: github
+    url: https://github.com/Example/shopist/tree/prod/rails-storefront
+  - name: Deployment
+    provider: github
+    url: https://github.com/Example/shopist/blob/prod/k8s/dd-trace-demo/templates/rails-storefront-deployment.yaml
+docs:
+  - name: Deployment Information
+    provider: link
+    url: https://docs.datadoghq.com/
+  - name: Service Documentation
+    provider: link
+    url: https://docs.datadoghq.com/
+tags: []
+integrations:
+    pagerduty: https://example.pagerduty.com/service-directory/XYZYX
+External Resources (Optional)
+{{< /code-block >}}
+
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://www.datadoghq.com/blog/unified-service-tagging/
+[2]: /tracing/service_catalog/
+[3]: /account_management/api-app-keys/
+[4]: https://github.com/DataDog/schema/blob/main/service-catalog/v2/schema.json
+[7]: https://app.datadoghq.com/services/setup
+[8]: /api/latest/service-definition/

--- a/content/en/tracing/service_catalog/service_metadata_structure.md
+++ b/content/en/tracing/service_catalog/service_metadata_structure.md
@@ -30,7 +30,50 @@ The Service Definition Schema is a structure that contains basic information abo
 
 #### Example
 {{< code-block lang="yaml" filename="service.datadog.yaml" collapsible="true" >}}
-
+schema-version: v2.1
+dd-service: web-store
+team: shopist
+contacts:
+ - type: slack
+   contact: https://datadogincidents.slack.com/archives/C01EWN6319S
+application: shopist
+description: shopist.com storefront
+tier: tier1
+lifecycle: production
+links:
+ - name: Demo Dashboard
+   type: dashboard
+   url: https://app.datadoghq.com/dashboard/krp-bq6-362
+ - name: Common Operations
+   type: runbook
+   url: https://datadoghq.atlassian.net/wiki/
+ - name: Disabling Deployments
+   type: runbook
+   url: https://datadoghq.atlassian.net/wiki/
+ - name: Rolling Back Deployments
+   type: runbook
+   url: https://datadoghq.atlassian.net/wiki/
+ - name: Source
+   type: repo
+   provider: github
+   url: https://github.com/DataDog/shopist/tree/prod/rails-storefront
+ - name: Deployment
+   type: repo
+   provider: github
+   url: https://github.com/DataDog/shopist/blob/prod/k8s/dd-trace-demo/templates/rails-storefront-deployment.yaml
+ - name: Deployment Information
+   provider: link
+   type: doc
+   url: https://docs.datadoghq.com/
+ - name: Service Documentation
+   provider: link
+   type: doc
+   url: https://docs.datadoghq.com/
+tags: []
+integrations:
+ pagerduty:
+   service-url: https://datadog.pagerduty.com/service-directory/XXXXXXX
+External Resources (Optional)
 {{< /code-block >}}
 
 ## Service Definition Schema (v2)

--- a/content/en/tracing/service_catalog/service_metadata_structure.md
+++ b/content/en/tracing/service_catalog/service_metadata_structure.md
@@ -15,12 +15,12 @@ further_reading:
 
 ## Overview
 
-Service Catalog uses Service Definition Schemas to store and display relevant metadata about your services. The schemas have built-in validation rules that ensure that only valid values are accepted and you can view warnings in the 'Definition tab in the side panel for any selected services. 
+Service Catalog uses Service Definition Schemas to store and display relevant metadata about your services. The schemas have built-in validation rules to ensure that only valid values are accepted and you can view warnings in the 'Definition' tab in the side panel for any selected services. 
 
-There are two supported versions of the schema. 
+There are two supported versions of the schema:
 
-- V2 is the earliest version, and contains some experimental features such as dd-team (this is removed from v2.1).
-- V2.1 supports additional UI elements like service groupings as well as fields like application, tier, lifecycle to make it easier to preserve context for your service ownership information. 
+- V2 is the earliest version, and contains some experimental features, such as `dd-team` (this is removed from v2.1).
+- V2.1 supports additional UI elements like service groupings, as well as fields like application, tier, lifecycle to make it easier to preserve context for your service ownership information.
 
 You can find the latest updates and additional information about the schemas on GitHub.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a new "Service Metadata Structure" page to the APM > Service Catalog section.

### Motivation
[DOCS-5236](https://datadoghq.atlassian.net/browse/DOCS-5236)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
