### PR TITLE
removing hash conditional for onload nav functions

### DIFF
--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -373,13 +373,10 @@ window.addEventListener('click', (event) => {
     rulesListClickHandler(event, 'default_rules');
 });
 
-if(!window.location.hash){
-    // runs onload for all pages that dont have a `hash` in the url.
-    window.onload = function () {
-        getPathElement();
-        setMobileNav();
-    };
-}
+window.onload = function () {
+    getPathElement();
+    setMobileNav();
+};
 
 // remove branch name from path
 function replacePath(inputPath) {


### PR DESCRIPTION
### What does this PR do?

Fixes sidebar navigation not expanding if visiting via a link with a hash.

Problem can be viewed by visiting this link: https://docs.datadoghq.com/account_management/org_settings/service_accounts/#overview
Visiting this link is fine: https://docs.datadoghq.com/account_management/org_settings/service_accounts/

### Motivation
https://datadoghq.atlassian.net/browse/WEB-3461

### Preview 

This link should now correctly expand the sidenav: https://docs-staging.datadoghq.com/fitzage/subnav-expansion/account_management/org_settings/service_accounts/#overview
And this link should still work correctly also: https://docs-staging.datadoghq.com/fitzage/subnav-expansion/account_management/org_settings/service_accounts/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
