### PR TITLE
Remove beta note from Teams page

### DIFF
--- a/content/en/account_management/teams.md
+++ b/content/en/account_management/teams.md
@@ -3,8 +3,6 @@ title: Teams
 kind: documentation
 ---
 
-<div class="alert alert-warning">The Teams feature is in beta and is not yet generally available.</div>
-
 ## Overview
 Datadog Teams allow groups of users to organize their team assets within Datadog and automatically filter their Datadog-wide experience to prioritize these assets.
 
@@ -78,12 +76,12 @@ The table below describes the products in which you can use the team filter:
 
 | Product List Page       | Filter basis                                                                     |
 |-------------------------|----------------------------------------------------------------------------------|
-| [Dashboards][7]         | Team handle                                                                      |
-| [Service Catalog][8]    | Team handle                                                                      |
-| [Incidents][9]          | Team handle                                                                      |
-| [Monitors][10]           | Team handle                                                                      |
-| [APM Error Tracking][11] | Service owned by teams (determined by ownership inside the [Service Catalog][8]) |
-| [Logs Error Tracking][12] | Service owned by teams (determined by ownership inside the [Service Catalog][8]) |
+| [Dashboards][6]         | Team handle                                                                      |
+| [Service Catalog][7]    | Team handle                                                                      |
+| [Incidents][8]          | Team handle                                                                      |
+| [Monitors][9]           | Team handle                                                                      |
+| [APM Error Tracking][10] | Service owned by teams (determined by ownership inside the [Service Catalog][7]) |
+| [Logs Error Tracking][11] | Service owned by teams (determined by ownership inside the [Service Catalog][7]) |
 
 
 ## Permissions
@@ -117,10 +115,9 @@ To enforce a strict membership model, configure your default team settings so **
 [3]: /monitors/incident_management/incident_details#overview-section
 [4]: /monitors/configuration/?tab=thresholdalert#add-metadata
 [5]: /tracing/service_catalog/setup#add-service-definition-metadata
-[6]: /monitors/service_level_objectives/#slo-tags
-[7]: https://app.datadoghq.com/dashboard/lists
-[8]: https://app.datadoghq.com/services
-[9]: https://app.datadoghq.com/incidents
-[10]: https://app.datadoghq.com/monitors/manage
-[11]: https://app.datadoghq.com/apm/error-tracking
-[12]: https://app.datadoghq.com/logs/error-tracking
+[6]: https://app.datadoghq.com/dashboard/lists
+[7]: https://app.datadoghq.com/services
+[8]: https://app.datadoghq.com/incidents
+[9]: https://app.datadoghq.com/monitors/manage
+[10]: https://app.datadoghq.com/apm/error-tracking
+[11]: https://app.datadoghq.com/logs/error-tracking

--- a/content/en/account_management/teams.md
+++ b/content/en/account_management/teams.md
@@ -76,12 +76,12 @@ The table below describes the products in which you can use the team filter:
 
 | Product List Page       | Filter basis                                                                     |
 |-------------------------|----------------------------------------------------------------------------------|
-| [Dashboards][6]         | Team handle                                                                      |
-| [Service Catalog][7]    | Team handle                                                                      |
-| [Incidents][8]          | Team handle                                                                      |
-| [Monitors][9]           | Team handle                                                                      |
-| [APM Error Tracking][10] | Service owned by teams (determined by ownership inside the [Service Catalog][7]) |
-| [Logs Error Tracking][11] | Service owned by teams (determined by ownership inside the [Service Catalog][7]) |
+| [Dashboards][7]         | Team handle                                                                      |
+| [Service Catalog][8]    | Team handle                                                                      |
+| [Incidents][9]          | Team handle                                                                      |
+| [Monitors][10]           | Team handle                                                                      |
+| [APM Error Tracking][11] | Service owned by teams (determined by ownership inside the [Service Catalog][8]) |
+| [Logs Error Tracking][12] | Service owned by teams (determined by ownership inside the [Service Catalog][8]) |
 
 
 ## Permissions
@@ -115,9 +115,10 @@ To enforce a strict membership model, configure your default team settings so **
 [3]: /monitors/incident_management/incident_details#overview-section
 [4]: /monitors/configuration/?tab=thresholdalert#add-metadata
 [5]: /tracing/service_catalog/setup#add-service-definition-metadata
-[6]: https://app.datadoghq.com/dashboard/lists
-[7]: https://app.datadoghq.com/services
-[8]: https://app.datadoghq.com/incidents
-[9]: https://app.datadoghq.com/monitors/manage
-[10]: https://app.datadoghq.com/apm/error-tracking
-[11]: https://app.datadoghq.com/logs/error-tracking
+[6]: /monitors/service_level_objectives/#slo-tags
+[7]: https://app.datadoghq.com/dashboard/lists
+[8]: https://app.datadoghq.com/services
+[9]: https://app.datadoghq.com/incidents
+[10]: https://app.datadoghq.com/monitors/manage
+[11]: https://app.datadoghq.com/apm/error-tracking
+[12]: https://app.datadoghq.com/logs/error-tracking


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes the note at the top of the Teams page announcing its beta status.

### Motivation
Teams is in the process of going GA. Only Gov remains in beta, and Teams will be turned on for it next week.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Don't merge yet.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
