### PR TITLE
Remove double-spacing

### DIFF
--- a/content/en/monitors/types/forecasts.md
+++ b/content/en/monitors/types/forecasts.md
@@ -30,7 +30,7 @@ To create a [forecast monitor][1] in Datadog, use the main navigation: *Monitors
 Any metric currently reporting to Datadog is available for monitors. For more information, see the [Metric Monitor][2] page.
 
 After defining the metric, the forecast monitor provides two preview graphs in the editor:
-{{< img src="monitors/monitor_types/forecasts/editor_graphs.png" alt="Editor graphs"  style="width:95%;">}}
+{{< img src="monitors/monitor_types/forecasts/editor_graphs.png" alt="Editor graphs" style="width:95%;">}}
 
 * The **Historical View** lets you explore the past metric data at different time scales.
 * The **Evaluation Preview** shows a combination of historical and predicted metric data.
@@ -46,7 +46,7 @@ After defining the metric, the forecast monitor provides two preview graphs in t
 
 Datadog automatically analyzes your chosen metric and sets several parameters for you. However, the options are available to edit under **Advanced Options**:
 
-{{< img src="monitors/monitor_types/forecasts/advanced_options.png" alt="Advanced options"  style="width:80%;">}}
+{{< img src="monitors/monitor_types/forecasts/advanced_options.png" alt="Advanced options" style="width:80%;">}}
 
 | Option                     | Description                                                                                                             |
 |----------------------------|-------------------------------------------------------------------------------------------------------------------------|
@@ -72,11 +72,11 @@ Use the linear algorithm for metrics that have steady trends but no repeating se
 | Simple   | Does a robust linear regression through the entire history.                                |
 | Reactive | Extrapolates recent behavior better at the risk of overfitting to noise, spikes, or dips.  |
 
-{{< img src="monitors/monitor_types/forecasts/linear_default.png" alt="linear default"  style="width:80%;">}}
+{{< img src="monitors/monitor_types/forecasts/linear_default.png" alt="linear default" style="width:80%;">}}
 
-{{< img src="monitors/monitor_types/forecasts/linear_simple.png" alt="linear simple"  style="width:80%;">}}
+{{< img src="monitors/monitor_types/forecasts/linear_simple.png" alt="linear simple" style="width:80%;">}}
 
-{{< img src="monitors/monitor_types/forecasts/linear_reactive.png" alt="linear reactive"  style="width:80%;" >}}
+{{< img src="monitors/monitor_types/forecasts/linear_reactive.png" alt="linear reactive" style="width:80%;" >}}
 
 {{% /tab %}}
 {{% tab "Seasonal" %}}
@@ -91,7 +91,7 @@ Use the seasonal algorithm for metrics with repeating patterns. There are three 
 
 **Note**: This algorithm requires at least two seasons of history and uses up to six seasons for forecasting.
 
-{{< img src="monitors/monitor_types/forecasts/seasonal.png" alt="seasonal"  style="width:80%;">}}
+{{< img src="monitors/monitor_types/forecasts/seasonal.png" alt="seasonal" style="width:80%;">}}
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -135,7 +135,7 @@ The following functions cannot be nested inside calls to the `forecast()` functi
 
 ## Further Reading
 
-{{< partial name="whats-next/whats-next.html"  >}}
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/monitors#create/forecast
 [2]: /monitors/types/metric/#define-the-metric


### PR DESCRIPTION
Removes double-spacing that's being replicated in the translated docs

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
