### PR TITLE
fix mobile nav on api docs and main docs

### DIFF
--- a/assets/scripts/components/algolia.js
+++ b/assets/scripts/components/algolia.js
@@ -5,7 +5,6 @@ import { configure, searchBox } from 'instantsearch.js/es/widgets';
 import { searchbarHits } from './algolia/searchbarHits';
 import { searchpageHits } from './algolia/searchpageHits';
 import { customPagination } from './algolia/customPagination';
-import { closeMobileNav } from '../components/mobile-nav';
 import { debounce } from '../utils/debounce';
 
 function getPageLanguage() {
@@ -185,7 +184,6 @@ function loadInstantSearch(asyncLoad) {
 
                 if (window.innerWidth <= 991) {
                     searchBoxWrapperMobile?.appendChild(searchBoxContainerContainer);
-                    closeMobileNav();
                 } else {
                     searchBoxWrapper?.appendChild(searchBoxContainerContainer);
                 }

--- a/assets/styles/instantsearch/searchbar-mobile.scss
+++ b/assets/styles/instantsearch/searchbar-mobile.scss
@@ -1,6 +1,7 @@
 .mobile-nav-search-wrapper .searchbox-container {
     filter: none;
     margin-top: 13px;
+    z-index: 10001; // move search box container in front of open .dropdown-menu elements
 
     #searchbox {
         z-index: 2;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

removes closing mobile nav function on resize. 
increases z-index on `.searchbox-container`

### Motivation
<!-- What inspired you to submit this pull request?-->

There was a small bug introduced [here](https://github.com/DataDog/documentation/pull/17230) where the mobile menu was being closed when the window was resized to 991px or less. This resulted in losing the mobile menu opened state that should match the equivalent opened left side nav

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

mobile menus on the api docs and main docs should open to the appropriate section.

https://docs-staging.datadoghq.com/stefon.simmons/fix-api-mobile-menu-2/api/latest/azure-integration/#update-azure-integration-host-filters

### Additional Notes
<!-- Anything else we should know when reviewing?-->
n/a
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
