### PR TITLE
Add DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED's doc

### DIFF
--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -319,7 +319,7 @@ A comma-separated list of query parameters to be collected as part of the URL. S
 `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED`
 : **INI**: `datadog.trace.http_post_data_param_allowed`<br>
 **Default**: ""<br>
-A comma-separated list of HTTP POST data fields to be collected. Leave empty if you don't want to collect any posted values. When setting this value to the wildcard `*`, all posted data will be collected, but the values for fields that match the `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP` obfuscation rule will be redacted. If specific fields are given, then only these fields' values are collected in clear, while the values for all other fields will be redacted. Added in version `0.86.0`.<br>
+A comma-separated list of HTTP POST data fields to be collected. Leave empty if you don't want to collect any posted values. When setting this value to the wildcard `*`, all posted data is collected, but the values for fields that match the `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP` obfuscation rule are redacted. If specific fields are given, then only these fields' values are visible, while the values for all other fields are redacted. Added in version `0.86.0`.<br>
 **Example**: 
   - The posted data is `foo[baz]=bar&foo[baz][key]=quz&foo[bar][password]=baz&foo[bar][baz]=quz`
   - `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED` is set to `foo.baz,foo.bar.password`<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -322,23 +322,19 @@ A comma-separated list of query parameters to be collected as part of the URL. S
 A comma-separated list of HTTP POST data fields to be collected. Leave empty if you don't want to collect any posted values. When setting this value to the wildcard `*`, all posted data is collected, but the values for fields that match the `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP` obfuscation rule are redacted. If specific fields are given, then only these fields' values are visible, while the values for all other fields are redacted. Added in version `0.86.0`.<br>
 **Example**: 
   - The posted data is `qux=quux&foo[bar][password]=Password12!&foo[bar][username]=admin&foo[baz][bar]=qux&foo[baz][key]=value`
-  - `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED` is set to `foo.baz,foo.bar.password`<br>
+  - `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED` is set to `foo.baz,foo.bar.password`
   - In this scenario, the collected metadata is:
     - `http.request.foo.bar.password=Password12!`
     - `http.request.foo.bar.username=<redacted>`
     - `http.request.foo.baz.bar=qux`
     - `http.request.foo.baz.key=value`
-    - `http.request.qux=<redacted>`
-    
+    - `http.request.qux=<redacted>`<br>
 With the same example, if the configuration variable is instead set to the wildcard, then the collected metadata is:
   - `http.request.foo.bar.password=<redacted>`
   - `http.request.foo.bar.username=admin`
   - `http.request.foo.baz.bar=qux`
   - `http.request.foo.baz.key=<redacted>`
   - `http.request.qux=quux`
-
-  
-
 
 `DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED`
 : **INI**: `datadog.trace.resource_uri_query_param_allowed`<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -319,7 +319,7 @@ A comma-separated list of query parameters to be collected as part of the URL. S
 `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED`
 : **INI**: `datadog.trace.http_post_data_param_allowed`<br>
 **Default**: ""<br>
-A comma-separated list of HTTP POST data fields to be collected as part the request. Set to empty by default to redact all posted values, or `*` to collect and redact them if needed. When specific fields are explicitly whitelisted, only those fields' values aren't be redacted. Added in version `0.86.0`.<br>
+A comma-separated list of HTTP POST data fields to be collected as part the request. Set to empty by default to redact all posted values, or `*` to collect and redact them if needed. When specific fields are explicitly whitelisted, only those fields' values aren't redacted. Added in version `0.86.0`.<br>
 **Example**: 
   - The posted data is `foo[baz]=bar&foo[baz][bar]=quz&foo[bar][password]=baz&foo[bar][baz]=quz`
   - `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED` is set to `foo.baz,foo.bar.password`<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -316,6 +316,20 @@ Set an application's version in traces and logs, for example: `1.2.3`, `6c44da20
 **Default**: `*`<br>
 A comma-separated list of query parameters to be collected as part of the URL. Set to empty to prevent collecting any parameters, or `*` to collect all parameters. Added in version `0.74.0`.
 
+`DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED`
+: **INI**: `datadog.trace.http_post_data_param_allowed`<br>
+**Default**: ""<br>
+A comma-separated list of HTTP POST data fields to be collected as part the request. Set to empty by default to redact all posted values, or `*` to collect and redact them if needed. When specific fields are explicitly whitelisted, only those fields' values won't be redacted. Added in version `0.86.0`.<br>
+**Example**: 
+  - The posted data is `foo[baz]=bar&foo[baz][bar]=quz&foo[bar][password]=baz&foo[bar][baz]=quz`
+  - `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED` is set to `foo.baz,foo.bar.password`<br>
+  - In this scenario, the collected metadata will be:
+    - `http.request.foo.baz=bar`
+    - `http.request.foo.baz.bar=quz`
+    - `http.request.foo.bar.password=baz`
+    - `http.request.foo.bar.baz=<redacted>`
+
+
 `DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED`
 : **INI**: `datadog.trace.resource_uri_query_param_allowed`<br>
 **Default**: `*`<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -319,7 +319,7 @@ A comma-separated list of query parameters to be collected as part of the URL. S
 `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED`
 : **INI**: `datadog.trace.http_post_data_param_allowed`<br>
 **Default**: ""<br>
-A comma-separated list of HTTP POST data fields to be collected as part the request. Set to empty by default to redact all posted values, or `*` to collect and redact them if needed. When specific fields are explicitly whitelisted, only those fields' values aren't redacted. Added in version `0.86.0`.<br>
+A comma-separated list of HTTP POST data fields to be collected as part the request. Leave empty to redact all posted values, or use `*` to collect and redact them if needed. When specific fields are explicitly allowed, only those fields' values remain. Added in version `0.86.0`.<br>
 **Example**: 
   - The posted data is `foo[baz]=bar&foo[baz][bar]=quz&foo[bar][password]=baz&foo[bar][baz]=quz`
   - `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED` is set to `foo.baz,foo.bar.password`<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -319,7 +319,7 @@ A comma-separated list of query parameters to be collected as part of the URL. S
 `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED`
 : **INI**: `datadog.trace.http_post_data_param_allowed`<br>
 **Default**: ""<br>
-A comma-separated list of HTTP POST data fields to be collected. Leave empty if you don’t want to collect any posted values. When setting this value to the wildcard `*`, all posted data will be collected, but the values for fields that match the `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP` obfuscation rule will be redacted. If specific fields are given, then only these fields’ values are collected in clear, while the values for all other fields will be redacted. Added in version `0.86.0`.<br>
+A comma-separated list of HTTP POST data fields to be collected. Leave empty if you don't want to collect any posted values. When setting this value to the wildcard `*`, all posted data will be collected, but the values for fields that match the `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP` obfuscation rule will be redacted. If specific fields are given, then only these fields' values are collected in clear, while the values for all other fields will be redacted. Added in version `0.86.0`.<br>
 **Example**: 
   - The posted data is `foo[baz]=bar&foo[baz][key]=quz&foo[bar][password]=baz&foo[bar][baz]=quz`
   - `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED` is set to `foo.baz,foo.bar.password`<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -319,7 +319,7 @@ A comma-separated list of query parameters to be collected as part of the URL. S
 `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED`
 : **INI**: `datadog.trace.http_post_data_param_allowed`<br>
 **Default**: ""<br>
-A comma-separated list of HTTP POST data fields to be collected as part the request. Leave empty to redact all posted values, or use `*` to collect and redact them if needed. When specific fields are explicitly allowed, only those fields' values remain. Added in version `0.86.0`.<br>
+A comma-separated list of HTTP POST data fields to be collected. Leave empty if you don’t want to collect any posted values. When setting this value to the wildcard `*`, all posted data will be collected, but the values for fields that match the `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP` obfuscation rule will be redacted. If specific fields are given, then only these fields’ values are collected in clear, while the values for all other fields will be redacted. Added in version `0.86.0`.<br>
 **Example**: 
   - The posted data is `foo[baz]=bar&foo[baz][key]=quz&foo[bar][password]=baz&foo[bar][baz]=quz`
   - `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED` is set to `foo.baz,foo.bar.password`<br>
@@ -350,7 +350,7 @@ The IP header to be used for client IP collection, for example: `x-forwarded-for
   ```
   (?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\s|%20)*(?:=|%3D)[^&]+|(?:"|%22)(?:\s|%20)*(?::|%3A)(?:\s|%20)*(?:"|%22)(?:%2[^2]|%[^2]|[^"%])+(?:"|%22))|bearer(?:\s|%20)+[a-z0-9\._\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\w=-]|%3D)+\.ey[I-L](?:[\w=-]|%3D)+(?:\.(?:[\w.+\/=-]|%3D|%2F|%2B)+)?|[\-]{5}BEGIN(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY[\-]{5}[^\-]+[\-]{5}END(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY|ssh-rsa(?:\s|%20)*(?:[a-z0-9\/\.+]|%2F|%5C|%2B){100,}
   ```
-  Regular expression used to obfuscate the query string included as part of the URL. Added in version `0.76.0`.
+  Regular expression used to obfuscate the query string included as part of the URL. This expression is also used in the redaction process for HTTP POST data. Added in version `0.76.0`.
 
 `DD_TRACE_PROPAGATION_STYLE_INJECT`
 : **INI**: `datadog.trace.propagation_style_inject`<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -329,7 +329,6 @@ A comma-separated list of HTTP POST data fields to be collected as part the requ
     - `http.request.foo.bar.password=baz`
     - `http.request.foo.bar.baz=<redacted>`
 
-
 `DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED`
 : **INI**: `datadog.trace.resource_uri_query_param_allowed`<br>
 **Default**: `*`<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -319,11 +319,11 @@ A comma-separated list of query parameters to be collected as part of the URL. S
 `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED`
 : **INI**: `datadog.trace.http_post_data_param_allowed`<br>
 **Default**: ""<br>
-A comma-separated list of HTTP POST data fields to be collected as part the request. Set to empty by default to redact all posted values, or `*` to collect and redact them if needed. When specific fields are explicitly whitelisted, only those fields' values won't be redacted. Added in version `0.86.0`.<br>
+A comma-separated list of HTTP POST data fields to be collected as part the request. Set to empty by default to redact all posted values, or `*` to collect and redact them if needed. When specific fields are explicitly whitelisted, only those fields' values aren't be redacted. Added in version `0.86.0`.<br>
 **Example**: 
   - The posted data is `foo[baz]=bar&foo[baz][bar]=quz&foo[bar][password]=baz&foo[bar][baz]=quz`
   - `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED` is set to `foo.baz,foo.bar.password`<br>
-  - In this scenario, the collected metadata will be:
+  - In this scenario, the collected metadata is:
     - `http.request.foo.baz=bar`
     - `http.request.foo.baz.bar=quz`
     - `http.request.foo.bar.password=baz`

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -321,13 +321,24 @@ A comma-separated list of query parameters to be collected as part of the URL. S
 **Default**: ""<br>
 A comma-separated list of HTTP POST data fields to be collected. Leave empty if you don't want to collect any posted values. When setting this value to the wildcard `*`, all posted data is collected, but the values for fields that match the `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP` obfuscation rule are redacted. If specific fields are given, then only these fields' values are visible, while the values for all other fields are redacted. Added in version `0.86.0`.<br>
 **Example**: 
-  - The posted data is `foo[baz]=bar&foo[baz][key]=quz&foo[bar][password]=baz&foo[bar][baz]=quz`
+  - The posted data is `qux=quux&foo[bar][password]=Password12!&foo[bar][username]=admin&foo[baz][bar]=qux&foo[baz][key]=value`
   - `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED` is set to `foo.baz,foo.bar.password`<br>
   - In this scenario, the collected metadata is:
-    - `http.request.foo.baz=bar`
-    - `http.request.foo.baz.key=quz`
-    - `http.request.foo.bar.password=baz`
-    - `http.request.foo.bar.baz=<redacted>`
+    - `http.request.foo.bar.password=Password12!`
+    - `http.request.foo.bar.username=<redacted>`
+    - `http.request.foo.baz.bar=qux`
+    - `http.request.foo.baz.key=value`
+    - `http.request.qux=<redacted>`
+    
+With the same example, if the configuration variable is instead set to the wildcard, then the collected metadata is:
+  - `http.request.foo.bar.password=<redacted>`
+  - `http.request.foo.bar.username=admin`
+  - `http.request.foo.baz.bar=qux`
+  - `http.request.foo.baz.key=<redacted>`
+  - `http.request.qux=quux`
+
+  
+
 
 `DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED`
 : **INI**: `datadog.trace.resource_uri_query_param_allowed`<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -328,13 +328,7 @@ A comma-separated list of HTTP POST data fields to be collected. Leave empty if 
     - `http.request.foo.bar.username=<redacted>`
     - `http.request.foo.baz.bar=qux`
     - `http.request.foo.baz.key=value`
-    - `http.request.qux=<redacted>`<br>
-With the same example, if the configuration variable is instead set to the wildcard, then the collected metadata is:
-  - `http.request.foo.bar.password=<redacted>`
-  - `http.request.foo.bar.username=admin`
-  - `http.request.foo.baz.bar=qux`
-  - `http.request.foo.baz.key=<redacted>`
-  - `http.request.qux=quux`
+    - `http.request.qux=<redacted>`
 
 `DD_TRACE_RESOURCE_URI_QUERY_PARAM_ALLOWED`
 : **INI**: `datadog.trace.resource_uri_query_param_allowed`<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -321,11 +321,11 @@ A comma-separated list of query parameters to be collected as part of the URL. S
 **Default**: ""<br>
 A comma-separated list of HTTP POST data fields to be collected as part the request. Leave empty to redact all posted values, or use `*` to collect and redact them if needed. When specific fields are explicitly allowed, only those fields' values remain. Added in version `0.86.0`.<br>
 **Example**: 
-  - The posted data is `foo[baz]=bar&foo[baz][bar]=quz&foo[bar][password]=baz&foo[bar][baz]=quz`
+  - The posted data is `foo[baz]=bar&foo[baz][key]=quz&foo[bar][password]=baz&foo[bar][baz]=quz`
   - `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED` is set to `foo.baz,foo.bar.password`<br>
   - In this scenario, the collected metadata is:
     - `http.request.foo.baz=bar`
-    - `http.request.foo.baz.bar=quz`
+    - `http.request.foo.baz.key=quz`
     - `http.request.foo.bar.password=baz`
     - `http.request.foo.bar.baz=<redacted>`
 


### PR DESCRIPTION
### What does this PR do?
This PR aims to documented a newly introduced option that was added as part of [#1971](https://github.com/DataDog/dd-trace-php/pull/1971) in dd-trace-php.
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
