### PR TITLE
add latest tag for serverless-buidpack

### DIFF
--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -183,7 +183,7 @@ Build your application by running the following command:
    ```shell
    pack build --builder=gcr.io/buildpacks/builder \
    --buildpack from=builder \
-   --buildpack datadog/serverless-buildpack \
+   --buildpack datadog/serverless-buildpack:latest \
    gcr.io/YOUR_PROJECT/YOUR_APP_NAME
    ```
 

--- a/content/fr/serverless/google_cloud_run/_index.md
+++ b/content/fr/serverless/google_cloud_run/_index.md
@@ -124,7 +124,7 @@ RUN apt-get update && apt-get install -y ca-certificates
    ```
    pack build --builder=gcr.io/buildpacks/builder \
    --buildpack from=builder \
-   --buildpack datadog/serverless-buildpack:beta4 \
+   --buildpack datadog/serverless-buildpack:latest \
    gcr.io/YOUR_PROJECT/YOUR_APP_NAME
 
    ```

--- a/content/ja/serverless/google_cloud_run/_index.md
+++ b/content/ja/serverless/google_cloud_run/_index.md
@@ -233,7 +233,7 @@ CMD ["rails", "server", "-b", "0.0.0.0"] (必要に応じて内容を変更し�
    ```shell
    pack build --builder=gcr.io/buildpacks/builder \
    --buildpack from=builder \
-   --buildpack datadog/serverless-buildpack \
+   --buildpack datadog/serverless-buildpack:latest \
    gcr.io/YOUR_PROJECT/YOUR_APP_NAME
    ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->


### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add the `latest` tag explicitely for serverless-buildpack
### Motivation
<!-- What inspired you to submit this pull request?-->
The command won't work otherwise

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
