### PR TITLE
Add version required for GitLab error messages

### DIFF
--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -188,6 +188,8 @@ view. In the drawer, a new tab named **Infrastructure** appears which contains t
 
 ### Error messages for pipeline failures
 
+Error messages are supported for GitLab versions 15.2.0+.
+
 For failed GitLab pipeline executions, each error under the `Errors` tab within a specific pipeline execution displays a message associated with the error type from GitLab.
 
 {{< img src="ci/ci_gitlab_failure_reason_new.png" alt="GitLab Failure Reason" style="width:100%;">}}

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -188,7 +188,7 @@ view. In the drawer, a new tab named **Infrastructure** appears which contains t
 
 ### Error messages for pipeline failures
 
-Error messages are supported for GitLab versions 15.2.0+.
+Error messages are supported for GitLab versions 15.2.0 and above.
 
 For failed GitLab pipeline executions, each error under the `Errors` tab within a specific pipeline execution displays a message associated with the error type from GitLab.
 


### PR DESCRIPTION
### What does this PR do?
This PR is a one-line change to clarify the required GitLab version customers must have in order to see specific error messages for pipeline execution failures. 

### Motivation
We received a support request about a customer only seeing `error:true`, and the reason behind this was that they were not on an updated version of GitLab. 


### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
