### PR TITLE
Fix typo in Datadog Source Code Integration page

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -33,7 +33,7 @@ If you have [APM][6] set up already, navigate to [**Integrations** > **Link Sour
 
 ## Tag your telemetry
 
-To link data to a specific commit, tag your telemetry with `git.commit.sha` and `git.repository_url` tags. Ensure that the `git.repository_url` tag does not contain protocols. For example, if your repository URL is `https://github.con/example_repo`, the value for the `git.repository_url` tag should be `github.com/example_repo`.
+To link data to a specific commit, tag your telemetry with `git.commit.sha` and `git.repository_url` tags. Ensure that the `git.repository_url` tag does not contain protocols. For example, if your repository URL is `https://github.com/example_repo`, the value for the `git.repository_url` tag should be `github.com/example_repo`.
 
 {{< tabs >}}
 {{% tab "Docker Runtime" %}}


### PR DESCRIPTION

### What does this PR do?
Update source-code-integration.md - Fix typo
"https://github.con/example_repo"  => "https://github.com/example_repo"

### Motivation


<!-- ### Preview -->


### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
