### PR TITLE
enhance API results in the search dropdown on API pages

### DIFF
--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -6,6 +6,6 @@ export function getHitData(hit) {
         category: hit.category ? hit.category : 'Documentation',
         subcategory: hit.subcategory ? hit.subcategory : title,
         title: hit.section_header ? hit.section_header : title,
-        content: hit._highlightResult.content.value
+        content: hit._highlightResult.content ? hit._highlightResult.content.value : ''
     };
 }

--- a/assets/scripts/components/algolia/searchbarHits.js
+++ b/assets/scripts/components/algolia/searchbarHits.js
@@ -26,7 +26,7 @@ const renderHits = (renderOptions, isFirstRender) => {
 
                 generatedElementsArray.push(element);
             }
-            console.log(generatedElementsArray)
+
             return generatedElementsArray;
         };
 
@@ -131,6 +131,7 @@ const renderHits = (renderOptions, isFirstRender) => {
         generateJoinedHits(apiHitsArray, 'API')
     ];
 
+    // Ensure API results render first if user performs a search from an API page.
     if (bodyClassContains('api')) {
         allJoinedListItemsHTML.pop()
         allJoinedListItemsHTML.unshift(generateJoinedHits(apiHitsArray, 'API'))

--- a/assets/scripts/components/algolia/searchbarHits.js
+++ b/assets/scripts/components/algolia/searchbarHits.js
@@ -1,5 +1,6 @@
 import { getHitData } from './getHitData';
 import { truncateContent } from '../../helpers/truncateContent';
+import { bodyClassContains } from '../../helpers/helpers';
 import connectHits from 'instantsearch.js/es/connectors/hits/connectHits';
 
 const renderHits = (renderOptions, isFirstRender) => {
@@ -25,7 +26,7 @@ const renderHits = (renderOptions, isFirstRender) => {
 
                 generatedElementsArray.push(element);
             }
-
+            console.log(generatedElementsArray)
             return generatedElementsArray;
         };
 
@@ -104,8 +105,12 @@ const renderHits = (renderOptions, isFirstRender) => {
             })
             .join('');
 
+        const enhanceApiCategoryHeader = category.toLowerCase() === 'api' && bodyClassContains('api')
+        const categoryLiClassList = 'ais-Hits-item ais-Hits-category'
+        const categoryParagraphClassList = enhanceApiCategoryHeader ? 'fw-bold text-primary' : ''
+
         return hitsArray.length
-            ? [`<li class="ais-Hits-item ais-Hits-category"><p>${category}</p></li>`, joinedListItems].join('')
+            ? [`<li class="${categoryLiClassList}"><p class="${categoryParagraphClassList}">${category}</p></li>`, joinedListItems].join('')
             : null;
     };
 
@@ -125,6 +130,11 @@ const renderHits = (renderOptions, isFirstRender) => {
         generateJoinedHits(guidesHitsArray, 'Guides'),
         generateJoinedHits(apiHitsArray, 'API')
     ];
+
+    if (bodyClassContains('api')) {
+        allJoinedListItemsHTML.pop()
+        allJoinedListItemsHTML.unshift(generateJoinedHits(apiHitsArray, 'API'))
+    }
 
     if (isFirstRender) {
         handleFirstRender(container);

--- a/assets/scripts/helpers/helpers.js
+++ b/assets/scripts/helpers/helpers.js
@@ -53,4 +53,6 @@ const getCookieByName = (name) => {
     return value;
 }
 
-export {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName}
+const bodyClassContains = (string) => document.body.classList.contains(string);
+
+export {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName, bodyClassContains}


### PR DESCRIPTION
### What does this PR do?
- API results should be rendered first when users perform a search from the dropdown while on an `api` page.
- the `API` header in the dropdown should have emphasized styling (bold/primary color) 

### Motivation
post-launch item from the search migration 

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/api-focused-dropdown-results/api/latest/?s=synthetics: API results should be first in the dropdown when on an API page

https://docs-staging.datadoghq.com/brian.deutsch/api-focused-dropdown-results/?s=synthetics: API results should not be first in the dropdown from home page

https://docs-staging.datadoghq.com/brian.deutsch/api-focused-dropdown-results/agent/?s=synthetics: API results should not be first in the dropdown from non-API docs pages

all of the above should be the same for mobile views as well, and there should be no console errors or inconsistencies in the UI. 

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
