### PR TITLE
Add Mobile Frustration Signals to documentation

### DIFF
--- a/content/en/real_user_monitoring/frustration_signals/_index.md
+++ b/content/en/real_user_monitoring/frustration_signals/_index.md
@@ -163,10 +163,6 @@ Click on an error in the **Errors** tab to open a side panel with error details.
 
 ## Watch frustration signals in Session Replay
 
-<div class="alert alert-warning">
-Session Replay is only available for Browser RUM.
-</div>
-
 In [Session Replay][7], you can observe a video-like replication of real user activity. Replays provide video evidence of the actions users take when they exhibit signs of frustration.
 
 A session replay's user journey details the events that occur in chronological order. Hover over an event to move to that point in time in the replay: for example, when a dead click occurred.
@@ -174,6 +170,10 @@ A session replay's user journey details the events that occur in chronological o
 {{< img src="real_user_monitoring/frustration_signals/session_replay_frustration_signals.png" alt="Frustration signals appear in a browser recording" style="width:90%;" >}}
 
  For more information, see the [Session Replay documentation][8].
+ 
+<div class="alert alert-warning">
+Session Replay is only available for Browser RUM.
+</div>
 
 ## Create alerts for frustration signals
 

--- a/content/en/real_user_monitoring/frustration_signals/_index.md
+++ b/content/en/real_user_monitoring/frustration_signals/_index.md
@@ -71,7 +71,7 @@ To start collecting frustration signals, add the following to your SDK configura
 {{< tabs >}}
 {{% tab "Swift" %}}
 
-``
+```
 .trackUIKitRUMActions()
 .trackFrustrations()
 ```
@@ -79,7 +79,7 @@ To start collecting frustration signals, add the following to your SDK configura
 {{% /tab %}}
 {{% tab "Objective-C" %}}
 
-``
+```
 [builder trackUIKitRUMActions];
 [builder trackFrustrations];
 ```

--- a/content/en/real_user_monitoring/frustration_signals/_index.md
+++ b/content/en/real_user_monitoring/frustration_signals/_index.md
@@ -40,7 +40,7 @@ First, you need the Browser RUM SDK version >= 4.14.0.
 
 To start collecting frustration signals, add the following to your SDK configuration:
 
-```
+```javascript
 window.DD_RUM.init({
   trackUserInteractions: true,
   trackFrustrations: true
@@ -56,7 +56,7 @@ First, you need the Android RUM SDK version >= 1.15.0.
 
 To start collecting frustration signals, add the following to your SDK configuration:
 
-```
+```kotlin
 .trackInteractions(true)
 .trackFrustrations(true)
 ```
@@ -68,24 +68,10 @@ First, you need the iOS RUM SDK version >= 1.13.0.
 
 To start collecting frustration signals, add the following to your SDK configuration:
 
-{{< tabs >}}
-{{% tab "Swift" %}}
-
-```
+```swift
 .trackUIKitRUMActions()
 .trackFrustrations()
 ```
-
-{{% /tab %}}
-{{% tab "Objective-C" %}}
-
-```
-[builder trackUIKitRUMActions];
-[builder trackFrustrations];
-```
-
-{{% /tab %}}
-{{< /tabs >}}
 
 {{% /tab %}}
 {{% tab "React Native RUM" %}}
@@ -94,7 +80,7 @@ First, you need the React Native RUM SDK version >= 1.5.0.
 
 To start collecting frustration signals, add the following to your SDK configuration:
 
-```
+```js
 const config = new DdSdkReactNativeConfiguration(
     '<CLIENT_TOKEN>',
     '<ENVIRONMENT_NAME>',

--- a/content/en/real_user_monitoring/frustration_signals/_index.md
+++ b/content/en/real_user_monitoring/frustration_signals/_index.md
@@ -23,15 +23,18 @@ Frustration signals help you identify your application's highest points of user 
 RUM collects three types of frustration signals:
 
 Rage Clicks
-: A user clicks on an element more than three times in a one-second sliding window.
+: A user clicks on an element more than three times in a one-second sliding window. Only available for Browser RUM.
 
 Dead Clicks
-: A user clicks on a static element that produces no action on the page.
+: A user clicks on a static element that produces no action on the page. Only available for Browser RUM.
 
-Error Clicks
-: A user clicks on an element right before a JavaScript error occurs.
+Error Clicks / Error Taps
+: A user clicks or taps on an element right before an error (e.g. JavaScript error) occurs. Available for both Browser and Mobile RUM.
 
 ## Requirements
+
+{{< tabs >}}
+{{% tab "Browser RUM" %}}
 
 First, you need the Browser RUM SDK version >= 4.14.0.
 
@@ -45,6 +48,78 @@ window.DD_RUM.init({
 ```
 
 Frustration signals require actions. Enabling `trackFrustrations` automatically enables `trackUserInteractions`.
+
+{{% /tab %}}
+{{% tab "Android RUM" %}}
+
+First, you need the Android RUM SDK version >= 1.15.0.
+
+To start collecting frustration signals, add the following to your SDK configuration:
+
+```
+.trackInteractions(true)
+.trackFrustrations(true)
+```
+
+{{% /tab %}}
+{{% tab "iOS RUM" %}}
+
+First, you need the iOS RUM SDK version >= 1.13.0.
+
+To start collecting frustration signals, add the following to your SDK configuration:
+
+{{< tabs >}}
+{{% tab "Swift" %}}
+
+``
+.trackUIKitRUMActions()
+.trackFrustrations()
+```
+
+{{% /tab %}}
+{{% tab "Objective-C" %}}
+
+``
+[builder trackUIKitRUMActions];
+[builder trackFrustrations];
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+{{% /tab %}}
+{{% tab "React Native RUM" %}}
+
+First, you need the React Native RUM SDK version >= 1.5.0.
+
+To start collecting frustration signals, add the following to your SDK configuration:
+
+```
+const config = new DdSdkReactNativeConfiguration(
+    '<CLIENT_TOKEN>',
+    '<ENVIRONMENT_NAME>',
+    '<RUM_APPLICATION_ID>',
+    true, // track user interactions (such as a tap on buttons)
+    true, // track XHR resources
+    true // track errors
+);
+
+config.trackFrustrations(true);
+```
+
+{{% /tab %}}
+{{% tab "Flutter RUM" %}}
+
+First, you need the Flutter RUM Plugin version >= 1.2.0.
+
+To start collecting frustration signals, add the following to your Plugin configuration:
+
+```
+xxx
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Usage
 
@@ -74,7 +149,7 @@ Frustration Count
 
 #### Sessions
 
-Click on a session with a value in the **Frustration Count** column to examine the user frustration detected. You can see the type of signal (`rage click`, `dead click`, or `error click`) and the event timeline, which shows what occurred during the session.
+Click on a session with a value in the **Frustration Count** column to examine the user frustration detected. You can see the type of signal (`rage click`, `dead click`, `error click`, or `error tap`) and the event timeline, which shows what occurred during the session.
 
 #### Views
 
@@ -101,6 +176,10 @@ Click on an error in the **Errors** tab to open a side panel with error details.
 {{< img src="real_user_monitoring/frustration_signals/errors_tab.png" alt="Errors Tab in the Actions side panel" style="width:90%;" >}}
 
 ## Watch frustration signals in Session Replay
+
+<div class="alert alert-warning">
+Session Replay is only available for Browser RUM.
+</div>
 
 In [Session Replay][7], you can observe a video-like replication of real user activity. Replays provide video evidence of the actions users take when they exhibit signs of frustration.
 

--- a/content/en/real_user_monitoring/frustration_signals/_index.md
+++ b/content/en/real_user_monitoring/frustration_signals/_index.md
@@ -172,7 +172,7 @@ A session replay's user journey details the events that occur in chronological o
  For more information, see the [Session Replay documentation][8].
  
 <div class="alert alert-warning">
-Session Replay is only available for Browser RUM.
+Session Replay is only available for Browser RUM at the moment.
 </div>
 
 ## Create alerts for frustration signals


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
