### PR TITLE
Lazy load vimeo player

### DIFF
--- a/layouts/shortcodes/vimeo.html
+++ b/layouts/shortcodes/vimeo.html
@@ -7,7 +7,7 @@
 {{ end }}
 
 <div class="video-container position-relative">
-  <video poster="{{ $posterImg }}" class="shadow-card-nohover w-100 video-controls" controls="">
+  <video poster="{{ $posterImg }}" class="shadow-card-nohover w-100 video-controls" controls="" preload="none">
     <source type="video/mp4" src="{{ .Get "url" }}">
   </video>
 </div>

--- a/layouts/shortcodes/vimeo.html
+++ b/layouts/shortcodes/vimeo.html
@@ -6,6 +6,8 @@
   {{ $posterImg = "/images/poster/tracing.png" }}
 {{ end }}
 
+<!-- Vimeo player -->
+
 <div class="video-container position-relative">
   <video poster="{{ $posterImg }}" class="shadow-card-nohover w-100 video-controls" controls="" preload="none">
     <source type="video/mp4" src="{{ .Get "url" }}">

--- a/layouts/shortcodes/vimeo.html
+++ b/layouts/shortcodes/vimeo.html
@@ -6,8 +6,6 @@
   {{ $posterImg = "/images/poster/tracing.png" }}
 {{ end }}
 
-<!-- Vimeo player -->
-
 <div class="video-container position-relative">
   <video poster="{{ $posterImg }}" class="shadow-card-nohover w-100 video-controls" controls="" preload="none">
     <source type="video/mp4" src="{{ .Get "url" }}">


### PR DESCRIPTION
### What does this PR do?
This adds `preload=none` to all vimeo player embeds so the mp4 files are fetched when the user interacts with the vimeo player, and not on page load

### Motivation
Notified of an increased Vimeo bandwith usage https://datadoghq.atlassian.net/browse/WEB-3491

### How to test

Current live site: https://docs.datadoghq.com/serverless/
1. Open up the dev console -> network
2. Filter for `.mp4`
3. Reload the page
You should see that the `file.mp4?loc=...` is fetched on page load

![Screen Shot 2023-04-18 at 10 49 42 AM](https://user-images.githubusercontent.com/9119168/232817245-cc2ed4cd-6552-4cfd-8fb8-23aa8a9d8b94.png)

vs

Preview site: https://docs-staging.datadoghq.com/ccole/vimeo-player-fix/serverless/
1. Open up the dev console -> network
2. Filter for `.mp4`
3. Reload the page
You should see that the `file.mp4?loc=...` is *not* fetched on page load
5. Click play button on video
You should see the  `file.mp4?loc=...` now being fetched, as expected

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
