### PR TITLE
fix: specify full rum intake origin urls

### DIFF
--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -72,13 +72,13 @@ To successfully proxy request to Datadog:
 
 The site parameter is an SDK [initialization parameter][1]. Datadog intake origins for each site are listed below:
 
-| Site    | Site Parameter            | Datadog intake origin                      |
-| ------- | ------------------------- | ------------------------------------------ |
-| US1     | `datadoghq.com` (default) | `https://browser-intake-datadoghq.com`     |
-| US3     | `us3.datadoghq.com`       | `https://browser-intake-us3-datadoghq.com` |
-| US5     | `us5.datadoghq.com`       | `https://browser-intake-us5-datadoghq.com` |
-| EU1     | `datadoghq.eu`            | `https://browser-intake-datadoghq.eu`      |
-| US1-FED | `ddog-gov.com`            | `https://browser-intake-ddog-gov.com`      |
+| Site    | Site Parameter            | Datadog intake origin                          |
+| ------- | ------------------------- | ---------------------------------------------- |
+| US1     | `datadoghq.com` (default) | `https://rum.browser-intake-datadoghq.com`     |
+| US3     | `us3.datadoghq.com`       | `https://rum.browser-intake-us3-datadoghq.com` |
+| US5     | `us5.datadoghq.com`       | `https://rum.browser-intake-us5-datadoghq.com` |
+| EU1     | `datadoghq.eu`            | `https://rum.browser-intake-datadoghq.eu`      |
+| US1-FED | `ddog-gov.com`            | `https://rum.browser-intake-ddog-gov.com`      |
 
 The Datadog intake origin corresponding to your site parameter should be defined in your proxy implementation.
 


### PR DESCRIPTION
### What does this PR do?
Specifies the full intake origin base urls. It seems they're missing the `rum` subdomain which is very confusing for readers (such as myself). I personally use us5 so I'm not 100% sure that all intake origins use the `rum` subdomain. Feel free to correct me.

### Motivation
Spent too much time figuring this out.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
