### PR TITLE
[DOCS-5228] Remove MacOS from tab in log troubleshooting guide

### DIFF
--- a/content/en/logs/guide/log-collection-troubleshooting-guide.md
+++ b/content/en/logs/guide/log-collection-troubleshooting-guide.md
@@ -82,7 +82,7 @@ If the Agent does not have the correct permissions, you might see one of the fol
 To fix the error, give the Datadog Agent user read, write, and execute permissions to the log file and subdirectories.
 
 {{< tabs >}}
-{{% tab "Linux and MacOS" %}}
+{{% tab "Linux" %}}
 1. Run the `namei` command to obtain more information about the file permissions:
    ```
    > namei -m /path/to/log/file


### PR DESCRIPTION
### What does this PR do?

Removes MacOS from the tab because the information is only for Linux.

### Motivation

[DOCS-5228](https://datadoghq.atlassian.net/browse/DOCS-5228)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5228]: https://datadoghq.atlassian.net/browse/DOCS-5228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ