### PR TITLE
WEB-3479 - bump the timeout value

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -116,3 +116,5 @@ outputFormats:
     isPlainText: true
     mediaType: "text/plain"
     notAlternative: true
+
+timeout: "45s"


### PR DESCRIPTION
### What does this PR do?

To help avoid sporadic errors such as this which i believe are down to some pages taking longer to render than others.
```
error calling partial: partial "name-of-partial.html" timed out after 30s. This is most likely due to infinite recursion. If this is just a slow template, you can try to increase the 'timeout' config setting.
```

Starting small this updates the timeout value from the default `30s` to `45s` more details on timeout here https://gohugo.io/getting-started/configuration/#timeout

### Motivation

https://datadoghq.atlassian.net/browse/WEB-3479

### Preview

just checking that the site builds still there should be no other visible changes

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
