### PR TITLE
[agent][kubernetes] update compatibility matrix

### DIFF
--- a/content/en/containers/kubernetes/installation.md
+++ b/content/en/containers/kubernetes/installation.md
@@ -42,10 +42,11 @@ For dedicated documentation and examples for monitoring the Kubernetes control p
 
 Some features related to later Kubernetes versions require a minimum Datadog Agent version.
 
-| Kubernetes version | Agent version  | Cluster Agent version | Reason                              |
+| Kubernetes version | Agent version  | Cluster Agent version | Reason                                |
 |--------------------|----------------|-----------------------|---------------------------------------|
-| 1.16.0+            | 7.19.0+        | 1.9.0+                | Kubelet metrics deprecation       |
-| 1.21.0+            | 7.36.0+        | 1.20.0+               | Kubernetes resource deprecation    |
+| 1.16.0+            | 7.19.0+        | 1.9.0+                | Kubelet metrics deprecation           |
+| 1.21.0+            | 7.36.0+        | 1.20.0+               | Kubernetes resource deprecation       |
+| 1.22.0+            | 7.37.0+        | 7.37.0+               | Support dynamic service account token |
 
 {{< tabs >}}
 {{% tab "Operator" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add a new entry in the agent vs kubernetes versions compatibility: Document the minimum agent version requires to support Kubernetes dynamic service account token feature introduced in Kubernetes 1.22+ (at beta stage)

### Motivation

keep doc up-to-date

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
