### PR TITLE
WEB-3501 - fix error when el non existant

### DIFF
--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -74,7 +74,9 @@ function loadPage(newUrl) {
                 searchBoxContainer.append(hitsContainer);
                 hitsContainer.append(hits);
 
-                sidenavSearchbarMount.append(searchBoxContainer);
+                if(sidenavSearchbarMount) {
+                  sidenavSearchbarMount.append(searchBoxContainer);
+                }
 
                 loadInstantSearch(asyncLoad=true);
             }


### PR DESCRIPTION
### What does this PR do?

`sidenavSearchbarMount` can sometimes be null, this pr accounts for this

### Motivation
https://datadoghq.atlassian.net/browse/WEB-3501

### Preview

https://docs-staging.datadoghq.com/david.jones/fix-js-bug/profiler/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
