### PR TITLE
Fixed displaying images in documentation

### DIFF
--- a/content/en/developers/faq/deploying-the-agent-on-raspberrypi.md
+++ b/content/en/developers/faq/deploying-the-agent-on-raspberrypi.md
@@ -28,7 +28,7 @@ kind: faq
 
 Example output after successful installation:
 
-![rasberypi_install](https://github.com/DataDog/documentation/blob/master/static/images/developers/faq/rasberypi_install.png)
+![RaspberryPI Install](https://raw.githubusercontent.com/DataDog/documentation/master/static/images/developers/faq/rasberypi_install.png)
 
 The Agent runs in the foreground. Some users find benefit in creating a `systemd` service for the Agent like this:
 
@@ -57,7 +57,7 @@ The Datadog Agent is installed in the working directory where you ran the instal
 
 Example of metrics being ingested from your Raspberry PI device:
 
-![raspberry_dashboard](https://github.com/DataDog/documentation/blob/master/static/images/developers/faq/rasberry_dashboard.png)
+![RaspberryPI Dashboard](https://raw.githubusercontent.com/DataDog/documentation/master/static/images/developers/faq/rasberry_dashboard.png)
 
 **Note**: Datadog does not officially support Raspbian.
 

--- a/content/en/developers/faq/deploying-the-agent-on-raspberrypi.md
+++ b/content/en/developers/faq/deploying-the-agent-on-raspberrypi.md
@@ -27,7 +27,8 @@ kind: faq
 **Note**: The installation process may take up to 30 minutes on some models of Raspberry PI.
 
 Example output after successful installation:
-{{< img src="developers/faq/rasberypi_install.png" alt="rasberypi_install" >}}
+
+![rasberypi_install](https://github.com/DataDog/documentation/blob/master/static/images/developers/faq/rasberypi_install.png)
 
 The Agent runs in the foreground. Some users find benefit in creating a `systemd` service for the Agent like this:
 
@@ -55,7 +56,8 @@ systemctl start datadog
 The Datadog Agent is installed in the working directory where you ran the installation command, for example: `/home/pi/.datadog-agent/`. 
 
 Example of metrics being ingested from your Raspberry PI device:
-{{< img src="developers/faq/rasberry_dashboard.png" alt="raspberry_dashboard" >}}
+
+![raspberry_dashboard](https://github.com/DataDog/documentation/blob/master/static/images/developers/faq/rasberry_dashboard.png)
 
 **Note**: Datadog does not officially support Raspbian.
 


### PR DESCRIPTION
Fixed the display of the images in deploying-the-agent-on-raspberrypi.md

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The PR includes the fix of display of images contained into deploying-the-agent-on-raspberrypi.md

### Motivation
I would like to solve the simple problem

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
