### PR TITLE
stop /fr/ or /ja/ doubling up in search results

### DIFF
--- a/assets/scripts/components/algolia/searchbarHits.js
+++ b/assets/scripts/components/algolia/searchbarHits.js
@@ -89,7 +89,10 @@ const renderHits = (renderOptions, isFirstRender) => {
             .map((item) => {
                 const hit = getHitData(item);
                 const displayContent = truncateContent(hit.content, 145);
-                const cleanRelpermalink = `${basePathName}${hit.relpermalink}`.replace('//', '/');
+                let cleanRelpermalink = `${basePathName}${hit.relpermalink}`.replace('//', '/');
+                if(hit.relpermalink.startsWith(basePathName)) {
+                  cleanRelpermalink = cleanRelpermalink.replace(basePathName, '/');
+                }
 
                 return `
                     <li class="ais-Hits-item">

--- a/assets/scripts/components/algolia/searchpageHits.js
+++ b/assets/scripts/components/algolia/searchpageHits.js
@@ -23,21 +23,24 @@ const renderHits = (renderOptions, isFirstRender) => {
             .map((item) => {
                 const hit = getHitData(item);
                 const displayContent = truncateContent(hit.content, 100);
-                const cleanRelpermalink = `${basePathName}${hit.relpermalink}`.replace('//', '/');
+                let cleanRelpermalink = `${basePathName}${hit.relpermalink}`.replace('//', '/');
+                if(hit.relpermalink.startsWith(basePathName)) {
+                  cleanRelpermalink = cleanRelpermalink.replace(basePathName, '/');
+                }
 
                 return `
                     <li class="ais-Hits-item">
                         <a href="${cleanRelpermalink}" target="_blank" rel="noopener noreferrer">
                             <div class="ais-Hits-row">
                                 <p class="ais-Hits-category">${hit.category}</p>
-                                
+
                                 <span class="ais-Hits-category-spacer">&#187;</span>
 
                                 ${
                                     hit.subcategory === hit.title
                                         ? `<p class="ais-Hits-title">${hit.title}</p>`
                                         : `<p class="ais-Hits-subcategory">${hit.subcategory}</p><span class="ais-Hits-category-spacer">&#187;</span><p class="ais-Hits-title">${hit.title}</p>`
-                                }   
+                                }
                             </div>
                             <div class="ais-Hits-row">
                                 <p class="ais-Hits-content">${displayContent}</p>


### PR DESCRIPTION
### What does this PR do?

stop links for search results when on other languages from doubling up

### Motivation

Slack

### Preview

Try entering some searches and clicking on results they should not have `/fr/fr/` or `/ja/ja/` in the hrefs

https://docs-staging.datadoghq.com/david.jones/cleanrellink/
https://docs-staging.datadoghq.com/david.jones/cleanrellink/fr/
https://docs-staging.datadoghq.com/david.jones/cleanrellink/ja/

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
