### PR TITLE
fix translated search links

### DIFF
--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -1,8 +1,9 @@
 export function getHitData(hit) {
     const title = hit.title ? hit.title : hit.type;
+    const cleanRelPermalink = hit.language == 'en' ? hit.relpermalink : hit.relpermalink.replace(`/${hit.language}/`, '')
 
     return {
-        relpermalink: hit.relpermalink,
+        relpermalink: cleanRelPermalink,
         category: hit.category ? hit.category : 'Documentation',
         subcategory: hit.subcategory ? hit.subcategory : title,
         title: hit.section_header ? hit.section_header : title,


### PR DESCRIPTION
### What does this PR do?
fix translated search relative permalinks

### Motivation
slack https://dd.slack.com/archives/C3CT8QA11/p1681992680647369

### Preview
searching from the dropdown and from the search page should have correct links in all languages

https://docs-staging.datadoghq.com/brian.deutsch/translated-search-links
https://docs-staging.datadoghq.com/brian.deutsch/translated-search-links/fr
https://docs-staging.datadoghq.com/brian.deutsch/translated-search-links/ja

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
