### PR TITLE
Revert synthetic ci change

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -422,7 +422,7 @@ synthetic_tests_preview:
   environment: "preview"
   variables:
     URL: ${PREVIEW_DOMAIN}
-  allow_failure: true
+  allow_failure: false
   cache: {}
   dependencies:
     - build_preview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Revert the change allowing the synthetic ci job to fail
### Motivation
<!-- What inspired you to submit this pull request?-->
Now that we have addressed the timeout issue we were having, we want to require these jobs again
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
