### PR TITLE
Update template_variables.md

### DIFF
--- a/content/en/dashboards/template_variables.md
+++ b/content/en/dashboards/template_variables.md
@@ -49,7 +49,7 @@ After creating a template variable, Datadog displays the number of sources using
 
 ### Logs, APM, and RUM queries
 
-Template variables work with log, APM, and RUM widgets because metrics, logs, APM, and RUM share the same tags.
+Template variables work with log, APM, and RUM widgets because logs, APM, and RUM share the same tags.
 Additionally, you can define log, APM, and RUM template variables based on [log][2], APM, or [RUM][3] facets. These variables start with `@`, for example: `@http.status_code`.
 
 On log, APM, and RUM widgets, you can use wildcards in the middle of a value (for example, `eng*@example.com`) or use multiple wildcards in a value (for example, `*prod*`).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Removing the word `metrics` from the doc as it does not fit under the heading:
[Logs, APM, and RUM queries](https://docs.datadoghq.com/dashboards/template_variables/#logs-apm-and-rum-queries)
Removing the word `metrics` will ensure the doc is not misleading and therefore not cause any confusion. 

### Motivation
<!-- What inspired you to submit this pull request?-->
This [support ticket](https://datadog.zendesk.com/agent/tickets/1178563)
The customer is trying to use a template variable in a metric query:
https://a.cl.ly/v1uPBL5m
You cannot use template variables in metric queries:
For reference, here is a [Notebook ](https://support-admin.us1.prod.dog/admin/switch_handle_get/org_id/209892?next_url=%2Fnotebook%2F5308718%2Fdd-support-1178563) demonstrating the use of tags for the query in the screenshot above. 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
