### PR TITLE
[K8s Operator] Moves credentials to global per v2alpha1 spec

### DIFF
--- a/content/en/getting_started/containers/datadog_operator.md
+++ b/content/en/getting_started/containers/datadog_operator.md
@@ -41,18 +41,19 @@ The [Datadog Operator][1] is an open source [Kubernetes Operator][2] that enable
   metadata:
     name: datadog
   spec:
+    global:
+      credentials:
+        apiSecret:
+          secretName: datadog-secret
+          keyName: api-key
+        appSecret:
+          secretName: datadog-secret
+          keyName: app-key
     features:
       apm:
         enabled: true
       logCollection:
         enabled: true
-    credentials:
-      apiSecret:
-        secretName: datadog-secret
-        keyName: api-key
-      appSecret:
-        secretName: datadog-secret
-        keyName: app-key
   ```
 
 4. Deploy the Datadog Agent:


### PR DESCRIPTION
### What does this PR do?
* Moves `spec.credentials` to `spec.global.credentials` per `v2alpha1` spec
### Motivation
* Self-testing, noticed the doc is incorrect and leads to the error : 
```
Error from server (BadRequest): error when creating "op.yaml": DatadogAgent in version "v2alpha1" cannot be handled as a DatadogAgent: strict decoding error: unknown field "spec.credentials"
```
* When the Operator spec was moved from `v1alpha1` to `v2alpha1`, some fields were modified and the previous snippet is now invalid.
* Spec reference (`v2alpha1`) : https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
