### PR TITLE
Update AP1 `Location` to "JP"

### DIFF
--- a/content/en/getting_started/site/_index.md
+++ b/content/en/getting_started/site/_index.md
@@ -24,7 +24,7 @@ You can identify which site you are on by matching your Datadog website URL to t
 | US5     | `https://us5.datadoghq.com` | `us5.datadoghq.com` | US       |
 | EU1     | `https://app.datadoghq.eu`  | `datadoghq.eu`      | EU       |
 | US1-FED | `https://app.ddog-gov.com`  | `ddog-gov.com`      | US       |
-| AP1     | `https://ap1.datadoghq.com` | `ap1.datadoghq.com` | JP       |
+| AP1     | `https://ap1.datadoghq.com` | `ap1.datadoghq.com` | Japan |
 
 ## SDK domains
 

--- a/content/en/getting_started/site/_index.md
+++ b/content/en/getting_started/site/_index.md
@@ -24,7 +24,7 @@ You can identify which site you are on by matching your Datadog website URL to t
 | US5     | `https://us5.datadoghq.com` | `us5.datadoghq.com` | US       |
 | EU1     | `https://app.datadoghq.eu`  | `datadoghq.eu`      | EU       |
 | US1-FED | `https://app.ddog-gov.com`  | `ddog-gov.com`      | US       |
-| AP1     | `https://ap1.datadoghq.com` | `ap1.datadoghq.com` | AP1      |
+| AP1     | `https://ap1.datadoghq.com` | `ap1.datadoghq.com` | JP       |
 
 ## SDK domains
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Updates the `Location` value associated with the AP1 datacenter in the [Access the Datadog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site) table.

### Motivation
<!-- What inspired you to submit this pull request?-->

"AP1" is the name of the datacenter, which is not quite the same as the `Location`. "JP" is more specific and in line with what we list in the `Location` column for other DCs (e.g. "US" for "US1").

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
