### PR TITLE
Update KSM documentation regarding nodes.by_condition

### DIFF
--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -123,7 +123,7 @@ Here is the mapping between deprecated tags and the official tags that have repl
 The Kubernetes State Metrics Core check is not backward compatible, be sure to read the changes carefully before migrating from the legacy `kubernetes_state` check.
 
 `kubernetes_state.node.by_condition`
-: A new metric with node name granularity. The legacy metric `kubernetes_state.nodes.by_condition` has been depricated in favor of this one. **Note:** This metric was backported into the Legacy check, where both it and the metric it replaces (`nodes.by_condition`) are available. 
+: A new metric with node name granularity. The legacy metric `kubernetes_state.nodes.by_condition` is deprecated in favor of this one. **Note:** This metric is backported into the Legacy check, where both metrics (it and the legacy metric it replaces) are available. 
 
 `kubernetes_state.persistentvolume.by_phase`
 : A new metric with persistentvolume name granularity. It replaces `kubernetes_state.persistentvolumes.by_phase`.

--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -123,7 +123,7 @@ Here is the mapping between deprecated tags and the official tags that have repl
 The Kubernetes State Metrics Core check is not backward compatible, be sure to read the changes carefully before migrating from the legacy `kubernetes_state` check.
 
 `kubernetes_state.node.by_condition`
-: A new metric with node name granularity. It replaces `kubernetes_state.nodes.by_condition`.
+: A new metric with node name granularity. The legacy metric `kubernetes_state.nodes.by_condition` has been depricated in favor of this one. **Note:** This metric was backported into the Legacy check, where both it and the metric it replaces (`nodes.by_condition`) are available. 
 
 `kubernetes_state.persistentvolume.by_phase`
 : A new metric with persistentvolume name granularity. It replaces `kubernetes_state.persistentvolumes.by_phase`.


### PR DESCRIPTION
The current documentation inaccurately implies that the `kubernetes_state.node.by_condition` metric is not available in the Legacy check. This is untrue; it was introduced to the Legacy check as KSM Core was being developed. The doc change here makes this distinction a bit more clear.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
[This escalation
](https://datadoghq.atlassian.net/browse/CONS-5522) noted the existance of the `node.by_condition` metric in Legacy KSM.
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
