### PR TITLE
Fix Heatmap setup instruction language and codeblock

### DIFF
--- a/content/en/real_user_monitoring/heatmaps/_index.md
+++ b/content/en/real_user_monitoring/heatmaps/_index.md
@@ -19,13 +19,13 @@ To get started with heatmaps:
 - You must be on the latest version of the SDK (v4.20.0 or later)
 - Enable [Session Replay][1].
 - Set`trackUserInteractions: true` in the SDK initialization to enable action tracking.
-- While heatmaps are in beta, enable the feature flag by adding the following code to the [package.json][2] file in the SDK:
+- While heatmaps are in beta, enable the feature flag by adding the following code to the [intitialization][2] of RUM:
 
-```json
+```diff
 datadogRum.init({
     ...
     trackUserInteractions: true,
-    enableExperimentalFeatures: ['clickmap']
++    enableExperimentalFeatures: ['clickmap']
 })
 ```
 
@@ -100,7 +100,7 @@ User information is not collected by default. Heatmaps use the user information 
 
 
 [1]: /real_user_monitoring/session_replay/
-[2]: https://github.com/DataDog/browser-sdk/blob/main/packages/rum/package.json
+[2]: https://docs.datadoghq.com/real_user_monitoring/browser/#npm
 [3]: https://app.datadoghq.com/rum/heatmap/view
 [4]: /real_user_monitoring/explorer/
 [5]: /real_user_monitoring/guide/alerting-with-conversion-rates/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Corrects the setup instructions for Heatmaps in RUM

### Motivation
- Incorrect instructions

### Additional Notes
- Unsure of whether `diff` support exists for DataDog's docs. If not, `js` would suffice as a change.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
