### PR TITLE
Update Announcement Banner for Appsec Report

### DIFF
--- a/config/_default/params.en.yaml
+++ b/config/_default/params.en.yaml
@@ -4,8 +4,8 @@ meta_title: Getting Started with Datadog
 meta_description: Datadog, the leading service for cloud-scale monitoring.
 disclaimer: "This page is not yet available in English, we are working on its translation. <br> May you have any questions or feedback about our current translation project, <a href=\"https://docs.datadoghq.com/fr/help/\">feel free to reach out to us!</a>"
 announcement_banner:
-  desktop_message: "Register for the Container Report Livestream"
-  mobile_message: "Register for the Container Report Livestream"
-  external_link: "https://www.datadoghq.com/event/container-livestream/?utm_source=organic&utm_medium=display&utm_campaign=dg-organic-websites-ww-homepage-banner-livewebinar-containerlivestream23"
+  desktop_message: "Read the State of Application Security Research Report"
+  mobile_message: "Report: State of Application Security"
+  external_link: "https://www.datadoghq.com/state-of-application-security/?utm_source=organic&utm_medium=display&utm_campaign=dg-organic-websites-ww-docs-announcement-report-applicationsecurity2023"
 exclude: []
 translate_status_banner: "This translation isn't up to date, for the latest english version click here"


### PR DESCRIPTION
### What does this PR do?
Update announcement banner for new 2023 appsec report on corpsite

### Motivation
https://datadoghq.atlassian.net/browse/WEB-3489

### Preview
[Docs preview](https://docs-staging.datadoghq.com/davidweid/new-2023-stateof-report)

### Additional Notes
- Only the banner has updated
- To be merged in after the report goes live on corpsite

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
