### PR TITLE
Fix retention filters screenshot image broken path

### DIFF
--- a/content/en/tracing/trace_pipeline/_index.md
+++ b/content/en/tracing/trace_pipeline/_index.md
@@ -37,7 +37,7 @@ You can generate metrics from ingested spans, and use those custom metrics for q
 
 After spans have been ingested by Datadog, some are kept for 15 days according to the [Retention Filters][5] that have been set on your account. The Datadog Intelligent Retention Filter indexes a proportion of traces to help you monitor the health of your applications. Plus, you can define your own custom retention filters to index trace data you want to keep in support your organization's goals.
 
-{{< img src="tracing/trace_indexing_and_ingestion/retention_filters/retention_filter_page.png" style="width:100%;" alt="Retention Filters Page" >}}
+{{< img src="tracing/trace_indexing_and_ingestion/retention_filters/retention_filters.png" style="width:100%;" alt="Retention Filters Page" >}}
 
 ## Trace usage metrics
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Previous commit removed the retention filters page screenshot, here: https://github.com/DataDog/documentation/commit/ad8cbf18d7dc0efdedf31eb8044ef7d64755ecba and added a new one under a different name, from `retention_filter_page.png` to `retention_filters.png`.

For reference, the old media was this one: https://github.com/DataDog/documentation/blob/e1144a46536b8da588d57333e90b5657f5ce3118/static/images/tracing/trace_indexing_and_ingestion/retention_filters/retention_filter_page.png
With this being the new one: https://github.com/DataDog/documentation/blob/ad8cbf18d7dc0efdedf31eb8044ef7d64755ecba/static/images/tracing/trace_indexing_and_ingestion/retention_filters/retention_filters.png

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
