### PR TITLE
opentelemetry: fix typo in python tracing docs

### DIFF
--- a/content/en/tracing/trace_collection/otel_instrumentation/python.md
+++ b/content/en/tracing/trace_collection/otel_instrumentation/python.md
@@ -38,7 +38,7 @@ The following OTel features implemented in the Datadog library as noted:
     ```
 
 3. Set `DD_TRACE_OTEL_ENABLED` environment variable to `True`.
-4. Run your application with `ddtrace-run`. This automatically configures the `Datadog Tracer Provider`. If your application cannot use `ddttrace-run` read [the `dd-trace-py` OpenTelemetry API docs][11] for additional configurations.
+4. Run your application with `ddtrace-run`. This automatically configures the `Datadog Tracer Provider`. If your application cannot use `ddtrace-run` read [the `dd-trace-py` OpenTelemetry API docs][11] for additional configurations.
 
 Datadog combines these OpenTelemetry spans with other Datadog APM spans into a single trace of your application. It supports [OpenTelemetry Automatic instrumentation][8] also.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Replaces `ddttrace-run` with `ddtrace-run`

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
