### PR TITLE
Minor clarification on Case Management / Error Tracking

### DIFF
--- a/content/en/monitors/case_management/_index.md
+++ b/content/en/monitors/case_management/_index.md
@@ -9,7 +9,7 @@ further_reading:
 
 ## Overview
 
-Datadog Case Management provides a centralized place to track, triage, and troubleshoot issues. Create cases from alerts, security signals, and error-tracking issues that you want to investigate.
+Datadog Case Management provides a centralized place to track, triage, and troubleshoot issues. Create cases from alerts, security signals, and Error Tracking issues that you want to investigate.
 
 You can assign cases to users or teams, establishing clear lines of ownership that persist throughout the lifespan of the case. Populate your cases with graphs, logs, and other telemetry data from across Datadog alongside information from external tools, such as messaging and issue-tracking apps.
 
@@ -38,7 +38,7 @@ Make bulk edits to cases from the [Case Management page][1]:
 You can create or update cases from several locations in Datadog:
 - Monitors
 - Security signals
-- Error tracking
+- Error Tracking for Logs
 - Workflows
 - The Case Management page
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Clarifies that Case Management integration is currently only available for Error Tracking for Logs, and not for Error Tracking for APM or RUM.

### Motivation
The current wording may lead users to believe that Case Management integration is enabled for all Error Tracking products.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
