### PR TITLE
Node.js tracer is out of alpha for apm-dbm link

### DIFF
--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -47,9 +47,9 @@ Data privacy
 |                                          | [pdo][20]            | {{< X >}} | {{< X >}} |
 |                                          | [MySQLi][21]         |           | {{< X >}} |
 | **Node.js:** [dd-trace-js][9] >= 3.17.0  |                      |           |           |
-|                                          | [postgres][10]       |   Alpha   |           |
-|                                          | [mysql][13]          |           |   Alpha   |
-|                                          | [mysql2][14]         |           |   Alpha   |
+|                                          | [postgres][10]       | {{< X >}} |           |
+|                                          | [mysql][13]          |           | {{< X >}} |
+|                                          | [mysql2][14]         |           | {{< X >}} |
 
 
 
@@ -297,10 +297,6 @@ Enable the database monitoring propagation feature by setting the following envi
 {{% /tab %}}
 
 {{% tab "Node.js" %}}
-
-<div class="alert alert-warning">
-DBM-APM linking for Node.js is in alpha release and may be unstable.
-</div>
 
 Install or update [dd-trace-js][1] to a version greater than `3.17.0` (or `2.30.0` if using end-of-life Node.js version 12):
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Node is now fully supported for mysql & postgres; update docs accordingly. 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
