### PR TITLE
[.NET Tracing] Added note that we don't support partial trust

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
@@ -22,7 +22,7 @@ The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual B
 
 ## Supported .NET Framework runtimes
 
-The .NET Tracer supports automatic and custom instrumentation on the following .NET Framework versions. It also supports [.NET Core][2].
+The .NET Tracer supports automatic and custom instrumentation on the following .NET Framework versions. It also supports [.NET Core][2]. The .NET Tracer does not support code running in partial trust environments.
 
 | .NET Framework Version  | Microsoft End of Life | Support level                       | Package version             | Datadog End of Life |
 | ----------------------- | --------------------- | ----------------------------------- | --------------------------- | ------------------- |


### PR DESCRIPTION
### What does this PR do?
Adds a note that the .NET Tracer doesn't support partial trust.

### Motivation
We don't support running in partial trust, so want to document it publicly

### Additional Notes
Partial trust only applied to .NET Framework, so don't need to duplicate on .NET Core page

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
