### PR TITLE
Fix list of scopable permissions

### DIFF
--- a/layouts/partials/rbac-permissions-table.html
+++ b/layouts/partials/rbac-permissions-table.html
@@ -1,6 +1,6 @@
 {{/* Scopable columns may be refactored or moved to a different page later, but should remain hardcoded for now. */}}
 
-{{ $scopable_permissions := slice "logs_read_data" "logs_write_exclusion_filters" "logs_write_processors" "logs_read_archives" "logs_read_index_data" }}
+{{ $scopable_permissions := slice "logs_write_exclusion_filters" "logs_write_processors" "logs_read_index_data" }}
 {{ $is_scopable := false }}
 {{ $hide_scopable_column := false }}
 {{ $permission_group := .group }}


### PR DESCRIPTION
### What does this PR do?
After getting questions several times, I wrote an internal wiki article on "scopable" permissions: https://datadoghq.atlassian.net/wiki/spaces/AAA/pages/2963967417/Scoped+Permissions (only accessible inside Datadog)

In doing the research, I noticed that the list of scopable permissions in our public docs is wrong. This PR should correct the error.

### Motivation
Want to fix an error!

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
https://docs-staging.datadoghq.com/stephen.rosenthal/fix-error-about-scopable-permissions/account_management/rbac/permissions/#log-management

### Additional Notes
n/a

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
