### PR TITLE
Remove fs from the public doc

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -91,7 +91,6 @@ For details about how to how to toggle and configure plugins, check out the [API
 | Module      | Support Type        | Notes |
 | ----------- | ------------------- | ------------------------------------------ |
 | [dns][22]   | Fully supported     |       |
-| [fs][23]    | Fully supported     |       |
 | [http][24]  | Fully supported     |       |
 | [https][25] | Fully supported     |       |
 | [http2][26] | Partially supported | Only HTTP2 clients are currently supported and not servers. |


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Remove `fs` from the Node.js compatibilities doc.

### Motivation
<!-- What inspired you to submit this pull request?-->

Release notes for 3.0.0 of the node.js tracer that we dropped support for fs:
> fs: remove fs plugin (#2137)

Ask on #support-apm before the change: https://dd.slack.com/archives/C4WC8C39Q/p1682595786121409

