### PR TITLE
Update CI Visibility Java onboarding instructions

### DIFF
--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -157,7 +157,7 @@ mvn clean verify -Pdd-civisibility
 {{% /tab %}}
 {{% tab "Gradle" %}}
 
-Make sure to set the `DD_TRACER_VERSION` environment variable to the tracer version you have previously downloaded, and `DD_TRACER_FOLDER` variable to the path where you have downloaded the tracer.
+Make sure to set the `DD_TRACER_VERSION` environment variable to the tracer version you have previously downloaded, and the `DD_TRACER_FOLDER` variable to the path where you have downloaded the tracer.
 
 Run your tests using the `org.gradle.jvmargs` system property to specify the path to the Datadog Java Tracer JAR.
 

--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -140,7 +140,7 @@ Run your tests using the `MAVEN_OPTS` environment variable to specify the path t
 When specifying tracer arguments, include the following:
 
 * Enable CI visibility by setting the `dd.civisibility.enabled` property to `true`.
-* Define the environment where the tests are being run using the `dd.env property` (e.g. `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
+* Define the environment where the tests are being run using the `dd.env property` (for example `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
 * Define the name of the service or library being tested in the `dd.service property`.
 
 For example:
@@ -164,7 +164,7 @@ Run your tests using the `org.gradle.jvmargs` system property to specify the pat
 When specifying tracer arguments, include the following:
 
 * Enable CI visibility by setting the `dd.civisibility.enabled` property to `true`.
-* Define the environment where the tests are being run using the `dd.env property` (e.g. `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
+* Define the environment where the tests are being run using the `dd.env property` (for example `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
 * Define the name of the service or library being tested in the `dd.service property`.
 
 For example:

--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -429,7 +429,7 @@ When CI Visibility is enabled, the following data is collected from your project
 
 Ensure that you are using the latest version of the tracer.
 
-Verify that your build system and testing framework are supported by CI Visibility (refer to the list of supported build systems and test frameworks).
+Verify that your build system and testing framework are supported by CI Visibility. See the list of [supported build systems and test frameworks](#compatibility).
 
 Ensure that the `dd.civisibility.enabled` property is set to `true` in the tracer arguments.
 

--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -449,7 +449,7 @@ If the plugin interferes with the build, disable it by adding `dd.civisibility.c
 
 In some cases attaching the tracer can break tests, especially if they run asserts on the internal state of the JVM or instances of third-party libraries' classes.
 
-While the best approach is such cases is to update the tests, there is also a quicker option of disabling the tracer's third-party libraries integrations.
+While the best approach is such cases is to update the tests, there is also a quicker option of disabling the tracer's third-party library integrations.
 
 The integrations provide additional insights into what happens in the tested code and are especially useful in integration tests, to monitor things like HTTP requests or database calls.
 They are enabled by default.

--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -433,7 +433,7 @@ Verify that your build system and testing framework are supported by CI Visibili
 
 Ensure that the `dd.civisibility.enabled` property is set to `true` in the tracer arguments.
 
-Check the build output for any errors that indicate tracer misconfiguration, such as an unset DD API KEY.
+Check the build output for any errors that indicate tracer misconfiguration, such as an unset `DD_API_KEY` environment variable.
 
 ### Tests or source code compilation fails when building a project with the tracer attached
 

--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -89,7 +89,7 @@ If the tracer library is already available locally on the server, you can procee
 Declare `DD_TRACER_VERSION` variable with the latest version of the artifacts accessible from the [Maven Repository][1] (without the preceding `v`: ![Maven Central][2]):
 
 {{< code-block lang="shell" >}}
-DD_TRACER_VERSION=... // e.g. 1.13.0
+DD_TRACER_VERSION=... // e.g. 1.14.0
 {{< /code-block >}}
 
 Run the command below to download the tracer JAR to your local Maven repository:
@@ -107,7 +107,7 @@ mvn org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=com.datadogh
 Declare `DD_TRACER_VERSION` variable with the latest version of the artifacts accessible from the [Maven Repository][1] (without the preceding `v`: ![Maven Central][2]):
 
 {{< code-block lang="shell" >}}
-DD_TRACER_VERSION=... // e.g. 1.13.0
+DD_TRACER_VERSION=... // e.g. 1.14.0
 {{< /code-block >}}
 
 Declare `DD_TRACER_FOLDER` variable with the path to the folder where you want to store the downloaded JAR:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update CI Visibility docs for Java:
- onboarding instructions are simplified taking into account the latest automatic configuration features in the Java tracer
- configuration section is updated accordingly
- troubleshooting section is updated accordingly

### Motivation
<!-- What inspired you to submit this pull request?-->
A new version of DD Java Tracer is being released, which contains automatic configuration logic, that allows to simplify customer onboarding process.
The PR removes those onboarding steps that are now redundant.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
