### PR TITLE
Remove message about agent from Grok Parser notes

### DIFF
--- a/content/en/logs/log_configuration/parsing.md
+++ b/content/en/logs/log_configuration/parsing.md
@@ -59,7 +59,6 @@ After processing, the following structured log is generated:
 * You must have unique rule names within the same Grok parser.
 * The rule name must contain only: alphanumeric characters, `_`, and `.`. It must start with an alphanumeric character.
 * Properties with null or empty values are not displayed.
-* A full list of regular expression syntax accepted by the Agent is available in the [RE2 repo][1].
 * The regex matcher applies an implicit `^`, to match the start of a string, and `$`, to match the end of a string.
 * Certain logs can produce large gaps of whitespace. Use `\n` and `\s+` to account for newlines and whitespace.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR removed a bullet point from our Grok Parsing documentation. This bullet point may be accurate but I do not think it belongs in this section. I'm happy to move it to another page if anyone is aware of a more appropriate location. Thanks!

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
