### PR TITLE
Fix Java tracer library context propagation

### DIFF
--- a/content/en/tracing/trace_collection/trace_context_propagation/java.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/java.md
@@ -20,15 +20,15 @@ The Java Tracer supports the following styles:
 
 Injection styles can be configured using:
 
-- System Property: `-Ddd.propagation.style.inject=Datadog,b3multi`
-- Environment Variable: `DD_PROPAGATION_STYLE_INJECT=Datadog,b3multi`
+- System Property: `-Ddd.trace.propagation.style.inject=datadog,b3multi`
+- Environment Variable: `DD_TRACE_PROPAGATION_STYLE_INJECT=datadog,b3multi`
 
 The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for injection. By default only Datadog injection style is enabled.
 
 Extraction styles can be configured using:
 
-- System Property: `-Ddd.propagation.style.extract=Datadog,b3multi`
-- Environment Variable: `DD_PROPAGATION_STYLE_EXTRACT=Datadog,b3multi`
+- System Property: `-Ddd.trace.propagation.style.extract=datadog,b3multi`
+- Environment Variable: `DD_TRACE_PROPAGATION_STYLE_EXTRACT=datadog,b3multi`
 
 The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for extraction. By default only Datadog extraction style is enabled.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update the Java tracer library context propagation documentation to use the latest settings available.

### Motivation
<!-- What inspired you to submit this pull request?-->

`DD_PROPAGATION_STYLE_INJECT` and `DD_PROPAGATION_STYLE_EXTRACT` are the old and now deprecated settings.
Moreover, they do not support all the propagation styles listed in the documentation page (`tracecontext` is missing) so this lead to confusion for customers.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
