### PR TITLE
CI Visibility: Add docs about code coverage reporting

### DIFF
--- a/content/en/continuous_integration/tests/dotnet.md
+++ b/content/en/continuous_integration/tests/dotnet.md
@@ -176,6 +176,14 @@ if (scope != null) {
 
 To create filters or `group by` fields for these tags, you must first create facets. For more information about adding tags, see the [Adding Tags][7] section of the .NET custom instrumentation documentation.
 
+### Reporting code coverage
+
+When code coverage is available, the Datadog Tracer (v2.31.0+) reports it under the `test.code_coverage.lines_pct` tag for your test sessions.
+
+If you are using [Coverlet][14] to compute your code coverage, indicate the path to the report file in the `DD_CIVISIBILITY_EXTERNAL_CODE_COVERAGE_PATH` environment variable when running `dd-trace`. The report file must be in the OpenCover or Cobertura formats. Alternatively, you can enable the Datadog Tracer's built-in code coverage calculation with the env var `DD_CIVISIBILITY_CODE_COVERAGE_ENABLED=true`. **Note:** When using Intelligent Test Runner, the tracer's built-in code coverage is enabled by default.
+
+You can see the evolution of the test coverage in the **Coverage** tab of a test session.
+
 ### Instrumenting BenchmarkDotNet tests
 
 To instrument your benchmark tests you need to:
@@ -885,3 +893,4 @@ In addition to that, if [Intelligent Test Runner][10] is enabled, the following 
 [11]: /continuous_integration/tests/dotnet/#instrumenting-benchmarkdotnet-tests
 [12]: https://www.nuget.org/packages/Datadog.Trace.BenchmarkDotNet
 [13]: /continuous_integration/tests/dotnet/#configuring-reporting-method
+[14]: https://github.com/coverlet-coverage/coverlet

--- a/content/en/continuous_integration/tests/javascript.md
+++ b/content/en/continuous_integration/tests/javascript.md
@@ -332,6 +332,14 @@ If the browser application being tested is instrumented using [RUM][6], your Cyp
 
 {{< /tabs >}}
 
+### Reporting code coverage
+
+When code coverage is available, the Datadog Tracer (v3.19.0+) reports it under the `test.code_coverage.lines_pct` tag for your test sessions.
+
+To compute the code coverage, you can use the `--coverage` flag in Jest or run your tests using [Istanbul][19] in other testing frameworks.
+
+You can see the evolution of the test coverage in the **Coverage** tab of a test session.
+
 ### Using Yarn >=2
 
 If you're using `yarn>=2` and a `.pnp.cjs` file, and you get the following error message when using `NODE_OPTIONS`:
@@ -519,3 +527,4 @@ In addition to that, if [Intelligent Test Runner][18] is enabled, the following 
 [16]: https://jestjs.io/docs/api#testeachtablename-fn-timeout
 [17]: https://www.npmjs.com/package/mocha-each
 [18]: /continuous_integration/intelligent_test_runner/
+[19]: https://istanbul.js.org/

--- a/content/en/continuous_integration/tests/swift.md
+++ b/content/en/continuous_integration/tests/swift.md
@@ -362,6 +362,13 @@ span?.end()
 
 The test target needs to link explicitly with `opentelemetry-swift`.
 
+### Reporting code coverage
+
+When code coverage is available, the Datadog SDK (v1.21.0+) reports it under the `test.code_coverage.lines_pct` tag for your test sessions.
+
+In XCode, you can enable the reporing of code coverage in your Test Plan configuration, within your Test Scheme.
+
+You can see the evolution of the test coverage in the **Coverage** tab of a test session.
 
 ## Using Info.plist for configuration
 


### PR DESCRIPTION
### What does this PR do?
Document that the tracers can report the code coverage when available.

### Motivation
Support for code coverage tracking being added to CI Visibility.

### Additional Notes
The referenced tracer versions have not been released yet (and the specific version numbers could change). Do not merge until the tracers supporting the new `test.code_coverage.lines_pct` tag have been released.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
