### PR TITLE
DOCS-5385, 5386 Add Two Entries to the Words Rule

### DIFF
--- a/.github/styles/Datadog/words.yml
+++ b/.github/styles/Datadog/words.yml
@@ -10,6 +10,7 @@ swap:
   'acknowledgement': acknowledgment
   'auto-complete': 'autocomplete'
   'a number of': few|several|many
+  'and/or': 'and|or|either or'
   'back end': backend
   'Datadog app': 'Datadog|Datadog site'
   'Datadog application': 'Datadog|Datadog site'
@@ -24,9 +25,10 @@ swap:
   'time board': timeboard
   'time series': timeseries
   'toplist': top list
+  'tradeoff': 'trade-off'
   'turnkey': turn-key
   'utilize': use
   'via': with|through
   'webserver': 'web server'
-  'web site': website
+  'web site': 'website'
   'multi-alert': 'multi alert'

--- a/.vale.ini
+++ b/.vale.ini
@@ -23,5 +23,5 @@ Datadog.pronouns = NO
 Datadog.sentencelength = NO
 Datadog.spaces = NO
 Datadog.tense = NO
-Datadog.words = NO
+Datadog.words = YES
 Datadog.quotes = NO


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update a couple of rules for the `words.yml` style recommendation, specifically adding `and/or` and `tradeoff`.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-5385, 5386; Docs Style Council

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
