### PR TITLE
Kari/fix trace prop envars

### DIFF
--- a/content/en/tracing/trace_collection/library_config/cpp.md
+++ b/content/en/tracing/trace_collection/library_config/cpp.md
@@ -71,12 +71,12 @@ If specified, adds the `version` tag with the specified value to all generated s
 : **Version**: v1.1.4 <br>
 If specified, will add tags to all generated spans. A comma-separated list of `key:value` pairs.
 
-`DD_PROPAGATION_STYLE_INJECT` 
+`DD_TRACE_PROPAGATION_STYLE_INJECT` 
 : **Version**: v0.4.1 <br>
 **Default**: `Datadog` <br>
 Propagation style(s) to use when injecting tracing headers. `Datadog`, `B3`, or `Datadog B3`.
 
-`DD_PROPAGATION_STYLE_EXTRACT` 
+`DD_TRACE_PROPAGATION_STYLE_EXTRACT` 
 : **Version**: v0.4.1 <br>
 **Default**: `Datadog` <br>
 Propagation style(s) to use when extracting tracing headers. `Datadog`, `B3`, or `Datadog B3`.

--- a/content/en/tracing/trace_collection/trace_context_propagation/cpp.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/cpp.md
@@ -17,13 +17,13 @@ Distributed headers injection and extraction is controlled by configuring inject
 
 Injection styles can be configured using:
 
-- Environment Variable: `DD_PROPAGATION_STYLE_INJECT="Datadog B3"`
+- Environment Variable: `DD_TRACE_PROPAGATION_STYLE_INJECT="Datadog B3"`
 
 The value of the environment variable is a comma (or space) separated list of header styles that are enabled for injection. By default only Datadog injection style is enabled.
 
 Extraction styles can be configured using:
 
-- Environment Variable: `DD_PROPAGATION_STYLE_EXTRACT="Datadog B3"`
+- Environment Variable: `DD_TRACE_PROPAGATION_STYLE_EXTRACT="Datadog B3"`
 
 The value of the environment variable is a comma (or space) separated list of header styles that are enabled for extraction. By default only Datadog extraction style is enabled.
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/go.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/go.md
@@ -13,8 +13,8 @@ Distributed headers injection and extraction is controlled by
 configuring injection/extraction styles. Supported styles are:
 `tracecontext`, `Datadog`, `B3` and `B3 single header`.
 
-- Configure injection styles using the `DD_PROPAGATION_STYLE_INJECT=tracecontext,B3` environment variable.
-- Configure extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=tracecontext,B3` environment variable.
+- Configure injection styles using the `DD_TRACE_PROPAGATION_STYLE_INJECT=tracecontext,B3` environment variable.
+- Configure extraction styles using the `DD_TRACE_PROPAGATION_STYLE_EXTRACT=tracecontext,B3` environment variable.
 - Configure both injection and extraction styles using the `DD_TRACE_PROPAGATION_STYLE=tracecontext,B3` environment variable.
 
 The values of these environment variables are comma-separated lists of
@@ -22,11 +22,11 @@ header styles enabled for injection or extraction. By default,
 the `tracecontext,Datadog` styles are enabled.
 
 To disable trace context propagation, set the value of the environment variables to `none`.
-- Disable injection styles using the `DD_PROPAGATION_STYLE_INJECT=none` environment variable.
-- Disable extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=none` environment variable.
-- Disable all trace context propagation (both inject and extract) using the `DD_PROPAGATION_STYLE=none` environment variable.
+- Disable injection styles using the `DD_TRACE_PROPAGATION_STYLE_INJECT=none` environment variable.
+- Disable extraction styles using the `DD_TRACE_PROPAGATION_STYLE_EXTRACT=none` environment variable.
+- Disable all trace context propagation (both inject and extract) using the `DD_TRACE_PROPAGATION_STYLE=none` environment variable.
 
-If multiple environment variables are set, `DD_PROPAGATION_STYLE_INJECT` and `DD_PROPAGATION_STYLE_EXTRACT`
+If multiple environment variables are set, `DD_TRACE_PROPAGATION_STYLE_INJECT` and `DD_TRACE_PROPAGATION_STYLE_EXTRACT`
 override any value provided in `DD_TRACE_PROPAGATION_STYLE`.
 
 If multiple extraction styles are enabled, extraction attempts are made

--- a/content/en/tracing/trace_collection/trace_context_propagation/python.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/python.md
@@ -10,10 +10,10 @@ The Datadog APM tracer supports extraction and injection of [B3][2] and [W3C][3]
 
 Distributed headers injection and extraction is controlled by
 configuring injection and extraction styles. Supported styles are:
-`tracecontext`, `Datadog`, `B3` and `B3 single header`.
+`tracecontext`, `datadog`, `B3` and `B3 single header`.
 
-- Configure injection styles using the `DD_PROPAGATION_STYLE_INJECT=tracecontext,B3` environment variable.
-- Configure extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=tracecontext,B3` environment variable.
+- Configure injection styles using the `DD_TRACE_PROPAGATION_STYLE_INJECT=tracecontext,B3` environment variable.
+- Configure extraction styles using the `DD_TRACE_PROPAGATION_STYLE_EXTRACT=tracecontext,B3` environment variable.
 - Configure both injection and extraction styles using the `DD_TRACE_PROPAGATION_STYLE=tracecontext,B3` environment variable.
 
 The values of these environment variables are comma-separated lists of
@@ -21,11 +21,11 @@ header styles enabled for injection or extraction. By default,
 the `tracecontext,Datadog` styles are enabled.
 
 To disable trace context propagation, set the value of the environment variables to `none`.
-- Disable injection styles using the `DD_PROPAGATION_STYLE_INJECT=none` environment variable.
-- Disable extraction styles using the `DD_PROPAGATION_STYLE_EXTRACT=none` environment variable.
-- Disable all trace context propagation (both inject and extract) using the `DD_PROPAGATION_STYLE=none` environment variable.
+- Disable injection styles using the `DD_TRACE_PROPAGATION_STYLE_INJECT=none` environment variable.
+- Disable extraction styles using the `DD_TRACE_PROPAGATION_STYLE_EXTRACT=none` environment variable.
+- Disable all trace context propagation (both inject and extract) using the `DD_TRACE_PROPAGATION_STYLE=none` environment variable.
 
-If multiple environment variables are set, `DD_PROPAGATION_STYLE_INJECT` and `DD_PROPAGATION_STYLE_EXTRACT`
+If multiple environment variables are set, `DD_TRACE_PROPAGATION_STYLE_INJECT` and `DD_TRACE_PROPAGATION_STYLE_EXTRACT`
 override any value provided in `DD_TRACE_PROPAGATION_STYLE`.
 
 If multiple extraction styles are enabled, extraction attempts are made

--- a/content/en/tracing/trace_collection/trace_context_propagation/ruby.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/ruby.md
@@ -20,13 +20,13 @@ Distributed headers injection and extraction is controlled by configuring inject
 
 Injection styles can be configured using:
 
-- Environment Variable: `DD_PROPAGATION_STYLE_INJECT=Datadog,b3`
+- Environment Variable: `DD_TRACE_PROPAGATION_STYLE_INJECT=Datadog,b3`
 
 The value of the environment variable is a comma-separated list of header styles that are enabled for injection. By default only Datadog injection style is enabled.
 
 Extraction styles can be configured using:
 
-- Environment Variable: `DD_PROPAGATION_STYLE_EXTRACT=Datadog,b3`
+- Environment Variable: `DD_TRACE_PROPAGATION_STYLE_EXTRACT=Datadog,b3`
 
 The value of the environment variable is a comma-separated list of header styles that are enabled for extraction. 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes regression in trace context propagation env var names

### Motivation
https://github.com/DataDog/documentation/pull/17915#issuecomment-1527080502 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
