### PR TITLE
DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP - java tracer

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -169,6 +169,11 @@ Statsd host to send health metrics to
 **Default**: Same as `dd.jmxfetch.statsd.port` <br>
 Statsd port to send health metrics to
 
+`dd.trace_obfuscation_query_string_regexp
+: **Environment Variable**: `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP`<br>
+**Default**: `null`<br>
+A regex to redact sensitive data from incoming requests’ query string reported in the http.url tag (matches are replaced with <redacted>)
+  
 `dd.http.client.tag.query-string`
 : **Environment Variable**: `DD_HTTP_CLIENT_TAG_QUERY_STRING`<br>
 **Default**: `false`<br>


### PR DESCRIPTION
### What does this PR do?
Document DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP, introduced by https://github.com/DataDog/dd-trace-java/pull/3595 in 0.104

### Motivation


<!-- ### Preview -->


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
