### PR TITLE
Remove mention of Synthetics from Monitor Tag Policies

### DIFF
--- a/content/en/monitors/settings/_index.md
+++ b/content/en/monitors/settings/_index.md
@@ -14,7 +14,7 @@ further_reading:
 
 Monitor tag policies allow you to enforce data validation on tags and tag values on your Datadog monitors. This ensures that alerts are sent to the correct downstream systems and workflows for triage and processing.
 
-<div class="alert alert-warning">After set up, tag policies apply to <strong>all</strong> Datadog monitors and Synthetic tests.</div>
+<div class="alert alert-warning">After set up, tag policies apply to <strong>all</strong> Datadog monitors</div>
 
 - To create a new monitor, it must adhere to your organization's tag policies.
 - Existing monitors that violate your organization's tag policies continue to provide alerts and notifications, but must be updated to match the tag policies before you can modify other settings.


### PR DESCRIPTION
This functionality was removed due to an incident : https://dd.slack.com/archives/C050UQCJM0F 

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Remove mention of Synthetics from Monitor Tag Policies

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
