### PR TITLE
Remove note about US3

### DIFF
--- a/content/en/integrations/syslog_ng.md
+++ b/content/en/integrations/syslog_ng.md
@@ -29,10 +29,6 @@ Configure Syslog-ng to gather logs from your host, containers, & services.
 
 ### Log collection
 
-{{% site-region region="us3" %}}
-**Log collection is not supported for the Datadog {{< region-param key="dd_site_name" >}} site**.
-{{% /site-region %}}
-
 1. Collect system logs and log files in `/etc/syslog-ng/syslog-ng.conf` and make sure the source is correctly defined:
 
     ```conf


### PR DESCRIPTION
### What does this PR do?

Remove note about US3 not being supported.

### Motivation

US3 is supported with the http module.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
