### PR TITLE
Change version presentation in integrations pages

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -312,7 +312,7 @@
     "other": "Our friendly, knowledgeable solutions engineers are here to help!"
   },
   "integration_version": {
-    "other": "Integration"
+    "other": "Integration version"
   },
   "beta_check":{
     "other": "Beta"

--- a/layouts/partials/integration-labels/integration-labels.html
+++ b/layouts/partials/integration-labels/integration-labels.html
@@ -62,7 +62,7 @@
 {{ with .Params.integration_version }}
 <div class="row integration-labels">
     <div class="integration-version col-12">
-        <span>{{ i18n "integration_version" }}</span><span>v{{ . }}</span>
+        <span>{{ i18n "integration_version" }}</span><span>{{ . }}</span>
     </div>
 
 </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

changes "v" to "version" at the top of Integrations pages in the docs 
![image](https://user-images.githubusercontent.com/12926135/235770889-1d4ec558-d9ec-4c93-aef2-3087e5ebc5e1.png)


### Motivation

Slack convo

![image](https://user-images.githubusercontent.com/12926135/235770972-40dbcfe9-e954-446c-a8ff-fe063c97ac0e.png)


<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
