### PR TITLE
[web-2006] Search relevance update

### DIFF
--- a/content/en/database_monitoring/_index.md
+++ b/content/en/database_monitoring/_index.md
@@ -15,7 +15,8 @@ further_reading:
 - link: "/database_monitoring/troubleshooting/"
   tag: "Documentation"
   text: "Troubleshooting"
-
+algolia:
+  tags: ['database monitoring', 'dbm']
 ---
 {{< site-region region="gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>

--- a/content/en/integrations/_index.md
+++ b/content/en/integrations/_index.md
@@ -23,6 +23,13 @@ cascade:
     subcategory: Integrations
     tags: ['ksm']
 - _target:
+    path: /integrations/google_cloud_platform.md
+  algolia:
+    rank: 60
+    category: Documentation
+    subcategory: Integrations
+    tags: ['gcp', 'google cloud platform']
+- _target:
     path: /integrations/*.md
   algolia:
     rank: 60


### PR DESCRIPTION
### What does this PR do?
Adds algolia tags for two pages to bump the search relevancy 

### Motivation
https://datadoghq.atlassian.net/browse/WEB-2006

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/more-search-relevance/search/?s=gcp `integrations/google_cloud_platform` should be first in results

https://docs-staging.datadoghq.com/brian.deutsch/more-search-relevance/search/?s=npm
`network_monitoring/performance` should be first in results

https://docs-staging.datadoghq.com/brian.deutsch/more-search-relevance/search/?s=dbm
`database_monitoring` should be first in results

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
