### PR TITLE
SL4J SimpleLogger documentation link corrected

### DIFF
--- a/content/ja/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/ja/tracing/troubleshooting/tracer_debug_logs.md
@@ -25,7 +25,7 @@ Datadog Java トレーサーのデバッグモードを有効にするには、J
 ```
 
 
-[1]: https://www.slf4j.org/api/org/slf4j/impl/SimpleLogger.html
+[1]: https://www.slf4j.org/api/org/slf4j/simple/SimpleLogger.html
 {{< /programming-lang >}}
 
 {{< programming-lang lang="python" >}}


### PR DESCRIPTION
### What does this PR do?
Documentation link for SL4J SimpleLogger on the Japanese page has been corrected.

### Motivation
Because the link was incorrect.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
