### PR TITLE
[error tracking] Add custom fingerprint docs for browser RUM

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3567,6 +3567,11 @@ main:
     parent: rum_error_tracking
     identifier: rum_error_tracking_flutter
     weight: 1407
+  - name: Custom Grouping
+    url: real_user_monitoring/error_tracking/custom_grouping
+    parent: rum_error_tracking
+    identifier: rum_error_tracking_custom_grouping
+    weight: 1408
   - name: Guides
     url: real_user_monitoring/guide/
     parent: rum

--- a/content/en/real_user_monitoring/error_tracking/custom_grouping.md
+++ b/content/en/real_user_monitoring/error_tracking/custom_grouping.md
@@ -1,0 +1,62 @@
+---
+title: Custom Grouping
+kind: documentation
+description: Customize how RUM errors are grouped into issues.
+further_reading:
+- link: "https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps"
+  tag: "GitHub"
+  text: "datadog-ci Source code"
+- link: "/real_user_monitoring/guide/upload-javascript-source-maps"
+  tag: "Documentation"
+  text: "Upload JavaScript source maps"
+- link: "/real_user_monitoring/error_tracking/"
+  tag: "Documentation"
+  text: "Learn about Error Tracking for Web and Mobile Applications"
+---
+
+## Overview
+
+Error Tracking intelligently groups similar errors into issues with a default strategy. By using _custom fingerprinting_, you can gain full control over the grouping decision and customize the grouping behavior for your Real User Monitoring (RUM)
+errors.
+
+Provide an `error.fingerprint` attribute that Error Tracking can use to group RUM errors into issues. While the value of the `error.fingerprint` attribute does not have any particular format or requirement, the content must be a string.
+
+If `error.fingerprint` is provided, the grouping behavior follows these rules:
+
+* Custom grouping takes precedence over the default strategy.
+* Custom grouping can be applied only to a subset of your RUM errors and can co-exist with the default strategy.
+* The content of `error.fingerprint` is used as-is without any modification.
+* RUM errors from the same service and with the same `error.fingerprint` attribute are grouped into the same issue.
+* RUM errors with different `service` attributes are grouped into different issues.
+
+## Setup
+
+Custom grouping only needs a RUM error and an `error.fingerprint` string attribute.
+
+If you aren’t already collecting RUM events with Datadog, see the [RUM documentation][1] to set up Real User Monitoring.
+
+### Example
+
+If you're already sending RUM events, add a new `error.fingerprint` attribute to your RUM error event.
+
+Here's an example for [collecting browser errors][2]:
+
+```javascript
+import { datadogRum } from '@datadog/browser-rum';
+
+// Send a custom error with context
+const error = new Error('Something went wrong');
+datadogRum.addError(error, {
+  'error.fingerprint': 'my-custom-grouping-material',
+});
+```
+
+In this case, `my-custom-grouping-material` is used to group these RUM errors into a single
+issue in Error Tracking.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /real_user_monitoring/
+[2]: /real_user_monitoring/browser/collecting_browser_errors/

--- a/content/en/real_user_monitoring/error_tracking/custom_grouping.md
+++ b/content/en/real_user_monitoring/error_tracking/custom_grouping.md
@@ -16,8 +16,7 @@ further_reading:
 
 ## Overview
 
-Error Tracking intelligently groups similar errors into issues with a default strategy. By using _custom fingerprinting_, you can gain full control over the grouping decision and customize the grouping behavior for your Real User Monitoring (RUM)
-errors.
+[Error Tracking][4] intelligently groups similar errors into issues with a default strategy. By using _custom fingerprinting_, you can gain full control over the grouping decision and customize the grouping behavior for your Real User Monitoring (RUM) errors.
 
 Provide an `error.fingerprint` attribute that Error Tracking can use to group RUM errors into issues. While the value of the `error.fingerprint` attribute does not have any particular format or requirement, the content must be a string.
 
@@ -31,15 +30,15 @@ If `error.fingerprint` is provided, the grouping behavior follows these rules:
 
 ## Setup for browser errors
 
-Custom grouping needs the [browser-sdk v4.42.0][3] (or more recent), a browser RUM error and an additional
-string attribute.
+In order to use custom grouping, you need the Datadog Browser SDK [v4.42.0 or later][3], a [browser RUM error][2], and an additional string attribute.
 
-If you aren't already collecting browser RUM events with Datadog, see the [RUM documentation][1] to set up Real User Monitoring.
+If you aren't already collecting Browser RUM events with Datadog, see the [Browser Monitoring setup documentation][1].
 
 ### Example
 
-If you're already [collecting browser errors][2], it's possible to add the attribute
-either by adding a `dd_fingerprint` attribute to the error object
+If you're already [collecting browser errors][2], it's possible to add the attribute by either:
+
+* Adding a `dd_fingerprint` attribute to the error object:
 
 ```javascript
 import { datadogRum } from '@datadog/browser-rum';
@@ -49,7 +48,7 @@ error.dd_fingerprint = 'my-custom-grouping-fingerprint'
 datadogRum.addError(error);
 ```
 
-or using the `beforeSend` callbadk with an `error.fingerprint` attribute
+* Or, using the `beforeSend` callback with an `error.fingerprint` attribute:
 
 ```javascript
 DD_RUM.init({
@@ -62,8 +61,7 @@ DD_RUM.init({
 })
 ```
 
-In both cases, `my-custom-grouping-material` is used to group the browser RUM errors into a single
-issue in Error Tracking.
+In both cases, `my-custom-grouping-material` is used to group the Browser RUM errors into a single issue in Error Tracking.
 
 ## Further Reading
 
@@ -72,3 +70,4 @@ issue in Error Tracking.
 [1]: /real_user_monitoring/
 [2]: /real_user_monitoring/browser/collecting_browser_errors/
 [3]: https://github.com/DataDog/browser-sdk/releases/tag/v4.42.0
+[4]: /real_user_monitoring/error_tracking

--- a/content/en/real_user_monitoring/error_tracking/custom_grouping.md
+++ b/content/en/real_user_monitoring/error_tracking/custom_grouping.md
@@ -33,11 +33,11 @@ If `error.fingerprint` is provided, the grouping behavior follows these rules:
 
 Custom grouping only needs a browser RUM error and an additional string attribute.
 
-If you aren’t already collecting browser RUM events with Datadog, see the [RUM documentation][1] to set up Real User Monitoring.
+If you aren't already collecting browser RUM events with Datadog, see the [RUM documentation][1] to set up Real User Monitoring.
 
 ### Example
 
-If you're already [collecting browser errors][2], it's possible to add the new attribute to your browser error event
+If you're already [collecting browser errors][2], it's possible to add the attribute
 either by adding a `dd_fingerprint` attribute to the error object
 
 ```javascript

--- a/content/en/real_user_monitoring/error_tracking/custom_grouping.md
+++ b/content/en/real_user_monitoring/error_tracking/custom_grouping.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Grouping
 kind: documentation
-description: Customize how RUM errors are grouped into issues.
+description: Customize how Browser RUM errors are grouped into issues.
 further_reading:
 - link: "https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps"
   tag: "GitHub"

--- a/content/en/real_user_monitoring/error_tracking/custom_grouping.md
+++ b/content/en/real_user_monitoring/error_tracking/custom_grouping.md
@@ -29,29 +29,39 @@ If `error.fingerprint` is provided, the grouping behavior follows these rules:
 * RUM errors from the same service and with the same `error.fingerprint` attribute are grouped into the same issue.
 * RUM errors with different `service` attributes are grouped into different issues.
 
-## Setup
+## Setup for broswer errors
 
-Custom grouping only needs a RUM error and an `error.fingerprint` string attribute.
+Custom grouping only needs a browser RUM error and an additional string attribute.
 
-If you aren’t already collecting RUM events with Datadog, see the [RUM documentation][1] to set up Real User Monitoring.
+If you aren’t already collecting browser RUM events with Datadog, see the [RUM documentation][1] to set up Real User Monitoring.
 
 ### Example
 
-If you're already sending RUM events, add a new `error.fingerprint` attribute to your RUM error event.
-
-Here's an example for [collecting browser errors][2]:
+If you're already [collecting browser errors][2], it's possible to add the new attribute to your browser error event
+either by adding a `dd_fingerprint` attribute to the error object
 
 ```javascript
 import { datadogRum } from '@datadog/browser-rum';
-
 // Send a custom error with context
 const error = new Error('Something went wrong');
-datadogRum.addError(error, {
-  'error.fingerprint': 'my-custom-grouping-material',
-});
+error.dd_fingerprint = 'my-custom-grouping-material'
+datadogRum.addError(error);
 ```
 
-In this case, `my-custom-grouping-material` is used to group these RUM errors into a single
+or using the `beforeSend` callbadk with an `error.fingerprint` attribute
+
+```javascript
+DD_RUM.init({
+  ...
+  beforeSend: () => {
+    if (event.type === 'error') {
+      event.error.fingerprint = 'my-custom-grouping-material'
+    }
+  },
+})
+```
+
+In both cases, `my-custom-grouping-material` is used to group the browser RUM errors into a single
 issue in Error Tracking.
 
 ## Further Reading

--- a/content/en/real_user_monitoring/error_tracking/custom_grouping.md
+++ b/content/en/real_user_monitoring/error_tracking/custom_grouping.md
@@ -29,7 +29,7 @@ If `error.fingerprint` is provided, the grouping behavior follows these rules:
 * RUM errors from the same service and with the same `error.fingerprint` attribute are grouped into the same issue.
 * RUM errors with different `service` attributes are grouped into different issues.
 
-## Setup for broswer errors
+## Setup for browser errors
 
 Custom grouping needs the [browser-sdk v4.42.0][3] (or more recent), a browser RUM error and an additional
 string attribute.

--- a/content/en/real_user_monitoring/error_tracking/custom_grouping.md
+++ b/content/en/real_user_monitoring/error_tracking/custom_grouping.md
@@ -45,7 +45,7 @@ either by adding a `dd_fingerprint` attribute to the error object
 import { datadogRum } from '@datadog/browser-rum';
 // Send a custom error with context
 const error = new Error('Something went wrong');
-error.dd_fingerprint = 'my-custom-grouping-material'
+error.dd_fingerprint = 'my-custom-grouping-fingerprint'
 datadogRum.addError(error);
 ```
 
@@ -56,7 +56,7 @@ DD_RUM.init({
   ...
   beforeSend: () => {
     if (event.type === 'error') {
-      event.error.fingerprint = 'my-custom-grouping-material'
+      event.error.fingerprint = 'my-custom-grouping-fingerprint'
     }
   },
 })

--- a/content/en/real_user_monitoring/error_tracking/custom_grouping.md
+++ b/content/en/real_user_monitoring/error_tracking/custom_grouping.md
@@ -31,7 +31,8 @@ If `error.fingerprint` is provided, the grouping behavior follows these rules:
 
 ## Setup for broswer errors
 
-Custom grouping only needs a browser RUM error and an additional string attribute.
+Custom grouping needs the [browser-sdk v4.42.0][3] (or more recent), a browser RUM error and an additional
+string attribute.
 
 If you aren't already collecting browser RUM events with Datadog, see the [RUM documentation][1] to set up Real User Monitoring.
 
@@ -70,3 +71,4 @@ issue in Error Tracking.
 
 [1]: /real_user_monitoring/
 [2]: /real_user_monitoring/browser/collecting_browser_errors/
+[3]: https://github.com/DataDog/browser-sdk/releases/tag/v4.42.0


### PR DESCRIPTION
Reverts DataDog/documentation#17297 and specifies the functionality is currently available only for the browser RUM SDK that's been introduced in https://github.com/DataDog/browser-sdk/pull/2189.
Docs for Android and iOS SKDs will follow when they'll be released.