### PR TITLE
add clarification for max/min aggregation in monitor types

### DIFF
--- a/content/en/monitors/types/metric.md
+++ b/content/en/monitors/types/metric.md
@@ -102,12 +102,14 @@ Any metric reporting to Datadog is available for monitors. Use the editor and th
 | Option           | Description                                                                                                                                                                   |
 |------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | average          | The series is averaged to produce a single value that is checked against the threshold. It adds the `avg()` function to your monitor query.                                   |
-| max              | If any single value in the generated series crosses the threshold, then an alert is triggered. It adds the max() function to your monitor query.                              |
-| min              | If all points in the evaluation window for your query cross the threshold, then an alert is triggered. It adds the min() function to your monitor query.                      |
+| max              | If any single value in the generated series crosses the threshold, then an alert is triggered. It adds the max() function to your monitor query.*                             |
+| min              | If all points in the evaluation window for your query cross the threshold, then an alert is triggered. It adds the min() function to your monitor query.*                     |
 | sum              | If the summation of every point in the series crosses the threshold, an alert is triggered. It adds the `sum()` function to your monitor query.                               |
 | percentile(pXX)  | If pXX percentage of points in the evaluation window for your query cross the threshold, then an alert is triggered. This option adds a `percentile` function to your monitor query. Only available for the distribution metric type.
 | Alert grouping   | If using a `Simple Alert`, the monitor aggregates over all reporting sources. If using a `Multi Alert`, the monitor applies the alert to each source, according to your group parameters. See [Alert grouping](#alert-grouping) for more details.
 | Evaluation window| The time period the monitor evaluates. Use preset time windows like `5 minutes`, `15 minutes`, `1 hour`, or `custom` to set a value between 1 minute and 730 hours (1 month). |
+
+\* These descriptions of max and min assume that the monitor alerts when the metric goes above the threshold. For monitors that alert when below the threshold, the max and min behavior is reversed.
 
 {{% /tab %}}
 {{% tab "Change" %}}
@@ -132,12 +134,14 @@ Any metric reporting to Datadog is available for monitors. Use the editor and th
 | change           | The absolute change of the value.                                                                                                                                             |
 | %&nbsp;change    | The percentage change of the value compared to its previous value. For example, the percentage change for a previous value of 2 with a current value of 4 is 100%.            |
 | average          | The series is averaged to produce a single value that is checked against the threshold. It adds the `avg()` function to your monitor query.                                   |
-| max              | If any single value in the generated series crosses the threshold, then an alert is triggered. It adds the max() function to your monitor query.                              |
-| min              | If all points in the evaluation window for your query cross the threshold, then an alert is triggered. It adds the min() function to your monitor query.                      |
+| max              | If any single value in the generated series crosses the threshold, then an alert is triggered. It adds the max() function to your monitor query.*                             |
+| min              | If all points in the evaluation window for your query cross the threshold, then an alert is triggered. It adds the min() function to your monitor query.*                     |
 | sum              | If the summation of every point in the series crosses the threshold, an alert is triggered. It adds the `sum()` function to your monitor query.                               |
 | percentile(pXX)  | If pXX percentage of points in the evaluation window for your query cross the threshold, then an alert is triggered. This option adds a `percentile` function to your monitor query. Only available for the distribution metric type.
 | Alert grouping   | If using a `Simple Alert`, the monitor aggregates over all reporting sources. If using a `Multi Alert`, the monitor applies the alert to each source, according to your group parameters. See [Alert grouping](#alert-grouping) for more details.
 | Evaluation window| The time period the monitor evaluates. Use preset time windows like `5 minutes`, `15 minutes`, `1 hour`, or `custom` to set a value between 1 minute and 730 hours (1 month). |
+
+\* These descriptions of max and min assume that the monitor alerts when the metric goes above the threshold. For monitors that alert when below the threshold, the max and min behavior is reversed.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Adds explanation asterisk to min and max descriptions of monitor aggregation, explaining that the behaviour reverses based on the trigger condition operator. 

It is copy of the text from
https://github.com/DataDog/documentation/blob/b20bdccb5790fae08318edaa7aff3a6976511dab/content/en/monitors/configuration/_index.md#L56

### Motivation
The min/max aggregation description is only work when the threshold is "above" condition.

This is clarified in the `configure monitors` page, but same table is in the metrics types page.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
