### PR TITLE
added_function_startSessionRecording

### DIFF
--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -67,6 +67,8 @@ datadogRum.init({
   trackResources: true,
   trackLongTasks: true,
   trackUserInteractions: true,
+  });
+DD_RUM.startSessionReplayRecording();
 })
 ```
 
@@ -90,6 +92,8 @@ datadogRum.init({
   trackResources: true,
   trackLongTasks: true,
   trackInteractions: true,
+  });
+DD_RUM.startSessionReplayRecording();
 })
 ```
 
@@ -111,6 +115,8 @@ datadogRum.init({
   sampleRate: 100,
   premiumSampleRate: 100, // if not included, the default is 100
   trackInteractions: true,
+  });
+DD_RUM.startSessionReplayRecording();
 })
 ```
 
@@ -132,6 +138,8 @@ datadogRum.init({
   sampleRate: 100,
   replaySampleRate: 100, // if not included, the default is 100
   trackInteractions: true,
+  });
+DD_RUM.startSessionReplayRecording();
 })
 ```
 
@@ -818,7 +826,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -839,7 +849,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -860,7 +872,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -881,7 +895,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -902,7 +918,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -923,7 +941,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -950,7 +970,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -971,7 +993,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -992,7 +1016,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1013,7 +1039,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1034,7 +1062,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1055,7 +1085,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1080,7 +1112,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       sampleRate: 100,
       premiumSampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1099,7 +1133,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       sampleRate: 100,
       premiumSampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1118,7 +1154,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       sampleRate: 100,
       premiumSampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1137,7 +1175,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       sampleRate: 100,
       premiumSampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1156,7 +1196,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       sampleRate: 100,
       premiumSampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1175,7 +1217,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       sampleRate: 100,
       premiumSampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1200,7 +1244,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       sampleRate: 100,
       replaySampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1219,7 +1265,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       sampleRate: 100,
       replaySampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1238,7 +1286,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       sampleRate: 100,
       replaySampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1257,7 +1307,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       sampleRate: 100,
       replaySampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1276,7 +1328,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       sampleRate: 100,
       replaySampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}
@@ -1295,7 +1349,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
       sampleRate: 100,
       replaySampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
+  })
 </script>
 ```
 {{</ site-region>}}

--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -167,7 +167,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
-    })
+    });
+   DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -193,7 +194,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
-    })
+    });
+   DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -219,7 +221,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
-    })
+    });
+   DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -245,7 +248,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
-    })
+    });
+   DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -271,7 +275,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
-    })
+    });
+   DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -297,7 +302,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
-    })
+    });
+   DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -329,7 +335,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackInteractions: true,
-    })
+    });
+   DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -355,7 +362,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackInteractions: true,
-    })
+    });
+   DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -381,7 +389,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackInteractions: true,
-    })
+    });
+   DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -407,7 +416,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackInteractions: true,
-    })
+    });
+   DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -459,7 +469,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackInteractions: true,
-    })
+    });
+   DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -489,7 +500,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       sampleRate: 100,
       premiumSampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+   DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -513,7 +525,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       sampleRate: 100,
       premiumSampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+   DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -537,7 +550,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       sampleRate: 100,
       premiumSampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -561,7 +575,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       sampleRate: 100,
       premiumSampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -585,7 +600,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       sampleRate: 100,
       premiumSampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -609,7 +625,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       sampleRate: 100,
       premiumSampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -639,7 +656,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       sampleRate: 100,
       replaySampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -663,7 +681,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       sampleRate: 100,
       replaySampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -687,7 +706,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       sampleRate: 100,
       replaySampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -711,7 +731,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       sampleRate: 100,
       replaySampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -735,7 +756,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       sampleRate: 100,
       replaySampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```
@@ -759,7 +781,8 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       sampleRate: 100,
       replaySampleRate: 100, // if not included, the default is 100
       trackInteractions: true,
-    })
+    });
+  DD_RUM.startSessionReplayRecording();
   })
 </script>
 ```


### PR DESCRIPTION
Added `DD_RUM.startSessionReplayRecording();` at the end of the CDN async code snippet. If not added, it won't start recording.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
