### PR TITLE
image version bump

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,7 +102,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-14529003
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-15527163
   tags:
     - "arch:amd64"
   rules:


### PR DESCRIPTION
### What does this PR do?
consume latest build image

### Motivation
an update to the image was needed in order to fix docs build caching: https://github.com/DataDog/websites-images/pull/118/files

### Preview
no changes here: https://docs-staging.datadoghq.com/brian.deutsch/image-bump/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
