### PR TITLE
[DOCS-5423] updating ISO date format

### DIFF
--- a/content/en/logs/log_configuration/processors.md
+++ b/content/en/logs/log_configuration/processors.md
@@ -96,8 +96,6 @@ If your logs have dates in an attribute that are not in this list, use the log d
 The recognized date formats are: <a href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO8601</a>, <a href="https://en.wikipedia.org/wiki/Unix_time">UNIX (the milliseconds EPOCH format)</a>, and <a href="https://www.ietf.org/rfc/rfc3164.txt">RFC3164</a>.
 </div>
 
-**Note**: As of ISO 8601-1:2019, the basic format is `T[hh][mm][ss]` and the extended format is `T[hh]:[mm]:[ss]`. Earlier versions omitted the T (representing time) in both formats.
-
 If your logs don't have a timestamp that conforms to the formats listed above, use the grok processor to extract the epoch time from the timestamp to a new attribute. The date remapper uses the newly defined attribute.
 
 To see how a custom date and time format can be parsed in Datadog, see [Parsing dates][3].
@@ -105,8 +103,10 @@ To see how a custom date and time format can be parsed in Datadog, see [Parsing 
 **Note**:
 
 * **Log events can be submitted up to 18h in the past and 2h in the future**.
+* As of ISO 8601-1:2019, the basic format is `T[hh][mm][ss]` and the extended format is `T[hh]:[mm]:[ss]`. Earlier versions omitted the T (representing time) in both formats.
 * If your logs don't contain any of the default attributes and you haven't defined your own date attribute, Datadog timestamps the logs with the date it received them.
 * If multiple log date remapper processors are applied to a given log, only the first one (according to the pipeline's order) is taken into account.
+
 
 {{< tabs >}}
 {{% tab "UI" %}}

--- a/content/en/logs/log_configuration/processors.md
+++ b/content/en/logs/log_configuration/processors.md
@@ -96,6 +96,8 @@ If your logs have dates in an attribute that are not in this list, use the log d
 The recognized date formats are: <a href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO8601</a>, <a href="https://en.wikipedia.org/wiki/Unix_time">UNIX (the milliseconds EPOCH format)</a>, and <a href="https://www.ietf.org/rfc/rfc3164.txt">RFC3164</a>.
 </div>
 
+**Note**: As of ISO 8601-1:2019, the basic format is `T[hh][mm][ss]` and the extended format is `T[hh]:[mm]:[ss]`. Earlier versions omitted the T (representing time) in both formats.
+
 If your logs don't have a timestamp that conforms to the formats listed above, use the grok processor to extract the epoch time from the timestamp to a new attribute. The date remapper uses the newly defined attribute.
 
 To see how a custom date and time format can be parsed in Datadog, see [Parsing dates][3].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Added a Note to indicate date the ISO date format now requires the `T` separator in front of the HH.
Decided against linking to the newer [ISO](https://www.iso.org/standard/70907.html) documentation as their docs note it is a "paid" document. So hence just adding a note to help avoid confusion.


### Motivation
https://datadoghq.atlassian.net/browse/LOGSS-6783

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
