### PR TITLE
Update nodejs.md to reflect correct NodeJS tracer version of Business…

### DIFF
--- a/content/en/security/application_security/enabling/compatibility/nodejs.md
+++ b/content/en/security/application_security/enabling/compatibility/nodejs.md
@@ -35,7 +35,7 @@ The following ASM capabilities are supported in the Node.js library, for the spe
 
 | ASM capability                   | Minimum NodeJS tracer version |
 | -------------------------------- | ----------------------------|
-| Threat Detection <br/> --> Business logic API  | 3.31.1 <br/>   |
+| Threat Detection <br/> --> Business logic API  | 3.13.1 <br/>   |
 | Threat Protection <br/> --> IP blocking <br/> --> Suspicious request blocking <br> --> User blocking   | <br/> --> 3.11.0<br/> --> not supported<br/> --> 3.11.0     |
 | Risk Management <br/> --> Third-party vulnerability detection <br/> --> Custom code vulnerability detection | 2.23.0 for NodeJS 12+, or 3.10.0 for NodeJS 14+ <br/><br/> |
 


### PR DESCRIPTION
… Logic tracking

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes a Typo that states that the version of the Datadog Node.js Tracer version necessary for Business Logic Threat Detection in Application Security Management is version **3.31.1**. As below, the correct version needed for this is tracer version **3.13.1**

Currently, the latest release of the Datadog tracer is Tracer version 3.20.0 as per the repo [here](https://github.com/DataDog/dd-trace-js)

### Motivation
Investigating for a Zendesk support ticket linked [here](https://datadog.zendesk.com/agent/tickets/1148017)
[This link contains the information that accurately reflects the version needed - 3.13.1 rather than 3.31.1](https://docs.datadoghq.com/security/application_security/threats/add-user-info/?tab=set_user#adding-business-logic-information-login-success-login-failure-any-business-logic-to-traces)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
