### PR TITLE
Add Data streams monitoring tile to landing page

### DIFF
--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -109,7 +109,7 @@ nav_sections:
         icon: database-2
         desc: Explore enriched dashboards, query metrics, and query samples
       - title: Data Streams Monitoring
-        link: data-streams/
+        link: data_streams/
         icon: datastreams-monitoring
         desc: Track and improve performance of your data streaming pipelines
       - title: Observability Pipelines

--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -108,6 +108,10 @@ nav_sections:
         link: database_monitoring/
         icon: database-2
         desc: Explore enriched dashboards, query metrics, and query samples
+      - title: Data Streams Monitoring
+        link: data-streams/
+        icon: datastreams-monitoring
+        desc: Track and improve performance of your data streaming pipelines
       - title: Observability Pipelines
         link: observability_pipelines/
         icon: pipelines


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add the Data Streams Monitoring tile to the docs landing page
https://a.cl.ly/mXuDgwqx 
![image](https://user-images.githubusercontent.com/41168354/236869489-d08403b1-f613-4229-875d-283f27c4ee02.png)


### Motivation
<!-- What inspired you to submit this pull request?-->
[DOCS-5420](https://datadoghq.atlassian.net/browse/DOCS-5420)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Do not merge, would like to get PM review of copy.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5420]: https://datadoghq.atlassian.net/browse/DOCS-5420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ