### PR TITLE
Remove SQLServer unrelated image

### DIFF
--- a/content/en/integrations/guide/collect-sql-server-custom-metrics.md
+++ b/content/en/integrations/guide/collect-sql-server-custom-metrics.md
@@ -82,9 +82,7 @@ After you update the SQL Server YAML file, [restart the Datadog Agent][7].
 
 #### Validation
 
-To verify your results, search for the metrics using the [Metrics Explorer][8]:
-
-{{< img src="integrations/faq/sql_metric_explorer.png" alt="Screenshot of Datadog's Metrics Explorer. On the left, the two items under 'Graph' are 'postgresql.employee_age' and 'postgresql.employee_salary.' On the right are two graphs showing employee age and employee salary." >}}
+To verify your results, search for the metrics using the [Metrics Explorer][8].
 
 #### Debugging
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Remove current image of postgresql metrics from a SQL Server guide.
Will not replace as the link to the Metrics Explorer takes the user directly to the Explorer page.

### Motivation
<!-- What inspired you to submit this pull request?-->
[DOCS-5440](https://datadoghq.atlassian.net/browse/DOCS-5440)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5440]: https://datadoghq.atlassian.net/browse/DOCS-5440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ