### PR TITLE
Update Terraformer docs to include api-url and remove unneeded config

### DIFF
--- a/content/en/agent/guide/how-to-import-datadog-resources-into-terraform.md
+++ b/content/en/agent/guide/how-to-import-datadog-resources-into-terraform.md
@@ -32,25 +32,14 @@ terraform {
 }
 
 # Configure the Datadog provider
-provider "datadog" {
-  api_key = var.datadog_api_key
-  app_key = var.datadog_app_key
-}
-
-variable "datadog_api_key" {
-  default = "<YOUR_API_KEY>"
-}
-
-variable "datadog_app_key" {
-  default = "<YOUR_APPLICATION_KEY>"
-}
+provider "datadog" {}
 ```
 
 Then run `terraform init` from within this directory to pull the datadog terraform provider.
 
 Now you can use `terraformer` to start importing resources. For example, to import Dashboard `abc-def-ghi` you can run
 
-`terraformer import datadog --resources=dashboard --filter=dashboard=abc-def-ghi --api-key <YOUR_API_KEY> --app-key <YOUR_APP_KEY>`
+`terraformer import datadog --resources=dashboard --filter=dashboard=abc-def-ghi --api-key <YOUR_API_KEY> --app-key <YOUR_APP_KEY> --api-url <YOUR_DATADOG_SITE_URL>`
 
 This generates a folder `generated` that contains both a terraform state file, as well as HCL terraform config files representing the imported resource.
 
@@ -71,7 +60,7 @@ generated
 
 ## Other examples of running terraformer
 
-All example commands require the `--api-key` and `--app-key` flags.
+All example commands require the `--api-key`, `--app-key`, and `--api-url` flags.
 
 * Import all monitors: `terraformer import datadog --resources=monitor`
 * Import monitor with id 1234: `terraformer import datadog --resources=monitor --filter=monitor=1234`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add previously unmentioned `--api-url` flag, and remove the api/app keys from the `main.tf` file since they aren't needed to use terraformer to import.

### Motivation
<!-- What inspired you to submit this pull request?-->

Docs are out of date and can lead to errors when following it.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
