### PR TITLE
Add limitation on integrations to IP Allowlist docs

### DIFF
--- a/content/en/account_management/org_settings/ip_allowlist.md
+++ b/content/en/account_management/org_settings/ip_allowlist.md
@@ -29,6 +29,8 @@ The IP allowlist feature does not block access to the following:
 - The [validate API key][2] endpoint, which the Agent uses before submitting data
 - [Public dashboards][3]
 
+Third-party integrations and applications that need access to Datadog’s public web-APIs may be impacted by the IP allowlist. Applications submitting telemetry like metrics, traces, logs, etc. from Agents and integrations, however, are unaffected. Datadog recommends utilizing the [Audit Trail][4] to monitor for IP addresses from third-parties.
+
 ### Functionality
 
 Only users with the **Org Management** permission can configure the IP allowlist.
@@ -52,7 +54,7 @@ When you enable or modify the IP allowlist, the system enforces constraints to m
 
 **Note:** The IP allowlist page only appears in the UI if your Datadog organization has the feature turned on.
 
-To find the [IP allowlist UI][4]:
+To find the [IP allowlist UI][5]:
 
 1. Navigate to **Organization Settings** from your account menu.
 1. Under **Access**, select **IP Allowlist**.
@@ -88,14 +90,15 @@ To toggle the IP allowlist status, click the **Enable** or **Disable** button.
 
 ## Managing the IP allowlist programmatically
 
-To manage the IP allowlist through the API, see the [public API documentation][5].
+To manage the IP allowlist through the API, see the [public API documentation][6].
 
-See the [`ip_allowlist` resource][6] to manage the IP allowlist in Terraform.
+See the [`ip_allowlist` resource][7] to manage the IP allowlist in Terraform.
 
 
 [1]: /api/latest/
 [2]: /api/latest/authentication/#validate-api-key
 [3]: /dashboards/sharing/
-[4]: https://app.datadoghq.com/organization-settings/ip-allowlist
-[5]: /api/latest/ip-allowlist/
-[6]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/ip_allowlist
+[4]: /account_management/audit_trail/
+[5]: https://app.datadoghq.com/organization-settings/ip-allowlist
+[6]: /api/latest/ip-allowlist/
+[7]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/ip_allowlist


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a small section on a limitation found about the IP allowlist feature and its effect on integrations. 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
