### PR TITLE
semantic color build error

### DIFF
--- a/layouts/shortcodes/semantic-color.html
+++ b/layouts/shortcodes/semantic-color.html
@@ -1,0 +1,4 @@
+{{- $file := "layouts/shortcodes/semantic-color.md" -}}
+{{- if (fileExists $file) -}}
+  {{- $file | readFile | markdownify -}}
+{{- end -}}


### PR DESCRIPTION
### What does this PR do?

semantic-color.md is generated in the build but it also used to exist locally to avoid local build errors such as cannot find file.

Recent changes mean that this file no longer exists locally by default, in order to avoid the build errors we now instead use a shortcode that will include the file if it exists.

### Motivation

Local build errors due to recent reconfigurations

### Preview

Check this page is still working
https://docs-staging.datadoghq.com/david.jones/fix-semantic-error/dashboards/guide/compatible_semantic_tags/

Check local build doesn't throw any errors

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
