### PR TITLE
DOCS-5282 Fix API source search term for Amazon Security Hub

### DIFF
--- a/content/en/integrations/faq/list-of-api-source-attribute-value.md
+++ b/content/en/integrations/faq/list-of-api-source-attribute-value.md
@@ -99,7 +99,7 @@ Search for events in the event explorer using `sources:<SEARCH_TERM>`.
 | Amazon S3                     | amazon s3                     | s3                         |
 | Amazon S3 Storage Lens        | amazon s3 storage lens        | s3storagelens              |
 | Amazon Sagemaker              | amazon sagemaker              | sagemaker                  |
-| Amazon Security Hub           | amazon security hub           | aws_security_hub        |
+| Amazon Security Hub           | amazon security hub           | amazon_security_hub        |
 | Amazon Ses                    | amazon ses                    | ses                        |
 | Amazon Shield                 | amazon shield                 | shield                     |
 | Amazon Sns                    | amazon sns                    | sns                        |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Corrects the search term under API source attributes for Amazon Security Hub.

I actually changed this yesterday based on what I found in the code, which was different from the original request. The requestor got back to me today with proof that his original request is correct. Updating the line to the correct value.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
