### PR TITLE
DOCS-5109 - Revert removal of Amazon ECS Data Collection

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -537,6 +537,11 @@ main:
     parent: containers_amazon_ecs
     identifier: containers_amazon_ecs_tags
     weight: 503
+  - name: Data collected
+    url: containers/amazon_ecs/data_collected/
+    parent: containers_amazon_ecs
+    identifier: containers_amazon_ecs_data_collected
+    weight: 504
   - name: AWS Fargate
     url: integrations/ecs_fargate/
     parent: containers

--- a/content/en/containers/amazon_ecs/_index.md
+++ b/content/en/containers/amazon_ecs/_index.md
@@ -3,7 +3,6 @@ title: Amazon ECS
 kind: documentation
 aliases:
   - /agent/amazon_ecs/
-  - /containers/amazon_ecs/data_collected
 further_reading:
 - link: "/agent/amazon_ecs/logs/"
   tag: "Documentation"
@@ -11,6 +10,9 @@ further_reading:
 - link: "/agent/amazon_ecs/apm/"
   tag: "Documentation"
   text: "Collect your application traces"
+- link: "/agent/amazon_ecs/data_collected/#metrics"
+  tag: "Documentation"
+  text: "Collect ECS metrics"
 - link: "https://www.datadoghq.com/blog/amazon-ecs-anywhere-monitoring/"
   tag: "Blog"
   text: "Announcing support for Amazon ECS Anywhere"

--- a/content/en/containers/amazon_ecs/data_collected.md
+++ b/content/en/containers/amazon_ecs/data_collected.md
@@ -1,0 +1,43 @@
+---
+title: Amazon ECS Data Collection
+kind: documentation
+aliases:
+  - /agent/amazon_ecs/data_collected
+further_reading:
+- link: "/agent/amazon_ecs/logs/"
+  tag: "Documentation"
+  text: "Collect your application logs"
+- link: "/agent/amazon_ecs/apm/"
+  tag: "Documentation"
+  text: "Collect your application traces"
+- link: "/agent/amazon_ecs/data_collected/#metrics"
+  tag: "Documentation"
+  text: "Collect ECS metrics"
+---
+
+## Data collected
+
+### Metrics
+
+Amazon ECS on EC2 is a container management service for Docker containers running on EC2 instances. Metrics collected by the Agent for Amazon ECS:
+
+{{< get-metrics-from-git "amazon_ecs" >}}
+
+Metrics collected by the Agent when deployed in a Docker container also include the same metrics collected by the Docker integration. See the [Docker integration metrics][1] for a complete list of metrics.
+
+**Note**: Docker metrics are tagged accordingly with the following tags: `container_name`, `task_arn`, `task_family`, `task_name`, `task_version`. No further configuration is required.
+
+### Events
+
+To reduce noise, the Amazon ECS integration is automatically set up to include only events that contain the following words: `drain`, `error`, `fail`, `insufficient memory`, `pending`, `reboot`, `terminate`. See example events below:
+
+{{< img src="integrations/amazon_ecs/aws_ecs_events.png" alt="AWS ECS Events" >}}
+
+To remove this include list and receive all events from your Datadog Amazon ECS integration, reach out to [Datadog support][2].
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://docs.datadoghq.com/agent/docker/data_collected/#metrics
+[2]: https://docs.datadoghq.com/help/

--- a/content/en/containers/amazon_ecs/logs.md
+++ b/content/en/containers/amazon_ecs/logs.md
@@ -7,6 +7,9 @@ further_reading:
 - link: "/agent/amazon_ecs/apm/"
   tag: "Documentation"
   text: "Collect your application traces"
+- link: "/agent/amazon_ecs/data_collected/#metrics"
+  tag: "Documentation"
+  text: "Collect ECS metrics"
 ---
 
 ## Overview

--- a/content/en/getting_started/integrations/aws.md
+++ b/content/en/getting_started/integrations/aws.md
@@ -159,7 +159,7 @@ For containerized environments, you can use the Datadog Agent, whether you're ma
 
 #### ECS with EC2 launch type
 
-Use the [Amazon ECS documentation][25] to run the [Datadog Docker Agent][26] on the EC2 instances in your ECS cluster. Review the [Amazon ECS on EC2][27] to see the metrics and events reported to your Datadog account.
+Use the [Amazon ECS documentation][25] to run the [Datadog Docker Agent][26] on the EC2 instances in your ECS cluster. Review the [Amazon ECS Data Collection documentation][27] to see the metrics and events reported to your Datadog account.
 
 #### ECS with Fargate launch type
 
@@ -236,7 +236,7 @@ If you encounter any issues, be sure to check out the [Troubleshooting][57] sect
 [24]: https://aws.amazon.com/fargate/
 [25]: /agent/amazon_ecs/?tab=awscli
 [26]: /agent/docker/?tab=standard
-[27]: /integrations/amazon_ecs
+[27]: /agent/amazon_ecs/data_collected/
 [28]: /integrations/ecs_fargate/?tab=fluentbitandfirelens
 [29]: /agent/kubernetes/distributions/?tab=helm#EKS
 [30]: /agent/kubernetes/?tab=helm


### PR DESCRIPTION
Reverts DataDog/documentation#17214

Restores the ECS EC2 Crawler info.
Ready to merge.