### PR TITLE
update nodejs doc with dd-trace 4.0.0 changes

### DIFF
--- a/content/en/profiler/enabling/nodejs.md
+++ b/content/en/profiler/enabling/nodejs.md
@@ -22,7 +22,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 ## Requirements
 
-The Datadog Profiler requires at least Node.js 14, but Node.js 16 or higher is recommended. **If you use a version of Node.js earlier than 16, some applications see tail latency spikes every minute when starting the next profile.**
+The Datadog Profiler requires at least Node.js 16.
 
 Continuous Profiler is not supported on serverless platforms, such as AWS Lambda.
 

--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -54,7 +54,7 @@ The following operating systems are officially supported by `dd-trace`. Any oper
 
 | dd-trace Version    | Operating System      | Architectures         | Minimum Versions                         |
 | ------------------- | --------------------- | --------------------- | ---------------------------------------- |
-| 3.x                 | Linux (glibc)         | arm, arm64, x64       | CentOS 7, Debian 9, RHEL 7, Ubuntu 14.04 |
+| 4.x, 3.x            | Linux (glibc)         | arm, arm64, x64       | CentOS 7, Debian 9, RHEL 7, Ubuntu 14.04 |
 |                     | Linux (musl)          | arm, arm64, x64       | Alpine 3.13                              |
 |                     | macOS                 | arm64, x64            | Catalina (10.15)                         |
 |                     | Windows               | ia32, x64             | Windows 8.1, Windows Server 2012         |
@@ -82,7 +82,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 | [koa][13]               | `>=2`    | Fully supported |                                            |
 | [microgateway-core][14] | `>=2.1`  | Fully supported | Core library for Apigee Edge. Support for the [edgemicro][15] CLI requires static patching using [@datadog/cli][16]. |
 | [moleculer][17]         | `>=0.14` | Fully supported |                                            |
-| [next][18]              | `>=9.5`  | Fully supported | CLI usage requires `NODE_OPTIONS='-r dd-trace/init'`. |
+| [next][18]              | `>=10.2` | Fully supported | CLI usage requires `NODE_OPTIONS='-r dd-trace/init'`. |
 | [paperplane][19]        | `>=2.3`  | Fully supported | Not supported in [serverless-mode][20]     |
 | [restify][21]           | `>=3`    | Fully supported |                                            |
 

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -29,7 +29,7 @@ further_reading:
 ---
 ## Compatibility requirements
 
-The latest Node.js Tracer supports versions `>=14`. For a full list of Datadog's Node.js version and framework support (including legacy and maintenance versions), see the [Compatibility Requirements][1] page.
+The latest Node.js Tracer supports versions `>=16`. For a full list of Datadog's Node.js version and framework support (including legacy and maintenance versions), see the [Compatibility Requirements][1] page.
 
 ## Installation and getting started
 
@@ -109,17 +109,21 @@ Read [tracer settings][3] for a list of initialization options.
 
 After the Agent is installed, follow these steps to add the Datadog tracing library to your Node.js applications:
 
-1. Install the Datadog Tracing library using npm for Node.js 14+:
+1. Install the Datadog Tracing library using npm for Node.js 16+:
 
     ```sh
     npm install dd-trace --save
+    ```
+    If you need to trace end-of-life Node.js version 14, install version 3.x of `dd-trace` by running:
+    ```
+    npm install dd-trace@latest-node14
     ```
     If you need to trace end-of-life Node.js version 12, install version 2.x of `dd-trace` by running:
     ```
     npm install dd-trace@latest-node12
     ```
     For more information on our distribution tags and Node.js runtime version support, see the [Compatibility Requirements][1] page.
-    If you are upgrading from a previous major version of the library (0.x, 1.x, or 2.x) to another major version (2.x or 3.x), read the [Migration Guide][5] to assess any breaking changes.
+    If you are upgrading from a previous major version of the library (0.x, 1.x, 2.x or 3.x) to another major version (2.x, 3.x or 4.x), read the [Migration Guide][5] to assess any breaking changes.
 
 2. Import and initialize the tracer either in code or via command line arguments. The Node.js tracing library needs to be imported and initialized **before** any other module.
 

--- a/content/en/tracing/trace_collection/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/dd_libraries/nodejs.md
@@ -123,6 +123,7 @@ After the Agent is installed, follow these steps to add the Datadog tracing libr
     npm install dd-trace@latest-node12
     ```
     For more information on our distribution tags and Node.js runtime version support, see the [Compatibility Requirements][1] page.
+    
     If you are upgrading from a previous major version of the library (0.x, 1.x, 2.x or 3.x) to another major version (2.x, 3.x or 4.x), read the [Migration Guide][5] to assess any breaking changes.
 
 2. Import and initialize the tracer either in code or via command line arguments. The Node.js tracing library needs to be imported and initialized **before** any other module.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Update Node.js doc with dd-trace 4.0.0 changes:

- Dropped support for Node 14.
- Dropped support for Next <10.2.

### Motivation
<!-- What inspired you to submit this pull request?-->

We have just released dd-trace-js 4.0.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
