### PR TITLE
URL of jira doc has been changed.

### DIFF
--- a/content/en/developers/community/libraries.md
+++ b/content/en/developers/community/libraries.md
@@ -192,7 +192,7 @@ If you've written a Datadog library and would like to add it to this page, send 
 [36]: https://web.oz.com/
 [37]: https://github.com/apiaryio/heroku-datadog-drain-golang
 [38]: https://apiary.io
-[39]: https://github.com/evernote/jiradog
+[39]: https://bitbucket.org/atlassian/jiradog/src/master/
 [40]: https://blog.loadimpact.com/how-to-send-k6-metrics-to-datadog
 [41]: https://github.com/meetup/launch-dogly
 [42]: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-datadog.html


### PR DESCRIPTION

### What does this PR do?
URL of jira doc has been changed.

### Motivation
Because I found an error in the link.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
