### PR TITLE
Enable prometheus receiver

### DIFF
--- a/content/en/opentelemetry/otel_collector_datadog_exporter.md
+++ b/content/en/opentelemetry/otel_collector_datadog_exporter.md
@@ -93,7 +93,7 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [hostmetrics, otlp]
+      receivers: [hostmetrics, prometheus, otlp]
       processors: [batch]
       exporters: [datadog]
     traces:


### PR DESCRIPTION
### What does this PR do?
Prometheus receiver was not enabled via pipelines in the service section.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
