### PR TITLE
Fix alias for event explorer in the left nav update

### DIFF
--- a/content/en/account_management/rbac/_index.md
+++ b/content/en/account_management/rbac/_index.md
@@ -210,5 +210,5 @@ The following resources allow granular access control:
 [11]: /dashboards/#permissions
 [12]: /monitors/notify/#permissions
 [13]: /security_platform/detection_rules/#limit-edit-access
-[14]: /monitors/service_level_objectives/#permissions
+[14]: /service_management/service_level_objectives/#permissions
 [15]: /synthetics/browser_tests/#permissions

--- a/content/en/account_management/teams.md
+++ b/content/en/account_management/teams.md
@@ -119,7 +119,7 @@ To enforce a strict membership model, configure your default team settings so **
 [3]: /service_management/incident_management/incident_details#overview-section
 [4]: /monitors/configuration/?tab=thresholdalert#add-metadata
 [5]: /tracing/service_catalog/setup#add-service-definition-metadata
-[6]: /monitors/service_level_objectives/#slo-tags
+[6]: /service_management/service_level_objectives/#slo-tags
 [7]: https://app.datadoghq.com/dashboard/lists
 [8]: https://app.datadoghq.com/services
 [9]: https://app.datadoghq.com/incidents

--- a/content/en/dashboards/guide/slo_data_source.md
+++ b/content/en/dashboards/guide/slo_data_source.md
@@ -35,5 +35,5 @@ The *Display* parameter allows you to break out the query by the groups that are
 
 
 [1]: /dashboards/scheduled_reports/
-[2]: /monitors/service_level_objectives/#slo-status-corrections
-[3]: /monitors/service_level_objectives/#configuration
+[2]: /service_management/service_level_objectives/#slo-status-corrections
+[3]: /service_management/service_level_objectives/#configuration

--- a/content/en/dashboards/widgets/event_stream.md
+++ b/content/en/dashboards/widgets/event_stream.md
@@ -44,7 +44,7 @@ The dedicated [widget JSON schema definition][4] for the event stream widget fol
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /events/
-[2]: /events/explorer/#search-syntax
+[1]: /service_management/events/
+[2]: /service_management/events/explorer/#search-syntax
 [3]: /api/latest/dashboards/
 [4]: /dashboards/graphing_json/widget_json/

--- a/content/en/dashboards/widgets/slo.md
+++ b/content/en/dashboards/widgets/slo.md
@@ -71,7 +71,7 @@ The dedicated [widget JSON schema definition][4] for the SLO Summary widget is:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /monitors/service_level_objectives/
+[1]: /service_management/service_level_objectives/
 [2]: /dashboards/template_variables/
 [3]: /api/latest/dashboards/
 [4]: /dashboards/graphing_json/widget_json/

--- a/content/en/dashboards/widgets/slo_list.md
+++ b/content/en/dashboards/widgets/slo_list.md
@@ -41,6 +41,6 @@ The dedicated [widget JSON schema definition][3] for the SLO List widget is:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /monitors/service_level_objectives/
+[1]: /service_management/service_level_objectives/
 [2]: /api/v1/dashboards/
 [3]: /dashboards/graphing_json/widget_json/

--- a/content/en/developers/_index.md
+++ b/content/en/developers/_index.md
@@ -79,7 +79,7 @@ A [custom check][11], also know as a custom Agent check, lets you send internal 
 
 {{< whatsnext desc="Learn about the types of data you can submit to Datadog and how to submit them:" >}}
     {{< nextlink href="/metrics" >}}<u>Custom Metrics</u>: A deep-dive into custom metrics at Datadog. This section explains metrics types, what they represent, how to submit them, and how they are used throughout Datadog.{{< /nextlink >}}
-    {{< nextlink href="events/guides/" >}}<u>Events</u>: Explore how to submit events to Datadog with custom Agent checks, DogStatsD, or the Datadog API.{{< /nextlink >}}
+    {{< nextlink href="service_management/events/guides/" >}}<u>Events</u>: Explore how to submit events to Datadog with custom Agent checks, DogStatsD, or the Datadog API.{{< /nextlink >}}
     {{< nextlink href="/developers/service_checks" >}}<u>Service Checks</u>: Explore how to submit the up or down status of a specific service to Datadog.{{< /nextlink >}}
 {{< /whatsnext >}}
 

--- a/content/en/getting_started/application/_index.md
+++ b/content/en/getting_started/application/_index.md
@@ -155,8 +155,8 @@ The [Datadog Mobile App][23], available on the [Apple App Store][24] and [Google
 [7]: /infrastructure/
 [8]: /getting_started/tagging/
 [9]: /infrastructure/hostmap/
-[10]: /events/
-[11]: /events/explorer/#event-analytics
+[10]: /service_management/events/
+[11]: /service_management/events/explorer/#event-analytics
 [12]: /dashboards/
 [13]: /dashboards/#screenboards
 [14]: /dashboards/functions/arithmetic/

--- a/content/en/getting_started/incident_management/_index.md
+++ b/content/en/getting_started/incident_management/_index.md
@@ -17,7 +17,7 @@ further_reading:
     - link: 'https://www.datadoghq.com/blog/incident-response-with-datadog/'
       tag: 'Blog'
       text: 'Incident Management with Datadog'
-    - link: '/service_management/incident_management/notification_rules'
+    - link: '/service_management/incident_management/incident_settings'
       tag: 'Documentation'
       text: 'Notification Rules'
     - link: '/integrations/slack/?tab=slackapplicationus#using-datadog-incidents'
@@ -174,7 +174,7 @@ If there are follow-up tasks that you and your team need to complete to ensure t
 
 Datadog Incident Management can be customized with different severity and status levels, based on your organization's needs, and also include additional information such as APM services and teams related to the incident. For more information, see this [section][9] of the Incident Management page.
 
-You can also set up notification rules to automatically notify specific people or services based on an incident's severity level. For more information, see the [Notification Rules][10] documentation.
+You can also set up notification rules to automatically notify specific people or services based on an incident's severity level. For more information, see the [Incident Settings][10] documentation.
 
 To customize Incident Management, go to the [incident settings page][11]. From the Datadog menu on the left-hand side, go to **Monitors** > **Incidents** (if you get an Incident Management welcome screen, click **Get Started**). Then on the top, click **Settings**.
 
@@ -199,7 +199,7 @@ You can also declare and edit incidents and quickly communicate to your teams th
 [7]: https://app.datadoghq.com/notebook/list
 [8]: https://app.datadoghq.com/incidents/settings#Messages
 [9]: /service_management/incident_management/#status-levels
-[10]: /service_management/incident_management/notification_rules
+[10]: /service_management/incident_management/incident_settings
 [11]: https://app.datadoghq.com/incidents/settings
 [12]: /service_management/mobile/
 [13]: https://apps.apple.com/app/datadog/id1391380318

--- a/content/en/getting_started/tagging/using_tags.md
+++ b/content/en/getting_started/tagging/using_tags.md
@@ -402,7 +402,7 @@ See this list for links to respective sections:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /getting_started/tagging/assigning_tags/
-[2]: /events/explorer
+[2]: /service_management/events/explorer
 [3]: /integrations/
 [4]: /infrastructure/hostmap/
 [5]: /infrastructure/

--- a/content/en/logs/guide/best-practices-for-log-management.md
+++ b/content/en/logs/guide/best-practices-for-log-management.md
@@ -203,7 +203,7 @@ If you want to see user activities, such as who changed the retention of an inde
 [14]: https://app.datadoghq.com/logs
 [15]: /logs/explorer/search/
 [16]: /logs/indexes/#set-daily-quota
-[17]: /events/explorer/#facets
+[17]: /service_management/events/explorer/#facets
 [18]: https://app.datadoghq.com/dash/integration/logs_estimated_usage
 [19]: https://app.datadoghq.com/dashboard/lists?q=Log+Management+-+Estimated+Usage
 [20]: /logs/log_configuration/indexes/#exclusion-filters

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -452,5 +452,5 @@ Within the zipped JSON file, each event's content is formatted as follows:
 [10]: /account_management/rbac/permissions#logs_read_index_data
 [11]: /account_management/rbac/permissions#logs_read_data
 [12]: /logs/explorer/live_tail/
-[13]: /events/explorer/
+[13]: /service_management/events/explorer/
 [14]: https://app.datadoghq.com/logs/pipelines/log-forwarding

--- a/content/en/monitors/_index.md
+++ b/content/en/monitors/_index.md
@@ -77,7 +77,7 @@ You can download a JSON file containing the definition of a monitor from the mon
 ## Other sections
 
 {{< whatsnext desc=" ">}}
-    {{< nextlink href="/monitors/service_level_objectives" >}}<u>Service Level Objectives</u>: Create, edit, or view your service level objectives using metrics or existing Datadog monitors.{{< /nextlink >}}
+    {{< nextlink href="/service_management/service_level_objectives" >}}<u>Service Level Objectives</u>: Create, edit, or view your service level objectives using metrics or existing Datadog monitors.{{< /nextlink >}}
     {{< nextlink href="/monitors/incident_management" >}}<u>Incident Management</u>: Declare and manage incidents.{{< /nextlink >}}
     {{< nextlink href="/monitors/guide" >}}<u>Guides</u>: Additional helpful articles about monitors and alerting.{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/monitors/guide/integrate-monitors-with-statuspage.md
+++ b/content/en/monitors/guide/integrate-monitors-with-statuspage.md
@@ -60,7 +60,7 @@ To create a [metric monitor][8] that triggers on Statuspage alerts:
 
 [1]: https://www.atlassian.com/software/statuspage
 [2]: /integrations/statuspage
-[3]: /events/explorer/
+[3]: /service_management/events/explorer/
 [4]: https://app.datadoghq.com/integrations
 [5]: https://app.datadoghq.com/event/explorer
 [6]: /dashboards/guide/custom_time_frames/

--- a/content/en/monitors/guide/slo-checklist.md
+++ b/content/en/monitors/guide/slo-checklist.md
@@ -104,4 +104,4 @@ _Example: 99% of requests should complete in less than 250 ms over a 30-day wind
 [4]: /integrations
 [5]: /tracing/trace_pipeline/generate_metrics/
 [6]: /logs/logs_to_metrics/
-[7]: /monitors/service_level_objectives/#searching-and-viewing-slos
+[7]: /service_management/service_level_objectives/#searching-and-viewing-slos

--- a/content/en/monitors/notify/downtimes.md
+++ b/content/en/monitors/notify/downtimes.md
@@ -213,7 +213,7 @@ Datadog can proactively mute monitors related to the manual shutdown of certain 
 [2]: http://daringfireball.net/projects/markdown/syntax
 [3]: /integrations/#cat-notification
 [4]: /monitors/manage/status/
-[5]: /events/explorer
+[5]: /service_management/events/explorer
 [6]: /api/v1/downtimes/#cancel-a-downtime
 [7]: /account_management/#preferences
 [8]: /integrations/amazon_ec2/#ec2-automuting

--- a/content/en/monitors/types/event.md
+++ b/content/en/monitors/types/event.md
@@ -82,7 +82,7 @@ The template variable is `{{event.tags.env}}`. The result of using this template
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/monitors#create/event
-[2]: /events/explorer/#search-syntax
+[2]: /service_management/events/explorer/#search-syntax
 [3]: /help/
 [4]: /monitors/configuration/#advanced-alert-conditions
 [5]: /monitors/notify/

--- a/content/en/monitors/types/slo.md
+++ b/content/en/monitors/types/slo.md
@@ -38,7 +38,7 @@ In addition to the [standard template variables][6] available across all monitor
 | `{{short_window_burn_rate}}` | The burn rate value observed by the short window (burn rate alerts only). |
 | `{{long_window_burn_rate}}` | The burn rate value observed by the long window (burn rate alerts only). |
 
-[1]: /monitors/service_level_objectives/
+[1]: /service_management/service_level_objectives/
 [2]: https://app.datadoghq.com/monitors/create/slo
 [3]: /service_management/service_level_objectives/error_budget/
 [4]: /service_management/service_level_objectives/burn_rate/

--- a/content/en/service_management/events/explorer/_index.md
+++ b/content/en/service_management/events/explorer/_index.md
@@ -2,8 +2,8 @@
 title: Events Explorer
 kind: documentation
 aliases:
-- /service_management/events/stream/
-- /service_management/events/explorer/
+- /events/stream/
+- /events/explorer/
 further_reading:
 - link: "/api/v1/events/"
   tag: "Documentation"

--- a/content/en/service_management/service_level_objectives/_index.md
+++ b/content/en/service_management/service_level_objectives/_index.md
@@ -282,7 +282,7 @@ To view, edit, and delete existing status corrections, click on the **Correction
 [12]: /mobile
 [13]: https://apps.apple.com/app/datadog/id1391380318
 [14]: https://play.google.com/store/apps/details?id=com.datadog.app
-[15]: /monitors/service_level_objectives/#saved-views
+[15]: /service_management/service_level_objectives/#saved-views
 [16]: /account_management/teams/#associate-resources-with-team-handles
 [17]: /api/latest/events/
 [18]: /dashboards/guide/slo_data_source/

--- a/content/en/service_management/service_level_objectives/error_budget.md
+++ b/content/en/service_management/service_level_objectives/error_budget.md
@@ -5,7 +5,7 @@ description: "Use Monitors to alert off of the error budget consumption of an SL
 aliases:
 - /monitors/service_level_objectives/error_budget/
 further_reading:
-- link: "/monitors/service_level_objectives/"
+- link: "/service_management/service_level_objectives/"
   tag: "Documentation"
   text: "Overview of Service Level Objectives"
 ---
@@ -70,7 +70,7 @@ resource "datadog_monitor" "metric-based-slo" {
 
 [1]: /service_management/service_level_objectives/metric/
 [2]: /service_management/service_level_objectives/monitor/
-[3]: /monitors/service_level_objectives/#key-terminology
+[3]: /service_management/service_level_objectives/#key-terminology
 [4]: https://app.datadoghq.com/slo
 [5]: /monitors/notify/
 [6]: /api/v1/monitors/#create-a-monitor

--- a/content/en/service_management/service_level_objectives/metric.md
+++ b/content/en/service_management/service_level_objectives/metric.md
@@ -9,7 +9,7 @@ further_reading:
 - link: "/metrics/"
   tag: "Documentation"
   text: "More information about metrics"
-- link: "/monitors/service_level_objectives/"
+- link: "/service_management/service_level_objectives/"
   tag: "Documentation"
   text: "SLO overview, configuration, and calculation"
 ---
@@ -67,8 +67,8 @@ While the SLO remains above the target percentage, the SLO's status will be disp
 [1]: https://docs.datadoghq.com/tracing/generate_metrics/
 [2]: https://docs.datadoghq.com/real_user_monitoring/generate_metrics
 [3]: https://docs.datadoghq.com/logs/log_configuration/logs_to_metrics/#overview
-[4]: /monitors/service_level_objectives
+[4]: /service_management/service_level_objectives
 [5]: https://app.datadoghq.com/slo
 [6]: https://app.datadoghq.com/slo/new/metric
 [7]: /metrics/distributions/#threshold-queries
-[8]: /monitors/service_level_objectives/monitor/
+[8]: /service_management/service_level_objectives/monitor/

--- a/content/en/service_management/service_level_objectives/monitor.md
+++ b/content/en/service_management/service_level_objectives/monitor.md
@@ -137,4 +137,4 @@ Confirm you are using the preferred SLI type for your use case. Datadog supports
 [2]: https://app.datadoghq.com/slo
 [3]: /service_management/service_level_objectives/metric/
 [4]: /synthetics/api_tests/?tab=httptest#alert-conditions
-[5]: /monitors/service_level_objectives/#slo-status-corrections
+[5]: /service_management/service_level_objectives/#slo-status-corrections

--- a/content/en/synthetics/search/_index.md
+++ b/content/en/synthetics/search/_index.md
@@ -15,7 +15,7 @@ further_reading:
 - link: "/continuous_testing/explorer"
   tag: "Documentation"
   text: "Learn about the Synthetic Monitoring & Continuous Testing Explorer"
-- link: "/events/explorer"
+- link: "/service_management/events/explorer"
   tag: "Documentation"
   text: "Learn about the Events Explorer"
 ---

--- a/content/en/tracing/service_catalog/scorecards.md
+++ b/content/en/tracing/service_catalog/scorecards.md
@@ -85,7 +85,7 @@ Click **View Details** from the scorecard, or open the service details side pane
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/services
-[2]: /monitors/service_level_objectives/
+[2]: /service_management/service_level_objectives/
 [3]: https://app.datadoghq.com/monitors/recommended
 [4]: /tracing/services/deployment_tracking/
 [5]: /tracing/other_telemetry/connect_logs_and_traces/

--- a/content/en/tracing/services/service_page.md
+++ b/content/en/tracing/services/service_page.md
@@ -207,7 +207,7 @@ View common patterns in your service's logs, and use facets like status in the s
 [2]: /tracing/services/resource_page/
 [3]: /monitors/types/apm/
 [4]: /tracing/error_tracking/
-[5]: /monitors/service_level_objectives/
+[5]: /service_management/service_level_objectives/
 [6]: /service_management/incident_management/
 [7]: /watchdog/
 [8]: /tracing/metrics/metrics_namespace/

--- a/content/en/universal_service_monitoring/guide/using_usm_metrics.md
+++ b/content/en/universal_service_monitoring/guide/using_usm_metrics.md
@@ -119,7 +119,7 @@ For more information, see the [Dashboards documentation][7].
 
 [1]: /universal_service_monitoring
 [2]: /tracing/service_catalog
-[3]: /monitors/service_level_objectives
+[3]: /service_management/service_level_objectives
 [4]: /tracing/metrics/metrics_namespace
 [5]: https://app.datadoghq.com/services
 [6]: /monitors/create/types/apm

--- a/content/en/watchdog/faulty_deployment_detection.md
+++ b/content/en/watchdog/faulty_deployment_detection.md
@@ -41,5 +41,5 @@ Watchdog attempts to determine if the new deployment is a plausible cause of the
 - This error pattern is common during deployments of the service, even when the new code version is not faulty.
 
 [1]: https://app.datadoghq.com/apm/services
-[2]: /events/explorer
+[2]: /service_management/events/explorer
 [3]: https://app.datadoghq.com/monitors/create


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix the alias for event explorer. Mistakenly changed the URL in the frontmatter which would cause a circular reference.

### Motivation
<!-- What inspired you to submit this pull request?-->
Build pointed out the error.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Original PR: https://github.com/DataDog/documentation/pull/17847

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
