### PR TITLE
fix inconsistent Python tracer version in APM-DBM docs

### DIFF
--- a/content/en/database_monitoring/guide/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/guide/connect_dbm_and_apm.md
@@ -222,9 +222,9 @@ client.query("SELECT 1;")
 
 {{% tab "Python" %}}
 
-Update your app dependencies to include [dd-trace-py>=1.7.0][1]:
+Update your app dependencies to include [dd-trace-py>=1.9.0][1]:
 ```
-pip install "ddtrace>=1.7.0"
+pip install "ddtrace>=1.9.0"
 ```
 
 Install [psycopg2][2] (**Note**: Connecting DBM and APM is not supported for MySQL clients):


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Table and tab were out of sync with regards to required Python tracer version. 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
