### PR TITLE
[Tracing][Guides] Add a powershell command equivalent to the curl one

### DIFF
--- a/content/en/tracing/guide/send_traces_to_agent_by_api.md
+++ b/content/en/tracing/guide/send_traces_to_agent_by_api.md
@@ -95,6 +95,10 @@ and each span is a dictionary with a `trace_id`, `span_id`, `resource` and so on
 
 ### Example
 
+{{< tabs >}}
+
+{{% tab "Shell" %}}
+
 {{< code-block lang="curl" >}}
 # Curl command
 curl -X PUT "http://localhost:8126/v0.3/traces" \
@@ -115,6 +119,38 @@ curl -X PUT "http://localhost:8126/v0.3/traces" \
 ]
 EOF
 {{< /code-block >}}
+
+{{% /tab %}}
+
+{{% tab "Powershell" %}}
+{{< code-block lang="curl" >}}
+
+# Invoke-RestMethod command
+
+$uri = "http://localhost:8126/v0.3/traces"
+$headers = @{
+    "Content-Type" = "application/json"
+}
+$body = @"
+[
+  [
+    {
+      "duration": 12345,
+      "name": "span_name",
+      "resource": "/home",
+      "service": "service_name",
+      "span_id": 987654321,
+      "start": 0,
+      "trace_id": 123456789
+    }
+  ]
+]
+"@
+
+Invoke-RestMethod -Uri $uri -Method Put -Body $body -Headers $headers
+{{< /code-block >}}
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a powershell command equivalent to the curl one

### Motivation
To make it easier for windows users

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
