### PR TITLE
Use the correct log group name for api-gateway in french page

### DIFF
--- a/content/fr/integrations/amazon_api_gateway.md
+++ b/content/fr/integrations/amazon_api_gateway.md
@@ -52,7 +52,7 @@ Pour activer la journalisation API Gateway :
 2. Sélectionnez l'API souhaitée et accédez à la section Stages.
 3. Dans l'onglet **Logs**, activez **Enable CloudWatch Logs** et **Enable Access Logging**.
 4. Sélectionnez le niveau `INFO` afin de récupérer l'ensemble des requêtes.
-5. Assurez-vous d'inclure `apigateway` dans le nom de votre **groupe Cloudwatch**.
+5. Assurez-vous d'inclure `api-gateway` au début du nom de votre **groupe Cloudwatch**.
 6. Sélectionnez le format JSON (les formats CLF et CSV sont également pris en charge), et ajoutez ce qui suit dans le champ **Log format** :
 
     ```text


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR update the name to use for the log group to be identify as an API gateway. The syntax used for the french page is wrong but the english one is good. `apigateway` is used instead of `api-gateway`. I also specify that this specific string has to be at the beginning of the group name "au début".

### Motivation
One of my customer struggle to configure to identify the source as apigeatway instead of cloudwatch and we realize that it is wrong on the french page. 

### Additional Notes 
Several values are correct but to be more aligned, I propose only the name included in the english version. Source code of this feature is [here](https://github.com/DataDog/datadog-serverless-functions/blob/9766769b8677db0bfb6fc7eaba8ecef6d909b53e/aws/logs_monitoring/parsing.py#L283)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
