### PR TITLE
DOCS-5458: Add site address shortcode to DBM Troubleshooting

### DIFF
--- a/content/en/database_monitoring/troubleshooting.md
+++ b/content/en/database_monitoring/troubleshooting.md
@@ -59,8 +59,7 @@ curl -vvv -X POST "https://dbquery-intake.datadoghq.com/api/v2/databasequery" \
 
 The responses should contain `{"status":"error","code":403,"errors":["Forbidden"],...}` if requests were successfully sent and a response was received.
 
-Some common causes of connection failure include [proxy setups][7] and firewalls, which outbound traffic to Datadog's endpoints. If you have a proxy or firewall, make sure the IPs addresses for the DBM endpoints are allowed. Refer to the APM block in Datadog's [IP addresses][6].
-
+Some common causes of connection failure include [proxy setups][7] and firewalls, which outbound traffic to Datadog's endpoints. If you have a proxy or firewall, make sure the IP addresses for the DBM endpoints are allowed. These addresses can be found in the APM block at `https://ip-ranges.`{{< region-param key="dd_site" code="true" >}}.
 
 ## Need more help?
 
@@ -72,5 +71,4 @@ If you are still experiencing problems, contact [Datadog Support][5] for help.
 [3]: /database_monitoring/setup_postgres/troubleshooting/
 [4]: /database_monitoring/setup_sql_server/troubleshooting/
 [5]: /help/
-[6]: https://ip-ranges.datadoghq.com
 [7]: /agent/proxy/?tab=linux


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds the site address shortcode to to the DBM Troubleshooting page. Ready to merge.

### Motivation
DOCS-5458

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
