### PR TITLE
Move synthetic testing to github

### DIFF
--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -27,19 +27,19 @@ jobs:
       - name: Check preview status
         id: check-status
         run: |
-          CHECK_SUITE_URL="https://api.github.com/repos/DataDig/documentation/commits/${{ github.sha }}/check-suites"
+          URL="https://docs-staging.datadoghq.com/${{steps.extract_branch.outputs.branch}}"
           for i in {1..10}
           do
-            status="$(curl -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' $CHECK_SUITE_URL | jq -r '.check_suites // [] | .[] | .check_runs // [] | .[] | select(.app.slug=="dd-gitlab" and .name=="build_preview") | .status')"
-            if [[ "$status" == "completed" ]]; then
-              echo "Preview build complete, moving on..."
+            status=$(curl -o /dev/null -s -w "%{http_code}\n" $URL)
+            if [[ "$status" == "200" ]]; then
+              echo "Preview site has been deployed"
               break
             else
-              echo "Waiting for check to complete..."
+              echo "Waiting for preview site to return 200..."
               sleep 60
             fi
-            if [[ $i -eq 10 && "$status" != "completed" ]]; then
-              echo "There was an issue with the preview build"
+            if [[ $i -eq 10 && "$status" != "200" ]]; then
+              echo "Preview site not responding...."
               exit 1
             fi
           done

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -24,18 +24,19 @@ jobs:
         id: check-status
         run: |
           URL="https://docs-staging.datadoghq.com/${{steps.extract_branch.outputs.branch}}"
+          SUCCESS_CODES=("200" "302" "304")
           for i in {1..10}
           do
             status=$(curl -o /dev/null -s -w "%{http_code}\n" $URL)
-            if [[ "$status" == "200" | "$status" == "302" | "$status" == "304" ]]; then
+            if [[ " ${SUCCESS_CODES[@]} " =~ " ${status} " ]]; then
               echo "Preview site has been deployed"
               break
             else
-              echo "Waiting for preview site to return 200 | 302 | 304..."
+              echo "Waiting for preview site to return 200 || 302 || 304..."
               echo "Currently returning ${status}"
               sleep 60
             fi
-            if [[ $i -eq 10 && "$status" != "200" | "$status" != "302" | "$status" != "304" ]]; then
+            if [[ $i -eq 10 && ! (" ${SUCCESS_CODES[@]} " =~ " ${status} ") ]]; then
               echo "Preview site returned ${status} for 10 minutes, there may be an issue with the preview site build"
               exit 1
             fi

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -24,14 +24,25 @@ jobs:
         shell: bash
         run: echo ${{steps.extract_branch.outputs.branch}}
 
-      - name: Wait for previews
-        uses: lewagon/wait-on-check-action@v1.3.1
+      - name: Check preview status
         id: check-status
-        with:
-          wait-interval: 60
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          check-name: 'dd-gitlab/build_preview'
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          CHECK_SUITE_URL="https://api.github.com/repos/DataDig/documentation/commits/ref/check-suites"
+          for i in {1..10}
+          do
+            status="$(curl -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' $CHECK_SUITE_URL | jq -r '.check_suites[] | .check_runs[] | select(.app.slug=="dd-gitlab" and .name=="build_preview") | .status')"
+            if [[ "$status" == "completed" ]]; then
+              echo "Preview build complete, moving on..."
+              break
+            else
+              echo "Waiting for check to complete..."
+              sleep 60
+            fi
+            if [[ $i -eq 10 && "$status" != "completed" ]]; then
+              echo "There was an issue with the preview build"
+              exit 1
+            fi
+          done
 
       - name: Run Datadog Synthetic tests
         uses: DataDog/synthetics-ci-github-action@v0.11.0

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -24,13 +24,13 @@ jobs:
         shell: bash
         run: echo ${{steps.extract_branch.outputs.branch}}
 
-      - name: Wait for preview status
-        uses: fountainhead/action-wait-for-check@v1.1.0
+      - name: Wait for tests to succeed
+        uses: lewagon/wait-on-check-action@v1.3.1
         id: check-status
         with:
-          intervalSeconds: 60
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: dd-gitlab/build_preview 
+          wait-interval: 60
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          check-name: dd-gitlab/build_preview 
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Run Datadog Synthetic tests

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -1,0 +1,34 @@
+name: Preview Synthetics
+on: [pull_request]
+
+# Stop the current running job if a new push is made to the PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  synthetic_testing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=$(echo ${{ github.event.pull_request.head.ref }})" >>$GITHUB_OUTPUT
+        id: extract_branch
+
+      - name: Echo brnach name
+        shell: bash
+        run: echo ${{steps.extract_branch.outputs.branch}}
+
+      - name: Run Datadog Synthetic tests
+        uses: DataDog/synthetics-ci-github-action@v0.11.0
+        env:
+          CI_COMMIT_REF_NAME: ${{steps.extract_branch.outputs.branch}}
+        with:
+          api_key: ${{secrets.DD_API_KEY}}
+          app_key: ${{secrets.DD_APP_KEY}}
+          config_path: './datadog-ci.preview.json'

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -20,10 +20,6 @@ jobs:
         run: echo "branch=$(echo ${{ github.event.pull_request.head.ref }})" >>$GITHUB_OUTPUT
         id: extract_branch
 
-      - name: Echo brnach name
-        shell: bash
-        run: echo ${{steps.extract_branch.outputs.branch}}
-
       - name: Check preview status
         id: check-status
         run: |
@@ -31,15 +27,16 @@ jobs:
           for i in {1..10}
           do
             status=$(curl -o /dev/null -s -w "%{http_code}\n" $URL)
-            if [[ "$status" == "200" ]]; then
+            if [[ "$status" == "200" | "$status" == "302" | "$status" == "304" ]]; then
               echo "Preview site has been deployed"
               break
             else
-              echo "Waiting for preview site to return 200..."
+              echo "Waiting for preview site to return 200 | 302 | 304..."
+              echo "Currently returning ${status}"
               sleep 60
             fi
-            if [[ $i -eq 10 && "$status" != "200" ]]; then
-              echo "Preview site not responding...."
+            if [[ $i -eq 10 && "$status" != "200" | "$status" != "302" | "$status" != "304" ]]; then
+              echo "Preview site returned ${status} for 10 minutes, there may be an issue with the preview site build"
               exit 1
             fi
           done

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check preview status
         id: check-status
         run: |
-          CHECK_SUITE_URL="https://api.github.com/repos/DataDig/documentation/commits/ref/check-suites"
+          CHECK_SUITE_URL="https://api.github.com/repos/DataDig/documentation/commits/${{ github.sha }}/check-suites"
           for i in {1..10}
           do
             status="$(curl -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' $CHECK_SUITE_URL | jq -r '.check_suites[] | .check_runs[] | select(.app.slug=="dd-gitlab" and .name=="build_preview") | .status')"

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -24,10 +24,11 @@ jobs:
         shell: bash
         run: echo ${{steps.extract_branch.outputs.branch}}
 
-      - name: Wait for build to succeed
+      - name: Wait for preview status
         uses: fountainhead/action-wait-for-check@v1.1.0
         id: check-status
         with:
+          intervalSeconds: 60
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: dd-gitlab/build_preview 
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -43,7 +44,7 @@ jobs:
           config_path: './datadog-ci.preview.json'
 
       - name: Preview did not build
-        if: steps.check-status.outputs.conclusion == 'success'
+        if: steps.check-status.outputs.conclusion == 'failure' || steps.check-status.outputs.conclusion == 'timed_out'
         shell: bash
         run: |
           echo "Preview failed to build, synthetics not run"

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -24,13 +24,13 @@ jobs:
         shell: bash
         run: echo ${{steps.extract_branch.outputs.branch}}
 
-      - name: Wait for tests to succeed
+      - name: Wait for previews
         uses: lewagon/wait-on-check-action@v1.3.1
         id: check-status
         with:
           wait-interval: 60
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          check-name: dd-gitlab/build_preview 
+          check-name: 'dd-gitlab/build_preview'
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Run Datadog Synthetic tests

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -34,7 +34,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Run Datadog Synthetic tests
-        if: steps.check-status.outputs.conclusion == 'success'
         uses: DataDog/synthetics-ci-github-action@v0.11.0
         env:
           CI_COMMIT_REF_NAME: ${{steps.extract_branch.outputs.branch}}
@@ -42,10 +41,3 @@ jobs:
           api_key: ${{secrets.DD_API_KEY}}
           app_key: ${{secrets.DD_APP_KEY}}
           config_path: './datadog-ci.preview.json'
-
-      - name: Preview did not build
-        if: steps.check-status.outputs.conclusion == 'failure' || steps.check-status.outputs.conclusion == 'timed_out'
-        shell: bash
-        run: |
-          echo "Preview failed to build, synthetics not run"
-          exit 1

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -30,7 +30,7 @@ jobs:
           CHECK_SUITE_URL="https://api.github.com/repos/DataDig/documentation/commits/${{ github.sha }}/check-suites"
           for i in {1..10}
           do
-            status="$(curl -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' $CHECK_SUITE_URL | jq -r '.check_suites[] | .check_runs[] | select(.app.slug=="dd-gitlab" and .name=="build_preview") | .status')"
+            status="$(curl -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' $CHECK_SUITE_URL | jq -r '.check_suites // [] | .[] | .check_runs // [] | .[] | select(.app.slug=="dd-gitlab" and .name=="build_preview") | .status')"
             if [[ "$status" == "completed" ]]; then
               echo "Preview build complete, moving on..."
               break

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -24,7 +24,16 @@ jobs:
         shell: bash
         run: echo ${{steps.extract_branch.outputs.branch}}
 
+      - name: Wait for build to succeed
+        uses: fountainhead/action-wait-for-check@v1.1.0
+        id: check-status
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: dd-gitlab/build_preview 
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
       - name: Run Datadog Synthetic tests
+        if: steps.check-status.outputs.conclusion == 'success'
         uses: DataDog/synthetics-ci-github-action@v0.11.0
         env:
           CI_COMMIT_REF_NAME: ${{steps.extract_branch.outputs.branch}}
@@ -32,3 +41,10 @@ jobs:
           api_key: ${{secrets.DD_API_KEY}}
           app_key: ${{secrets.DD_APP_KEY}}
           config_path: './datadog-ci.preview.json'
+
+      - name: Preview did not build
+        if: steps.check-status.outputs.conclusion == 'success'
+        shell: bash
+        run: |
+          echo "Preview failed to build, synthetics not run"
+          exit 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -456,18 +456,3 @@ set_redirect_metadata_live:
   script:
     - in-isolation run_update_redirect_metadata
   interruptible: true
-
-synthetic_tests_preview:
-  <<: *base_template
-  <<: *preview_rules
-  stage: post-deploy
-  environment: "preview"
-  variables:
-    URL: ${PREVIEW_DOMAIN}
-  allow_failure: false
-  cache: {}
-  dependencies:
-    - build_preview
-  script:
-    - run_preview_synthetic_tests "./datadog-ci.preview.json"
-  interruptible: true


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Moves synthetics to a github action that only runs on PRs to lessen the amount of runs we perform

### Motivation
<!-- What inspired you to submit this pull request?-->
We are currently running synthetics on every branch push, which is adding up quickly
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Successful action run https://github.com/DataDog/documentation/actions/runs/5006537461/jobs/8971948050

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
