### PR TITLE
fix-toc-site-region-updates-agent pgs

### DIFF
--- a/assets/scripts/region-redirects.js
+++ b/assets/scripts/region-redirects.js
@@ -88,7 +88,7 @@ function regionOnChangeHandler(region) {
  */
 function hideNonRegionSpecificTOC(regionSelected=false) {
     const allTOCItems = document.querySelectorAll('#TableOfContents li')
-    const hiddenHeaders = document.querySelectorAll('.site-region-container.d-none > h3')
+    const hiddenHeaders = document.querySelectorAll('.site-region-container.d-none > h3, .site-region-container.d-none > h2')
     const hiddenHeaderIDs = [...hiddenHeaders].map(el => `#${el.id}`)
 
     allTOCItems.forEach(item => {

--- a/content/en/agent/guide/how_remote_config_works.md
+++ b/content/en/agent/guide/how_remote_config_works.md
@@ -18,12 +18,11 @@ further_reading:
   text: "Using Datadog Audit Trail"
 ---
 
-{{< site-region region="gov" >}}
+{{% site-region region="gov" %}}
 
 <div class="alert alert-warning">Remote configuration is not available on the US1-FED Datadog site.</div>
 
-
-{{< /site-region >}}
+{{% /site-region %}}
 
 ## Overview
 Remote Configuration is a Datadog capability that allows you to remotely configure the behavior of Datadog components (for example, Agents, tracing libraries, and Observability Pipelines Worker) deployed in your infrastructure, for select product features. Use Remote Configuration to apply configurations to Datadog components in your environment on demand, decreasing management costs, reducing friction between teams, and accelerating issue resolution times.
@@ -57,7 +56,7 @@ The following products and features are supported with Remote Config:
 ### Application Performance Monitoring (APM)
 <div class="alert alert-info">This feature is in private beta.</div>
 
-- **Remotely instrument your Kubernetes services with APM**: Remotely instrument your services in Kubernetes with Datadog APM through Datadog Library Injection, and manage your deployments all within the Datadog UI. Available for Java, Node and Python applications. See [Setting up Remote instrumentation][13] for more information.
+- **Remotely instrument your Kubernetes services with APM**: Remotely instrument your services in Kubernetes with Datadog APM through Datadog Library Injection, and manage your deployments all within the Datadog UI. Available for Java, Node and Python applications. See [Setting up Remote instrumentation][2] for more information.
 - **Remotely set Agent sampling rate**: Remotely configure the Datadog Agent to change its trace sampling rates and set rules to scale your organization's trace ingestion according to your needs, without needing to restart your Datadog Agent.
 
 ### Dynamic Instrumentation
@@ -69,12 +68,12 @@ The following products and features are supported with Remote Config:
 
 <div class="alert alert-info">This feature is in beta.</div>
 
-- **Automatic default agent rule updates**: Automatically receive and update the default Agent rules maintained by Datadog as new Agent detections and enhancements are released. See [Setting Up Cloud Workload Security][11] for more information.
+- **Automatic default agent rule updates**: Automatically receive and update the default Agent rules maintained by Datadog as new Agent detections and enhancements are released. See [Setting Up Cloud Workload Security][3] for more information.
 
 ### Observability Pipelines
 <div class="alert alert-info">This feature is in private beta.</div>
 
-- **Remotely deploy and update [Observability Pipelines Workers][10] (OPW)**: Build and edit pipelines in the Datadog UI, rolling out your configuration changes to OPW instances running in your environment.
+- **Remotely deploy and update [Observability Pipelines Workers][4] (OPW)**: Build and edit pipelines in the Datadog UI, rolling out your configuration changes to OPW instances running in your environment.
 
 ## Security considerations
 
@@ -84,7 +83,7 @@ Datadog implements the following safeguards to protect the confidentiality, inte
 * Datadog never sends configurations unless requested by Agents, and only sends configurations relevant to the requesting Agent.
 * Because the configuration requests are initiated from your Agents to Datadog over HTTPS (port 443), there is no need to open additional ports in your network firewall.
 * The communication between your Agents and Datadog is encrypted using HTTPS, and is authenticated and authorized using your Datadog API key.
-* Only users with the [`api_keys_write`][3] permissions are authorized to enable or disable Remote Configuration capability on the API key and use the supported product features.
+* Only users with the [`api_keys_write`][5] permissions are authorized to enable or disable Remote Configuration capability on the API key and use the supported product features.
 * Your configuration changes submitted through the Datadog UI are signed and validated on the Agent and requesting Datadog components, verifying integrity of the configuration.
 
 ## Enabling Remote Configuration
@@ -99,17 +98,17 @@ Datadog implements the following safeguards to protect the confidentiality, inte
   |----------------------------------------|---------------|---------------|---------------|---------------|
   | Dynamic Instrumentation |               | 1.5.0         | 2.22.0        |               |
 
-  For ASM Protection capabilities and ASM 1-click activation, see [Compatibility Requirements][12].
+  For ASM Protection capabilities and ASM 1-click activation, see [Compatibility Requirements][6].
 
 ### Setup
 
 To enable Remote Configuration:
 
-1. Ensure your RBAC permissions include [`org_management`][9], so you can enable Remote Configuration for your organization.
+1. Ensure your RBAC permissions include [`org_management`][7], so you can enable Remote Configuration for your organization.
 
-2. Ensure your RBAC permissions include [`api_keys_write`][3], so you can create a new API key with the Remote Configuration capability, or add the capability to an existing API key. Contact your organization's Datadog administrator to update your permissions if you don't have it. A key with this capability allows you to authenticate and authorize your Agent to use Remote Configuration.
+2. Ensure your RBAC permissions include [`api_keys_write`][5], so you can create a new API key with the Remote Configuration capability, or add the capability to an existing API key. Contact your organization's Datadog administrator to update your permissions if you don't have it. A key with this capability allows you to authenticate and authorize your Agent to use Remote Configuration.
 
-3. On the [Remote Configuration][4] page, enable Remote Configuration. This enables Datadog components across your organization to receive configurations from Datadog.
+3. On the [Remote Configuration][8] page, enable Remote Configuration. This enables Datadog components across your organization to receive configurations from Datadog.
 
 4. Select an existing API key or create a new API key, and enable the Remote Config capability on the key:
 
@@ -151,25 +150,25 @@ datadog:
 6. Restart your Agent for the changes to take effect. 
 
 After you perform these steps, your Agent requests its configuration from Datadog, and the features that use remote configuration are enabled:
-- [CWS default agent rules][5] update automatically as released.
-- [Datadog Remote instrumentation][13] is enabled.
-- [APM Agent-level sampling rates][6] are applied.  
-- [Dynamic Instrumentation][7] is enabled.
-- [ASM 1-Click enablement, IP blocking, and attack pattern updates][8] are enabled.
+- [CWS default agent rules][9] update automatically as released.
+- [Datadog Remote instrumentation][2] is enabled.
+- [APM Agent-level sampling rates][10] are applied.  
+- [Dynamic Instrumentation][11] is enabled.
+- [ASM 1-Click enablement, IP blocking, and attack pattern updates][12] are enabled.
 
 ## Best practices
 
 ### Datadog Audit Trail
 
-Use [Datadog Audit Trail][14] to monitor organization access and Remote Configuration enabled events. Audit Trail allows your administrators and security teams to track the creation, deletion, and modification of Datadog API and application keys. After Audit Trail is configured, you can view events related to Remote Configuration enabled features and who has requested these changes. Audit Trail allows you to reconstruct sequences of events, and establish robust Datadog monitoring for Remote Configuration. 
+Use [Datadog Audit Trail][13] to monitor organization access and Remote Configuration enabled events. Audit Trail allows your administrators and security teams to track the creation, deletion, and modification of Datadog API and application keys. After Audit Trail is configured, you can view events related to Remote Configuration enabled features and who has requested these changes. Audit Trail allows you to reconstruct sequences of events, and establish robust Datadog monitoring for Remote Configuration. 
 
 ### Monitors
 
-Configure [monitors][15] to receive notifications when an event of interest is encountered.
+Configure [monitors][14] to receive notifications when an event of interest is encountered.
 
 ## Troubleshooting
 
-If you experience issues using Remote Configuration, use the following troubleshooting guidelines. If you need further assistance, contact [Datadog support][2].
+If you experience issues using Remote Configuration, use the following troubleshooting guidelines. If you need further assistance, contact [Datadog support][15].
 
 ### Restart the Agent
 
@@ -181,33 +180,33 @@ To use Remote Configuration, both the Agent and the Observability Pipelines Work
 
 ### Enable Remote Configuration at the organization level
 
-To enable Remote Configuration at the [Organization][4] level in the Datadog UI, follow the **Organization Settings > Security > Remote Configuration** menu. This allows your authenticated and authorized Datadog components to remotely receive configurations and security detection rules of supported features from Datadog. Only users who have the [`org_management`][9] RBAC permission can enable Remote Configuration at the Organization level.
+To enable Remote Configuration at the [Organization][8] level in the Datadog UI, follow the **Organization Settings > Security > Remote Configuration** menu. This allows your authenticated and authorized Datadog components to remotely receive configurations and security detection rules of supported features from Datadog. Only users who have the [`org_management`][7] RBAC permission can enable Remote Configuration at the Organization level.
 
 ### Enable Remote Configuration on the API key
 
-To authenticate and authorize the Agent to receive configurations and security detection rules, and to allow the Observability Pipelines Worker to receive configurations, enable Remote Configuration on the relevant API Key. Only users who have the [`api_keys_write`][3] RBAC permission can enable Remote Configuration on the API Key.
+To authenticate and authorize the Agent to receive configurations and security detection rules, and to allow the Observability Pipelines Worker to receive configurations, enable Remote Configuration on the relevant API Key. Only users who have the [`api_keys_write`][5] RBAC permission can enable Remote Configuration on the API Key.
 
-**Note:** If you have [`api_keys_write`][3] RBAC permission, but are missing Remote Configuration [Organization][4] level permissions, you cannot enable Remote Configuration on a new or an existing API Key. You only have permission to disable Remote Configuration on an existing API Key.
+**Note:** If you have [`api_keys_write`][5] RBAC permission, but are missing Remote Configuration [Organization][8] level permissions, you cannot enable Remote Configuration on a new or an existing API Key. You only have permission to disable Remote Configuration on an existing API Key.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /getting_started/site/
-[2]: /help/
-[3]: /account_management/rbac/permissions#api-and-application-keys
-[4]: https://app.datadoghq.com/organization-settings/remote-config
-[5]: /security/default_rules/#cat-workload-security
-[6]: /tracing/trace_pipeline/ingestion_controls/#managing-ingestion-for-all-services-at-the-agent-level
-[7]: /dynamic_instrumentation/?tab=configurationyaml#enable-remote-configuration
-[8]: /security/application_security/how-appsec-works/#built-in-protection
-[9]: /account_management/rbac/permissions#access-management
-[10]: /observability_pipelines/#observability-pipelines-worker
-[11]: /security/cloud_workload_security/setup
-[12]: /security/application_security/enabling/compatibility/
-[13]: /tracing/trace_collection/library_injection_remote/
-[14]: /account_management/audit_trail
-[15]: /monitors/
+[2]: /tracing/trace_collection/library_injection_remote/
+[3]: /security/cloud_workload_security/setup
+[4]: /observability_pipelines/#observability-pipelines-worker
+[5]: /account_management/rbac/permissions#api-and-application-keys
+[6]: /security/application_security/enabling/compatibility/
+[7]: /account_management/rbac/permissions#access-management
+[8]: https://app.datadoghq.com/organization-settings/remote-config
+[9]: /security/default_rules/#cat-workload-security
+[10]: /tracing/trace_pipeline/ingestion_controls/#managing-ingestion-for-all-services-at-the-agent-level
+[11]: /dynamic_instrumentation/?tab=configurationyaml#enable-remote-configuration
+[12]: /security/application_security/how-appsec-works/#built-in-protection
+[13]: /account_management/audit_trail
+[14]: /monitors/
+[15]: /help/
 [16]: /agent/guide/how_remote_config_works/?tab=configurationyamlfile#setup
 [17]: /agent/guide/network
 [18]: /agent/proxy/

--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -52,12 +52,12 @@ All Agent traffic is sent over SSL. The destination is dependent on the Datadog 
 : `rum.`{{< region-param key="browser_sdk_endpoint_domain" code="true" >}}<br>
 `session-replay.`{{< region-param key="browser_sdk_endpoint_domain" code="true" >}}
 
-{{< site-region region="us,eu,us3,us5,ap1" >}}
+{{% site-region region="us,eu,us3,us5,ap1" %}}
 [Remote Configuration][1]
 : `config.`{{< region-param key="dd_site" code="true" >}}
 
 [1]: /agent/guide/how_remote_config_works
-{{< /site-region >}}
+{{% /site-region %}}
 
 [Synthetics private location][8]
 : Worker v>=1.5.0 `intake.synthetics.`{{< region-param key="dd_site" code="true" >}} is the only endpoint to configure.<br>
@@ -65,16 +65,15 @@ API test results for worker v>0.1.6 `intake.synthetics.`{{< region-param key="dd
 Browser test results for worker v>0.2.0 `intake-v2.synthetics.`{{< region-param key="dd_site" code="true" >}}<br>
 API test results for worker v<0.1.5 `api.`{{< region-param key="dd_site" code="true" >}}
 
-{{< site-region region="us,eu,us3,us5,ap1" >}}
+{{% site-region region="us,eu,us3,us5,ap1" %}}
 [Database Monitoring][2]
 : `dbm-metrics-intake.`{{< region-param key="dd_site" code="true" >}}<br>
 `dbquery-intake.`{{< region-param key="dd_site" code="true" >}}
 
 [2]: /database_monitoring/
-{{< /site-region >}}
+{{% /site-region %}}
 
-{{< site-region region="us" >}}
-
+{{% site-region region="us" %}}
 [Logs][1] & [HIPAA logs][2]
 : TCP: `agent-intake.logs.datadoghq.com`<br>
 HTTP: `agent-http-intake.logs.datadoghq.com`<br>
@@ -89,11 +88,9 @@ Other: See [logs endpoints][3]
 [1]: /logs/
 [2]: /data_security/logs/#hipaa-enabled-customers
 [3]: /logs/log_collection/#logging-endpoints
+{{% /site-region %}}
 
-{{< /site-region >}}
-
-{{< site-region region="eu" >}}
-
+{{% site-region region="eu" %}}
 [Logs][1] & [HIPAA logs][2]
 : TCP: `agent-intake.logs.datadoghq.eu`<br>
 HTTP: `agent-http-intake.logs.datadoghq.eu`<br>
@@ -108,11 +105,9 @@ Other: See [logs endpoints][3]
 [1]: /logs/
 [2]: /data_security/logs/#hipaa-enabled-customers
 [3]: /logs/log_collection/#logging-endpoints
+{{% /site-region %}}
 
-{{< /site-region >}}
-
-{{< site-region region="us3" >}}
-
+{{% site-region region="us3" %}}
 [Logs][1] & [HIPAA logs][2]
 : HTTP: `agent-http-intake.logs.us3.datadoghq.com`<br>
 Other: See [logs endpoints][3]
@@ -125,11 +120,9 @@ Other: See [logs endpoints][3]
 [1]: /logs/
 [2]: /data_security/logs/#hipaa-enabled-customers
 [3]: /logs/log_collection/#logging-endpoints
+{{% /site-region %}}
 
-{{< /site-region >}}
-
-{{< site-region region="us5" >}}
-
+{{% site-region region="us5" %}}
 [Logs][1] & [HIPAA logs][2]
 : HTTP: `agent-http-intake.logs.us5.datadoghq.com`<br>
 Other: See [logs endpoints][3]
@@ -142,11 +135,9 @@ Other: See [logs endpoints][3]
 [1]: /logs/
 [2]: /data_security/logs/#hipaa-enabled-customers
 [3]: /logs/log_collection/#logging-endpoints
+{{% /site-region %}}
 
-{{< /site-region >}}
-
-{{< site-region region="ap1" >}}
-
+{{% site-region region="ap1" %}}
 [Logs][1] & [HIPAA logs][2]
 : HTTP: `agent-http-intake.logs.ap1.datadoghq.com`<br>
 Other: See [logs endpoints][3]
@@ -154,11 +145,9 @@ Other: See [logs endpoints][3]
 [1]: /logs/
 [2]: /data_security/logs/#hipaa-enabled-customers
 [3]: /logs/log_collection/#logging-endpoints
+{{% /site-region %}}
 
-{{< /site-region >}}
-
-{{< site-region region="gov" >}}
-
+{{% site-region region="gov" %}}
 [Logs][1] & [HIPAA logs][2]
 : HTTP: `agent-http-intake.logs.ddog-gov.com`<br>
 Other: See [logs endpoints][3]
@@ -171,8 +160,7 @@ Other: See [logs endpoints][3]
 [1]: /logs/
 [2]: /data_security/logs/#hipaa-enabled-customers
 [3]: /logs/log_collection/#logging-endpoints
-
-{{< /site-region >}}
+{{% /site-region %}}
 
 All other Agent data
 : `<VERSION>-app.agent.`{{< region-param key="dd_site" code="true" >}}<br>
@@ -232,7 +220,7 @@ Open the following ports to benefit from all the **Agent** functionalities:
 
 #### Outbound
 
-{{< site-region region="us" >}}
+{{% site-region region="us" %}}
 
 443/tcp
 : Port for most Agent data (Metrics, APM, Live Processes/Containers)
@@ -256,9 +244,9 @@ See [logs endpoints][3] for other connection types.
 [3]: /logs/log_collection/#logging-endpoints
 [4]: /agent/basic_agent_usage/kubernetes/
 
-{{< /site-region >}}
+{{% /site-region %}}
 
-{{< site-region region="eu" >}}
+{{% site-region region="eu" %}}
 
 443/tcp
 : Port for most Agent data (Metrics, APM, Live Processes/Containers)
@@ -282,9 +270,9 @@ See [logs endpoints][3] for other connection types.
 [3]: /logs/log_collection/#logging-endpoints
 [4]: /agent/basic_agent_usage/kubernetes/
 
-{{< /site-region >}}
+{{% /site-region %}}
 
-{{< site-region region="us3,us5,gov" >}}
+{{% site-region region="us3,us5,gov" %}}
 
 443/tcp
 : Port for most Agent data (Metrics, APM, Live Processes/Containers)
@@ -304,7 +292,7 @@ See [default NTP targets][2].
 [3]: /logs/log_collection/#logging-endpoints
 [4]: /agent/basic_agent_usage/kubernetes/
 
-{{< /site-region >}}
+{{% /site-region %}}
 
 #### Inbound
 

--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -3,11 +3,11 @@ title: Connect to Datadog over AWS PrivateLink
 kind: guide
 ---
 
-{{< site-region region="us3,us5,eu,gov,ap1" >}}
+{{% site-region region="us3,us5,eu,gov,ap1" %}}
 <div class="alert alert-warning">Datadog PrivateLink does not support the selected Datadog site.</div>
 {{< /site-region >}}
 
-{{< site-region region="us" >}}
+{{% site-region region="us" %}}
 This guide walks you through how to configure [AWS PrivateLink][1] for use with Datadog.
 
 ## Overview
@@ -130,7 +130,7 @@ However, to route traffic to Datadog's PrivateLink offering in `us-east-1` from 
 
 8. Click on the VPC endpoint ID to check its status.
 9. Wait for the status to move from _Pending_ to _Available_. This can take up to 10 minutes.
-10. After creating the endpoint, use VPC peering to make the PrivateLink endpoint available in another region to send telemetry to Datadog over PrivateLink. For more information, read the [Work With VPC Peering connections][10] page in AWS.
+10. After creating the endpoint, use VPC peering to make the PrivateLink endpoint available in another region to send telemetry to Datadog over PrivateLink. For more information, read the [Work With VPC Peering connections][2] page in AWS.
 
 {{< img src="agent/guide/private_link/vpc_status.png" alt="VPC status" style="width:80%;" >}}
 
@@ -166,22 +166,22 @@ This returns `metrics.agent.datadoghq.com`, the private hosted zone name that yo
 2. Within each new Route53 private hosted zone, create an A record with the same name. Toggle the **Alias** option, then under **Route traffic to**, choose **Alias to VPC endpoint**, **us-east-1**, and enter the DNS name of the VPC endpoint associated with the DNS name.
 
    **Notes**:
-      - To retrieve your DNS name, see the [View endpoint service private DNS name configuration documentation.][2]
+      - To retrieve your DNS name, see the [View endpoint service private DNS name configuration documentation.][4]
       - The Agent sends telemetry to versioned endpoints, for example, `<version>-app.agent.datadoghq.com` which resolves to `metrics.agent.datadoghq.com` through a CNAME alias. Therefore, you only need to set up a private hosted zone for `metrics.agent.datadoghq.com`.
 
 {{< img src="agent/guide/private_link/create-an-a-record.png" alt="Create an A record" style="width:90%;" >}}
 
 3. Configure VPC peering and routing between the VPC in `us-east-1` that contains the Datadog PrivateLink endpoints and the VPC in the region where the Datadog Agents run.
 
-4. If the VPCs are in different AWS accounts, the VPC containing the Datadog Agent must be authorized to associate with the Route53 private hosted zones before continuing. Create a [VPC association authorization][4] for each Route53 private hosted zone using the region and VPC ID of the VPC where the Datadog Agent runs. This option is not available in the AWS Console. It must be configured using the AWS CLI, SDK, or API.
+4. If the VPCs are in different AWS accounts, the VPC containing the Datadog Agent must be authorized to associate with the Route53 private hosted zones before continuing. Create a [VPC association authorization][5] for each Route53 private hosted zone using the region and VPC ID of the VPC where the Datadog Agent runs. This option is not available in the AWS Console. It must be configured using the AWS CLI, SDK, or API.
 
 5. Edit the Route53 hosted zone to add the non-us-east-1 VPC.
 
 {{< img src="agent/guide/private_link/edit-route53-hosted-zone.png" alt="Edit a Route53 private hosted zone" style="width:80%;" >}}
 
-6. VPCs that have the Private Hosted Zone (PHZ) attached need to have certain settings toggled on, specifically `enableDnsHostnames` and `enableDnsSupport` in the VPCs that the PHZ is associated with. See [Considerations when working with a private hosted zone][5].
+6. VPCs that have the Private Hosted Zone (PHZ) attached need to have certain settings toggled on, specifically `enableDnsHostnames` and `enableDnsSupport` in the VPCs that the PHZ is associated with. See [Considerations when working with a private hosted zone][6].
 
-7. [Restart the Agent][6] to send data to Datadog through AWS PrivateLink.
+7. [Restart the Agent][7] to send data to Datadog through AWS PrivateLink.
 
 #### Troubleshooting DNS resolution and connectivity
 
@@ -193,11 +193,11 @@ If DNS is resolving to public IP addresses, then the Route53 zone has **not** be
 
 If DNS resolves correctly, but connections to `port 443` are failing, then VPC peering or routing may be misconfigured, or port 443 may not be allowed outbound to the CIDR block of the VPC in `us-east-1`.
 
-The VPCs with Private Hosted Zone (PHZ) attached need to have a couple of settings toggled on. Specifically, `enableDnsHostnames` and `enableDnsSupport` need to be turned on in the VPCs that the PHZ is associated with. See [Amazon VPC settings][5].
+The VPCs with Private Hosted Zone (PHZ) attached need to have a couple of settings toggled on. Specifically, `enableDnsHostnames` and `enableDnsSupport` need to be turned on in the VPCs that the PHZ is associated with. See [Amazon VPC settings][6].
 
 ### Datadog Agent
 
-1. If you are collecting logs data, ensure your Agent is configured to send logs over HTTPS. If the data is not already there, add the following to the [Agent `datadog.yaml` configuration file][7]:
+1. If you are collecting logs data, ensure your Agent is configured to send logs over HTTPS. If the data is not already there, add the following to the [Agent `datadog.yaml` configuration file][8]:
 
     ```yaml
     logs_config:
@@ -210,23 +210,23 @@ The VPCs with Private Hosted Zone (PHZ) attached need to have a couple of settin
     DD_LOGS_CONFIG_FORCE_USE_HTTP=true
     ```
 
-    This configuration is required when sending logs to Datadog with AWS PrivateLink and the Datadog Agent, and is not required for the Lambda Extension. For more details, see [Agent log collection][8].
+    This configuration is required when sending logs to Datadog with AWS PrivateLink and the Datadog Agent, and is not required for the Lambda Extension. For more details, see [Agent log collection][9].
 
-2. If your Lambda Extension loads the Datadog API Key from AWS Secrets Manager using the ARN specified by the environment variable `DD_API_KEY_SECRET_ARN`, you need to [create a VPC endpoint for Secrets Manager][9].
+2. If your Lambda Extension loads the Datadog API Key from AWS Secrets Manager using the ARN specified by the environment variable `DD_API_KEY_SECRET_ARN`, you need to [create a VPC endpoint for Secrets Manager][10].
 
-3. [Restart the Agent][6].
+3. [Restart the Agent][7].
 
 
 [1]: /help/
-[2]: https://docs.aws.amazon.com/vpc/latest/privatelink/view-vpc-endpoint-service-dns-name.html
+[2]: https://docs.aws.amazon.com/vpc/latest/peering/working-with-vpc-peering.html
 [3]: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html
-[4]: https://docs.amazonaws.cn/en_us/Route53/latest/DeveloperGuide/hosted-zone-private-associate-vpcs-different-accounts.html
-[5]: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zone-private-considerations.html#hosted-zone-private-considerations-vpc-settings
-[6]: /agent/guide/agent-commands/?tab=agentv6v7#restart-the-agent
-[7]: /agent/guide/agent-configuration-files/?tab=agentv6v7#agent-main-configuration-file
-[8]: https://docs.datadoghq.com/agent/logs/?tab=tailexistingfiles#send-logs-over-https
-[9]: https://docs.aws.amazon.com/secretsmanager/latest/userguide/vpc-endpoint-overview.html
-[10]: https://docs.aws.amazon.com/vpc/latest/peering/working-with-vpc-peering.html
+[4]: https://docs.aws.amazon.com/vpc/latest/privatelink/view-vpc-endpoint-service-dns-name.html
+[5]: https://docs.amazonaws.cn/en_us/Route53/latest/DeveloperGuide/hosted-zone-private-associate-vpcs-different-accounts.html
+[6]: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zone-private-considerations.html#hosted-zone-private-considerations-vpc-settings
+[7]: /agent/guide/agent-commands/?tab=agentv6v7#restart-the-agent
+[8]: /agent/guide/agent-configuration-files/?tab=agentv6v7#agent-main-configuration-file
+[9]: https://docs.datadoghq.com/agent/logs/?tab=tailexistingfiles#send-logs-over-https
+[10]: https://docs.aws.amazon.com/secretsmanager/latest/userguide/vpc-endpoint-overview.html
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -238,8 +238,8 @@ Additional helpful documentation, links, and articles:
 - [Enable log collection with the Agent][3]
 - [Collect logs from your AWS services][4]
 
+{{< /site-region >}}
 [1]: https://aws.amazon.com/privatelink/
 [2]: https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html
 [3]: /agent/logs
 [4]: /integrations/amazon_web_services/#log-collection
-{{< /site-region >}}

--- a/content/en/agent/logs/proxy.md
+++ b/content/en/agent/logs/proxy.md
@@ -92,7 +92,7 @@ logs_config:
 
 HAProxy should be installed on a host that has connectivity to Datadog. Use the following configuration file if you do not already have it configured.
 
-{{< site-region region="us" >}}
+{{% site-region region="us" %}}
 
 ```conf
 # Basic configuration
@@ -155,8 +155,8 @@ If successful, the file will be located at `/etc/ssl/certs/ca-bundle.crt` for Ce
 
 Once the HAProxy configuration is in place, you can reload it or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (for example, `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.com` fails over to another IP.
 
-{{< /site-region >}}
-{{< site-region region="eu" >}}
+{{% /site-region %}}
+{{% site-region region="eu" %}}
 
 ```conf
 # Basic configuration
@@ -218,7 +218,7 @@ If successful, the file will be located at `/etc/ssl/certs/ca-bundle.crt` for Ce
 
 Once the HAProxy configuration is in place, you can reload it or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (for example, `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.eu` fails over to another IP.
 
-{{< /site-region >}}
+{{% /site-region %}}
 
 {{% /tab %}}
 
@@ -241,7 +241,7 @@ logs_config:
 
 In this example, `nginx.conf` can be used to proxy Agent traffic to Datadog. The last server block in this configuration does TLS wrapping to ensure internal plaintext logs are encrypted between your proxy and Datadog's log intake API endpoint:
 
-{{< site-region region="us" >}}
+{{% site-region region="us" %}}
 
 ```conf
 user nginx;
@@ -261,8 +261,8 @@ stream {
 }
 ```
 
-{{< /site-region >}}
-{{< site-region region="eu" >}}
+{{% /site-region %}}
+{{% site-region region="eu" %}}
 
 ```conf
 user nginx;
@@ -282,7 +282,7 @@ stream {
 }
 ```
 
-{{< /site-region >}}
+{{% /site-region %}}
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -50,7 +50,7 @@
       </div>
 
       <div class="mainContent-wrapper order-2 order-lg-0 col-12 {{ if eq .Params.disable_sidebar true }}col-lg-9{{ else }}col-lg-7{{ end }} main">
-        <div class="{{ if and (eq $.Section "integrations") (eq $.Kind "page") }}integrations-single{{ end }}"
+        <div class='{{ if and (eq $.Section "integrations") (eq $.Kind "page") }}integrations-single{{ end }}'
           id="mainContent">
           {{ block "main" . }}{{ end }}
           {{ partial "page-edit.html" (dict "ctx" $ctx "type" "contribute") }}

--- a/layouts/shortcodes/site-region.html
+++ b/layouts/shortcodes/site-region.html
@@ -1,16 +1,16 @@
-{{/*  if indenting, indent 2 chars or else the markdown engine thinks it is a codeblock
-    https://discourse.gohugo.io/t/nested-shortcodes-converting-to-pre-code-blocks/28033/4    
+{{/*  
+    keep all markup below left aligned   
 */}}
 {{ if  not (.Get "region") }}
 {{ errorf "Site region error: Missing region for param 'region': %s" .Position }}
 {{ end }}
 
 {{ $region := .Get "region" }}
-{{ $listOfPages := slice "account_management" }}
+{{ $listOfPages := slice "account_management" "agent" }}
 {{ if in $listOfPages .Page.Type}}
-  <div class="d-none site-region-container" data-region="{{ $region }}">
-    {{.Inner}}
-  </div>
+<div class="d-none site-region-container" data-region="{{ $region }}">
+{{.Inner}}
+</div>
 {{ else }}
-  <div class="d-none site-region-container" data-region="{{ $region }}"><p>{{- .Inner | markdownify -}}</p></div>
+<div class="d-none site-region-container" data-region="{{ $region }}"><p>{{- .Inner | markdownify -}}</p></div>
 {{ end }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
updates site-region shortcode syntax on en `/agent` pages to allow for `.

### Motivation
<!-- What inspired you to submit this pull request?-->
As a part of this card: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-3279

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

Check that the TOC items are showing for the preview links below
Check that the hyperlinks on the modified files take you to the appropriate place: 
https://docs-staging.datadoghq.com/stefon.simmons/fix-site-region-agent-pgs/

Specifically, notice that the TOC appears now on this page: https://docs-staging.datadoghq.com/stefon.simmons/fix-site-region-agent-pgs/agent/guide/private-link/?tab=vpcpeering


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
