### PR TITLE
link check remove after_script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -387,10 +387,6 @@ link_checks:on-schedule:
     - find ./public -name "*.html" -exec sed -i -e "s#/api/v2/#/api/latest/#g" {} +
     - "sed -i'' -e 's/CheckInternalHash: false/CheckInternalHash: true/' .htmltest.yml"
     - htmltest
-  after_script:
-    - "[ -f /usr/local/bin/helpers.sh ] && source /usr/local/bin/helpers.sh"  # source helpers
-    - RESULT="⛈ htmltest result; the following issues were found:\n$(tail -n +2 ./tmp/.htmltest/htmltest.log)\n--------------------" # output all but first line
-    - if grep -q "not exist" tmp/.htmltest/htmltest.log; then notify_slack "${RESULT}" "#31b834"; fi
   artifacts:
     paths:
       - ./tmp/.htmltest


### PR DESCRIPTION
### What does this PR do?

removes the after_script step on the scheduled anchor link check job

### Motivation

To avoid an error we were seeing

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes

No changes to site

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
