### PR TITLE
Stefon.simmons/fix site networkmonitoring pgs

### DIFF
--- a/content/en/getting_started/database_monitoring/_index.md
+++ b/content/en/getting_started/database_monitoring/_index.md
@@ -13,9 +13,9 @@ further_reading:
       text: 'Database performance monitoring with Datadog'
 ---
 
-{{< site-region region="gov" >}}
+{{% site-region region="gov" %}}
 <div class="alert alert-warning">Database Monitoring is not available for your selected Datadog site ({{< region-param key="dd_site_name" >}}).</div>
-{{< /site-region >}}
+{{% /site-region %}}
 
 ## Overview
 

--- a/content/en/getting_started/incident_management/_index.md
+++ b/content/en/getting_started/incident_management/_index.md
@@ -31,9 +31,9 @@ further_reading:
       text: 'Best practices for writing incident postmortems'
 ---
 
-{{< site-region region="gov" >}}
+{{% site-region region="gov" %}}
 <div class="alert alert-warning">Incident Management is not available for your selected Datadog site ({{< region-param key="dd_site_name" >}}).</div>
-{{< /site-region >}}
+{{% /site-region %}}
 
 ## Overview
 

--- a/content/en/getting_started/site/_index.md
+++ b/content/en/getting_started/site/_index.md
@@ -84,15 +84,15 @@ Different Datadog sites may support different functionalities depending on the i
 
 For example, to see the documentation for the Datadog for Government site, select **US1-FED**.
 
-{{< site-region region="gov" >}}
+{{% site-region region="gov" %}}
 
 ## Access the Datadog for Government site
 
 The Datadog for Government site (US1-FED) is meant to allow US government agencies and partners to monitor their applications and infrastructure. For information about the Datadog for Government site's security and compliance controls and frameworks, as well as how it supports FedRAMP, see the [Security page][1].
 
-[1]: https://www.datadoghq.com/security/
-{{< /site-region >}}
+{{% /site-region %}}
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+[1]: https://www.datadoghq.com/security/

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -440,7 +440,7 @@ To set up on AWS ECS, see the [AWS ECS][1] documentation page.
 {{% /tab %}}
 {{< /tabs >}}
 
-{{< site-region region="us,us3,us5,eu" >}}
+{{% site-region region="us,us3,us5,eu" %}}
 ### Enhanced Resolution
 
 Optionally, enable resource collection for cloud integrations to allow Network Performance Monitoring to discover cloud-managed entities.
@@ -453,7 +453,7 @@ For additional information around these capabilities, please see [Cloud service 
   [2]: /integrations/amazon_web_services/#resource-collection
   [3]: /network_monitoring/performance/network_page/#cloud-service-enhanced-resolution
 
-{{< /site-region >}}
+{{% /site-region %}}
 
 ## Further Reading
 {{< partial name="whats-next/whats-next.html" >}}

--- a/layouts/shortcodes/site-region.html
+++ b/layouts/shortcodes/site-region.html
@@ -6,7 +6,7 @@
 {{ end }}
 
 {{ $region := .Get "region" }}
-{{ $listOfPages := slice "account_management" "agent" }}
+{{ $listOfPages := slice "account_management" "agent" "network_monitoring"}}
 {{ if in $listOfPages .Page.Type}}
 <div class="d-none site-region-container" data-region="{{ $region }}">
 {{.Inner}}

--- a/layouts/shortcodes/site-region.html
+++ b/layouts/shortcodes/site-region.html
@@ -6,7 +6,7 @@
 {{ end }}
 
 {{ $region := .Get "region" }}
-{{ $listOfPages := slice "account_management" "agent" "network_monitoring"}}
+{{ $listOfPages := slice "account_management" "agent" "network_monitoring" "getting_started"}}
 {{ if in $listOfPages .Page.Type}}
 <div class="d-none site-region-container" data-region="{{ $region }}">
 {{.Inner}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

updates site-region shortcode syntax on en `/network_monitoring` and `/getting_started` pages.

### Motivation
<!-- What inspired you to submit this pull request?-->

As a part of this card: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-3279

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

Check that the TOC items are showing for the preview links below
Check that the hyperlinks on the modified files take you to the appropriate place:
https://docs-staging.datadoghq.com/stefon.simmons/fix-site-region-agent-pgs/

Specifically, notice that the TOC appears on this page now: https://docs-staging.datadoghq.com/stefon.simmons/fix-site-region-agent-pgs/agent/guide/private-link/?tab=vpcpeering

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
