### PR TITLE
Update instrumentation command of Azure Container Apps

### DIFF
--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -99,7 +99,7 @@ COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
 
 # install the Datadog js tracing library, either here or in package.json
 
-npm i dd-trace@2.2.0
+RUN npm i dd-trace@2.2.0
 
 # enable the Datadog tracing library
 ENV NODE_OPTIONS="--require dd-trace/init"


### PR DESCRIPTION
I believe it is missing `RUN`.

Error message when running azure build commands:
```
> az acr build --registry $ACR_NAME --image $API_NAME .
Packing source code into tar to upload...
Uploading archived source code from '/var/folders/kz/xqpbjdv964s74w6w3j4q8vxm0000gq/T/build_archive_8d4eabac2a3043a5a891b3c24595603f.tar.gz'...
Sending context (8.998 KiB) to registry: acaalbumskimip...
Queued a build with ID: cxk
Waiting for an agent...
2023/05/18 15:01:48 Downloading source code...
2023/05/18 15:01:49 Finished downloading source code
2023/05/18 15:01:49 Using acb_vol_00a33031-4589-4472-88cc-5b877588d786 as the home volume
2023/05/18 15:01:49 Setting up Docker configuration...
2023/05/18 15:01:50 Successfully set up Docker configuration
2023/05/18 15:01:50 Logging in to registry: acaalbumskimip.azurecr.io
2023/05/18 15:01:51 Successfully logged into acaalbumskimip.azurecr.io
2023/05/18 15:01:51 Executing step ID: build. Timeout(sec): 28800, Working directory: '', Network: ''
2023/05/18 15:01:51 Scanning for dependencies...
2023/05/18 15:01:52 Successfully scanned dependencies
2023/05/18 15:01:52 Launching container with name: build
Sending build context to Docker daemon   51.2kB
Error response from daemon: dockerfile parse error line 17: unknown instruction: NPM
2023/05/18 15:01:52 Container failed during run: build. No retries remaining.
failed to run step ID: build: exit status 1

Run ID: cxk failed after 5s. Error: failed during run, err: exit status 1
Run failed
```