### PR TITLE
DOCS-5481 - adding some alert boxes about a change in docker hub policies

### DIFF
--- a/content/en/agent/faq/docker-hub.md
+++ b/content/en/agent/faq/docker-hub.md
@@ -2,6 +2,11 @@
 title: Docker Hub
 kind: faq
 ---
+
+<div class="alert alert-warning">On July 10 2023, Docker Hub will start enforcing download rate limits to Datadog's Docker Hub registries. Image pulls from these registries count against your rate limit quota.<br/><br/>
+
+Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from other registries where no rate limits apply. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
+
 If you are using Docker, there are several container images available through [GCR][11], and [ECR][12]. If you need to use Docker Hub:
 
 | Datadog service                         | Docker Hub                               | Docker Pull Command                                        |

--- a/content/en/containers/cluster_agent/_index.md
+++ b/content/en/containers/cluster_agent/_index.md
@@ -33,6 +33,10 @@ If you're using Docker, the Datadog Cluster Agent is available on Docker Hub and
 |--------------------------------------------------|-----------------------------------------------------------|
 | [hub.docker.com/r/datadog/cluster-agent][2]      | [gcr.io/datadoghq/cluster-agent][3]                       |
 
+<div class="alert alert-warning">On July 10 2023, Docker Hub will start enforcing download rate limits to Datadog's Docker Hub registries. Image pulls from these registries count against your rate limit quota.<br/><br/>
+
+Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from other registries where no rate limits apply. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
+
 **Note**: To take advantage of all features from the Datadog Cluster Agent, you must run Kubernetes v1.10+.
 
 {{< whatsnext desc="This section includes the following topics:">}}

--- a/content/en/containers/docker/_index.md
+++ b/content/en/containers/docker/_index.md
@@ -35,6 +35,10 @@ further_reading:
 
 The Datadog Docker Agent is the containerized version of the host [Agent][1]. The Docker Agent supports Docker, containerd, and Podman runtimes. The official [Docker image][2] is available on Docker Hub, GCR, and ECR-Public.
 
+<div class="alert alert-warning">On July 10 2023, Docker Hub will start enforcing download rate limits to Datadog's Docker Hub registries. Image pulls from these registries count against your rate limit quota.<br/><br/>
+
+Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from other registries where no rate limits apply. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
+
 Images are available for 64-bit x86 and Arm v8 architectures.
 
 | ECR-Public                                                           | GCR                                                             | Docker Hub                                             |

--- a/content/en/containers/kubernetes/installation.md
+++ b/content/en/containers/kubernetes/installation.md
@@ -182,6 +182,10 @@ Next, enable the Datadog features that you'd like to use: [APM][5], [Logs][6]
 
 ### Container registries
 
+<div class="alert alert-warning">On July 10 2023, Docker Hub will start enforcing download rate limits to Datadog's Docker Hub registries. Image pulls from these registries count against your rate limit quota.<br/><br/>
+
+Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from other registries where no rate limits apply. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
+
 If Google Container Registry ([gcr.io/datadoghq][8]) is not accessible in your deployment region, use another registry with the following configuration in the `values.yaml` file:
 
 - For the public AWS ECR registry ([public.ecr.aws/datadog][9]), use the following:

--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -40,6 +40,10 @@ DogStatsD is available on Docker Hub and GCR:
 |--------------------------------------------------|-----------------------------------------------------------|
 | [hub.docker.com/r/datadog/dogstatsd][3]          | [gcr.io/datadoghq/dogstatsd][4]                           |
 
+<div class="alert alert-warning">On July 10 2023, Docker Hub will start enforcing download rate limits to Datadog's Docker Hub registries. Image pulls from these registries count against your rate limit quota.<br/><br/>
+
+Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from other registries where no rate limits apply. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
+
 ## How it works
 
 DogStatsD accepts [custom metrics][5], [events][6], and [service checks][7] over UDP and periodically aggregates and forwards them to Datadog.

--- a/content/en/tracing/trace_collection/library_injection_local.md
+++ b/content/en/tracing/trace_collection/library_injection_local.md
@@ -36,6 +36,10 @@ To learn more about Kubernetes Admission Controller, read [Kubernetes Admission 
 
 ## Container registries
 
+<div class="alert alert-warning">On July 10 2023, Docker Hub will start enforcing download rate limits to Datadog's Docker Hub registries. Image pulls from these registries count against your rate limit quota.<br/><br/>
+
+Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from other registries where no rate limits apply. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
+
 Datadog publishes instrumentation libraries images on gcr.io, Docker Hub, and AWS ECR:
 | Language   | gcr.io                              | hub.docker.com                              | gallery.ecr.aws                            |
 |------------|-------------------------------------|---------------------------------------------|-------------------------------------------|


### PR DESCRIPTION
adds an alert about upcoming docker hub changes to every page where docker hub is relevant. (there are other docker hub mentions, but those are mostly just "for docker hub, see this other page" situations, where said other page is one of the ones in this PR that has the new alert box.)

i have stared at the use of future tense here, and have concluded this is just a situation where we have to use future tense. it's a concrete event in the future that has been determined by a third party.

i am creating a ticket so that after july 10, these alert boxes will be in the present tense.