### PR TITLE
Move sample RUM sessions section for flutter

### DIFF
--- a/content/en/real_user_monitoring/flutter/advanced_configuration.md
+++ b/content/en/real_user_monitoring/flutter/advanced_configuration.md
@@ -207,22 +207,6 @@ For example, if the current tracking consent is `TrackingConsent.pending` and yo
 
 Likewise, if you change the value from `TrackingConsent.pending` to `TrackingConsent.notGranted`, the Flutter RUM SDK wipes all data and does not collect any future data.
 
-## Sample RUM sessions
-
-To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while [initializing the Flutter RUM SDK][2] as a percentage between 0 and 100.
-
-For example, to keep only 50% of sessions, use:
-
-```dart
-final config = DdSdkConfiguration(
-    // other configuration...
-    rumConfiguration: RumConfiguration(
-        applicationId: '<YOUR_APPLICATION_ID>',
-        sessionSamplingRate: 50.0,
-    ),
-);
-```
-
 ## Sending data when device is offline
 
 RUM ensures availability of data when your user device is offline. In cases of low-network areas, or when the device battery is too low, all RUM events are first stored on the local device in batches. They are sent as soon as the network is available, and the battery is high enough to ensure the Flutter RUM SDK does not impact the end user's experience. If the network is not available with your application running in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.

--- a/content/en/real_user_monitoring/flutter/setup.md
+++ b/content/en/real_user_monitoring/flutter/setup.md
@@ -127,6 +127,22 @@ You can initialize RUM using one of two methods in your `main.dart` file.
    });
    ```
 
+### Sample RUM sessions
+
+To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while [initializing the Flutter RUM SDK][2] as a percentage between 0 and 100.
+
+For example, to keep only 50% of sessions, use:
+
+```dart
+final config = DdSdkConfiguration(
+    // other configuration...
+    rumConfiguration: RumConfiguration(
+        applicationId: '<YOUR_APPLICATION_ID>',
+        sessionSamplingRate: 50.0,
+    ),
+);
+```
+
 ### Set tracking consent
 
 To be compliant with the GDPR regulation, the Datadog Flutter SDK requires the `trackingConsent` value at initialization.

--- a/content/en/real_user_monitoring/flutter/setup.md
+++ b/content/en/real_user_monitoring/flutter/setup.md
@@ -129,7 +129,7 @@ You can initialize RUM using one of two methods in your `main.dart` file.
 
 ### Sample RUM sessions
 
-To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while [initializing the Flutter RUM SDK][2] as a percentage between 0 and 100.
+To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while [initializing the Flutter RUM SDK][2] as a percentage between 0 and 100. By default, `sessionSamplingRate` is set to 100 (keep all sessions).
 
 For example, to keep only 50% of sessions, use:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Moves the **Sample RUM sessions** section from the **Flutter > Advanced Configuration** page to **Flutter > Setup** page.

### Motivation
To make it inline with other SDK pages, per [DOCS-5487](https://datadoghq.atlassian.net/browse/DOCS-5487).

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5487]: https://datadoghq.atlassian.net/browse/DOCS-5487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ