### PR TITLE
[NET-3152] add public documentation Azure loadbalancers and application gateways

### DIFF
--- a/content/en/network_monitoring/performance/network_page.md
+++ b/content/en/network_monitoring/performance/network_page.md
@@ -195,8 +195,6 @@ If you have [setup][9] enhanced resolution for AWS or Azure, NPM can filter and 
  - subscription_id
  - sku_name
  - custom (user-defined) tags applied to Azure Loadbalancers and Application Gateways
- {{% /tab %}}
-{{< /tabs >}}
 
 
 ### Domain resolution

--- a/content/en/network_monitoring/performance/network_page.md
+++ b/content/en/network_monitoring/performance/network_page.md
@@ -182,7 +182,7 @@ If you have [setup][9] enhanced resolution for AWS or Azure, NPM can filter and 
  {{< /tabs >}}
 
 #### Azure
- {{< tabs >}}
+{{< tabs >}}
  {{% tab "Loadbalancers and Application Gateways" %}}
  - name
  - loadbalancer

--- a/content/en/network_monitoring/performance/network_page.md
+++ b/content/en/network_monitoring/performance/network_page.md
@@ -137,7 +137,7 @@ NPM automatically maps
 To monitor other endpoints where an Agent cannot be installed (such as public APIs), group the destination in the Network Overview by the [`domain` tag](#domain-resolution). Or, see the section below for cloud service resolution.
 
 ### Cloud service enhanced resolution
-If you have [setup][9] enhanced resolution for AWS or Azure, NPM can filter and group network traffic with several resources collected from these cloud providers. Depending on the cloud provider and resource, you have different sets of tags available to query with. Azure loadbalancers only have user-defined tags. For AWS, Datadog applies the tags defined below in addition to the user-defined tags.
+If you have [setup][9] enhanced resolution for AWS or Azure, NPM can filter and group network traffic with several resources collected from these cloud providers. Depending on the cloud provider and resource, you have different sets of tags available to query with. Datadog applies the tags defined below in addition to the user-defined tags.
 
  #### Amazon Web Services
  {{< tabs >}}
@@ -180,6 +180,24 @@ If you have [setup][9] enhanced resolution for AWS or Azure, NPM can filter and 
  {{% /tab %}}
 
  {{< /tabs >}}
+
+#### Azure
+ {{< tabs >}}
+ {{% tab "Loadbalancers and Application Gateways" %}}
+ - name
+ - loadbalancer
+ - cloud_provider
+ - region
+ - type
+ - resource_group
+ - tenant_name
+ - subscription_name
+ - subscription_id
+ - sku_name
+ - custom (user-defined) tags applied to Azure Loadbalancers and Application Gateways
+ {{% /tab %}}
+{{< /tabs >}}
+
 
 ### Domain resolution
 

--- a/content/en/network_monitoring/performance/network_page.md
+++ b/content/en/network_monitoring/performance/network_page.md
@@ -183,7 +183,6 @@ If you have [setup][9] enhanced resolution for AWS or Azure, NPM can filter and 
 
 #### Azure
 ##### Loadbalancers and Application Gateways
- {{% tab "Loadbalancers and Application Gateways" %}}
  - name
  - loadbalancer
  - cloud_provider

--- a/content/en/network_monitoring/performance/network_page.md
+++ b/content/en/network_monitoring/performance/network_page.md
@@ -182,7 +182,7 @@ If you have [setup][9] enhanced resolution for AWS or Azure, NPM can filter and 
  {{< /tabs >}}
 
 #### Azure
-{{< tabs >}}
+##### Loadbalancers and Application Gateways
  {{% tab "Loadbalancers and Application Gateways" %}}
  - name
  - loadbalancer

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -444,7 +444,7 @@ To set up on AWS ECS, see the [AWS ECS][1] documentation page.
 ### Enhanced Resolution
 
 Optionally, enable resource collection for cloud integrations to allow Network Performance Monitoring to discover cloud-managed entities.
-- Install the [Azure integration][1] for visibility into Azure load balancers and NAT gateways.
+- Install the [Azure integration][1] for visibility into Azure load balancers and application gateways.
 - Install the [AWS Integration][2] for visibility into AWS Load Balancer. **you must enable ENI and EC2 metric collection**
 
 For additional information around these capabilities, please see [Cloud service enhanced resolution][3].

--- a/content/en/network_monitoring/performance/setup.md
+++ b/content/en/network_monitoring/performance/setup.md
@@ -441,13 +441,13 @@ To set up on AWS ECS, see the [AWS ECS][1] documentation page.
 {{< /tabs >}}
 
 {{< site-region region="us,us3,us5,eu" >}}
-### Enhanced Resolution
+### Enhanced resolution
 
 Optionally, enable resource collection for cloud integrations to allow Network Performance Monitoring to discover cloud-managed entities.
 - Install the [Azure integration][1] for visibility into Azure load balancers and application gateways.
 - Install the [AWS Integration][2] for visibility into AWS Load Balancer. **you must enable ENI and EC2 metric collection**
 
-For additional information around these capabilities, please see [Cloud service enhanced resolution][3].
+For additional information around these capabilities, see [Cloud service enhanced resolution][3].
 
   [1]: /integrations/azure
   [2]: /integrations/amazon_web_services/#resource-collection


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR mentions the fact that we now support application gateways for Azure. It also includes the set of tags available for azure resources.

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/jira/software/projects/NET/boards/133?selectedIssue=NET-3152

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
