### PR TITLE
Fix GCP cloud schemas

### DIFF
--- a/content/en/security/cspm/custom_rules/schema.md
+++ b/content/en/security/cspm/custom_rules/schema.md
@@ -9,7 +9,7 @@ aliases:
 list_section:
   AWS: Review detailed information about AWS resource types in the following pages.
   Azure: Review detailed information about Azure resource types in the following pages.
-  Google Cloud: Review detailed information about Google Cloud resource types in the following pages.
+  GCP: Review detailed information about Google Cloud resource types in the following pages.
 
 ---
 When you [write custom rules for CSPM][1], you specify the resource types that are referenced by the rules.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes an issue with the CSPM Google Cloud schemas not displaying as expected. Ready to merge.

### Motivation
We changed the word GCP to Google Cloud in a previous PR, but it turns out the single sourcing for the cloud schemas is tied directly to the term "GCP".

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
