### PR TITLE
use advanced syntax on index

### DIFF
--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -40,7 +40,8 @@ const updateSettings = (index) => {
         minWordSizefor2Typos: 7,
         ignorePlurals: true,
         optionalWords: ['the', 'without'],
-        separatorsToIndex: '_@.#'
+        separatorsToIndex: '_@.#',
+        advancedSyntax: true
     };
 
     return index.setSettings(settings, { forwardToReplicas: true });


### PR DESCRIPTION
### What does this PR do?

Enable [advancedSyntax searching](https://www.algolia.com/doc/api-reference/api-parameters/advancedSyntax/) so that exact strings can be searched

### Motivation

Somewhat related to [WEB-3641](https://datadoghq.atlassian.net/browse/WEB-3641) , [WEB-3658](https://datadoghq.atlassian.net/browse/WEB-3658) 
It gives more accurate results when searching exact strings

### Preview

Try searching for `"image name instead of the regular"` including quotes and you will get the exact page vs without quotes where it may pickup others

https://docs-staging.datadoghq.com/david.jones/advanced-syntax/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[WEB-3641]: https://datadoghq.atlassian.net/browse/WEB-3641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-3658]: https://datadoghq.atlassian.net/browse/WEB-3658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ