### PR TITLE
[PROF-7321] Recomend using Ruby profiler "no signals" workaround if needed

### DIFF
--- a/content/en/profiler/profiler_troubleshooting/ruby.md
+++ b/content/en/profiler/profiler_troubleshooting/ruby.md
@@ -81,7 +81,7 @@ Datadog.configure do |c|
 end
 ```
 
-Note that the above setting is only available starting in `dd-trace-rb` 1.12.0.
+**Note**: The above setting is only available starting in `dd-trace-rb` 1.12.0.
 
 Let our team know if you find or suspect any incompatibilities [by opening a support ticket][2].
 Doing this enables Datadog to add them to the auto-detection list, and to work with the gem/library authors to fix the issue.

--- a/content/en/profiler/profiler_troubleshooting/ruby.md
+++ b/content/en/profiler/profiler_troubleshooting/ruby.md
@@ -59,7 +59,7 @@ Datadog.configure do |c|
 end
 ```
 
-## Unexpected run-time failures and errors from Ruby gems that use native extensions in `dd-trace-rb` 1.11.0+
+## Unexpected failures or errors from Ruby gems that use native extensions in `dd-trace-rb` 1.11.0+
 
 Starting from `dd-trace-rb` 1.11.0, the "CPU Profiling 2.0" profiler gathers data by sending `SIGPROF` unix signals to Ruby applications, enabling finer-grained data gathering.
 
@@ -72,15 +72,18 @@ The following incompatibilities are known:
 
 In these cases, the profiler automatically detects the incompatibility and applies a workaround.
 
-If you encounter run-time failures or errors from Ruby gems that use native extensions, you can revert back to the legacy profiler which does not use `SIGPROF` signals. To revert to the legacy profiler, set the `DD_PROFILING_FORCE_ENABLE_LEGACY` environment variable to `true`, or in code:
+If you encounter failures or errors from Ruby gems that use native extensions other than those listed above, you can manually enable the "no signals" workaround, which avoids the use of `SIGPROF` signals.
+To enable this workaround, set the `DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED` environment variable to `true`, or in code:
 
 ```ruby
 Datadog.configure do |c|
-  c.profiling.advanced.force_enable_legacy_profiler = true
+  c.profiling.advanced.no_signals_workaround_enabled = true
 end
 ```
 
-Let our team know if you find or suspect any such incompatibilities [by opening a support ticket][2].
+Note that the above setting is only available starting in `dd-trace-rb` 1.12.0.
+
+Let our team know if you find or suspect any incompatibilities [by opening a support ticket][2].
 Doing this enables Datadog to add them to the auto-detection list, and to work with the gem/library authors to fix the issue.
 
 ## Further Reading


### PR DESCRIPTION
**What does this PR do?**:

In #17552 we documented that the new Ruby "CPU Profiling 2.0" profiler uses unix signals, and that in rare cases this can cause incompatibilities with some other Ruby gems.

At the time, the recommended workaround was to fall back to the legacy profiler.

For `dd-trace-rb` 1.12.0 we'll have a better solution, a new setting that we're calling the "no signals" workaround (https://github.com/DataDog/dd-trace-rb/pull/2873).

This PR updates the documentation to point customers at this better solution, and drops references to using the legacy profiler as we're planning to deprecate it soon.

**Motivation**:

Update the customer guidance for dealing with signal-based incompatibilities.

**Additional Notes**:

This PR is in good shape for review (I hope), but we should hold off on merging it until `dd-trace-rb` 1.12.0 is actually released.

I'll make a note here when that happens :)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
