### PR TITLE
Add cloud cost monitor to navigation

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1010,76 +1010,81 @@ main:
     parent: monitor_types
     identifier: monitor_types_ci
     weight: 206
+  - name: Cloud Cost
+    url: monitors/types/cloud_cost/
+    parent: monitor_types
+    identifier: monitor_types_cloud_cost
+    weight: 207
   - name: Composite
     url: monitors/types/composite/
     parent: monitor_types
     identifier: monitor_types_composite
-    weight: 207
+    weight: 208
   - name: Error Tracking
     url: monitors/types/error_tracking/
     parent: monitor_types
     identifier: monitor_types_error_tracking
-    weight: 208
+    weight: 209
   - name: Event
     url: monitors/types/event/
     parent: monitor_types
     identifier: monitor_types_event
-    weight: 209
+    weight: 210
   - name: Forecast
     url: monitors/types/forecasts/
     parent: monitor_types
     identifier: monitor_types_forecasts
-    weight: 210
+    weight: 211
   - name: Integration
     url: monitors/types/integration/
     parent: monitor_types
     identifier: monitor_types_integration
-    weight: 211
+    weight: 212
   - name: Live Process
     url: monitors/types/process/
     parent: monitor_types
     identifier: monitor_types_process
-    weight: 212
+    weight: 213
   - name: Logs
     url: monitors/types/log/
     parent: monitor_types
     identifier: monitor_types_log
-    weight: 213
+    weight: 214
   - name: Network
     url: monitors/types/network/
     parent: monitor_types
     identifier: monitor_types_network
-    weight: 214
+    weight: 215
   - name: Outlier
     url: monitors/types/outlier/
     parent: monitor_types
     identifier: monitor_types_outlier
-    weight: 215
+    weight: 216
   - name: Process Check
     url: monitors/types/process_check/
     parent: monitor_types
     identifier: monitor_types_process_check
-    weight: 216
+    weight: 217
   - name: Real User Monitoring
     url: monitors/types/real_user_monitoring/
     parent: monitor_types
     identifier: monitor_types_rum
-    weight: 217
+    weight: 218
   - name: Service Check
     url: monitors/types/service_check/
     parent: monitor_types
     identifier: monitor_types_service_check
-    weight: 218
+    weight: 219
   - name: SLO Alerts
     url: monitors/types/slo/
     parent: monitor_types
     identifier: monitor_types_slo
-    weight: 219
+    weight: 220
   - name: Watchdog
     url: monitors/types/watchdog/
     parent: monitor_types
     identifier: monitor_types_watchdog
-    weight: 220
+    weight: 221
   - name: Notifications
     url: monitors/notify/
     parent: alerting

--- a/content/en/monitors/types/_index.md
+++ b/content/en/monitors/types/_index.md
@@ -25,6 +25,7 @@ further_reading:
 {{< nextlink href="/monitors/types/apm" >}}<strong>APM</strong>: Monitor APM metrics or trace queries.{{< /nextlink >}}
 {{< nextlink href="/monitors/types/audit_trail" >}}<strong>Audit Trail</strong>: Alert when a specified type of audit log exceeds a user-defined threshold over a given period of time.{{< /nextlink >}}
 {{< nextlink href="/monitors/types/ci" >}}<strong>CI</strong>: Monitor CI pipelines and tests data gathered by Datadog.{{< /nextlink >}}
+{{< nextlink href="/monitors/types/cloud_cost" >}}<strong>Cloud Cost</strong>: Monitor cost changes associated with cloud platforms.{{< /nextlink >}}
 {{< nextlink href="/monitors/types/composite" >}}<strong>Composite</strong>: Alert on an expression combining multiple monitors.{{< /nextlink >}}
 {{< nextlink href="/monitors/types/error_tracking" >}}<strong>Error Tracking</strong>: Monitor issues in your applications gathered by Datadog.{{< /nextlink >}}
 {{< nextlink href="/monitors/types/event" >}}<strong>Event</strong>: Monitor events gathered by Datadog.{{< /nextlink >}}

--- a/content/en/monitors/types/cloud_cost.md
+++ b/content/en/monitors/types/cloud_cost.md
@@ -1,7 +1,6 @@
 ---
 title: Cloud Cost Monitor
 kind: documentation
-private: true
 description: "Monitor costs associated with cloud platforms."
 further_reading:
 - link: "https://docs.datadoghq.com/cloud_cost_management/?tab=aws#overview"
@@ -17,10 +16,6 @@ further_reading:
   tag: "Documentation"
   text: "Consult your monitor status"
 ---
-
-<div class="alert alert-warning">
-The feature discussed on this page is in private beta. Contact your Customer Success Manager to learn more about it.
-</div>
 
 ## Overview
 Get proactive notifications on cost changes to help mitigate unexpected cloud spend. Cloud Cost Monitors help you identify cost changes quickly so you can investigate the cause. You can configure your alerts to catch unexpected changes.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- Add Cloud Cost to the Monitor Types page
- Add Cloud Cost to the left navigation
- Remove the private beta banner

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/browse/DOCS-5173

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Ready to merge after review

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
