### PR TITLE
[WEB-3464] Adds TrustArc cookie consent banner to Docs site

### DIFF
--- a/assets/scripts/cookie-banner.js
+++ b/assets/scripts/cookie-banner.js
@@ -1,0 +1,49 @@
+window.addEventListener('load', function () {
+    const { env } = document.documentElement.dataset;
+
+    if (env !== 'development') {
+        // add trustarc script to head
+        const trustarc = document.createElement('script');
+        trustarc.setAttribute('src','https://consent.trustarc.com/v2/notice/ufocto');
+        document.head.appendChild(trustarc);
+
+        // add divs
+        const divA = document.createElement("div");
+        const divB = document.createElement("div");
+        divA.id = "teconsent";
+        divA.style = "cursor: pointer; color:#fff"
+        divB.id = "consent-banner";
+        divB.style = "position:fixed; bottom:0px; right:0px; width:100%; z-index:-1";
+        document.body.appendChild(divA);
+        document.body.appendChild(divB);
+        
+        // update Cookie link
+        this.setTimeout(function () {
+            const target = document.getElementById('truste-consent-track');
+            const prefsElement = document.getElementById('teconsent');
+            const cookieLink = document.querySelector('footer a[href*="/cookies"]');
+
+            if (target) {
+                // update z-index on banner
+                const observer = new MutationObserver(function (mutations) {
+                    mutations.forEach(function () {
+                        if (target.style.display === 'none') {
+                            target.parentElement.style.zIndex = -1
+                        } else {
+                            target.parentElement.style.setProperty('z-index', '999999', 'important');
+                        }
+                    });
+                });
+
+                if (target.style.display !== 'none') {
+                    target.parentElement.style.setProperty('z-index', '999999', 'important');
+                }
+
+                observer.observe(target, { attributes: true, attributeFilter: ['style'] });
+            }
+
+            // replace Cookie link with Prefs div
+            return (cookieLink && document.getElementById('teconsent').innerHTML.length > 0) ? cookieLink.replaceWith(prefsElement) : false;
+        }, 500);
+    }
+});

--- a/assets/scripts/main-dd-js.js
+++ b/assets/scripts/main-dd-js.js
@@ -6,6 +6,7 @@ import 'bootstrap/js/dist/collapse';
 import './datadog-docs';
 import './utms';
 import './alpine';
+import './cookie-banner';
 
 import './components/copy-code';
 import './components/global-modals';

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,11 +3,7 @@
   data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0"
   class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner announcement{{ end }}">
 
-<head>
-  <!-- TrustArc -->
-  <script type="text/javascript" src="https://consent.trustarc.com/v2/autoblockasset/core.min.js?cmId=ufocto"></script>
-  <script type="text/javascript" src="https://consent.trustarc.com/v2/autoblock?cmId=ufocto"></script>
-  
+<head>  
   {{ partialCached "header-scripts.html" . }}
 
   <meta charset="utf-8">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,10 @@
   class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner announcement{{ end }}">
 
 <head>
-
+  <!-- TrustArc -->
+  <script type="text/javascript" src="https://consent.trustarc.com/v2/autoblockasset/core.min.js?cmId=ufocto"></script>
+  <script type="text/javascript" src="https://consent.trustarc.com/v2/autoblock?cmId=ufocto"></script>
+  
   {{ partialCached "header-scripts.html" . }}
 
   <meta charset="utf-8">

--- a/layouts/partials/header-scripts.html
+++ b/layouts/partials/header-scripts.html
@@ -1,3 +1,7 @@
+<!-- TrustArc -->
+<script type="text/javascript" src="https://consent.trustarc.com/v2/autoblockasset/core.min.js?cmId=ufocto"></script>
+<script type="text/javascript" src="https://consent.trustarc.com/v2/autoblock?cmId=ufocto"></script>
+
 {{ if .Params.header_scripts }}
     {{ range $k, $v := .Params.header_scripts }}
 


### PR DESCRIPTION
### What does this PR do?
Adds TrustArc dependent scripts and logic for cookie consent banner. No visible changes except from EU-region

### Preview
https://docs-staging.datadoghq.com/nsollecito/cookie-banner/

### Additional Notes
<img width="1222" alt="Screenshot 2023-05-24 at 1 43 41 PM" src="https://github.com/DataDog/documentation/assets/1014995/89aa04f5-807b-4f37-9bf3-84eca9a253df">


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
