### PR TITLE
(DOCS-5548) Fix Vale

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,8 +7,6 @@ jobs:
     timeout-minutes: 5
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: Clone Datadog Vale
       uses: actions/checkout@v3
@@ -18,21 +16,12 @@ jobs:
     
     - name: Edit StylesPath in Vale config file 
       run: sed -i 's/\.\.\/datadog-vale\/styles/datadog-vale\/styles/' .vale.ini
-
-    - name: Find changed files
-      id: changed_files
-      uses: tj-actions/changed-files@v35
-      with:
-        separator: ","
-        include_all_old_new_renamed_files: true
     
     - name: Run Vale
       uses: errata-ai/vale-action@reviewdog
       with:
-        separator: ","
         reporter: github-pr-check
         fail_on_error: true
-        filter_mode: diff_context
-        files: ${{ steps.changed_files.outputs.all_changed_files }}
+        filter_mode: added
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
There seems to be a bug in the Vale action that makes the `files` and `filter_mode` variables mutually exclusive. The check was finding errors in parts of the files that had not been modified in the commits, which was leading to confusion. It was especially annoying in large PRs like the translation PRs. This removes the `files` logic from the action so that the checks will pass as long as there are no errors in directly modified lines.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
