### PR TITLE
Add heroku buildpack for PHP

### DIFF
--- a/content/en/developers/community/libraries.md
+++ b/content/en/developers/community/libraries.md
@@ -89,6 +89,10 @@ Heroku emits dyno metrics through logs. To convert these logs into metrics and s
 * [Heroku Datadog Log Drain][35] written in Nodejs by [Oz][36].
 * [Heroku Datadog Log Drain][37] written in Go by [Apiary][38].
 
+To use the tracer or profiler on Heroku you may use a buildpack.
+
+* [Heroku Datadog PHP Tracer/Profiler Buildpack][65] maintained by [SpeedCurve][66].
+
 ### Jira
 
 A [tool][39] to poll data from Jira and upload it as metrics to Datadog.
@@ -218,3 +222,5 @@ If you've written a Datadog library and would like to add it to this page, send 
 [62]: https://github.com/urosgruber/dd-agent-FreeBSD
 [63]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/networking/dd-agent
 [64]: mailto:opensource@datadoghq.com
+[65]: https://github.com/SpeedCurve-Metrics/heroku-buildpack-php-ddtrace
+[66]: https://www.speedcurve.com/

--- a/content/en/developers/community/libraries.md
+++ b/content/en/developers/community/libraries.md
@@ -91,7 +91,7 @@ Heroku emits dyno metrics through logs. To convert these logs into metrics and s
 
 To use the PHP tracer or profiler on Heroku, use the following buildpack.
 
-* [Heroku Datadog PHP Tracer/Profiler Buildpack][65] maintained by [SpeedCurve][66].
+* [Heroku Datadog PHP Tracer and Profiler Buildpack][65] maintained by [SpeedCurve][66].
 
 ### Jira
 

--- a/content/en/developers/community/libraries.md
+++ b/content/en/developers/community/libraries.md
@@ -89,7 +89,7 @@ Heroku emits dyno metrics through logs. To convert these logs into metrics and s
 * [Heroku Datadog Log Drain][35] written in Nodejs by [Oz][36].
 * [Heroku Datadog Log Drain][37] written in Go by [Apiary][38].
 
-To use the tracer or profiler on Heroku you may use a buildpack.
+To use the PHP tracer or profiler on Heroku, use the following buildpack.
 
 * [Heroku Datadog PHP Tracer/Profiler Buildpack][65] maintained by [SpeedCurve][66].
 


### PR DESCRIPTION
### What does this PR do?

We found out due to a customer request, that there is a 3rd party maintaining a Heroku Buildpack which adds the PHP tracer (and with [this PR](https://github.com/SpeedCurve-Metrics/heroku-buildpack-php-ddtrace/pull/3) also the profiler) to Heroku.

### Motivation

Have customers on Heroku find this and enable them to use the PHP tracer and profiler

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
