### PR TITLE
Remove line about scoped permissions

### DIFF
--- a/content/en/account_management/rbac/permissions.md
+++ b/content/en/account_management/rbac/permissions.md
@@ -41,7 +41,7 @@ All users can read all data types. Admin and Standard users have write permissio
 
 **Note**: When adding a new custom role to a user, make sure to remove the out-of-the-box Datadog role associated with that user in order to enforce the new role permissions.
 
-In addition to the general permissions, you can define more granular permissions for specific assets or data types. Permissions can be either global or scoped to a subset of elements. Find below the details of these options and the impact they have on each available permission.
+In addition to the general permissions, you can define more granular permissions for specific assets or data types. In the tables below, find the details of these options and the impact they have on each available permission.
 
 {{% permissions %}}
 


### PR DESCRIPTION
### What does this PR do?
A product manager requested that we remove the "Scoped" column from the permissions on this page. The Websites team is doing that. This change removes the accompanying text.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-3646

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
ready to merge

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
