### PR TITLE
Fix configuration key name  from "trace.obfuscation.query.string.regexp" to "obfuscation.query.string.regexp"

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -231,8 +231,8 @@ Statsd host to send JMX metrics to. If you are using Unix Domain Sockets, use an
 **Default**: `8125`<br>
 StatsD port to send JMX metrics to. If you are using Unix Domain Sockets, input 0.
 
-`dd.trace.obfuscation.query.string.regexp`
-: **Environment Variable**: `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP`<br>
+`dd.obfuscation.query.string.regexp`
+: **Environment Variable**: `DD_OBFUSCATION_QUERY_STRING_REGEXP`<br>
 **Default**: `null`<br>
 A regex to redact sensitive data from incoming requests' query string reported in the `http.url` tag (matches are replaced with <redacted>).
   


### PR DESCRIPTION

### What does this PR do?
There is a discrepancy in the Java tracer compared to the other tracers.
The configuration key in Java is dd.obfuscation.query.string.regexp while it's dd.trace.obfuscation.query.string.regexp in the other tracers.

### Motivation
Having documentation that matches the code

<!-- ### Preview -->


### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
