### PR TITLE
Add DD_SITE config on heroku-ruby

### DIFF
--- a/content/en/agent/guide/heroku-ruby.md
+++ b/content/en/agent/guide/heroku-ruby.md
@@ -80,6 +80,9 @@ heroku labs:enable runtime-dyno-metadata -a $APPNAME
 # Set hostname in Datadog as appname.dynotype.dynonumber for metrics continuity
 heroku config:add DD_DYNO_HOST=true
 
+# Set your hostzone (eg: us5.datadoghq.com) 
+heroku config:add DD_SITE=$DD_SITE
+
 # Add this buildpack and set your Datadog API key
 heroku buildpacks:add --index 1 https://github.com/DataDog/heroku-buildpack-datadog.git
 heroku config:add DD_API_KEY=$DD_API_KEY

--- a/content/en/agent/guide/heroku-ruby.md
+++ b/content/en/agent/guide/heroku-ruby.md
@@ -80,7 +80,7 @@ heroku labs:enable runtime-dyno-metadata -a $APPNAME
 # Set hostname in Datadog as appname.dynotype.dynonumber for metrics continuity
 heroku config:add DD_DYNO_HOST=true
 
-# Set your hostzone (eg: us5.datadoghq.com) 
+# Set your Datadog site (for example, us5.datadoghq.com) 
 heroku config:add DD_SITE=$DD_SITE
 
 # Add this buildpack and set your Datadog API key


### PR DESCRIPTION
### What does this PR do?
- Add DD_SITE configuration on docs for heroku

### Motivation
Since datadog support multiple zones we need to set the DD_SITE env.

### Additional Notes
Perhaps I should provide guidance on how to get the right zone?

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
