### PR TITLE
Add AD v2 annotations documentation to cluster and endpoint checks

### DIFF
--- a/content/en/containers/cluster_agent/clusterchecks.md
+++ b/content/en/containers/cluster_agent/clusterchecks.md
@@ -338,6 +338,67 @@ instances:
 
 ### Configuration from Kubernetes service annotations
 
+{{< tabs >}}
+{{% tab "Kubernetes (AD v2)" %}}
+
+**Note:** AD Annotations v2 was introduced in Datadog Agent 7.36 to simplify integration configuration. For previous versions of the Datadog Agent, use AD Annotations v1.
+
+The syntax for annotating services is similar to that for [annotating Kubernetes Pods][1]:
+
+```yaml
+ad.datadoghq.com/service.checks: |
+  {
+    "<INTEGRATION_NAME>": {
+      "init_config": <INIT_CONFIG>,
+      "instances": [<INSTANCE_CONFIG>]
+    }
+  }
+```
+
+This syntax supports a `%%host%%` [template variable][11], which is replaced by the service's IP. The `kube_namespace` and `kube_service` tags are automatically added to the instance.
+
+#### Example: HTTP check on an NGINX-backed service
+
+The following service definition exposes the Pods from the `my-nginx` deployment and runs an [HTTP check][10] to measure the latency of the load balanced service:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+    name: my-nginx
+    labels:
+        run: my-nginx
+        tags.datadoghq.com/env: "prod"
+        tags.datadoghq.com/service: "my-nginx"
+        tags.datadoghq.com/version: "1.19.0"
+    annotations:
+      ad.datadoghq.com/service.checks: |
+        {
+          "http_check": {
+            "init_config": {},
+            "instances": [
+              {
+                "url":"http://%%host%%",
+                "name":"My Nginx",
+                "timeout":1
+              }
+            ]
+          }
+        }
+spec:
+    ports:
+        - port: 80
+          protocol: TCP
+    selector:
+        run: my-nginx
+```
+
+In addition, each Pod should be monitored with the [NGINX check][12], as it enables the monitoring of each worker as well as the aggregated service.
+
+{{% /tab %}}
+
+{{% tab "Kubernetes (AD v1)" %}}
+
 The syntax for annotating services is similar to that for [annotating Kubernetes Pods][1]:
 
 ```yaml
@@ -382,6 +443,9 @@ spec:
 ```
 
 In addition, each Pod should be monitored with the [NGINX check][12], as it enables the monitoring of each worker as well as the aggregated service.
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Validation
 

--- a/content/en/containers/cluster_agent/clusterchecks.md
+++ b/content/en/containers/cluster_agent/clusterchecks.md
@@ -395,6 +395,10 @@ spec:
 
 In addition, each Pod should be monitored with the [NGINX check][12], as it enables the monitoring of each worker as well as the aggregated service.
 
+[1]: /agent/kubernetes/integrations/
+[10]: /integrations/http_check/
+[11]: /agent/faq/template_variables/
+[12]: /integrations/nginx/
 {{% /tab %}}
 
 {{% tab "Kubernetes (AD v1)" %}}
@@ -443,6 +447,11 @@ spec:
 ```
 
 In addition, each Pod should be monitored with the [NGINX check][12], as it enables the monitoring of each worker as well as the aggregated service.
+
+[1]: /agent/kubernetes/integrations/
+[10]: /integrations/http_check/
+[11]: /agent/faq/template_variables/
+[12]: /integrations/nginx/
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/containers/cluster_agent/endpointschecks.md
+++ b/content/en/containers/cluster_agent/endpointschecks.md
@@ -220,6 +220,8 @@ instances:
 {{< tabs >}}
 {{% tab "Kubernetes (AD v2)" %}}
 
+**Note:** AD Annotations v2 was introduced in Datadog Agent 7.36 to simplify integration configuration. For previous versions of the Datadog Agent, use AD Annotations v1.
+
 The syntax for annotating services is similar to that for [annotating Kubernetes Pods][1]:
 
 ```yaml

--- a/content/en/containers/cluster_agent/endpointschecks.md
+++ b/content/en/containers/cluster_agent/endpointschecks.md
@@ -292,6 +292,11 @@ spec:
         app: nginx
 ```
 
+[1]: /containers/kubernetes/integrations/?tab=kubernetesadv2
+[9]: /integrations/http_check/
+[11]: /agent/kubernetes/integrations/?tab=kubernetes#supported-template-variables
+[12]: /integrations/nginx/
+[13]: /getting_started/tagging/unified_service_tagging
 
 {{% /tab %}}
 
@@ -355,6 +360,12 @@ spec:
     selector:
         app: nginx
 ```
+
+[9]: /integrations/http_check/
+[10]: /agent/kubernetes/integrations/?tab=kubernetes#template-source-kubernetes-pod-annotations
+[11]: /agent/kubernetes/integrations/?tab=kubernetes#supported-template-variables
+[12]: /integrations/nginx/
+[13]: /getting_started/tagging/unified_service_tagging
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
Cluster checks and Endpoint checks documentation were not up to date, as they didn't include v2 of the AD annotations, which are recommended from Agent 7.36.

This PR adds this.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
