### PR TITLE
Add fips enabled options in Agent definition when using FIPS on ECS

### DIFF
--- a/content/en/containers/amazon_ecs/_index.md
+++ b/content/en/containers/amazon_ecs/_index.md
@@ -234,7 +234,7 @@ To send data to Datadog's GOVCLOUD datacenter, add the `fips-proxy` sidecar cont
      (...)
           {
             "name": "fips-proxy",
-            "image": "datadog/fips-proxy:0.5.0",
+            "image": "datadog/fips-proxy:0.5.2",
             "portMappings": [
                 {
                     "containerPort": 9803,

--- a/content/en/containers/amazon_ecs/_index.md
+++ b/content/en/containers/amazon_ecs/_index.md
@@ -322,6 +322,10 @@ You also need to update the environment variables of the Datadog Agent's contain
             "environment": [
               (...)
                 {
+                    "name": "DD_FIPS_ENABLED",
+                    "value": "true"
+                },
+                {
                     "name": "DD_FIPS_PORT_RANGE_START",
                     "value": "9803"
                 },


### PR DESCRIPTION
### What does this PR do?

Add an Agent option in the FIPS section for ECS

### Motivation

`DD_FIPS_ENABLED` is needed to correctly configure the Agent

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

https://docs-staging.datadoghq.com/nicolas.guerguadj/add-fips-enabled-for-ecs/containers/amazon_ecs/?tab=awscli#fips-proxy-for-govcloud-environments

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
