### PR TITLE
WEB-2437 - add support for tabs and partial comments everywhere

### DIFF
--- a/local/bin/py/build/actions/comment_conversion.py
+++ b/local/bin/py/build/actions/comment_conversion.py
@@ -1,0 +1,21 @@
+import re
+
+regex_tabs_open = re.compile(r"<!-- xxx tabs xxx -->", re.MULTILINE)
+regex_tabs_close = re.compile(r"<!-- xxz tabs xxx -->", re.MULTILINE)
+regex_tab_open = re.compile(r"<!-- xxx tab", re.MULTILINE)
+regex_tab_close = re.compile(r"<!-- xxz tab xxx -->", re.MULTILINE)
+regex_tab_end = re.compile(r" xxx -->", re.MULTILINE)
+regex_partial_open = re.compile(r"<!-- partial", re.MULTILINE)
+regex_partial_close = re.compile(r"partial -->", re.MULTILINE)
+
+
+def replace_comments(text):
+    output = text
+    output = re.sub(regex_tabs_open, "{{< tabs >}}", output, 0)
+    output = re.sub(regex_tabs_close, "{{< /tabs >}}", output, 0)
+    output = re.sub(regex_tab_open, "{{% tab", output, 0)
+    output = re.sub(regex_tab_close, "{{% /tab %}}", output, 0)
+    output = re.sub(regex_tab_end, " %}}", output, 0)
+    output = re.sub(regex_partial_open, "", output, 0)
+    output = re.sub(regex_partial_close, "", output, 0)
+    return output

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -26,6 +26,7 @@ from os.path import (
 )
 
 from actions.format_link import format_link_file
+from actions.comment_conversion import replace_comments
 
 try:
     from assetlib.classifiers import get_all_classifier_names, get_non_deprecated_classifiers
@@ -84,27 +85,6 @@ class Integrations:
         )
         self.regex_h1_replace = re.compile(
             r"^(#{1})(?!#)(.*)", re.MULTILINE
-        )
-        self.regex_tabs_open = re.compile(
-            r"<!-- xxx tabs xxx -->", re.MULTILINE
-        )
-        self.regex_tabs_close = re.compile(
-            r"<!-- xxz tabs xxx -->", re.MULTILINE
-        )
-        self.regex_tab_open = re.compile(
-            r"<!-- xxx tab", re.MULTILINE
-        )
-        self.regex_tab_close = re.compile(
-            r"<!-- xxz tab xxx -->", re.MULTILINE
-        )
-        self.regex_tab_end = re.compile(
-            r" xxx -->", re.MULTILINE
-        )
-        self.regex_partial_open = re.compile(
-            r"<!-- partial", re.MULTILINE
-        )
-        self.regex_partial_close = re.compile(
-            r"partial -->", re.MULTILINE
         )
         self.regex_metrics = re.compile(
             r"(#{3} Metrics\n)([\s\S]*this integration.|[\s\S]*this check.)([\s\S]*)(#{3} Events\n)",
@@ -777,27 +757,7 @@ class Integrations:
             result = re.sub(
                 self.regex_h1, "", result, 1
             )
-            result = re.sub(
-                self.regex_tabs_open, "{{< tabs >}}", result, 0
-            )
-            result = re.sub(
-                self.regex_tabs_close, "{{< /tabs >}}", result, 0
-            )
-            result = re.sub(
-                self.regex_tab_open, "{{% tab", result, 0
-            )
-            result = re.sub(
-                self.regex_tab_close, "{{% /tab %}}", result, 0
-            )
-            result = re.sub(
-                self.regex_tab_end, " %}}", result, 0
-            )
-            result = re.sub(
-                self.regex_partial_open, "", result, 0
-            )
-            result = re.sub(
-                self.regex_partial_close, "", result, 0
-            )
+            result = replace_comments(result)
             # result = re.sub(
             #     self.regex_site_region, r"{{% \1 %}}", result, 0
             # )

--- a/local/bin/py/build/actions/pull_and_push_file.py
+++ b/local/bin/py/build/actions/pull_and_push_file.py
@@ -6,6 +6,7 @@ import yaml
 
 from os.path import basename
 from process_agent_config import process_agent_config
+from actions.comment_conversion import replace_comments
 
 TEMPLATE = """\
 ---
@@ -35,6 +36,10 @@ def pull_and_push_file(content, content_dir):
             new_yml = yaml.safe_load(fm)
         elif len(split) == 1:
             txt = split[0]
+
+        # replace html comments with shortcodes
+        txt = replace_comments(txt)
+
         # If options include front params, then the H1 title of the source file is striped
         # and the options front params are inlined
         if "front_matters" in content["options"]:

--- a/local/bin/py/build/actions/pull_and_push_folder.py
+++ b/local/bin/py/build/actions/pull_and_push_folder.py
@@ -8,6 +8,8 @@ from itertools import chain
 from os import makedirs
 from os.path import basename
 
+from actions.comment_conversion import replace_comments
+
 TEMPLATE = """\
 ---
 {front_matter}
@@ -69,6 +71,10 @@ def pull_and_push_folder(content, content_dir):
                 txt,
                 count=0,
             )
+
+            # replace html comments with shortcodes
+            txt = replace_comments(txt)
+
             file_content = TEMPLATE.format(front_matter=front_matter, content=txt.strip())
             # Replacing the master README.md by _index.md to follow Hugo logic
             if file_name.endswith("README.md"):


### PR DESCRIPTION
### What does this PR do?

move comment to shortcode replacements to a seperate file and use it in other file sourcing beyond integrations

### Motivation

https://datadoghq.atlassian.net/browse/WEB-2437

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
