### PR TITLE
GKE Autopilot doc changes. 

### DIFF
--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -235,7 +235,7 @@ Since Agent 7.26, no specific configuration is required for GKE (whether you run
 
 GKE Autopilot requires some configuration, shown below.
 
-Datadog recommends that you specify resource limits for the Agent container. Autopilot sets a relatively low default limit (50m CPU, 100Mi memory) that may quickly lead the Agent container to OOMKill depending on your environment. If applicable, also specify resource limits for the Trace Agent and Process Agent containers. Additionally, you may wish to reate a priority class for the agent in order to ensure it is scheduled. 
+Datadog recommends that you specify resource limits for the Agent container. Autopilot sets a relatively low default limit (50m CPU, 100Mi memory) that may quickly lead the Agent container to OOMKill depending on your environment. If applicable, also specify resource limits for the Trace Agent and Process Agent containers. Additionally, you may wish to create a priority class for the Agent in order to ensure it is scheduled. 
 
 {{< tabs >}}
 {{% tab "Helm" %}}

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -279,8 +279,6 @@ agents:
           memory: 200Mi
     
     priorityClassCreate: true
-    priorityClassName: datadog-priority
-    priorityClassValue: 1000
 
 providers:
   gke:

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -235,7 +235,7 @@ Since Agent 7.26, no specific configuration is required for GKE (whether you run
 
 GKE Autopilot requires some configuration, shown below.
 
-Datadog recommends that you specify resource limits for the Agent container. Autopilot sets a relatively low default limit (50m CPU, 100Mi memory) that may quickly lead the Agent container to OOMKill depending on your environment. If applicable, also specify resource limits for the Trace Agent and Process Agent containers.
+Datadog recommends that you specify resource limits for the Agent container. Autopilot sets a relatively low default limit (50m CPU, 100Mi memory) that may quickly lead the Agent container to OOMKill depending on your environment. If applicable, also specify resource limits for the Trace Agent and Process Agent containers. Additionally, you may wish to reate a priority class for the agent in order to ensure it is scheduled. 
 
 {{< tabs >}}
 {{% tab "Helm" %}}
@@ -263,17 +263,11 @@ agents:
         requests:
           cpu: 200m
           memory: 256Mi
-        limits:
-          cpu: 200m
-          memory: 256Mi
 
     traceAgent:
       # resources for the Trace Agent container
       resources:
         requests:
-          cpu: 100m
-          memory: 200Mi
-        limits:
           cpu: 100m
           memory: 200Mi
 
@@ -283,9 +277,10 @@ agents:
         requests:
           cpu: 100m
           memory: 200Mi
-        limits:
-          cpu: 100m
-          memory: 200Mi
+    
+    priorityClassCreate: true
+    priorityClassName: datadog-priority
+    priorityClassValue: 1000
 
 providers:
   gke:


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Makes a few minor tweaks to the GKE Autopilot docs based on information submitted on [this card](https://datadoghq.atlassian.net/browse/CONS-5598), which comes from a Google employee working to test our product on autopilot. 

Specifically it removes `resources.limits` from the spec since Autopilot doesn't use them, and adds a priority class to the agent to help it get scheduled. 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
