### PR TITLE
session replay recording length question

### DIFF
--- a/content/en/account_management/billing/rum.md
+++ b/content/en/account_management/billing/rum.md
@@ -17,7 +17,11 @@ A session is a user journey on your web or mobile application. A session usually
 
 ## When does a session expire?
 
-A session expires after 15 minutes of inactivity, and its duration is limited to 4 hours. After 4 hours, a new session is automatically created. 
+A session expires after 15 minutes of inactivity, and its duration is limited to 4 hours. After 4 hours, a new session is automatically created.
+
+## How long are Session Replay recordings?
+
+Session Replay recordings can vary based on the session length. For example, if you're observing short, 5-8 second Session Replays, that means the user ended their session after 5-8 seconds.
 
 ## What data does Datadog RUM & Session Replay collect?
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a new Q&A to the Account Management section about Session Replay lengths.

### Motivation
Reduce customer confusion about short Session Replays, per [DOCS-5499](https://datadoghq.atlassian.net/browse/DOCS-5499).

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Ready for merge.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5499]: https://datadoghq.atlassian.net/browse/DOCS-5499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ