### PR TITLE
fix glossary ja - [WEB-3672]

### DIFF
--- a/assets/styles/pages/_glossary.scss
+++ b/assets/styles/pages/_glossary.scss
@@ -20,21 +20,10 @@
             background: white;
             width: 100%;
             top: 89px;
-
-            &:lang(ja) {
-                height: 130px;
-            }
         }
 
         @include media-breakpoint-up(lg) {
             top: 95px;
-
-            &:lang(ja) {
-                height: 150px;
-            }
-        }
-        .nav{
-            height: 50px;
         }
 
         button.filter-btn{

--- a/content/fr/glossary/_index.md
+++ b/content/fr/glossary/_index.md
@@ -7,6 +7,7 @@ scrollspy:
   offset: 5
   target: '#glossary-nav'
 title: Glossaire
+filter_all: All
 ---
 
 <div class="alert alert-info"><strong>Bienvenue sur notre glossaire (version bêta) !</strong> Nous travaillons activement à compiler une liste complète des termes utilisés, ce qui peut prendre du temps. Si vous souhaitez nous faire part de votre avis sur le fonctionnement de ce glossaire ou demander l'ajout d'un terme, merci de cliquer sur le lien <strong>Feedback</strong>.</a></div>

--- a/layouts/glossary/list.html
+++ b/layouts/glossary/list.html
@@ -56,7 +56,7 @@
                     {{ $curr_letter := $.Scratch.Get "curr_letter" }}
                     {{ $core_products_string := (delimit (.Params.core_product | default "") ",") }}
                     <!-- Letter Header -->
-                    {{ if ne $first_char $curr_letter }}
+                    {{ if and (ne $first_char $curr_letter) (not (in $letters $first_char)) }}
                         {{ $.Scratch.Set "curr_letter" $first_char }}
                         {{ $letters = $letters | append $first_char }}
                         <h2 

--- a/layouts/glossary/list.html
+++ b/layouts/glossary/list.html
@@ -35,7 +35,7 @@
             window.scroll(0, 0)
         },
         setGlossaryNavHeight (nav) {
-            this.glossaryNavHeight = nav.getBoundingClientRect().height - 25
+            this.glossaryNavHeight = nav.getBoundingClientRect().height - 50
         },
         setActiveGlossaryLetterToHighlight (glossaryLetterEl) {
             const letterDistanceFromTop = glossaryLetterEl.getBoundingClientRect().top
@@ -55,7 +55,6 @@
                     {{ $first_char := substr .Title 0 1 | upper }}
                     {{ $curr_letter := $.Scratch.Get "curr_letter" }}
                     {{ $core_products_string := (delimit (.Params.core_product | default "") ",") }}
-
                     <!-- Letter Header -->
                     {{ if ne $first_char $curr_letter }}
                         {{ $.Scratch.Set "curr_letter" $first_char }}
@@ -91,7 +90,7 @@
                         <h4 
                         id="{{ anchorize .Params.Title }}" 
                         class="glossary-term font-24-28"
-                        :style="{scrollMarginTop: `${glossaryNavHeight+10}px`}"
+                        :style="{scrollMarginTop: `${glossaryNavHeight+30}px`}"
                         x-init="$nextTick(() => appendToFilteredLetters($el.parentElement))"
                         >
                             {{ .Params.Title }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

1. removes restrictive height on glossary nav
   - adjusts the scroll to positioning
2.  removes duplicate letter headers in ja glossary
3. add 'All' button text to the france glossary

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/browse/WEB-3672

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/stefon.simmons/fix-glossary-ja/ja/glossary/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
