### PR TITLE
DOCS-5470 Fix java example import statement

### DIFF
--- a/content/en/security/application_security/threats/add-user-info.md
+++ b/content/en/security/application_security/threats/add-user-info.md
@@ -50,8 +50,10 @@ User monitoring tags are applied on the root span and start with the prefix `usr
 The example below shows how to obtain the root span, add the relevant user monitoring tags, and enable user blocking capability:
 
 ```java
-import datadog.trace.api.GlobalTracer;
-import datadog.appsec.api.Blocking;
+import io.opentracing.Span;
+import io.opentracing.util.GlobalTracer;
+import datadog.appsec.api.blocking.Blocking;
+import datadog.trace.api.interceptor.MutableSpan;
 
 // Get the active span
 final Span span = GlobalTracer.get().activeSpan();


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Corrects the import statement in the java example

### Motivation

https://github.com/DataDog/documentation/issues/18103 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
