### PR TITLE
Clarify rate metric type submission for dogstatsd

### DIFF
--- a/content/en/metrics/custom_metrics/dogstatsd_metrics_submission.md
+++ b/content/en/metrics/custom_metrics/dogstatsd_metrics_submission.md
@@ -21,7 +21,7 @@ While StatsD accepts only metrics, DogStatsD accepts all three of the major Data
 
 [COUNT](#count), [GAUGE](#gauge), and [SET](#set) metric types are familiar to StatsD users. `TIMER` from StatsD is a sub-set of `HISTOGRAM` in DogStatsD. Additionally, you can submit [HISTOGRAM](#histogram) and [DISTRIBUTION](#distribution) metric types using DogStatsD.
 
-**Note**: Depending on the submission method used, the actual metric type stored within Datadog might differ from the submission metric type.
+**Note**: Depending on the submission method used, the actual metric type stored within Datadog might differ from the submission metric type. When submitting a RATE metric type through DogStatsD, the metric appears as a GAUGE in-app to ensure relevant comparison across different Agents.
 
 ## Functions
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add note that Rate metric type is shown as gauge for DogstatsD submissions

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/browse/DOCS-5133

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Resolves Issue #17427 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
