### PR TITLE
Clarify version links

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/dd_libraries/java.md
@@ -115,9 +115,8 @@ After the agent is installed, to begin tracing your applications:
    wget -O dd-java-agent.jar https://dtdg.co/latest-java-tracer
    ```
 
-   **Note:** To download a specific major version, use the `https://dtdg.co/java-tracer-vX` link instead, where `vX` is the desired version.
-   For example, use `https://dtdg.co/java-tracer-v0` for the latest version 0.
-   Alternatively, see Datadog's [Maven repository][3] for any specific version.
+   **Note:** To download the latest build of a specific **major** version, use the `https://dtdg.co/java-tracer-vX` link instead, where `X` is the desired major version.
+   For example, use `https://dtdg.co/java-tracer-v1` for the latest version 1 build. Minor version numbers must not be included. Alternatively, see Datadog's [Maven repository][3] for any specific version.
 
 2. To run your app from an IDE, Maven or Gradle application script, or `java -jar` command, with the Continuous Profiler, deployment tracking, and logs injection (if you are sending logs to Datadog), add the `-javaagent` JVM argument and the following configuration options, as applicable:
 


### PR DESCRIPTION
### What does this PR do?
Updates and clarifies the major version link for the java tracer.

### Motivation
People were confused when the full x.y.z format link wasn't working.


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
