### PR TITLE
(maint) Fix Vale

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,7 +1,7 @@
 StylesPath = "../datadog-vale/styles"
 MinAlertLevel = suggestion
 
-[content/en/**/*.md]
+[*.md]
 BasedOnStyles = Datadog
 Datadog.Trademarks = NO
 BlockIgnores = (?s) *({{< ?code-block [^>]* >}}.*?{{< ?/ ?code-block >}})

--- a/content/en/agent/guide/agent-5-autodiscovery.md
+++ b/content/en/agent/guide/agent-5-autodiscovery.md
@@ -12,8 +12,6 @@ Autodiscovery was previously called Service Discovery. It's still called Service
 
 Docker is being [adopted rapidly][1]. Orchestration platforms like Docker Swarm, Kubernetes, and Amazon ECS make running Dockerized services easier and more resilient by managing orchestration and replication across hosts. But all of that makes monitoring more difficult. How can you reliably monitor a service which is unpredictably shifting from one host to another?
 
-A perfectly reasonable sentence.
-
 The Datadog Agent can automatically track which services are running where, thanks to its Autodiscovery feature. Autodiscovery lets you define configuration templates for Agent checks and specify which containers each check should apply to.
 
 The Agent enables, disables, and regenerates static check configurations from the templates as containers come and go. When your NGINX container moves from 10.0.0.6 to 10.0.0.17, Autodiscovery helps the Agent update its NGINX check configuration with the new IP address so it can keep collecting NGINX metrics without any action on your part.

--- a/content/en/agent/guide/agent-5-autodiscovery.md
+++ b/content/en/agent/guide/agent-5-autodiscovery.md
@@ -12,6 +12,8 @@ Autodiscovery was previously called Service Discovery. It's still called Service
 
 Docker is being [adopted rapidly][1]. Orchestration platforms like Docker Swarm, Kubernetes, and Amazon ECS make running Dockerized services easier and more resilient by managing orchestration and replication across hosts. But all of that makes monitoring more difficult. How can you reliably monitor a service which is unpredictably shifting from one host to another?
 
+A perfectly reasonable sentence.
+
 The Datadog Agent can automatically track which services are running where, thanks to its Autodiscovery feature. Autodiscovery lets you define configuration templates for Agent checks and specify which containers each check should apply to.
 
 The Agent enables, disables, and regenerates static check configurations from the templates as containers come and go. When your NGINX container moves from 10.0.0.6 to 10.0.0.17, Autodiscovery helps the Agent update its NGINX check configuration with the new IP address so it can keep collecting NGINX metrics without any action on your part.


### PR DESCRIPTION
Fixes the Vale linter. Unfortunately, the config file doesn't like it when we use a file path glob. It only expects file extensions there. So the action will check everything, which takes a little longer. The action itself is still confined to content/en, so it shouldn't run on the translation PRs. And it should only fail on errors added in the PR.

Should be good to merge. 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
