### PR TITLE
[profiling] Fix dualshipping instructions.

### DIFF
--- a/content/en/agent/guide/dual-shipping.md
+++ b/content/en/agent/guide/dual-shipping.md
@@ -55,17 +55,10 @@ In `datadog.yaml`:
 apm_config:
   [...]
   additional_endpoints:
-    "intake.profile.datadoghq.com":
+    "https://trace.agent.datadoghq.com":
     - apikey2
     - apikey3
-    "intake.profile.datadoghq.eu":
-    - apikey4
-
-  profiling_additional_endpoints:
-    "intake.profile.datadoghq.com":
-    - apikey2
-    - apikey3
-    "intake.profile.datadoghq.eu":
+    "https://trace.agent.datadoghq.eu":
     - apikey4
 ```
 
@@ -75,9 +68,35 @@ Requires Agent version >= 6.19 or 7.19.
 
 ```bash
 DD_APM_ADDITIONAL_ENDPOINTS='{\"https://trace.agent.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://trace.agent.datadoghq.eu\": [\"apikey4\"]}'
-
-DD_APM_PROFILING_ADDITIONAL_ENDPOINTS='{\"https://trace.agent.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://trace.agent.datadoghq.eu\": [\"apikey4\"]}'
 ```
+
+## Profiling
+
+### YAML configuration
+
+Requires Agent version >= 6.7.0.
+
+In `datadog.yaml`:
+
+```yaml
+apm_config:
+  [...]
+  profiling_additional_endpoints:
+    "https://intake.profile.datadoghq.com/api/v2/profile":
+    - apikey2
+    - apikey3
+    "https://intake.profile.datadoghq.eu/api/v2/profile":
+    - apikey4
+```
+
+### Environment variable configuration
+
+Requires Agent version >= 6.19 or 7.19.
+
+```bash
+DD_APM_PROFILING_ADDITIONAL_ENDPOINTS='{\"https://intake.profile.datadoghq.com/api/v2/profile\": [\"apikey2\", \"apikey3\"], \"https://intake.profile.datadoghq.eu/api/v2/profile\": [\"apikey4\"]}'
+```
+
 
 ## Live Processes
 

--- a/content/en/agent/guide/dual-shipping.md
+++ b/content/en/agent/guide/dual-shipping.md
@@ -70,7 +70,7 @@ Requires Agent version >= 6.19 or 7.19.
 DD_APM_ADDITIONAL_ENDPOINTS='{\"https://trace.agent.datadoghq.com\": [\"apikey2\", \"apikey3\"], \"https://trace.agent.datadoghq.eu\": [\"apikey4\"]}'
 ```
 
-## Profiling
+## Continuous Profiler
 
 ### YAML configuration
 


### PR DESCRIPTION
### What does this PR do?
Fix wrong examples for profiling dual shipping. 

Also separated profiling dual shipping instructions into its own section, separate from APM for extra clarity that one doesn't necessarily require the other.

Finally, fixed wrong URLs in tracing additional endpoints, yaml version.

### Motivation
Fix wrong instructions.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
