### PR TITLE
expose associated core-products in term container

### DIFF
--- a/layouts/glossary/list.html
+++ b/layouts/glossary/list.html
@@ -72,6 +72,7 @@
                     :class="shouldShowGlossaryTerm('{{ $core_products_string }}') && 'show'" 
                     x-cloak x-show="shouldShowGlossaryTerm('{{ $core_products_string }}')" 
                     data-letter='{{ $first_char | lower }}'
+                    data-products="{{ $core_products_string }}"
                     x-init="$watch('filterValue', _ => appendToFilteredLetters($el))"
                     >
                     


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
add data-products attribute to 'glossary-term-container'.
  - exposes the associated `core-products` of a glossary term for synthetic testing use

### Motivation
<!-- What inspired you to submit this pull request?-->
need to monitor and test glossary functionality via synthetics
 
### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
there should be no visual change: https://docs-staging.datadoghq.com/stefon.simmons/add-data-attr-to-glossary-terms/glossary


### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
