### PR TITLE
Revert "DOCS-4870 update name of module tarball (#16939)"

### DIFF
--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -326,7 +326,7 @@ get_latest_release() {
 BASE_IMAGE=nginx:1.23.2-alpine
 BASE_IMAGE_WITHOUT_COLONS=$(echo "$BASE_IMAGE" | tr ':' '_')
 RELEASE_TAG=$(get_latest_release DataDog/nginx-datadog)
-tarball="nginx_$NGINX_IMAGE_TAG-ngx_http_datadog_module.so.tgz"
+tarball="$BASE_IMAGE_WITHOUT_COLONS-ngx_http_datadog_module.so.tgz"
 wget "https://github.com/DataDog/nginx-datadog/releases/download/$RELEASE_TAG/$tarball"
 tar -xzf "$tarball" -C /usr/lib/nginx/modules
 rm "$tarball"


### PR DESCRIPTION
This reverts commit 6dd624fb762cb8dc8a2d3ff217720429d1733610. The associated customer issue referred to an older version of this documentation. The change made in #16939 then made the installation instructions incorrect. This revision undoes that change, as the "before" of the diff was correct (and more recent than that to which the customer was referring, which is what caused the mix-up).

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
