### PR TITLE
nginx-datadog v1.0.0

### DIFF
--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -335,7 +335,7 @@ load_module modules/ngx_http_datadog_module.so;
 ```
 
 The default configuration connects to a local Datadog Agent and produces traces
-for all NGINX locations. Specify custom configuration via the dedicated
+for all NGINX locations. Specify custom configuration using the dedicated
 `datadog_*` directives described in the Datadog module's [API documentation][15].
 
 For example, the following NGINX configuration sets the service name to
@@ -485,7 +485,7 @@ The [Ingress-NGINX Controller for Kubernetes][13] versions 0.23.0+ include the
 OpenTracing NGINX module.
 
 To enable Datadog tracing, create or edit a ConfigMap to set `enable-opentracing: "true"` and the `datadog-collector-host` to which traces should be sent.
-The name of the ConfigMap will be cited explicitly by the Ingress-NGINX Controller container's command line argument, defaulting to `--configmap=$(POD_NAMESPACE)/nginx-configuration`.
+The name of the ConfigMap is cited explicitly by the Ingress-NGINX Controller container's command line argument, defaulting to `--configmap=$(POD_NAMESPACE)/nginx-configuration`.
 If ingress-nginx was installed via helm chart, this ConfigMap will be named like `Release-Name-nginx-ingress-controller`.
 
 The ingress controller manages both the `nginx.conf` and `/etc/nginx/opentracing.json` files. Tracing is enabled for all `location` blocks.

--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -328,8 +328,6 @@ ls -l /usr/lib/nginx/modules/ngx_http_datadog_module.so
 ```
 
 ### NGINX configuration with Datadog module
-TODO: rewrite this section
-
 In the topmost section of the NGINX configuration, load the Datadog module.
 
 ```nginx
@@ -337,8 +335,8 @@ load_module modules/ngx_http_datadog_module.so;
 ```
 
 The default configuration connects to a local Datadog Agent and produces traces
-for all NGINX locations. Specify custom configuration in a `datadog` JSON block
-within the `http` section of the NGINX configuration.
+for all NGINX locations. Specify custom configuration via the dedicated
+`datadog_*` directives described in the Datadog module's [API documentation][15].
 
 For example, the following NGINX configuration sets the service name to
 `usage-internal-nginx` and the sampling rate to 10%.
@@ -347,19 +345,12 @@ For example, the following NGINX configuration sets the service name to
 load_module modules/ngx_http_datadog_module.so;
 
 http {
-  datadog {
-    "service": "usage-internal-nginx",
-    "sample_rate": 0.1
-  }
+  datadog_service_name usage-internal-nginx;
+  datadog_sample_rate 0.1;
+
+  # servers, locations...
 }
 ```
-
-For information about fields supported by the `datadog` directive and about
-other configuration directives supported by the module, see the [API
-documentation](https://github.com/DataDog/nginx-datadog/blob/master/doc/API.md).
-
-### NGINX Sampling with the Datadog Module
-TODO: Might be able to include this  above.
 
 ## NGINX with OpenTracing module
 The OpenTracing project provides an NGINX module for distributed tracing. The
@@ -579,6 +570,7 @@ variable. To define sampling rules in the Ingress Controller:
 [12]: https://github.com/DataDog/dd-opentracing-cpp/blob/master/doc/sampling.md
 [13]: https://github.com/kubernetes/ingress-nginx
 [14]: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#main-snippet
+[15]: https://github.com/DataDog/nginx-datadog/blob/master/doc/API.md
 {{% /tab %}}
 {{% tab "Istio" %}}
 

--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -13,13 +13,13 @@ further_reading:
   text: "Envoy documentation"
 - link: "https://www.nginx.com/"
   tag: "Documentation"
-  text: "Nginx website"
+  text: "NGINX website"
 - link: "https://kubernetes.github.io/ingress-nginx/user-guide/third-party-addons/opentracing/"
   tag: "Documentation"
-  text: "Nginx Ingress Controller OpenTracing"
+  text: "NGINX Ingress Controller OpenTracing"
 - link: "https://github.com/opentracing-contrib/nginx-opentracing"
   tag: "Source Code"
-  text: "Nginx plugin for OpenTracing"
+  text: "NGINX plugin for OpenTracing"
 - link: "https://istio.io/"
   tag: "Documentation"
   text: "Istio website"
@@ -291,26 +291,20 @@ The available [environment variables][3] depend on the version of the C++ tracer
 [2]: /tracing/trace_pipeline/ingestion_mechanisms/#in-the-agent
 [3]: /tracing/setup/cpp/#environment-variables
 {{% /tab %}}
-{{% tab "Nginx" %}}
+{{% tab "NGINX" %}}
 
-Datadog APM supports Nginx in multiple configurations:
-- Nginx operated as a proxy with tracing provided by the new Datadog module.
-- Nginx operated as a proxy with tracing provided by the OpenTracing module.
-- Nginx as an Ingress Controller for Kubernetes.
+Datadog APM supports NGINX in multiple configurations:
+- NGINX operated as a proxy with tracing provided by the Datadog module.
+- NGINX operated as a proxy with tracing provided by the OpenTracing module.
+- NGINX as an Ingress Controller for Kubernetes.
 
-## Nginx with Datadog module
-Datadog provides an Nginx module for distributed tracing.
-
-<div class="alert alert-warning">
-Datadog Nginx module is in beta. Send feedback to
-<a href="https://docs.datadoghq.com/help/">support</a>.
-We'd love to hear about your experience with the new module.
-</div>
+## NGINX with Datadog module
+Datadog provides an NGINX module for distributed tracing.
 
 ### Module installation
-There is one version of the Datadog Nginx module for each supported Docker
+There is one version of the Datadog NGINX module for each supported Docker
 image. Install the module by downloading the appropriate file from the
-[latest nginx-datadog GitHub release][1] and extracting it into Nginx's modules
+[latest nginx-datadog GitHub release][1] and extracting it into NGINX's modules
 directory.
 
 For example, the module compatible with the Docker image
@@ -333,18 +327,20 @@ rm "$tarball"
 ls -l /usr/lib/nginx/modules/ngx_http_datadog_module.so
 ```
 
-### Nginx configuration with Datadog module
-In the topmost section of the Nginx configuration, load the Datadog module.
+### NGINX configuration with Datadog module
+TODO: rewrite this section
+
+In the topmost section of the NGINX configuration, load the Datadog module.
 
 ```nginx
 load_module modules/ngx_http_datadog_module.so;
 ```
 
 The default configuration connects to a local Datadog Agent and produces traces
-for all Nginx locations. Specify custom configuration in a `datadog` JSON block
-within the `http` section of the nginx configuration.
+for all NGINX locations. Specify custom configuration in a `datadog` JSON block
+within the `http` section of the NGINX configuration.
 
-For example, the following Nginx configuration sets the service name to
+For example, the following NGINX configuration sets the service name to
 `usage-internal-nginx` and the sampling rate to 10%.
 
 ```nginx
@@ -362,19 +358,22 @@ For information about fields supported by the `datadog` directive and about
 other configuration directives supported by the module, see the [API
 documentation](https://github.com/DataDog/nginx-datadog/blob/master/doc/API.md).
 
-## Nginx with OpenTracing module
-The OpenTracing project provides an Nginx module for distributed tracing. The
+### NGINX Sampling with the Datadog Module
+TODO: Might be able to include this  above.
+
+## NGINX with OpenTracing module
+The OpenTracing project provides an NGINX module for distributed tracing. The
 module loads any OpenTracing-compatible plugin, such as the Datadog plugin.
 
-### Plugin installation
+### Datadog OpenTracing Plugin installation
 
 **Note**: this plugin does not work on Linux distributions that use older versions of `libstdc++`. This includes RHEL/Centos 7 and AmazonLinux 1.
-A workaround for this is to run Nginx from a Docker container. An example Dockerfile is available [here][4].
+A workaround for this is to run NGINX from a Docker container. An example Dockerfile is available [here][4].
 
 The following plugins must be installed:
 
-- Nginx plugin for OpenTracing - [linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz][5] - installed in `/usr/lib/nginx/modules`
-- Datadog OpenTracing C++ Plugin - [linux-amd64-libdd_opentracing_plugin.so.gz][6] - installed somewhere accessible to Nginx, for example `/usr/local/lib`
+- OpenTracing NGINX module - [linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz][5] - installed in `/usr/lib/nginx/modules`
+- Datadog OpenTracing C++ Plugin - [linux-amd64-libdd_opentracing_plugin.so.gz][6] - installed somewhere accessible to NGINX, for example `/usr/local/lib`
 
 Commands to download and install these modules:
 
@@ -388,17 +387,17 @@ get_latest_release() {
 NGINX_VERSION=1.17.3
 OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)"
 DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)"
-# Install Nginx plugin for OpenTracing
+# Install OpenTracing NGINX module
 wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz
 tar zxf linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz -C /usr/lib/nginx/modules
-# Install Datadog Opentracing C++ Plugin
+# Install Datadog OpenTracing C++ Plugin
 wget https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTRACING_CPP_VERSION}/linux-amd64-libdd_opentracing_plugin.so.gz
 gunzip linux-amd64-libdd_opentracing_plugin.so.gz -c > /usr/local/lib/libdd_opentracing_plugin.so
 ```
 
-### Nginx configuration with OpenTracing module
+### NGINX configuration with OpenTracing module
 
-The Nginx configuration must load the OpenTracing module.
+The NGINX configuration must load the OpenTracing module.
 
 ```nginx
 # Load OpenTracing module
@@ -416,7 +415,7 @@ The `http` block enables the OpenTracing module and loads the Datadog tracer:
     opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/nginx/dd-config.json;
 ```
 
-The `log_format with_trace_id` block is for correlating logs and traces. See the [example Nginx config][7] file for the complete format. The `$opentracing_context_x_datadog_trace_id` value captures the trace ID, and `$opentracing_context_x_datadog_parent_id` captures the span ID.
+The `log_format with_trace_id` block is for correlating logs and traces. See the [example NGINX config][7] file for the complete format. The `$opentracing_context_x_datadog_trace_id` value captures the trace ID, and `$opentracing_context_x_datadog_parent_id` captures the span ID.
 
 The `location` block within the server where tracing is desired should add the following:
 
@@ -437,26 +436,24 @@ A config file for the Datadog tracing implementation is also required:
 }
 ```
 
-The `service` value can be modified to a meaningful value for your usage of Nginx.
-The `agent_host` value may need to be changed if Nginx is running in a container or orchestrated environment.
+The `service` value can be modified to a meaningful value for your usage of NGINX.
+The `agent_host` value may need to be changed if NGINX is running in a container or orchestrated environment.
 
 Complete examples:
 
 * [nginx.conf][7]
 * [dd-config.json][8]
 
-After completing this configuration, HTTP requests to Nginx will initiate and propagate Datadog traces, and will appear in the APM UI.
+After completing this configuration, HTTP requests to NGINX will initiate and propagate Datadog traces, and will appear in the APM UI.
 
-## Nginx Sampling
+### NGINX Sampling with the OpenTracing Module
 
-To control the volume of Nginx traces that are sent to Datadog, specify a
-sampling rate in the configuration JSON by setting the `sample_rate` property
-to a value between `0.0` (0%) and `1.0` (100%).
-- If you are using the Datadog module, the JSON configuration is in the
-  [datadog][9] directive.
-- If you are using the OpenTracing module, the JSON configuration is the file
-  passed as an argument to `opentracing_load_tracer`
-  (`/etc/nginx/dd-config.json` in the example above).
+To control the volume of NGINX traces that are sent to Datadog by the
+OpenTracing module, specify a sampling rate in the configuration JSON by setting
+the `sample_rate` property to a value between `0.0` (0%) and `1.0` (100%).
+
+The JSON configuration is the file passed as an argument to
+`opentracing_load_tracer` (`/etc/nginx/dd-config.json` in the example above).
 
 ```json
 {
@@ -468,9 +465,13 @@ to a value between `0.0` (0%) and `1.0` (100%).
 }
 ```
 
-If no sample rate is specified, the [Datadog Agent calculated sampling rates][10] (10 traces per second per Agent) are applied.
+If no sample rate is specified, the [Datadog Agent calculated sampling rates][10] (10 traces per second, per Agent by default) are applied.
 
-Set **by-service** sampling rates with the `sampling_rules` configuration parameter. Configure a rate limit by setting the parameter `sampling_limit_per_second` to a number of traces per second per service instance. If no `sampling_limit_per_second` value is set, a limit of 100 traces per second is applied.
+Set **per-service** sampling rates with the `sampling_rules` configuration
+parameter. Configure an overall rate limit by setting the parameter
+`sampling_limit_per_second` to a number of traces per second per NGINX worker.
+If no `sampling_limit_per_second` value is set, a default limit of 100 traces
+per second is applied.
 
 For example, to send 50% of the traces for the service named `nginx`, up to `50` traces per second:
 
@@ -480,19 +481,20 @@ For example, to send 50% of the traces for the service named `nginx`, up to `50`
   "service": "nginx",
   "agent_host": "localhost",
   "agent_port": 8126,
-  "sampling_rules": [{"service":"nginx", "sample_rate":0.5}],
-  "sampling_limit_per_second":50
+  "sampling_rules": [{"service":"nginx", "sample_rate": 0.5}],
+  "sampling_limit_per_second": 50
 }
 ```
 
-Read more about sampling configuration options of the [dd-opentracing-cpp][11] library in the [respository documentation][12].
+Read more about sampling configuration options of the [dd-opentracing-cpp][11] library in the [repository documentation][12].
 
-## Nginx Ingress Controller for Kubernetes
+## Ingress-NGINX Controller for Kubernetes
 
-The [Kubernetes ingress-nginx][13] controller versions 0.23.0+ include the Nginx plugin for OpenTracing.
+The [Ingress-NGINX Controller for Kubernetes][13] versions 0.23.0+ include the
+OpenTracing NGINX module.
 
-To enable this plugin, create or edit a ConfigMap to set `enable-opentracing: "true"` and the `datadog-collector-host` to which traces should be sent.
-The name of the ConfigMap will be cited explicitly by the nginx-ingress controller container's command line argument, defaulting to `--configmap=$(POD_NAMESPACE)/nginx-configuration`.
+To enable Datadog tracing, create or edit a ConfigMap to set `enable-opentracing: "true"` and the `datadog-collector-host` to which traces should be sent.
+The name of the ConfigMap will be cited explicitly by the Ingress-NGINX Controller container's command line argument, defaulting to `--configmap=$(POD_NAMESPACE)/nginx-configuration`.
 If ingress-nginx was installed via helm chart, this ConfigMap will be named like `Release-Name-nginx-ingress-controller`.
 
 The ingress controller manages both the `nginx.conf` and `/etc/nginx/opentracing.json` files. Tracing is enabled for all `location` blocks.
@@ -533,8 +535,8 @@ To set a different service name per Ingress using annotations:
 The above overrides the default `nginx-ingress-controller.ingress-nginx` service name.
 
 ### Ingress Controller Sampling
-The Nginx Ingress Controller for Kubernetes uses [v1.2.1][14] of the Datadog
-tracing library, `dd-opentracing-cpp`.
+The Ingress-NGINX Controller for Kubernetes uses `dd-opentracing-cpp` as its
+underlying Datadog tracing library.
 
 To control the volume of Ingress Controller traces that are sent to Datadog,
 specify a sampling rule that matches all traces. The `sample_rate` configured
@@ -544,7 +546,7 @@ rules are specified, then sampling defaults to 100%.
 Specify sampling rules by using the `DD_TRACE_SAMPLING_RULES` environment
 variable. To define sampling rules in the Ingress Controller:
 
-1. Instruct Nginx to forward the environment variable to its worker processes by adding the following [main-snippet][14] to the `data` section of the Ingress Controller's `ConfigMap`:
+1. Instruct NGINX to forward the environment variable to its worker processes by adding the following [main-snippet][14] to the `data` section of the Ingress Controller's `ConfigMap`:
    ```yaml
    data:
      main-snippet: "env DD_TRACE_SAMPLING_RULES;"


### PR DESCRIPTION
### What does this PR do?
This revision alters the "tracing a proxy" section of the APM/tracing documentation to account for [recent changes][1] to our nginx module.

The `nginx-datadog` module is now configured differently. Additionally, the underlying tracing module is now `dd-trace-cpp` instead of `dd-opentracing-cpp`. One consequence of this is that now the underlying tracer of `nginx-datadog` is different than the underlying tracer of `ingress-nginx`, which still uses `dd-opentracing-cpp`.

I propose the following documentation changes:

- The section on our nginx module, `nginx-datadog`, includes an updated example and refers to the source repository for further information.
- The section on sampling with nginx is now specific to the OpenTracing module (with our plugin). Previously, it applied to both the datadog module and the OpenTracing module.
- I replaced mixed use of "nginx" and "Nginx" with the official stylized "NGINX".
- I sharpened the distinction between the term "module," which refers to an NGINX add-on, and the term "plugin," which refers to an OpenTracing implementation.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.

[1]: https://github.com/DataDog/nginx-datadog/pull/23
