### PR TITLE
Node.js: add cross reference to esbuild page from serverless page

### DIFF
--- a/content/en/security/application_security/enabling/compatibility/serverless.md
+++ b/content/en/security/application_security/enabling/compatibility/serverless.md
@@ -22,7 +22,7 @@ code_lang_weight: 90
 ### Supported languages and their requirements
 
 Node.js
-: If you are bundling using webpack or esbuild, [mark the Datadog libraries as external][4].
+: If you are bundling using webpack or esbuild, [follow the specific bundler instruction][4].
 
 Python
 : 

--- a/content/en/security/application_security/enabling/compatibility/serverless.md
+++ b/content/en/security/application_security/enabling/compatibility/serverless.md
@@ -22,7 +22,7 @@ code_lang_weight: 90
 ### Supported languages and their requirements
 
 Node.js
-: If you are bundling using webpack or esbuild, [follow the specific bundler instruction][4].
+: If you are bundling using webpack or esbuild, [follow the specific bundler instructions][4].
 
 Python
 : 

--- a/content/en/serverless/guide/serverless_tracing_and_webpack.md
+++ b/content/en/serverless/guide/serverless_tracing_and_webpack.md
@@ -53,6 +53,7 @@ Datadog's tracing libraries (`dd-trace`) are known to be not compatible with bun
 1. Follow the [installation instructions for Node.js][2] and ensure the Datadog Lambda layer for Node.js is added to your Lambda function.
 2. Remove `datadog-lambda-js` and `dd-trace` from your `package.json` and the build process.
 3. Mark `datadog-lambda-js` and `dd-trace` as [externals][4]. This tells the bundler to skip building them as dependencies, since they are already available in the Lambda runtime provided by the Datadog Lambda layer.
+4. Follow the steps on the [Esbuild support][6] page to use Datadog's Esbuild plugin. This enables instrumentation of bundled dependencies.
     
     **esbuild.config.js (if using esbuild-config)**
     
@@ -79,3 +80,4 @@ Datadog's tracing libraries (`dd-trace`) are known to be not compatible with bun
 [3]: https://webpack.js.org/configuration/externals/
 [4]: https://esbuild.github.io/api/#external
 [5]: https://github.com/serverless-heaven/serverless-webpack#node-modules--externals
+[6]: /tracing/trace_collection/dd_libraries/nodejs/?tab=containers#esbuild-support


### PR DESCRIPTION
### What does this PR do?
- adds a cross reference to the new esbuild page from the existing serverless page

### Motivation
- the serverless page doesn't mention the new plugin which is helpful to users

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
