### PR TITLE
Add IP allowlist stipulation about API key access

### DIFF
--- a/content/en/account_management/org_settings/ip_allowlist.md
+++ b/content/en/account_management/org_settings/ip_allowlist.md
@@ -22,14 +22,14 @@ If a user's IP is not contained in the IP allowlist, they are effectively blocke
 - Datadog's web UI
 - Datadog's public [API][1], including both documented and unpublished endpoints
 - Datadog's mobile apps (iOS, Android)
-- Third-party applications that access Datadog through OAuth
+- Third-party integrations and applications that access Datadog through OAuth
 
 The IP allowlist feature does not block access to the following:
 - Data ingest endpoints to which the Agent sends data, such as metrics, traces, and logs
 - The [validate API key][2] endpoint, which the Agent uses before submitting data
 - [Public dashboards][3]
 
-Third-party integrations and applications that need access to Datadog's public web APIs may be impacted by the IP allowlist. Applications that have access to a user-generated API key and that submit telemetry such as metrics, traces, and logs from the Agent and integrations are unaffected. Datadog recommends utilizing the [Audit Trail][4] to monitor for IP addresses from third parties.
+Applications and integrations that submit telemetry such as metrics, traces, and logs from the Agent and those that use an API key provided by the user are unaffected by the IP allowlist. Datadog recommends utilizing the [Audit Trail][4] to monitor for IP addresses from third parties.
 
 ### Functionality
 

--- a/content/en/account_management/org_settings/ip_allowlist.md
+++ b/content/en/account_management/org_settings/ip_allowlist.md
@@ -29,7 +29,7 @@ The IP allowlist feature does not block access to the following:
 - The [validate API key][2] endpoint, which the Agent uses before submitting data
 - [Public dashboards][3]
 
-Third-party integrations and applications that need access to Datadog's public web APIs may be impacted by the IP allowlist. Applications submitting telemetry such as metrics, traces, and logs from the Agent and integrations are unaffected. Datadog recommends utilizing the [Audit Trail][4] to monitor for IP addresses from third parties.
+Third-party integrations and applications that need access to Datadog's public web APIs may be impacted by the IP allowlist. Applications that have access to a user-generated API key and that submit telemetry such as metrics, traces, and logs from the Agent and integrations are unaffected. Datadog recommends utilizing the [Audit Trail][4] to monitor for IP addresses from third parties.
 
 ### Functionality
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds that it needs user-generated API key, it cannot generate an API key itself under the IP allowlist

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/browse/ACCESS-1604
Comment from Marketplace/Integration PMs

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
