### PR TITLE
Update FIPS proxy version to 0.5.3

### DIFF
--- a/content/en/containers/amazon_ecs/_index.md
+++ b/content/en/containers/amazon_ecs/_index.md
@@ -234,7 +234,7 @@ To send data to Datadog's GOVCLOUD datacenter, add the `fips-proxy` sidecar cont
      (...)
           {
             "name": "fips-proxy",
-            "image": "datadog/fips-proxy:0.5.2",
+            "image": "datadog/fips-proxy:0.5.3",
             "portMappings": [
                 {
                     "containerPort": 9803,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation

A new version is out to fix CVE

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes


https://docs-staging.datadoghq.com/nicolas.guerguadj/ecs-fips-0.5.3/containers/amazon_ecs/?tab=awscli#fips-proxy-for-govcloud-environments (FED-US1 only)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
