### PR TITLE
Update cluster_agent_autoscaling_metrics.md

### DIFF
--- a/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
+++ b/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
@@ -173,7 +173,7 @@ For autoscaling to work correctly, custom queries must follow these rules:
 
 - The query **must** be syntactically correct, otherwise it prevents the refresh of **ALL** metrics used for autoscaling (effectively stopping autoscaling).
 - The query result **must** output only one series (otherwise, the results are considered invalid).
-- The query **should** yield at least two timestamped points (it's possible to use a query that returns a single point, though in this case, autoscaling may use incomplete points).
+- The query **should** yield at least two non-null timestamped points (it's possible to use a query that returns a single point, though in this case, autoscaling may use incomplete points).
 
 **Note**: While the query is arbitrary, the start and end times are still set at `Now() - 5 minutes` and `Now()` by default.
 


### PR DESCRIPTION
Updated the reqs for autoscaling that the query should yield two  non-null timestamped points.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This adds clarification on the requirements to use auto scaling custom queries .

### Motivation
Customer Appsflyer (1000028301) has asked for this update

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
