### PR TITLE
[DOCS-5601] adding DD_SITE to Docker log collection

### DIFF
--- a/content/en/containers/docker/log.md
+++ b/content/en/containers/docker/log.md
@@ -49,7 +49,8 @@ The CLI commands on this page are for the Docker runtime. Replace `docker` with 
 To run a [Docker container][1] that embeds the Datadog Agent to monitor your host, use the following command for your respective operating system:
 
 ### Linux
-
+For the following configuration, replace `<DD_SITE>` with {{< region-param key="dd_site" >}}:
+{{< site-region region="us,eu,us3,us5,ap1,gov" >}}
 ```shell
 docker run -d --name datadog-agent \
            --cgroupns host \
@@ -58,6 +59,7 @@ docker run -d --name datadog-agent \
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
            -e DD_CONTAINER_EXCLUDE="name:datadog-agent" \
+           -e DD_SITE=<DD_SITE>
            -v /var/run/docker.sock:/var/run/docker.sock:ro \
            -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
            -v /proc/:/host/proc/:ro \
@@ -65,9 +67,11 @@ docker run -d --name datadog-agent \
            -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
            gcr.io/datadoghq/agent:latest
 ```
+{{< /site-region >}}
 
 ### Windows
-
+For the following configuration, replace `<DD_SITE>` with {{< region-param key="dd_site" >}}:
+{{< site-region region="us,eu,us3,us5,ap1,gov" >}}
 ```shell
 docker run -d --name datadog-agent \
            --cgroupns host \
@@ -76,15 +80,18 @@ docker run -d --name datadog-agent \
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
            -e DD_CONTAINER_EXCLUDE="name:datadog-agent" \
+           -e DD_SITE=<DD_SITE>
            -v \\.\pipe\docker_engine:\\.\pipe\docker_engine \
            -v c:\programdata\docker\containers:c:\programdata\docker\containers:ro
            gcr.io/datadoghq/agent:latest
 ```
+{{< /site-region >}}
 
 ### macOS
-
 Add the path `/opt/datadog-agent/run` under Docker Desktop -> Settings -> Resources -> File sharing.
 
+For the following configuration, replace `<DD_SITE>` with {{< region-param key="dd_site" >}}:
+{{< site-region region="us,eu,us3,us5,ap1,gov" >}}
 ```shell
 docker run -d --name datadog-agent \
            --cgroupns host \
@@ -94,11 +101,13 @@ docker run -d --name datadog-agent \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
            -e DD_LOGS_CONFIG_DOCKER_CONTAINER_USE_FILE=true \
            -e DD_CONTAINER_EXCLUDE="name:datadog-agent" \
+           -e DD_SITE=<DD_SITE>
            -v /var/run/docker.sock:/var/run/docker.sock:ro \
            -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
            -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
            gcr.io/datadoghq/agent:latest
 ```
+{{< /site-region >}}
 
 It is recommended that you pick the latest version of the Datadog Agent. Consult the full list of available [images for Agent v6][2] on GCR.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Docker log collection was missing `DD_SITE` in the installation instructions, this needed updating to notify the reader to change the value from the default if they are not on us1 (i.e. us5).

### Motivation
https://datadoghq.atlassian.net/browse/DOCS-5601

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
