### PR TITLE
Moved Downtimes out of Notify and under Alerting

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1104,35 +1104,35 @@ main:
     url: monitors/notify/variables/
     parent: monitors_notify
     identifier: monitors_notify_variables
-    weight: 201
+    weight: 301
   - name: Downtimes
-    url: monitors/notify/downtimes/
-    parent: monitors_notify
+    url: monitors/downtimes/
+    parent: alerting
     identifier: monitors_notify_downtimes
-    weight: 202
+    weight: 4
   - name: Manage Monitors
     url: monitors/manage/
     parent: alerting
     identifier: monitors_manage
-    weight: 4
+    weight: 5
   - name: Search Monitors
     url: monitors/manage/search/
     parent: monitors_manage
     identifier: monitors_manage_search
-    weight: 301
+    weight: 501
   - name: Monitor Status
     url: monitors/manage/status/
     parent: monitors_manage
     identifier: monitors_manage_status
-    weight: 302
+    weight: 502
   - name: Check Summary
     url: monitors/manage/check_summary/
     parent: monitors_manage
     identifier: monitors_check_summary
-    weight: 303
+    weight: 503
   - name: Monitor Settings
     url: monitors/settings/
-    weight: 5
+    weight: 6
     parent: alerting
     identifier: monitor_settings
   - name: Guides

--- a/content/en/monitors/downtimes/_index.md
+++ b/content/en/monitors/downtimes/_index.md
@@ -3,7 +3,7 @@ title: Downtimes
 kind: documentation
 description: "Schedule downtimes for your Datadog monitors to prevent alerts during specific time periods"
 aliases:
-    - /monitors/downtimes/
+- /monitors/notify/downtimes/
 further_reading:
 - link: "/monitors/guide/suppress-alert-with-downtimes"
   tag: "Guide"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- Move Downtimes section up one level 
- Change alias in the downtimes pages

### Motivation
<!-- What inspired you to submit this pull request?-->
[DOCS-5622](https://datadoghq.atlassian.net/browse/DOCS-5622)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Still working on this

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
