### PR TITLE
Add doc for using OTel with Node.js

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1468,6 +1468,11 @@ main:
     parent: tracing_otel_inst
     identifier: tracing_otel_inst_go
     weight: 104
+  - name: Node.js
+    url: tracing/trace_collection/otel_instrumentation/nodejs/
+    parent: tracing_otel_inst
+    identifier: tracing_otel_inst_nodejs
+    weight: 105
   - name: .NET
     url: tracing/trace_collection/otel_instrumentation/dotnet/
     parent: tracing_otel_inst

--- a/content/en/tracing/trace_collection/otel_instrumentation/nodejs.md
+++ b/content/en/tracing/trace_collection/otel_instrumentation/nodejs.md
@@ -17,7 +17,7 @@ further_reading:
 ## Requirements and limitations
 
 <!-- TODO: version needs to corrected after release -->
-- Datadog Node.js tracing library `dd-trace` version 4.0.0 or greater.
+- Datadog Node.js tracing library `dd-trace` version 4.2.0+, 3.23.0+, or v2.36.0+.
 
 The following OTel features implemented in the Datadog library as noted:
 

--- a/content/en/tracing/trace_collection/otel_instrumentation/nodejs.md
+++ b/content/en/tracing/trace_collection/otel_instrumentation/nodejs.md
@@ -1,0 +1,79 @@
+---
+title: Custom Instrumentation of Node.js Applications with the OpenTelemetry API
+kind: documentation
+description: 'Instrument your Node.js application with OTel API to send traces to Datadog.'
+code_lang: nodejs
+type: multi-code-lang
+code_lang_weight: 20
+further_reading:
+    - link: 'tracing/glossary/'
+      tag: 'Documentation'
+      text: 'Explore your services, resources, and traces'
+---
+
+{{% otel-custom-instrumentation %}}
+
+
+## Requirements and limitations
+
+<!-- TODO: version needs to corrected after release -->
+- Datadog Node.js tracing library `dd-trace` version 4.0.0 or greater.
+
+The following OTel features implemented in the Datadog library as noted:
+
+| Feature                               | Support notes                       |
+|---------------------------------------|--------------------------------------|
+| [OTel Context propagation][1]         | [Datadog distributed header format][9] is used instead. | 
+| [Span processors][2]                  | Unsupported                                          | 
+| [Span Exporters][3]                   | Unsupported                                            |
+| Trace/span [ID generators][4]         | ID generation is performed by `ddtrace`.           |
+
+
+## Configuring OTel to use the Datadog tracing library
+
+1. Add your desired manual OTel instrumentation to your Node.js code following the [OTel Node.js Manual Instrumentation documentation][5].
+2. Add the `dd-trace` module to your package.json:
+
+    ```sh
+    npm install dd-trace
+    ```
+
+3. Initialize the dd-trace module in your application:
+
+    ```js
+    const tracer = require('dd-trace').init({
+      // ...
+    })
+    ```
+
+4. Get TracerProvider from tracer:
+
+    ```js
+    const { TracerProvider } = tracer
+    ```
+
+5. Construct and register a TracerProvider:
+
+    ```js
+    const provider = new TracerProvider()
+    provider.register()
+    ```
+
+6. Run your application.
+
+Datadog combines these OpenTelemetry spans with other Datadog APM spans into a single trace of your application. It supports [integration instrumentation][7] and [OpenTelemetry Automatic instrumentation][8] also.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://opentelemetry.io/docs/instrumentation/js/propagation/
+[2]: https://opentelemetry.io/docs/reference/specification/trace/sdk/#span-processor
+[3]: https://opentelemetry.io/docs/reference/specification/trace/sdk/#span-exporter
+[4]: https://opentelemetry.io/docs/reference/specification/trace/sdk/#id-generators
+[5]: https://opentelemetry.io/docs/instrumentation/js/instrumentation/
+[6]: /tracing/trace_collection/dd_libraries/nodejs/#additional-configuration
+[7]: /tracing/trace_collection/dd_libraries/nodejs#integration-instrumentation
+[8]: https://opentelemetry.io/docs/instrumentation/js/automatic/
+[9]: /tracing/trace_collection/trace_context_propagation/nodejs/
+[10]: /tracing/trace_collection/dd_libraries/nodejs/#custom-logging

--- a/content/en/tracing/trace_collection/otel_instrumentation/nodejs.md
+++ b/content/en/tracing/trace_collection/otel_instrumentation/nodejs.md
@@ -4,7 +4,7 @@ kind: documentation
 description: 'Instrument your Node.js application with OTel API to send traces to Datadog.'
 code_lang: nodejs
 type: multi-code-lang
-code_lang_weight: 20
+code_lang_weight: 40
 further_reading:
     - link: 'tracing/glossary/'
       tag: 'Documentation'
@@ -38,7 +38,7 @@ The following OTel features implemented in the Datadog library as noted:
     npm install dd-trace
     ```
 
-3. Initialize the dd-trace module in your application:
+3. Initialize the `dd-trace` module in your application:
 
     ```js
     const tracer = require('dd-trace').init({
@@ -46,13 +46,13 @@ The following OTel features implemented in the Datadog library as noted:
     })
     ```
 
-4. Get TracerProvider from tracer:
+4. Get `TracerProvider` from `tracer`:
 
     ```js
     const { TracerProvider } = tracer
     ```
 
-5. Construct and register a TracerProvider:
+5. Construct and register a `TracerProvider`:
 
     ```js
     const provider = new TracerProvider()

--- a/layouts/partials/apm/apm-otel-instrumentation.html
+++ b/layouts/partials/apm/apm-otel-instrumentation.html
@@ -31,6 +31,13 @@
         </a>
       </div>
       <div class="col">
+        <a class="card h-100" href="nodejs">
+          <div class="card-body text-center py-2 px-1">
+            {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
+          </div>
+        </a>
+      </div>
+      <div class="col">
         <a class="card h-100" href="dotnet">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}


### PR DESCRIPTION
blocked by https://github.com/DataDog/dd-trace-js/pull/2498

What does this PR do?
Adds docs for using OTel with Node.js. Rebranch of https://github.com/DataDog/documentation/pull/18403 

Motivation
The OTel SDK for Node.js is landing soon, this provides docs for it.