### PR TITLE
Remove the word "currently" from feature flag docs

### DIFF
--- a/content/en/real_user_monitoring/feature_flag_tracking/_index.md
+++ b/content/en/real_user_monitoring/feature_flag_tracking/_index.md
@@ -35,7 +35,7 @@ Feature flag tracking is available in the RUM Browser SDK. To start, set up [RUM
 
 You can start collecting feature flag data for [custom feature flag management solutions][3], or using one of our integration partners. 
 
-We currently support integrations with:
+We support integrations with:
 
 {{< partial name="rum/rum-feature-flag-tracking.html" >}}
 

--- a/content/en/real_user_monitoring/guide/setup-feature-flag-data-collection.md
+++ b/content/en/real_user_monitoring/guide/setup-feature-flag-data-collection.md
@@ -178,19 +178,19 @@ const client = LDClient.initialize("<APP_KEY>", "<USER_ID>", {
 {{% /tab %}}
 {{% tab "iOS" %}}
 
-LaunchDarkly does not currently support this integration. Create a ticket with LaunchDarkly to request this feature.
+LaunchDarkly does not support this integration. Create a ticket with LaunchDarkly to request this feature.
 
 
 {{% /tab %}}
 {{% tab "Android" %}}
 
-LaunchDarkly does not currently support this integration. Create a ticket with LaunchDarkly to request this feature.
+LaunchDarkly does not support this integration. Create a ticket with LaunchDarkly to request this feature.
 
 
 {{% /tab %}}
 {{% tab "Flutter" %}}
 
-LaunchDarkly does not currently support this integration. Create a ticket with LaunchDarkly to request this feature.
+LaunchDarkly does not support this integration. Create a ticket with LaunchDarkly to request this feature.
 
 
 {{% /tab %}}
@@ -326,18 +326,18 @@ Initialize Flagsmith's SDK with the `datadogRum` option, which reports feature f
 {{% /tab %}}
 {{% tab "iOS" %}}
 
-Flagsmith does not currently support this integration. Create a ticket with Flagsmith to request this feature.
+Flagsmith does not support this integration. Create a ticket with Flagsmith to request this feature.
 
 
 {{% /tab %}}
 {{% tab "Android" %}}
 
-Flagsmith does not currently support this integration. Create a ticket with Flagsmith to request this feature.
+Flagsmith does not support this integration. Create a ticket with Flagsmith to request this feature.
 
 {{% /tab %}}
 {{% tab "Flutter" %}}
 
-Flagsmith does not currently support this integration. Create a ticket with Flagsmith to request this feature.
+Flagsmith does not support this integration. Create a ticket with Flagsmith to request this feature.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes the word "currently" from the Feature Flag Tracking article and guide.

### Motivation
A kind Vale reminder reminded me to remove this language.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
