### PR TITLE
[ci-visibility] Add reference to ITR for cypress

### DIFF
--- a/content/en/continuous_integration/intelligent_test_runner/javascript.md
+++ b/content/en/continuous_integration/intelligent_test_runner/javascript.md
@@ -46,7 +46,7 @@ NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app DD_CIV
 
 ### Cypress setup
 
-For Intelligent Test Runner for Cypress to work, you need to instrument your web application with code coverage. You can read more about it in the [Cypress documentation][4]. A quick way to check that you've successfully enabled code coverage is navigating to your web app with Cypress and check the global variable `window.__coverage__`. This is what `dd-trace` leverages to collect code coverage for Intelligent Test Runner.
+For Intelligent Test Runner for Cypress to work, you must instrument your web application with code coverage. You can read more about enabling code coverage in the [Cypress documentation][4]. To check that you've successfully enabled code coverage, navigate to your web app with Cypress and check the global variable `window.__coverage__`. This is what `dd-trace` uses to collect code coverage for Intelligent Test Runner.
 
 
 #### UI activation

--- a/content/en/continuous_integration/intelligent_test_runner/javascript.md
+++ b/content/en/continuous_integration/intelligent_test_runner/javascript.md
@@ -24,6 +24,9 @@ Intelligent Test Runner is only supported in the following versions and testing 
 * `cucumber-js>=7.0.0`
   * From `dd-trace>=3.16.0` or `dd-trace>=2.29.0`.
   * Run cucumber-js with [`nyc`][1] to enable code coverage.
+* `cypress>=6.7.0`
+  * From `dd-trace>=4.2.0`, `dd-trace>=3.23.0` or `dd-trace>=2.36.0`.
+  * Instrument your web application with code coverage: see more in [Cypress setup](#cypress-setup)
 
 ## Setup
 
@@ -41,9 +44,13 @@ After setting these environment variables, run your tests as you normally do:
 NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app DD_CIVISIBILITY_AGENTLESS_ENABLED=true DD_API_KEY=$API_KEY DD_APPLICATION_KEY=$APP_KEY yarn test
 {{< /code-block >}}
 
+### Cypress setup
+
+For Intelligent Test Runner for Cypress to work, you need to instrument your web application with code coverage. You can read more about it in the [Cypress documentation][4]. A quick way to check that you've successfully enabled code coverage is navigating to your web app with Cypress and check the global variable `window.__coverage__`. This is what `dd-trace` leverages to collect code coverage for Intelligent Test Runner.
+
 
 #### UI activation
-In addition to setting the environment variables, you or a user in your organization with "Intelligent Test Runner Activation" permissions must activate the Intelligent Test Runner on the [Test Service Settings][4] page.
+In addition to setting the environment variables, you or a user in your organization with "Intelligent Test Runner Activation" permissions must activate the Intelligent Test Runner on the [Test Service Settings][5] page.
 
 {{< img src="continuous_integration/itr_overview.png" alt="Intelligent test runner enabled in test service settings in the CI section of Datadog.">}}
 
@@ -57,4 +64,5 @@ Intelligent test runner for Javascript skips entire _test suites_ (test files) r
 [1]: https://www.npmjs.com/package/nyc
 [2]: /continuous_integration/tests/javascript
 [3]: https://app.datadoghq.com/organization-settings/application-keys
-[4]: https://app.datadoghq.com/ci/settings/test-service
+[4]: https://docs.cypress.io/guides/tooling/code-coverage#Instrumenting-code
+[5]: https://app.datadoghq.com/ci/settings/test-service


### PR DESCRIPTION
### What does this PR do?
Add instructions for Intelligent Test Runner (ITR) for Cypress.

### Motivation
Allow cypress users to use ITR.

### Preview

https://docs-staging.datadoghq.com/juan-fernandez/add-itr-cypress-instructions/continuous_integration/intelligent_test_runner/javascript/#cypress-setup


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
