### PR TITLE
Add warning threshold in the forecast monitor

### DIFF
--- a/content/en/monitors/types/forecasts.md
+++ b/content/en/monitors/types/forecasts.md
@@ -40,7 +40,9 @@ After defining the metric, the forecast monitor provides two preview graphs in t
 * Trigger an alert when the edge of the forecast confidence bounds goes `above` or `below`.
 * the threshold within the next `24 hours`, `1 week`, `1 month`, etc. or `custom` to set a value between 12 hours and 3 months.
 * Alert threshold: >= `<NUMBER>`
+* Warning threshold: >= `<NUMBER>`
 * Alert [recovery threshold][3]: < `<NUMBER>`
+* Warning [recovery threshold][3]: < `<NUMBER>`
 
 #### Advanced options
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adding warning threshold as the list of parameter which can be configured. 

### Motivation
Warning threshold just got added to forecast monitors.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/nils/forecast-and-warning/monitors/types/forecasts/?tab=linear#set-alert-conditions

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
