### PR TITLE
Update documentation to rename generic-router to generic-device

### DIFF
--- a/content/en/network_monitoring/devices/profiles.md
+++ b/content/en/network_monitoring/devices/profiles.md
@@ -20,7 +20,7 @@ Network Device Monitoring uses profiles to tell the Datadog Agent the metrics an
 
 By default, all profiles in the Agent configuration directory are loaded. To customize the specific profiles for collection, explicitly reference them by filename under `definition_file`, or provide an inline list under `definition`. Any of the Datadog profiles can be listed by name. Additional custom profiles can be referenced by the file path in the config, or placed in the configuration directory.
 
-**Note**: The generic profile is [generic_router.yaml][1], which supports routers, switches, etc.
+**Note**: The generic profile is [generic-device.yaml][1], which supports routers, switches, etc.
 
 ### sysOID mapped devices
 
@@ -65,5 +65,5 @@ For more Datadog provided profiles, see the [GitHub repository][2].
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/profiles/generic-router.yaml
+[1]: https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/profiles/generic-device.yaml
 [2]: https://github.com/DataDog/integrations-core/tree/master/snmp/datadog_checks/snmp/data/profiles

--- a/content/fr/network_monitoring/devices/profiles.md
+++ b/content/fr/network_monitoring/devices/profiles.md
@@ -19,7 +19,7 @@ La fonctionnalité Network Device Monitoring utilise des profils pour indiquer �
 
 Par défaut, tous les profils dans le répertoire de configuration sont chargés. Pour personnaliser les profils spécifiques à recueillir, spécifiez leur nom de fichier sous `definition_file`, ou incorporez-les sous forme de liste à `definition`. Tous les profils Datadog peuvent être spécifiés en indiquant leur nom. Pour fournir des profils personnalisés supplémentaires, indiquez leur chemin dans la configuration, ou ajoutez-les au répertoire de configuration.
 
-**Remarque **: le profil générique est [generic_router.yaml][1], qui prend en charge les routeurs, les switchs, etc.
+**Remarque **: le profil générique est [generic-device.yaml][1], qui prend en charge les routeurs, les switchs, etc.
 
 ### Appareils mappés avec un sysOID
 
@@ -64,5 +64,5 @@ Pour en savoir plus sur les profils fournis par Datadog, consultez le [référen
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/profiles/generic-router.yaml
+[1]: https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/profiles/generic-device.yaml
 [2]: https://github.com/DataDog/integrations-core/tree/master/snmp/datadog_checks/snmp/data/profiles

--- a/content/ja/network_monitoring/devices/profiles.md
+++ b/content/ja/network_monitoring/devices/profiles.md
@@ -19,7 +19,7 @@ further_reading:
 
 デフォルトでは、Agent コンフィギュレーションディレクトリ内のすべてのプロファイルがロードされます。コレクションの特定のプロファイルをカスタマイズするには、`definition_file` でファイル名別に明示的に参照するか、`definition` でインラインリストを指定します。Datadog プロファイルはいずれも名前別にリストできます。追加のカスタムプロファイルは、コンフィギュレーション内でファイルパスで参照するか、コンフィギュレーションディレクトリに配置できます。
 
-**注**: 一般的なプロファイルは [generic_router.yaml][1] で、ルーターやスイッチなどをサポートしています。
+**注**: 一般的なプロファイルは [generic-device.yaml][1] で、ルーターやスイッチなどをサポートしています。
 
 ### sysOID マップデバイス
 
@@ -64,5 +64,5 @@ Datadog が提供するプロファイルの詳細については、[GitHub リ�
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/profiles/generic-router.yaml
+[1]: https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/profiles/generic-device.yaml
 [2]: https://github.com/DataDog/integrations-core/tree/master/snmp/datadog_checks/snmp/data/profiles


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Rename `generic-router` to `generic-device`

### Motivation
<!-- What inspired you to submit this pull request?-->
We are renaming the profile `generic-router` to `generic-device`. This PR updates the documentation to reflect this change.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Depends on this PR [Rename generic-router to generic-profile](https://github.com/DataDog/integrations-core/pull/14723#top)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
