### PR TITLE
[dotnet profiler] Exception and lock contention profilers are GA for .NET in 2.31

### DIFF
--- a/content/en/profiler/enabling/dotnet.md
+++ b/content/en/profiler/enabling/dotnet.md
@@ -53,9 +53,9 @@ The following profiling features are available in the following minimum versions
 |----------------------|-----------------------------------------|---------------------------------------|
 | Wall time profiling        | 2.7.0+                     |All supported runtime versions.      |
 | CPU profiling        | 2.15.0+                       | All supported runtime versions.      |
-| Exceptions profiling        | beta, 2.10.0+                       | All supported runtime versions.      |
+| Exceptions profiling        | 2.31.0+                       | All supported runtime versions.      |
 | Allocations profiling        | beta, 2.18.0+                       | .NET 6+      |
-| Lock Contention profiling        | beta, 2.18.0+                       | .NET 5+      |
+| Lock Contention profiling        | 2.31.0+                       | .NET 5+      |
 | Live heap profiling        | beta, 2.22.0+                       | .NET 7+      |
 | [Code Hotspots][12]        | 2.7.0+                       | All supported runtime versions.      |
 | [Endpoint Profiling][13]            | 2.15.0+                       | All supported runtime versions.      |

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -167,19 +167,19 @@ Wall Time
 CPU (v2.15+)
 : The time each method spent running on the CPU.
 
-Thrown Exceptions (beta, v2.10+)
+Thrown Exceptions (v2.31+)
 : The number of caught or uncaught exceptions raised by each method, as well as their type and message.
 
 Allocations (beta, v2.18+)
 : The number and size of allocated objects by each method, as well as their type.<br />
 _Requires: .NET 6+_
 
-Lock (beta, v2.18+)
+Lock (v2.31+)
 : The number of times threads are waiting for a lock and for how long.<br />
 _Requires: .NET 5+_
 
 Live Heap (beta, v2.22+)
-: A subset of the allocated objects (with their class name) that are still in memory and for how long.<br />
+: A subset of the allocated objects (with their class name) that are still in memory.<br />
 _Requires: .NET 7+_
 
 [1]: /profiler/enabling/dotnet/#requirements


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the exception and lock contention profiler to GA since 2.31

### Motivation
GA Features are implemented

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
