### PR TITLE
Remove public specification for beta

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -137,7 +137,7 @@
                     {{ if (and $endpointVisibility.isVisibleVersion (eq $versionNum "v1") (gt $versionCount 1)) }}
                       {{ $collapsedAnchorStr := (print $endpoint.action.summary " " (replace $versionNum "1" "2")) }}
                       <div class="alert alert-warning mb-2 unstable-newer">
-                        <p class="alert-warning">Note: For the "v2" version of this endpoint, which is in public beta, see <a class="toggle-version-tab" href="#{{ $collapsedAnchorStr | anchorize }}">{{- $collapsedAnchorStr -}}.</a></p>
+                        <p class="alert-warning">Note: For the "v2" version of this endpoint, which is in beta, see <a class="toggle-version-tab" href="#{{ $collapsedAnchorStr | anchorize }}">{{- $collapsedAnchorStr -}}.</a></p>
                       </div>
                     {{ end }}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Remove the "public" specification for beta. The 

### Motivation
<!-- What inspired you to submit this pull request?-->
[DOCS-5606](https://datadoghq.atlassian.net/browse/DOCS-5606) 
Requested by the engineers working on the new Downtimes V2 endpoint. They noticed that there was a discrepancy between the V1 beta and V2 beta alerts and requested removal of the "public" specification.
![image](https://github.com/DataDog/documentation/assets/41168354/c0b6bbe3-8b01-4963-8d1a-28172449087c)
![image](https://github.com/DataDog/documentation/assets/41168354/68f8094f-949b-49f8-8b25-d050180fec32)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
