### PR TITLE
Fix links for instrumenting Go tracing

### DIFF
--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -51,7 +51,7 @@ Follow [these instructions][2] to install and configure the Go tracing library i
 
 
 [1]: https://github.com/DataDog/crpb/tree/main/go
-[2]: /tracing/trace_collection/dd_libraries/ruby#instrument-your-application
+[2]: /tracing/trace_collection/dd_libraries/go/?tab=containers#instrument-your-application
 
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}

--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -51,7 +51,7 @@ Follow [these instructions][2] to install and configure the Go tracing library i
 
 
 [1]: https://github.com/DataDog/crpb/tree/main/go
-[2]: /tracing/trace_collection/dd_libraries/go/?tab=containers#instrument-your-application
+[2]: /tracing/trace_collection/dd_libraries/go/?tab=containers#installation-and-getting-started
 
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -226,7 +226,7 @@ Follow [these instructions][2] to install and configure the Go tracing library i
 
 
 [1]: https://github.com/DataDog/crpb/tree/main/go
-[2]: /tracing/trace_collection/dd_libraries/ruby#instrument-your-application
+[2]: /tracing/trace_collection/dd_libraries/go/?tab=containers#instrument-your-application
 
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -226,7 +226,7 @@ Follow [these instructions][2] to install and configure the Go tracing library i
 
 
 [1]: https://github.com/DataDog/crpb/tree/main/go
-[2]: /tracing/trace_collection/dd_libraries/go/?tab=containers#instrument-your-application
+[2]: /tracing/trace_collection/dd_libraries/go/?tab=containers#installation-and-getting-started
 
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}

--- a/content/ja/serverless/azure_container_apps/_index.md
+++ b/content/ja/serverless/azure_container_apps/_index.md
@@ -51,7 +51,7 @@ CMD ["/path/to/your-go-binary"]
 
 
 [1]: https://github.com/DataDog/crpb/tree/main/go
-[2]: /ja/tracing/trace_collection/dd_libraries/ruby#instrument-your-application
+[2]: /ja/tracing/trace_collection/dd_libraries/go/?tab=containers#instrument-your-application
 
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}

--- a/content/ja/serverless/azure_container_apps/_index.md
+++ b/content/ja/serverless/azure_container_apps/_index.md
@@ -51,7 +51,7 @@ CMD ["/path/to/your-go-binary"]
 
 
 [1]: https://github.com/DataDog/crpb/tree/main/go
-[2]: /ja/tracing/trace_collection/dd_libraries/go/?tab=containers#instrument-your-application
+[2]: /ja/tracing/trace_collection/dd_libraries/go/?tab=containers#installation-and-getting-started
 
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}

--- a/content/ja/serverless/google_cloud_run/_index.md
+++ b/content/ja/serverless/google_cloud_run/_index.md
@@ -223,7 +223,7 @@ CMD ["rails", "server", "-b", "0.0.0.0"] (必要に応じて内容を変更し�
 
 
 [1]: https://github.com/DataDog/crpb/tree/main/go
-[2]: /ja/tracing/trace_collection/dd_libraries/ruby#instrument-your-application
+[2]: /ja/tracing/trace_collection/dd_libraries/go/?tab=containers#instrument-your-application
 
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}

--- a/content/ja/serverless/google_cloud_run/_index.md
+++ b/content/ja/serverless/google_cloud_run/_index.md
@@ -223,7 +223,7 @@ CMD ["rails", "server", "-b", "0.0.0.0"] (必要に応じて内容を変更し�
 
 
 [1]: https://github.com/DataDog/crpb/tree/main/go
-[2]: /ja/tracing/trace_collection/dd_libraries/go/?tab=containers#instrument-your-application
+[2]: /ja/tracing/trace_collection/dd_libraries/go/?tab=containers#installation-and-getting-started
 
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}


### PR DESCRIPTION
There are two places in the docs where we are trying to point to the Go tab of instrumentation but it instead points to Ruby, this PR fixes those

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
