### PR TITLE
Add some visudo context for translators

### DIFF
--- a/content/en/agent/troubleshooting/permissions.md
+++ b/content/en/agent/troubleshooting/permissions.md
@@ -95,7 +95,7 @@ dd-agent ALL=NOPASSWD: /bin/ls /proc/*/fd/
 
 This allows the process check to use `sudo` to execute the `ls` command but only to the list of contents of the path `/proc/*/fd/`.
 
-If you see this line in the Datadog `error.log` file: `sudo: sorry, you must have a tty to run sudo`, you should `visudo` and comment out the line `Default requiretty`.
+If you see this line in the Datadog `error.log` file: `sudo: sorry, you must have a tty to run sudo`, you should use `visudo` to comment out the line `Default requiretty` in your sudoers file.
 
 {{% /tab %}}
 {{% tab "Agent v6 & v7" %}}


### PR DESCRIPTION
Adds some more context on what is meant by using visudo. Requested by translators.

Ready to merge.