### PR TITLE
Resolves issue #18434, replace broken link

### DIFF
--- a/content/en/dashboards/functions/smoothing.md
+++ b/content/en/dashboards/functions/smoothing.md
@@ -155,6 +155,6 @@ For more information on the weighted() modifier, see [How does weighted() work?]
     {{< nextlink href="/dashboards/functions/timeshift" >}}Timeshift: Shift your metric data point along the timeline. {{< /nextlink >}}
 {{< /whatsnext >}}
 
-[1]: http://futuredata.stanford.edu/asap
+[1]: https://github.com/stanford-futuredata/ASAP
 [2]: https://www.datadoghq.com/blog/auto-smoother-asap
 [3]: /dashboards/guide/how-weighted-works


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Replace broken link with a github repo link

### Motivation
<!-- What inspired you to submit this pull request?-->
[DOCS-5627](https://datadoghq.atlassian.net/browse/DOCS-5627)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Resolves issue <a href="https://github.com/DataDog/documentation/issues/18434">[Smoothing: Broken link to Stanford ASAP algorithm page](https://github.com/DataDog/documentation/issues/18434)</a>

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5627]: https://datadoghq.atlassian.net/browse/DOCS-5627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ