### PR TITLE
[doc] Updated manual cancellation behaviour

### DIFF
--- a/content/en/monitors/downtimes/_index.md
+++ b/content/en/monitors/downtimes/_index.md
@@ -114,7 +114,7 @@ Monitors trigger events when they change between possible states: `ALERT`, `WARN
 
 By default, if a monitor is in an alert-worthy state (`ALERT`, `WARNING`, or `NO DATA`) when a downtime expires, the monitor triggers a new notification. This applies to monitors that change state during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`), and to monitors that already have an alert-worthy state when downtime begins. If a downtime is manually canceled, notifications are not sent, even if the monitor has entered an alert-worthy state.
 
-To override the default behavior, specify which notifications should be sent at the end of downtimes with the options in the "Notify Your Team" section.
+To override the default behavior, specify which notifications should be sent at the end of downtimes with the options in the "Notify Your Team" section. For downtimes created via API, the the default behaviour is to exclude is_cancelled option.
 
 {{< img src="monitors/downtimes/downtime_cancel_expire_notification.png" alt="Configure Notify your team section of a monitor with specific downtime conditions" style="width:100%;">}}
 

--- a/content/en/monitors/downtimes/_index.md
+++ b/content/en/monitors/downtimes/_index.md
@@ -114,7 +114,7 @@ Monitors trigger events when they change between possible states: `ALERT`, `WARN
 
 By default, if a monitor is in an alert-worthy state (`ALERT`, `WARNING`, or `NO DATA`) when a downtime expires, the monitor triggers a new notification. This applies to monitors that change state during downtime (such as from `OK` to `ALERT`, `WARNING`, or `NO DATA`), and to monitors that already have an alert-worthy state when downtime begins. If a downtime is manually canceled, notifications are not sent, even if the monitor has entered an alert-worthy state.
 
-To override the default behavior, specify which notifications should be sent at the end of downtimes with the options in the "Notify Your Team" section. For downtimes created via API, the the default behaviour is to exclude is_cancelled option.
+To override the default behavior, specify which notifications should be sent at the end of downtimes with the options in the "Notify Your Team" section. For downtimes created with the API, the default behavior is to exclude `is_cancelled` option.
 
 {{< img src="monitors/downtimes/downtime_cancel_expire_notification.png" alt="Configure Notify your team section of a monitor with specific downtime conditions" style="width:100%;">}}
 


### PR DESCRIPTION
updated the document by adding an additional line regarding default behaviour for API [MNTS-89814]

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[MNTS-89814]: https://datadoghq.atlassian.net/browse/MNTS-89814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ