### PR TITLE
[ci-visibility] Add troubleshooting item about JUnit reports timestamps

### DIFF
--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -11,15 +11,19 @@ kind: documentation
 
 1. Make sure that at least one pipeline has finished executing. Pipeline execution information is only sent after the pipeline has finished.
 2. Make sure the Datadog Agent host is properly configured and it's reachable by the Datadog Plugin. You can test connectivity by clicking on the **Check connectivity with the Datadog Agent** button on the Jenkins plugin configuration UI.
-3. Check for any errors in the Jenkins logs. You can enable debug-level logs for the Datadog plugin by [creating a `logging.properties` file][13] and adding the line: `org.datadog.level = ALL`.
-4. If you still don't see any results, [contact Support][1] for troubleshooting help.
+3. Check for any errors in the Jenkins logs. You can enable debug-level logs for the Datadog plugin by [creating a `logging.properties` file][1] and adding the line: `org.datadog.level = ALL`.
+4. If you still don't see any results, [contact Support][2] for troubleshooting help.
 
 ### Your tests are instrumented, but Datadog isn't showing any data
 
-1. Go to the [Setup Tracing on CI Tests][2] page for the language you're instrumenting and check the _Compatibility_ section. Make sure the testing framework you are using is supported.
-2. Check if you see any test results in the [Test Runs][3] section. If you do see results there, but not in the [Tests][4] section, Git information is missing. See [Data appears in Test Runs but not Tests](#data-appears-in-test-runs-but-not-tests) to troubleshoot it.
-3. If you are reporting the data through the Datadog Agent, make sure it is running on the host where tests are run (accessible at `localhost:8126`), or if accessible on another hostname or port, make sure you run your tests with the appropriate Agent hostname set in the `DD_AGENT_HOST` and the appropriate port in `DD_TRACE_AGENT_PORT` environment variables. You can activate [debug mode][5] in the tracer to check if it's able to connect to the Agent.
-4. If you still don't see any results, [contact Support][1] for troubleshooting help.
+1. Go to the [Setup Tracing on CI Tests][3] page for the language you're instrumenting and check the _Compatibility_ section. Make sure the testing framework you are using is supported.
+2. Check if you see any test results in the [Test Runs][4] section. If you do see results there, but not in the [Tests][5] section, Git information is missing. See [Data appears in Test Runs but not Tests](#data-appears-in-test-runs-but-not-tests) to troubleshoot it.
+3. If you are reporting the data through the Datadog Agent, make sure it is running on the host where tests are run (accessible at `localhost:8126`), or if accessible on another hostname or port, make sure you run your tests with the appropriate Agent hostname set in the `DD_AGENT_HOST` and the appropriate port in `DD_TRACE_AGENT_PORT` environment variables. You can activate [debug mode][6] in the tracer to check if it's able to connect to the Agent.
+4. If you still don't see any results, [contact Support][2] for troubleshooting help.
+
+### You are uploading JUnit test reports with `datadog-ci` but some or all tests are missing
+If you are uploading JUnit test report files with `datadog-ci` CLI, make sure that the timestamp of the reported tests is not older than **18 hours** before the moment the report is uploaded.
+
 
 ### Pipeline not found
 
@@ -27,9 +31,9 @@ A "Pipeline not found" message is shown when you click on incomplete data coming
 
 ### Data appears in test runs but not tests
 
-If you can see test results data in the **Test Runs** tab, but not the **Tests** tab, Git metadata (repository, commit and/or branch) is probably missing. To confirm this is the case, open a test execution in the [Test Runs][3] section, and check that there is no `git.repository_url`, `git.commit.sha`, or `git.branch`. If these tags are not populated, nothing shows in the [Tests][4] section.
+If you can see test results data in the **Test Runs** tab, but not the **Tests** tab, Git metadata (repository, commit and/or branch) is probably missing. To confirm this is the case, open a test execution in the [Test Runs][4] section, and check that there is no `git.repository_url`, `git.commit.sha`, or `git.branch`. If these tags are not populated, nothing shows in the [Tests][5] section.
 
-1. Tracers first use the environment variables, if any, set by the CI provider to collect Git information. See [Running tests inside a container][6] for a list of environment variables that the tracer attempts to read for each supported CI provider. At a minimum, this populates the repository, commit hash, and branch information.
+1. Tracers first use the environment variables, if any, set by the CI provider to collect Git information. See [Running tests inside a container][7] for a list of environment variables that the tracer attempts to read for each supported CI provider. At a minimum, this populates the repository, commit hash, and branch information.
 2. Next, tracers fetch Git metadata using the local `.git` folder, if present, by executing `git` commands. This populates all Git metadata fields, including commit message, author, and committer information. Ensure the `.git` folder is present and the `git` binary is installed and in `$PATH`. This information is used to populate attributes not detected in the previous step.
 3. You can also provide Git information manually using environment variables, which override information detected by any of the previous steps. The supported environment variables for providing Git information are the following:
 
@@ -81,11 +85,11 @@ If you can see test results data in the **Test Runs** tab, but not the **Tests**
 
 ### The tests wall time is empty
 
-If you cannot see the tests wall time it is likely that the CI provider metadata is missing. To confirm this is the case, open a test execution in the [Test Runs][3] section, and check if the `ci.pipeline.id`, `ci.pipeline.name`, `ci.pipeline.number`, or `ci.job.url` tags are missing. If these tags are not populated, then nothing shows in the wall time column.
+If you cannot see the tests wall time it is likely that the CI provider metadata is missing. To confirm this is the case, open a test execution in the [Test Runs][4] section, and check if the `ci.pipeline.id`, `ci.pipeline.name`, `ci.pipeline.number`, or `ci.job.url` tags are missing. If these tags are not populated, then nothing shows in the wall time column.
 
-1. Tracers use the environment variables set by the CI provider to collect this information. See [Running tests inside a container][6] for a list of environment variables that the tracer attempts to read for each supported CI provider. Make sure that the environment variables have the expected values set.
-2. Check that you are running your tests in a supported CI provider. For a list of supported CI providers, see [Running tests inside a container][6]. Only these CI providers can extract the information to enrich the test metadata with CI information.
-3. If you still don't see the wall time, contact [Datadog support][1] for help.
+1. Tracers use the environment variables set by the CI provider to collect this information. See [Running tests inside a container][7] for a list of environment variables that the tracer attempts to read for each supported CI provider. Make sure that the environment variables have the expected values set.
+2. Check that you are running your tests in a supported CI provider. For a list of supported CI providers, see [Running tests inside a container][7]. Only these CI providers can extract the information to enrich the test metadata with CI information.
+3. If you still don't see the wall time, contact [Datadog support][2] for help.
 
 ### The tests wall time is not what is expected
 
@@ -100,7 +104,7 @@ This is done using the following algorithm:
 2. The calculated wall time is associated to a given hash. **Note**: If there are multiple jobs that execute tests, the wall time is calculated for each job, and the maximum from all calculated wall times is shown.
 
 #### Possible issues with wall time calculation
-If you're using a library for testing time-dependent code, like [timecop][7] for Ruby or [FreezeGun][8] for Python, it is possible that test timestamps are wrong, and therefore calculated wall times. If this is the case, make sure that modifications to time are rolled back before finishing your tests.
+If you're using a library for testing time-dependent code, like [timecop][8] for Ruby or [FreezeGun][9] for Python, it is possible that test timestamps are wrong, and therefore calculated wall times. If this is the case, make sure that modifications to time are rolled back before finishing your tests.
 
 ### The test status numbers are not what is expected
 
@@ -111,9 +115,9 @@ The test status numbers are calculated based on the unique tests that were colle
 If the numbers are lower than expected, it is likely that either the library or the tool you are using to collect test data cannot collect test parameters and/or some test configurations.
 
 1. If you are uploading JUnit test report files:
-    1. If you are running the same tests in different environment configurations, [make sure you are setting those configuration tags during the upload][9].
-    2. If you are running parameterized tests, it's very likely that the JUnit report does not have that information. [Try using a native library to report test data][10].
-2. If you still don't see the expected results, [contact Datadog support][1] for troubleshooting help.
+    1. If you are running the same tests in different environment configurations, [make sure you are setting those configuration tags during the upload][10].
+    2. If you are running parameterized tests, it's very likely that the JUnit report does not have that information. [Try using a native library to report test data][3].
+2. If you still don't see the expected results, [contact Datadog support][2] for troubleshooting help.
 
 #### The passed/failed/skipped numbers are different than expected
 
@@ -176,18 +180,17 @@ If you are authoring a commit that includes any of those cases, you can force-di
 
 ### Need further help?
 
-Still need help? Contact [Datadog support][1].
+Still need help? Contact [Datadog support][2].
 
-[1]: /help/
-[2]: /continuous_integration/tests/
-[3]: https://app.datadoghq.com/ci/test-runs
-[4]: https://app.datadoghq.com/ci/test-services
-[5]: /tracing/troubleshooting/tracer_debug_logs
-[6]: /continuous_integration/tests/containers/
-[7]: https://github.com/travisjeffery/timecop
-[8]: https://github.com/spulec/freezegun
-[9]: /continuous_integration/tests/junit_upload/?tabs=linux#collecting-environment-configuration-metadata
-[10]: /continuous_integration/tests/
+[1]: https://www.jenkins.io/doc/book/system-administration/viewing-logs/
+[2]: /help/
+[3]: /continuous_integration/tests/
+[4]: https://app.datadoghq.com/ci/test-runs
+[5]: https://app.datadoghq.com/ci/test-services
+[6]: /tracing/troubleshooting/tracer_debug_logs
+[7]: /continuous_integration/tests/containers/
+[8]: https://github.com/travisjeffery/timecop
+[9]: https://github.com/spulec/freezegun
+[10]: /continuous_integration/tests/junit_upload/?tabs=linux#collecting-environment-configuration-metadata
 [11]: https://app.datadoghq.com/ci/settings/repository
 [12]: /continuous_integration/intelligent_test_runner/
-[13]: https://www.jenkins.io/doc/book/system-administration/viewing-logs/


### PR DESCRIPTION
### What does this PR do?
Add troubleshooting item to reflect that old timestamps will be discarded. 

### Motivation
Make it easier to customer to find issues.

### Preview

https://docs-staging.datadoghq.com/juan-fernandez/add-note-about-junit-timestamps/continuous_integration/troubleshooting/#you-are-uploading-junit-test-reports-with-datadog-ci-but-some-or-all-tests-are-missing

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
