### PR TITLE
Add React Native new arch support

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/reactnative.md
@@ -386,6 +386,12 @@ const config = new DdSdkReactNativeConfiguration(
 )
 ```
 
+## New architecture support
+
+The [React Native new architecture][17] is supported by the RUM React Native SDK since its version `1.8.0`.
+
+The minimum supported React Native version for the new architecture is `0.71`.
+
 ## Troubleshooting
 
 ### Usage with `use_frameworks!`
@@ -438,3 +444,4 @@ end
 [14]: https://stackoverflow.com/questions/37388126/use-frameworks-for-only-some-pods-or-swift-pods/60914505#60914505
 [15]: /getting_started/tagging/#define-tags
 [16]: https://github.com/DataDog/dd-sdk-reactnative-examples/tree/main/rum-react-navigation
+[17]: https://reactnative.dev/docs/the-new-architecture/landing-page

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/reactnative.md
@@ -388,7 +388,7 @@ const config = new DdSdkReactNativeConfiguration(
 
 ## New architecture support
 
-The [React Native new architecture][17] is supported by the RUM React Native SDK since its version `1.8.0`.
+The [React Native new architecture][17] is supported by the RUM React Native SDK in version `>=1.8.0`.
 
 The minimum supported React Native version for the new architecture is `0.71`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Document support for the new architecture of React Native, upcoming in release `1.8.0` of the React Native SDK.

There is no additional step required to use the SDK with the new architecture.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
