### PR TITLE
Add Java Live Heap profile types

### DIFF
--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -230,7 +230,7 @@ The allocation profiler engine does not depend on the `/proc/sys/kernel/perf_eve
 _Since: v1.17.0_
 
 The live-heap profiler engine is useful for investigating the overall memory usage of your service and identifying potential memory leaks.
-The engine samples allocations and keeps track of whether those samples survived the most recent GC cycle. The number of surviving samples is used to estimate the number of live objects in the heap.
+The engine samples allocations and keeps track of whether those samples survived the most recent garbage collection cycle. The number of surviving samples is used to estimate the number of live objects in the heap.
 The number of tracked samples is limited to avoid unbounded growth of the profiler's memory usage.
 
 The engine is disabled by default, but you can enable it with:

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -33,12 +33,12 @@ Allocated Memory
 
 Heap Live Objects
 : The number of objects allocated by each method in heap memory that have not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
-_Requires: Java 11_
+_Requires: Java 11_ <br />
 _Since: 1.17.0_
 
 Heap Live Size
 : The amount of heap memory allocated by each method that has not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
-_Requires: Java 11_
+_Requires: Java 11_ <br />
 _Since: 1.17.0_
 
 Wall Time in Native Code


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
It adds the documentation for Java Live-Heap Profiler feature

### Motivation
We are going to GA the Java Live-Heap Profiler shortly and the documentation must be ready for that

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Merging this needs to be postponed till after dd-java-agent v1.17.0 is generally available.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
