### PR TITLE
(DOCS-5644) Add redirects to workflow actions

### DIFF
--- a/local/bin/py/build/actions/workflows.py
+++ b/local/bin/py/build/actions/workflows.py
@@ -47,6 +47,7 @@ def workflows(content, content_dir):
                         action_data['bundle'] = data.get('name')
                         action_data['bundle_title'] = data.get('title').strip()
                         action_data['source'] = data.get('icon', {}).get('integration_id', '')
+                        action_data['aliases'] = [f'/workflows/actions_catalog/{output_file_name}_{action_name}']
                         # if this is a dd. bundle then lets use the datadog integration id
                         if not action_data['source'] and 'datadog' in action_data['bundle_title'].lower():
                             action_data['source'] = '_datadog'


### PR DESCRIPTION
We recently moved workflows under `service_management` and [we're getting some reports](https://datadoghq.atlassian.net/browse/DOCS-5644) that the redirects for the actions are breaking.

Not sure if this is the best way to fix it. Suggestions welcome.

Please ensure the web team has reviewed before merging.

Note: Not sure if this requires caching to be turned off to preview. It worked fine locally.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
