### PR TITLE
[CIAPP] Remove (beta) note from logs collection for junitxml and gitlab

### DIFF
--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -232,7 +232,7 @@ See the table below for the message and domain correlated with each error type. 
 <!-- | ---------- | ---------- | ---------- | -->
 <!-- | :---        |    :----:   |          ---: | -->
 
-## Enable job log collection (beta)
+## Enable job log collection
 
 The following GitLab versions support collecting job logs:
 * GitLab.com (SaaS)

--- a/content/en/continuous_integration/tests/junit_upload.md
+++ b/content/en/continuous_integration/tests/junit_upload.md
@@ -198,7 +198,7 @@ See [Providing metadata with XPath expressions](#providing-metadata-with-xpath-e
 **Example**: `test.suite=/testcase/@classname`<br/>
 **Note**: Tags specified using `--xpath-tag` and with `--tags` or `DD_TAGS` environment variable are merged. xpath-tag gets the highest precedence, as the value is usually different for each test.
 
-`--logs` **(beta)**
+`--logs`
 : Enable forwarding content from the XML reports as [Logs][6]. The content inside `<system-out>`, `<system-err>`, and `<failure>` is collected as logs. Logs from elements inside a `<testcase>` are automatically connected to the test.<br/>
 **Environment variable**: `DD_CIVISIBILITY_LOGS_ENABLED`<br/>
 **Default**: `false`<br/>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This has been marked as beta for too long so I think it's okay to remove now

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
