### PR TITLE
RUMM-3290 Add Error Tracking page for Roku

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3614,11 +3614,16 @@ main:
     parent: rum_error_tracking
     identifier: rum_error_tracking_flutter
     weight: 1407
+  - name: Track Roku Errors
+    url: real_user_monitoring/error_tracking/roku/
+    parent: rum_error_tracking
+    identifier: rum_error_tracking_roku
+    weight: 1408
   - name: Custom Grouping
     url: real_user_monitoring/error_tracking/custom_grouping
     parent: rum_error_tracking
     identifier: rum_error_tracking_custom_grouping
-    weight: 1408
+    weight: 1409
   - name: Guides
     url: real_user_monitoring/guide/
     parent: rum

--- a/content/en/real_user_monitoring/error_tracking/roku.md
+++ b/content/en/real_user_monitoring/error_tracking/roku.md
@@ -1,0 +1,63 @@
+---
+title: Roku Crash Reporting and Error Tracking
+kind: documentation
+description: Set up Error Tracking for your Roku channels.
+further_reading:
+- link: '/real_user_monitoring/error_tracking/'
+  tag: 'Error Tracking'
+  text: 'Get started with Error Tracking'
+- link: '/real_user_monitoring/error_tracking/explorer'
+  tag: 'Documentation'
+  text: 'Visualize Error Tracking data in the Explorer'
+---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">RUM for Roku is not available on the US1-FED Datadog site.</div>
+{{< /site-region >}}
+
+{{< site-region region="us,us3,us5,eu,ap1" >}}
+<div class="alert alert-info">RUM for Roku is in beta.</div>
+{{< /site-region >}}
+
+## Overview
+
+Error Tracking processes errors collected from the RUM Roku SDK. 
+
+Enable Roku Crash Reporting and Error Tracking to get comprehensive crash reports and error trends with Real User Monitoring. With this feature, you can access:
+
+- Aggregated Roku crash dashboards and attributes
+- Trend analysis with Roku error tracking
+
+Your crash reports appear in [**Error Tracking**][1].
+
+## Setup
+
+If you have not set up the Roku SDK yet, follow the [in-app setup instructions][2] or see the [Roku RUM setup documentation][3].
+
+1. Add the latest version of the [RUM Roku SDK][4] to your ROPM dependencies (or download the zip archive).
+2. Configure your application's `env` when [initializing the SDK][5].
+
+For any given error, you can access the file path, line number, and a code snippet for each frame of the related stack trace.
+
+## Forward errors to Datadog
+
+Whenever you perform an operation that might throw an exception, you can forward the error to Datadog by adding the following code snippet:
+
+```brightscript
+    try
+        doSomethingThatMightThrowAnException()
+    catch error
+        m.global.datadogRumAgent.callfunc("addError", error)
+    end try
+```
+
+[1]: https://app.datadoghq.com/rum/error-tracking
+[2]: https://app.datadoghq.com/rum/application/create
+[3]: https://docs.datadoghq.com/real_user_monitoring/roku/#setup
+[4]: https://github.com/DataDog/dd-sdk-roku
+[5]: https://docs.datadoghq.com/real_user_monitoring/android/advanced_configuration/?tabs=kotlin#initialization-parameters
+
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add the Error Tracking documentation for our Roku RUM integration

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
