### PR TITLE
Update custom_metrics.md

### DIFF
--- a/content/en/account_management/billing/custom_metrics.md
+++ b/content/en/account_management/billing/custom_metrics.md
@@ -309,7 +309,7 @@ The following standard integrations can potentially emit custom metrics.
 | Type of integrations                           | Integrations                                                                       |
 |------------------------------------------------|------------------------------------------------------------------------------------|
 | Limited to 350 custom metrics by default.      | [ActiveMQ XML][11] / [Go-Expvar][12] / [Java-JMX][13]                              |
-| No default limit on custom metrics collection. | [Nagios][14] /[PDH Check][15] /[OpenMetrics][16] /[Windows Services][17] /[WMI][18] /[Prometheus][27] |
+| No default limit on custom metrics collection. | [Nagios][14] /[PDH Check][15] /[OpenMetrics][16] /[Windows performance counters][17] /[WMI][18] /[Prometheus][27] |
 | Can be configured to collect custom metrics.   | [MySQL][19] /[Oracle][20] /[Postgres][21] /[SQL Server][22]                        |
 | Custom metrics sent from cloud integrations    | [AWS][23]                                                                          |
 
@@ -339,7 +339,7 @@ For billing questions, contact your [Customer Success][10] Manager.
 [14]: /integrations/nagios/
 [15]: /integrations/pdh_check/
 [16]: /integrations/openmetrics/
-[17]: /integrations/windows_service/
+[17]: /integrations/windows_performance_counters/
 [18]: /integrations/wmi_check/
 [19]: /integrations/mysql/
 [20]: /integrations/oracle/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

The Windows Service integration does not emit custom metrics (or any metrics) and should not be on this list.

The Windows Performance Counter integration (which replaces the deprecated PDH and WMI integrations) exclusively emits custom metrics.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

[related PR](https://github.com/DataDog/integrations-core/pull/13721) that removes the custom metrics note from the Windows Service integrations docs

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
