### PR TITLE
WEB-3658 - highlight adjustments

### DIFF
--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -2,8 +2,7 @@ export function getHitData(hit, qry = '') {
     const title = hit.title ? hit.title : hit.type;
     const cleanRelPermalink =
         hit.language == 'en' ? hit.relpermalink : hit.relpermalink.replace(`/${hit.language}/`, '');
-    const words = qry.split(' ');
-    const orMatches = words.map((word, index) => (index === words.length - 1) ? `${word}` : `${word}|`).join('');
+    const orMatches = qry.split(' ').filter(word => word).join('|');
     const regexQry = new RegExp(`(${orMatches})`, 'gi');
     const highlightedTitle = (hit._highlightResult.title.value || title).replace(regexQry, '<mark>$1</mark>');
     const highlightedContent = (hit._highlightResult.content.value || '').replace(regexQry, '<mark>$1</mark>');

--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -1,15 +1,20 @@
-export function getHitData(hit) {
+export function getHitData(hit, qry = '') {
     const title = hit.title ? hit.title : hit.type;
     const cleanRelPermalink =
         hit.language == 'en' ? hit.relpermalink : hit.relpermalink.replace(`/${hit.language}/`, '');
+    const words = qry.split(' ');
+    const orMatches = words.map((word, index) => (index === words.length - 1) ? `${word}` : `${word}|`).join('');
+    const regexQry = new RegExp(`(${orMatches})`, 'gi');
+    const highlightedTitle = (hit._highlightResult.title.value || title).replace(regexQry, '<mark>$1</mark>');
+    const highlightedContent = (hit._highlightResult.content.value || '').replace(regexQry, '<mark>$1</mark>');
 
     return {
         relpermalink: cleanRelPermalink,
         category: hit.category ? hit.category : 'Documentation',
         subcategory: hit.subcategory ? hit.subcategory : title,
-        title: hit._highlightResult.title ? hit._highlightResult.title.value : title,
+        title: highlightedTitle,
         section_header: hit.section_header || null,
-        content: hit._highlightResult.content ? hit._highlightResult.content.value : '',
+        content: highlightedContent,
         content_snippet: hit._snippetResult ? hit._snippetResult.content.value : '',
         content_snippet_match_level: hit._snippetResult ? hit._snippetResult.content.matchLevel : ''
     };

--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -4,8 +4,12 @@ export function getHitData(hit, qry = '') {
         hit.language == 'en' ? hit.relpermalink : hit.relpermalink.replace(`/${hit.language}/`, '');
     const orMatches = qry.split(' ').filter(word => word).join('|');
     const regexQry = new RegExp(`(${orMatches})`, 'gi');
-    const highlightedTitle = (hit._highlightResult.title.value || title).replace(regexQry, '<mark>$1</mark>');
-    const highlightedContent = (hit._highlightResult.content.value || '').replace(regexQry, '<mark>$1</mark>');
+    let highlightedTitle = (hit._highlightResult.title.value || title);
+    let highlightedContent = (hit._highlightResult.content.value || '');
+    if(qry) {
+      highlightedTitle = highlightedTitle.replace(regexQry, '<mark>$1</mark>');
+      highlightedContent = highlightedContent.replace(regexQry, '<mark>$1</mark>');
+    }
 
     return {
         relpermalink: cleanRelPermalink,

--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -7,7 +7,7 @@ export function getHitData(hit) {
         relpermalink: cleanRelPermalink,
         category: hit.category ? hit.category : 'Documentation',
         subcategory: hit.subcategory ? hit.subcategory : title,
-        title,
+        title: hit._highlightResult.title ? hit._highlightResult.title.value : title,
         section_header: hit.section_header || null,
         content: hit._highlightResult.content ? hit._highlightResult.content.value : '',
         content_snippet: hit._snippetResult ? hit._snippetResult.content.value : '',

--- a/assets/scripts/components/algolia/searchbarHits.js
+++ b/assets/scripts/components/algolia/searchbarHits.js
@@ -1,5 +1,5 @@
 import { getHitData } from './getHitData';
-import { truncateContent } from '../../helpers/truncateContent';
+import { truncateContentAtHighlight } from '../../helpers/truncateContent';
 import { bodyClassContains } from '../../helpers/helpers';
 import connectHits from 'instantsearch.js/es/connectors/hits/connectHits';
 
@@ -88,7 +88,7 @@ const renderHits = (renderOptions, isFirstRender) => {
         const joinedListItems = hitsArray
             .map((item) => {
                 const hit = getHitData(item);
-                const displayContent = truncateContent(
+                const displayContent = truncateContentAtHighlight(
                     hit.content_snippet_match_level === 'full' ? hit.content_snippet : hit.content,
                     145
                 );

--- a/assets/scripts/components/algolia/searchbarHits.js
+++ b/assets/scripts/components/algolia/searchbarHits.js
@@ -88,10 +88,7 @@ const renderHits = (renderOptions, isFirstRender) => {
         const joinedListItems = hitsArray
             .map((item) => {
                 const hit = getHitData(item, renderOptions.results.query);
-                const displayContent = truncateContentAtHighlight(
-                    hit.content_snippet_match_level === 'full' ? hit.content_snippet : hit.content,
-                    145
-                );
+                const displayContent = truncateContentAtHighlight(hit.content, 145);
                 const cleanRelpermalink = `${basePathName}${hit.relpermalink}`.replace('//', '/');
                 const section_header = hit.section_header ? `&raquo; ${hit.section_header}` : '';
 

--- a/assets/scripts/components/algolia/searchbarHits.js
+++ b/assets/scripts/components/algolia/searchbarHits.js
@@ -87,7 +87,7 @@ const renderHits = (renderOptions, isFirstRender) => {
     const generateJoinedHits = (hitsArray, category) => {
         const joinedListItems = hitsArray
             .map((item) => {
-                const hit = getHitData(item);
+                const hit = getHitData(item, renderOptions.results.query);
                 const displayContent = truncateContentAtHighlight(
                     hit.content_snippet_match_level === 'full' ? hit.content_snippet : hit.content,
                     145

--- a/assets/scripts/components/algolia/searchpageHits.js
+++ b/assets/scripts/components/algolia/searchpageHits.js
@@ -23,7 +23,7 @@ const renderHits = (renderOptions, isFirstRender) => {
         const subcategory = `<p class="ais-Hits-subcategory">${hit.subcategory}</p>`;
         const pageTitle = `<p class="ais-Hits-title">${hit.title}</p>`;
         const baseTitleHierarchy =
-            hit.subcategory === hit.title
+            hit.subcategory === hit.title.replace(/(<mark>|<\/mark>)/gm, '')
                 ? `${category}${spacer}${pageTitle}`
                 : `${category}${spacer}${subcategory}${spacer}${pageTitle}`;
 
@@ -37,13 +37,13 @@ const renderHits = (renderOptions, isFirstRender) => {
         return hitsArray
             .map((item) => {
                 const hit = getHitData(item, renderOptions.results.query);
-                const displayContent = truncateContentAtHighlight(hit.content, 145);
+                const displayContent = truncateContentAtHighlight(hit.content, 300);
                 const cleanRelpermalink = `${basePathName}${hit.relpermalink}`.replace('//', '/');
 
                 return `
                     <li class="ais-Hits-item">
                         <a href="${cleanRelpermalink}" target="_blank" rel="noopener noreferrer">
-                            <div class="ais-Hits-row">${getTitleHierarchyHTML(item)}</div>
+                            <div class="ais-Hits-row">${getTitleHierarchyHTML(hit)}</div>
                             <div class="ais-Hits-row">
                                 <p class="ais-Hits-content">${displayContent}</p>
                             </div>

--- a/assets/scripts/components/algolia/searchpageHits.js
+++ b/assets/scripts/components/algolia/searchpageHits.js
@@ -1,5 +1,5 @@
 import { getHitData } from './getHitData';
-import { truncateContent } from '../../helpers/truncateContent';
+import { truncateContentAtHighlight } from '../../helpers/truncateContent';
 import connectHits from 'instantsearch.js/es/connectors/hits/connectHits';
 
 const renderHits = (renderOptions, isFirstRender) => {
@@ -37,9 +37,9 @@ const renderHits = (renderOptions, isFirstRender) => {
         return hitsArray
             .map((item) => {
                 const hit = getHitData(item);
-                const displayContent = truncateContent(
+                const displayContent = truncateContentAtHighlight(
                     hit.content_snippet_match_level === 'full' ? hit.content_snippet : hit.content,
-                    100
+                    145
                 );
                 const cleanRelpermalink = `${basePathName}${hit.relpermalink}`.replace('//', '/');
 

--- a/assets/scripts/components/algolia/searchpageHits.js
+++ b/assets/scripts/components/algolia/searchpageHits.js
@@ -36,11 +36,8 @@ const renderHits = (renderOptions, isFirstRender) => {
     const generateJoinedHits = (hitsArray) => {
         return hitsArray
             .map((item) => {
-                const hit = getHitData(item);
-                const displayContent = truncateContentAtHighlight(
-                    hit.content_snippet_match_level === 'full' ? hit.content_snippet : hit.content,
-                    145
-                );
+                const hit = getHitData(item, renderOptions.results.query);
+                const displayContent = truncateContentAtHighlight(hit.content, 145);
                 const cleanRelpermalink = `${basePathName}${hit.relpermalink}`.replace('//', '/');
 
                 return `

--- a/assets/scripts/helpers/truncateContent.js
+++ b/assets/scripts/helpers/truncateContent.js
@@ -10,7 +10,6 @@ export const truncateContentAtHighlight = (content, length) => {
   /*
     Find the first largest highlight match and slice the content so this is visible in the snippet.
   */
-  const midpoint = Math.round(length * 0.5);
   let new_content = content;
   let matches = [...content.matchAll(new RegExp('<mark>(.*?)<\\/mark>(?! <mark>)', 'gm'))]
     .sort(m => m[0].length)
@@ -22,9 +21,15 @@ export const truncateContentAtHighlight = (content, length) => {
     let start = first;
     if(start < 0) start = 0
     let end = start + length;
-    new_content = `${content.slice(start, end)} ...`;
+    if(end > content.length) {
+      start = start - (end - content.length);
+      if(start < 0) start = 0
+      end = length;
+    }
+    new_content = `${content.slice(start, end).trim()} ...`;
   } else {
-    new_content = truncateContent(content, length)
+    // no highlighted words lets just truncate it normally..
+    new_content = truncateContent(content, length);
   }
   return new_content;
 };

--- a/assets/scripts/helpers/truncateContent.js
+++ b/assets/scripts/helpers/truncateContent.js
@@ -5,3 +5,26 @@ export const truncateContent = (content, length) => {
         return content;
     }
 };
+
+export const truncateContentAtHighlight = (content, length) => {
+  /*
+    Find the first largest highlight match and slice the content so this is visible in the snippet.
+  */
+  const midpoint = Math.round(length * 0.5);
+  let new_content = content;
+  let matches = [...content.matchAll(new RegExp('<mark>(.*?)<\\/mark>(?! <mark>)', 'gm'))]
+    .sort(m => m[0].length)
+    .map(m => m.index)
+    .reverse();
+  if(matches.length) {
+    const first = matches[0];
+    // slice with our matched highlight in the middle somewhere
+    let start = first;
+    if(start < 0) start = 0
+    let end = start + length;
+    new_content = `${content.slice(start, end)} ...`;
+  } else {
+    new_content = truncateContent(content, length)
+  }
+  return new_content;
+};

--- a/assets/scripts/helpers/truncateContent.js
+++ b/assets/scripts/helpers/truncateContent.js
@@ -10,26 +10,31 @@ export const truncateContentAtHighlight = (content, length) => {
   /*
     Find the first largest highlight match and slice the content so this is visible in the snippet.
   */
-  let new_content = content;
+  // Find all the <mark> matches sort them numerically and then return a custom object containing start & end indexes
   let matches = [...content.matchAll(new RegExp('<mark>(.*?)<\\/mark>(?! <mark>)', 'gm'))]
-    .sort(m => m[0].length)
-    .map(m => m.index)
+    .sort((a, b) => a[0].length - b[0].length)
+    .map(m => {return { "start": m.index, "end": m.index + m[0].length}})
     .reverse();
   if(matches.length) {
     const first = matches[0];
     // slice with our matched highlight in the middle somewhere
-    let start = first;
-    if(start < 0) start = 0
+    let start = (first.start < 0) ? 0 : first.start;
     let end = start + length;
     if(end > content.length) {
       start = start - (end - content.length);
       if(start < 0) start = 0
-      end = length;
+      end = start + length;
     }
-    new_content = `${content.slice(start, end).trim()} ...`;
+    // if start or end is in a highlighted word <mark> and slicing is breaking the html tag then fix it.
+    matches.forEach((match) => {
+      // we are trying to truncate during a match, set to end of match.
+      if(end > match.start && end < match.end) {
+        end = match.end;
+      }
+    });
+    return `${content.slice(start, end).trim()} ...`;
   } else {
     // no highlighted words lets just truncate it normally..
-    new_content = truncateContent(content, length);
+    return truncateContent(content, length);
   }
-  return new_content;
 };

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -2,8 +2,9 @@
     {{ $.Scratch.Add "algoliaindex" slice }}
     {{ $section := $.Site.GetPage "section" .Section }}
     {{ $hugo_context := . }}
+    {{ $apiPagesWithoutTypeAPI := slice "api/latest/_index.md" "api/latest/rate-limits/_index.md" "api/latest/scopes/_index.md" }}
 
-    {{ range where (where .Site.AllPages "Kind" "!=" "home") "Type" "!=" "api" }}
+    {{ range (where (where (where .Site.AllPages "Kind" "!=" "home") "Type" "!=" "api") "File.Path" "not in" $apiPagesWithoutTypeAPI) }}
         {{ $page := . }}
         {{ if and ($page.IsDescendant $section) (ne $page.Params.private true) (ne $page.Params.kind "faq") (not $page.Draft) (not (isset .Params "external_redirect")) }}
             {{ $rel_path := (print $page.File.Lang "/" $page.File.Path) }}


### PR DESCRIPTION
### What does this PR do?

Improve search dropdown highlighting by adjusting content we truncate and also highlighting clientside with JS when algolia stops.

### Motivation

To improve visible matching
https://datadoghq.atlassian.net/browse/WEB-3658

### Preview

searchbar anywhere: https://docs-staging.datadoghq.com/david.jones/snippet-improve/
search results page: https://docs-staging.datadoghq.com/david.jones/snippet-improve/search/

Testing
- search for "image name instead of the regular" (including quotes)
- search for docker or other keywords such as cloudfront or eks logging

and inspect the results, you should see highlighting more often than not.

### Additional Notes

Note that while this is an improvement i've noticed that some results still don't highlight anything even though the keywords are appearing. See card for more details

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
