### PR TITLE
If api page, use api_index from algolia

### DIFF
--- a/assets/scripts/components/algolia.js
+++ b/assets/scripts/components/algolia.js
@@ -25,7 +25,7 @@ function sendSearchRumAction(searchQuery, clickthroughLink = '') {
             page: window.location.pathname,
             lang: getPageLanguage(),
             clickthroughLink
-        })
+        });
     }
 }
 
@@ -176,21 +176,21 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
                 }
             };
 
-            const handleOutsideSearchbarClick = (e) => {                
+            const handleOutsideSearchbarClick = (e) => {
                 // Intercept user clicks within algolia dropdown to send custom RUM event before redirect.
                 if (hitsContainer.contains(e.target)) {
-                    e.preventDefault()
+                    e.preventDefault();
                 }
-                
+
                 let target = e.target;
 
                 do {
                     if (target === searchBoxContainerContainer) return;
 
                     if (target && target.href && hitsContainer.contains(e.target)) {
-                        sendSearchRumAction(search.helper.state.query, target.href)
-                        window.history.pushState({}, '', target.href)
-                        window.location.reload()
+                        sendSearchRumAction(search.helper.state.query, target.href);
+                        window.history.pushState({}, '', target.href);
+                        window.location.reload();
                     }
 
                     target = target.parentNode;
@@ -205,19 +205,19 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
         } else {
             // Handle sending search RUM events from click events on the search results page.
             hitsContainer.addEventListener('click', (e) => {
-                e.preventDefault()
-                let target = e.target
+                e.preventDefault();
+                let target = e.target;
 
                 do {
                     if (target.href) {
-                        sendSearchRumAction(search.helper.state.query, target.href)
-                        window.history.pushState({}, '', target.href)
-                        window.location.reload()
+                        sendSearchRumAction(search.helper.state.query, target.href);
+                        window.history.pushState({}, '', target.href);
+                        window.location.reload();
                     }
 
-                    target = target.parentNode
-                } while (target)
-            })
+                    target = target.parentNode;
+                } while (target);
+            });
         }
 
         // Pages that aren't homepage or search page need to move the searchbar on mobile

--- a/assets/scripts/components/algolia.js
+++ b/assets/scripts/components/algolia.js
@@ -33,7 +33,7 @@ const { env } = document.documentElement.dataset;
 const pageLanguage = getPageLanguage();
 const algoliaConfig = getConfig(env).algoliaConfig;
 const searchClient = algoliasearch(algoliaConfig.appId, algoliaConfig.apiKey);
-const indexName = algoliaConfig.index;
+let indexName = algoliaConfig.index;
 
 function loadInstantSearch(currentPageWasAsyncLoaded) {
     const searchBoxContainerContainer = document.querySelector('.searchbox-container');
@@ -44,6 +44,7 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
     const pageTitleScrollTo = document.querySelector('#pagetitle');
     const filtersDocs = `language: ${pageLanguage}`;
     const homepage = document.querySelector('.kind-home');
+    const apiPage = document.querySelector('body.api');
     let searchResultsPage = document.querySelector('.search_results_page');
     let basePathName = '/';
     let numHits = 5;
@@ -60,6 +61,10 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
 
     if (pageLanguage !== 'en') {
         basePathName += `${pageLanguage}/`;
+    }
+
+    if (apiPage) {
+        indexName = algoliaConfig.api_index;
     }
 
     if (searchResultsPage) {

--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -1,6 +1,7 @@
 export function getHitData(hit) {
     const title = hit.title ? hit.title : hit.type;
-    const cleanRelPermalink = hit.language == 'en' ? hit.relpermalink : hit.relpermalink.replace(`/${hit.language}/`, '')
+    const cleanRelPermalink =
+        hit.language == 'en' ? hit.relpermalink : hit.relpermalink.replace(`/${hit.language}/`, '');
 
     return {
         relpermalink: cleanRelPermalink,

--- a/assets/scripts/components/algolia/searchbarHits.js
+++ b/assets/scripts/components/algolia/searchbarHits.js
@@ -88,9 +88,12 @@ const renderHits = (renderOptions, isFirstRender) => {
         const joinedListItems = hitsArray
             .map((item) => {
                 const hit = getHitData(item);
-                const displayContent = truncateContent(hit.content_snippet_match_level === "full" ? hit.content_snippet : hit.content, 145);
+                const displayContent = truncateContent(
+                    hit.content_snippet_match_level === 'full' ? hit.content_snippet : hit.content,
+                    145
+                );
                 const cleanRelpermalink = `${basePathName}${hit.relpermalink}`.replace('//', '/');
-                const section_header = (hit.section_header) ? `&raquo; ${hit.section_header}` : ""
+                const section_header = hit.section_header ? `&raquo; ${hit.section_header}` : '';
 
                 return `
                     <li class="ais-Hits-item">
@@ -106,12 +109,15 @@ const renderHits = (renderOptions, isFirstRender) => {
             })
             .join('');
 
-        const enhanceApiCategoryHeader = category.toLowerCase() === 'api' && bodyClassContains('api')
-        const categoryLiClassList = 'ais-Hits-item ais-Hits-category'
-        const categoryParagraphClassList = enhanceApiCategoryHeader ? 'fw-bold text-primary' : ''
+        const enhanceApiCategoryHeader = category.toLowerCase() === 'api' && bodyClassContains('api');
+        const categoryLiClassList = 'ais-Hits-item ais-Hits-category';
+        const categoryParagraphClassList = enhanceApiCategoryHeader ? 'fw-bold text-primary' : '';
 
         return hitsArray.length
-            ? [`<li class="${categoryLiClassList}"><p class="${categoryParagraphClassList}">${category}</p></li>`, joinedListItems].join('')
+            ? [
+                  `<li class="${categoryLiClassList}"><p class="${categoryParagraphClassList}">${category}</p></li>`,
+                  joinedListItems
+              ].join('')
             : null;
     };
 
@@ -134,8 +140,8 @@ const renderHits = (renderOptions, isFirstRender) => {
 
     // Ensure API results render first if user performs a search from an API page.
     if (bodyClassContains('api')) {
-        allJoinedListItemsHTML.pop()
-        allJoinedListItemsHTML.unshift(generateJoinedHits(apiHitsArray, 'API'))
+        allJoinedListItemsHTML.pop();
+        allJoinedListItemsHTML.unshift(generateJoinedHits(apiHitsArray, 'API'));
     }
 
     if (isFirstRender) {

--- a/assets/scripts/components/algolia/searchpageHits.js
+++ b/assets/scripts/components/algolia/searchpageHits.js
@@ -18,25 +18,29 @@ const renderHits = (renderOptions, isFirstRender) => {
     };
 
     const getTitleHierarchyHTML = (hit) => {
-        const spacer = '<span class="ais-Hits-category-spacer">&#187;</span>'
-        const category = `<p class="ais-Hits-category">${hit.category}</p>`
-        const subcategory = `<p class="ais-Hits-subcategory">${hit.subcategory}</p>`
-        const pageTitle = `<p class="ais-Hits-title">${hit.title}</p>`
-        const baseTitleHierarchy = hit.subcategory === hit.title
-            ? `${category}${spacer}${pageTitle}`
-            : `${category}${spacer}${subcategory}${spacer}${pageTitle}`
+        const spacer = '<span class="ais-Hits-category-spacer">&#187;</span>';
+        const category = `<p class="ais-Hits-category">${hit.category}</p>`;
+        const subcategory = `<p class="ais-Hits-subcategory">${hit.subcategory}</p>`;
+        const pageTitle = `<p class="ais-Hits-title">${hit.title}</p>`;
+        const baseTitleHierarchy =
+            hit.subcategory === hit.title
+                ? `${category}${spacer}${pageTitle}`
+                : `${category}${spacer}${subcategory}${spacer}${pageTitle}`;
 
         return hit.section_header
             ? `${baseTitleHierarchy}${spacer}<p class="ais-Hits-title">${hit.section_header}</p>`
-            : `${baseTitleHierarchy}`
-    }
+            : `${baseTitleHierarchy}`;
+    };
 
     // Returns a bunch of <li>s
     const generateJoinedHits = (hitsArray) => {
         return hitsArray
             .map((item) => {
                 const hit = getHitData(item);
-                const displayContent = truncateContent(hit.content_snippet_match_level === "full" ? hit.content_snippet : hit.content, 100);
+                const displayContent = truncateContent(
+                    hit.content_snippet_match_level === 'full' ? hit.content_snippet : hit.content,
+                    100
+                );
                 const cleanRelpermalink = `${basePathName}${hit.relpermalink}`.replace('//', '/');
 
                 return `
@@ -60,7 +64,6 @@ const renderHits = (renderOptions, isFirstRender) => {
 
     const aisHits = document.createElement('div');
     const aisHitsList = document.createElement('ol');
-
 
     if (isFirstRender) {
         addAttributesToEmptyElements();

--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -109,7 +109,8 @@ const updateReplicas = (client, indexName) => {
 
     Object.entries(replicas).forEach(([replicaIndexName, replicaSettings]) => {
         console.log(`Updating replica ${replicaIndexName}..`);
-        console.log(`Replica settings as follows: ${replicaSettings}`);
+        console.log(`Replica settings as follows:`);
+        console.log(replicaSettings);
         const index = client.initIndex(replicaIndexName);
         index.setSettings(replicaSettings).then((response) => {
             console.log(`Index ${replicaIndexName} configuration update complete...`);

--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -32,9 +32,7 @@ const updateSettings = (index) => {
         customRanking: ['desc(rank)'],
         attributesToHighlight: ['title', 'section_header', 'content', 'tags'],
         attributesForFaceting: ['language', 'searchable(tags)'],
-        attributesToSnippet: [
-            'content:20'
-        ],
+        attributesToSnippet: ['content:20'],
         indexLanguages: ['ja', 'en', 'fr'],
         queryLanguages: ['ja', 'en', 'fr'],
         attributeForDistinct: 'full_url',
@@ -151,10 +149,12 @@ const sync = () => {
         .catch((err) => console.error(err));
 
     updateSynonyms(index)
-        .then(() => console.log(`${indexName} synonyms update complete`))
+        .then(() => {
+            console.log(`${indexName} synonyms update complete`);
+            updateReplicas(client, indexName);
+        })
         .catch((err) => console.error(err));
 
-    updateReplicas(client, indexName);
     updateIndex(indexName);
 };
 

--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -107,8 +107,6 @@ const updateReplicas = (client, indexName) => {
 
     Object.entries(replicas).forEach(([replicaIndexName, replicaSettings]) => {
         console.log(`Updating replica ${replicaIndexName}..`);
-        console.log(`Replica settings as follows:`);
-        console.log(replicaSettings);
         const index = client.initIndex(replicaIndexName);
         index.setSettings(replicaSettings).then((response) => {
             console.log(`Index ${replicaIndexName} configuration update complete...`);
@@ -145,14 +143,14 @@ const sync = () => {
     const index = client.initIndex(indexName);
 
     updateSettings(index)
-        .then(() => console.log(`${indexName} settings update complete`))
+        .then(() => {
+            console.log(`${indexName} settings update complete`);
+            updateReplicas(client, indexName);
+        })
         .catch((err) => console.error(err));
 
     updateSynonyms(index)
-        .then(() => {
-            console.log(`${indexName} synonyms update complete`);
-            updateReplicas(client, indexName);
-        })
+        .then(() => console.log(`${indexName} synonyms update complete`))
         .catch((err) => console.error(err));
 
     updateIndex(indexName);

--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -109,6 +109,7 @@ const updateReplicas = (client, indexName) => {
 
     Object.entries(replicas).forEach(([replicaIndexName, replicaSettings]) => {
         console.log(`Updating replica ${replicaIndexName}..`);
+        console.log(`Replica settings as follows: ${replicaSettings}`);
         const index = client.initIndex(replicaIndexName);
         index.setSettings(replicaSettings).then((response) => {
             console.log(`Index ${replicaIndexName} configuration update complete...`);


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- Updates `algolia.js` to use the `api_index` from the config for algolia search if it is an API page
- Updates `algolia-index-sync.js` to correctly apply the `customRanking` value to the replica index

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/browse/WEB-3732

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
Preview: https://docs-staging.datadoghq.com/davidweid/update-api-search/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
