### PR TITLE
[serverless] Add datadog-ci workaround for package too large error

### DIFF
--- a/content/en/serverless/guide/serverless_package_too_large.md
+++ b/content/en/serverless/guide/serverless_package_too_large.md
@@ -63,6 +63,10 @@ Also inspect other dependencies (the `node_modules` folder) that are included in
 
 Using a bundler like [Webpack][6] or [esbuild][7] can dramatically reduce your deployment package size by only including the code that is used. See [Node.js Lambda Tracing and Bundlers Compatibility][8] for required webpack configurations.
 
+## Alternately use datadog-ci
+
+Depending on your use case, you may find it easier to use the `datadog-ci lambda instrument` command to work around issues with package sizes. You can find documentation for this command in the [datadog-ci repo][9].
+
 ## Get help
 
 If you need the Datadog support team to help investigate, include the following information in your ticket:
@@ -83,3 +87,4 @@ If you need the Datadog support team to help investigate, include the following 
 [6]: https://webpack.js.org
 [7]: https://esbuild.github.io/
 [8]: /serverless/guide/serverless_tracing_and_bundlers/
+[9]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/lambda#readme

--- a/content/en/serverless/guide/serverless_package_too_large.md
+++ b/content/en/serverless/guide/serverless_package_too_large.md
@@ -65,7 +65,7 @@ Using a bundler like [Webpack][6] or [esbuild][7] can dramatically reduce your d
 
 ## Alternately use datadog-ci
 
-Depending on your use case, you may find it easier to use the `datadog-ci lambda instrument` command to work around issues with package sizes. The `datadog-ci lambda instrument` command configures the same instrumentation as serverless-plugin-datadog. You can find documentation for this command in the [datadog-ci repo][9].
+Depending on your use case, you may find it easier to use the `datadog-ci lambda instrument` command to work around issues with package sizes. The `datadog-ci lambda instrument` command configures the same instrumentation as serverless-plugin-datadog. For more information, see the [datadog-ci repo][9].
 
 ## Get help
 

--- a/content/en/serverless/guide/serverless_package_too_large.md
+++ b/content/en/serverless/guide/serverless_package_too_large.md
@@ -63,7 +63,7 @@ Also inspect other dependencies (the `node_modules` folder) that are included in
 
 Using a bundler like [Webpack][6] or [esbuild][7] can dramatically reduce your deployment package size by only including the code that is used. See [Node.js Lambda Tracing and Bundlers Compatibility][8] for required webpack configurations.
 
-## Alternately use datadog-ci
+## Datadog-ci
 
 Depending on your use case, you may find it easier to use the `datadog-ci lambda instrument` command to work around issues with package sizes. The `datadog-ci lambda instrument` command configures the same instrumentation as serverless-plugin-datadog. For more information, see the [datadog-ci repo][9].
 

--- a/content/en/serverless/guide/serverless_package_too_large.md
+++ b/content/en/serverless/guide/serverless_package_too_large.md
@@ -65,7 +65,7 @@ Using a bundler like [Webpack][6] or [esbuild][7] can dramatically reduce your d
 
 ## Alternately use datadog-ci
 
-Depending on your use case, you may find it easier to use the `datadog-ci lambda instrument` command to work around issues with package sizes. You can find documentation for this command in the [datadog-ci repo][9].
+Depending on your use case, you may find it easier to use the `datadog-ci lambda instrument` command to work around issues with package sizes. The `datadog-ci lambda instrument` command configures the same instrumentation as serverless-plugin-datadog. You can find documentation for this command in the [datadog-ci repo][9].
 
 ## Get help
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a workaround for the package too large error

### Motivation
Met with a customer having this issue who wasn't aware this is an option

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
