### PR TITLE
horizontal scroll on code blocks "```"

### DIFF
--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -150,7 +150,7 @@ pre {
         font-size: 14px;
         line-height: 27px;
         color: #555555;
-        white-space: pre-wrap;
+        white-space: pre;
         background-color: transparent;
         border-radius: 0;
         border: none;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

enable horizontal scroll on fenced codeblocks (markdown codeblocks)

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-3688

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

all codeblocks with content that was wrapped should now overflow the container. you should be able to horizontally scroll for more content:
- https://docs-staging.datadoghq.com/stefon.simmons/web-3688/containers/amazon_ecs/apm/?tab=ec2metadataendpoint#configure-the-trace-agent-endpoint

- https://docs-staging.datadoghq.com/stefon.simmons/web-3688/account_management/saml/troubleshooting/#roles-errors

- https://docs-staging.datadoghq.com/stefon.simmons/web-3688/security/default_rules/aws-iam-role-trust-policy-misconfigured-github/#remediation

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
