### PR TITLE
DOCS-3766 CI Visibility Pipelines and Tests Index Page Edits

### DIFF
--- a/content/en/continuous_integration/pipelines/_index.md
+++ b/content/en/continuous_integration/pipelines/_index.md
@@ -5,20 +5,25 @@ aliases:
   - /continuous_integration/pipelines_setup/
   - /continuous_integration/explore_pipelines/
 further_reading:
+    - link: "/monitors/types/ci/"
+      tag: "Documentation"
+      text: "Creating CI Pipeline Monitors"
     - link: "/continuous_integration/troubleshooting/"
       tag: "Documentation"
-      text: "Troubleshooting CI"
+      text: "Troubleshooting CI Visibility"
 ---
 
 {{< site-region region="gov" >}}
 <div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-Your pipelines appear in the [Pipelines][1] page under the CI menu.
+## Overview
+
+The [**Pipelines**][1] page provides a pipeline-first view into your CI health by displaying important metrics and results from your pipelines. It can help you investigate performance problems and test failures that concern you the most because you work on the related code, not because you maintain the pipelines they are run in.
 
 ## Setup
 
-{{< whatsnext desc="Select your CI provider to set up pipeline visibility in Datadog:" >}}
+{{< whatsnext desc="Select your CI provider to set up Pipeline Visibility in Datadog:" >}}
     {{< nextlink href="continuous_integration/pipelines/azure" >}}Azure{{< /nextlink >}}
     {{< nextlink href="continuous_integration/pipelines/buildkite" >}}Buildkite{{< /nextlink >}}
     {{< nextlink href="continuous_integration/pipelines/circleci" >}}CircleCI{{< /nextlink >}}
@@ -30,6 +35,11 @@ Your pipelines appear in the [Pipelines][1] page under the CI menu.
     {{< nextlink href="continuous_integration/pipelines/custom_commands" >}}Custom Commands{{< /nextlink >}}
     {{< nextlink href="continuous_integration/pipelines/custom_tags_and_metrics" >}}Custom Tags and Metrics{{< /nextlink >}}
 {{< /whatsnext >}}
+
+## Explore pipelines
+
+To see your pipelines, navigate to **CI** > **Pipelines**.
+
 ## Pipelines health overview
 
 The Pipelines page shows aggregate stats for the default branch of each pipeline over the selected time frame, as well as the status of the latest pipeline execution. Use this page to see all your pipelines and get a quick view of their health. The Pipelines page shows metrics for the _default_ branch, usually named something like `main` or `prod`.
@@ -89,9 +99,13 @@ Alternatively, click the [**Analytics**][6] button to interactively filter and g
 
 {{< img src="ci/ci-pipelines-execution.png" alt="Analytics for a pipeline execution" style="width:100%;">}}
 
-## Communicate about CI pipelines data
+## Use CI pipelines data
 
-CI pipeline data is available when you create widgets in [Dashboards][7] and [Notebooks][8].
+When creating a [dashboards][9] and [notebooks][10], you can use pipeline execution data in your search query, which updates the visualization widget options.
+
+## Export data to a monitor
+
+You can export your search query to a [CI Pipeline monitor][11] on the Pipelines Executions page by clicking the **Export** button in the **All Test Runs** or **Pipeline Executions**.
 
 ## Further reading
 
@@ -106,3 +120,6 @@ CI pipeline data is available when you create widgets in [Dashboards][7] and [No
 [6]: https://app.datadoghq.com/ci/pipeline-executions?viz=timeseries
 [7]: https://app.datadoghq.com/dashboard/lists
 [8]: https://app.datadoghq.com/notebook/list
+[9]: /dashboards/
+[10]: /notebooks/
+[11]: /monitors/types/ci/

--- a/content/en/continuous_integration/tests/_index.md
+++ b/content/en/continuous_integration/tests/_index.md
@@ -4,15 +4,18 @@ kind: documentation
 aliases:
   - /continuous_integration/explore_tests/
 further_reading:
+    - link: "/monitors/types/ci/"
+      tag: "Documentation"
+      text: "Creating CI Test Monitors"
     - link: "/continuous_integration/guides/find_flaky_tests/"
-      tag: "Guide"
+      tag: "Documentation"
       text: "Finding Flaky Tests"
     - link: "/continuous_integration/guides/rum_integration/"
-      tag: "Guide"
+      tag: "Documentation"
       text: "Linking CI Visibility and RUM"
     - link: "/continuous_integration/troubleshooting/"
       tag: "Documentation"
-      text: "Troubleshooting CI"
+      text: "Troubleshooting CI Visibility"
     - link: "https://www.datadoghq.com/blog/ci-test-visibility-with-rum/"
       tag: "Blog"
       text: "Troubleshoot end-to-end tests with CI Visibility and RUM"
@@ -22,13 +25,13 @@ further_reading:
 <div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-The [Tests][1] page, under the CI menu in Datadog, provides a test-first view into your CI health by showing you important metrics and results from your tests. It can help you investigate performance problems and test failures that concern you primarily because you work on the related code (and less because you maintain the pipelines they are run in).
+## Overview
+
+The [**Tests**][1] page provides a test-first view into your CI health by displaying important metrics and results from your tests. It can help you investigate performance problems and test failures that concern you the most because you work on the related code, not because you maintain the pipelines they are run in.
 
 ## Setup
 
-
-
-{{< whatsnext desc="Choose a language to set up test visibility in Datadog:" >}}
+{{< whatsnext desc="Choose a language to set up Test Visibility in Datadog:" >}}
     {{< nextlink href="continuous_integration/tests/dotnet" >}}.NET{{< /nextlink >}}
     {{< nextlink href="continuous_integration/tests/java" >}}Java{{< /nextlink >}}
     {{< nextlink href="continuous_integration/tests/javascript" >}}JavaScript{{< /nextlink >}}
@@ -39,7 +42,7 @@ The [Tests][1] page, under the CI menu in Datadog, provides a test-first view in
 {{< /whatsnext >}}
 ## Explore tests
 
-The Tests page shows the _Branches_ view and the _Default Branches_ view.
+To see your tests, navigate to **CI** > **Tests** and select between the [**Branches**](#branches-view) or [**Default Branches** view](#default-branches-view).
 
 ### Branches view
 
@@ -96,7 +99,7 @@ In addition to tests, CI Visibility provides visibility over the whole testing p
 {{< img src="ci/ci-test-suite-visibility.png" alt="Test Suite Visibility" style="width:100%;">}}
 
 #### Sessions
-Test sessions are the highest level of aggregation. They correspond one to one to a test command, such as `yarn test`, `mvn test` or `dotnet test`.
+Test sessions are the highest level of aggregation. They correspond one to one to a test command, such as `yarn test`, `mvn test`, or `dotnet test`.
 
 #### Module
 The definition of module changes slightly per language:
@@ -111,7 +114,7 @@ An example of a module is `SwiftLintFrameworkTests`, which corresponds to a test
 #### Suite
 A test suite is a group of tests exercising the same unit of code.
 
-An example of a test suite is `src/commands/junit/__tests__/upload.test.ts`, which corresponds to a test file in [`datadog-ci`][10]
+An example of a test suite is `src/commands/junit/__tests__/upload.test.ts`, which corresponds to a test file in [`datadog-ci`][10].
 
 #### Compatibility
 Not every language supported by CI Visibility has support for test suite level visibility:
@@ -124,9 +127,13 @@ Not every language supported by CI Visibility has support for test suite level v
 
 Additionally, test suite level visibility is only supported in Agentless mode.
 
-## Communicate about CI tests data
+## Use CI tests data
 
-Test execution data is available when you create widgets in [Dashboards][14] and [Notebooks][15].
+When creating a [dashboards][14] and [notebooks][15], you can use test execution data in your search query, which updates the visualization widget options.
+
+## Create a monitor
+
+When you evaluate failed or flaky tests, or the performance of a CI test on the Test Runs page, click **Create Monitor** to create a [CI Test monitor][16]. 
 
 ## Further reading
 
@@ -147,3 +154,4 @@ Test execution data is available when you create widgets in [Dashboards][14] and
 [13]: /continuous_integration/tests/javascript/#test-suite-level-visibility-compatibility
 [14]: https://app.datadoghq.com/dashboard/lists
 [15]: https://app.datadoghq.com/notebook/list
+[16]: /monitors/types/ci/

--- a/content/en/continuous_integration/tests/javascript.md
+++ b/content/en/continuous_integration/tests/javascript.md
@@ -28,17 +28,17 @@ Supported test frameworks:
 * Jest >= 24.8.0
   * Only `jsdom` (in package `jest-environment-jsdom`) and `node` (in package `jest-environment-node`) are supported as test environments. Custom environments like `@jest-runner/electron/environment` in `jest-electron-runner` are not supported.
   * Only [`jest-circus`][1] is supported as [`testRunner`][2].
-  * Jest >= 28 is only supported from `dd-trace>=2.7.0`
+  * Jest >= 28 is only supported from `dd-trace>=2.7.0`.
 * Mocha >= 5.2.0
   * Mocha >= 9.0.0 has [partial support](#known-limitations).
   * Mocha [parallel mode][3] is not supported.
 * Cucumber-js >= 7.0.0
 * Cypress >= 6.7.0
-  * From `dd-trace>=1.4.0`
+  * From `dd-trace>=1.4.0`.
 * Playwright >= 1.18.0
   * From `dd-trace>=3.13.0` and `dd-trace>=2.26.0` for 2.x release line.
 
-The instrumentation works at runtime, so any transpilers such as TypeScript, Webpack, Babel, or others are supported out of the box.
+The instrumentation works at runtime, so any transpilers such as TypeScript, Webpack, or Babel are supported out-of-the-box.
 
 ### Test suite level visibility compatibility
 [Test suite level visibility][4] is fully supported from `dd-trace>=3.14.0` and `dd-trace>=2.27.0`. Jest, Mocha, Playwright, Cypress, and Cucumber are supported.
@@ -104,13 +104,13 @@ Additionally, configure which [Datadog site][2] to which you want to send data.
 
 ## Installing the JavaScript tracer
 
-To install the [JavaScript tracer][5], run:
+To install the [JavaScript Tracer][5], run:
 
 ```bash
 yarn add --dev dd-trace
 ```
 
-For more information, see the [JavaScript tracer installation docs][6].
+For more information, see the [JavaScript Tracer installation documentation][6].
 
 
 ## Instrument your tests
@@ -123,7 +123,7 @@ Set the `NODE_OPTIONS` environment variable to `-r dd-trace/ci/init`. Run your t
 NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app yarn test
 ```
 
-**Important**: if you set a value for `NODE_OPTIONS`, make sure it does not overwrite `-r dd-trace/ci/init`. This can be done using the `${NODE_OPTIONS:-}` clause:
+**Note**: If you set a value for `NODE_OPTIONS`, make sure it does not overwrite `-r dd-trace/ci/init`. This can be done using the `${NODE_OPTIONS:-}` clause:
 
 {{< code-block lang="json" filename="package.json" >}}
 {
@@ -158,7 +158,7 @@ Set the `NODE_OPTIONS` environment variable to `-r dd-trace/ci/init`. Run your t
 NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app yarn test
 ```
 
-**Important**: if you set a value for `NODE_OPTIONS`, make sure it does not overwrite `-r dd-trace/ci/init`. This can be done using the `${NODE_OPTIONS:-}` clause:
+**Note**: If you set a value for `NODE_OPTIONS`, make sure it does not overwrite `-r dd-trace/ci/init`. This can be done using the `${NODE_OPTIONS:-}` clause:
 
 {{< code-block lang="json" filename="package.json" >}}
 {
@@ -211,9 +211,9 @@ To create filters or `group by` fields for these tags, you must first create fac
 
 {{% tab "Cypress" %}}
 
-### Cypress >=10
+### Cypress version 10 or later
 
-Use the Cypress API documentation to [learn how to write plugins][1] for `cypress>=10`.
+Use the Cypress API documentation to [learn how to write plugins][101] for `cypress>=10`.
 
 In your `cypress.config.js` file, set the following:
 
@@ -255,33 +255,33 @@ module.exports = defineConfig({
 })
 {{< /code-block >}}
 
-### Cypress<10
+### Cypress before version 10
 
 These are the instructions if you're using a version older than `cypress@10`.
 
-1. Set [`pluginsFile`][2] to `"dd-trace/ci/cypress/plugin"`, for example through [`cypress.json`][3]:
-{{< code-block lang="json" filename="cypress.json" >}}
-{
-  "pluginsFile": "dd-trace/ci/cypress/plugin"
-}
-{{< /code-block >}}
+1. Set [`pluginsFile`][102] to `"dd-trace/ci/cypress/plugin"`, for example, through [`cypress.json`][103]:
+   {{< code-block lang="json" filename="cypress.json" >}}
+   {
+     "pluginsFile": "dd-trace/ci/cypress/plugin"
+   }
+   {{< /code-block >}}
 
-If you've already defined a `pluginsFile`, you can still initialize the instrumentation with:
-{{< code-block lang="javascript" filename="cypress/plugins/index.js" >}}
-module.exports = (on, config) => {
-  // your previous code is before this line
-  require('dd-trace/ci/cypress/plugin')(on, config)
-}
-{{< /code-block >}}
+   If you've already defined a `pluginsFile`, you can still initialize the instrumentation with:
+   {{< code-block lang="javascript" filename="cypress/plugins/index.js" >}}
+   module.exports = (on, config) => {
+     // your previous code is before this line
+     require('dd-trace/ci/cypress/plugin')(on, config)
+   }
+   {{< /code-block >}}
 
-2. Add the following line to the **top level** of your [`supportFile`][4]:
-{{< code-block lang="javascript" filename="cypress/support/index.js" >}}
-// Your code can be before this line
-// require('./commands')
-require('dd-trace/ci/cypress/support')
-// Your code can also be after this line
-// Cypress.Commands.add('login', (email, pw) => {})
-{{< /code-block >}}
+2. Add the following line to the **top level** of your [`supportFile`][104]:
+   {{< code-block lang="javascript" filename="cypress/support/index.js" >}}
+   // Your code can be before this line
+   // require('./commands')
+   require('dd-trace/ci/cypress/support')
+   // Your code can also be after this line
+   // Cypress.Commands.add('login', (email, pw) => {})
+   {{< /code-block >}}
 
 
 Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:
@@ -314,31 +314,31 @@ it('renders a hello world', () => {
 })
 ```
 
-To create filters or `group by` fields for these tags, you must first create facets. For more information about adding tags, see the [Adding Tags][5] section of the Node.js custom instrumentation documentation.
+To create filters or `group by` fields for these tags, you must first create facets. For more information about adding tags, see the [Adding Tags][105] section of the Node.js custom instrumentation documentation.
 
 ### Cypress - RUM integration
 
-If the browser application being tested is instrumented using [RUM][6], your Cypress test results and their generated RUM browser sessions and session replays are automatically linked. Learn more in the [RUM integration][7] guide.
+If the browser application being tested is instrumented using [Browser Monitoring][106], your Cypress test results and their generated RUM browser sessions and session replays are automatically linked. For more information, see the [Instrumenting your browser tests with RUM guide][107].
 
 
-[1]: https://docs.cypress.io/api/plugins/writing-a-plugin#Plugins-API
-[2]: https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Plugins-file
-[3]: https://docs.cypress.io/guides/references/configuration#cypress-json
-[4]: https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Support-file
-[5]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
-[6]: /real_user_monitoring/browser/#setup
-[7]: /continuous_integration/guides/rum_integration/
+[101]: https://docs.cypress.io/api/plugins/writing-a-plugin#Plugins-API
+[102]: https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Plugins-file
+[103]: https://docs.cypress.io/guides/references/configuration#cypress-json
+[104]: https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Support-file
+[105]: /tracing/trace_collection/custom_instrumentation/nodejs?tab=locally#adding-tags
+[106]: /real_user_monitoring/browser/#setup
+[107]: /continuous_integration/guides/rum_integration/
 {{% /tab %}}
 
 {{< /tabs >}}
 
 ### Reporting code coverage
 
-When tests are instrumented with [Istanbul][7], the Datadog Tracer (v3.20.0+) reports it under the `test.code_coverage.lines_pct` tag for your test sessions.
+When tests are instrumented with [Istanbul][7], the Datadog Tracer (v3.20.0 or later) reports it under the `test.code_coverage.lines_pct` tag for your test sessions.
 
 You can see the evolution of the test coverage in the **Coverage** tab of a test session.
 
-### Using Yarn >=2
+### Using Yarn 2 or later
 
 If you're using `yarn>=2` and a `.pnp.cjs` file, and you get the following error message when using `NODE_OPTIONS`:
 
@@ -433,12 +433,12 @@ From `dd-trace>=3.15.0` and `dd-trace>=2.28.0`, CI Visibility automatically uplo
 ## Known limitations
 
 ### ES modules
-[Mocha >=9.0.0][9] uses an ESM-first approach to load test files. That means that if ES modules are used (for example, by defining test files with the `.mjs` extension), _the instrumentation is limited_. Tests are detected, but there isn't visibility into your test. For more information about ES modules, see the [Node.js documentation][10].
+[Mocha >=9.0.0][10] uses an ESM-first approach to load test files. That means that if [ES modules][11] are used (for example, by defining test files with the `.mjs` extension), _the instrumentation is limited_. Tests are detected, but there isn't visibility into your test. For more information about ES modules, see the [Node.js documentation][9].
 
 ### Browser tests
-Browser tests executed with `mocha`, `jest`, `cucumber`, `cypress`, and `playwright` are instrumented by `dd-trace-js`, but visibility into the browser session itself is not provided by default (for example, network calls, user actions, page loads, etc.).
+Browser tests executed with `mocha`, `jest`, `cucumber`, `cypress`, and `playwright` are instrumented by `dd-trace-js`, but visibility into the browser session itself is not provided by default (for example, network calls, user actions, page loads, and more.).
 
-If you want visibility into the browser process, consider using [RUM & Session Replay][11]. When using Cypress, test results and their generated RUM browser sessions and session replays are automatically linked. Learn more in the [RUM integration][12] guide.
+If you want visibility into the browser process, consider using [RUM & Session Replay][11]. When using Cypress, test results and their generated [RUM browser sessions][12] and session replays are automatically linked. For more information, see the [Instrumenting your browser tests with RUM guide][13].
 
 ### Cypress interactive mode
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds a section about creating/exporting CI Visibility monitors, addresses consistency nits, and updates links in the Further Reading sections.

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-3766

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
