### PR TITLE
add copy buttons to fenced `shell` code blocks - [WEB-3706]

### DIFF
--- a/assets/scripts/components/copy-code.js
+++ b/assets/scripts/components/copy-code.js
@@ -1,28 +1,55 @@
-// Script to add copy-clipboard functionality to blog post code snippetss
+// Script to add copy-clipboard functionality to code snippets within the code-block shortcode and fenced codeblocks
 
+
+// Add copy button to fenced codeblocks of specific languages
+const dataLangs = ['shell']
+const highlights = document.querySelectorAll("div.highlight")
+
+highlights.forEach(highlightEl => {
+    const codeLang = highlightEl.querySelector('[data-lang]').dataset.lang
+    const isNotInCodeBlockShortcode = !highlightEl.parentElement.classList.contains('code-snippet')
+
+    const shouldAddCopyBtn = dataLangs.includes(codeLang) && isNotInCodeBlockShortcode
+    if(shouldAddCopyBtn){
+        highlightEl.classList.add('code-snippet','fenced')
+        const copyBtn = `
+        <div class="code-button-wrapper position-absolute">
+            <button class="btn text-primary js-copy-button">Copy</button>
+        </div>
+        `
+        highlightEl.insertAdjacentHTML('beforeend', copyBtn)
+    }
+})
+
+
+// Add Event Listener
 const copyButtons = document.querySelectorAll('.js-copy-button');
 
 if (copyButtons.length) {
-    copyButtons.forEach(elem => {
-        elem.addEventListener('click', function(event) {
-
-            const codeSnippetElement = event.target
-                .closest('.code-snippet')
-                .querySelector('.chroma');
-
-            const windowSelection = window.getSelection();
-            const range = document.createRange();
-            range.selectNodeContents(codeSnippetElement);
-            windowSelection.removeAllRanges();
-            window.getSelection().addRange(range);
-            document.execCommand('copy');
-            windowSelection.removeAllRanges();
-
-            elem.textContent = "Copied!";
-            setTimeout(function() {
-                elem.textContent = "Copy"
-            }, 1000)
-
-        });
+    copyButtons.forEach(btn => {
+        btn.addEventListener('click', (e) => copyCode(e, btn));
     });
+}
+
+
+
+// EVENT FUNCTION
+function copyCode (event, btn){
+    const codeSnippetElement = event.target
+    .closest('.code-snippet')
+    .querySelector('.chroma');
+
+    // Create a range object
+    const range = document.createRange();
+    // Select the node
+    range.selectNode(codeSnippetElement);
+    // create system clipboard object
+    const Clipboard = navigator.clipboard
+    // write code snippet text
+    Clipboard.writeText(codeSnippetElement.textContent).then(() => {
+        btn.textContent = "Copied!";
+        setTimeout(function() {
+            btn.textContent = "Copy"
+        }, 1000)
+    })
 }

--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -272,6 +272,51 @@ details {
         }
     }
 }
+
+.code-snippet.fenced {
+    position: relative;
+    padding-right: 0 !important;
+    pre {
+        padding: 30px 10px;
+    }
+    code {
+        white-space: pre;
+    }
+    &.wrap {
+        code {
+            white-space: normal !important;
+        }
+    }
+    &:hover {
+        .code-button-wrapper {
+            opacity: 1;
+        }
+    }
+    .code-button-wrapper {
+        opacity: 0;
+        right: 0;
+        top: 0;
+        padding: 1rem 1rem 0 0;
+        transition: opacity 0.2s ease-in-out;
+        z-index: 1;
+        button {
+            background-color: $white;
+            box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.25);
+            border-radius: 4px;
+            padding: 8px 25px;
+            transition: box-shadow 0.2s ease-in-out;
+            &:hover {
+                box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.45);
+            }
+            &:active,
+            &:focus {
+                box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.45) !important;
+            }
+        }
+    }
+}
+
+
 .code-filename-wrapper {
     background-color: $codesnippet-filename-bg;
     min-height: 5px;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add copy buttons to fenced `shell` code blocks

### Motivation
<!-- What inspired you to submit this pull request?-->

all `shell` code blocks should have a copy button when you hover over the codeblock. 
https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-3706

ex: https://docs-staging.datadoghq.com/stefon.simmons/WEB-3706/agent/guide/agent-fips-proxy/?tab=hostorvm


### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->



### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
