### PR TITLE
fix missing span argument in nodejs instrument example

### DIFF
--- a/content/en/tracing/guide/instrument_custom_method.md
+++ b/content/en/tracing/guide/instrument_custom_method.md
@@ -230,9 +230,11 @@ function write (transactions) {
   // Use `tracer.trace` context manager to trace blocks of inline code
   tracer.trace('BackupLedger.write', () => {
     for (const transaction of transactions) {
-      // Add custom metadata to the "persist_transaction" span
-      span.setTag('transaction.id', transaction.id)
-      this.ledger[transaction.id] = transaction
+      tracer.trace('BackupLedger.persist' , (span) => {
+        // Add custom metadata to the "persist_transaction" span
+        span.setTag('transaction.id', transaction.id)
+        this.ledger[transaction.id] = transaction
+      })
     }
   })
 


### PR DESCRIPTION
the second argument for `tracer.trace` is missing the `span` argument which is used to add custom tags.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
