### PR TITLE
Fix Log Archives Set permission Google Cloud Storage

### DIFF
--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -182,16 +182,12 @@ Only Datadog users with the [`logs_write_archive` permission][3] can create, mod
 {{% tab "Google Cloud Storage" %}}
 
 1. Grant your Datadog Google Cloud service account permissions to write your archives to your bucket.
-
-   * If you're creating a new Service Account, this can be done from the [Google Cloud Credentials page][1].
-   * If you're updating an existing Service Account, this can be done from the [Google Cloud IAM Admin page][2].
-
-2. Add the role under **Storage** called **Storage Object Admin**.
+2. Select your Datadog Google Cloud service account principal from the [Google Cloud IAM Admin page][1] and select **Edit principal**
+3. Select **ADD ANOTHER ROLE**, and input the Role called **Storage Object Admin**, and save.
 
    {{< img src="logs/archives/gcp_role_storage_object_admin.png" alt="Add the Storage Object Admin role to your Datadog Google Cloud Service Account." style="width:75%;">}}
 
-[1]: https://console.cloud.google.com/apis/credentials
-[2]: https://console.cloud.google.com/iam-admin/iam
+[1]: https://console.cloud.google.com/iam-admin/iam
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update "Set permissions" > "google Cloud Storage" section. 

### Motivation
<!-- What inspired you to submit this pull request?-->
The current guide was still based on the old Google Cloud console UI and incorrect.
Updated with reference to how to write Azure in the same section.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
The image of "logs/archives/gcp_role_storage_object_admin.png" at line 188(current 191) should be replaced with [this new UI screen shot](https://a.cl.ly/6quJ596P).
However I couldn't identify where to replace it, so I want you to change it.

Even if the image did not change, this change should be applied.

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
