### PR TITLE
Add GA PHP allocation profiling version number

### DIFF
--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -194,10 +194,10 @@ Wall Time
 CPU
 : Shows the time each function spent running on the CPU.
 
-Allocations (v0.88+, beta since v0.84)
+Allocations (v0.88+, beta from v0.84 - v0.87)
 : The number of allocations by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.
 
-Allocated memory (v0.88+, beta since v0.84)
+Allocated memory (v0.88+, beta from v0.84 to v0.87)
 : The amount of heap memory allocated by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.
 
 [1]: /profiler/enabling/php/#requirements

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -194,10 +194,10 @@ Wall Time
 CPU
 : Shows the time each function spent running on the CPU.
 
-Allocations (v0.88+, beta from v0.84 - v0.87)
+Allocations (v0.88+)
 : The number of allocations by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.
 
-Allocated memory (v0.88+, beta from v0.84 to v0.87)
+Allocated memory (v0.88+)
 : The amount of heap memory allocated by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.
 
 [1]: /profiler/enabling/php/#requirements

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -210,10 +210,10 @@ CPU
 : The time each function spent running on the CPU.
 
 Allocations
-: The number of allocations by each function during the profiling period (default: 59s), including allocations which were subsequently freed. Stack allocations are not tracked. 
+: The number of allocations by each function during the profiling period (default: 59s), including allocations which were subsequently freed. Stack allocations are not tracked.
 
 Allocated memory
-: The amount of heap memory allocated by each function during the profiling period (default: 59s), including allocations which were subsequently freed. Stack allocations are not tracked. 
+: The amount of heap memory allocated by each function during the profiling period (default: 59s), including allocations which were subsequently freed. Stack allocations are not tracked.
 
 [1]: /profiler/enabling/ddprof/
 {{< /programming-lang >}}

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -194,10 +194,10 @@ Wall Time
 CPU
 : Shows the time each function spent running on the CPU.
 
-Allocations (beta, v0.84+)
+Allocations (v0.88+, beta since v0.84)
 : The number of allocations by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.
 
-Allocated memory (beta, v0.84+)
+Allocated memory (v0.88+, beta since v0.84)
 : The amount of heap memory allocated by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.
 
 [1]: /profiler/enabling/php/#requirements

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -120,13 +120,13 @@ Whether to enable the endpoint data collection in profiles. Added in version `0.
 `DD_PROFILING_ALLOCATION_ENABLED`
 : **INI**: `datadog.profiling.allocation_enabled`. INI available since `0.88.0`.<br>
 **Default**: `1`<br>
-Enable the experimental allocation size and allocation bytes profile type. Added in version `0.88.0`.
+Enable the experimental allocation size and allocation bytes profile type. Added in version `0.88.0`.<br>
 **Note:** Supersedes `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED`, if both are set this one takes precedence.
 
-`DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED`
+`DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED` (deprecated since v0.88)
 : **INI**: `datadog.profiling.experimental_allocation_enabled`. INI available since `0.84.0`.<br>
 **Default**: `0`<br>
-Enable the experimental allocation size and allocation bytes profile type. Added in version `0.84.0`.
+Enable the experimental allocation size and allocation bytes profile type. Added in version `0.84.0`.<br>
 **Note:** Superseded by `DD_PROFILING_ALLOCATION_ENABLED`, if both are set `DD_PROFILING_ALLOCATION_ENABLED` takes precedence.
 
 `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED`

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -327,7 +327,7 @@ A comma-separated list of query parameters to be collected as part of the URL. S
 : **INI**: `datadog.trace.http_post_data_param_allowed`<br>
 **Default**: ""<br>
 A comma-separated list of HTTP POST data fields to be collected. Leave empty if you don't want to collect any posted values. When setting this value to the wildcard `*`, all posted data is collected, but the values for fields that match the `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP` obfuscation rule are redacted. If specific fields are given, then only these fields' values are visible, while the values for all other fields are redacted. Added in version `0.86.0`.<br>
-**Example**: 
+**Example**:
   - The posted data is `qux=quux&foo[bar][password]=Password12!&foo[bar][username]=admin&foo[baz][bar]=qux&foo[baz][key]=value`
   - `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED` is set to `foo.baz,foo.bar.password`
   - In this scenario, the collected metadata is:
@@ -483,7 +483,7 @@ When the application runs in a docker container, the path `/proc/self` should al
 
 ### Headers extraction and injection
 
-Read [Trace Context Propagation][11] for information about configuring the PHP tracing library to extract and inject headers for propagating distributed trace context. 
+Read [Trace Context Propagation][11] for information about configuring the PHP tracing library to extract and inject headers for propagating distributed trace context.
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -117,10 +117,17 @@ Enable the Datadog profiler. Added in version `0.69.0`. See [Enabling the PHP Pr
 **Default**: `1`<br>
 Whether to enable the endpoint data collection in profiles. Added in version `0.79.0`.
 
+`DD_PROFILING_ALLOCATION_ENABLED`
+: **INI**: `datadog.profiling.allocation_enabled`. INI available since `0.88.0`.<br>
+**Default**: `1`<br>
+Enable the experimental allocation size and allocation bytes profile type. Added in version `0.88.0`.
+**Note:** Supersedes `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED`, if both are set this one takes precedence.
+
 `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED`
 : **INI**: `datadog.profiling.experimental_allocation_enabled`. INI available since `0.84.0`.<br>
 **Default**: `0`<br>
 Enable the experimental allocation size and allocation bytes profile type. Added in version `0.84.0`.
+**Note:** Superseded by `DD_PROFILING_ALLOCATION_ENABLED`, if both are set `DD_PROFILING_ALLOCATION_ENABLED` takes precedence.
 
 `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED`
 : **INI**: `datadog.profiling.experimental_cpu_time_enabled`. INI available since `0.82.0`.<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -120,7 +120,7 @@ Whether to enable the endpoint data collection in profiles. Added in version `0.
 `DD_PROFILING_ALLOCATION_ENABLED`
 : **INI**: `datadog.profiling.allocation_enabled`. INI available since `0.88.0`.<br>
 **Default**: `1`<br>
-Enable the experimental allocation size and allocation bytes profile type. Added in version `0.88.0`.<br>
+Enable the allocation size and allocation bytes profile type. Added in version `0.88.0`.<br>
 **Note:** Supersedes `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED` environment variable (`datadog.profiling.experimental_allocation_enabled` INI setting) which was available since `0.84`. If both are set this one takes precedence.
 
 `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED`

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -121,13 +121,7 @@ Whether to enable the endpoint data collection in profiles. Added in version `0.
 : **INI**: `datadog.profiling.allocation_enabled`. INI available since `0.88.0`.<br>
 **Default**: `1`<br>
 Enable the experimental allocation size and allocation bytes profile type. Added in version `0.88.0`.<br>
-**Note:** Supersedes `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED`, if both are set this one takes precedence.
-
-`DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED` (deprecated since v0.88)
-: **INI**: `datadog.profiling.experimental_allocation_enabled`. INI available since `0.84.0`.<br>
-**Default**: `0`<br>
-Enable the experimental allocation size and allocation bytes profile type. Added in version `0.84.0`.<br>
-**Note:** Superseded by `DD_PROFILING_ALLOCATION_ENABLED`, if both are set `DD_PROFILING_ALLOCATION_ENABLED` takes precedence.
+**Note:** Supersedes `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED` environment variable (`datadog.profiling.experimental_allocation_enabled` INI setting) which was available since `0.84`. If both are set this one takes precedence.
 
 `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED`
 : **INI**: `datadog.profiling.experimental_cpu_time_enabled`. INI available since `0.82.0`.<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -121,7 +121,7 @@ Whether to enable the endpoint data collection in profiles. Added in version `0.
 : **INI**: `datadog.profiling.allocation_enabled`. INI available since `0.88.0`.<br>
 **Default**: `1`<br>
 Enable the allocation size and allocation bytes profile type. Added in version `0.88.0`.<br>
-**Note:** Supersedes `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED` environment variable (`datadog.profiling.experimental_allocation_enabled` INI setting) which was available since `0.84`. If both are set this one takes precedence.
+**Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED` environment variable (`datadog.profiling.experimental_allocation_enabled` INI setting), which was available since `0.84`. If both are set, this one takes precedence.
 
 `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED`
 : **INI**: `datadog.profiling.experimental_cpu_time_enabled`. INI available since `0.82.0`.<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
With the PHP profiler `0.88.0` allocation profiling is GA.

### Motivation
Have up to date docs :-D 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
