### PR TITLE
Update how NLog5.0+ should be used for log injection

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/dotnet.md
@@ -125,7 +125,19 @@ To automatically inject correlation identifiers into your log messages:
 
 2. Enable auto-instrumentation tracing of your app by following the [instructions to install the .NET Tracer][1].
 
-3. Enable mapped diagnostic context (MDC), as shown in the following example code for NLog version 4.6+:
+3. Enable mapped diagnostic context (MDC), as shown in the following example code for NLog version 5.0+:
+
+```xml
+  <!-- Add includeScopeProperties="true" to emit ScopeContext properties -->
+  <layout xsi:type="JsonLayout" includeScopeProperties="true">
+    <attribute name="date" layout="${longdate}" />
+    <attribute name="level" layout="${level:upperCase=true}"/>
+    <attribute name="message" layout="${message}" />
+    <attribute name="exception" layout="${exception:format=ToString}" />
+  </layout>
+```
+
+For NLog version 4.6+:
 
 ```xml
   <!-- Add includeMdlc="true" to emit MDC properties -->


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Add information on how to configure log injection in NLog 5.0+

### Motivation

We have updated the tracer internally to use a new way to inject properties. The older version shown for NLog version 4.6+ works as well for 5.0+, but will stop working once NLog 6.0 is released eventually. We want customers that follow documentation to be ready when that release happens.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
