### PR TITLE
Fix logrus example

### DIFF
--- a/content/en/logs/log_collection/go.md
+++ b/content/en/logs/log_collection/go.md
@@ -36,7 +36,7 @@ For a classic Go configuration, open a `main.go` file and paste in the following
 package main
 
 import (
-  log "github.com/Sirupsen/logrus"
+  log "github.com/sirupsen/logrus"
 )
 
 func main() {
@@ -57,7 +57,7 @@ These metas can be `hostname`, `username`, `customers`, `metric` or any informat
 package main
 
 import (
-  log "github.com/Sirupsen/logrus"
+  log "github.com/sirupsen/logrus"
 )
 
 func main() {


### PR DESCRIPTION
The uppercase `S` is wrong. See official example to confirm:

https://github.com/sirupsen/logrus#example

Trying to install the package with an uppercase letter also produces an error:

```
$ go get github.com/Sirupsen/logrus
go: downloading github.com/Sirupsen/logrus v1.9.3
go: github.com/Sirupsen/logrus@v1.9.3: parsing go.mod:
	module declares its path as: github.com/sirupsen/logrus
	       but was required as: github.com/Sirupsen/logrus
```

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
