### PR TITLE
Add benchmark test regressions section

### DIFF
--- a/content/en/continuous_integration/tests/_index.md
+++ b/content/en/continuous_integration/tests/_index.md
@@ -58,7 +58,7 @@ There's also information about the wall time of the most recent test suite run, 
 Hovering over the commit author avatar shows detailed information about the latest commit.
 
 #### Benchmark test regressions
-A benchmark test run is marked as a regression when its duration is five times the standard deviation above the mean for the same test in the default branch. The mean of the default branch is calculated over the 200 most recent test runs. A benchmark test will have @test.type:benchmark.
+A benchmark test run is marked as a regression when its duration is five times the standard deviation above the mean for the same test in the default branch. The mean of the default branch is calculated over the 200 most recent test runs. A benchmark test has @test.type:benchmark.
 
 Benchmark test regressions are evaluated per commit in an effort to tie performance regressions to specific code changes.
 

--- a/content/en/continuous_integration/tests/_index.md
+++ b/content/en/continuous_integration/tests/_index.md
@@ -57,6 +57,11 @@ There's also information about the wall time of the most recent test suite run, 
 
 Hovering over the commit author avatar shows detailed information about the latest commit.
 
+#### Benchmark test regressions
+Regression is a test run that has a duration of 5 times standard deviation above the mean of latest test runs on the default branch. It's being detected only for test runs that have @test.type:benchmark
+
+For each branch there is a number of benchmark regressions for the latest commit.
+
 #### Investigate for more details
 
 Click on the row to see test suite run details such as test results for the last commit on this branch (or you can switch branches), failing tests and the most common errors, slow tests, flaky tests, and a complete list of test runs over the time frame selected. You can filter this list of test runs by facet to get to the information you want to see most.

--- a/content/en/continuous_integration/tests/_index.md
+++ b/content/en/continuous_integration/tests/_index.md
@@ -58,9 +58,9 @@ There's also information about the wall time of the most recent test suite run, 
 Hovering over the commit author avatar shows detailed information about the latest commit.
 
 #### Benchmark test regressions
-Regression is a test run that has a duration of 5 times standard deviation above the mean of latest test runs on the default branch. It's being detected only for test runs that have @test.type:benchmark
+A benchmark test run is marked as a regression when its duration is five times the standard deviation above the mean for the same test in the default branch. The mean of the default branch is calculated over the 200 most recent test runs. A benchmark test will have @test.type:benchmark.
 
-For each branch there is a number of benchmark regressions for the latest commit.
+Benchmark test regressions are evaluated per commit in an effort to tie performance regressions to specific code changes.
 
 #### Investigate for more details
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add benchmark test regressions section in the Branches description of CI Test VIsibility.

### Motivation
<!-- What inspired you to submit this pull request?-->

Release of a new feature to detect benchmark test regressions.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
