### PR TITLE
Add PHP logs correlation documentation

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -71,7 +71,7 @@ The PHP tracer replaces the placeholders with the corresponding values. For exam
 [2022-12-09 16:02:42] production.INFO: Hello, World! [dd.trace_id="1234567890abcdef" dd.span_id="1234567890abcdef" status="info"]
 ```
 
-Note that the brackets are mandatory if you plan on using the default parsing rules provided in the PHP [log pipeline][7]. If you are using a custom parsing rule, you can omit the brackets if needed.
+**Note**: the brackets are mandatory if you plan on using the default parsing rules provided in the PHP [log pipeline][7]. If you are using a custom parsing rule, you can omit the brackets if needed.
 
 #### Append the trace correlation identifiers to your message {#append-the-trace-correlation-identifiers-to-your-message}
 
@@ -91,7 +91,7 @@ The PHP tracer appends the available trace correlation identifiers to the log me
 [2022-12-09 16:02:42] production.DEBUG: Hello, World! [dd.trace_id="1234567890abcdef" dd.span_id="1234567890abcdef" dd.service="laravel" dd.version="8.0.0" dd.env="production" status="debug"]
 ```
 
-Note that if there is a placeholder in your message or if a trace id already present in the message, it takes precedence and the PHP tracer does **not** further modify the message.
+**Note**: if there is a placeholder in your message or if a trace id already present in the message, it takes precedence and the PHP tracer does **not** further modify the message.
 
 #### Add the trace correlation identifiers to the log context {#add-the-trace-correlation-identifiers-to-the-log-context}
 
@@ -111,7 +111,7 @@ The PHP tracer adds the available trace correlation identifiers to the log conte
 [2022-12-09 16:02:42] production.DEBUG: Hello, World! {"dd.trace_id":"1234567890abcdef","dd.span_id":"1234567890abcdef","dd.service":"laravel","dd.version":"8.0.0","dd.env":"production","status":"debug"}
 ```
 
-Note that if there is a placeholder in your message or if the trace id is already present in the message, the PHP tracer does **not** add the trace correlation identifiers to the log context.
+**Note**: if there is a placeholder in your message or if the trace id is already present in the message, the PHP tracer does **not** add the trace correlation identifiers to the log context.
 
 
 ## Manual injection

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -61,9 +61,7 @@ For example, if you are using the [Monolog][4] library in a Laravel application,
 
 ```php
 use Illuminate\Support\Facades\Log;
-
-...
-
+# ...
 Log::info('Hello, World! [%dd.trace_id% %dd.span_id% %status%]');
 ```
 
@@ -83,9 +81,7 @@ For example, if you are using the [Monolog][4] library in a Laravel application 
 
 ```php
 use Illuminate\Support\Facades\Log;
-
-...
-
+# ...
 Log::debug('Hello, World!');
 ```
 
@@ -105,9 +101,7 @@ For example, if you are using the [Monolog][4] library in a Laravel application 
 
 ```php
 use Illuminate\Support\Facades\Log;
-
-...
-
+# ...
 Log::debug('Hello, World!');
 ```
 

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -24,15 +24,15 @@ further_reading:
 
 ## Automatic injection
 
-Starting in version **0.89.0**, the PHP tracer automatically injects trace correlation identifiers into application logs. For automatic injection to be enabled, the environment variable (resp. directive) `DD_TRACE_LOGS_ENABLED` (resp. `datadog.trace.logs_enabled`) must be set to `true`.
+Starting in version `0.89.0`, the PHP tracer automatically injects trace correlation identifiers into application logs. To enable automatic injection, set the environment variable `DD_LOGS_INJECTION` (INI setting `datadog.logs_injection`) to `true`.
 
 The PHP tracer supports PSR-3 compliant loggers, such as [Monolog][4] or [Laminas Log][5].
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> It is strongly encouraged setting up your logging library to produce your logs in JSON format to:
+  <strong></strong>: Set up your logging library to produce logs in JSON format so that:
   <ul>
-    <li>Avoid the need for <a href="/logs/log_configuration/parsing">custom parsing rules</a>.</li>
-    <li>Ensure that stack traces are properly wrapped into the log event.</li>
+    <li>You don't need <a href="/logs/log_configuration/parsing">custom parsing rules</a>.</li>
+    <li>Stack traces are properly wrapped into the log event.</li>
   </ul>
 </div>
 
@@ -42,7 +42,6 @@ If you haven't done so already, configure the PHP tracer with `DD_ENV`, `DD_SERV
 
 The PHP tracer provides various ways to configure the injection of trace correlation identifiers into your logs:
 - [Use placeholders in your message](#use-placeholders-in-your-message)
-- [Append the trace correlation identifiers to your message](#append-the-trace-correlation-identifiers-to-your-message)
 - [Add the trace correlation identifiers to the log context](#add-the-trace-correlation-identifiers-to-the-log-context)
 
 #### Use placeholders in your message {#use-placeholders-in-your-message}
@@ -53,7 +52,6 @@ You can use placeholders in your message to automatically inject trace correlati
 - `%dd.service%`: the service name
 - `%dd.version%`: the service version
 - `%dd.env%`: the service environment
-- `%status%`: the severity level of the log event
 
 Placeholders are case-sensitive and must be enclosed in `%` characters.
 
@@ -71,27 +69,7 @@ The PHP tracer replaces the placeholders with the corresponding values. For exam
 [2022-12-09 16:02:42] production.INFO: Hello, World! [dd.trace_id="1234567890abcdef" dd.span_id="1234567890abcdef" status="info"]
 ```
 
-**Note**: the brackets are mandatory if you plan on using the default parsing rules provided in the PHP [log pipeline][7]. If you are using a custom parsing rule, you can omit the brackets if needed.
-
-#### Append the trace correlation identifiers to your message {#append-the-trace-correlation-identifiers-to-your-message}
-
-You can append the trace correlation identifiers to your message by using the `DD_TRACE_APPEND_TRACE_IDS_TO_LOGS` environment variable. The PHP tracer appends the available trace correlation identifiers at the end of your message enclosed in brackets, **hence modifying the original message**.
-
-For example, if you are using the [Monolog][4] library in a Laravel application as follows:
-
-```php
-use Illuminate\Support\Facades\Log;
-# ...
-Log::debug('Hello, World!');
-```
-
-The PHP tracer appends the available trace correlation identifiers to the log message. The logged message above could be transformed into:
-
-```
-[2022-12-09 16:02:42] production.DEBUG: Hello, World! [dd.trace_id="1234567890abcdef" dd.span_id="1234567890abcdef" dd.service="laravel" dd.version="8.0.0" dd.env="production" status="debug"]
-```
-
-**Note**: if there is a placeholder in your message or if a trace id already present in the message, it takes precedence and the PHP tracer does **not** further modify the message.
+**Note**: The brackets are mandatory if you plan on using the default parsing rules provided in the PHP [log pipeline][7]. If you are using a custom parsing rule, you can omit the brackets if needed.
 
 #### Add the trace correlation identifiers to the log context {#add-the-trace-correlation-identifiers-to-the-log-context}
 
@@ -111,7 +89,7 @@ The PHP tracer adds the available trace correlation identifiers to the log conte
 [2022-12-09 16:02:42] production.DEBUG: Hello, World! {"dd.trace_id":"1234567890abcdef","dd.span_id":"1234567890abcdef","dd.service":"laravel","dd.version":"8.0.0","dd.env":"production","status":"debug"}
 ```
 
-**Note**: if there is a placeholder in your message or if the trace id is already present in the message, the PHP tracer does **not** add the trace correlation identifiers to the log context.
+**Note**: If there is a placeholder in your message or if a trace ID is already present in the message, the PHP tracer does **not** add the trace correlation identifiers to the log context.
 
 
 ## Manual injection

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -41,9 +41,9 @@ The PHP tracer supports PSR-3 compliant loggers, such as [Monolog][4] or [Lamina
 If you haven't done so already, configure the PHP tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This provides the best experience for adding `env`, `service`, and `version` to your logs (see [Unified Service Tagging][6] for more details).
 
 The PHP tracer provides various ways to configure the injection of trace correlation identifiers into your logs:
-- [Use placeholders in your message][#use-placeholders-in-your-message]
-- [Append the trace correlation identifiers to your message][#append-the-trace-correlation-identifiers-to-your-message]
-- [Add the trace correlation identifiers to the log context][#add-the-trace-correlation-identifiers-to-the-log-context]
+- [Use placeholders in your message](#use-placeholders-in-your-message)
+- [Append the trace correlation identifiers to your message](#append-the-trace-correlation-identifiers-to-your-message)
+- [Add the trace correlation identifiers to the log context](#add-the-trace-correlation-identifiers-to-the-log-context)
 
 #### Use placeholders in your message {#use-placeholders-in-your-message}
 

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -38,7 +38,7 @@ The PHP tracer supports PSR-3 compliant loggers, such as [Monolog][4] or [Lamina
 
 ### Configure injection in logs
 
-If you haven’t done so already, configure the PHP tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best experience for adding `env`, `service`, and `version` to your logs (see [Unified Service Tagging][6] for more details).
+If you haven't done so already, configure the PHP tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best experience for adding `env`, `service`, and `version` to your logs (see [Unified Service Tagging][6] for more details).
 
 The PHP tracer provides various ways to configure the injection of trace correlation identifiers into your logs:
 - [Use placeholders in your message][#use-placeholders-in-your-message]
@@ -65,7 +65,7 @@ use Illuminate\Support\Facades\Log;
 Log::info('Hello, World! [%dd.trace_id% %dd.span_id% %status%]');
 ```
 
-The PHP tracer will replace the placeholders with the corresponding values. For example, the logged message above could be transformed into:
+The PHP tracer replaces the placeholders with the corresponding values. For example, the logged message above could be transformed into:
 
 ```
 [2022-12-09 16:02:42] production.INFO: Hello, World! [dd.trace_id="1234567890abcdef" dd.span_id="1234567890abcdef" status="info"]
@@ -75,7 +75,7 @@ Note that the brackets are mandatory if you plan on using the default parsing ru
 
 #### Append the trace correlation identifiers to your message {#append-the-trace-correlation-identifiers-to-your-message}
 
-You can append the trace correlation identifiers to your message by using the `DD_TRACE_APPEND_TRACE_IDS_TO_LOGS` environment variable. The PHP tracer will append the available trace correlation identifiers at the end of your message enclosed in brackets, **hence modifying the original message**.
+You can append the trace correlation identifiers to your message by using the `DD_TRACE_APPEND_TRACE_IDS_TO_LOGS` environment variable. The PHP tracer appends the available trace correlation identifiers at the end of your message enclosed in brackets, **hence modifying the original message**.
 
 For example, if you are using the [Monolog][4] library in a Laravel application as follows:
 
@@ -85,13 +85,13 @@ use Illuminate\Support\Facades\Log;
 Log::debug('Hello, World!');
 ```
 
-The PHP tracer will append the available trace correlation identifiers to the log message. The logged message above could be transformed into:
+The PHP tracer appends the available trace correlation identifiers to the log message. The logged message above could be transformed into:
 
 ```
 [2022-12-09 16:02:42] production.DEBUG: Hello, World! [dd.trace_id="1234567890abcdef" dd.span_id="1234567890abcdef" dd.service="laravel" dd.version="8.0.0" dd.env="production" status="debug"]
 ```
 
-Note that if there is a placeholder in your message or if a trace id already present in the message, it will take precedence and the PHP tracer will **not** further modify the message.
+Note that if there is a placeholder in your message or if a trace id already present in the message, it takes precedence and the PHP tracer does **not** further modify the message.
 
 #### Add the trace correlation identifiers to the log context {#add-the-trace-correlation-identifiers-to-the-log-context}
 
@@ -105,13 +105,13 @@ use Illuminate\Support\Facades\Log;
 Log::debug('Hello, World!');
 ```
 
-The PHP tracer will add the available trace correlation identifiers to the log context. The logged message above could be transformed into:
+The PHP tracer adds the available trace correlation identifiers to the log context. The logged message above could be transformed into:
 
 ```
 [2022-12-09 16:02:42] production.DEBUG: Hello, World! {"dd.trace_id":"1234567890abcdef","dd.span_id":"1234567890abcdef","dd.service":"laravel","dd.version":"8.0.0","dd.env":"production","status":"debug"}
 ```
 
-Note that if there is a placeholder in your message or if the trace id is already present in the message, the PHP tracer **will not** add the trace correlation identifiers to the log context.
+Note that if there is a placeholder in your message or if the trace id is already present in the message, the PHP tracer does **not** add the trace correlation identifiers to the log context.
 
 
 ## Manual injection

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -45,7 +45,7 @@ The PHP tracer provides various ways to configure the injection of trace correla
 - [Append the trace correlation identifiers to your message][#append-the-trace-correlation-identifiers-to-your-message]
 - [Add the trace correlation identifiers to the log context][#add-the-trace-correlation-identifiers-to-the-log-context]
 
-#### Use placeholders in your message
+#### Use placeholders in your message {#use-placeholders-in-your-message}
 
 You can use placeholders in your message to automatically inject trace correlation identifiers into your logs. The PHP tracer supports the following placeholders:
 - `%dd.trace_id%`: the trace ID
@@ -73,7 +73,7 @@ The PHP tracer will replace the placeholders with the corresponding values. For 
 
 Note that the brackets are mandatory if you plan on using the default parsing rules provided in the PHP [log pipeline][7]. If you are using a custom parsing rule, you can omit the brackets if needed.
 
-#### Append the trace correlation identifiers to your message
+#### Append the trace correlation identifiers to your message {#append-the-trace-correlation-identifiers-to-your-message}
 
 You can append the trace correlation identifiers to your message by using the `DD_TRACE_APPEND_TRACE_IDS_TO_LOGS` environment variable. The PHP tracer will append the available trace correlation identifiers at the end of your message enclosed in brackets, **hence modifying the original message**.
 
@@ -93,7 +93,7 @@ The PHP tracer will append the available trace correlation identifiers to the lo
 
 Note that if there is a placeholder in your message or if a trace id already present in the message, it will take precedence and the PHP tracer will **not** further modify the message.
 
-#### Add the trace correlation identifiers to the log context
+#### Add the trace correlation identifiers to the log context {#add-the-trace-correlation-identifiers-to-the-log-context}
 
 The default behavior of the PHP tracer is to add the trace correlation identifiers to the log context.
 

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -29,14 +29,16 @@ Starting in version **0.89.0**, the PHP tracer automatically injects trace corre
 The PHP tracer supports PSR-3 compliant loggers, such as [Monolog][4] or [Laminas Log][5].
 
 <div class="alert alert-warning">
-<strong>Note:</strong> It is strongly encouraged setting up your logging library to produce your logs in JSON format to:
-- Avoid the need for [custom parsing rules][6].
-- Ensure that stack traces are properly wrapped into the log event.
+  <strong>Note:</strong> It is strongly encouraged setting up your logging library to produce your logs in JSON format to:
+  <ul>
+    <li>Avoid the need for <a href="/logs/log_configuration/parsing">custom parsing rules</a>.</li>
+    <li>Ensure that stack traces are properly wrapped into the log event.</li>
+  </ul>
 </div>
 
 ### Configure injection in logs
 
-If you haven’t done so already, configure the PHP tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best experience for adding `env`, `service`, and `version` to your logs (see [Unified Service Tagging][7] for more details).
+If you haven’t done so already, configure the PHP tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best experience for adding `env`, `service`, and `version` to your logs (see [Unified Service Tagging][6] for more details).
 
 The PHP tracer provides various ways to configure the injection of trace correlation identifiers into your logs:
 - [Use placeholders in your message][#use-placeholders-in-your-message]
@@ -71,7 +73,7 @@ The PHP tracer will replace the placeholders with the corresponding values. For 
 [2022-12-09 16:02:42] production.INFO: Hello, World! [dd.trace_id="1234567890abcdef" dd.span_id="1234567890abcdef" status="info"]
 ```
 
-Note that the brackets are mandatory if you plan on using the default parsing rules provided in the PHP [log pipeline][8]. If you are using a custom parsing rule, you can omit the brackets if needed.
+Note that the brackets are mandatory if you plan on using the default parsing rules provided in the PHP [log pipeline][7]. If you are using a custom parsing rule, you can omit the brackets if needed.
 
 #### Append the trace correlation identifiers to your message
 
@@ -213,6 +215,5 @@ If your application uses json logs format instead of appending trace_id and span
 [3]: /tracing/troubleshooting/correlated-logs-not-showing-up-in-the-trace-id-panel/?tab=custom
 [4]: https://github.com/Seldaek/monolog
 [5]: https://github.com/laminas/laminas-log
-[6]: /logs/log_configuration/parsing
-[7]: /getting_started/tagging/unified_service_tagging
-[8]: /logs/log_configuration/pipelines
+[6]: /getting_started/tagging/unified_service_tagging
+[7]: /logs/log_configuration/pipelines

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -41,8 +41,28 @@ The PHP tracer supports PSR-3 compliant loggers, such as [Monolog][4] or [Lamina
 If you haven't done so already, configure the PHP tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This provides the best experience for adding `env`, `service`, and `version` to your logs (see [Unified Service Tagging][6] for more details).
 
 The PHP tracer provides various ways to configure the injection of trace correlation identifiers into your logs:
-- [Use placeholders in your message](#use-placeholders-in-your-message)
 - [Add the trace correlation identifiers to the log context](#add-the-trace-correlation-identifiers-to-the-log-context)
+- [Use placeholders in your message](#use-placeholders-in-your-message)
+
+#### Add the trace correlation identifiers to the log context {#add-the-trace-correlation-identifiers-to-the-log-context}
+
+The default behavior of the PHP tracer is to add the trace correlation identifiers to the log context.
+
+For example, if you are using the [Monolog][4] library in a Laravel application as follows:
+
+```php
+use Illuminate\Support\Facades\Log;
+# ...
+Log::debug('Hello, World!');
+```
+
+The PHP tracer adds the available trace correlation identifiers to the log context. The logged message above could be transformed into:
+
+```
+[2022-12-09 16:02:42] production.DEBUG: Hello, World! {"dd.trace_id":"1234567890abcdef","dd.span_id":"1234567890abcdef","dd.service":"laravel","dd.version":"8.0.0","dd.env":"production","status":"debug"}
+```
+
+**Note**: If there is a placeholder in your message or if a trace ID is already present in the message, the PHP tracer does **not** add the trace correlation identifiers to the log context.
 
 #### Use placeholders in your message {#use-placeholders-in-your-message}
 
@@ -70,26 +90,6 @@ The PHP tracer replaces the placeholders with the corresponding values. For exam
 ```
 
 **Note**: The brackets are mandatory if you plan on using the default parsing rules provided in the PHP [log pipeline][7]. If you are using a custom parsing rule, you can omit the brackets if needed.
-
-#### Add the trace correlation identifiers to the log context {#add-the-trace-correlation-identifiers-to-the-log-context}
-
-The default behavior of the PHP tracer is to add the trace correlation identifiers to the log context.
-
-For example, if you are using the [Monolog][4] library in a Laravel application as follows:
-
-```php
-use Illuminate\Support\Facades\Log;
-# ...
-Log::debug('Hello, World!');
-```
-
-The PHP tracer adds the available trace correlation identifiers to the log context. The logged message above could be transformed into:
-
-```
-[2022-12-09 16:02:42] production.DEBUG: Hello, World! {"dd.trace_id":"1234567890abcdef","dd.span_id":"1234567890abcdef","dd.service":"laravel","dd.version":"8.0.0","dd.env":"production","status":"debug"}
-```
-
-**Note**: If there is a placeholder in your message or if a trace ID is already present in the message, the PHP tracer does **not** add the trace correlation identifiers to the log context.
 
 
 ## Manual injection

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -38,7 +38,7 @@ The PHP tracer supports PSR-3 compliant loggers, such as [Monolog][4] or [Lamina
 
 ### Configure injection in logs
 
-If you haven't done so already, configure the PHP tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This will provide the best experience for adding `env`, `service`, and `version` to your logs (see [Unified Service Tagging][6] for more details).
+If you haven't done so already, configure the PHP tracer with `DD_ENV`, `DD_SERVICE`, and `DD_VERSION`. This provides the best experience for adding `env`, `service`, and `version` to your logs (see [Unified Service Tagging][6] for more details).
 
 The PHP tracer provides various ways to configure the injection of trace correlation identifiers into your logs:
 - [Use placeholders in your message][#use-placeholders-in-your-message]
@@ -57,7 +57,7 @@ You can use placeholders in your message to automatically inject trace correlati
 
 Placeholders are case-sensitive and must be enclosed in `%` characters.
 
-For example, if you are using the [Monolog][4] library in a Laravel application, you can configure the injection of trace correlation identifiers into a log message as follows:
+For example, if you are using the [Monolog][4] library in a Laravel application, you can configure the injection into a log message as follows:
 
 ```php
 use Illuminate\Support\Facades\Log;

--- a/content/en/tracing/trace_collection/compatibility/php.md
+++ b/content/en/tracing/trace_collection/compatibility/php.md
@@ -99,14 +99,14 @@ The following table enumerates some of the frameworks and versions Datadog succe
 | CodeIgniter    | 3.x                  | PHP 7+                     | Generic web tracing             |
 | Drupal         |                      | All supported PHP versions | Generic web tracing             |
 | FuelPHP        | 1.1                  | PHP 7+                     | Generic web tracing             |
-| Laminas        |                      | All supported PHP versions | Framework-level instrumentation |     
+| Laminas        |                      | All supported PHP versions | Framework-level instrumentation |
 | Laravel        | 4.2, 5.x, 6.x        | All supported PHP versions | Framework-level instrumentation |
 | Laravel 8      | 8.x (tracer `0.52.0+`) | All supported PHP versions | Framework-level instrumentation |
 | Lumen          |   5.2+                 | All supported PHP versions | Framework-level instrumentation |
 | Magento        | 1, 2                 | All supported PHP versions | Generic web tracing             |
 | Neos Flow      | 1.1                  | All supported PHP versions | Generic web tracing             |
 | Phalcon        | 1.3, 3.4             | All supported PHP versions | Generic web tracing             |
-| RoadRunner     | 2.x                  | All supported PHP versions | Framework-level instrumentationq |
+| RoadRunner     | 2.x                  | All supported PHP versions | Framework-level instrumentation |
 | Slim           | 2.x, 3.x, 4.x        | All supported PHP versions | Framework-level instrumentation |
 | Symfony        | 2.x, 3.3, 3.4, 4.x, 5.x, 6.x | All supported PHP versions | Framework-level instrumentation |
 | WordPress      | 4.x, 5.x             | PHP 7+                     | Framework-level instrumentation |

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -208,7 +208,7 @@ Automatically flush the tracer when all the spans are closed; set to `1` in conj
 `DD_TRACE_APPEND_TRACE_IDS_TO_LOGS`
 : **INI**: `datadog.trace.append_trace_ids_to_logs`<br>
 **Default**: `0`<br>
-Append the logs correlation identifiers to logged messages. Use with caution as the message is modified. Refer to the [logs correlation documentation][16] for more information on its usage. Added in version `0.88.0`.
+Append the logs correlation identifiers to logged messages. Use with caution as the message is modified. See [logs correlation documentation][16] for more information on its usage. Added in version `0.88.0`.
 
 `DD_TRACE_CLI_ENABLED`
 : **INI**: `datadog.trace.cli_enabled`<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -148,6 +148,13 @@ The default app name. For versions <0.47.0 this is `DD_SERVICE_NAME`.
 **Default**: `null`<br>
 Change the default name of an APM integration. Rename one or more integrations at a time, for example: `DD_SERVICE_MAPPING=pdo:payments-db,mysqli:orders-db` (see [Integration names](#integration-names)).
 
+`DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED`
+: **INI**: `datadog.trace.128_bit_traceid_logging_enabled`<br>
+**Default**: `0`<br>
+Enable printing of the full 128-bit ID when formatting trace IDs for logs correlation.
+When false (default), only the low 64-bits of the trace ID are printed, formatted as an integer. This means if the trace ID is only 64 bits, the full ID is printed.
+When true, the trace ID is printed as a full 128-bit ID in hexadecimal format. This is the case even if the ID itself is only 64 bits.
+
 `DD_TRACE_HEALTH_METRICS_ENABLED`
 : **INI**: `datadog.trace_health_metrics_enabled`<br>
 **Default**: `false`<br>
@@ -197,6 +204,11 @@ The port used to connect to DogStatsD, used in combination with `DD_AGENT_HOST` 
 : **INI**: `datadog.trace.auto_flush_enabled`<br>
 **Default**: `0`<br>
 Automatically flush the tracer when all the spans are closed; set to `1` in conjunction with `DD_TRACE_GENERATE_ROOT_SPAN=0` to trace [long-running processes][14].
+
+`DD_TRACE_APPEND_TRACE_IDS_TO_LOGS`
+: **INI**: `datadog.trace.append_trace_ids_to_logs`<br>
+**Default**: `0`<br>
+Append the logs correlation identifiers to logged messages. Use with caution as the message is modified. Refer to the [logs correlation documentation][16] for more information on its usage. Added in version `0.88.0`.
 
 `DD_TRACE_CLI_ENABLED`
 : **INI**: `datadog.trace.cli_enabled`<br>
@@ -496,3 +508,4 @@ Read [Trace Context Propagation][11] for information about configuring the PHP t
 [13]: /agent/guide/network/#configure-ports
 [14]: /tracing/guide/trace-php-cli-scripts/#long-running-cli-scripts
 [15]: /tracing/guide/trace-php-cli-scripts/
+[16]: /tracing/other_telemetry/connect_logs_and_traces/php

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -107,6 +107,12 @@ Whether to enable distributed tracing.
 **Default**: `null`<br>
 Set an application's environment, for example: `prod`, `pre-prod`, `stage`. Added in version `0.47.0`.
 
+`DD_LOGS_INJECTION`
+: **INI**: `datadog.logs_injection`<br>
+**Default**: `0`<br>
+Enables or disables automatic injection of correlation identifiers into application logs. Added in version `0.89.0`<br>
+See [logs correlation documentation][16] for more information.
+
 `DD_PROFILING_ENABLED`
 : **INI**: `datadog.profiling.enabled`. INI available since `0.82.0`.<br>
 **Default**: `1`<br>
@@ -204,11 +210,6 @@ The port used to connect to DogStatsD, used in combination with `DD_AGENT_HOST` 
 : **INI**: `datadog.trace.auto_flush_enabled`<br>
 **Default**: `0`<br>
 Automatically flush the tracer when all the spans are closed; set to `1` in conjunction with `DD_TRACE_GENERATE_ROOT_SPAN=0` to trace [long-running processes][14].
-
-`DD_TRACE_APPEND_TRACE_IDS_TO_LOGS`
-: **INI**: `datadog.trace.append_trace_ids_to_logs`<br>
-**Default**: `0`<br>
-Append the logs correlation identifiers to logged messages. Use with caution as the message is modified. See [logs correlation documentation][16] for more information on its usage. Added in version `0.88.0`.
 
 `DD_TRACE_CLI_ENABLED`
 : **INI**: `datadog.trace.cli_enabled`<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Explains the new various way to connect logs and traces in PHP

### Motivation
Adds some necessary documentation on the upcoming **automatic log injection feature** coming on the PHP tracer -datadog/dd-trace-php#2118

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
