### PR TITLE
CIAPP-6501 Use agentless mode for Cloud CI python CI visbility

### DIFF
--- a/content/en/continuous_integration/tests/python.md
+++ b/content/en/continuous_integration/tests/python.md
@@ -31,17 +31,25 @@ Supported test frameworks:
 * pytest >= 3.0.0
   * pytest < 5 when using Python 2
 
-## Installing the Datadog Agent
+## Configuring reporting method
 
-To report test results to Datadog, you need to install the Datadog Agent.
+To report test results to Datadog, you need to configure the Datadog Python library:
 
-### Using an on-premises CI provider
+{{< tabs >}}
 
-If you are running tests on an on-premises CI provider, such as Jenkins or self-managed GitLab CI, install the Datadog Agent on each worker node by following the [Agent installation instructions][1].
+{{% tab "On-Premises CI Provider (Datadog Agent)" %}}
+
+If you are running tests on an on-premises CI provider, such as Jenkins or self-managed GitLab CI, install the Datadog Agent on each worker node by following the [Agent installation instructions][1]. This is the recommended option as test results are then automatically linked to the underlying host metrics.
 
 If the CI provider is using a container-based executor, set the `DD_AGENT_HOST` environment variable on all builds (which defaults to `http://localhost:8126`) to an endpoint that is accessible from within build containers, as using `localhost` inside the build references the container itself and not the underlying worker node where the Datadog Agent is running.
 
 If you are using a Kubernetes executor, Datadog recommends using the [Datadog Admission Controller][2], which automatically sets the `DD_AGENT_HOST` environment variable in the build pods to communicate with the local Datadog Agent.
+
+[1]: /agent/
+[2]: https://docs.datadoghq.com/agent/cluster_agent/admission_controller/
+{{% /tab %}}
+
+{{% tab "Cloud CI provider (Agentless)" %}}
 
 ### Using a cloud CI provider
 
@@ -49,243 +57,25 @@ If you are using a cloud CI provider with no access to the underlying worker nod
 
 To run the Datadog Agent as a container acting as a simple results forwarder, use the Docker image `gcr.io/datadoghq/agent:latest` and the following environment variables:
 
+`DD_CIVISIBILITY_AGENTLESS_ENABLED=true` (Required)
+: Enables or disables Agentless mode.<br/>
+**Default**: `false`
+
 `DD_API_KEY` (Required)
-: The [Datadog API key][3] used to upload the test results.<br/>
+: The [Datadog API key][1] used to upload the test results.<br/>
 **Default**: (none)
 
-`DD_INSIDE_CI` (Required)
-: Disables the monitoring of the Datadog Agent container, as the underlying host is not accessible.<br/>
-**Default**: `false`<br/>
-**Required value**: `true`
-
-`DD_HOSTNAME` (Required)
-: Disables the reporting of hostnames associated with tests, as the underlying host cannot be monitored.<br/>
-**Default**: (autodetected)<br/>
-**Required value**: `none`
-
-{{< site-region region="us3,us5,eu,ap1" >}}
-Additionally, configure the Datadog site to use the selected one ({{< region-param key="dd_site_name" >}}):
+Additionally, configure the [Datadog site][2] to send data to:
 
 `DD_SITE`
 : The Datadog site to upload results to.<br/>
 **Default**: `datadoghq.com`<br/>
 **Selected site**: {{< region-param key="dd_site" code="true" >}}
-{{< /site-region >}}
 
-#### CI provider configuration examples
-
-The following sections provide CI provider-specific instructions to run and configure the Agent to report test information.
-
-{{< tabs >}}
-{{% tab "Azure Pipelines" %}}
-
-To run the Datadog Agent in Azure Pipelines, define a new container in the [resources section][1] and link it with the job declaring it as a [service container][2].
-
-{{< site-region region="us" >}}
-{{< code-block lang="yaml" filename="azure-pipeline.yml" >}}
-variables:
-  ddApiKey: $(DD_API_KEY)
-
-resources:
-  containers:
-    - container: dd_agent
-      image: gcr.io/datadoghq/agent:latest
-      ports:
-        - 8126:8126
-      env:
-        DD_API_KEY: $(ddApiKey)
-        DD_INSIDE_CI: "true"
-        DD_HOSTNAME: "none"
-
-jobs:
-  - job: test
-    services:
-      dd_agent: dd_agent
-    steps:
-      - script: make test
-{{< /code-block >}}
-{{< /site-region >}}
-{{< site-region region="us3,us5,eu,ap1" >}}
-Replace `<DD_SITE>` with the selected site: {{< region-param key="dd_site" code="true" >}}.
-
-{{< code-block lang="yaml" filename="azure-pipeline.yml" >}}
-variables:
-  ddApiKey: $(DD_API_KEY)
-
-resources:
-  containers:
-    - container: dd_agent
-      image: gcr.io/datadoghq/agent:latest
-      ports:
-        - 8126:8126
-      env:
-        DD_API_KEY: $(ddApiKey)
-        DD_INSIDE_CI: "true"
-        DD_HOSTNAME: "none"
-        DD_SITE: "<DD_SITE>"
-
-jobs:
-  - job: test
-    services:
-      dd_agent: dd_agent
-    steps:
-      - script: make test
-{{< /code-block >}}
-{{< /site-region >}}
-
-Add your [Datadog API key][3] to your [project environment variables][4] with the key `DD_API_KEY`.
-
-[1]: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/resources?view=azure-devops&tabs=schema
-[2]: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/service-containers?view=azure-devops&tabs=yaml
-[3]: https://app.datadoghq.com/organization-settings/api-keys
-[4]: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch
+[1]: https://app.datadoghq.com/organization-settings/api-keys
+[2]: /getting_started/site/
 {{% /tab %}}
-{{% tab "GitLab CI" %}}
 
-To run the Agent in GitLab, define the Agent container under [services][1].
-
-{{< site-region region="us" >}}
-{{< code-block lang="yaml" filename=".gitlab-ci.yml" >}}
-variables:
-  DD_API_KEY: $DD_API_KEY
-  DD_INSIDE_CI: "true"
-  DD_HOSTNAME: "none"
-  DD_AGENT_HOST: "datadog-agent"
-
-test:
-  services:
-    - name: gcr.io/datadoghq/agent:latest
-  script:
-    - make test
-{{< /code-block >}}
-{{< /site-region >}}
-{{< site-region region="us3,us5,eu,ap1" >}}
-
-Replace `<DD_SITE>` with the selected site: {{< region-param key="dd_site" code="true" >}}.
-
-{{< code-block lang="yaml" filename=".gitlab-ci.yml" >}}
-variables:
-  DD_API_KEY: $DD_API_KEY
-  DD_INSIDE_CI: "true"
-  DD_HOSTNAME: "none"
-  DD_AGENT_HOST: "datadog-agent"
-  DD_SITE: "<DD_SITE>"
-
-test:
-  services:
-    - name: gcr.io/datadoghq/agent:latest
-  script:
-    - make test
-{{< /code-block >}}
-{{< /site-region >}}
-
-Add your [Datadog API key][2] to your [project environment variables][3] with the key `DD_API_KEY`.
-
-[1]: https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#what-is-a-service
-[2]: https://app.datadoghq.com/organization-settings/api-keys
-[3]: https://docs.gitlab.com/ee/ci/variables/README.html#custom-environment-variables
-{{% /tab %}}
-{{% tab "GitHub Actions" %}}
-
-To run the Agent in GitHub Actions, use the [Datadog Agent GitHub Action][1] `datadog/agent-github-action`.
-
-{{< site-region region="us" >}}
-{{< code-block lang="yaml" >}}
-jobs:
-  test:
-    steps:
-      - name: Start the Datadog Agent locally
-        uses: datadog/agent-github-action@v1
-        with:
-          api_key: ${{ secrets.DD_API_KEY }}
-      - run: make test
-{{< /code-block >}}
-{{< /site-region >}}
-{{< site-region region="us3,us5,eu,ap1" >}}
-
-Replace `<datadog_site>` with the selected site: {{< region-param key="dd_site" code="true" >}}.
-
-{{< code-block lang="yaml" >}}
-jobs:
-  test:
-    steps:
-      - name: Start the Datadog Agent locally
-        uses: datadog/agent-github-action@v1
-        with:
-          api_key: ${{ secrets.DD_API_KEY }}
-          datadog_site: <datadog_site>
-      - run: make test
-{{< /code-block >}}
-{{< /site-region >}}
-
-Add your [Datadog API key][2] to your [project secrets][3] with the key `DD_API_KEY`.
-
-[1]: https://github.com/marketplace/actions/datadog-agent
-[2]: https://app.datadoghq.com/organization-settings/api-keys
-[3]: https://docs.github.com/en/actions/reference/encrypted-secrets
-{{% /tab %}}
-{{% tab "CircleCI" %}}
-
-To run the Agent in CircleCI, launch the Agent container before running tests by using the [datadog/agent CircleCI orb][1], and stop it after to ensure results are sent to Datadog.
-
-{{< site-region region="us" >}}
-{{< code-block lang="yaml" filename=".circleci/config.yml" >}}
-version: 2.1
-
-orbs:
-  datadog-agent: datadog/agent@0
-
-jobs:
-  test:
-    docker:
-      - image: circleci/<language>:<version_tag>
-    steps:
-      - checkout
-      - datadog-agent/setup
-      - run: make test
-      - datadog-agent/stop
-
-workflows:
-  test:
-    jobs:
-      - test
-{{< /code-block >}}
-{{< /site-region >}}
-{{< site-region region="us3,us5,eu,ap1" >}}
-
-Replace `<DD_SITE>` with the selected site: {{< region-param key="dd_site" code="true" >}}.
-
-{{< code-block lang="yaml" filename=".circleci/config.yml" >}}
-version: 2.1
-
-orbs:
-  datadog-agent: datadog/agent@0
-
-jobs:
-  test:
-    docker:
-      - image: circleci/<language>:<version_tag>
-    environment:
-      DD_SITE: "<DD_SITE>"
-    steps:
-      - checkout
-      - datadog-agent/setup
-      - run: make test
-      - datadog-agent/stop
-
-workflows:
-  test:
-    jobs:
-      - test
-{{< /code-block >}}
-{{< /site-region >}}
-
-Add your [Datadog API key][2] to your [project environment variables][3] with the key `DD_API_KEY`.
-
-[1]: https://circleci.com/developer/orbs/orb/datadog/agent
-[2]: https://app.datadoghq.com/organization-settings/api-keys
-[3]: https://circleci.com/docs/2.0/env-vars/
-{{% /tab %}}
 {{< /tabs >}}
 
 

--- a/content/en/continuous_integration/tests/python.md
+++ b/content/en/continuous_integration/tests/python.md
@@ -39,7 +39,7 @@ To report test results to Datadog, you need to configure the Datadog Python libr
 
 {{% tab "On-Premises CI Provider (Datadog Agent)" %}}
 
-If you are running tests on an on-premises CI provider, such as Jenkins or self-managed GitLab CI, install the Datadog Agent on each worker node by following the [Agent installation instructions][1]. This is the recommended option as test results are then automatically linked to the underlying host metrics.
+Install the [Datadog Agent][1] on each worker if you are running tests on an on-premises CI provider (eg Jenkins or self-managed GitLab CI). This is the recommended option as test results are then automatically linked to the underlying host metrics.
 
 If the CI provider is using a container-based executor, set the `DD_AGENT_HOST` environment variable on all builds (which defaults to `http://localhost:8126`) to an endpoint that is accessible from within build containers, as using `localhost` inside the build references the container itself and not the underlying worker node where the Datadog Agent is running.
 

--- a/content/en/continuous_integration/tests/python.md
+++ b/content/en/continuous_integration/tests/python.md
@@ -39,7 +39,7 @@ To report test results to Datadog, you need to configure the Datadog Python libr
 
 {{% tab "On-Premises CI Provider (Datadog Agent)" %}}
 
-Install the [Datadog Agent][1] on each worker if you are running tests on an on-premises CI provider (eg Jenkins or self-managed GitLab CI). This is the recommended option as test results are then automatically linked to the underlying host metrics.
+Install the [Datadog Agent][1] on each worker if you are running tests on an on-premises CI provider such as Jenkins or self-managed GitLab CI. This is the recommended option as test results are then automatically linked to the underlying host metrics.
 
 If the CI provider is using a container-based executor, set the `DD_AGENT_HOST` environment variable on all builds (which defaults to `http://localhost:8126`) to an endpoint that is accessible from within build containers, as using `localhost` inside the build references the container itself and not the underlying worker node where the Datadog Agent is running.
 


### PR DESCRIPTION
### What does this PR do?
* Convert agent/agentless instructions to tabs
* Update environment variables to reflect agentless mode

### Motivation
Python CI visibility should use agentless mode when running in cloud CI providers.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
