### PR TITLE
Redirect event widgets to list or timeseries

### DIFF
--- a/content/en/dashboards/widgets/event_stream.md
+++ b/content/en/dashboards/widgets/event_stream.md
@@ -7,4 +7,4 @@ aliases:
     - /graphing/widgets/event_stream/
 ---
 
-<div class="alert alert-warning">The Event Stream widget is supported through the <a href="https://docs.datadoghq.com/dashboards/widgets/list/"> List widget</a>.</div>
+<div class="alert alert-warning">The Event Stream widget is supported through the <a href="https://docs.datadoghq.com/dashboards/widgets/list/">List widget</a>.</div>

--- a/content/en/dashboards/widgets/event_stream.md
+++ b/content/en/dashboards/widgets/event_stream.md
@@ -2,49 +2,9 @@
 title: Event Stream Widget
 kind: documentation
 description: "Display filtered events from the Event Stream."
+private: true
 aliases:
     - /graphing/widgets/event_stream/
-further_reading:
-- link: "/events/explorer/"
-  tag: "Documentation"
-  text: "Events Explorer"
-- link: "/dashboards/graphing_json/"
-  tag: "Documentation"
-  text: "Building Dashboards using JSON"
-- link: "/dashboards/graphing_json/widget_json/"
-  tag: "Documentation"
-  text: "Widget JSON schema"
-- link: "/dashboards/graphing_json/request_json/"
-  tag: "Documentation"
-  text: "Request JSON schema"
 ---
 
-The event stream is a widget version of the stream of events on the [Event Explorer view][1].
-
-**Note:** This widget displays only the 100 most recent events.
-
-## Setup
-
-### Configuration
-
-1. Enter a [search query][2] to filter the event stream.
-1. Use the size parameter to choose to display either only the events title or the full event body.
-1. Choose whether your widget has a custom time frame or the global time frame.
-1. Give the graph a title.
-
-## API
-
-This widget can be used with the [Dashboards API][3].
-
-The dedicated [widget JSON schema definition][4] for the event stream widget follows:
-
-{{< dashboards-widgets-api >}}
-
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
-
-[1]: /service_management/events/
-[2]: /service_management/events/explorer/#search-syntax
-[3]: /api/latest/dashboards/
-[4]: /dashboards/graphing_json/widget_json/
+<div class="alert alert-warning">The Event Stream widget is supported through the <a href="https://docs.datadoghq.com/dashboards/widgets/list/"> List widget</a>.</div>

--- a/content/en/dashboards/widgets/event_timeline.md
+++ b/content/en/dashboards/widgets/event_timeline.md
@@ -7,4 +7,4 @@ aliases:
     - /graphing/widgets/event_timeline/
 ---
 
-<div class="alert alert-warning">The Event Timeline widget is supported through the <a href="https://docs.datadoghq.com/dashboards/widgets/timeseries/"> Timeseries widget</a>.</div>
+<div class="alert alert-warning">The Event Timeline widget is supported through the <a href="https://docs.datadoghq.com/dashboards/widgets/timeseries/">Timeseries widget</a>.</div>

--- a/content/en/dashboards/widgets/event_timeline.md
+++ b/content/en/dashboards/widgets/event_timeline.md
@@ -2,45 +2,9 @@
 title: Event Timeline Widget
 kind: documentation
 description: "Display your Event Stream Timeline in a widget."
+private: true
 aliases:
     - /graphing/widgets/event_timeline/
-further_reading:
-- link: "/events/explorer/"
-  tag: "Documentation"
-  text: "Events Explorer"
-- link: "/dashboards/widgets/event_stream/"
-  tag: "Documentation"
-  text: "Event Stream Widget"
-- link: "/dashboards/graphing_json/"
-  tag: "Documentation"
-  text: "Building Dashboards using JSON"
-
-
 ---
 
-The event timeline is a widget version of the timeline that appears at the top of the [Event Explorer view][1]:
-
-{{< img src="dashboards/widgets/event_timeline/event_timeline_example.png" alt="Event timeline of Error status events over the last 2 days" >}}
-
-## Setup
-
-### Configuration
-
-1. Enter a [search query][1] to filter the event stream.
-2. Choose whether your widget has a custom timeframe or the dashboard's global timeframe.
-
-## API
-
-This widget can be used with the [Dashboards API][2].
-
-The dedicated [widget JSON schema definition][3] for the event timeline widget is:
-
-{{< dashboards-widgets-api >}}
-
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
-
-[1]: /events/
-[2]: /api/latest/dashboards/
-[3]: /dashboards/graphing_json/widget_json/
+<div class="alert alert-warning">The Event Timeline widget is supported through the <a href="https://docs.datadoghq.com/dashboards/widgets/timeseries/"> Timeseries widget</a>.</div>

--- a/content/en/dashboards/widgets/list.md
+++ b/content/en/dashboards/widgets/list.md
@@ -8,6 +8,8 @@ further_reading:
 - link: "/notebooks/"
   tag: "Documentation"
   text: "Notebooks"
+algolia:
+  tags: ['event stream']
 ---
 
 The list widget enables you to display a list of events and issues coming from different sources.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- Add Event Stream and Event Timeline widget redirect alerts to List and Timeseries respectively.
- Add algolia tag for List for 'event stream'
- Make event stream and timeline pages private for search

### Motivation
<!-- What inspired you to submit this pull request?-->
[DOCS-5653](https://datadoghq.atlassian.net/browse/DOCS-5653)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Ready to merge after review

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5653]: https://datadoghq.atlassian.net/browse/DOCS-5653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ