### PR TITLE
Move usage details to nest under Plan and Usage

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3994,7 +3994,12 @@ main:
   - name: Plan and Usage
     url: account_management/plan_and_usage/
     parent: account_management
+    identifier: account_management_plan_and_usage
     weight: 8
+  - name: Usage Details
+    url: account_management/plan_and_usage/usage_details/
+    parent: account_management_plan_and_usage
+    weight: 801
   - name: Billing
     url: account_management/billing/
     parent: account_management

--- a/content/en/account_management/billing/_index.md
+++ b/content/en/account_management/billing/_index.md
@@ -94,7 +94,7 @@ If you pay by check, ACH, or wire, invoices are emailed to the billing email add
 
 {{< whatsnext desc="Specific billing topics:">}}
     {{< nextlink href="account_management/billing/pricing/" >}}Pricing{{< /nextlink >}}
-    {{< nextlink href="account_management/billing/usage_details/" >}}Usage details{{< /nextlink >}}
+    {{< nextlink href="account_management/plan_and_usage/usage_details/" >}}Usage details{{< /nextlink >}}
     {{< nextlink href="account_management/billing/usage_metrics/" >}}Usage Metrics{{< /nextlink >}}
     {{< nextlink href="account_management/billing/credit_card/" >}}Credit card{{< /nextlink >}}
     {{< nextlink href="account_management/billing/custom_metrics/" >}}Custom metrics{{< /nextlink >}}

--- a/content/en/account_management/billing/custom_metrics.md
+++ b/content/en/account_management/billing/custom_metrics.md
@@ -11,15 +11,15 @@ further_reading:
 
 If a metric is not submitted from one of the [more than {{< translate key="integration_count" >}} Datadog integrations][1] it's considered a [custom metric][2]<sup>[(1)](#standard-integrations)</sup>.
 
-**A custom metric is uniquely identified by a combination of a metric name and tag values (including the host tag)**. In general, any metric you send using [DogStatsD][25] or through a [custom Agent Check][26] is a custom metric.
+**A custom metric is uniquely identified by a combination of a metric name and tag values (including the host tag)**. In general, any metric you send using [DogStatsD][3] or through a [custom Agent Check][4] is a custom metric.
 
 Your monthly billable count for custom metrics (reflected on the Usage page) is calculated by taking the total of all distinct custom metrics for each hour in a given month, and dividing it by the number of hours in the month to compute a monthly average value.
 
-Metrics without Limits™ users see monthly billable volumes for _ingested_ and _indexed_ custom metrics on their Usage page. Learn more about ingested and indexed custom metrics and [Metrics without Limits™][3]. 
+Metrics without Limits™ users see monthly billable volumes for _ingested_ and _indexed_ custom metrics on their Usage page. Learn more about ingested and indexed custom metrics and [Metrics without Limits™][5]. 
 
 ## Counting custom metrics
 
-The number of custom metrics associated with a particular metric name depends on its metric [submission type][4]. Below are examples of how to count your custom metrics based on the following scenario below:
+The number of custom metrics associated with a particular metric name depends on its metric [submission type][6]. Below are examples of how to count your custom metrics based on the following scenario below:
 
 Suppose you're submitting a metric, `request.Latency`, from two hosts (`host:A`,`host:B`), which measures the latency of your endpoint requests. You're submitting this metric with two tag keys:
 
@@ -283,9 +283,9 @@ Learn more about [Metrics without Limits™][2].
 
 ## Tracking custom metrics
 
-Administrative users (those with [Datadog Admin roles][5]) can see the monthly average number of **ingested** and **indexed** custom metrics per hour. The top custom metrics table also lists the average number of **indexed** custom metrics on the [usage details page][6]. See the [Usage Details][7] documentation for more information.
+Administrative users (those with [Datadog Admin roles][7]) can see the monthly average number of **ingested** and **indexed** custom metrics per hour. The top custom metrics table also lists the average number of **indexed** custom metrics on the [usage details page][8]. See the [Usage Details][9] documentation for more information.
 
-For more real-time tracking of the count of custom metrics for a particular metric name, click into the metric name on the [Metrics Summary page][8]. You can view the number of **ingested** custom metrics and **indexed** custom metrics on the metric's details sidepanel. 
+For more real-time tracking of the count of custom metrics for a particular metric name, click into the metric name on the [Metrics Summary page][10]. You can view the number of **ingested** custom metrics and **indexed** custom metrics on the metric's details sidepanel. 
 {{< img src="account_management/billing/custom_metrics/mwl_sidepanel_ingested.jpg" alt="Metrics Summary sidepanel" style="width:80%;">}}
 
 
@@ -300,7 +300,7 @@ These allocations are counted across your entire infrastructure. For example, if
 
 {{< img src="account_management/billing/custom_metrics/host_custom_metrics.png" alt="Allocations for Custom Metrics" >}}
 
-The billable number of indexed custom metrics is based on the average number of custom metrics (from all paid hosts) per hour over a given month. The billable number of ingested custom metrics only grows if you've used Metrics without Limits™ to configure your metric. Contact [Sales][9] or your [Customer Success][10] Manager to discuss custom metrics for your account or to purchase an additional custom metrics package.
+The billable number of indexed custom metrics is based on the average number of custom metrics (from all paid hosts) per hour over a given month. The billable number of ingested custom metrics only grows if you've used Metrics without Limits™ to configure your metric. Contact [Sales][11] or your [Customer Success][12] Manager to discuss custom metrics for your account or to purchase an additional custom metrics package.
 
 ## Standard integrations
 
@@ -308,16 +308,16 @@ The following standard integrations can potentially emit custom metrics.
 
 | Type of integrations                           | Integrations                                                                       |
 |------------------------------------------------|------------------------------------------------------------------------------------|
-| Limited to 350 custom metrics by default.      | [ActiveMQ XML][11] / [Go-Expvar][12] / [Java-JMX][13]                              |
-| No default limit on custom metrics collection. | [Nagios][14] /[PDH Check][15] /[OpenMetrics][16] /[Windows performance counters][17] /[WMI][18] /[Prometheus][27] |
-| Can be configured to collect custom metrics.   | [MySQL][19] /[Oracle][20] /[Postgres][21] /[SQL Server][22]                        |
-| Custom metrics sent from cloud integrations    | [AWS][23]                                                                          |
+| Limited to 350 custom metrics by default.      | [ActiveMQ XML][13] / [Go-Expvar][14] / [Java-JMX][15]                              |
+| No default limit on custom metrics collection. | [Nagios][16] /[PDH Check][17] /[OpenMetrics][18] /[Windows performance counters][19] /[WMI][20] /[Prometheus][21] |
+| Can be configured to collect custom metrics.   | [MySQL][22] /[Oracle][23] /[Postgres][24] /[SQL Server][25]                        |
+| Custom metrics sent from cloud integrations    | [AWS][26]                                                                          |
 
 ## Troubleshooting
 
-For technical questions, contact [Datadog support][24].
+For technical questions, contact [Datadog support][27].
 
-For billing questions, contact your [Customer Success][10] Manager.
+For billing questions, contact your [Customer Success][12] Manager.
 
 ## Further Reading
 
@@ -325,28 +325,28 @@ For billing questions, contact your [Customer Success][10] Manager.
 
 [1]: /integrations/
 [2]: /metrics/custom_metrics/
-[3]: /metrics/metrics-without-limits
-[4]: /metrics/types/#metric-types
-[5]: /account_management/users/default_roles/
-[6]: https://app.datadoghq.com/billing/usage
-[7]: /account_management/billing/usage_details/
-[8]: https://app.datadoghq.com/metric/summary
-[9]: mailto:sales@datadoghq.com
-[10]: mailto:success@datadoghq.com
-[11]: /integrations/activemq/#activemq-xml-integration
-[12]: /integrations/go_expvar/
-[13]: /integrations/java/
-[14]: /integrations/nagios/
-[15]: /integrations/pdh_check/
-[16]: /integrations/openmetrics/
-[17]: /integrations/windows_performance_counters/
-[18]: /integrations/wmi_check/
-[19]: /integrations/mysql/
-[20]: /integrations/oracle/
-[21]: /integrations/postgres/
-[22]: /integrations/sqlserver/
-[23]: /integrations/amazon_web_services/
-[24]: /help/
-[25]: /metrics/custom_metrics/dogstatsd_metrics_submission/
-[26]: /metrics/custom_metrics/agent_metrics_submission/
-[27]: /integrations/prometheus
+[3]: /metrics/custom_metrics/dogstatsd_metrics_submission/
+[4]: /metrics/custom_metrics/agent_metrics_submission/
+[5]: /metrics/metrics-without-limits
+[6]: /metrics/types/#metric-types
+[7]: /account_management/users/default_roles/
+[8]: https://app.datadoghq.com/billing/usage
+[9]: /account_management/plan_and_usage/usage_details/
+[10]: https://app.datadoghq.com/metric/summary
+[11]: mailto:sales@datadoghq.com
+[12]: mailto:success@datadoghq.com
+[13]: /integrations/activemq/#activemq-xml-integration
+[14]: /integrations/go_expvar/
+[15]: /integrations/java/
+[16]: /integrations/nagios/
+[17]: /integrations/pdh_check/
+[18]: /integrations/openmetrics/
+[19]: /integrations/windows_performance_counters/
+[20]: /integrations/wmi_check/
+[21]: /integrations/prometheus
+[22]: /integrations/mysql/
+[23]: /integrations/oracle/
+[24]: /integrations/postgres/
+[25]: /integrations/sqlserver/
+[26]: /integrations/amazon_web_services/
+[27]: /help/

--- a/content/en/account_management/multi_organization.md
+++ b/content/en/account_management/multi_organization.md
@@ -165,5 +165,5 @@ Usage Attribution is an advanced feature included in the Enterprise plan. For al
 [6]: /api/
 [7]: https://www.datadoghq.com/blog/managing-datadog-with-terraform
 [8]: /monitors/manage/
-[9]: /account_management/billing/usage_details/
+[9]: /account_management/plan_and_usage/usage_details/
 [10]: /account_management/billing/usage_attribution/

--- a/content/en/account_management/plan_and_usage/usage_details.md
+++ b/content/en/account_management/plan_and_usage/usage_details.md
@@ -1,6 +1,8 @@
 ---
 title: Usage Details
 kind: documentation
+aliases:
+  - /account_management/billing/usage_details/
 ---
 
 ## Overview

--- a/content/en/metrics/_index.md
+++ b/content/en/metrics/_index.md
@@ -200,5 +200,5 @@ Read the [metrics summary documentation][22] for more details.
 [18]: /dashboards/functions/
 [19]: /metrics/distributions/
 [20]: https://app.datadoghq.com/metric/summary
-[21]: /account_management/billing/usage_details/
+[21]: /account_management/plan_and_usage/usage_details/
 [22]: /metrics/summary/


### PR DESCRIPTION
### What does this PR do?
Moves the Usage Details page to nest under Plan and Usage. Was previously under Billing. Updates the location of the page, adds an alias, and updates incoming links.

### Motivation
Requested by the Revenue Engineering product manager, Katherine Broner. Her reasoning is that Usage Details and the new Cost Details page logically belong together, under Plan and Usage.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Will create a follow-on PR to move the images.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
