### PR TITLE
Add note for log samples in monitors

### DIFF
--- a/content/en/monitors/types/log.md
+++ b/content/en/monitors/types/log.md
@@ -81,7 +81,7 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 
 #### Log samples and breaching values toplist
 
-When a logs monitor is triggered, samples or values can be added to the notification message.
+When a logs monitor is triggered, samples or values can be added to the notification message. Samples include solely the message of a log. Logs without a message are not included in samples. In order to add the content of a log attribute to the monitor’s message, use Log monitor [template variables][9] directly in the monitor’s message body.
 
 | Monitor Setup                    | Can be added to notification message |
 |----------------------------------|--------------------------------------|
@@ -116,3 +116,4 @@ Include a sample of 10 logs in the alert notification:
 [6]: /logs/explorer/facets/#measures
 [7]: /monitors/configuration/#advanced-alert-conditions
 [8]: /monitors/notify/
+[9]: /monitors/notify/variables/?tab=is_alert#matching-attributetag-variables

--- a/content/en/monitors/types/log.md
+++ b/content/en/monitors/types/log.md
@@ -81,7 +81,7 @@ For detailed instructions on the **Say what's happening** and **Notify your team
 
 #### Log samples and breaching values toplist
 
-When a logs monitor is triggered, samples or values can be added to the notification message. Samples include solely the message of a log. Logs without a message are not included in samples. In order to add the content of a log attribute to the monitor’s message, use Log monitor [template variables][9] directly in the monitor’s message body.
+When a logs monitor is triggered, samples or values can be added to the notification message. Logs without a message are not included in samples. In order to add the content of a log attribute to the monitor's message, use Log monitor [template variables][9] directly in the monitor's message body.
 
 | Monitor Setup                    | Can be added to notification message |
 |----------------------------------|--------------------------------------|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a note in the Log monitor documentation to outline the fact that samples are only included in monitor notifications for logs that include a message. 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
