### PR TITLE
fix missing scope

### DIFF
--- a/layouts/shortcodes/api-scopes.html
+++ b/layouts/shortcodes/api-scopes.html
@@ -44,6 +44,9 @@ For each scope find the common tags and group them together
   {{ $intersect := len (intersect $tagGroups $scope_obj.tags) }}
   {{ if or (and (eq $intersect 0) (ne $counter 0)) (eq $counter (sub $total 1)) }}
     {{ if $tagGroups}}
+      {{ if (eq $counter (sub $total 1)) }}
+        {{ $scopeGroups = ($scopeGroups | append $scope) | uniq }}
+      {{ end }}
       {{ $tagStr := (print (delimit $tagGroups ", ")) }}
       {{ $s.SetInMap "tags" $tagStr $scopeGroups }}
     {{ end }}


### PR DESCRIPTION
### What does this PR do?

Fixes another bug where the last scope wasn't showing on api scopes page

### Motivation

Missing an entry on scopes

### Preview

Check that the last entry with users has `user_access_read`
https://docs-staing.datadoghq.com/david.jones/scopes/api/latest/scopes/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
