### PR TITLE
add table wrapper to x-scroll

### DIFF
--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -790,6 +790,10 @@ video {
 }
 
 // Tables
+.table-wrapper {
+    overflow-x: auto;
+}
+
 table,
 .table {
     width: 100%;

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,6 +7,8 @@
         {{ partial "breadcrumbs.html" . }}
     </div>
   </div>
-  {{ partial "translate_status_banner/translate_status_banner.html" . }}
-  {{ .Content }}
+  {{ partial "translate_status_banner/translate_status_banner.html" . }} 
+
+  {{ $wrappedTable := printf "<div class=table-wrapper> ${1} </div>" }} 
+  {{ .Content | replaceRE "(<table>(?:.|\n)+?</table>)" $wrappedTable | safeHTML }}
 {{ end }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

adds table wrapper to scroll tables on mobile. prevents broken layout on mobile

### Motivation
<!-- What inspired you to submit this pull request?-->

fix broken layout on mobile

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

on viewport 365px < 768px you should be able to horizontally scroll tables.

ex: 
- https://docs-staging.datadoghq.com/stefon.simmons/scroll-tables-on-mobile/real_user_monitoring/browser/data_collected/#session-metrics

- http://localhost:1313/logs/log_configuration/attributes_naming_convention/#web-access

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
