### PR TITLE
DOCS 5517: updating k8s configuration page 

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -454,7 +454,7 @@ main:
     parent: containers_kubernetes
     identifier: containers_kubernetes_installation
     weight: 301
-  - name: Configuration
+  - name: Further Configuration
     url: containers/kubernetes/configuration
     parent: containers_kubernetes
     identifier: containers_kubernetes_configuration

--- a/content/en/containers/cluster_agent/_index.md
+++ b/content/en/containers/cluster_agent/_index.md
@@ -27,7 +27,7 @@ Using the Datadog Cluster Agent allows you to:
 * Enable the collection of cluster level data, such as the monitoring of services or SPOF and events.
 * Use Horizontal Pod Autoscaling (HPA) with custom Kubernetes metrics and external metrics. See the [Autoscaling on custom and external metrics guide][1] for more details.
 
-If you installed the Datadog Agent using Helm chart v2.7.0 or Datadog Operator v1.0.0+, the Datadog Cluster Agent is enabled by default.
+If you installed the Datadog Agent using Helm chart v2.7.0 or Datadog Operator v1.0.0+, the **Datadog Cluster Agent is enabled by default**.
 
 If you're using Docker, the Datadog Cluster Agent is available on Docker Hub and GCR:
 
@@ -50,7 +50,7 @@ Some features related to later Kubernetes versions require a minimum Datadog Age
 | 1.22.0+            | 7.37.0+        | 7.37.0+               | Support dynamic service account token |
 
 {{< whatsnext desc="This section includes the following topics:">}}
-    {{< nextlink href="/agent/cluster_agent/setup" >}}<u>Setup</u>: Setup your Datadog Cluster Agent in your Kubernetes Cluster.{{< /nextlink >}}
+    {{< nextlink href="/agent/cluster_agent/setup" >}}<u>Setup</u>: Setup the Datadog Cluster Agent in your Kubernetes Cluster.{{< /nextlink >}}
     {{< nextlink href="/agent/cluster_agent/commands" >}}<u>Commands & Options</u>: List of all commands and options available for the Cluster Agent.{{< /nextlink >}}
     {{< nextlink href="/agent/cluster_agent/clusterchecks" >}}<u>Cluster Checks</u>: Cluster checks provide the ability to Autodiscover and perform checks on load-balanced cluster services like Kubernetes services.{{< /nextlink >}}
     {{< nextlink href="/agent/cluster_agent/endpointschecks" >}}<u>Endpoint Checks</u>: Endpoint checks extend cluster checks to monitor any endpoint behind cluster services.{{< /nextlink >}}

--- a/content/en/containers/cluster_agent/_index.md
+++ b/content/en/containers/cluster_agent/_index.md
@@ -27,6 +27,8 @@ Using the Datadog Cluster Agent allows you to:
 * Enable the collection of cluster level data, such as the monitoring of services or SPOF and events.
 * Use Horizontal Pod Autoscaling (HPA) with custom Kubernetes metrics and external metrics. See the [Autoscaling on custom and external metrics guide][1] for more details.
 
+If you installed the Datadog Agent using Helm chart v2.7.0 or Datadog Operator v1.0.0+, the Datadog Cluster Agent is enabled by default.
+
 If you're using Docker, the Datadog Cluster Agent is available on Docker Hub and GCR:
 
 | Docker Hub                                       | GCR                                                       |
@@ -37,7 +39,15 @@ If you're using Docker, the Datadog Cluster Agent is available on Docker Hub and
 
 Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from other registries where no rate limits apply. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
 
-**Note**: To take advantage of all features from the Datadog Cluster Agent, you must run Kubernetes v1.10+.
+### Minimum Agent and Cluster Agent versions
+
+Some features related to later Kubernetes versions require a minimum Datadog Agent version.
+
+| Kubernetes version | Agent version  | Cluster Agent version | Reason                                |
+|--------------------|----------------|-----------------------|---------------------------------------|
+| 1.16.0+            | 7.19.0+        | 1.9.0+                | Kubelet metrics deprecation           |
+| 1.21.0+            | 7.36.0+        | 1.20.0+               | Kubernetes resource deprecation       |
+| 1.22.0+            | 7.37.0+        | 7.37.0+               | Support dynamic service account token |
 
 {{< whatsnext desc="This section includes the following topics:">}}
     {{< nextlink href="/agent/cluster_agent/setup" >}}<u>Setup</u>: Setup your Datadog Cluster Agent in your Kubernetes Cluster.{{< /nextlink >}}

--- a/content/en/containers/cluster_agent/clusterchecks.md
+++ b/content/en/containers/cluster_agent/clusterchecks.md
@@ -1,5 +1,5 @@
 ---
-title: Cluster Checks with Autodiscovery
+title: Cluster Checks
 kind: documentation
 aliases:
     - /agent/autodiscovery/clusterchecks
@@ -19,7 +19,7 @@ further_reading:
 
 ## Overview
 
-The Datadog Agent automatically discovers containers and creates check configurations by using [Autodiscovery mechanism][1].
+The Datadog Agent automatically discovers containers and creates check configurations by using the [Autodiscovery mechanism][1].
 
 _Cluster checks_ extend this mechanism to monitor noncontainerized workloads, including:
 

--- a/content/en/containers/cluster_agent/setup.md
+++ b/content/en/containers/cluster_agent/setup.md
@@ -24,8 +24,6 @@ algolia:
 
 If you deploy the Datadog Agent using Helm chart v2.7.0+ or Datadog Operator v0.7.0+, the Cluster Agent is enabled by default.
 
-If you are using other methods, like a DaemonSet, follow these steps:
-
 {{< tabs >}}
 {{% tab "Helm" %}}
 
@@ -73,7 +71,7 @@ When set manually, this token must be 32 alphanumeric characters.
 
 [1]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md#override
 {{% /tab %}}
-{{% tab "DaemonSet" %}}
+{{% tab "Manual (DaemonSet)" %}}
 
 To set up the Datadog Cluster Agent using a DaemonSet:
 1. [Configure Cluster Agent RBAC permissions](#configure-cluster-agent-rbac-permissions).

--- a/content/en/containers/guide/kubernetes_daemonset.md
+++ b/content/en/containers/guide/kubernetes_daemonset.md
@@ -223,7 +223,7 @@ Send custom metrics with [the StatsD protocol][24]:
 |----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` | Listen to DogStatsD packets from other containers (required to send custom metrics).                                                                       |
 | `DD_HISTOGRAM_PERCENTILES`       | The histogram percentiles to compute (separated by spaces). The default is `0.95`.                                                                         |
-| `DD_HISTOGRAM_AGGREGATES`        | The histogram aggregates to compute (separated by spaces). The default is "max median avg count".                                                          |
+| `DD_HISTOGRAM_AGGREGATES`        | The histogram aggregates to compute (separated by spaces). The default is `"max median avg count"`.                                                          |
 | `DD_DOGSTATSD_SOCKET`            | Path to the Unix socket to listen to. Must be in a `rw` mounted volume.                                                                                    |
 | `DD_DOGSTATSD_ORIGIN_DETECTION`  | Enable container detection and tagging for Unix socket metrics.                                                                                            |
 | `DD_DOGSTATSD_TAGS`              | Additional tags to append to all metrics, events, and service checks received by this DogStatsD server, for example: `"env:golden group:retrievers"`. |
@@ -264,7 +264,7 @@ Additional examples are available on the [Container Discover Management][27] pag
 
 | Env Variable                        | Description                                                                                                                                                                                                                                                         |
 |-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DD_PROCESS_AGENT_CONTAINER_SOURCE` | Overrides container source auto-detection to force a single source. e.g `"docker"`, `"ecs_fargate"`, `"kubelet"`. This is no longer needed since Agent v7.35.0.                                                                                                     |
+| `DD_PROCESS_AGENT_CONTAINER_SOURCE` | Overrides container source auto-detection to force a single source. Example: `"docker"`, `"ecs_fargate"`, `"kubelet"`. This is no longer needed since Agent v7.35.0.                                                                                                     |
 | `DD_HEALTH_PORT`                    | Set this to `5555` to expose the Agent health check at port `5555`.                                                                                                                                                                                                 |
 | `DD_CLUSTER_NAME`                   | Set a custom Kubernetes cluster identifier to avoid host alias collisions. The cluster name can be up to 40 characters with the following restrictions: Lowercase letters, numbers, and hyphens only. Must start with a letter. Must end with a number or a letter. |
 

--- a/content/en/containers/guide/kubernetes_daemonset.md
+++ b/content/en/containers/guide/kubernetes_daemonset.md
@@ -182,6 +182,95 @@ Alternatively, to collect the Kubernetes events from a Node Agent, set the envir
   value: "true"
 ```
 
+## Environment variables
+
+The following is the list of environment variables available for the Datadog Agent using a DaemonSet. 
+
+### Global options
+
+| Env Variable         | Description                                                                                                                                                                                                                                                                                                                                      |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DD_API_KEY`         | Your Datadog API key (**required**)                                                                                                                                                                                                                                                                                                              |
+| `DD_ENV`             | Sets the global `env` tag for all data emitted.                                                                                                                                                                                                                                                                                                  |
+| `DD_HOSTNAME`        | Hostname to use for metrics (if autodetection fails)                                                                                                                                                                                                                                                                                             |
+| `DD_TAGS`            | Host tags separated by spaces. For example: `simple-tag-0 tag-key-1:tag-value-1`                                                                                                                                                                                                                                                                 |
+| `DD_SITE`            | Destination site for your metrics, traces, and logs. Your `DD_SITE` is {{< region-param key="dd_site" code="true">}}. Defaults to `datadoghq.com`.                                                                                                                                                                                               |
+| `DD_DD_URL`          | Optional setting to override the URL for metric submission.                                                                                                                                                                                                                                                                                      |
+| `DD_URL` (6.36+/7.36+)            | Alias for `DD_DD_URL`. Ignored if `DD_DD_URL` is already set.                                                                                                                                                                                                                                                                                    |
+| `DD_CHECK_RUNNERS`   | The Agent runs all checks concurrently by default (default value = `4` runners). To run the checks sequentially, set the value to `1`. If you need to run a high number of checks (or slow checks) the `collector-queue` component might fall behind and fail the healthcheck. You can increase the number of runners to run checks in parallel. |
+| `DD_LEADER_ELECTION` | If multiple instances of the Agent are running in your cluster, set this variable to `true` to avoid the duplication of event collection.                                                                                                                                                                                                                         |
+
+### Proxy settings
+
+Starting with Agent v6.4.0 (and v6.5.0 for the Trace Agent), you can override the Agent proxy settings with the following environment variables:
+
+| Env Variable             | Description                                                            |
+|--------------------------|------------------------------------------------------------------------|
+| `DD_PROXY_HTTP`          | An HTTP URL to use as a proxy for `http` requests.                     |
+| `DD_PROXY_HTTPS`         | An HTTPS URL to use as a proxy for `https` requests.                   |
+| `DD_PROXY_NO_PROXY`      | A space-separated list of URLs for which no proxy should be used.      |
+| `DD_SKIP_SSL_VALIDATION` | An option to test if the Agent is having issues connecting to Datadog. |
+
+For more information about proxy settings, see the [Agent v6 Proxy documentation][23].
+
+
+
+### DogStatsD (custom metrics)
+
+Send custom metrics with [the StatsD protocol][24]:
+
+| Env Variable                     | Description                                                                                                                                                |
+|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` | Listen to DogStatsD packets from other containers (required to send custom metrics).                                                                       |
+| `DD_HISTOGRAM_PERCENTILES`       | The histogram percentiles to compute (separated by spaces). The default is `0.95`.                                                                         |
+| `DD_HISTOGRAM_AGGREGATES`        | The histogram aggregates to compute (separated by spaces). The default is "max median avg count".                                                          |
+| `DD_DOGSTATSD_SOCKET`            | Path to the Unix socket to listen to. Must be in a `rw` mounted volume.                                                                                    |
+| `DD_DOGSTATSD_ORIGIN_DETECTION`  | Enable container detection and tagging for Unix socket metrics.                                                                                            |
+| `DD_DOGSTATSD_TAGS`              | Additional tags to append to all metrics, events, and service checks received by this DogStatsD server, for example: `"env:golden group:retrievers"`. |
+
+Learn more about [DogStatsD over Unix Domain Sockets][25].
+
+### Tagging
+
+Datadog automatically collects common tags from Kubernetes. To extract even more tags, use the following options:
+
+| Env Variable                            | Description             |
+|-----------------------------------------|-------------------------|
+| `DD_KUBERNETES_POD_LABELS_AS_TAGS`      | Extract pod labels      |
+| `DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS` | Extract pod annotations |
+
+See the [Kubernetes Tag Extraction][26] documentation to learn more.
+
+### Ignore containers
+
+Exclude containers from logs collection, metrics collection, and Autodiscovery. Datadog excludes Kubernetes and OpenShift `pause` containers by default. These allowlists and blocklists apply to Autodiscovery only; traces and DogStatsD are not affected. These environment variables support regular expressions in their values.
+
+| Env Variable                   | Description                                                                                                                                                                                                                        |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DD_CONTAINER_INCLUDE`         | Allowlist of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`                                                                              |
+| `DD_CONTAINER_EXCLUDE`         | Blocklist of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"`, `image:.*`                                                                              |
+| `DD_CONTAINER_INCLUDE_METRICS` | Allowlist of containers whose metrics you wish to include.                                                                                                                                                                         |
+| `DD_CONTAINER_EXCLUDE_METRICS` | Blocklist of containers whose metrics you wish to exclude.                                                                                                                                                                         |
+| `DD_CONTAINER_INCLUDE_LOGS`    | Allowlist of containers whose logs you wish to include.                                                                                                                                                                            |
+| `DD_CONTAINER_EXCLUDE_LOGS`    | Blocklist of containers whose logs you wish to exclude.                                                                                                                                                                            |
+| `DD_AC_INCLUDE`                | **Deprecated**. Allowlist of containers to include (separated by spaces). Use `.*` to include all. For example: `"image:image_name_1 image:image_name_2"`, `image:.*`                                                              |
+| `DD_AC_EXCLUDE`                | **Deprecated**. Blocklist of containers to exclude (separated by spaces). Use `.*` to exclude all. For example: `"image:image_name_3 image:image_name_4"` (**Note**: This variable is only honored for Autodiscovery.), `image:.*` |
+
+Additional examples are available on the [Container Discover Management][27] page.
+
+**Note**: The `kubernetes.containers.running`, `kubernetes.pods.running`, `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings. All containers are counted.
+
+### Misc
+
+| Env Variable                        | Description                                                                                                                                                                                                                                                         |
+|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DD_PROCESS_AGENT_CONTAINER_SOURCE` | Overrides container source auto-detection to force a single source. e.g `"docker"`, `"ecs_fargate"`, `"kubelet"`. This is no longer needed since Agent v7.35.0.                                                                                                     |
+| `DD_HEALTH_PORT`                    | Set this to `5555` to expose the Agent health check at port `5555`.                                                                                                                                                                                                 |
+| `DD_CLUSTER_NAME`                   | Set a custom Kubernetes cluster identifier to avoid host alias collisions. The cluster name can be up to 40 characters with the following restrictions: Lowercase letters, numbers, and hyphens only. Must start with a letter. Must end with a number or a letter. |
+
+You can add extra listeners and config providers using the `DD_EXTRA_LISTENERS` and `DD_EXTRA_CONFIG_PROVIDERS` environment variables. They are added in addition to the variables defined in the `listeners` and `config_providers` section of the `datadog.yaml` configuration file.
+
+
 [1]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 [2]: /resources/yaml/datadog-agent-all-features.yaml
 [3]: /resources/yaml/datadog-agent-windows-all-features.yaml
@@ -204,3 +293,8 @@ Alternatively, to collect the Kubernetes events from a Node Agent, set the envir
 [20]: /getting_started/site/
 [21]: /agent/docker/?tab=standard#ignore-containers
 [22]: /containers/kubernetes/log
+[23]: /agent/proxy/#agent-v6
+[24]: /developers/dogstatsd/
+[25]: /developers/dogstatsd/unix_socket/
+[26]: /containers/kubernetes/tag/
+[27]: /agent/guide/autodiscovery-management/

--- a/content/en/containers/kubernetes/_index.md
+++ b/content/en/containers/kubernetes/_index.md
@@ -31,13 +31,15 @@ further_reading:
 
 Run the Datadog Agent in your Kubernetes cluster to start collecting your cluster and applications metrics, traces, and logs.
 
-**Note**: Agent v6.0+ only supports Kubernetes v1.7.6+. For prior versions of Kubernetes, consult the [Legacy Kubernetes versions section][1].
+**Note**: Agent v6.0+ only supports Kubernetes v1.7.6+. For prior versions of Kubernetes, see [Legacy Kubernetes versions][1].
 
 For Agent commands, see the [Agent Commands guides][2].
 
+For information pertaining to the Datadog Cluster Agent, which provides a streamlined approach to collecting cluster level monitoring data, see [Cluster Agent for Kubernetes][3].
+
 {{< whatsnext desc="This section includes the following topics:">}}
   {{< nextlink href="/agent/kubernetes/installation">}}<u>Installation</u>: Install the Datadog Agent in a Kubernetes environment.{{< /nextlink >}}
-  {{< nextlink href="/agent/kubernetes/configuration">}}<u>Configuration</u>: Collect events, override proxy settings, send custom metrics with DogStatsD, configure container allowlists and blocklists, and reference the full list of available environment variables.{{< /nextlink >}}
+  {{< nextlink href="/agent/kubernetes/configuration">}}<u>Further Configuration</u>: Collect events, override proxy settings, send custom metrics with DogStatsD, configure container allowlists and blocklists, and reference the full list of available environment variables.{{< /nextlink >}}
   {{< nextlink href="/agent/kubernetes/distributions">}}<u>Distributions</u>: Review base configurations for major Kubernetes distributions, including AWS Elastic Kubernetes Service (EKS), Azure Kubernetes Service (AKS), Google Kubernetes Engine (GKE), Red Hat OpenShift, Rancher, and Oracle Container Engine for Kubernetes (OKE).{{< /nextlink >}}
   {{< nextlink href="/agent/kubernetes/apm">}}<u>APM</u>: Set up trace collection: configure the Agent to accept traces, configure your Pods to communicate with the Agent, and configure your application tracers to emit traces.{{< /nextlink >}}
   {{< nextlink href="/agent/kubernetes/log">}}<u>Log collection</u>: Set up log collection in a Kubernetes environment.{{< /nextlink >}}
@@ -54,3 +56,4 @@ For Agent commands, see the [Agent Commands guides][2].
 
 [1]: /agent/faq/kubernetes-legacy/
 [2]: /agent/guide/agent-commands/
+[3]: /containers/cluster_agent/

--- a/content/en/containers/kubernetes/apm.md
+++ b/content/en/containers/kubernetes/apm.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Trace Collection
+title: Kubernetes APM - Trace Collection
 kind: documentation
 aliases:
     - /agent/kubernetes/apm

--- a/content/en/containers/kubernetes/configuration.md
+++ b/content/en/containers/kubernetes/configuration.md
@@ -1,5 +1,5 @@
 ---
-title: Configure the Datadog Agent on Kubernetes
+title: Further Configure the Datadog Agent on Kubernetes
 kind: documentation
 aliases:
     - /integrations/faq/gathering-kubernetes-events
@@ -11,18 +11,79 @@ aliases:
 
 After you have installed the Datadog Agent in your Kubernetes environment, you may choose additional configuration options.
 
-## Live Containers
+This page contains instructions for the following:
 
-The [Datadog Agent][1] and [Cluster Agent][2] can be configured to retrieve Kubernetes resources for [Live Containers][3]. This feature allows you to monitor the state of pods, deployments and other Kubernetes concepts in a specific namespace or availability zone, view resource specifications for failed pods within a deployment, correlate node activity with related logs, and more.
+- Configure DogStatsD
+- Enable APM
+- Enable log collection
+- Enable process collection
+- Enable NPM
+- Enable event collection
 
-See the [Live Containers][4] documentation for configuration instructions and additional information.
+## Containers view
+
+To make use of Datadog's [Container Explorer][3], enable the Process Agent. 
+
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+
+The Datadog Operator enables the Process Agent by default. 
+
+For verification, ensure that `features.liveContainerCollection.enabled` is set to `true` in your `datadog-agent.yaml`:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+      appKey: <DATADOG_APP_KEY>
+  features:
+    liveContainerCollection:
+      enabled: true
+```
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+If you are using the [official Helm chart][1], enable the `processAgent.enabled` parameter in your [`values.yaml`][2] file:
+
+```yaml
+datadog:
+  # (...)
+  processAgent:
+    enabled: true
+```
+
+Then, upgrade your Helm chart.
+
+In some setups, the Process Agent and Cluster Agent cannot automatically detect a Kubernetes cluster name. If this happens, the feature does not start, and the following warning displays in the Cluster Agent log: `Orchestrator explorer enabled but no cluster name set: disabling.` In this case, you must set `datadog.clusterName` to your cluster name in `values.yaml`.
+
+```yaml
+datadog:
+  #(...)
+  clusterName: <YOUR_CLUSTER_NAME>
+  #(...)
+  processAgent:
+    enabled: true
+```
+
+[1]: https://github.com/DataDog/helm-charts
+[2]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
+{{% /tab %}}
+{{< /tabs >}}
+
+See the [Containers view][15] documentation for additional information.
 
 ## Event collection
 
 {{< tabs >}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
-Event collection is enabled by default by the Datadog Operator. This can be managed by the configuration `features.eventCollection.collectKubernetesEvents` in your `DatadogAgent` configuration.
+Event collection is enabled by default by the Datadog Operator. This can be managed in the configuration `features.eventCollection.collectKubernetesEvents` in your `datadog-agent.yaml`.
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -40,13 +101,14 @@ spec:
       collectKubernetesEvents: true
 ```
 
-The Cluster Agent collects and reports the Kubernetes events.
+The [Cluster Agent][1] collects and reports the Kubernetes events.
 
+[1]: /containers/cluster_agent
 
 {{% /tab %}}
 {{% tab "Helm" %}}
 
-If you want Kubernetes events to be collected by the Datadog Cluster Agent, ensure that the `clusterAgent.enabled`, `datadog.collectEvents` and `clusterAgent.rbac.create` options are set to true in your `values.yaml` file.
+To collect Kubernetes events with the Datadog Cluster Agent, ensure that the `clusterAgent.enabled`, `datadog.collectEvents` and `clusterAgent.rbac.create` options are set to `true` in your `values.yaml` file.
 
 ```yaml
 datadog:
@@ -57,7 +119,7 @@ clusterAgent:
     create: true
 ```
 
-If you don't want to use the Cluster Agent, you can still have a Node Agent collect Kubernetes events by setting `datadog.leaderElection`, `datadog.collectEvents` and `agents.rbac.create` options to true in your `values.yaml` file.
+If you don't want to use the Cluster Agent, you can still have a Node Agent collect Kubernetes events by setting `datadog.leaderElection`, `datadog.collectEvents`, and `agents.rbac.create` options to `true` in your `values.yaml` file.
 
 ```yaml
 datadog:
@@ -67,6 +129,8 @@ agents:
   rbac:
     create: true
 ```
+
+[1]: /containers/cluster_agent
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -194,3 +258,4 @@ You can add extra listeners and config providers using the `DD_EXTRA_LISTENERS` 
 [12]: /agent/guide/secrets-management/
 [13]: /agent/guide/autodiscovery-management/
 [14]: /containers/guide/kubernetes_daemonset#cluster-agent-event-collection
+[15]: https://docs.datadoghq.com/infrastructure/containers/?tab=datadogoperator

--- a/content/en/containers/kubernetes/configuration.md
+++ b/content/en/containers/kubernetes/configuration.md
@@ -14,7 +14,7 @@ After you have installed the Datadog Agent in your Kubernetes environment, you m
 ### Enable Datadog to collect:
 - [Traces (APM)](#enable-apm-and-tracing)
 - [Kubernetes events](#enable-kubernetes-event-collection)
-- [NPM](#enable-npm)
+- [NPM](#enable-npm-collection)
 - [Logs](#enable-log-collection)
 - [Processes](#enable-process-collection)
 
@@ -23,7 +23,7 @@ After you have installed the Datadog Agent in your Kubernetes environment, you m
 - [Integrations](#integrations)
 - [Containers view](#containers-view)
 - [Orchestrator Explorer](#orchestrator-explorer)
-- [External metrics server](#external-metrics-server)
+- [External metrics server](#custom-metrics-server)
 
 ### More configurations
 - [Environment variables](#environment-variables)

--- a/content/en/containers/kubernetes/installation.md
+++ b/content/en/containers/kubernetes/installation.md
@@ -119,8 +119,6 @@ Using the Datadog Operator requires the following prerequisites:
 {{% /tab %}}
 {{% tab "Helm" %}}
 
-To install the chart with a custom release name, `<RELEASE_NAME>` (for example, `datadog-agent`):
-
 ### Prerequisites
 
 - [Helm][1]

--- a/content/en/containers/kubernetes/installation.md
+++ b/content/en/containers/kubernetes/installation.md
@@ -6,60 +6,61 @@ aliases:
     - /agent/kubernetes/helm
     - /agent/kubernetes/installation
 further_reading:
-    - link: 'infrastructure/livecontainers/'
-      tag: 'Documentation'
-      text: 'Live Containers'
     - link: '/agent/kubernetes/configuration'
       tag: 'Documentation'
-      text: 'Configure the Datadog Agent on Kubernetes'
-    - link: '/agent/kubernetes/integrations'
-      tag: 'Documentation'
-      text: 'Configure integrations'
-    - link: '/agent/kubernetes/apm'
-      tag: 'Documentation'
-      text: 'Collect your application traces'
-    - link: 'agent/kubernetes/log'
-      tag: 'Documentation'
-      text: 'Collect your application logs'
-    - link: '/agent/kubernetes/tag'
-      tag: 'Documentation'
-      text: 'Assign tags to all data emitted by a container, Pod, or Node'
+      text: 'Further Configure the Datadog Agent on Kubernetes'
+    - link: 'https://github.com/DataDog/helm-charts/blob/main/charts/datadog/README.md#all-configuration-options'
+      tag: 'GitHub'
+      text: 'Datadog Helm chart - All configuration options'
+    - link: 'https://github.com/DataDog/helm-charts/blob/main/charts/datadog/README.md#upgrading'
+      tag: 'GitHub'
+      text: 'Upgrading Datadog Helm'
 ---
 
-## Installation
+## Overview
 
-This page provides instructions on installing the Datadog Agent in a Kubernetes environment. For dedicated documentation and examples for major Kubernetes distributions including AWS Elastic Kubernetes Service (EKS), Azure Kubernetes Service (AKS), Google Kubernetes Engine (GKE), Red Hat OpenShift, Rancher, and Oracle Container Engine for Kubernetes (OKE), see [Kubernetes distributions][1].
+This page provides instructions on installing the Datadog Agent in a Kubernetes environment. By default, the Datadog Agent runs in a DaemonSet.
+
+For dedicated documentation and examples for major Kubernetes distributions including AWS Elastic Kubernetes Service (EKS), Azure Kubernetes Service (AKS), Google Kubernetes Engine (GKE), Red Hat OpenShift, Rancher, and Oracle Container Engine for Kubernetes (OKE), see [Kubernetes distributions][1].
 
 For dedicated documentation and examples for monitoring the Kubernetes control plane, see [Kubernetes control plane monitoring][2].
 
-### Minimum Agent and Cluster Agent versions
+### Minimum Kubernetes and Datadog Agent versions
 
 Some features related to later Kubernetes versions require a minimum Datadog Agent version.
 
-| Kubernetes version | Agent version  | Cluster Agent version | Reason                                |
-|--------------------|----------------|-----------------------|---------------------------------------|
-| 1.16.0+            | 7.19.0+        | 1.9.0+                | Kubelet metrics deprecation           |
-| 1.21.0+            | 7.36.0+        | 1.20.0+               | Kubernetes resource deprecation       |
-| 1.22.0+            | 7.37.0+        | 7.37.0+               | Support dynamic service account token |
+| Kubernetes version | Agent version  | Reason                                |
+|--------------------|----------------|---------------------------------------|
+| 1.16.0+            | 7.19.0+        | Kubelet metrics deprecation           |
+| 1.21.0+            | 7.36.0+        |  Kubernetes resource deprecation       |
+| 1.22.0+            | 7.37.0+        |  Support dynamic service account token |
+
+See also: [Minimum Kubernetes and Cluster Agent versions][8].
+
+## Installation
+
+You have the following options for installing the Datadog Agent on Kubernetes:
+
+- The [Datadog Operator][9], a [Kubernetes Operator][10] (Recommended)
+- [Helm][11]
+- Manual installation. See [Manually install and configure the Datadog Agent on Kubernetes with DaemonSet][12].
 
 {{< tabs >}}
 {{% tab "Operator" %}}
 
 <div class="alert alert-warning">The Datadog Operator is Generally Available with the 1.0.0 version, and it reconciles the version <code>v2alpha1</code> of the DatadogAgent Custom Resource. </div>
 
-[The Datadog Operator][1] is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options.
+The [Datadog Operator][1] is a way to deploy the Datadog Agent on Kubernetes and OpenShift. It reports deployment status, health, and errors in its Custom Resource status, and it limits the risk of misconfiguration thanks to higher-level configuration options.
 
-## Prerequisites
+### Prerequisites
 
 Using the Datadog Operator requires the following prerequisites:
 
-- **Kubernetes Cluster version >= v1.20.X**: Tests were done on versions >= `1.20.0`. Still, it should work on versions `>= v1.11.0`. For earlier versions, because of limited CRD support, the Operator may not work as expected.
+- **Kubernetes Cluster version v1.20.X+**: Tests were done on v1.20.0+; should be supported in v1.11.0+. For earlier versions, because of limited CRD support, the Operator may not work as expected.
 - [`Helm`][2] for deploying the `datadog-operator`.
 - [`Kubectl` CLI][3] for installing the `datadog-agent`.
 
-## Deploy an Agent with the Operator
-
-To deploy the Datadog Agent with the operator in the minimum number of steps, see the [`datadog-operator`][4] Helm chart. Here are the steps:
+### Deploy an Agent with the Operator
 
 1. Install the [Datadog Operator][5]:
 
@@ -73,9 +74,9 @@ To deploy the Datadog Agent with the operator in the minimum number of steps, se
    ```shell
    kubectl create secret generic datadog-secret --from-literal api-key=<DATADOG_API_KEY> --from-literal app-key=<DATADOG_APP_KEY>
    ```
-   Replace `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your [Datadog API and application keys][6]
+   Replace `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your [Datadog API][6] and [application keys][7].
 
-2. Create a file with the spec of your Datadog Agent deployment configuration. The simplest configuration is as follows:
+2. Create a file, `datadog-agent.yaml`, with the spec of your Datadog Agent deployment configuration. The simplest configuration is as follows:
 
    ```yaml
    kind: DatadogAgent
@@ -107,9 +108,89 @@ To deploy the Datadog Agent with the operator in the minimum number of steps, se
    ```shell
    kubectl apply -f /path/to/your/datadog-agent.yaml
    ```
+[1]: https://github.com/DataDog/datadog-operator
+[2]: https://helm.sh
+[3]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
+[4]: https://github.com/DataDog/helm-charts/tree/master/charts/datadog-operator
+[5]: https://artifacthub.io/packages/helm/datadog/datadog-operator
+[6]: https://app.datadoghq.com/organization-settings/api-keys
+[7]: https://app.datadoghq.com/organization-settings/application-keys
+[10]: /getting_started/site
+{{% /tab %}}
+{{% tab "Helm" %}}
 
-## Cleanup
+To install the chart with a custom release name, `<RELEASE_NAME>` (for example, `datadog-agent`):
 
+### Prerequisites
+
+- [Helm][1]
+- If this is a fresh install, add the Helm Datadog repo:
+    ```bash
+    helm repo add datadog https://helm.datadoghq.com
+    helm repo update
+    ```
+
+### Install the chart
+
+1. Create an empty `datadog-values.yaml` file. Any parameters not specified in this file default to those set in [`values.yaml`][14].
+
+2. Create a Kubernetes Secret to store your Datadog [API key][3] and [app key][15]:
+   
+   ```bash
+   kubectl create secret generic datadog-secret --from-literal api-key=$DD_API_KEY --from-literal app-key=$DD_APP_KEY
+   ```
+3. Set the following parameters in your `datadog-values.yaml` to reference the secret:
+   ```
+   datadog:
+    apiKeyExistingSecret: datadog-secret
+    appKeyExistingSecret: datadog-secret
+    site: <DATADOG_SITE>
+   ```
+   Replace `<DATADOG_SITE>` with your [Datadog site][13]. For example, `datadoghq.com` or `datadoghq.eu`.
+3. Run the following command:
+   ```bash
+   helm install <RELEASE_NAME> \
+    -f datadog-values.yaml \
+    --set targetSystem=<TARGET_SYSTEM> \
+    datadog/datadog
+   ```
+
+- `<RELEASE_NAME>`: Your release name. For example, `datadog-agent`.
+
+- `<TARGET_SYSTEM>`: The name of your OS. For example, `linux` or `windows`.
+
+
+**Note**: If you are using Helm < v3, run the following:
+   ```bash
+   helm install --name <RELEASE_NAME> \
+    -f datadog-values.yaml \
+    --set targetSystem=<TARGET_SYSTEM> \
+    datadog/datadog
+   ```
+
+[1]: https://v3.helm.sh/docs/intro/install/
+[2]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
+[3]: https://app.datadoghq.com/organization-settings/api-keys
+[4]: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics
+[5]: /agent/kubernetes/apm?tab=helm
+[6]: /agent/kubernetes/log?tab=helm
+
+[8]: https://gcr.io/datadoghq
+[9]: https://gallery.ecr.aws/datadog/
+[10]: https://hub.docker.com/u/datadog/
+[11]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/docs/Migration_1.x_to_2.x.md
+[12]: /integrations/kubernetes_state_core
+[13]: /getting_started/site
+[14]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml
+[15]: https://app.datadoghq.com/organization-settings/application-keys
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Cleanup
+
+{{< tabs >}}
+{{% tab "Operator" %}}
 The following command deletes all the Kubernetes resources created by the above instructions:
 
 ```shell
@@ -117,11 +198,28 @@ kubectl delete datadogagent datadog
 helm delete my-datadog-operator
 ```
 
-For further details on setting up Operator, including information about using tolerations, refer to the [Datadog Operator advanced setup guide][7].
+For further details on setting up Datadog Operator, including information about using tolerations, refer to the [Datadog Operator advanced setup guide][1].
 
-## Unprivileged
+[1]: https://github.com/DataDog/datadog-operator/blob/main/docs/installation.md
 
-(Optional) To run an unprivileged installation, add the following to the [Datadog custom resource (CR)][8]:
+{{% /tab %}}
+{{% tab "Helm" %}}
+To uninstall/delete the `<RELEASE_NAME>` deployment:
+
+```bash
+helm uninstall <RELEASE_NAME>
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+
+### Unprivileged
+
+(Optional) To run an unprivileged installation:
+
+{{< tabs >}}
+{{% tab "Operator" %}}
+Add the following to the Datadog custom resource (CR) in your `datadog-agent`.yaml:
 
 ```yaml
 agent:
@@ -132,59 +230,36 @@ agent:
         - <DOCKER_GROUP_ID>
 ```
 
-where `<USER_ID>` is the UID to run the agent and `<DOCKER_GROUP_ID>` is the group ID owning the Docker or containerd socket.
+{{% /tab %}}
+{{% tab "Helm" %}}
+Add the following in your `datadog-values.yaml` file:
 
-## Container registries
+```yaml
+datadog:
+  securityContext:
+      runAsUser: <USER_ID>
+      supplementalGroups:
+        - <DOCKER_GROUP_ID>
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+- `<USER_ID>` is the UID to run the Agent.
+- `<DOCKER_GROUP_ID>` is the group ID owning the Docker or containerd socket.
+
+### Container registries
+
+{{< tabs >}}
+{{% tab "Operator" %}}
 
 To modify the container image registry, see the [Changing Container Registry][9] guide.
 
-[1]: https://github.com/DataDog/datadog-operator
-[2]: https://helm.sh
-[3]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
-[4]: https://github.com/DataDog/helm-charts/tree/master/charts/datadog-operator
-[5]: https://artifacthub.io/packages/helm/datadog/datadog-operator
-[6]: https://app.datadoghq.com/organization-settings/api-keys
-[7]: /agent/guide/operator-advanced
-[8]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.md
+
 [9]: /agent/guide/changing_container_registry/#kubernetes-with-the-datadog-operator
-[10]: /getting_started/site
+
 {{% /tab %}}
 {{% tab "Helm" %}}
-
-To install the chart with a custom release name, `<RELEASE_NAME>` (for example, `datadog-agent`):
-
-1. [Install Helm][1].
-2. Using the [Datadog `values.yaml` configuration file][2] as a reference, create your `values.yaml`. Datadog recommends that your `values.yaml` only contain values that need to be overridden, as it allows a smooth experience when upgrading chart versions.
-3. If this is a fresh install, add the Helm Datadog repo:
-    ```bash
-    helm repo add datadog https://helm.datadoghq.com
-    helm repo update
-    ```
-4. Retrieve your Datadog API key from your [Agent installation instructions][3] and run:
-
-- **Helm v3+**
-
-    ```bash
-    helm install <RELEASE_NAME> -f values.yaml  --set datadog.apiKey=<DATADOG_API_KEY> datadog/datadog --set targetSystem=<TARGET_SYSTEM>
-    ```
-
-    Replace `<TARGET_SYSTEM>` with the name of your OS: `linux` or `windows`.
-
-- **Helm v1/v2**
-
-    ```bash
-    helm install -f values.yaml --name <RELEASE_NAME> --set datadog.apiKey=<DATADOG_API_KEY> datadog/datadog
-    ```
-
-This chart adds the Datadog Agent to all nodes in your cluster with a DaemonSet. It also optionally deploys the [kube-state-metrics chart][4] and uses it as an additional source of metrics about the cluster. A few minutes after installation, Datadog begins to report hosts and metrics.
-
-Next, enable the Datadog features that you'd like to use: [APM][5], [Logs][6]
-
-**Notes**:
-
-- For a full list of the Datadog chart's configurable parameters and their default values, see the [Datadog Helm repository README][7].
-
-### Container registries
 
 <div class="alert alert-warning">On July 10 2023, Docker Hub will start enforcing download rate limits to Datadog's Docker Hub registries. Image pulls from these registries count against your rate limit quota.<br/><br/>
 
@@ -208,67 +283,25 @@ If Google Container Registry ([gcr.io/datadoghq][8]) is not accessible in your d
 
 - It is recommended to use the public AWS ECR registry ([public.ecr.aws/datadog][9]) when the Datadog chart is deployed in an AWS environment.
 
-### Upgrading from chart v1.x
-
-The Datadog chart has been refactored in v2.0 to regroup the `values.yaml` parameters in a more logical way.
-
-If your current chart version deployed is earlier than `v2.0.0`, follow the [migration guide][11] to map your previous settings with the new fields.
-
-### Kube state metrics core in chart v2.x
-
-In new deployments, Datadog recommends using the newer `kube-state-metrics` core with the following values:
-
-```yaml
-...
-datadog:
-...
-  kubeStateMetricsCore:
-    enabled: true
-...
-```
-
-For details about `kube-state-metrics` core, read the [Kubernetes State Metrics Core documentation][12].
-
-### Unprivileged
-
-(Optional) To run an unprivileged installation, add the following in the `values.yaml` file:
-
-```yaml
-datadog:
-  securityContext:
-      runAsUser: <USER_ID>
-      supplementalGroups:
-        - <DOCKER_GROUP_ID>
-```
-
-where `<USER_ID>` is the UID to run the agent and `<DOCKER_GROUP_ID>` is the group ID owning the docker or containerd socket.
-
-[1]: https://v3.helm.sh/docs/intro/install/
-[2]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
-[3]: https://app.datadoghq.com/organization-settings/api-keys
-[4]: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics
-[5]: /agent/kubernetes/apm?tab=helm
-[6]: /agent/kubernetes/log?tab=helm
-[7]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog
 [8]: https://gcr.io/datadoghq
 [9]: https://gallery.ecr.aws/datadog/
 [10]: https://hub.docker.com/u/datadog/
-[11]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/docs/Migration_1.x_to_2.x.md
-[12]: /integrations/kubernetes_state_core
+
 {{% /tab %}}
 {{< /tabs >}}
 
 ## Next steps
 
-To configure Live Containers, see [Live Containers][3].
+- **Monitor your Kubernetes infrastructure in Datadog**. If you used a Datadog Operator or Helm install, you can start monitoring your containers in Datadog's [Containers view][13]. For more information, see the [Containers view documentation][14].
 
-To collect events, override proxy settings, send custom metrics with DogStatsD, configure container allowlists and blocklists, or reference the full list of available environment variables, see [Configure the Datadog Agent on Kubernetes][4].
+- **Configure APM**. See [Kubernetes APM - Trace Collection][15].
+- **Configure log collection**. See [Kubernetes log collection][7].
+- **Configure integrations**. See [Integrations & Autodiscovery][5].
+- **Other configurations**: To collect events, override proxy settings, send custom metrics with DogStatsD, configure container allowlists and blocklists, or reference the full list of available environment variables, see [Further Kubernetes Configuration][4].
 
-To configure integrations, see [Integrations & Autodiscovery][5].
+## Further Reading
 
-To set up APM, see [Kubernetes Trace Collection][6].
-
-To set up log collection, see [Kubernetes Log Collection][7].
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/kubernetes/distributions
 [2]: /agent/kubernetes/control_plane
@@ -277,3 +310,11 @@ To set up log collection, see [Kubernetes Log Collection][7].
 [5]: /agent/kubernetes/integrations/
 [6]: /agent/kubernetes/apm/
 [7]: /agent/kubernetes/log/
+[8]: /containers/cluster_agent/#minimum-agent-and-cluster-agent-versions
+[9]: /containers/datadog_operator
+[10]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
+[11]: https://helm.sh
+[12]: /containers/guide/kubernetes_daemonset/
+[13]: https://app.datadoghq.com/containers
+[14]: /infrastructure/containers
+[15]: /containers/kubernetes/apm

--- a/content/en/containers/kubernetes/installation.md
+++ b/content/en/containers/kubernetes/installation.md
@@ -146,7 +146,7 @@ To install the chart with a custom release name, `<RELEASE_NAME>` (for example, 
     appKeyExistingSecret: datadog-secret
     site: <DATADOG_SITE>
    ```
-   Replace `<DATADOG_SITE>` with your [Datadog site][13]. For example, `datadoghq.com` or `datadoghq.eu`.
+   Replace `<DATADOG_SITE>` with your [Datadog site][13]. Your site is {{< region-param key="dd_site" code="true" >}}. (Ensure the correct SITE is selected on the right).
 3. Run the following command:
    ```bash
    helm install <RELEASE_NAME> \


### PR DESCRIPTION
overhauls k8s installation and configuration pages. this could use an editorial review but should otherwise be good to merge. all information taken directly from datadog-operator repo and helm chart.