### PR TITLE
Add precision on RUM connectivity attributes

### DIFF
--- a/content/en/real_user_monitoring/android/data_collected.md
+++ b/content/en/real_user_monitoring/android/data_collected.md
@@ -55,6 +55,13 @@ The following device-related attributes are attached automatically to all events
 | `device.brand`  | string | The device brand as reported by the device (System User-Agent).  |
 | `device.model`   | string | The device model as reported by the device (System User-Agent).    |
 | `device.name` | string | The device name as reported by the device (System User-Agent).  |
+
+### Connectivity
+
+The following netowrk-related attributes are attached automatically to Resource and Error events collected by Datadog:
+
+| Attribute name                           | Type   | Description                                     |
+|------------------------------------------|--------|-------------------------------------------------|
 | `connectivity.status` | string | Status of device network reachability (`connected`, `not connected`, or `maybe`). |
 | `connectivity.interfaces` | string | The list of available network interfaces (for example, `bluetooth`, `cellular`, `ethernet`, or `wifi`). |
 | `connectivity.cellular.technology` | string | The type of a radio technology used for cellular connection. |

--- a/content/en/real_user_monitoring/android/data_collected.md
+++ b/content/en/real_user_monitoring/android/data_collected.md
@@ -58,7 +58,7 @@ The following device-related attributes are attached automatically to all events
 
 ### Connectivity
 
-The following netowrk-related attributes are attached automatically to Resource and Error events collected by Datadog:
+The following network-related attributes are attached automatically to Resource and Error events collected by Datadog:
 
 | Attribute name                           | Type   | Description                                     |
 |------------------------------------------|--------|-------------------------------------------------|

--- a/content/en/real_user_monitoring/ios/data_collected.md
+++ b/content/en/real_user_monitoring/ios/data_collected.md
@@ -68,7 +68,7 @@ The following device-related attributes are attached automatically to all events
 
 ### Connectivity
 
-The following netowrk-related attributes are attached automatically to Resource and Error events collected by Datadog:
+The following network-related attributes are attached automatically to Resource and Error events collected by Datadog:
 
 | Attribute name                           | Type   | Description                                     |
 |------------------------------------------|--------|-------------------------------------------------|

--- a/content/en/real_user_monitoring/ios/data_collected.md
+++ b/content/en/real_user_monitoring/ios/data_collected.md
@@ -65,6 +65,13 @@ The following device-related attributes are attached automatically to all events
 | `device.brand`                       | string | The device brand as reported by the device (System User-Agent).                                           |
 | `device.model`                       | string | The device model as reported by the device (System User-Agent).                                           |
 | `device.name`                        | string | The device name as reported by the device (System User-Agent).                                            |
+
+### Connectivity
+
+The following netowrk-related attributes are attached automatically to Resource and Error events collected by Datadog:
+
+| Attribute name                           | Type   | Description                                     |
+|------------------------------------------|--------|-------------------------------------------------|
 | `connectivity.status`                | string | Status of device network reachability (`connected`, `not connected`, `maybe`).                           |
 | `connectivity.interfaces`            | string | The list of available network interfaces (for example, `bluetooth`, `cellular`, `ethernet`, or `wifi`). |
 | `connectivity.cellular.technology`   | string | The type of a radio technology used for cellular connection.                                              |

--- a/content/en/real_user_monitoring/roku/data_collected.md
+++ b/content/en/real_user_monitoring/roku/data_collected.md
@@ -63,10 +63,6 @@ The following device-related attributes are attached automatically to all events
 | `device.brand`                       | string | The device brand as reported by the device (System User-Agent).                                         |
 | `device.model`                       | string | The device model as reported by the device (System User-Agent).                                         |
 | `device.name`                        | string | The device name as reported by the device (System User-Agent).                                          |
-| `connectivity.status`                | string | Status of device network reachability (`connected`, `not connected`, or `maybe`).                       |
-| `connectivity.interfaces`            | string | The list of available network interfaces (for example, `bluetooth`, `cellular`, `ethernet`, or `wifi`). |
-| `connectivity.cellular.technology`   | string | The type of a radio technology used for cellular connection.                                            |
-| `connectivity.cellular.carrier_name` | string | The name of the SIM carrier.                                                                            |
 
 
 ### Operating system


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add precision on the RUM connectivity attribute as they're not available on *all* the RUM events.

### Motivation
A customer got confused and thought some data was missing.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
