### PR TITLE
(maint) Fix casing in workflow redirects

### DIFF
--- a/local/bin/py/build/actions/workflows.py
+++ b/local/bin/py/build/actions/workflows.py
@@ -47,7 +47,7 @@ def workflows(content, content_dir):
                         action_data['bundle'] = data.get('name')
                         action_data['bundle_title'] = data.get('title').strip()
                         action_data['source'] = data.get('icon', {}).get('integration_id', '')
-                        action_data['aliases'] = [f'/workflows/actions_catalog/{output_file_name}_{action_name}']
+                        action_data['aliases'] = [f'/workflows/actions_catalog/{output_file_name}_{action_name}'.lower()]
                         # if this is a dd. bundle then lets use the datadog integration id
                         if not action_data['source'] and 'datadog' in action_data['bundle_title'].lower():
                             action_data['source'] = '_datadog'


### PR DESCRIPTION
Fixes redirects for workflow actions with mixed casing in their filenames

Wait for CorpWeb review before merge

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
