### PR TITLE
(maint) Fix casing in workflow redirects

### DIFF
--- a/local/bin/py/build/actions/workflows.py
+++ b/local/bin/py/build/actions/workflows.py
@@ -55,7 +55,7 @@ def workflows(content, content_dir):
                         output_content = TEMPLATE.format(front_matter=yaml.dump(action_data, default_flow_style=False).strip(), content=content)
                         dest_dir = Path(f"{content_dir}{dest_path}")
                         dest_dir.mkdir(exist_ok=True)
-                        name = f"{output_file_name}_{action_name}"
+                        name = f"{output_file_name}_{action_name}".lower()
                         dest_file = dest_dir.joinpath(name).with_suffix('.md')
                         with open(dest_file, mode='w', encoding='utf-8') as out_file:
                             out_file.write(output_content)

--- a/local/bin/py/build/actions/workflows.py
+++ b/local/bin/py/build/actions/workflows.py
@@ -47,7 +47,7 @@ def workflows(content, content_dir):
                         action_data['bundle'] = data.get('name')
                         action_data['bundle_title'] = data.get('title').strip()
                         action_data['source'] = data.get('icon', {}).get('integration_id', '')
-                        action_data['aliases'] = [f'/workflows/actions_catalog/{output_file_name}_{action_name}']
+                        action_data['aliases'] = [f'/workflows/actions_catalog/{output_file_name}_{action_name}'.lower()]
                         # if this is a dd. bundle then lets use the datadog integration id
                         if not action_data['source'] and 'datadog' in action_data['bundle_title'].lower():
                             action_data['source'] = '_datadog'

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: false
+    cache_enabled: true
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: true
+    cache_enabled: false
 
 - data:
     - org_name: jenkinsci
@@ -94,7 +94,7 @@
             file_name: '_index.md'
             front_matters:
               dependencies: ["https://github.com/DataDog/integrations-core/blob/master/docs/dev/README.md"]
-              
+
         - action: pull-and-push-folder
           branch: master
           globs:
@@ -348,7 +348,7 @@
               title: Static Analysis and CircleCI Orbs
               kind: documentation
               description: Use Datadog and CircleCI to run Static Analysis jobs in a CI pipeline.
-      
+
       - repo_name: datadog-static-analyzer-github-action
         contents:
         - action: pull-and-push-file


### PR DESCRIPTION
Fixes redirects for workflow actions with mixed casing in their filenames

Good to merge

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
