### PR TITLE
revise nginx ingress controller trace sampling documentation

### DIFF
--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -545,7 +545,7 @@ metadata:
 data:
   datadog-collector-host: $HOST_IP
   enable-opentracing: "true"
-  datadog-sample-rate: 0.4
+  datadog-sample-rate: "0.4"
 ```
 
 <div class="alert alert-warning">


### PR DESCRIPTION
… to account for an ongoing bug.

### What does this PR do?
This PR revises the [nginx ingress controller trace sampling documentation][1] so that it reflects:

1. a simpler way to set sampling rate (using a `ConfigMap` instead of sampling rules)
2. a bug that is preventing the ingress controller from using sampling rates calculated by the Datadog Agent, such as those that might result from a "remotely configured" traces-per-second setting.

### Motivation
At least two customers have created Support tickets about this bug.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.

[1]: https://docs.datadoghq.com/tracing/trace_collection/proxy_setup/?tab=nginx#ingress-controller-sampling