### PR TITLE
DOCS-5451 time control in urls

### DIFF
--- a/content/en/dashboards/guide/custom_time_frames.md
+++ b/content/en/dashboards/guide/custom_time_frames.md
@@ -63,4 +63,18 @@ Both fixed and relative custom time frames are supported:
   * Months: `mo`, `mos`, `mon`, `mons`, `month`, `months`
 * `today`, `yesterday`, `this month`, `this year`, and `last year` are calculated when entered. They won't continue to update as time passes.
 
+## URLs
+
+You can manipulate time queries in the URL of a dashboard.
+
+Consider the following dashboard URL:
+
+```
+https://app.datadoghq.com/dash/host/<DASHBOARD_ID>?from_ts=<QUERY_START>&to_ts=<QUERY_END>&live=true
+```
+
+* The `from_ts` parameter is the Unix milliseconds timestamp of the query starting time. For example, `1683518770980`.
+* The `to_ts` parameter is the Unix milliseconds timestamp of the query ending time. For example, `1683605233205`.
+* `live=true` indicates that relative time specifications are retained when a query is saved or shared. You can also use `live=false`.
+
 [1]: /dashboards/#display-utc-time


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds an explanation of time control in URLS to the bottom of the Custom Time Frames guide.
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->
escalated from zendesk

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
ready to merge

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
