### PR TITLE
Integration Categories Straight Quotes Update 

### DIFF
--- a/layouts/shortcodes/integration_categories.md
+++ b/layouts/shortcodes/integration_categories.md
@@ -38,20 +38,20 @@
 | Category::Source Control | Integrations that monitor source code collaboration tools such as Git. |
 | Category::Testing | Integrations that monitor technologies that run browser tests, load testing, and more. |
 | Category::Tracing | Integrations that send in or query traces from Datadog, and interact with Datadog APM.  |
-| Offering::Integration | This is an offering that submits or queries data from a user’s Datadog account. |
+| Offering::Integration | This is an offering that submits or queries data from a user's Datadog account. |
 | Offering::Professional Service | This is a paid offering that provides third-party professional services, such as consulting, integration creation, and more to Datadog customers through the Datadog Marketplace. |
 | Offering::Software License | This is a paid offering that provides a subscription to a SaaS product through the Datadog Marketplace. |
 | Offering::UI Extension | This is a custom dashboard widget that displays a rendered, interactive iFrame on the dashboards of Datadog users. |
-| Queried Data Type::Metrics | An integration that reads metrics from a Datadog user’s account. |
-| Queried Data Type::Logs | An integration that reads logs from a Datadog user’s account. |
-| Queried Data Type::Traces | An integration that reads traces from a Datadog user’s account. |
-| Queried Data Type::Events | An integration that reads events from a Datadog user’s account. |
-| Queried Data Type::Incidents | An integration that reads incidents from a Datadog user’s account. |
-| Submitted Data Type::Metrics | An integration that sends metrics into a Datadog user’s account. |
-| Submitted Data Type::Logs | An integration that sends logs into a Datadog user’s account. |
-| Submitted Data Type::Traces | An integration that sends traces into a Datadog user’s account. |
-| Submitted Data Type::Events | An integration that sends events into a Datadog user’s account. |
-| Submitted Data Type::Incidents | An integration that sends incidents into a Datadog user’s account. |
+| Queried Data Type::Metrics | An integration that reads metrics from a Datadog user's account. |
+| Queried Data Type::Logs | An integration that reads logs from a Datadog user's account. |
+| Queried Data Type::Traces | An integration that reads traces from a Datadog user's account. |
+| Queried Data Type::Events | An integration that reads events from a Datadog user's account. |
+| Queried Data Type::Incidents | An integration that reads incidents from a Datadog user's account. |
+| Submitted Data Type::Metrics | An integration that sends metrics into a Datadog user's account. |
+| Submitted Data Type::Logs | An integration that sends logs into a Datadog user's account. |
+| Submitted Data Type::Traces | An integration that sends traces into a Datadog user's account. |
+| Submitted Data Type::Events | An integration that sends events into a Datadog user's account. |
+| Submitted Data Type::Incidents | An integration that sends incidents into a Datadog user's account. |
 | Supported OS::Android | An integration that can run on and query/submit data from Android.  |
 | Supported OS::Any | An integration that can run on and query/submit data from any OS.  |
 | Supported OS::HP-UX | An integration that can run on and query/submit data from HP-UX.  |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Uses straight quotes instead of curly quotes in the Integration Categories shortcode.

### Motivation
<!-- What inspired you to submit this pull request?-->

Spotted in Vale output, ready to merge.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
