### PR TITLE
Fixed metric name typo

### DIFF
--- a/content/en/serverless/azure_app_services/azure_app_services_windows.md
+++ b/content/en/serverless/azure_app_services/azure_app_services_windows.md
@@ -74,7 +74,7 @@ For example:
 
 ### Installation
 
-1. Configure the [Azure integration][1] to monitor your web app or function. Verify it is configured correctly by ensuring that you see the corresponding `azure.app_service.count` or `azure.functions.count` metric in Datadog. **Note**: This step is critical for metric/trace correlation, functional trace panel views, and improves the overall experience of using Datadog with Azure App Services.
+1. Configure the [Azure integration][1] to monitor your web app or function. Verify it is configured correctly by ensuring that you see the corresponding `azure.app_services.count` or `azure.functions.count` metric in Datadog. **Note**: This step is critical for metric/trace correlation, functional trace panel views, and improves the overall experience of using Datadog with Azure App Services.
 
 2. Open the [Azure Portal][3] and navigate to the dashboard for the Azure app you wish to instrument with Datadog.
 


### PR DESCRIPTION
Metric is called azure.app_services.count, was documented as azure.app_service.count on this page.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Changed documented metric from azure.app_service.count to azure.app_services.count


### Motivation
Found this typo while searching for azure.app_service.count in the Metrics Summary. The actual metric is documented here: https://docs.datadoghq.com/integrations/azure_app_services/ 

### Additional Notes
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
