### PR TITLE
Fix widgets page

### DIFF
--- a/content/en/dashboards/widgets/_index.md
+++ b/content/en/dashboards/widgets/_index.md
@@ -18,57 +18,84 @@ Widgets are building blocks for your dashboards. They allow you to visualize and
 
 ### Graphs
 {{< whatsnext desc="Generic widgets to graph data from Datadog products: ">}}
-    {{< nextlink href="/dashboards/widgets/change" >}}<img src="/images/dashboards/widgets/icons/change_light_large.png" /> Change{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/distribution" >}}<img src="/images/dashboards/widgets/icons/distribution_light_large.png" /> Distribution{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/funnel" >}}<img src="/images/dashboards/widgets/icons/funnel_light_large.png" /> Funnel{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/geomap" >}}<img src="/images/dashboards/widgets/icons/geomap_light_large.png" /> Geomap{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/heat_map" >}}<img src="/images/dashboards/widgets/icons/heatmap_light_large.png" /> Heatmap{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/pie_chart" >}}<img src="/images/dashboards/widgets/icons/pie_light_large.png" /> Pie Chart{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/query_value" >}}<img src="/images/dashboards/widgets/icons/query-value_light_large.png" /> Query Value{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/scatter_plot" >}}<img src="/images/dashboards/widgets/icons/scatter-plot_light_large.png" /> Scatter Plot{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/table" >}}<img src="/images/dashboards/widgets/icons/table_light_large.png" /> Table{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/treemap" >}}<img src="/images/dashboards/widgets/icons/treemap_light_large.png" /> Treemap{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/timeseries" >}}<img src="/images/dashboards/widgets/icons/timeseries_light_large.png" /> Timeseries{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/top_list" >}}<img src="/images/dashboards/widgets/icons/top-list_light_large.png" /> Top List{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/change" 
+        img="dashboards/widgets/icons/change_light_large.png">}} Change {{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/distribution"
+        img="dashboards/widgets/icons/distribution_light_large.png">}} Distribution{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/funnel"
+        img="dashboards/widgets/icons/funnel_light_large.png">}} Funnel{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/geomap" 
+        img="dashboards/widgets/icons/geomap_light_large.png">}} Geomap{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/heat_map"
+        img="dashboards/widgets/icons/heatmap_light_large.png">}} Heatmap{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/pie_chart"
+        img="dashboards/widgets/icons/pie_light_large.png">}} Pie Chart{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/query_value"
+        img="dashboards/widgets/icons/query-value_light_large.png">}} Query Value{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/scatter_plot"
+        img="dashboards/widgets/icons/scatter-plot_light_large.png">}} Scatter Plot{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/table"
+        img="dashboards/widgets/icons/table_light_large.png">}} Table{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/treemap"
+        img="dashboards/widgets/icons/treemap_light_large.png">}} Treemap{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/timeseries"
+        img="dashboards/widgets/icons/timeseries_light_large.png">}} Timeseries{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/top_list"
+        img="dashboards/widgets/icons/top-list_light_large.png">}} Top List{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ### Groups
 {{< whatsnext desc="Display your widgets under groups: ">}}
-    {{< nextlink href="/dashboards/widgets/group" >}}<img src="/images/dashboards/widgets/icons/placeholder_light_large.png" /> Group{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/group"
+        img="dashboards/widgets/icons/placeholder_light_large.png">}} Group{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ### Annotations and embeds
 {{< whatsnext desc="Decoration widgets to visually structure and annotate dashboards: ">}}
-    {{< nextlink href="/dashboards/widgets/free_text" >}}<img src="/images/dashboards/widgets/icons/free-text_light_large.png" /> Free Text{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/iframe" >}}<img src="/images/dashboards/widgets/icons/iframe_light_large.png" /> Iframe{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/image" >}}<img src="/images/dashboards/widgets/icons/image_light_large.png" /> Image{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/note" >}}<img src="/images/dashboards/widgets/icons/notes_light_large.png" /> Notes and Links{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/free_text" 
+        img="dashboards/widgets/icons/free-text_light_large.png">}} Free Text{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/iframe" 
+        img="dashboards/widgets/icons/iframe_light_large.png">}} Iframe{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/image" 
+        img="dashboards/widgets/icons/image_light_large.png">}} Image{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/note" 
+        img="dashboards/widgets/icons/notes_light_large.png">}} Notes and Links{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ### Lists and streams
 {{< whatsnext desc="Display a list of events and issues coming from different sources: ">}}
-    {{< nextlink href="/dashboards/widgets/list" >}}<img src="/images/dashboards/widgets/icons/change_light_large.png" /> List{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/list"
+        img="dashboards/widgets/icons/change_light_large.png">}} List{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ### Alerting and response
 {{< whatsnext desc="Summary widgets to display Monitoring information: ">}}
-    {{< nextlink href="/dashboards/widgets/alert_graph" >}}<img src="/images/dashboards/widgets/icons/alert-graph_light_large.png" /> Alert Graph{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/alert_value" >}}<img src="/images/dashboards/widgets/icons/alert-value_light_large.png" /> Alert Value{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/check_status" >}}<img src="/images/dashboards/widgets/icons/check-status_light_large.png" /> Check Status{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/monitor_summary" >}}<img src="/images/dashboards/widgets/icons/monitor-summary_light_large.png" /> Monitor Summary{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/alert_graph" 
+        img="dashboards/widgets/icons/alert-graph_light_large.png">}} Alert Graph{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/alert_value" 
+        img="dashboards/widgets/icons/alert-value_light_large.png">}}Alert Value{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/check_status" 
+        img="dashboards/widgets/icons/check-status_light_large.png">}} Check Status{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/monitor_summary" 
+        img="dashboards/widgets/icons/monitor-summary_light_large.png">}} Monitor Summary{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ### Architecture
 {{< whatsnext desc="Visualize infrastructure and architecture data: ">}}
-    {{< nextlink href="/dashboards/widgets/hostmap" >}}<img src="/images/dashboards/widgets/icons/host-map_light_large.png" /> Hostmap{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/topology_map" >}}<img src="/images/dashboards/widgets/icons/service-map_light_large.png" /> Topology Map{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/service_summary" >}}<img src="/images/dashboards/widgets/icons/service-summary_light_large.png" /> Service Summary{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/hostmap" 
+        img="dashboards/widgets/icons/host-map_light_large.png">}} Hostmap{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/topology_map" 
+        img="dashboards/widgets/icons/service-map_light_large.png">}} Topology Map{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/service_summary" 
+        img="dashboards/widgets/icons/service-summary_light_large.png">}} Service Summary{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ### Performance and reliability
 {{< whatsnext desc="Site reliability visualizations: ">}}
-    {{< nextlink href="/dashboards/widgets/slo" >}}<img src="/images/dashboards/widgets/icons/slo-summary_light_large.png" /> Service Level Objective (SLO) Summary{{< /nextlink >}}
-    {{< nextlink href="/dashboards/widgets/slo_list" >}}<img src="/images/dashboards/widgets/icons/slo-list_light_large.png" /> Service Level Objective (SLO) List{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/slo" 
+        img="dashboards/widgets/icons/slo-summary_light_large.png">}} Service Level Objective (SLO) Summary{{< /nextlink >}}
+    {{< nextlink href="/dashboards/widgets/slo_list" 
+        img="dashboards/widgets/icons/slo-list_light_large.png">}} Service Level Objective (SLO) List{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ## Full screen

--- a/layouts/shortcodes/nextlink.html
+++ b/layouts/shortcodes/nextlink.html
@@ -1,6 +1,7 @@
 {{ $dot := . }}
 {{- $href := .Get "href" -}}
 {{- $tag := .Get "tag" -}}
+{{- $img := .Get "img" -}}
 {{- $text := .Inner -}}
 
 {{ if eq (substr $href 0 4) "http"}}
@@ -27,13 +28,19 @@
 
 {{- with .Parent -}}
     <a class="list-group-item list-group-item-white list-group-item-action d-flex justify-content-between align-items-center" href="{{ $link }}">
-        <span class="w-100 d-flex justify-content-between"><span class="text">{{ $text }}</span>{{ if $tag }}<span class="badge badge-white pe-2 border-0">{{ $tag | upper }}</span>{{ end }}</span>
+        {{ with $img }}
+            {{ partial "img.html" (dict "root" $dot "src" $img "class" "img-fluid") }}
+        {{ end }}    
+        <span class="w-100 d-flex justify-content-between {{ with $img }} ps-1 {{ end }}"><span class="text">{{ $text }}</span>{{ if $tag }}<span class="badge badge-white pe-2 border-0">{{ $tag | upper }}</span>{{ end }}</span>
         {{ partial "img.html" (dict "root" $dot "src" "icons/list-group-arrow.png" "class" "img-fluid static" "alt" "more") }}
         {{ partial "img.html" (dict "root" $dot "src" "icons/list-group-arrow-r.png" "class" "img-fluid hover" "alt" "more" "disable_lazy" "true") }}
     </a>
 {{- else -}}
     <a class="list-group-item list-group-item-white list-group-item-action d-flex justify-content-between align-items-center" href="{{ $link }}">
-        <span class="w-100 d-flex justify-content-between"><span class="text">{{ $text }}</span>{{ if $tag }}<span class="badge badge-white pe-2 border-0">{{ $tag | upper }}</span>{{ end }}</span>
+        {{ with $img }}
+            {{ partial "img.html" (dict "root" $dot "src" $img "class" "img-fluid") }}
+        {{ end }}   
+        <span class="w-100 d-flex justify-content-between {{ with $img }} ps-1 {{ end }}"><span class="text">{{ $text }}</span>{{ if $tag }}<span class="badge badge-white pe-2 border-0">{{ $tag | upper }}</span>{{ end }}</span>
         {{ partial "img.html" (dict "root" $dot "src" "icons/list-group-arrow.png" "class" "img-fluid static" "alt" "more") }}
         {{ partial "img.html" (dict "root" $dot "src" "icons/list-group-arrow-r.png" "class" "img-fluid hover" "alt" "more" "disable_lazy" "true") }}
     </a>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

- Fixes the issue with widget icons rendering on preview sites, and also updates the sourcing of the images to be served through imigix for optimization

### Motivation
<!-- What inspired you to submit this pull request?-->
Widget icons don't currently load on preview sites
https://dd.slack.com/archives/C0DESMBQU/p1687890249511809?thread_ts=1687886463.904819&cid=C0DESMBQU
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
