### PR TITLE
[Flutter] Add documentation for different routing packages

### DIFF
--- a/content/en/real_user_monitoring/flutter/_index.md
+++ b/content/en/real_user_monitoring/flutter/_index.md
@@ -37,6 +37,8 @@ To initialize the Datadog Flutter SDK for RUM, see [Setup][3].
 
 ## Automatically track views
 
+### Flutter Navigator v1
+
 The [Datadog Flutter Plugin][4] can automatically track named routes using the `DatadogNavigationObserver` on your MaterialApp:
 
 ```dart
@@ -50,9 +52,33 @@ MaterialApp(
 
 This works if you are using named routes or if you have supplied a name to the `settings` parameter of your `PageRoute`.
 
-Alternatively, you can use the `DatadogRouteAwareMixin` property in conjunction with the `DatadogNavigationObserverProvider` property to start and stop your RUM views automatically. With `DatadogRouteAwareMixin`, move any logic from `initState` to `didPush`.
+If you are not using named routes, you can use `DatadogRouteAwareMixin` in conjunction with the `DatadogNavigationObserverProvider` widget to start and stop your RUM views automatically. With `DatadogRouteAwareMixin`, move any logic from `initState` to `didPush`.
 
-To rename your views or supply custom paths, provide a [`viewInfoExtractor`][8] callback. This function can fall back to the default behavior of the observer by calling `defaultViewInfoExtractor`. For example:
+### Flutter Navigator v2
+
+If you are using Flutter Navigator v2.0, which uses the `MaterialApp.router` named constructor, the setup will vary based on the routing middleware you are using, if any. Since [go_router][11], uses the same observer interface as Flutter Navigator v1, so the `DatadogNavigationObserver` can be added to other observers as a parameter to `GoRouter`.
+
+```dart
+final _router = GoRouter(
+  routes: [
+    // Your route information here
+  ],
+  observers: [
+    DatadogNavigationObserver(datadogSdk: DatadogSdk.instance),
+  ],
+);
+MaterialApp.router(
+  routerConfig: _router,
+  // Your remaining setup
+)
+```
+
+For examples that use routers other than `go_router` see Advanced Configuration - Automatic View Tracking
+
+
+### Renaming Views
+
+For all setups, you can rename views or supply custom paths by providing a [`viewInfoExtractor`][8] callback. This function can fall back to the default behavior of the observer by calling `defaultViewInfoExtractor`. For example:
 
 ```dart
 RumViewInfo? infoExtractor(Route<dynamic> route) {
@@ -72,7 +98,6 @@ var observer = DatadogNavigationObserver(
   viewInfoExtractor: infoExtractor,
 );
 ```
-
 
 ## Automatically track resources
 
@@ -109,3 +134,4 @@ In order to enable Datadog [Distributed Tracing][6], you must set the `DdSdkConf
 [8]: https://pub.dev/documentation/datadog_flutter_plugin/latest/datadog_flutter_plugin/ViewInfoExtractor.html
 [9]: https://api.flutter.dev/flutter/dart-io/HttpOverrides/current.html
 [10]: https://pub.dev/documentation/datadog_tracking_http_client/latest/datadog_tracking_http_client/DatadogTrackingHttpOverrides-class.html
+[11]: https://pub.dev/packages/go_router

--- a/content/en/real_user_monitoring/flutter/advanced_configuration.md
+++ b/content/en/real_user_monitoring/flutter/advanced_configuration.md
@@ -15,6 +15,85 @@ further_reading:
 
 If you have not set up the Datadog Flutter SDK for RUM yet, follow the [in-app setup instructions][1] or refer to the [RUM Flutter setup documentation][2].
 
+## Automatic View Tracking
+
+If you are using Flutter Navigator v2.0, your setup for automatic view tracking will differ depending on your routing middleware. Here, we document how to integrate with the most popular routing packages.
+
+### go_router
+
+Since [go_router][8], uses the same observer interface as Flutter Navigator v1, so the `DatadogNavigationObserver` can be added to other observers as a parameter to `GoRouter`.
+
+```dart
+final _router = GoRouter(
+  routes: [
+    // Your route information here
+  ],
+  observers: [
+    DatadogNavigationObserver(datadogSdk: DatadogSdk.instance),
+  ],
+);
+MaterialApp.router(
+  routerConfig: _router,
+  // Your remaining setup
+)
+```
+
+### AutoRoute
+
+[AutoRoute][9] can use a `DatadogNavigationObserver` provided as one of the `navigatorObservers` as part of its `config` method.
+
+```dart
+return MaterialApp.router(
+  routerConfig: _router.config(
+    navigatorObservers: () => [
+      DatadogNavigationObserver(
+        datadogSdk: DatadogSdk.instance,
+      ),
+    ],
+  ),
+  // Your remaining setup
+);
+```
+
+However, if you are using AutoRoute's tab routing, you need to extend Datadog's default observer with AutoRoute's `AutoRouteObserver` interface.
+
+```dart
+class DatadogAutoRouteObserver extends DatadogNavigationObserver
+    implements AutoRouterObserver {
+  DatadogAutoRouteObserver({required super.datadogSdk});
+
+  // only override to observer tab routes
+  @override
+  void didInitTabRoute(TabPageRoute route, TabPageRoute? previousRoute) {
+    datadogSdk.rum?.startView(route.path, route.name);
+  }
+
+  @override
+  void didChangeTabRoute(TabPageRoute route, TabPageRoute previousRoute) {
+    datadogSdk.rum?.startView(route.path, route.name);
+  }
+}
+```
+
+This new object replaces the simpler `DatadogNavigationObserver` in creation of AutoRoute's config.
+
+### Beamer
+
+[Beamer][10] can use the `DatadogNavigationObserver` as an argument to `BeamerDelegate`
+
+```dart
+final routerDelegate = BeamerDelegate(
+  locationBuilder: RoutesLocationBuilder(
+    routes: {
+      // Your route config
+    },
+  ),
+  navigatorObservers: [
+    DatadogNavigationObserver(DatadogSdk.instance),
+  ]
+);
+```
+
 ## Enrich user sessions
 
 Flutter RUM automatically tracks attributes such as user activity, views (using the `DatadogNavigationObserver`), errors, native crashes, and network requests (using the Datadog Tracking HTTP Client). See the [RUM Data Collection documentation][3] to learn about the RUM events and default attributes. You can further enrich user session information and gain finer control over the attributes collected by tracking custom events.
@@ -226,3 +305,6 @@ This means that even if users open your application while offline, no data is lo
 [5]: https://github.com/DataDog/dd-sdk-flutter/tree/main/packages/datadog_tracking_http_client
 [6]: https://pub.dev/documentation/datadog_flutter_plugin/latest/datadog_flutter_plugin/
 [7]: https://pub.dev/documentation/datadog_flutter_plugin/latest/datadog_flutter_plugin/DatadogNavigationObserver-class.html
+[8]: https://pub.dev/packages?q=go_router
+[9]: https://pub.dev/packages/auto_route
+[10]: https://pub.dev/packages/beamer


### PR DESCRIPTION
### What does this PR do?

the documentation on how to do automatic view tracking only explained the older method of navigation. We've added documentation to the main index page for the most common router (`go_router`) and added a few sections for the next three most popular under "Advanced Configuration"

### Motivation
Client confusion.

### Additional Notes


### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
