### PR TITLE
Point go.mod at the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.5.2-0.20230623165541-a20dddb9f7c1 // indirect
+require github.com/DataDog/websites-modules v1.4.63 // indirect
 
 
 // replace github.com/DataDog/websites-modules => /Users/david.weid/Documents/Github/websites-modules

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,2 @@
-github.com/DataDog/websites-modules v1.5.2-0.20230623165541-a20dddb9f7c1 h1:I51X1n9iIi+D3J1xQbr50muxZ/L6KVpQ2LcVg2E0mQQ=
-github.com/DataDog/websites-modules v1.5.2-0.20230623165541-a20dddb9f7c1/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
-
+github.com/DataDog/websites-modules v1.4.63 h1:SqD/n9a+xTpf76ersPB4WZLtSAacCB13JSEF8+2Utuw=
+github.com/DataDog/websites-modules v1.4.63/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- update the `go.mod` and `go.sum` files to point at the most current version of websites modules
### Motivation
<!-- What inspired you to submit this pull request?-->
There appears to have been some drift introduced into the master branch for websites modules due to a workflow not being completed. This will fix that drift and set things right so future changes will work as expected.
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

To test:
- pull this branch down
- run `make start`
- ensure site starts as expected and pages load (mostly the footer/header)

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
