### PR TITLE
Cleanup Anchor Links in Developers Documentation

### DIFF
--- a/content/en/developers/authorization/oauth2_endpoints.md
+++ b/content/en/developers/authorization/oauth2_endpoints.md
@@ -46,7 +46,7 @@ https://app.datadoghq.com/oauth2/v1/authorize?redirect_uri=http://localhost:500/
 
 #### Success Response
 
-If a user successfully grants the access request, your application [obtains an authorization code](#Obtain-an-authorization-code) and redirects the user to the redirect URI with the authorization `code`, as well as the `site` parameter, in the query component. 
+If a user successfully grants the access request, your application [obtains an authorization code](#obtain-an-authorization-code) and redirects the user to the redirect URI with the authorization `code`, as well as the `site` parameter, in the query component. 
 
 #### Error Response
 

--- a/content/en/developers/authorization/oauth2_in_datadog.md
+++ b/content/en/developers/authorization/oauth2_in_datadog.md
@@ -58,7 +58,7 @@ You can start the authorization process in Datadog by clicking **Connect Account
 
 When kicking off authorization from a third-party location—anywhere outside of the Datadog integration tile—you need to account for the [Datadog site][17] (such as EU, US1, US3, or US5) when routing users through the authorization flow and building out the URL for the `authorization` and `token` endpoints. 
 
-To ensure that users are authorizing in the correct site, always direct them to the US1 Datadog site (`app.datadoghq.com`), and from there, they can select their region. Once the authorization flow is complete, ensure that all followup API calls use the correct site that is returned as a query parameter with the `redirect_uri` (See Step 5 in [Implement the OAuth protocol](#Implement-the-oauth-protocol)).
+To ensure that users are authorizing in the correct site, always direct them to the US1 Datadog site (`app.datadoghq.com`), and from there, they can select their region. Once the authorization flow is complete, ensure that all followup API calls use the correct site that is returned as a query parameter with the `redirect_uri` (See Step 5 in [Implement the OAuth protocol](#implement-the-oauth-protocol)).
 
 When users initiate authorization from the Datadog integration tile, they are required to have corresponding permissions for all requested scopes. If authorization is initiated from somewhere other than the integration tile, users without all of the required permissions may complete authorization (but are prompted to re-authorize with proper permissions when returning to the integration tile). To avoid this, users should be routed from third-party platforms to the Datadog integration tile to begin authorization. 
 

--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -196,7 +196,7 @@ To set [tag cardinality][6] for the metrics collected using origin detection, se
 [2]: https://github.com/containernetworking/cni
 [3]: https://kubernetes.io/docs/setup/independent/troubleshooting-kubeadm/#hostport-services-do-not-work
 [4]: /getting_started/tagging/unified_service_tagging
-[5]: /developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
+[5]: /developers/dogstatsd/unix_socket/?tab=host#using-origin-detection-for-container-tagging
 [6]: /getting_started/tagging/assigning_tags/#environment-variables
 [7]: /metrics/custom_metrics/
 {{% /tab %}}

--- a/content/en/developers/dogstatsd/datagram_shell.md
+++ b/content/en/developers/dogstatsd/datagram_shell.md
@@ -27,11 +27,11 @@ This section specifies the raw datagram format for metrics, events, and service 
 
 | Parameter                           | Required | Description                                                                                                                                                    |
 | ----------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<METRIC_NAME>`                     | Yes      | A string that contains only ASCII alphanumerics, underscores, and periods. See the [metric naming policy][1].                                                  |
+| `<METRIC_NAME>`                     | Yes      | A string that contains only ASCII alphanumerics, underscores, and periods. See the [metric naming policy][101].                                                  |
 | `<VALUE>`                           | Yes      | An integer or float.                                                                                                                                           |
-| `<TYPE>`                            | Yes      | `c` for COUNT, `g` for GAUGE, `ms` for TIMER, `h` for HISTOGRAM, `s` for SET, `d` for DISTRIBUTION. See [Metric Types][2] for more details.                    |
+| `<TYPE>`                            | Yes      | `c` for COUNT, `g` for GAUGE, `ms` for TIMER, `h` for HISTOGRAM, `s` for SET, `d` for DISTRIBUTION. See [Metric Types][102] for more details.                    |
 | `<SAMPLE_RATE>`                     | No       | A float between `0` and `1`, inclusive. Only works with COUNT, HISTOGRAM, DISTRIBUTION, and TIMER metrics. The default is `1`, which samples 100% of the time. |
-| `<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>` | No       | A comma separated list of strings. Use colons for key/value tags (`env:prod`). For guidance on defining tags, see [Getting Started with Tags][3].              |
+| `<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>` | No       | A comma separated list of strings. Use colons for key/value tags (`env:prod`). For guidance on defining tags, see [Getting Started with Tags][103].              |
 
 Here are some example datagrams:
 
@@ -72,7 +72,7 @@ The container ID is prefixed by `c:`, for example:
 
 - `page.views:1|g|#env:dev|c:83c0a99c0a54c0c187f461c7980e9b57f3f6a8b0c918c8d93df19a9de6f3fe1d`: The Datadog Agent adds container tags like `image_name` and `image_tag` to the `page.views` metric.
 
-Read more about container tags in the [Kubernetes][4] and [Docker][5] tagging documentation.
+Read more about container tags in the [Kubernetes][104] and [Docker][105] tagging documentation.
 
 ### DogStatsD protocol v1.3
 
@@ -90,11 +90,11 @@ The value is a Unix timestamp (UTC) and must be prefixed by `T`, for example:
 
 - `page.views:15|c|#env:dev|T1656581400`: A COUNT indicating that 15 page views happened on the 30th of June, 2022 at 9:30am UTC
 
-[1]: /metrics/#naming-metrics
-[2]: /metrics/types/
-[3]: /getting_started/tagging/
-[4]: /agent/kubernetes/tag/?tab=containerizedagent#out-of-the-box-tags
-[5]: /agent/docker/tag/?tab=containerizedagent#out-of-the-box-tagging
+[101]: /metrics/#metric-name
+[102]: /metrics/types/
+[103]: /getting_started/tagging/
+[104]: /containers/kubernetes/tag/?tab=containerizedagent#out-of-the-box-tags
+[105]: /containers/docker/tag/?tab=containerizedagent#out-of-the-box-tagging
 {{% /tab %}}
 {{% tab "Events" %}}
 
@@ -112,7 +112,7 @@ The value is a Unix timestamp (UTC) and must be prefixed by `T`, for example:
 | `k:<AGGREGATION_KEY>`                | No       | Add an aggregation key to group the event with others that have the same key. No default.                              |
 | `p:<PRIORITY>`                       | No       | Set to `normal` or `low`. Default `normal`.                                                                            |
 | `s:<SOURCE_TYPE_NAME>`               | No       | Add a source type to the event. No default.                                                                            |
-| `t:<ALERT_TYPE>`                     | No       | Set to `error`, `warning`, `info` or `success`. Default `info`.                                                        |
+| `t:<ALERT_TYPE>`                     | No       | Set to `error`, `warning`, `info`, or `success`. Default `info`.                                                        |
 | `#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>` | No       | The colon in tags is part of the tag list string and has no parsing purpose like for the other parameters. No default. |
 
 Here are some example datagrams:
@@ -138,7 +138,7 @@ _e{21,42}:An exception occurred|Cannot parse JSON request:\\n{"foo: "bar"}|p:low
 | `d:<TIMESTAMP>`                      | No       | Add a timestamp to the check. The default is the current Unix epoch timestamp.                                                          |
 | `h:<HOSTNAME>`                       | No       | Add a hostname to the event (no default).                                                                                               |
 | `#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>` | No       | Set the tags of the event. A list of strings separated by comma (no default).                                                           |
-| `m:<SERVICE_CHECK_MESSAGE>`          | No       | A message describing the current state of the service check. This field MUST be positioned last among the metadata fields (no default). |
+| `m:<SERVICE_CHECK_MESSAGE>`          | No       | A message describing the current state of the service check. This field must be positioned last among the metadata fields (no default). |
 
 Here's an example datagram:
 

--- a/content/en/developers/guide/query-data-to-a-text-file-step-by-step.md
+++ b/content/en/developers/guide/query-data-to-a-text-file-step-by-step.md
@@ -43,6 +43,6 @@ See additional examples in the [Datadog API documentation][1].
 [4]: https://app.datadoghq.com/organization-settings/api-keys
 [5]: https://app.datadoghq.com/metric/summary
 [6]: https://app.datadoghq.com/infrastructure
-[7]: /api/#rate-limiting
+[7]: /api/latest/rate-limits/
 [8]: https://virtualenv.pypa.io/en/stable
 [9]: https://pypi.org/project/datadog


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Addresses broken anchor links in the Developers doc set + https://github.com/DataDog/integrations-core/pull/15099.

### Motivation
<!-- What inspired you to submit this pull request?-->

Link checker output, ready to merge.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
