### PR TITLE
(DOCS-5629) Tail glossary entry

### DIFF
--- a/content/en/agent/guide/dogstream.md
+++ b/content/en/agent/guide/dogstream.md
@@ -64,7 +64,7 @@ If your custom log parser is not working, the first thing to check are the Agent
 * If all goes well you should see `dogstream: parsing {filename} with {function name} (requested {config option text})`.
 
 <div class="alert alert-warning">
-To test that dogstreams are working, append a line-don't edit an existing one-to any log file you've configured the Agent to watch. The Agent only tails the end of each log file, so it doesn't notice any changes you make elsewhere in the file.
+To test that dogstreams are working, append a line-don't edit an existing one-to any log file you've configured the Agent to watch. The Agent only <a href="/glossary/#tail">tails</a> the end of each log file, so it doesn't notice any changes you make elsewhere in the file.
 </div>
 
 ### Writing parsing functions

--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -18,6 +18,9 @@ further_reading:
 - link: "/logs/logging_without_limits/"
   tag: "Documentation"
   text: "Logging without Limits*"
+- link: "/glossary/#tail"
+  tag: Glossary
+  text: 'Glossary entry for "tail"'
 algolia:
   tags: ['advanced log filter']
 ---

--- a/content/en/glossary/terms/tail.md
+++ b/content/en/glossary/terms/tail.md
@@ -1,10 +1,8 @@
 ---
 title: tail
-synonyms:
-  - tailing
 core_product:
   - log management
 ---
-Tailing is derived from the `tail` command in Unix and Linux operating systems. When you tail a log file, you print out the last few lines of the file instead of printing the entire log file. Usually, you tail a file when you're trying to find the most recent events in a log file. You can set the Datadog Agent up to tail a log file. For more information see [Custom log collection][1]
+Tailing is derived from the `tail` command in Unix and Linux operating systems. Tailing is an alternative to printing the entire contents of a file. When you tail a log file, you print the last few lines of the file to the terminal. Tailing is commonly used with log files to find the most recently logged events for a process or service. You can set the Datadog Agent up to tail a log file. For more information see [Custom log collection][1].
 
 [1]: /agent/logs/?tab=tailfiles#custom-log-collection

--- a/content/en/glossary/terms/tail.md
+++ b/content/en/glossary/terms/tail.md
@@ -1,0 +1,10 @@
+---
+title: tail
+synonyms:
+  - tailing
+core_product:
+  - log management
+---
+Tailing is derived from the `tail` command in Unix and Linux operating systems. When you tail a log file, you print out the last few lines of the file instead of printing the entire log file. Usually, you tail a file when you're trying to find the most recent events in a log file. You can set the Datadog Agent up to tail a log file. For more information see [Custom log collection][1]
+
+[1]: /agent/logs/?tab=tailfiles#custom-log-collection

--- a/content/en/glossary/terms/tail.md
+++ b/content/en/glossary/terms/tail.md
@@ -3,6 +3,6 @@ title: tail
 core_product:
   - log management
 ---
-Tailing is derived from the `tail` command in Unix and Linux operating systems. Tailing is an alternative to printing the entire contents of a file. When you tail a log file, you print the last few lines of the file to the terminal. Tailing is commonly used with log files to find the most recently logged events for a process or service. You can set the Datadog Agent up to tail a log file. For more information see [Custom log collection][1].
+The term _tail_ is derived from the `tail` command in Unix and Linux operating systems. Tailing is an alternative to printing the entire contents of a file. When you tail a file, you print the last few lines of the file to the terminal. Tailing is commonly used with log files to find the most recently logged events for a process or service. You can set the Datadog Agent up to tail a log file. For more information see [Custom log collection][1].
 
 [1]: /agent/logs/?tab=tailfiles#custom-log-collection

--- a/content/en/logs/guide/container-agent-to-tail-logs-from-host.md
+++ b/content/en/logs/guide/container-agent-to-tail-logs-from-host.md
@@ -13,6 +13,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/docker-logging/"
   tag: "Blog"
   text: "Docker Logging Best Practices"
+- link: "/glossary/#tail"
+  tag: Glossary
+  text: 'Glossary entry for "tail"'
 ---
 
 <div class="alert alert-info">Datadog recommends using <b>STDOUT/STDERR</b> to collect container logs.</div>

--- a/content/en/logs/guide/custom-log-file-with-heightened-read-permissions.md
+++ b/content/en/logs/guide/custom-log-file-with-heightened-read-permissions.md
@@ -10,6 +10,9 @@ further_reading:
 - link: "/logs/explorer/"
   tag: "Documentation"
   text: "Learn how to explore your logs"
+- link: "/glossary/#tail"
+  tag: Glossary
+  text: 'Glossary entry for "tail"'  
 ---
 
 Often, log files, especially system logs such as *syslog* or *journald*, have heightened read-permissions blocking the Datadog Agent log collection as it does not have *sudo* or *admin* access.

--- a/content/en/logs/guide/mechanisms-ensure-logs-not-lost.md
+++ b/content/en/logs/guide/mechanisms-ensure-logs-not-lost.md
@@ -10,13 +10,16 @@ further_reading:
 - link: "/logs/explorer/"
   tag: "Documentation"
   text: "Learn how to explore your logs"
+- link: "/glossary/#tail"
+  tag: Glossary
+  text: 'Glossary entry for "tail"'
 ---
 
 **The Datadog Agent has several mechanisms to ensure that no logs are lost**.
 
 ## Log rotate
 
-When a file is rotated, the Agent keeps tailing the old file while starting to tail the newly created file in parallel.
+When a file is rotated, the Agent keeps [tailing][1] the old file while starting to tail the newly created file in parallel.
 Although the Agent continues to tail the old file, a 60-second timeout after the log rotation is set to ensure the agent is using its resources to tail the most up-to-date files.
 
 ## Network issues
@@ -36,3 +39,5 @@ As for files, Datadog stores a pointer for each tailed container. Therefore, in 
 However, if the tailed container is removed before the network is available again, the logs are not accessible anymore.
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /glossary/#tail

--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -25,6 +25,9 @@ further_reading:
 - link: "/logs/faq/log-collection-troubleshooting-guide/"
   tag: "FAQ"
   text: "Log Collection Troubleshooting Guide"
+- link: "/glossary/#tail"
+  tag: Glossary
+  text: 'Glossary entry for "tail"'
 ---
 
 To send your C# logs to Datadog, use one of the following approaches:
@@ -37,7 +40,7 @@ This page details setup examples for the `Serilog`, `NLog`, `log4net`, and `Micr
 
 ## File-tail logging with the Datadog Agent
 
-The recommended approach for C# log collection is to output your logs to a file and then tail that file with your Datadog Agent. This enables the Datadog Agent to enrich the logs with additional metadata.
+The recommended approach for C# log collection is to output your logs to a file and then [tail][20] that file with your Datadog Agent. This enables the Datadog Agent to enrich the logs with additional metadata.
 
 Datadog strongly encourages setting up your logging library to produce your logs in JSON format to avoid the need for [custom parsing rules][1].
 
@@ -648,3 +651,4 @@ In the `Serilog.WriteTo` array, add an entry for `DatadogLogs`. An example is sh
 [17]: /logs/log_configuration/pipelines/?tab=source
 [18]: /api/latest/logs/#send-logs
 [19]: https://www.nuget.org/packages/Serilog.Sinks.Datadog.Logs
+[20]: /glossary/#tail

--- a/content/en/logs/log_collection/go.md
+++ b/content/en/logs/log_collection/go.md
@@ -22,9 +22,12 @@ further_reading:
 - link: "/logs/faq/log-collection-troubleshooting-guide/"
   tag: "FAQ"
   text: "Log Collection Troubleshooting Guide"
+- link: "/glossary/#tail"
+  tag: Glossary
+  text: 'Glossary entry for "tail"'  
 ---
 
-To send your Go logs to Datadog, log to a file and then tail that file with your Datadog Agent. You can use the following setup with [logrus][1], an open source logging library.
+To send your Go logs to Datadog, log to a file and then [tail][11] that file with your Datadog Agent. You can use the following setup with [logrus][1], an open source logging library.
 
 Datadog strongly encourages setting up your logging library to produce your logs in JSON to avoid the need for [custom parsing rules][2].
 
@@ -127,3 +130,4 @@ If APM is enabled for this application, the correlation between application logs
 [8]: /logs/log_configuration/parsing/?tab=matchers
 [9]: /logs/explorer/#overview
 [10]: /tracing/other_telemetry/connect_logs_and_traces/go/
+[11]: /glossary/#tail

--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -25,9 +25,12 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/java-logging-guide/"
   tag: "Blog"
   text: "How to collect, customize, and standardize Java logs"
+- link: "/glossary/#tail"
+  tag: Glossary
+  text: 'Glossary entry for "tail"'
 ---
 
-To send your logs to Datadog, log to a file and tail that file with your Datadog Agent.
+To send your logs to Datadog, log to a file and [tail][14] that file with your Datadog Agent.
 
 Stack traces from typical Java logs are split into multiple lines, which makes them difficult to associate to the original log event. For example:
 
@@ -536,3 +539,4 @@ To generate this JSON:
 [11]: https://github.com/logstash/logstash-logback-encoder
 [12]: https://github.com/logstash/logstash-logback-encoder#prefixsuffixseparator
 [13]: /logs/log_configuration/parsing/#key-value-or-logfmt
+[14]: /glossary/#tail

--- a/content/en/logs/log_collection/nodejs.md
+++ b/content/en/logs/log_collection/nodejs.md
@@ -19,12 +19,15 @@ further_reading:
 - link: "/logs/faq/log-collection-troubleshooting-guide/"
   tag: "FAQ"
   text: "Log Collection Troubleshooting Guide"
+- link: "/glossary/#tail"
+  tag: Glossary
+  text: 'Glossary entry for "tail"'  
 ---
 
 
 ## Configure your logger
 
-To send your logs to Datadog, log to a file and tail that file with your Datadog Agent. Use the [Winston][1] logging library to log from your Node.js application.
+To send your logs to Datadog, log to a file and [tail][14] that file with your Datadog Agent. Use the [Winston][1] logging library to log from your Node.js application.
 
 Winston is available through [NPM][2], to get started, you want to add the dependency to your code:
 
@@ -205,3 +208,4 @@ Make sure that the parameter `max_connect_retries` is not set to `1` (the defaul
 [11]: /logs/log_configuration/parsing/?tab=matchers
 [12]: /logs/explorer/#overview
 [13]: https://github.com/winstonjs/winston/blob/master/docs/transports.md#datadog-transport
+[14]: /glossary/#tail

--- a/content/en/logs/log_collection/php.md
+++ b/content/en/logs/log_collection/php.md
@@ -22,11 +22,14 @@ further_reading:
 - link: /logs/faq/log-collection-troubleshooting-guide
   tag: "Documentation"
   text: "Log Collection Troubleshooting Guide"
+- link: "/glossary/#tail"
+  tag: Glossary
+  text: 'Glossary entry for "tail"'  
 ---
 
 ## Overview
 
-To send your PHP logs to Datadog, log to a file and then tail that file with your Datadog Agent. This page details setup examples for the [Monolog][8], [Zend-Log][9], and [Symfony][10] logging libraries.
+To send your PHP logs to Datadog, log to a file and then [tail][14] that file with your Datadog Agent. This page details setup examples for the [Monolog][8], [Zend-Log][9], and [Symfony][10] logging libraries.
 
 ## Setup
 
@@ -550,3 +553,4 @@ Add the following:
 [11]: /agent/logs/?tab=tailfiles#activate-log-collection
 [12]: /agent/logs/?tab=tailfiles#custom-log-collection
 [13]: /agent/guide/agent-configuration-files/?tab=agentv6v7#agent-configuration-directory
+[14]: /glossary/#tail

--- a/content/en/logs/log_collection/python.md
+++ b/content/en/logs/log_collection/python.md
@@ -19,11 +19,14 @@ further_reading:
 - link: "/logs/faq/log-collection-troubleshooting-guide/"
   tag: "Documentation"
   text: "Log Collection Troubleshooting Guide"
+- link: "/glossary/#tail"
+  tag: Glossary
+  text: 'Glossary entry for "tail"'  
 ---
 
 ## Overview
 
-To send your Python logs to Datadog, configure a Python logger to log to a file on your host and then tail that file with the Datadog Agent.
+To send your Python logs to Datadog, configure a Python logger to log to a file on your host and then [tail][12] that file with the Datadog Agent.
 
 ## Configure your logger
 
@@ -97,3 +100,4 @@ Once this is done, the log should have the following format:
 [9]: /agent/guide/agent-commands/?tab=agentv6v7#agent-status-and-information
 [10]: /logs/log_configuration/parsing/
 [11]: /logs/explorer/#overview
+[12]: /glossary/#tail

--- a/content/en/logs/log_collection/ruby.md
+++ b/content/en/logs/log_collection/ruby.md
@@ -19,11 +19,14 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/log-file-control-with-logrotate/"
   tag: "Blog"
   text: "How to manage log files using logrotate"
+- link: "/glossary/#tail"
+  tag: Glossary
+  text: 'Glossary entry for "tail"'  
 ---
 
 ## Overview
 
-To send your logs to Datadog, log to a file with [`Lograge`][1] and tail this file with your Datadog Agent. When setting up logging with Ruby, keep in mind the [reserved attributes][2].
+To send your logs to Datadog, log to a file with [`Lograge`][1] and [tail][11] this file with your Datadog Agent. When setting up logging with Ruby, keep in mind the [reserved attributes][2].
 
 Using Lograge, you can transform the standard text-based log format, like in this example:
 
@@ -208,3 +211,4 @@ The hash is converted into JSON and you can carry out analytics for `user` and `
 [8]: /agent/guide/agent-commands/?tab=agentv6v7#agent-status-and-information
 [9]: /logs/log_configuration/parsing
 [10]: /logs/explorer/
+[11]: /glossary/#tail


### PR DESCRIPTION
Adds a glossary entry for tail. See <a href="https://github.com/DataDog/documentation/pull/18437">[Update csharp.md](https://github.com/DataDog/documentation/pull/18437)</a>

Preview glossary entry here: 
https://docs-staging.datadoghq.com/heston/glossary-tailing/glossary/#tail

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
