### PR TITLE
(maint) Fix preview links for glossary files

### DIFF
--- a/local/bin/py/preview-links-template.mako
+++ b/local/bin/py/preview-links-template.mako
@@ -4,7 +4,9 @@ import os
 
 h2 = "##"
 h3 = '###'
-p = re.compile('content/en/(.*?).md')
+pattern1 = re.compile('content/en/(.*?).md')
+pattern2 = re.compile('content/en/glossary/terms/(.*?).md')
+
 
 branch = os.environ["branch"]
 %>
@@ -13,40 +15,52 @@ ${h2} Preview links (active after the `build_preview` check completes)
 
 % if added:
 ${h3} New or renamed files
-    % for filename in added:
-        % if p.match(filename):
+% for filename in added:
+% if pattern2.match(filename):
+<% filename = filename.replace('content/en/', '').replace('terms/', '#').replace('.md', '') %>\
+* https://docs-staging.datadoghq.com/${branch}/${filename}
+% elif pattern1.match(filename):
 <% filename = filename.replace('content/en/', '').replace('_index', '').replace('.md', '') %>\
 * https://docs-staging.datadoghq.com/${branch}/${filename}
-        % endif         
-    % endfor
+% endif         
+% endfor
 % endif
 
 % if deleted:
 ${h3} Removed or renamed files (these should redirect)
-    % for filename in deleted:
-        % if p.match(filename):
+% for filename in deleted:
+% if pattern2.match(filename):
+<% filename = filename.replace('content/en/', '').replace('terms/', '#').replace('.md', '') %>\
+* https://docs-staging.datadoghq.com/${branch}/${filename}
+% elif pattern1.match(filename):
 <% filename = filename.replace('content/en/', '').replace('_index', '').replace('.md', '') %>\
-* https://docs-staging.datadoghq.com/${branch}/${filename}     
-        % endif         
-    % endfor
+* https://docs-staging.datadoghq.com/${branch}/${filename}
+% endif         
+% endfor
 % endif
 
 % if renamed:
 ${h3} Renamed files
-    % for filename in renamed:
-        % if p.match(filename):
+% for filename in renamed:
+% if pattern2.match(filename):
+<% filename = filename.replace('content/en/', '').replace('terms/', '#').replace('.md', '') %>\
+* https://docs-staging.datadoghq.com/${branch}/${filename}
+% elif pattern1.match(filename):
 <% filename = filename.replace('content/en/', '').replace('_index', '').replace('.md', '') %>\
 * https://docs-staging.datadoghq.com/${branch}/${filename} 
-        % endif         
-    % endfor
+% endif         
+% endfor
 % endif
 
 % if modified:
 ${h3} Modified Files
-    % for filename in modified:
-        % if p.match(filename):
+% for filename in modified:
+% if pattern2.match(filename):
+<% filename = filename.replace('content/en/', '').replace('terms/', '#').replace('.md', '') %>\
+* https://docs-staging.datadoghq.com/${branch}/${filename}
+% elif pattern1.match(filename):
 <% filename = filename.replace('content/en/', '').replace('_index', '').replace('.md', '') %>\
 * https://docs-staging.datadoghq.com/${branch}/${filename}
-        % endif         
-    % endfor
+% endif         
+% endfor
 % endif


### PR DESCRIPTION
I noticed the preview links for glossary files 404. This should fix them.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
