### PR TITLE
Mark the Java Live Heap Profiler as Beta

### DIFF
--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -31,13 +31,13 @@ Allocations
 Allocated Memory
 : The amount of heap memory allocated by each method, including allocations which were subsequently freed.
 
-Heap Live Objects
-: The number of objects allocated by each method in heap memory that have not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
+Heap Live Objects (beta)
+: The number of objects allocated by each method in heap memory that have not yet been garbage collected. This is useful for identifying potential memory leaks.<br />
 _Requires: Java 11_ <br />
 _Since: 1.17.0_
 
-Heap Live Size
-: The amount of heap memory allocated by each method that has not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
+Heap Live Size (beta)
+: The estimated amount of heap memory allocated by each method that has not yet been garbage collected. This is useful for establishing the lower boundary of the heap memory usage of your service and identifying potential memory leaks.<br />
 _Requires: Java 11_ <br />
 _Since: 1.17.0_
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Marks the Java Live Heap Profiler as 'beta'

### Motivation
At the last moment we are deciding to mark the Java Live Heap Profiler feature as 'beta'

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
