### PR TITLE
Bump datadog-lambda-python layer to version 75

### DIFF
--- a/layouts/shortcodes/latest-lambda-layer-version.html
+++ b/layouts/shortcodes/latest-lambda-layer-version.html
@@ -6,7 +6,7 @@
 
 <!-- Python Layer -->
 {{- if eq (.Get "layer") "python" -}}
-    74
+    75
 {{- end -}}
 
 <!-- Node Layer -->


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Bumps the python layer to 75

### Motivation
I just released 75

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
