### PR TITLE
React Native router instrumentation

### DIFF
--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -39,40 +39,40 @@ Starting with [version 2.17.0][3], you can add view names and assign them to a d
 
 1. Set `trackViewsManually` to true when initializing the RUM Browser SDK.
 
-{{< tabs >}}
-{{% tab "NPM" %}}
-```javascript
-import { datadogRum } from '@datadog/browser-rum';
+   {{< tabs >}}
+   {{% tab "NPM" %}}
+   ```javascript
+   import { datadogRum } from '@datadog/browser-rum';
 
-datadogRum.init({
-    ...,
-    trackViewsManually: true,
-    ...
-});
-```
-{{% /tab %}}
-{{% tab "CDN async" %}}
-```javascript
-window.DD_RUM.onReady(function() {
-    window.DD_RUM.init({
-        ...,
-        trackViewsManually: true,
-        ...
-    })
-})
-```
-{{% /tab %}}
-{{% tab "CDN sync" %}}
-```javascript
-window.DD_RUM &&
-    window.DD_RUM.init({
-        ...,
-        trackViewsManually: true,
-        ...
-    });
-```
-{{% /tab %}}
-{{< /tabs >}}
+   datadogRum.init({
+       ...,
+       trackViewsManually: true,
+       ...
+   });
+   ```
+   {{% /tab %}}
+   {{% tab "CDN async" %}}
+   ```javascript
+   window.DD_RUM.onReady(function() {
+       window.DD_RUM.init({
+           ...,
+           trackViewsManually: true,
+           ...
+       })
+   })
+   ```
+   {{% /tab %}}
+   {{% tab "CDN sync" %}}
+   ```javascript
+   window.DD_RUM &&
+       window.DD_RUM.init({
+           ...,
+           trackViewsManually: true,
+           ...
+       });
+   ```
+   {{% /tab %}}
+   {{< /tabs >}}
 
 2. You must start views for each new page or route change (for single-page applications). RUM data is collected when the view starts. Starting with [version 4.13.0][17], you can also optionally define the associated service name and version.
 
@@ -82,73 +82,222 @@ window.DD_RUM &&
 
    For more information, see [Setup Browser Monitoring][4].
 
-<details open>
-  <summary>Latest version</summary>
-The following example manually tracks the page views on the <code>checkout</code> page in a RUM application. Use <code>checkout</code> for the view name and associate the <code>purchase</code> service with version <code>1.2.3</code>.
+   <details open>
+     <summary>Latest version</summary>
+   The following example manually tracks the page views on the <code>checkout</code> page in a RUM application. Use <code>checkout</code> for the view name and associate the <code>purchase</code> service with version <code>1.2.3</code>.
 
-{{< tabs >}}
-{{% tab "NPM" %}}
-```javascript
-datadogRum.startView({
-  name: 'checkout',
-  service: 'purchase',
-  version: '1.2.3'
-})
-```
+   {{< tabs >}}
+   {{% tab "NPM" %}}
+   ```javascript
+   datadogRum.startView({
+     name: 'checkout',
+     service: 'purchase',
+     version: '1.2.3'
+   })
+   ```
 
-{{% /tab %}}
-{{% tab "CDN async" %}}
-```javascript
-window.DD_RUM.onReady(function() {
-    window.DD_RUM.startView({
-      name: 'checkout',
-      service: 'purchase',
-      version: '1.2.3'
-    })
-})
-```
-{{% /tab %}}
-{{% tab "CDN sync" %}}
-```javascript
-window.DD_RUM && window.DD_RUM.startView({
-  name: 'checkout',
-  service: 'purchase',
-  version: '1.2.3'
-})
-```
-{{% /tab %}}
-{{< /tabs >}}
-</details>
+   {{% /tab %}}
+   {{% tab "CDN async" %}}
+   ```javascript
+   window.DD_RUM.onReady(function() {
+       window.DD_RUM.startView({
+         name: 'checkout',
+         service: 'purchase',
+         version: '1.2.3'
+       })
+   })
+   ```
+   {{% /tab %}}
+   {{% tab "CDN sync" %}}
+   ```javascript
+   window.DD_RUM && window.DD_RUM.startView({
+     name: 'checkout',
+     service: 'purchase',
+     version: '1.2.3'
+   })
+   ```
+   {{% /tab %}}
+   {{< /tabs >}}
+   </details>
 
-<details>
-  <summary>before <code>v4.13.0</code></summary>
-The following example manually tracks the page views on the <code>checkout</code> page in a RUM application. No service or version can be specified.
+   <details>
+     <summary>before <code>v4.13.0</code></summary>
+   The following example manually tracks the page views on the <code>checkout</code> page in a RUM application. No service or version can be specified.
 
-{{< tabs >}}
-{{% tab "NPM" %}}
-```javascript
-datadogRum.startView('checkout')
-```
+   {{< tabs >}}
+   {{% tab "NPM" %}}
+   ```javascript
+   datadogRum.startView('checkout')
+   ```
 
-{{% /tab %}}
-{{% tab "CDN async" %}}
-```javascript
-window.DD_RUM.onReady(function() {
-    window.DD_RUM.startView('checkout')
-})
-```
-{{% /tab %}}
-{{% tab "CDN sync" %}}
-```javascript
-window.DD_RUM && window.DD_RUM.startView('checkout')
-```
-{{% /tab %}}
-{{< /tabs >}}
+   {{% /tab %}}
+   {{% tab "CDN async" %}}
+   ```javascript
+   window.DD_RUM.onReady(function() {
+       window.DD_RUM.startView('checkout')
+   })
+   ```
+   {{% /tab %}}
+   {{% tab "CDN sync" %}}
+   ```javascript
+   window.DD_RUM && window.DD_RUM.startView('checkout')
+   ```
+   {{% /tab %}}
+   {{< /tabs >}}
 
-</details>
-
+   </details>
 
 If you are using React, Angular, Vue, or any other frontend framework, Datadog recommends implementing the `startView` logic at the framework router level.
+
+### React Native router instrumentation
+
+To override default RUM view names so that they are aligned with how you've defined them in your React Native application, you need to follow the below steps.
+
+**Note**: These instructions are specific to the **React Router v6** library.
+
+1. Set `trackViewsManually` to `true` when initializing the RUM browser SDK as described [above](#override-default-rum-view-names).
+
+2. Start views for each new page or route change (for single-page applications).
+
+   {{< tabs >}}
+   {{% tab "NPM" %}}
+   ```javascript
+      import { matchRoutes, useLocation } from 'react-router-dom';
+      import { routes } from 'path/to/routes';
+      import { datadogRum } from "@datadog/browser-rum";
+
+      export default function App() {
+        // Track every route change with useLocation API
+       let location = useLocation();
+
+       useEffect(() => {
+         const routeMatches = matchRoutes(routes, location.pathname);
+         const viewName = routeMatches && computeViewName(routeMatches);
+         if (viewName) {
+           datadogRum.startView({name: viewName})
+         }
+       }, [location.pathname]);
+
+       ...
+      }
+
+      // Compute view name out of routeMatches
+      function computeViewName(routeMatches) {
+       let viewName = "";
+       for (let index = 0; index < routeMatches.length; index++) {
+         const routeMatch = routeMatches[index];
+         const path = routeMatch.route.path;
+         // Skeep pathless routes
+         if (!path) {
+           continue;
+         }
+
+         if (path.startsWith("/")) {
+          // Handle absolute child route paths
+           viewName = path;
+         } else {
+          // Handle route paths ending with "/"
+           viewName += viewName.endsWith("/") ? path : `/${path}`;
+         }
+       }
+
+       return viewName || '/';
+      }
+   ```
+
+   {{% /tab %}}
+   {{% tab "CDN async" %}}
+   ```javascript
+      import { matchRoutes, useLocation } from 'react-router-dom';
+      import { routes } from 'path/to/routes';
+
+      export default function App() {
+        // Track every route change with useLocation API
+       let location = useLocation();
+
+       useEffect(() => {
+         const routeMatches = matchRoutes(routes, location.pathname);
+         const viewName = routeMatches && computeViewName(routeMatches);
+         if (viewName) {
+           DD_RUM.onReady(function() {
+             DD_RUM.startView({name: viewName})
+           })
+         }
+       }, [location.pathname]);
+
+       ...
+      }
+
+      // Compute view name out of routeMatches
+      function computeViewName(routeMatches) {
+       let viewName = "";
+       for (let index = 0; index < routeMatches.length; index++) {
+         const routeMatch = routeMatches[index];
+         const path = routeMatch.route.path;
+         // Skeep pathless routes
+         if (!path) {
+           continue;
+         }
+
+         if (path.startsWith("/")) {
+          // Handle absolute child route paths
+           viewName = path;
+         } else {
+          // Handle route paths ending with "/"
+           viewName += viewName.endsWith("/") ? path : `/${path}`;
+         }
+       }
+
+       return viewName || '/';
+      }
+   ```
+   {{% /tab %}}
+   {{% tab "CDN sync" %}}
+   ```javascript
+      import { matchRoutes, useLocation } from 'react-router-dom';
+      import { routes } from 'path/to/routes';
+
+      export default function App() {
+        // Track every route change with useLocation API
+       let location = useLocation();
+
+       useEffect(() => {
+         const routeMatches = matchRoutes(routes, location.pathname);
+         const viewName = routeMatches && computeViewName(routeMatches);
+         if (viewName) {
+           window.DD_RUM &&
+             window.DD_RUM.startView({name: viewName})
+         }
+       }, [location.pathname]);
+
+       ...
+      }
+
+      // Compute view name out of routeMatches
+      function computeViewName(routeMatches) {
+       let viewName = "";
+       for (let index = 0; index < routeMatches.length; index++) {
+         const routeMatch = routeMatches[index];
+         const path = routeMatch.route.path;
+         // Skeep pathless routes
+         if (!path) {
+           continue;
+         }
+
+         if (path.startsWith("/")) {
+          // Handle absolute child route paths
+           viewName = path;
+         } else {
+          // Handle route paths ending with "/"
+           viewName += viewName.endsWith("/") ? path : `/${path}`;
+         }
+       }
+
+       return viewName || '/';
+      }
+   ```
+   {{% /tab %}}
+   {{< /tabs >}}
 
 ## Enrich and control RUM data
 

--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -149,15 +149,15 @@ Starting with [version 2.17.0][3], you can add view names and assign them to a d
 
 If you are using React, Angular, Vue, or any other frontend framework, Datadog recommends implementing the `startView` logic at the framework router level.
 
-### React Native router instrumentation
+### React router instrumentation
 
-To override default RUM view names so that they are aligned with how you've defined them in your React Native application, you need to follow the below steps.
+To override default RUM view names so that they are aligned with how you've defined them in your React application, you need to follow the below steps.
 
 **Note**: These instructions are specific to the **React Router v6** library.
 
 1. Set `trackViewsManually` to `true` when initializing the RUM browser SDK as described [above](#override-default-rum-view-names).
 
-2. Start views for each new page or route change (for single-page applications).
+2. Start views for each route change.
 
    {{< tabs >}}
    {{% tab "NPM" %}}
@@ -174,7 +174,7 @@ To override default RUM view names so that they are aligned with how you've defi
          const routeMatches = matchRoutes(routes, location.pathname);
          const viewName = routeMatches && computeViewName(routeMatches);
          if (viewName) {
-           datadogRum.startView({name: viewName})
+           datadogRum.startView({name: viewName});
          }
        }, [location.pathname]);
 
@@ -220,8 +220,8 @@ To override default RUM view names so that they are aligned with how you've defi
          const viewName = routeMatches && computeViewName(routeMatches);
          if (viewName) {
            DD_RUM.onReady(function() {
-             DD_RUM.startView({name: viewName})
-           })
+             DD_RUM.startView({name: viewName});
+           });
          }
        }, [location.pathname]);
 
@@ -266,7 +266,7 @@ To override default RUM view names so that they are aligned with how you've defi
          const viewName = routeMatches && computeViewName(routeMatches);
          if (viewName) {
            window.DD_RUM &&
-             window.DD_RUM.startView({name: viewName})
+             window.DD_RUM.startView({name: viewName});
          }
        }, [location.pathname]);
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
- Adds instructions on how to override default RUM view names specifically for React Native applications.
- Indents previously added code blocks.

### Motivation
[DOCS-5793](https://datadoghq.atlassian.net/browse/DOCS-5793)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Ready to merge following reviews by Nhien and Aymeric.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5793]: https://datadoghq.atlassian.net/browse/DOCS-5793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ