### PR TITLE
(maint) Add corpweb to the go module files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,8 @@
 /config/                  @DataDog/corpweb @DataDog/documentation
 /config/_default/menus/   @DataDog/documentation
 package.json              @DataDog/corpweb @DataDog/documentation
+go.mod                    @DataDog/corpweb @DataDog/documentation  
+go.sum                    @DataDog/corpweb @DataDog/documentation  
 
 # SDK versions
 .github/workflows/bump_versions.yml   @DataDog/integrations-tools-and-libraries @DataDog/documentation


### PR DESCRIPTION
Probably good for the web team to look at these files too

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
