### PR TITLE
fix-carousel height on integrations carousel

### DIFF
--- a/assets/styles/components/_integrations.scss
+++ b/assets/styles/components/_integrations.scss
@@ -714,6 +714,7 @@ $screen-md-max: ($screen-lg-min - 1) !default;
                 grid-template-rows: 1fr;
 
                 .carousel-item__horizontal {
+                    min-height: 0;
                     grid-column: 1/-1;
                     grid-row: 1/-1;
                     &:not(.video-item) {

--- a/assets/styles/components/_integrations.scss
+++ b/assets/styles/components/_integrations.scss
@@ -714,7 +714,7 @@ $screen-md-max: ($screen-lg-min - 1) !default;
                 grid-template-rows: 1fr;
 
                 .carousel-item__horizontal {
-                    min-height: 0;
+                    min-height: fit-content;
                     grid-column: 1/-1;
                     grid-row: 1/-1;
                     &:not(.video-item) {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

fix-carousel height on integrations carousel

### Motivation
<!-- What inspired you to submit this pull request?-->

`.carousel-item__horizontal` items could extend the inherited height of `.carousel-top-row` due to being a child of a grid display. setting a min-height other than auto fixes it 

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

check that carousel item doesnt overlap the item description and counter

https://docs-staging.datadoghq.com/stefon.simmons/fix-height-carousel-item/integrations/buoyant_cloud/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
