### PR TITLE
Add note to help debugging misconfiguration

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -89,6 +89,8 @@ In a Docker environment, use the label `com.datadoghq.ad.logs` on the **containe
 
 **Note**: Escape regex characters in your patterns when using labels. For example, `\d` becomes `\\d`, `\w` becomes `\\w`, etc.
 
+**Note**: The label value must follow JSON syntax. e.g. No trailing comma, no comment.
+
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
@@ -126,6 +128,8 @@ spec:
 ```
 
 **Note**: Escape regex characters in your patterns when using pod annotations. For example, `\d` becomes `\\d`, `\w` becomes `\\w`, etc.
+
+**Note**: The annotation value must follow JSON syntax. e.g. No trailing comma, no comment.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -89,7 +89,7 @@ In a Docker environment, use the label `com.datadoghq.ad.logs` on the **containe
 
 **Note**: Escape regex characters in your patterns when using labels. For example, `\d` becomes `\\d`, `\w` becomes `\\w`, etc.
 
-**Note**: The label value must follow JSON syntax. e.g. No trailing comma, no comment.
+**Note**: The label value must follow JSON syntax, which means you should not include any trailing commas or comments.
 
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
@@ -129,7 +129,7 @@ spec:
 
 **Note**: Escape regex characters in your patterns when using pod annotations. For example, `\d` becomes `\\d`, `\w` becomes `\\w`, etc.
 
-**Note**: The annotation value must follow JSON syntax. e.g. No trailing comma, no comment.
+**Note**: The label value must follow JSON syntax, which means you should not include any trailing commas or comments.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add note to [Advanced Log Collection Configurations](https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=kubernetes)

### Motivation
<!-- What inspired you to submit this pull request?-->

We experienced `log_processing_rules` not working several times due to JSON syntax violation.
In Docker/Kubernetes environment, the label/annotation value is just a part of YAML, but it must be correct JSON. 
So suggested to add note to help people debugging misconfiguration.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
