### PR TITLE
Add the instrumentation telemetry intake endpoint to the public documents for APM

### DIFF
--- a/content/en/agent/guide/network.md
+++ b/content/en/agent/guide/network.md
@@ -31,7 +31,8 @@ All Agent traffic is sent over SSL. The destination is dependent on the Datadog 
 ## Destinations
 
 [APM][1]
-: `trace.agent.`{{< region-param key="dd_site" code="true" >}}
+: `trace.agent.`{{< region-param key="dd_site" code="true" >}}<br>
+`instrumentation-telemetry-intake.`{{< region-param key="dd_site" code="true" >}}
 
 [Live Containers][3] & [Live Process][4]
 : `process.`{{< region-param key="dd_site" code="true" >}}

--- a/content/es/agent/guide/network.md
+++ b/content/es/agent/guide/network.md
@@ -32,7 +32,8 @@ Todo el tráfico del Agent se envía a través de SSL. El destino depende del se
 ## Destinos
 
 [APM][1]
-: `trace.agent.`{{< region-param key="dd_site" code="true" >}}
+: `trace.agent.`{{< region-param key="dd_site" code="true" >}}<br>
+`instrumentation-telemetry-intake.`{{< region-param key="dd_site" code="true" >}}
 
 [Live Containers][3] y [Live process][4]
 : `process.`{{< region-param key="dd_site" code="true" >}}

--- a/content/fr/agent/guide/network.md
+++ b/content/fr/agent/guide/network.md
@@ -29,7 +29,8 @@ L'intégralité du trafic de l'Agent est envoyé via SSL. La destination dépend
 ## Destinations
 
 [APM][1]
-: `trace.agent.`{{< region-param key="dd_site" code="true" >}}
+: `trace.agent.`{{< region-param key="dd_site" code="true" >}}<br>
+`instrumentation-telemetry-intake.`{{< region-param key="dd_site" code="true" >}}
 
 [Live Containers][3] & [Live Process][4]
 : `process.`{{< region-param key="dd_site" code="true" >}}

--- a/content/ja/agent/guide/network.md
+++ b/content/ja/agent/guide/network.md
@@ -32,7 +32,8 @@ title: ネットワークトラフィック
 ## 送信先
 
 [APM][1]
-: `trace.agent.`{{< region-param key="dd_site" code="true" >}}
+: `trace.agent.`{{< region-param key="dd_site" code="true" >}}<br>
+`instrumentation-telemetry-intake.`{{< region-param key="dd_site" code="true" >}}
 
 [ライブコンテナ][3] & [ライブプロセス][4]
 : `process.`{{< region-param key="dd_site" code="true" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
For customers using APM, the Datadog agent will currently send APM instrumentation telemetry to `instrumentation-telemetry-intake.datadoghq.com`, however, this is not explicitly mentioned in our network documentation on https://docs.datadoghq.com/agent/guide/network/?tab=agentv6v7 . This PR addresses this shortcoming.

### Motivation
<!-- What inspired you to submit this pull request?-->
Jira: https://datadoghq.atlassian.net/browse/AIT-7693 . This omission in the documentation was originally reported by a customer.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
