### PR TITLE
Add new Redis obfuscation variable

### DIFF
--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -113,6 +113,8 @@ apm_config:
   obfuscation:
     redis:
       enabled: true
+      # If true, replaces all arguments with a single "?".
+      remove_all_args: true
 ```
 
 [1]: /tracing/glossary/#spans


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds documentation for a new Redis obfuscation environment variable introduced in [this PR](https://github.com/DataDog/datadog-agent/pull/17844). 

### Motivation
Certain Redis commands can reveal sensitive information (i.e. hash, password, etc) that should not be public or saved to the backend. This PR will allow the user to enable full obfuscation of Redis commands to hide all arguments instead of just certain ones.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
