### PR TITLE
Fix DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED documentation

### DIFF
--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -129,7 +129,7 @@ Enable generation of 128-bit trace IDs. By default, only 64-bit IDs are generate
 : **Default**: `false` <br>
 Enable printing of the full 128-bit ID when formatting a span with '%v'.
 When false (default), only the low 64-bits of the trace ID are printed, formatted as an integer. This means if the trace ID is only 64 bits, the full ID is printed.
-When true, the trace ID is printed as a full 128-bit ID in hexadecimal format. This is the case even if the ID itself is only 64 bits.
+When true, the trace ID is printed as a full 128-bit ID in hexadecimal format, except if the ID itself is only 64 bits - in which case, it is formatted as an integer.
 
 
 ## Configure APM environment name

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -276,7 +276,7 @@ Enable generation of 128-bit trace IDs. By default, only 64-bit IDs are generate
 **Default**: `false` <br>
 Enable printing of the full 128-bit ID when formatting a span within logs using MDC.
 When false (default), only the low 64-bits of the trace ID are printed, formatted as an integer. This means if the trace ID is only 64 bits, the full ID is printed.
-When true, the trace ID is printed as a full 128-bit ID in hexadecimal format, except if the ID itself is only 64 bits (then formatted as an integer).
+When true, the trace ID is printed as a full 128-bit ID in hexadecimal format, except if the ID itself is only 64 bits - in which case, it is formatted as an integer.
 
 **Note**:
 

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -276,7 +276,7 @@ Enable generation of 128-bit trace IDs. By default, only 64-bit IDs are generate
 **Default**: `false` <br>
 Enable printing of the full 128-bit ID when formatting a span within logs using MDC.
 When false (default), only the low 64-bits of the trace ID are printed, formatted as an integer. This means if the trace ID is only 64 bits, the full ID is printed.
-When true, the trace ID is printed as a full 128-bit ID in hexadecimal format. This is the case even if the ID itself is only 64 bits.
+When true, the trace ID is printed as a full 128-bit ID in hexadecimal format, except if the ID itself is only 64 bits (then formatted as an integer).
 
 **Note**:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR fixes the documentation of `DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED` behavior.

### Motivation
<!-- What inspired you to submit this pull request?-->

The description is not compliant with the RFC nor the documentation.
The issue was brought to eng from support.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

There is the same sentence for the Go Tracer. I don't know what the implementation status is or who to contact about it?

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
