### PR TITLE
Add error tracking attribute info

### DIFF
--- a/content/en/logs/error_tracking/backend.md
+++ b/content/en/logs/error_tracking/backend.md
@@ -26,14 +26,12 @@ If you are already sending stack traces to Datadog but they are not in `error.st
 
 To configure inline code snippets in issues, set up the [source code integration][9]. Adding code snippets in Error Tracking for Logs does not require APM; the enrichment tags and linked repository is the same for both.
 
-#### Attributes for stack traces
+#### Attributes for error tracking
 
-When logging stack traces, there are specific attributes that have a dedicated UI display within your Datadog application such as the logger name, the current thread, the error type, and the stack trace itself. To enable these functionalities use the following attribute names:
+There are specific attributes that have a dedicated UI display within Datadog. To enable these functionalities for Error Tracking use the following attribute names:
 
 | Attribute            | Description                                                             |
 |----------------------|-------------------------------------------------------------------------|
-| `logger.name`        | Name of the logger                                                      |
-| `logger.thread_name` | Name of the current thread                                              |
 | `error.stack`        | Actual stack trace                                                      |
 | `error.message`      | Error message contained in the stack trace                              |
 | `error.kind`         | The type or "kind" of an error (for example, "Exception", or "OSError") |

--- a/content/en/logs/error_tracking/backend.md
+++ b/content/en/logs/error_tracking/backend.md
@@ -25,6 +25,23 @@ For backend languages such as **C#**, **.NET**, **Go**, and **Node.js**, the cod
 If you are already sending stack traces to Datadog but they are not in `error.stack`, you can set up a [generic log remapper][8] to remap the stack trace to the correct attribute in Datadog.
 
 To configure inline code snippets in issues, set up the [source code integration][9]. Adding code snippets in Error Tracking for Logs does not require APM; the enrichment tags and linked repository is the same for both.
+
+#### Attributes for stack traces
+
+When logging stack traces, there are specific attributes that have a dedicated UI display within your Datadog application such as the logger name, the current thread, the error type, and the stack trace itself. To enable these functionalities use the following attribute names:
+
+| Attribute            | Description                                                             |
+|----------------------|-------------------------------------------------------------------------|
+| `logger.name`        | Name of the logger                                                      |
+| `logger.thread_name` | Name of the current thread                                              |
+| `error.stack`        | Actual stack trace                                                      |
+| `error.message`      | Error message contained in the stack trace                              |
+| `error.kind`         | The type or "kind" of an error (for example, "Exception", or "OSError") |
+
+**Note**: By default, integration Pipelines attempt to remap default logging library parameters to those specific attributes and parse stack traces or traceback to automatically extract the `error.message` and `error.kind`.
+
+For more information, see the complete [source code attributes documentation][11].
+
 ### C# and .NET
 
 {{< tabs >}}
@@ -264,3 +281,4 @@ end
 [8]: /logs/log_configuration/processors/?tab=ui#remapper
 [9]: https://app.datadoghq.com/source-code/setup/apm
 [10]: /logs/log_collection/
+[11]: /logs/log_configuration/attributes_naming_convention/#source-code


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- Add information about attributes that need to be added to the Error Logs for the UI to display Error Tracking elements

### Motivation
<!-- What inspired you to submit this pull request?-->
[DOCS-5791](https://datadoghq.atlassian.net/browse/DOCS-5791)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Ready to merge after review.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5791]: https://datadoghq.atlassian.net/browse/DOCS-5791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ