### PR TITLE
Document JIT vs allocation profiling

### DIFF
--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -209,9 +209,11 @@ CPU
 
 Allocations (v0.88+)
 : The number of allocations by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.
+_Note: Not availble when JIT is active_
 
 Allocated memory (v0.88+)
 : The amount of heap memory allocated by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.
+_Note: Not availble when JIT is active_
 
 [1]: /profiler/enabling/php/#requirements
 {{< /programming-lang >}}

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -213,7 +213,7 @@ _Note: Not available when JIT is active_
 
 Allocated memory (v0.88+)
 : The amount of heap memory allocated by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.<br />
-_Note: Not availble when JIT is active_
+_Note: Not available when JIT is active_
 
 [1]: /profiler/enabling/php/#requirements
 {{< /programming-lang >}}

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -208,11 +208,11 @@ CPU
 : Shows the time each function spent running on the CPU.
 
 Allocations (v0.88+)
-: The number of allocations by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.
+: The number of allocations by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.<br />
 _Note: Not availble when JIT is active_
 
 Allocated memory (v0.88+)
-: The amount of heap memory allocated by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.
+: The amount of heap memory allocated by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.<br />
 _Note: Not availble when JIT is active_
 
 [1]: /profiler/enabling/php/#requirements

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -209,7 +209,7 @@ CPU
 
 Allocations (v0.88+)
 : The number of allocations by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.<br />
-_Note: Not availble when JIT is active_
+_Note: Not available when JIT is active_
 
 Allocated memory (v0.88+)
 : The amount of heap memory allocated by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.<br />

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -120,8 +120,8 @@ Whether to enable the endpoint data collection in profiles. Added in version `0.
 `DD_PROFILING_ALLOCATION_ENABLED`
 : **INI**: `datadog.profiling.allocation_enabled`. INI available since `0.88.0`.<br>
 **Default**: `1`<br>
-Enable the allocation size and allocation bytes profile type. Added in version `0.88.0`.<br>
-**Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED` environment variable (`datadog.profiling.experimental_allocation_enabled` INI setting), which was available since `0.84`. If both are set, this one takes precedence.
+Enable the allocation size and allocation bytes profile type. Added in version `0.88.0`. When an active JIT is detected, allocation profiling will be turned off due to a bug in the ZendEngine.<br>
+**Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED` environment variable (`datadog.profiling.experimental_allocation_enabled` INI setting), which was available since `0.84`. If both are set, this one takes precedence. 
 
 `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED`
 : **INI**: `datadog.profiling.experimental_cpu_time_enabled`. INI available since `0.82.0`.<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -120,7 +120,7 @@ Whether to enable the endpoint data collection in profiles. Added in version `0.
 `DD_PROFILING_ALLOCATION_ENABLED`
 : **INI**: `datadog.profiling.allocation_enabled`. INI available since `0.88.0`.<br>
 **Default**: `1`<br>
-Enable the allocation size and allocation bytes profile type. Added in version `0.88.0`. When an active JIT is detected, allocation profiling will be turned off due to a bug in the ZendEngine.<br>
+Enable the allocation size and allocation bytes profile type. Added in version `0.88.0`. When an active JIT is detected, allocation profiling is turned off due to a limitation of the ZendEngine.<br>
 **Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED` environment variable (`datadog.profiling.experimental_allocation_enabled` INI setting), which was available since `0.84`. If both are set, this one takes precedence. 
 
 `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Document the fact that an active JIT disables PHP allocation profiling.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
