### PR TITLE
CIAPP-7029: CI test viz: remove python beta note

### DIFF
--- a/content/en/continuous_integration/tests/python.md
+++ b/content/en/continuous_integration/tests/python.md
@@ -19,9 +19,6 @@ further_reading:
 <div class="alert alert-warning">CI Visibility is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-<div class="alert alert-info">Python test instrumentation is in beta.
-</div>
-
 ## Compatibility
 
 Supported Python interpreters:


### PR DESCRIPTION
### What does this PR do?
This removes the "Python test visibility support is in beta" note.

### Motivation
Python test visibility support is going GA.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
