### PR TITLE
[STAT-378] update static analysis docs

### DIFF
--- a/content/en/continuous_integration/static_analysis/rules/_index.md
+++ b/content/en/continuous_integration/static_analysis/rules/_index.md
@@ -359,10 +359,11 @@ Rules for Python to avoid inappropriate wording in the code and comments.
 
 **Ruleset ID:** `python-pandas`
 
-A set of rules to check that pandas code is used the right way
- - `import` declarations follow coding guidelines
- - avoid deprecated code and methods
- - avoid inefficient code whenever possible
+A set of rules to check that pandas code is used appropriately.
+
+ - Ensures `import` declarations follow coding guidelines.
+ - Avoid deprecated code and methods.
+ - Avoid inefficient code whenever possible.
 
 {{< sa-rule-list "python_pandas_data" >}}
 

--- a/content/en/continuous_integration/static_analysis/rules/_index.md
+++ b/content/en/continuous_integration/static_analysis/rules/_index.md
@@ -177,7 +177,7 @@ python_best_practices_data:
     text: "do not use too many nested if conditions"
   - link: "/continuous_integration/static_analysis/rules/python-best-practices/too-many-while"
     tag: "too-many-while"
-    text: "do not use too many nested while"
+    text: "do not use too many nested loops and conditions "
   - link: "/continuous_integration/static_analysis/rules/python-best-practices/type-check-isinstance"
     tag: "type-check-isinstance"
     text: "use isinstance instead of type"
@@ -243,6 +243,34 @@ python_inclusive_data:
   - link: "/continuous_integration/static_analysis/rules/python-inclusive/variable-name"
     tag: "variable-name"
     text: "check variable names for wording issues"
+python_pandas_data:
+  - link: "/continuous_integration/static_analysis/rules/python-pandas/arith-operator-not-functions"
+    tag: "arith-operator-not-functions"
+    text: "Use arithmetic operator instead of a function"
+  - link: "/continuous_integration/static_analysis/rules/python-pandas/avoid-inplace"
+    tag: "avoid-inplace"
+    text: "Avoid using inplace=True"
+  - link: "/continuous_integration/static_analysis/rules/python-pandas/comp-operator-not-function"
+    tag: "comp-operator-not-function"
+    text: "Use operators to compare values, not functions"
+  - link: "/continuous_integration/static_analysis/rules/python-pandas/import-as-pd"
+    tag: "import-as-pd"
+    text: "Import pandas according to coding guidelines"
+  - link: "/continuous_integration/static_analysis/rules/python-pandas/isna-instead-of-isnull"
+    tag: "isna-instead-of-isnull"
+    text: "Use isna instead of isnull"
+  - link: "/continuous_integration/static_analysis/rules/python-pandas/loc-not-ix"
+    tag: "loc-not-ix"
+    text: "prefer iloc or loc rather than ix"
+  - link: "/continuous_integration/static_analysis/rules/python-pandas/notna-instead-of-notnull"
+    tag: "notna-instead-of-notnull"
+    text: "prefer notna to notnull"
+  - link: "/continuous_integration/static_analysis/rules/python-pandas/pivot-table"
+    tag: "pivot-table"
+    text: "Use pivot_table instead of pivot or unstack"
+  - link: "/continuous_integration/static_analysis/rules/python-pandas/use-read-csv-not-read-table"
+    tag: "use-read-csv-not-read-table"
+    text: "prefer read_csv to read_table"
 further_reading:
   - link: "/continuous_integration/static_analysis/"
     tag: "Documentation"
@@ -324,6 +352,19 @@ Rules specifically for Flask best practices and security.
 Rules for Python to avoid inappropriate wording in the code and comments.
 
 {{< sa-rule-list "python_inclusive_data" >}}
+
+<br>
+
+### Good practices for data science with pandas
+
+**Ruleset ID:** `python-pandas`
+
+A set of rules to check that pandas code is used the right way
+ - `import` declarations follow coding guidelines
+ - avoid deprecated code and methods
+ - avoid inefficient code whenever possible
+
+{{< sa-rule-list "python_pandas_data" >}}
 
 <br>
 

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -429,6 +429,16 @@
             path_to_remove: 'rulesets/python-inclusive/'
             front_matters:
               disable_edit: true
+
+        - action: pull-and-push-folder
+          branch: main
+          globs:
+          - rulesets/python-pandas/*.md
+          options:
+            dest_dir: '/continuous_integration/static_analysis/rules/python-pandas/'
+            path_to_remove: 'rulesets/python-pandas/'
+            front_matters:
+              disable_edit: true
               
       - repo_name: datadog-cdk-constructs
         contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -431,6 +431,16 @@
             front_matters:
               disable_edit: true
 
+        - action: pull-and-push-folder
+          branch: main
+          globs:
+          - rulesets/python-pandas/*.md
+          options:
+            dest_dir: '/continuous_integration/static_analysis/rules/python-pandas/'
+            path_to_remove: 'rulesets/python-pandas/'
+            front_matters:
+              disable_edit: true
+
       - repo_name: datadog-cdk-constructs
         contents:
         - action: pull-and-push-file


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This updates the static analysis landing page and provided minor upgrades to other rules.

### Motivation

We've added a new ruleset, `python-pandas`, that we need to add to the documentation as it's publicly available. We've made incremental changes to existing rules as well.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes

This cannot be merged until the Static Analysis' source repo PR is merged to `main`: [Source PR](https://github.com/DataDog/datadog-static-analyzer-rule-docs/pull/7)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
