### PR TITLE
DOCS-5808 ASM OSS Vuln - add go and ruby supported version numbers

### DIFF
--- a/content/en/security/application_security/enabling/compatibility/_index.md
+++ b/content/en/security/application_security/enabling/compatibility/_index.md
@@ -18,7 +18,7 @@ The following ASM capabilities are supported relative to each language's tracing
 | -------------------------------- | ----------------------------------|----------------------------|----------------------------|----------------------------|----------------------------|----------------------------|----------------------------|
 | Threat Detection| 1.8.0 | 2.23.0 | 3.13.1 | 1.9.0   | 1.47.0  | 1.9.0| 0.84.0 |
 | Threat Protection | 1.9.0 | 2.26.0 | 3.19.0| 1.10.0  |  v1.50.0|  1.11.0    | 0.86.0   |
-| Vulnerability Management for Open Source Software (OSS)  | 1.1.4 | 2.16.0 |2.23.0 for Node.js 12+, or 3.10.0 for Node.js 14+ | 1.5.0 | not supported| not supported| not supported|
+| Vulnerability Management for Open Source Software (OSS)  | 1.1.4 | 2.16.0 |2.23.0 for Node.js 12+, or 3.10.0 for Node.js 14+ | 1.5.0 | 1.49.0 | 1.11.0 | not supported|
 | Vulnerability Management for Code-level (beta)   |1.15.0| private beta | 2.32.0 for NodeJS 12+, or 3.19.0 for NodeJS 14+ | private beta | not supported<br/>| not supported| not supported|
 
 

--- a/content/en/security/application_security/enabling/compatibility/go.md
+++ b/content/en/security/application_security/enabling/compatibility/go.md
@@ -14,7 +14,7 @@ The following ASM capabilities are supported in the Go library, for the specifie
 | -------------------------------- | ----------------------------|
 | Threat Detection| 1.47.0  |
 | Threat Protection |  1.50.0   |
-| Vulnerability Management for Open Source Software (OSS) | not supported |
+| Vulnerability Management for Open Source Software (OSS) | 1.49.0 |
 | Vulnerability Management for Code-level (beta) | not supported |
 
 The minimum tracer version to get all supported ASM capabilities for Go is 1.50.0.
@@ -51,7 +51,6 @@ You must be running Datadog Agent v5.21.1+
 - Distributed Tracing to see attack flows through your applications
 
 ##### ASM Capability Notes
-- **Vulnerability Management for OSS** is not supported
 - **Vulnerability Management for Code-level** is not supported
 
 
@@ -70,7 +69,6 @@ You must be running Datadog Agent v5.21.1+
 - Request-based blocking
 
 ##### ASM Capability Notes
-- **Vulnerability Management for OSS** is not supported
 - **Vulnerability Management for Code-level** is not supported
 
 | Framework         | Threat Detection supported?    | Threat Protection supported?                                              |
@@ -90,7 +88,6 @@ You must be running Datadog Agent v5.21.1+
 - error and stacktrace capturing
 
 ##### ASM Capability Notes
-- **Vulnerability Management for OSS** is not supported
 - **Vulnerability Management for Code-level** is not supported
 - **Threat Protection** also works at the HTTP request (input) layer, and so works for all databases by default, even those not listed in the table below.
 

--- a/content/en/security/application_security/enabling/compatibility/ruby.md
+++ b/content/en/security/application_security/enabling/compatibility/ruby.md
@@ -14,7 +14,7 @@ The following ASM capabilities are supported in the Ruby library, for the specif
 | -------------------------------- | ----------------------------|
 | Threat Detection  | 1.9.0  |
 | Threat Protection | 1.11.0 |
-| Vulnerability Management for Open Source Software (OSS) | not supported |
+| Vulnerability Management for Open Source Software (OSS) | 1.11.0 |
 | Vulnerability Management for Code-level (beta) | not supported |
 
 The minimum tracer version to get all supported ASM capabilities for Ruby is 1.11.0.
@@ -49,7 +49,6 @@ These are supported on the following architectures:
 - Distributed Tracing to see attack flows through your applications
 
 ##### ASM Capability Notes
-- **Vulnerability Management for OSS** is not supported
 - **Vulnerability Management for Code** is not supported
 
 | Framework                | Threat Detection supported? | Threat Protection supported? |
@@ -75,7 +74,6 @@ These are supported on the following architectures:
 - Request-based blocking
 
 ##### ASM Capability Notes
-- **Vulnerability Management for OSS** is not supported
 - **Vulnerability Management for Code-level** is not supported
 
 | Framework         | Threat Detection supported?    | Threat Protection supported?                                              |
@@ -94,7 +92,6 @@ These are supported on the following architectures:
 - error and stacktrace capturing
 
 ##### ASM Capability Notes
-- **Vulnerability Management for OSS** is not supported
 - **Vulnerability Management for Code-level** is not supported
 - **Threat Protection** also works at the HTTP request (input) layer, and so works for all databases by default, even those not listed in the table below. 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds supported version info for Go and Ruby OSS Vuln in ASM. This is ready to merge when approved.

### Motivation
DOCS-5808

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
