### PR TITLE
Remove 404 Link in SAML Troubleshooting 

### DIFF
--- a/content/en/account_management/saml/troubleshooting.md
+++ b/content/en/account_management/saml/troubleshooting.md
@@ -103,14 +103,13 @@ If you are having trouble logging in because of a role-based error, contact your
 
 ## Identity provider (IdP) errors
 
-If you encounter an error coming from your IdP such as Google, Active Directory, Azure, LastPass, Okta, and more:
+If you encounter an error coming from your IdP such as Google, Active Directory, Azure, Okta, and more:
 
 - If you encounter an issue in Google's Admin Console, see [SAML app error messages][10].
 - If you encounter an issue in Active Directory, see [Debug SAML-based single sign-on to applications in Azure Active Directory][11].
 - If you encounter an issue in AuthO, see [Troubleshoot SAML Configurations][12].
 - If you encounter an issue in Azure, see [An app page shows an error message after the user signs in][13].
 - If you encounter an issue in Google, see [Datadog cloud application][14].
-- If you encounter an issue in LastPass, see the [Datadog App Integration][15].
 - If you encounter an issue in Okta, see [Receiving 404 error when attempting to sign into application][16].
 - If you encounter an issue in SafeNet, see [SafeNet Trusted Access for Datadog][17].
 
@@ -156,7 +155,6 @@ Before reaching out to Datadog support, contact your Administrator. You may need
 [12]: https://auth0.com/docs/troubleshoot/troubleshoot-authentication/troubleshoot-saml-configurations
 [13]: https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/application-sign-in-problem-application-error
 [14]: https://support.google.com/a/answer/7553768
-[15]: https://support.logmeininc.com/lastpass/help/datadog-app-integration
 [16]: https://support.okta.com/help/s/article/Receiving-404-error-when-attempting-to-sign-into-application?language=en_US
 [17]: https://resources.safenetid.com/help/Datadog/Index.htm
 [18]: https://www.datadoghq.com/support/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Remove mention of LastPass/broken docs link.

### Motivation
<!-- What inspired you to submit this pull request?-->

Flagged by translators in Transifex

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
