### PR TITLE
Add JSON syntax note next to every regex note

### DIFF
--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -129,7 +129,7 @@ spec:
 
 **Note**: Escape regex characters in your patterns when using pod annotations. For example, `\d` becomes `\\d`, `\w` becomes `\\w`, etc.
 
-**Note**: The label value must follow JSON syntax, which means you should not include any trailing commas or comments.
+**Note**: The annotation value must follow JSON syntax, which means you should not include any trailing commas or comments.
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -210,6 +210,8 @@ In a Docker environment, use the label `com.datadoghq.ad.logs` on the **containe
 
 **Note**: Escape regex characters in your patterns when using labels. For example, `\d` becomes `\\d`, `\w` becomes `\\w`, etc.
 
+**Note**: The label value must follow JSON syntax, which means you should not include any trailing commas or comments.
+
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
@@ -247,6 +249,8 @@ spec:
 ```
 
 **Note**: Escape regex characters in your patterns when using pod annotations. For example, `\d` becomes `\\d`, `\w` becomes `\\w`, etc.
+
+**Note**: The annotation value must follow JSON syntax, which means you should not include any trailing commas or comments.
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -298,6 +302,8 @@ In a Docker environment, use the label `com.datadoghq.ad.logs` on your container
 
 **Note**: Escape regex characters in your patterns when using labels. For example, `\d` becomes `\\d`, `\w` becomes `\\w`, etc.
 
+**Note**: The label value must follow JSON syntax, which means you should not include any trailing commas or comments.
+
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
@@ -336,6 +342,8 @@ spec:
 ```
 
 **Note**: Escape regex characters in your patterns when using pod annotations. For example, `\d` becomes `\\d`, `\w` becomes `\\w`, etc.
+
+**Note**: The annotation value must follow JSON syntax, which means you should not include any trailing commas or comments.
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -436,6 +444,8 @@ spec:
 ```
 
 **Note**: Escape regex characters in your patterns when performing multi-line aggregation with pod annotations. For example, `\d` becomes `\\d`, `\w` becomes `\\w`, etc.
+
+**Note**: The annotation value must follow JSON syntax, which means you should not include any trailing commas or comments.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

following up on #18802 

### Motivation
<!-- What inspired you to submit this pull request?-->

While looking over updated doc after #18802, 
found some config example have regex escaping note and JSON syntax note and some have regex note only (yes, my oversight).

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
