### PR TITLE
Add Language Support Banners for Agentless Instructions in Test Visibility Documentation

### DIFF
--- a/content/en/continuous_integration/tests/dotnet.md
+++ b/content/en/continuous_integration/tests/dotnet.md
@@ -49,6 +49,8 @@ To report test results to Datadog, you need to configure the Datadog .NET librar
 {{% /tab %}}
 {{% tab "Cloud CI provider (Agentless)" %}}
 
+<div class="alert alert-info">Agentless mode is available in Datadog .NET library versions >= 2.5.1</div>
+
 {{% ci-agentless %}}
 
 {{% /tab %}}

--- a/content/en/continuous_integration/tests/java.md
+++ b/content/en/continuous_integration/tests/java.md
@@ -44,6 +44,8 @@ To report test results to Datadog, you need to configure the Datadog Java librar
 
 {{% tab "Cloud CI provider (Agentless)" %}}
 
+<div class="alert alert-info">Agentless mode is available in Datadog Java library versions >= 0.101.0</div>
+
 {{% ci-agentless %}}
 
 {{% /tab %}}

--- a/content/en/continuous_integration/tests/javascript.md
+++ b/content/en/continuous_integration/tests/javascript.md
@@ -71,6 +71,8 @@ To report test results to Datadog, you need to configure the Datadog JavaScript 
 
 {{% tab "Cloud CI provider (Agentless)" %}}
 
+<div class="alert alert-info">Agentless mode is available in Datadog JavaScript library versions >= 2.5.0</div>
+
 {{% ci-agentless %}}
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds the language requirement banners back in the Agentless tab.

### Motivation
<!-- What inspired you to submit this pull request?-->

Chat with Romain on Slack, ready to merge

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
