### PR TITLE
[CCMV] Update CCM _index.md page to include billing conductor

### DIFF
--- a/content/en/cloud_cost_management/_index.md
+++ b/content/en/cloud_cost_management/_index.md
@@ -179,6 +179,13 @@ The following out-of-the-box tags are also available for filtering and grouping 
 [4]: https://docs.aws.amazon.com/cur/latest/userguide/view-cur.html
 [5]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create-console.html
 [6]: https://docs.aws.amazon.com/cur/latest/userguide/data-dictionary.html
+
+### Billing conductor
+Billing conductor enables you to simplify the bill by customizing the billing rates, distribute credits and fees, and shared overhead costs at your discretion. You will also be able to select which accounts to include in the CUR.
+
+To create a billing conductor CUR, please follow [these instructions](https://docs.aws.amazon.com/cur/latest/userguide/cur-data-view.html) from AWS. Make sure the CUR meets [Datadog's requirements](https://docs.datadoghq.com/cloud_cost_management/?tab=aws#prerequisite-generate-a-cost-and-usage-report).
+Once the billing conductor CUR created, please follow the instructions above to set it up in Datadog.
+
 {{% /tab %}}
 
 {{% tab "Azure" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Includes Billing Conductor section for AWS tab in CCM documentation
Preview: https://docs-staging.datadoghq.com/crousseaux-ccm-billing-conductor/cloud_cost_management/

### Motivation
We recently added support for AWS Billing Conductor

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
