### PR TITLE
Add note about nodejs deprecation

### DIFF
--- a/content/en/logs/guide/azure-logging-guide.md
+++ b/content/en/logs/guide/azure-logging-guide.md
@@ -7,6 +7,12 @@ further_reading:
   text: "Learn how to explore your logs"
 ---
 
+<div class="alert alert-warning">
+<a href="https://nodejs.org/en/blog/announcements/nodejs16-eol">NodeJS 16</a> will deprecate September 23, 2023.
+</div>
+
+<div class="alert alert-warning">On September 11 2023, <a href="https://nodejs.org/en/blog/announcements/nodejs16-eol">Node.JS 16</a> will reach end of life. Datadog will update support for the newer version prior to deprecation. </div>
+
 ## Overview
 
 Use this guide to set up logging from your Azure subscriptions to Datadog.

--- a/content/en/logs/guide/azure-logging-guide.md
+++ b/content/en/logs/guide/azure-logging-guide.md
@@ -7,11 +7,7 @@ further_reading:
   text: "Learn how to explore your logs"
 ---
 
-<div class="alert alert-warning">
-<a href="https://nodejs.org/en/blog/announcements/nodejs16-eol">NodeJS 16</a> will deprecate September 23, 2023.
-</div>
-
-<div class="alert alert-warning">On September 11 2023, <a href="https://nodejs.org/en/blog/announcements/nodejs16-eol">Node.JS 16</a> will reach end of life. Datadog will update support for the newer version prior to deprecation. </div>
+<div class="alert alert-warning">On September 11 2023, <a href="https://nodejs.org/en/blog/announcements/nodejs16-eol">Node.JS 16</a> will reach end of life. Datadog plans to update support for the newer version prior to deprecation. </div>
 
 ## Overview
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- Add a general note about the Nodejs 16 deprecations.

### Motivation
<!-- What inspired you to submit this pull request?-->
- [DOCS-5799](https://datadoghq.atlassian.net/browse/DOCS-5799)
- Support has been receiving a number of tickets from customers about this and requested a note to let customers know that we are aware of node runtimes being deprecated and we change them continuously as we hear of new ones.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
- Ready to merge after review.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5799]: https://datadoghq.atlassian.net/browse/DOCS-5799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ