### PR TITLE
[CIAPP-7105] Update test regressions section

### DIFF
--- a/content/en/continuous_integration/tests/_index.md
+++ b/content/en/continuous_integration/tests/_index.md
@@ -60,10 +60,12 @@ There's also information about the wall time of the most recent test suite run, 
 
 Hovering over the commit author avatar shows detailed information about the latest commit.
 
-#### Benchmark test regressions
-A benchmark test run is marked as a regression when its duration is five times the standard deviation above the mean for the same test in the default branch. The mean of the default branch is calculated over the 200 most recent test runs. A benchmark test has @test.type:benchmark.
+#### Test regressions
+A test run is marked as a regression when its duration is five times the mean and greater than the max duration for the same test in the default branch. The mean and the max of the default branch is calculated over the last week test runs.
 
-Benchmark test regressions are evaluated per commit in an effort to tie performance regressions to specific code changes.
+A benchmark test run is marked as a regression when its duration is five times the standard deviation above the mean for the same test in the default branch. A benchmark test has @test.type:benchmark.
+
+Test regressions are evaluated per commit in an effort to tie performance regressions to specific code changes.
 
 #### Investigate for more details
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update test regressions section in CI Test Visibility page.

### Motivation
<!-- What inspired you to submit this pull request?-->
CI VIsibility is launching regressions detection support for all types of tests.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
