### PR TITLE
(ci) Fix preview link poster

### DIFF
--- a/.github/workflows/preview_link.yml
+++ b/.github/workflows/preview_link.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/local/bin/py/preview-links-template.mako
+++ b/local/bin/py/preview-links-template.mako
@@ -1,20 +1,10 @@
 <%
-import re
 import os
 
 h2 = "##"
 h3 = '###'
-pattern1 = re.compile('content/en/(.*?).md')
-pattern2 = re.compile('content/en/glossary/terms/(.*?).md')
 
 branch = os.environ["branch"]
-
-def compile_filename(filename):
-    if pattern2.match(filename):
-        filename = filename.replace('content/en/', '').replace('terms/', '#').replace('.md', '')
-    elif pattern1.match(filename):
-        filename = filename.replace('content/en/', '').replace('_index', '').replace('.md', '')
-    return filename    
 %>
 
 ${h2} Preview links (active after the `build_preview` check completes)
@@ -22,27 +12,27 @@ ${h2} Preview links (active after the `build_preview` check completes)
 % if added:
 ${h3} New or renamed files
 % for filename in added:
-* https://docs-staging.datadoghq.com/${branch}/${compile_filename(filename)}
-% endfor 
+* https://docs-staging.datadoghq.com/${branch}/${filename}
+% endfor
 % endif
 
 % if deleted:
 ${h3} Removed or renamed files (these should redirect)
 % for filename in deleted:
-* https://docs-staging.datadoghq.com/${branch}/${compile_filename(filename)}
-% endfor 
+* https://docs-staging.datadoghq.com/${branch}/${filename}
+% endfor
 % endif
 
 % if renamed:
 ${h3} Renamed files
 % for filename in renamed:
-* https://docs-staging.datadoghq.com/${branch}/${compile_filename(filename)}
-% endfor 
+* https://docs-staging.datadoghq.com/${branch}/${filename}
+% endfor
 % endif
 
 % if modified:
 ${h3} Modified Files
 % for filename in modified:
-* https://docs-staging.datadoghq.com/${branch}/${compile_filename(filename)}
-% endfor 
+* https://docs-staging.datadoghq.com/${branch}/${filename}
+% endfor
 % endif

--- a/local/bin/py/preview_links.py
+++ b/local/bin/py/preview_links.py
@@ -1,5 +1,6 @@
 from mako.template import Template
 import argparse
+import re
 
 parser=argparse.ArgumentParser()
 
@@ -12,13 +13,33 @@ args=parser.parse_args()
 
 comment_template = Template(filename='local/bin/py/preview-links-template.mako')
 
+pattern1 = re.compile('content/en/(.*?).md')
+pattern2 = re.compile('content/en/glossary/terms/(.*?).md')
+
+def compile_filename(filename):
+    if pattern2.match(filename):
+        filename = filename.replace('content/en/', '').replace('terms/', '#').replace('.md', '')
+        return filename
+    elif pattern1.match(filename):
+        filename = filename.replace('content/en/', '').replace('_index', '').replace('.md', '')
+        return filename
+
+def sort_files(file_string):
+    final_array = []
+    initial_array = file_string.split(" ")
+    for filename in initial_array:
+        if filename.endswith('.md'):
+            if pattern1.match(filename) or pattern2.match(filename):
+                final_array.append(compile_filename(filename))
+    return final_array        
+
 # It looks like renamed files are counted as removed/added. I'm going to leave "renamed" in for
 # now to see if this behavior is consistent. 
 with open('.github/preview-links-template.md', 'w') as f:
     f.write(comment_template.render(
-                deleted = args.deleted.split(" ") if args.deleted else False,
-                renamed = args.renamed.split(" ") if args.renamed else False,
-                modified = args.modified.split(" ") if args.modified else False,
-                added = args.added.split(" ") if args.added else False
+                deleted = sort_files(args.deleted) if args.deleted else False,
+                renamed = sort_files(args.renamed) if args.renamed else False,
+                modified = sort_files(args.modified) if args.modified else False,
+                added = sort_files(args.added) if args.added else False
                 )
             )


### PR DESCRIPTION
Attempts to fix an issue where unrelated/unchanged files were being posted in the preview links section:
- Moves most of the filename logic out of the mako file
- Ensures that only markdown files are posted in the preview links
- Changes fetch depth in the workflow to `0`. I suspect this is the main reason why unchanged files are making it into the links section. The [documentation for the action](https://github.com/tj-actions/changed-files#usage) notes that you should set this parameter (but mentions that you can ommit it for PRs, which is why we initially didn't use it). This will probably result in the action taking longer to run, but probably not as long as the preview build itself, so not a big issue.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
