### PR TITLE
Bump Search Results for CI Visibility Tests Documentation

### DIFF
--- a/content/en/continuous_integration/tests/_index.md
+++ b/content/en/continuous_integration/tests/_index.md
@@ -22,7 +22,7 @@ further_reading:
 cascade:
     algolia:
         rank: 70
-        tags: ["ci test", "ci tests"]
+        tags: ['ci test', 'ci tests']
 ---
 
 {{< site-region region="gov" >}}

--- a/content/en/continuous_integration/tests/_index.md
+++ b/content/en/continuous_integration/tests/_index.md
@@ -19,6 +19,10 @@ further_reading:
     - link: "https://www.datadoghq.com/blog/ci-test-visibility-with-rum/"
       tag: "Blog"
       text: "Troubleshoot end-to-end tests with CI Visibility and RUM"
+cascade:
+    algolia:
+        rank: 70
+        tags: ["ci test", "ci tests"]
 ---
 
 {{< site-region region="gov" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

In the current docs search, CI Visibility search results are being displayed after search results for Continuous Testing.

### Motivation
<!-- What inspired you to submit this pull request?-->

Chat with Kassen, ready to merge.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
