### PR TITLE
Fix Prometheus Scrape autodiscovery rules for container name

### DIFF
--- a/content/en/containers/kubernetes/prometheus.md
+++ b/content/en/containers/kubernetes/prometheus.md
@@ -287,9 +287,8 @@ Only the parameters [on this page][2] are supported for OpenMetrics v2 with Auto
 
 The Autodiscovery configuration can be based on container names, Kubernetes annotations, or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
-`kubernetes_container_names` is a list of container names to target, it supports the `*` wildcard.
-
-`kubernetes_annotations` contains two maps of annotations to define the discovery rules: `include` and `exclude`.
+- `kubernetes_container_names` is a list of container names to target, in regex format
+- `kubernetes_annotations` contains two maps of annotations to define the discovery rules: `include` and `exclude`.
 
 **Note:** The default value of `kubernetes_annotations` in the Datadog Agent configuration is the following:
 
@@ -338,9 +337,8 @@ Only the parameters [on this page][2] are supported for OpenMetrics v2 with Auto
 
 The Autodiscovery configuration can be based on container names, Kubernetes annotations, or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
-`kubernetes_container_names` is a list of container names to target, it supports the `*` wildcard.
-
-`kubernetes_annotations` contains two maps of annotations to define the discovery rules: `include` and `exclude`.
+- `kubernetes_container_names` is a list of container names to target, in regex format
+- `kubernetes_annotations` contains two maps of annotations to define the discovery rules: `include` and `exclude`.
 
 **Note:** The default value of `kubernetes_annotations` in the Datadog Agent configuration is the following:
 

--- a/content/en/containers/kubernetes/prometheus.md
+++ b/content/en/containers/kubernetes/prometheus.md
@@ -287,7 +287,7 @@ Only the parameters [on this page][2] are supported for OpenMetrics v2 with Auto
 
 The Autodiscovery configuration can be based on container names, Kubernetes annotations, or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
-- `kubernetes_container_names` is a list of container names to target, in regex format
+- `kubernetes_container_names` is a list of container names to target, in regular expression format.
 - `kubernetes_annotations` contains two maps of annotations to define the discovery rules: `include` and `exclude`.
 
 **Note:** The default value of `kubernetes_annotations` in the Datadog Agent configuration is the following:
@@ -337,7 +337,7 @@ Only the parameters [on this page][2] are supported for OpenMetrics v2 with Auto
 
 The Autodiscovery configuration can be based on container names, Kubernetes annotations, or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
 
-- `kubernetes_container_names` is a list of container names to target, in regex format
+- `kubernetes_container_names` is a list of container names to target, in regular expression format.
 - `kubernetes_annotations` contains two maps of annotations to define the discovery rules: `include` and `exclude`.
 
 **Note:** The default value of `kubernetes_annotations` in the Datadog Agent configuration is the following:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Change the wording to clarify that these `kubernetes_container_names` filters are regex formatted, not wildcard formatted. As well as change to bullets to look nicer.

Example can do:

```yaml
      - autodiscovery:
          kubernetes_annotations:
            include:
              prometheus.io/scrape: "true"
          kubernetes_container_names:
          - ^example-.*
```
To match those pods with the annotation and containers starting with the phrase `example-`

### Motivation
<!-- What inspired you to submit this pull request?-->
Clarify the handling as can create the checks unexpectedly otherwise

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
https://docs-staging.datadoghq.com/jack.davenport/scrape-rules/containers/kubernetes/prometheus/?tab=kubernetesadv2#advanced-configuration

### Additional Notes
<!-- Anything else we should know when reviewing?-->

Code for reference, not a new change has been this way:
- https://github.com/DataDog/datadog-agent/blob/7.46.x/pkg/autodiscovery/common/types/prometheus.go#L251-L267

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
