### PR TITLE
Remove note specifying not to add object lock for s3 archives

### DIFF
--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -83,8 +83,6 @@ Go into your [AWS console][1] and [create an S3 bucket][2] to send your archives
 **Notes:**
 
 - Do not make your bucket publicly readable.
-- Do not set [Object Lock][3] because the last data needs to be rewritten in some rare cases (typically a timeout).
-
 - For [US1, US3, and US5 sites][4], see [AWS Pricing][5] for inter-region data transfer fees and how cloud storage costs may be impacted. Consider creating your storage bucket in `us-east-1` to manage your inter-region data transfer fees.
 
 [1]: https://s3.console.aws.amazon.com/s3


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

It's not a problem for s3, because enabling object lock forces the use of versioning, and trying to upload the same object just creates a new version.

cf https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-overview.html
<img width="1182" alt="Screenshot 2023-07-11 at 18 12 08" src="https://github.com/DataDog/documentation/assets/19330189/4383e9b2-d79a-4812-9f80-e210a30430d7">

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
