### PR TITLE
Update WebSocket Test Failure Errors

### DIFF
--- a/content/en/synthetics/api_tests/websocket_tests.md
+++ b/content/en/synthetics/api_tests/websocket_tests.md
@@ -167,10 +167,14 @@ These reasons include the following:
 : The SSL connection couldn't be performed. [See the dedicated error page for more information][9].
 
 `TIMEOUT`
-: The request couldn't be completed in a reasonable time. Two types of `TIMEOUT` can happen:
+: The request couldn't be completed in a reasonable time. Two types of `TIMEOUT` errors can happen:
   - `TIMEOUT: The request couldn't be completed in a reasonable time.` indicates that the request duration hit the test defined timeout (default is set to 60s). 
   For each request only the completed stages for the request are displayed in the network waterfall. For example, in the case of `Total response time` only being displayed, the timeout occurred during the DNS resolution.
   - `TIMEOUT: Overall test execution couldn't be completed in a reasonable time.` indicates that the test duration (request + assertions) hits the maximum duration (60.5s).
+
+`WEBSOCKET`
+: The WebSocket connection was closed or cannot be opened. One type of `WEBSOCKET` error can happen:
+  - `WEBSOCKET: Received message longer than the maximum supported length.` indicates that the response message length hits the maximum length (50kb). 
 
 ## Permissions
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Document the maximum length of the response message for WebSocket test that can raise an error.

### Motivation
<!-- What inspired you to submit this pull request?-->

Chat with Cheryl and Keith in #support-synthetics on Slack, ready to merge.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
