### PR TITLE
custom toc testing

### DIFF
--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -1,6 +1,6 @@
 import { updateTOC, buildTOCMap } from './table-of-contents';
 import initCodeTabs from './codetabs';
-import { redirectToRegion } from '../region-redirects';
+import { redirectToRegion, hideTOCItems } from '../region-redirects';
 import { initializeIntegrations } from './integrations';
 import { initializeGroupedListings } from './grouped-item-listings';
 import {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName } from '../helpers/helpers';
@@ -222,12 +222,12 @@ function loadPage(newUrl) {
             }
 
             const {pageCodeLang} = document.documentElement.dataset;
-
             addCodeTabEventListeners();
             addCodeBlockVisibilityToggleEventListeners();
             activateCodeLangNav(pageCodeLang)
             redirectCodeLang();
             toggleMultiCodeLangNav(pageCodeLang);
+            hideTOCItems(true)
 
             // Gtag virtual pageview
             gtag('config', gaTag, { page_path: pathName });

--- a/assets/scripts/region-redirects.js
+++ b/assets/scripts/region-redirects.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
         redirectToRegion()
     }
-    hideNonRegionSpecificTOC()
+    hideTOCItems()
 
     if (regionSelector) {
         const options = regionSelector.querySelectorAll('.dropdown-item');
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
             option.addEventListener('click', () => {
                 const region = option.dataset.value;
                 regionOnChangeHandler(region);
-                hideNonRegionSpecificTOC(true)
+                hideTOCItems(true)
             })
         })
     }
@@ -83,21 +83,22 @@ function regionOnChangeHandler(region) {
 }
 
 /**
- * Hides Hugo TOC items that are not {{ site-region }} shortcode specific
- * @param {boolean} regionSelected - region selected via site select dropdown
+ * Hides TOC items that are not {{ site-region }} shortcode specific
+ * Hides all TOC items that are related to headers nested in {{ tabs }}
+ * @param {boolean} shouldResetTOC - region selected via site select dropdown or loading the page asynchronously
  */
-function hideNonRegionSpecificTOC(regionSelected=false) {
+function hideTOCItems(shouldResetTOC=false) {
     const allTOCItems = document.querySelectorAll('#TableOfContents li')
     const hiddenHeaders = document.querySelectorAll('.site-region-container.d-none > h3, .site-region-container.d-none > h2')
     const hiddenHeaderIDs = [...hiddenHeaders].map(el => `#${el.id}`)
-
+    
     const tabNestedHeaders = document.querySelectorAll('.code-tabs > .tab-content > .tab-pane > h3')
     const tabNestedHeaderIDs = [...tabNestedHeaders].map(el => `#${el.id}`)
-
+    
     allTOCItems.forEach(item => {
         const refID = item.querySelector('a')?.hash
-        if(regionSelected){
-            // display all items
+        if(shouldResetTOC){
+            // display all items if region selected or async loading
             item.classList.remove('d-none')
         }
         if(hiddenHeaderIDs.includes(refID)){
@@ -105,7 +106,7 @@ function hideNonRegionSpecificTOC(regionSelected=false) {
             item.classList.add('d-none')
         }
         if(tabNestedHeaderIDs.includes(refID)){
-            // hide all toc items related to headers that are nested in {{tabs}}. 
+            // hide all toc items related to headers that are nested in {{tabs}} 
             item.classList.add('d-none')
         }
     })
@@ -195,4 +196,4 @@ function redirectToRegion(region = '') {
     }
 }
 
-export { redirectToRegion, getDDSiteFromReferrer };
+export { redirectToRegion, getDDSiteFromReferrer, hideTOCItems };

--- a/assets/scripts/region-redirects.js
+++ b/assets/scripts/region-redirects.js
@@ -92,7 +92,7 @@ function hideTOCItems(shouldResetTOC=false) {
     const hiddenHeaders = document.querySelectorAll('.site-region-container.d-none > h3, .site-region-container.d-none > h2')
     const hiddenHeaderIDs = [...hiddenHeaders].map(el => `#${el.id}`)
     
-    const tabNestedHeaders = document.querySelectorAll('.code-tabs > .tab-content > .tab-pane > h3')
+    const tabNestedHeaders = document.querySelectorAll('.code-tabs > .tab-content > .tab-pane > h3, .code-tabs > .tab-content > .tab-pane > h2')
     const tabNestedHeaderIDs = [...tabNestedHeaders].map(el => `#${el.id}`)
     
     allTOCItems.forEach(item => {

--- a/assets/scripts/region-redirects.js
+++ b/assets/scripts/region-redirects.js
@@ -83,13 +83,16 @@ function regionOnChangeHandler(region) {
 }
 
 /**
- * Hides Hugo TOC items that are not {{% site-region %}} specific
+ * Hides Hugo TOC items that are not {{ site-region }} shortcode specific
  * @param {boolean} regionSelected - region selected via site select dropdown
  */
 function hideNonRegionSpecificTOC(regionSelected=false) {
     const allTOCItems = document.querySelectorAll('#TableOfContents li')
     const hiddenHeaders = document.querySelectorAll('.site-region-container.d-none > h3, .site-region-container.d-none > h2')
     const hiddenHeaderIDs = [...hiddenHeaders].map(el => `#${el.id}`)
+
+    const tabNestedHeaders = document.querySelectorAll('.code-tabs > .tab-content > .tab-pane > h3')
+    const tabNestedHeaderIDs = [...tabNestedHeaders].map(el => `#${el.id}`)
 
     allTOCItems.forEach(item => {
         const refID = item.querySelector('a')?.hash
@@ -98,6 +101,11 @@ function hideNonRegionSpecificTOC(regionSelected=false) {
             item.classList.remove('d-none')
         }
         if(hiddenHeaderIDs.includes(refID)){
+            // since the headers are hidden, also hide the related toc item
+            item.classList.add('d-none')
+        }
+        if(tabNestedHeaderIDs.includes(refID)){
+            // hide all toc items related to headers that are nested in {{tabs}}. 
             item.classList.add('d-none')
         }
     })

--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -3,11 +3,11 @@ title: Connect to Datadog over AWS PrivateLink
 kind: guide
 ---
 
-{{< site-region region="us3,us5,eu,gov,ap1" >}}
+{{% site-region region="us3,us5,eu,gov,ap1" %}}
 <div class="alert alert-warning">Datadog PrivateLink does not support the selected Datadog site.</div>
-{{< /site-region >}}
+{{% /site-region %}}
 
-{{< site-region region="us" >}}
+{{% site-region region="us" %}}
 This guide walks you through how to configure [AWS PrivateLink][1] for use with Datadog.
 
 ## Overview
@@ -242,4 +242,4 @@ Additional helpful documentation, links, and articles:
 [2]: https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html
 [3]: /agent/logs
 [4]: /integrations/amazon_web_services/#log-collection
-{{< /site-region >}}
+{{% /site-region %}}

--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -3,11 +3,11 @@ title: Connect to Datadog over AWS PrivateLink
 kind: guide
 ---
 
-{{% site-region region="us3,us5,eu,gov,ap1" %}}
+{{< site-region region="us3,us5,eu,gov,ap1" >}}
 <div class="alert alert-warning">Datadog PrivateLink does not support the selected Datadog site.</div>
 {{< /site-region >}}
 
-{{% site-region region="us" %}}
+{{< site-region region="us" >}}
 This guide walks you through how to configure [AWS PrivateLink][1] for use with Datadog.
 
 ## Overview
@@ -23,7 +23,7 @@ Datadog exposes AWS PrivateLink endpoints in **us-east-1**.
 However, to route traffic to Datadog's PrivateLink offering in `us-east-1` from other regions, use inter-region [Amazon VPC peering][2]. Inter-region VPC peering enables you to establish connections between VPCs across different AWS regions. This allows VPC resources in different regions to communicate with each other using private IP addresses. For more details, see [Amazon VPC peering][2].
 
 {{< tabs >}}
-{{% tab "us-east-1" %}}
+{{% tab "us-east-1" %}} 
 
 1. Connect the AWS Console to region **us-east-1** and create a VPC endpoint.
 
@@ -238,8 +238,8 @@ Additional helpful documentation, links, and articles:
 - [Enable log collection with the Agent][3]
 - [Collect logs from your AWS services][4]
 
-{{< /site-region >}}
 [1]: https://aws.amazon.com/privatelink/
 [2]: https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html
 [3]: /agent/logs
 [4]: /integrations/amazon_web_services/#log-collection
+{{< /site-region >}}

--- a/content/en/integrations/guide/azure-native-programmatic-management.md
+++ b/content/en/integrations/guide/azure-native-programmatic-management.md
@@ -11,7 +11,7 @@ further_reading:
   text: "Managing the Azure Native Integration"
 ---
 
-{{% site-region region="us3" %}}
+{{< site-region region="us3" >}}
 
 ## Overview
 
@@ -77,12 +77,12 @@ Once the Datadog resource is set up in your Azure account, configure log collect
 [3]: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/datadog_monitors
 [4]: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/datadog_monitors#role-assignment
 [5]: https://learn.microsoft.com/en-us/azure/partner-solutions/datadog/create#configure-metrics-and-logs
-{{% /site-region %}}
+{{< /site-region >}}
 
-{{% site-region region="us,us5,eu,ap1,gov" %}}
+{{< site-region region="us,us5,eu,ap1,gov" >}}
 
 <div class="alert alert-info">The Azure Native integration is only available for organizations on Datadog's US3 site. If you're using a different <a href="https://docs.datadoghq.com/getting_started/site/" target="_blank">Datadog site</a>, see the standard <a href="https://docs.datadoghq.com/integrations/guide/azure-programmatic-management/" target="_blank">Azure Programmatic Management guide</a>. If you're using the Datadog US3 site, <a href="?site=us3" target="_blank">change the site selector</a> on the right of this page.</div>
 
-{{% /site-region %}}
+{{< /site-region >}}
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -19,6 +19,16 @@ The Datadog Agent and some tracing libraries have options available to address t
 
 If your fine-tuning needs aren't covered and you need assistance, reach out to [the Datadog support team][1].
 
+## Top
+this is a new header above a site-region
+
+{{< site-region region="us3,eu">}}
+## Testing this Header 
+Does this header and info appear using the page fragment
+
+{{< /site-region >}}
+## Bottom
+this is a new header below a site-region
 ## Generalizing resource names and filtering baseline
 
 Datadog enforces several filtering mechanisms on spans as a baseline, to provide sound defaults for basic security and generalize resource names to facilitate grouping during analysis. In particular:

--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -19,16 +19,6 @@ The Datadog Agent and some tracing libraries have options available to address t
 
 If your fine-tuning needs aren't covered and you need assistance, reach out to [the Datadog support team][1].
 
-## Top
-this is a new header above a site-region
-
-{{< site-region region="us3,eu">}}
-## Testing this Header 
-Does this header and info appear using the page fragment
-
-{{< /site-region >}}
-## Bottom
-this is a new header below a site-region
 ## Generalizing resource names and filtering baseline
 
 Datadog enforces several filtering mechanisms on spans as a baseline, to provide sound defaults for basic security and generalize resource names to facilitate grouping during analysis. In particular:

--- a/layouts/partials/table-of-contents/scraped-toc.html
+++ b/layouts/partials/table-of-contents/scraped-toc.html
@@ -1,7 +1,6 @@
 {{/*  
     TOC that is able to render markdown headers nested in `site-region` shortcodes.
-    Using the markdown shortcodes `%%` may cause 
-    This prevents link movement caused by the format link script.
+    This is an alternative solution to changing site-region shortcodes across docs to use md shortcode syntax ({{% %}}) 
 */}}
 <nav id="TableOfContents">
     <ul>

--- a/layouts/partials/table-of-contents/scraped-toc.html
+++ b/layouts/partials/table-of-contents/scraped-toc.html
@@ -1,0 +1,34 @@
+{{/*  
+    TOC that is able to render markdown headers nested in `site-region` shortcodes.
+    Using the markdown shortcodes `%%` may cause 
+    This prevents link movement caused by the format link script.
+*/}}
+<nav id="TableOfContents">
+    <ul>
+    {{ $headers_html := (findRE `<h([2-3]).*?>.*<\/h[2-3]>` .Content) }}
+    {{ $prev_h_level := 3 }}
+    {{ $level_nested := 0 }}
+    {{ range $i, $header := $headers_html }}
+      {{ $heading_info := split (replaceRE `<h([2-3]).*?id=\"(.*)\".*?>(.*)<\/h[2-3]>` "$1,$2,$3" $header) "," }}
+
+      {{ $h_level := (index $heading_info 0) }}
+      {{ $h_id := (index $heading_info 1) }}
+      {{ $h_title := (index $heading_info 2) }}
+
+      {{ if gt $h_level $prev_h_level }}
+          <ul>
+          {{ $level_nested = $prev_h_level }}
+      {{ else if le $h_level $level_nested }}
+          </li></ul>
+          {{ $level_nested = 0 }}
+      {{ else if ne $i 0 }}
+          </li>
+      {{ end }}
+
+      <li>
+          <a href="#{{ $h_id }}">{{ $h_title }}</a>
+
+      {{ $prev_h_level = $h_level }}
+    {{ end }}
+    </ul>
+</nav>

--- a/layouts/partials/table-of-contents/table-of-contents.html
+++ b/layouts/partials/table-of-contents/table-of-contents.html
@@ -1,15 +1,4 @@
 {{ $ctx := . }}
-{{- define "partials/headings" -}}
-  {{- $ctx := .ctx -}}
-  <ul>
-    {{- range $k, $v := .data -}}
-       <li id="{{ $v.ID | anchorize }}">
-          <a href="#{{ $v.ID | anchorize }}">{{ $v.Title }}</a>
-          {{- partial "partials/headings" (dict "data" $v.Headings "ctx" $ctx) -}}
-       </li>
-    {{- end -}}
-  </ul>
-{{- end -}}
 <div class="js-toc-container toc-container">
     <div class="toc">
         <div class="js-toc {{ if .Params.disable_toc }} d-none {{ else }} {{ end }}">
@@ -38,8 +27,22 @@
                   </ul>
                 </nav>
               {{ else }}
-                <nav id="TableOfContents">
-                  {{- partial "partials/headings" (dict "data" (index .Fragments.Headings 0).Headings "ctx" $ctx) -}}
+                <nav id="TableOfContents"><ul>
+                  {{ $list := slice }}
+                  {{ $res := (findRE `<h([1-6]).*?>.*<\/h[1-6]>` .Content) }}
+                  {{ $prevH := 0 }}
+                  {{ range $i, $head := $res }}
+                    {{ $res := replaceRE `<h([1-6]).*?id=\"(.*)\".*?>(.*)<\/h[1-6]>` "$1,$2,$3" $head }}
+                    {{ $s := split $res ","}}
+                    {{ $hlevel := (index $s 0) }}
+                    {{ $id := (index $s 1) }}
+                    {{ $title := (index $s 2) }}
+                    {{ $list = $list | append (dict "ID" $id "Title" $title "Headings" "") }}
+                    <li>
+                        <a href="#{{ $id }}">{{ $title }}</a>
+                    </li>
+                  {{ end }}
+                  </ul>
                 </nav>
               {{ end }}
             {{ end }}

--- a/layouts/partials/table-of-contents/table-of-contents.html
+++ b/layouts/partials/table-of-contents/table-of-contents.html
@@ -27,6 +27,7 @@
                   </ul>
                 </nav>
               {{ else }}
+                {{ if in .RawContent "{{< site-region" }}
                 <nav id="TableOfContents"><ul>
                   {{ $list := slice }}
                   {{ $res := (findRE `<h([1-6]).*?>.*<\/h[1-6]>` .Content) }}
@@ -44,6 +45,9 @@
                   {{ end }}
                   </ul>
                 </nav>
+                {{ else }}
+                  {{ .TableOfContents }}
+                {{ end }}
               {{ end }}
             {{ end }}
         </div>

--- a/layouts/partials/table-of-contents/table-of-contents.html
+++ b/layouts/partials/table-of-contents/table-of-contents.html
@@ -28,35 +28,7 @@
                 </nav>
               {{ else }}
                 {{ if in .RawContent "{{< site-region" }}
-                  <nav id="TableOfContents">
-                    <ul>
-                    {{ $res := (findRE `<h([1-6]).*?>.*<\/h[1-6]>` .Content) }}
-                    {{ $prevH := 100 }}
-                    {{ $levelNested := 0 }}
-                    {{ range $i, $head := $res }}
-                      {{ $res := replaceRE `<h([1-6]).*?id=\"(.*)\".*?>(.*)<\/h[1-6]>` "$1,$2,$3" $head }}
-                      {{ $s := split $res ","}}
-                      {{ $hlevel := (index $s 0) }}
-                      {{ $id := (index $s 1) }}
-                      {{ $title := (index $s 2) }}
-
-                      {{ if gt $hlevel $prevH }}
-                          <ul>
-                          {{ $levelNested = $prevH }}
-                      {{ else if le $hlevel $levelNested }}
-                          </li></ul>
-                          {{ $levelNested = 0 }}
-                      {{ else if ne $i 0 }}
-                          </li>
-                      {{ end }}
-
-                      <li>
-                          <a href="#{{ $id }}">{{ $title }}</a>
-
-                      {{ $prevH = $hlevel }}
-                    {{ end }}
-                    </ul>
-                  </nav>
+                  {{ partial "table-of-contents/scraped-toc.html" . }}
                 {{ else }}
                   {{ .TableOfContents }}
                 {{ end }}

--- a/layouts/partials/table-of-contents/table-of-contents.html
+++ b/layouts/partials/table-of-contents/table-of-contents.html
@@ -28,23 +28,35 @@
                 </nav>
               {{ else }}
                 {{ if in .RawContent "{{< site-region" }}
-                <nav id="TableOfContents"><ul>
-                  {{ $list := slice }}
-                  {{ $res := (findRE `<h([1-6]).*?>.*<\/h[1-6]>` .Content) }}
-                  {{ $prevH := 0 }}
-                  {{ range $i, $head := $res }}
-                    {{ $res := replaceRE `<h([1-6]).*?id=\"(.*)\".*?>(.*)<\/h[1-6]>` "$1,$2,$3" $head }}
-                    {{ $s := split $res ","}}
-                    {{ $hlevel := (index $s 0) }}
-                    {{ $id := (index $s 1) }}
-                    {{ $title := (index $s 2) }}
-                    {{ $list = $list | append (dict "ID" $id "Title" $title "Headings" "") }}
-                    <li>
-                        <a href="#{{ $id }}">{{ $title }}</a>
-                    </li>
-                  {{ end }}
-                  </ul>
-                </nav>
+                  <nav id="TableOfContents">
+                    <ul>
+                    {{ $res := (findRE `<h([1-6]).*?>.*<\/h[1-6]>` .Content) }}
+                    {{ $prevH := 100 }}
+                    {{ $levelNested := 0 }}
+                    {{ range $i, $head := $res }}
+                      {{ $res := replaceRE `<h([1-6]).*?id=\"(.*)\".*?>(.*)<\/h[1-6]>` "$1,$2,$3" $head }}
+                      {{ $s := split $res ","}}
+                      {{ $hlevel := (index $s 0) }}
+                      {{ $id := (index $s 1) }}
+                      {{ $title := (index $s 2) }}
+
+                      {{ if gt $hlevel $prevH }}
+                          <ul>
+                          {{ $levelNested = $prevH }}
+                      {{ else if le $hlevel $levelNested }}
+                          </li></ul>
+                          {{ $levelNested = 0 }}
+                      {{ else if ne $i 0 }}
+                          </li>
+                      {{ end }}
+
+                      <li>
+                          <a href="#{{ $id }}">{{ $title }}</a>
+
+                      {{ $prevH = $hlevel }}
+                    {{ end }}
+                    </ul>
+                  </nav>
                 {{ else }}
                   {{ .TableOfContents }}
                 {{ end }}

--- a/layouts/partials/table-of-contents/table-of-contents.html
+++ b/layouts/partials/table-of-contents/table-of-contents.html
@@ -1,5 +1,15 @@
 {{ $ctx := . }}
-
+{{- define "partials/headings" -}}
+  {{- $ctx := .ctx -}}
+  <ul>
+    {{- range $k, $v := .data -}}
+       <li id="{{ $v.ID | anchorize }}">
+          <a href="#{{ $v.ID | anchorize }}">{{ $v.Title }}</a>
+          {{- partial "partials/headings" (dict "data" $v.Headings "ctx" $ctx) -}}
+       </li>
+    {{- end -}}
+  </ul>
+{{- end -}}
 <div class="js-toc-container toc-container">
     <div class="toc">
         <div class="js-toc {{ if .Params.disable_toc }} d-none {{ else }} {{ end }}">
@@ -28,7 +38,9 @@
                   </ul>
                 </nav>
               {{ else }}
-                {{ .TableOfContents }}
+                <nav id="TableOfContents">
+                  {{- partial "partials/headings" (dict "data" (index .Fragments.Headings 0).Headings "ctx" $ctx) -}}
+                </nav>
               {{ end }}
             {{ end }}
         </div>


### PR DESCRIPTION
### What does this PR do?

An alternative solution to the site-region syntax updates:

In some situations using a site-region shortcode with `<` is causing the table of contents to omit items.

This PR resolves this by using the built in `.TableOfContents` for most sections except pages with `<` style site-region shortcodes in which case we load a custom toc that will read the rendered page headers and generate a correct version.

js changes:
- hideTOCItems that are not specific to the selected region.
  - hides toc items that have corresponding headers nested in tabs. (this ensures the new scrapped toc works like the hugo tableofcontents)
  - adding this function to the async-loading script to hide toc items when a page is accessed by navigating the left nav.

### Motivation

In relation to:
- https://github.com/DataDog/documentation/pull/18401
- https://github.com/DataDog/documentation/pull/18169
- https://github.com/DataDog/documentation/pull/17329
- https://github.com/DataDog/documentation/pull/16295

### Preview


using the new scrapped toc:
- https://docs-staging.datadoghq.com/david.jones/custom-toc/integrations/guide/azure-native-manual-setup/?tab=link#supported-platforms
- https://docs-staging.datadoghq.com/david.jones/custom-toc/logs/guide/azure-native-logging-guide/?tab=azurecliv20#monitor-the-integration-status
- https://docs-staging.datadoghq.com/david.jones/custom-toc/network_monitoring/performance/setup/?tab=agentlinux#setup
- https://docs-staging.datadoghq.com/david.jones/custom-toc/integrations/guide/azure-native-programmatic-management/

using the hugo table of contents:
- https://docs-staging.datadoghq.com/david.jones/custom-toc/agent/guide/private-link/?tab=useast1
- https://docs-staging.datadoghq.com/david.jones/custom-toc/integrations/azure/#setup

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
