### PR TITLE
DOCS-5854 changing custom-code to code-level naming

### DIFF
--- a/content/en/security/application_security/enabling/java.md
+++ b/content/en/security/application_security/enabling/java.md
@@ -118,14 +118,14 @@ java -javaagent:dd-java-agent.jar \
 
 {{< img src="/security/application_security/appsec-getstarted-threat-and-vuln.mp4" alt="Video showing Signals explorer and details, and Vulnerabilities explorer and details." video="true" >}}
 
-## Enabling custom code vulnerability detection
+## Enabling code-level vulnerability detection
 
-If your service runs a [tracing library version that supports Vulnerability Management for Custom Code Vulnerability Detection][3], enable the capability by setting the `DD_IAST_ENABLED=true` environment variable and restarting your service.
+If your service runs a [tracing library version that supports Vulnerability Management for code-Level vulnerability detection][3], enable the capability by setting the `DD_IAST_ENABLED=true` environment variable and restarting your service.
 
-To detect custom code vulnerabilities for your service:
+To detect code-level vulnerabilities for your service:
 
 1. [Update your Datadog Agent][6] to at least version 7.41.1.
-2. Update your tracing library to at least the minimum version needed to turn on custom code vulnerability detection. For details, see [ASM capabilities support][3].
+2. Update your tracing library to at least the minimum version needed to turn on code-level vulnerability detection. For details, see [ASM capabilities support][3].
 3. Add the `DD_IAST_ENABLED=true` environment variable to your application configuration.
 
    From the command line:
@@ -195,9 +195,9 @@ Update your ECS task definition JSON file, by adding this in the environment sec
    {{< /tabs >}}
 
 4. Restart your service.
-5. To see Application Vulnerability Management for custom code vulnerabilities in action, browse your service and the custom code vulnerabilities appear in the [Vulnerability Explorer][4]. The `SOURCE` column shows the Custom Code value.
+5. To see Application Vulnerability Management for code-level vulnerabilities in action, browse your service and the code-level vulnerabilities appear in the [Vulnerability Explorer][4]. The `SOURCE` column shows the Code value.
 
-{{< img src="/security/application_security/Custom_Code_vulnerability.mp4" alt="Video showing Vulnerabilities tab, Custom Code source, and inspecting the custom code vulnerability" video="true" >}}
+{{< img src="/security/application_security/Code-Level-Vulnerability-Details.mp4" alt="Video showing Vulnerabilities tab, Code source, and inspecting the code vulnerability" video="true" >}}
 
 If you need additional assistance, contact [Datadog support][5].
 

--- a/content/en/security/application_security/enabling/nodejs.md
+++ b/content/en/security/application_security/enabling/nodejs.md
@@ -151,14 +151,14 @@ DD_APPSEC_ENABLED=true node app.js
 
 {{< img src="/security/application_security/appsec-getstarted-threat-and-vuln.mp4" alt="Video showing Signals explorer and details, and Vulnerabilities explorer and details." video="true" >}}
 
-## Enabling custom code vulnerability detection
-If your service is running a [tracing library version that supports Vulnerability Management for Custom Code Vulnerability Detection][3], enable it by setting the `DD_IAST_ENABLED=true` environment variable and restart your service.
+## Enabling code-level vulnerability detection
+If your service runs a [tracing library version that supports Vulnerability Management for code-level vulnerability detection][3], enable the capability by setting the `DD_IAST_ENABLED=true` environment variable and restarting your service.
 
 
-To leveraging custom code vulnerability detection capabilities for your service:
+To leverage code-level vulnerability detection capabilities for your service:
 
 1. [Update your Datadog Agent][4] to at least version 7.41.1.
-2. Update your tracing library to at least the minimum version needed to turn on custom code vulnerability detection. For details, see [ASM capabilities support][3].
+2. Update your tracing library to at least the minimum version needed to turn on code-level vulnerability detection. For details, see [ASM capabilities support][3].
 3. Add the `DD_IAST_ENABLED=true` environment variable to your application configuration.
 
    If you initialize the APM library on the command line using the `--require` option to Node.js:
@@ -225,9 +225,9 @@ Update your ECS task definition JSON file, by adding this in the environment sec
 {{< /tabs >}}
 
 4. Restart your service.
-5. To see Application Vulnerability Management for custom code vulnerabilities in action, browse your service and the custom code vulnerabilities appear in the [Vulnerability Explorer][5]. The `SOURCE` column shows the Custom Code value.
+5. To see Application Vulnerability Management for code-level vulnerabilities in action, browse your service and the code-level vulnerabilities appear in the [Vulnerability Explorer][5]. The `SOURCE` column shows the Code value.
 
-{{< img src="/security/application_security/Custom_Code_vulnerability.mp4" alt="Video showing Vulnerabilities tab, Custom Code source, and inspecting the custom code vulnerability" video="true" >}}
+{{< img src="/security/application_security/Code-Level-Vulnerability-Details.mp4" alt="Video showing Vulnerabilities tab, Code source, and inspecting the code-level vulnerability" video="true" >}}
 
 If you need additional assistance, contact [Datadog support][6].
 

--- a/content/en/security/application_security/vulnerability_management/_index.md
+++ b/content/en/security/application_security/vulnerability_management/_index.md
@@ -43,20 +43,20 @@ The explorer also offers remediation recommendations for detected vulnerabilitie
 
 {{< img src="security/application_security/appsec-vuln-details2.png" alt="Application Vulnerability Management vulnerability details page showing affected services, links to infrastructure, suggested remediation, and links to more information." style="width:100%;" >}}
 
-## Detect known open source vulnerabilities
+## Manage open source vulnerabilities
 
 Application Vulnerability Management detects the open source libraries used by your application at runtime, and reports security vulnerabilities associated with them. In order to do it, Application Vulnerability Management combines various public open source software known vulnerability data sources along with data obtained by Datadog security research team. Datadog does not scan your source code and the analysis is based on how your application behaves during runtime.
 
-## Detect custom code vulnerabilities
+## Manage code-level vulnerabilities
 
-<div class="alert alert-info">Custom code vulnerabilities (<em>unknown vulnerabilities</em>) detection for Application Vulnerability Management is in beta. To use it for your service, follow the <a href="/security/application_security/enabling/">Setup instructions.</a></div>
+<div class="alert alert-info">Code-level vulnerabilities detection for Application Vulnerability Management is in beta. To use it for your service, follow follow the <a href="/security/application_security/enabling/">Setup instructions.</a></div>
 
 Datadog is able to indicate the file name and line number where the vulnerability is located, without scanning the source code.
 
-The custom code vulnerabilities it can find include:
+The code-level vulnerabilities it can find include:
 
-- Insecure Cipher
-- Insecure Hashing
+- Weak Cipher
+- Weak Hash
 - SQL injection
 - Path traversal
 - LDAP injection
@@ -67,9 +67,9 @@ The custom code vulnerabilities it can find include:
 - Cookie without SameSite Flag
 - Unvalidated Redirect
 
-### Disabling custom code vulnerability detection capability
+### Disabling code-level vulnerability detection capability
 
-To disable custom code vulnerability detection capability in Vulnerability Management, remove the `DD_IAST_ENABLED=true` environment variable from your application configuration, and restart your service.
+To disable code-level vulnerability detection capability in Vulnerability Management, remove the `DD_IAST_ENABLED=true` environment variable from your application configuration, and restart your service.
 
 If you need additional help, contact [Datadog support][1].
 

--- a/content/en/security/application_security/vulnerability_management/_index.md
+++ b/content/en/security/application_security/vulnerability_management/_index.md
@@ -49,7 +49,7 @@ Application Vulnerability Management detects the open source libraries used by y
 
 ## Manage code-level vulnerabilities
 
-<div class="alert alert-info">Code-level vulnerabilities detection for Application Vulnerability Management is in beta. To use it for your service, follow follow the <a href="/security/application_security/enabling/">Setup instructions.</a></div>
+<div class="alert alert-info">Code-level vulnerabilities detection for Application Vulnerability Management is in beta. To use it for your service, follow the <a href="/security/application_security/enabling/">Setup instructions.</a></div>
 
 Datadog is able to indicate the file name and line number where the vulnerability is located, without scanning the source code.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR changes naming references from "custom code vulnerability detection" to the new name "code-level vulnerability detection". The changes include changes to the Application Vulnerability management doc, as well as the 2 currently supported libraries for this capability (node.js and java).
Includes also new video for both libraries.

### Motivation
[DOCS-5854](https://datadoghq.atlassian.net/browse/DOCS-5854)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5854]: https://datadoghq.atlassian.net/browse/DOCS-5854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ