### PR TITLE
Update clustercheckrunners.md | Rewriting Summary section at the top

### DIFF
--- a/content/en/containers/guide/clustercheckrunners.md
+++ b/content/en/containers/guide/clustercheckrunners.md
@@ -21,7 +21,7 @@ The Cluster Agent can dispatch out two types of checks: [endpoint checks][1] and
 Endpoint checks are dispatched specifically to the regular Datadog Agent on the same node as the application pod endpoints. Executing endpoint checks on the same node as the application endpoint allows proper tagging of the metrics.
 
 Cluster checks monitor internal Kubernetes services, as well as external services like managed databases and network devices, and can be dispatched much more freely.
-The Cluster Check Runners are an optional strategy to have a small set of Agents dedicated to just running the cluster checks, leaving the endpoint checks to the normal Agent. This can be beneficial to control the dispatching of cluster checks, especially when the scale of your cluster checks increases.
+Using Cluster Check Runners is optional. When you use Cluster Check Runners, a small, dedicated set of Agents runs the cluster checks, leaving the endpoint checks to the normal Agent. This strategy can be beneficial to control the dispatching of cluster checks, especially when the scale of your cluster checks increases.
 
 ## Set up
 

--- a/content/en/containers/guide/clustercheckrunners.md
+++ b/content/en/containers/guide/clustercheckrunners.md
@@ -16,7 +16,11 @@ further_reading:
   text: "Cluster Checks"
 ---
 
-The Cluster Agent can dispatch out two types of checks, [endpoint checks][1] and [cluster checks][2]. These are slightly different as endpoint checks are dispatched specifically to the regular Datadog Agent on the same node as the application pod endpoints. This allows proper tagging of the metrics. Cluster checks monitor internal Kubernetes services, as well as external services like managed databases and network devices, and can be dispatched much more freely.
+The Cluster Agent can dispatch out two types of checks: [endpoint checks][1] and [cluster checks][2]. The checks are slightly different. 
+
+Endpoint checks are dispatched specifically to the regular Datadog Agent on the same node as the application pod endpoints. Executing endpoint checks on the same node as the application endpoint allows proper tagging of the metrics.
+
+Cluster checks monitor internal Kubernetes services, as well as external services like managed databases and network devices, and can be dispatched much more freely.
 The Cluster Check Runners are an optional strategy to have a small set of Agents dedicated to just running the cluster checks, leaving the endpoint checks to the normal Agent. This can be beneficial to control the dispatching of cluster checks, especially when the scale of your cluster checks increases.
 
 ## Set up

--- a/content/en/containers/guide/clustercheckrunners.md
+++ b/content/en/containers/guide/clustercheckrunners.md
@@ -16,9 +16,8 @@ further_reading:
   text: "Cluster Checks"
 ---
 
-While the regular Datadog Agent executes [endpoint checks][1] for your node and application Pods, a _cluster check runner_ is specifically dedicated to running [_cluster checks_][2], which monitor internal Kubernetes services, as well as external services like managed databases and network devices.
-
-**Note**: When using a cluster check runner, it is not necessary to enable cluster checks for the regular Datadog Agent.
+The Cluster Agent can dispatch out two types of checks, [endpoint checks][1] and [cluster checks][2]. These are slightly different as endpoint checks are dispatched specifically to the regular Datadog Agent on the same node as the application pod endpoints. This allows proper tagging of the metrics. Cluster checks monitor internal Kubernetes services, as well as external services like managed databases and network devices, and can be dispatched much more freely.
+The Cluster Check Runners are an optional strategy to have a small set of Agents dedicated to just running the cluster checks, leaving the endpoint checks to the normal Agent. This can be beneficial to control the dispatching of cluster checks, especially when the scale of your cluster checks increases.
 
 ## Set up
 


### PR DESCRIPTION
See context for this here: https://dd.slack.com/archives/C4UD9L724/p1689091684804119

This new description (credit to Jack Davenport) is more informational and removes the misleading 'Note' section from before that had some customers confused. (this note section: Note: When using a cluster check runner, it is not necessary to enable cluster checks for the regular Datadog Agent.)

In the words of Jack Davenport
its not necessary to enable cluster checks for the regular Datadog Agent - but given Helm and the Operator is managing everything for you that note isn’t really adding anything that the preceding paragraph isn’t covering. Its just adding a wrinkle where there doesn’t need to be. If there was a DaemonSet set of instructions that would make sense to have there.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
