### PR TITLE
Revamp JMX Autodiscovery doc

### DIFF
--- a/content/en/containers/guide/autodiscovery-with-jmx.md
+++ b/content/en/containers/guide/autodiscovery-with-jmx.md
@@ -24,7 +24,7 @@ If you are using the Java tracer for your applications, you can alternatively ta
 
 ## Prerequisites
 ### Agent JMX image
-The default Datadog Agent image does **not** come with the JMX utilities installed. In order to setup a JMX integration you need to append `-jmx` to your Agent image's tag. 
+The default Datadog Agent image does **not** come with the JMX utilities installed. In order to set up a JMX integration you need to append `-jmx` to your Agent image's tag.
 
 For example, `gcr.io/datadoghq/agent:latest-jmx`.
 
@@ -77,11 +77,11 @@ The Datadog Agent comes with several JMX integrations pre-configured.
 
 These integrations have a `metrics.yaml` file predefined to match the expected pattern of the returned JMX metrics per application. Use these as your `<INTEGRATION_NAME>` as appropriate for your applications in the following sections to take advantage of those configurations. 
 
-Alternatively use the `<INTEGRATION_NAME>` of `jmx` to setup a basic JMX integration and collect the default `jvm.*` metrics only.
+Alternatively use the `<INTEGRATION_NAME>` of `jmx` to set up a basic JMX integration and collect the default `jvm.*` metrics only.
 
 ## Autodiscovery configurations
 
-Once you are using the JMX version of the Datadog Agent image and chosen your `<INTEGRATION_NAME>` you can configure your integration with autodiscovery. Use either:
+Once you are using the JMX version of the Datadog Agent image and choose your `<INTEGRATION_NAME>` you can configure your integration with autodiscovery. Use either:
 
 - [Autodiscovery annotations](#autodiscovery-annotations)
 - [Autodiscovery configuration files](#autodiscovery-configuration-files)
@@ -141,7 +141,7 @@ In this example:
 
 With this configuration the Datadog Agent discovers this pod and makes a request to the JMX Server relative to the `%%host%%` [Autodiscovery template variable][3], resolving to the IP address of the discovered pod. This is why the `java.rmi.server.hostname` is set to the `POD_IP` address previously populated with the [Kubernetes downward API][5].
 
-**Note**: The `JAVA_OPTS` environment variable is commonly used in Java based container images as a startup parameter (ex: `java $JAVA_OPTS -jar app.jar`). If you are using a custom application, or, your application doesn't follow this pattern set these system properties manually.
+**Note**: The `JAVA_OPTS` environment variable is commonly used in Java based container images as a startup parameter (ex: `java $JAVA_OPTS -jar app.jar`). If you are using a custom application, or, your application doesn't follow this pattern, set these system properties manually.
 
 
 ### Example Tomcat Autodiscovery annotations
@@ -254,9 +254,9 @@ instances:
     port: "<JMX_PORT>"
 ```
 
-Replace `<SHORT_IMAGE>` with the short image name of your desired container. For example the container image `gcr.io/CompanyName/my-app:latest` would have short image name of `my-app`. As the Datadog Agent discovers that container it sets up the JMX configuration as described in this file. 
+Replace `<SHORT_IMAGE>` with the short image name of your desired container. For example the container image `gcr.io/CompanyName/my-app:latest` would have a short image name of `my-app`. As the Datadog Agent discovers that container it sets up the JMX configuration as described in this file.
 
-You can alternatively reference and specify [custom identifiers to you containers][4] if you do not want to base this on the short image name.
+You can alternatively reference and specify [custom identifiers to your containers][4] if you do not want to base this on the short image name.
 
 The configuration files similar to the annotations can use [Autodiscovery template variables][3], in this case the `host` configuration is using `%%host%%` to resolve to the IP Address of the discovered container.
 
@@ -317,7 +317,7 @@ spec:
 
 {{% tab "Custom Image" %}}
 ### Custom Agent image with configuration files
-If you can't mount those files in the Agent container (like on AWS ECS), you should re-build the Agent docker image with the desired configuration files in it. For example:
+If you can't mount those files in the Agent container (like on AWS ECS), you should build the Agent docker image with the desired configuration files in it. For example:
 
   ```Dockerfile
   FROM gcr.io/datadoghq/agent:latest-jmx
@@ -331,7 +331,7 @@ Then use this new custom image as your regular containerized Agent.
 {{< /tabs >}}
 
 ### Expose JMX Server
-Similar to the autodiscovery annotations sample, you still need to setup the JMX Server in a way that allows the Agent to access it. This is the same structure as before:
+Similar to the autodiscovery annotations sample, you still need to set up the JMX Server in a way that allows the Agent to access it. This is the same structure as before:
 
 ```yaml
 spec:

--- a/content/en/containers/guide/autodiscovery-with-jmx.md
+++ b/content/en/containers/guide/autodiscovery-with-jmx.md
@@ -18,329 +18,394 @@ further_reading:
       text: 'Dynamically assign and collect tags from your application'
 ---
 
-Leverage integrations autodiscovery annotations or use Autodiscovery Container Identifiers to collect your JMX-applications metrics from your pods in Kubernetes. Autodiscovery annotations is the recommended way to configure your Datadog-JMX integration, if the set of configuration parameters is too long to fit in annotations, use the [Autodiscovery Container Identifiers](#autodiscovery-container-identifiers) method.
+Leverage Datadog's JMX based integrations to collect the JMX-applications metrics from your pods in Kubernetes. In containerized environments there are a few differences in how the Agent connects to the JMX server. Autodiscovery features make it possible to dynamically setup these integrations.
+
+If you are using the Java tracer for your applications, you can alternatively take advantage of the [Java runtime metrics][12] feature to send these metrics to the Agent.
+
+## Prerequisites
+### Agent JMX image
+The default Datadog Agent image does **not** come with the JMX utilities installed. In order to setup a JMX integration you need to append `-jmx` to your Agent image's tag. 
+
+For example, `gcr.io/datadoghq/agent:latest-jmx`.
+
+This can be added by the following configuration:
+
+{{< tabs >}}
+{{% tab "Helm" %}}
+```yaml
+agents:
+  image:
+    tagSuffix: jmx
+```
+{{% /tab %}}
+{{% tab "Operator" %}}
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  #(...)
+  override:
+    nodeAgent:
+      image:
+        jmxEnabled: true
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+### Available JMX integrations
+The Datadog Agent comes with several JMX integrations pre-configured.
+
+  | Integration Name         | Metrics file       | Configuration file      |
+  |--------------------------|--------------------|-------------------------|
+  | [activemq][41]           | [metrics.yaml][42] | [conf.yaml.example][43] |
+  | [cassandra][44]          | [metrics.yaml][45] | [conf.yaml.example][46] |
+  | [confluent_platform][47] | [metrics.yaml][48] | [conf.yaml.example][49] |
+  | [hazelcast][50]          | [metrics.yaml][51] | [conf.yaml.example][52] |
+  | [hive][53]               | [metrics.yaml][54] | [conf.yaml.example][55] |
+  | [hivemq][56]             | [metrics.yaml][57] | [conf.yaml.example][58] |
+  | [hudi][59]               | [metrics.yaml][60] | [conf.yaml.example][61] |
+  | [ignite][62]             | [metrics.yaml][63] | [conf.yaml.example][64] |
+  | [jboss_wildfly][66]      | [metrics.yaml][67] | [conf.yaml.example][68] |
+  | [kafka][69]              | [metrics.yaml][70] | [conf.yaml.example][71] |
+  | [presto][72]             | [metrics.yaml][73] | [conf.yaml.example][74] |
+  | [solr][75]               | [metrics.yaml][76] | [conf.yaml.example][77] |
+  | [sonarqube][78]          | [metrics.yaml][79] | [conf.yaml.example][80] |
+  | [tomcat][81]             | [metrics.yaml][82] | [conf.yaml.example][83] |
+  | [weblogic][84]           | [metrics.yaml][85] | [conf.yaml.example][86] |
+
+These integrations have a `metrics.yaml` file predefined to match the expected pattern of the returned JMX metrics per application. Use these as your `<INTEGRATION_NAME>` as appropriate for your applications in the following sections to take advantage of those configurations. 
+
+Alternatively use the `<INTEGRATION_NAME>` of `jmx` to setup a basic JMX integration and collect the default `jvm.*` metrics only.
+
+## Autodiscovery configurations
+
+Once you are using the JMX version of the Datadog Agent image and chosen your `<INTEGRATION_NAME>` you can configure your integration with autodiscovery. Use either:
+
+- [Autodiscovery annotations](#autodiscovery-annotations)
+- [Autodiscovery configuration files](#autodiscovery-configuration-files)
+
+Autodiscovery annotations are the recommended way to configure your Datadog-JMX integration. However, if you need to heavily customize the configuration parameters the Autodiscovery configuration file method may be easier to manage rather than annotations.
 
 ## Autodiscovery annotations
 
-The autodiscovery annotations logic consists in applying the JMX check configuration elements, through annotations, to your pod in order to allow the Agent to "automatically discover" them and configure its JMX check accordingly:
+The autodiscovery annotations logic consists of applying the JMX check configuration through annotations on your Java based pods in order to allow the Agent to "automatically discover" them and configure its JMX check accordingly. Ensure these annotations are on the created Pod, and not on the object (Deployment, DaemonSet, etc) creating the pod. 
 
-1. [Launch the Agent in your Kubernetes cluster][1] **with the `gcr.io/datadoghq/agent:latest-jmx` image name** instead of the regular `gcr.io/datadoghq/agent:latest`.
-
-2. Apply the Autodiscovery annotations to the containers containing your JMX-application:
-
-    ```yaml
-    apiVersion: v1
-    kind: Pod
-    metadata:
-        name: <POD_NAME>
-        annotations:
-            ad.datadoghq.com/<CONTAINER_IDENTIFIER>.check_names: '["<INTEGRATION_NAME>"]'
-            ad.datadoghq.com/<CONTAINER_IDENTIFIER>.init_configs: '[{"is_jmx": true, "collect_default_metrics": true}]'
-            ad.datadoghq.com/<CONTAINER_IDENTIFIER>.instances: '[{"host": "%%host%%","port":"<JMX_PORT>"}]'
-            ad.datadoghq.com/<CONTAINER_IDENTIFIER>.logs: '[{"source":"<INTEGRATION_NAME>","service":"<INTEGRATION_NAME>"}]'
-        # (...)
-
-    spec:
-        containers:
-            - name: '<CONTAINER_IDENTIFIER>'
-            # (...)
-              env:
-              - name: POD_IP
-                valueFrom:
-                  fieldRef:
-                    fieldPath: status.podIP
-
-              - name: JAVA_OPTS
-                value: >-
-                  -Xms256m -Xmx6144m
-                  -Dcom.sun.management.jmxremote
-                  -Dcom.sun.management.jmxremote.authenticate=false
-                  -Dcom.sun.management.jmxremote.ssl=false
-                  -Dcom.sun.management.jmxremote.local.only=false
-                  -Dcom.sun.management.jmxremote.port=<JMX_PORT>
-                  -Dcom.sun.management.jmxremote.rmi.port=<JMX_PORT>
-                  -Djava.rmi.server.hostname=$(POD_IP)
-    ```
-
-      The `JAVA_OPTS` environment variable needs to be created, so that your JMX server allows the agent to connect to the RMI registry.
-
-      **Note**:
-      - `<JMX_PORT>` references the port that exposes JMX metrics.
-      - In the example above, the connection to the RMI registry is not in SSL if you want to use SSL, use `"rmi_registry_ssl": true` in the `ad.datadoghq.com/<CONTAINER_IDENTIFIER>.instances` annotation and remove the corresponding `Dcom.sun.management.jmxremote` from `JAVA_OPTS`.
-
-The list of JMX-ready integrations name `<INTEGRATION_NAME>` are:
-
-- [activemq][2]
-- [cassandra][3]
-- [confluent_platform][4]
-- [hive][5]
-- [jboss_wildfly][6]
-- [kafka][7]
-- [solr][8]
-- [presto][9]
-- [tomcat][10]
-
-For instance if you have a tomcat running exposing its JMX metrics on port `9012` you would do:
+Apply the Autodiscovery annotations to the containers containing your JMX-application with the following template:
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-    name: tomcat-test
-    annotations:
-        ad.datadoghq.com/tomcat.check_names: '["tomcat"]'
-        ad.datadoghq.com/tomcat.init_configs: '[{"is_jmx": true, "collect_default_metrics": true}]'
-        ad.datadoghq.com/tomcat.instances: '[{"host": "%%host%%","port":"9012"}]'
-        ad.datadoghq.com/tomcat.logs: '[{"source":"Tomcat","service":"Tomcat"}]'
-
+  name: <POD_NAME>
+  annotations:
+    ad.datadoghq.com/<CONTAINER_IDENTIFIER>.checks: |
+      {
+        "<INTEGRATION_NAME>": {
+          "init_config": {
+            "is_jmx": true,
+            "collect_default_metrics": true
+          },
+          "instances": [{
+            "host": "%%host%%",
+            "port": "<JMX_PORT>"
+          }]
+        }
+      }
+    # (...)
 spec:
-    containers:
-        - name: tomcat
-          image: tomcat:8.0
-          imagePullPolicy: Always
-          ports:
-              - containerPort: 9012
-          env:
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-
-            - name: JAVA_OPTS
-              value: >-
-                -Xms256m -Xmx6144m
-                -Dcom.sun.management.jmxremote
-                -Dcom.sun.management.jmxremote.authenticate=false
-                -Dcom.sun.management.jmxremote.ssl=false
-                -Dcom.sun.management.jmxremote.local.only=false
-                -Dcom.sun.management.jmxremote.port=9012
-                -Dcom.sun.management.jmxremote.rmi.port=9012
-                -Djava.rmi.server.hostname=$(POD_IP)
+  containers:
+    - name: '<CONTAINER_IDENTIFIER>'
+      # (...)
+      env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: JAVA_OPTS
+          value: >-
+            -Dcom.sun.management.jmxremote
+            -Dcom.sun.management.jmxremote.authenticate=false
+            -Dcom.sun.management.jmxremote.ssl=false
+            -Dcom.sun.management.jmxremote.local.only=false
+            -Dcom.sun.management.jmxremote.port=<JMX_PORT>
+            -Dcom.sun.management.jmxremote.rmi.port=<JMX_PORT>
+            -Djava.rmi.server.hostname=$(POD_IP)
 ```
 
-## Autodiscovery container identifiers
+In this example:
+- The `<CONTAINER_IDENTIFIER>` matches the desired container within your pod
+- The `<INTEGRATION_NAME>` matches the desired integration relative to the previous section
+- The `<JMX_PORT>` can be set as desired, as long as it matches between the annotations and `JAVA_OPTS`
 
-If you need to pass a more complex configuration for your Datadog-JMX integration, leverage [Autodiscovery Container Identifiers][11] to pass custom integration configuration file or custom `metrics.yaml` file.
+With this configuration the Datadog Agent discovers this pod and makes a request to the JMX Server relative to the `%%host%%` [Autodiscovery template variable][28], resolving to the IP address of the discovered pod. This is why the `java.rmi.server.hostname` is set to the `POD_IP` address previously populated with the [Kubernetes downward API][30].
 
-### Agent preparation
+**Note**: The `JAVA_OPTS` environment variable is commonly used in Java based container images as a startup parameter (ex: `java $JAVA_OPTS -jar app.jar`). If you are using a custom application, or, your application doesn't follow this pattern set these system properties manually.
 
-Choose whether your Agent is running as a container in your cluster, or on your host directly:
+
+### Example Tomcat Autodiscovery annotations
+For instance to run the `tomcat` JMX integration against port `9012` you would configure this as:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tomcat-test
+  annotations:
+    ad.datadoghq.com/tomcat.checks: |
+      {
+        "tomcat": {
+          "init_config": {
+            "is_jmx": true,
+            "collect_default_metrics": true
+          },
+          "instances": [{
+            "host": "%%host%%",
+            "port": "9012"
+          }]
+        }
+      }
+spec:
+  containers:
+    - name: tomcat
+      image: tomcat:8.0
+      imagePullPolicy: Always
+      ports:
+        - name: jmx-metrics
+          containerPort: 9012
+      env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: JAVA_OPTS
+          value: >-
+            -Dcom.sun.management.jmxremote
+            -Dcom.sun.management.jmxremote.authenticate=false
+            -Dcom.sun.management.jmxremote.ssl=false
+            -Dcom.sun.management.jmxremote.local.only=false
+            -Dcom.sun.management.jmxremote.port=9012
+            -Dcom.sun.management.jmxremote.rmi.port=9012
+            -Djava.rmi.server.hostname=$(POD_IP)
+```
+
+### Custom metric annotation template
+If you need to collect additional metrics from these integrations you can add them to the `init_config` section with the required format. For example:
+
+```yaml
+ad.datadoghq.com/<CONTAINER_IDENTIFIER>.checks: |
+  {
+    "<INTEGRATION_NAME>": {
+      "init_config": {
+        "is_jmx": true,
+        "collect_default_metrics": true,
+        "conf": [{
+          "include": {
+            "domain": "java.lang",
+            "type": "OperatingSystem",
+            "attribute": {
+               "FreePhysicalMemorySize": {
+                 "metric_type": "gauge",
+                 "alias": "jvm.free_physical_memory"
+               } 
+            }
+          }
+        }]
+      },
+      "instances": [{
+        "host": "%%host%%",
+        "port": "<JMX_PORT>"
+      }]
+    }
+  }
+```          
+
+See the [JMX Integration docs][31] for more information about the formatting for these metrics.
+
+## Autodiscovery configuration files
+
+If you need to pass a more complex custom configuration for your Datadog-JMX integration, having all the configurations within the annotations may be impractical. In these cases leverage [Autodiscovery Container Identifiers][11] to pass custom integration configuration files as well as a custom `metrics.yaml` file.
+
+### Agent file format
+
+When taking advantage of configuration files the Agent needs a configuration file and an optional `metrics.yaml` file for the metrics to collect. These files can either be mounted into the Agent pod or built into the container image. 
+
+The configuration file naming convention is to first identify the `<INTEGRATION NAME>` from the [prerequisite steps of available integrations](#available-jmx-integrations). Once this is determined the Agent needs a configuration file named relative to that integration, or within that integration's config directory. For example for the `tomcat` integration create either:
+
+- `/etc/datadog-agent/conf.d/tomcat.yaml`
+- `/etc/datadog-agent/conf.d/tomcat.d/conf.yaml`
+
+Any custom `metrics.yaml` file should be included in the integration's config directory.
+
+This configuration file should include `ad_identifiers` for the autodiscovery logic.
+
+```yaml
+ad_identifiers:
+  - "<SHORT_IMAGE>"
+
+init_config:
+  is_jmx: true
+  conf:
+    <METRICS_TO_COLLECT>
+
+instances:
+  - host: "%%host%%"
+    port: "<JMX_PORT>"
+```
+
+Replace `<SHORT_IMAGE>` with the short image name of your desired container. For example the container image `gcr.io/CompanyName/my-app:latest` would have short image name of `my-app`. As the Datadog Agent discovers that container it sets up the JMX configuration as described in this file. 
+
+You can alternatively reference and specify [custom identifiers to you containers][29] if you do not want to base this on the short image name. 
+
+The configuration files similar to the annotations can use [Autodiscovery Template Variables][28], in this case the `host` configuration is using `%%host%%` to resolve to the IP Address of the discovered container.
+
+Consult the [JMX Integration docs][31] as well as the [example configurations for the pre-provided integrations](#available-jmx-integrations) for more information about structuring your `init_config` and `instances` configuration for the `<METRICS_TO_COLLECT>`.
 
 {{< tabs >}}
-{{% tab "Container Agent" %}}
+{{% tab "Helm" %}}
+### Helm mounted configuration file
+In Helm use the `datadog.confd` option to mount in configuration files:
 
-If your Agent is running in your cluster and you want to autodiscover your container to collect JMX metrics:
+```yaml
+datadog:
+  confd:
+    <INTEGRATION_NAME>.yaml: |
+      ad_identifiers:
+        - "<SHORT_IMAGE>"
 
-1. Make sure to run the Agent image **the `gcr.io/datadoghq/agent:latest-jmx`** instead of the regular `gcr.io/datadoghq/agent:latest` image.
-
-2. Get the configuration files `conf.yaml` and `metrics.yaml` associated to your integration. Find below the list of Datadog-JMX based integration with their associated files:
-
-    | Integration Name             | Metrics file       | Configuration file      |
-    | ----------------------- | ------------------ | ----------------------- |
-    | [activemq][1]           | [metrics.yaml][2]  | [conf.yaml.example][3]  |
-    | [cassandra][4]          | [metrics.yaml][5]  | [conf.yaml.example][6]  |
-    | [confluent_platform][7] | [metrics.yaml][8]  | [conf.yaml.example][9] |
-    | [hive][10]              | [metrics.yaml][11] | [conf.yaml.example][12] |
-    | [jboss_wildfly][13]     | [metrics.yaml][14] | [conf.yaml.example][15] |
-    | [kafka][16]             | [metrics.yaml][17] | [conf.yaml.example][18] |
-    | [solr][19]              | [metrics.yaml][20] | [conf.yaml.example][21] |
-    | [presto][22]            | [metrics.yaml][23] | [conf.yaml.example][24] |
-    | [tomcat][25]            | [metrics.yaml][26] | [conf.yaml.example][27] |
-
-3. Rename the `conf.yaml.example` file into `conf.yaml`.
-
-4. Replace the parameter values from `conf.yaml` to fit the Agent Autodiscovery logic. The configuration files have host parameter values by default, use the [Autodiscovery Template Variables][28] logic instead. In the following Tomcat check example, the `host` parameter value is changed from `localhost` to `%%host%%`:
-
-    ```yaml
-    init_config:
-        ## @param is_jmx - boolean - required
-        ## Whether or not this file is a configuration for a JMX integration.
-        #
+      init_config:
         is_jmx: true
 
-        ## @param collect_default_metrics - boolean - required
-        ## Whether or not the check should collect all default metrics.
-        #
-        collect_default_metrics: true
+      instances:
+        - host: "%%host%%"
+          port: "<JMX_PORT>"
+```
 
-    instances:
-        ## @param host - string - required
-        ## Tomcat JMX hostname to connect to.
-        #
-        - host: '%%host%%'
-
-          ## @param port - integer - required
-          ## Tomcat JMX port to connect to.
-          #
-          port: 9012
-    ```
-
-5. To specify to the Agent that you want to apply this configuration file to your application container, configure an `ad_identifiers` parameter at the beginning of your `conf.yaml` file:
-
-    ```yaml
-    ad_identifiers:
-        - '<CUSTOM_AD_IDENTIFIER>'
-
-    init_config:
-        # (...)
-    instances:
-        # (...)
-    ```
-
-     **Note**: The example above uses a custom `ad_identifers` value, but you can specify the [container short image][29] as `ad_identifiers` if needed.
-
-6. Mount those configuration files (`conf.yaml` and `metrics.yaml`) in your Agent in the `conf.d/<INTEGRATION_NAME>.d/` folder.
-
-7. (Optional) - If you can't mount those files in the Agent container (like on AWS ECS), you should re-build the Agent docker image with those two configuration files in it:
-
-    ```conf
-    FROM gcr.io/datadoghq/agent:latest-jmx
-    COPY <PATH_JMX_CONF_FILE> conf.d/tomcat.d/
-    COPY <PATH_JMX_METRICS_FILE> conf.d/tomcat.d/
-    ```
-
-     Then use this new custom image as the regular containerized Agent.
-
-[1]: /integrations/activemq/
-[2]: https://github.com/DataDog/integrations-core/blob/master/activemq/datadog_checks/activemq/data/metrics.yaml
-[3]: https://github.com/DataDog/integrations-core/blob/master/activemq/datadog_checks/activemq/data/conf.yaml.example
-[4]: /integrations/cassandra/
-[5]: https://github.com/DataDog/integrations-core/blob/master/cassandra/datadog_checks/cassandra/data/metrics.yaml
-[6]: https://github.com/DataDog/integrations-core/blob/master/cassandra/datadog_checks/cassandra/data/conf.yaml.example
-[7]: /integrations/confluent_platform/
-[8]: https://github.com/DataDog/integrations-core/blob/master/confluent_platform/datadog_checks/confluent_platform/data/metrics.yaml
-[9]: https://github.com/DataDog/integrations-core/blob/master/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
-[10]: /integrations/hive/
-[11]: https://github.com/DataDog/integrations-core/blob/master/hive/datadog_checks/hive/data/metrics.yaml
-[12]: https://github.com/DataDog/integrations-core/blob/master/hive/datadog_checks/hive/data/conf.yaml.example
-[13]: /integrations/jboss_wildfly/
-[14]: https://github.com/DataDog/integrations-core/blob/master/jboss_wildfly/datadog_checks/jboss_wildfly/data/metrics.yaml
-[15]: https://github.com/DataDog/integrations-core/blob/master/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
-[16]: /integrations/kafka/
-[17]: https://github.com/DataDog/integrations-core/blob/master/kafka/datadog_checks/kafka/data/metrics.yaml
-[18]: https://github.com/DataDog/integrations-core/blob/master/kafka/datadog_checks/kafka/data/conf.yaml.example
-[19]: /integrations/solr/
-[20]: https://github.com/DataDog/integrations-core/blob/master/solr/datadog_checks/solr/data/metrics.yaml
-[21]: https://github.com/DataDog/integrations-core/blob/master/solr/datadog_checks/solr/data/conf.yaml.example
-[22]: /integrations/presto/
-[23]: https://github.com/DataDog/integrations-core/blob/master/presto/datadog_checks/presto/data/metrics.yaml
-[24]: https://github.com/DataDog/integrations-core/blob/master/presto/datadog_checks/presto/data/conf.yaml.example
-[25]: /integrations/tomcat/
-[26]: https://github.com/DataDog/integrations-core/blob/master/tomcat/datadog_checks/tomcat/data/metrics.yaml
-[27]: https://github.com/DataDog/integrations-core/blob/master/tomcat/datadog_checks/tomcat/data/conf.yaml.example
-[28]: /agent/faq/template_variables/
-[29]: /agent/guide/ad_identifiers/#short-image-container-identifiers
 {{% /tab %}}
-{{% tab "Host Agent" %}}
 
-If your Agent is running on a host and you want to autodiscover your container to collect JMX metrics:
+{{% tab "Operator" %}}
+### Operator mounted configuration file
+With the Operator you can add an override to mount in the configuration files:
 
-1. [Enable autodiscovery for your Agent][1].
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  #(...)
+  override:
+    nodeAgent:
+      image:
+        jmxEnabled: true
+      extraConfd:
+        configDataMap:
+          <INTEGRATION_NAME>.yaml: |-
+            ad_identifiers:
+              - "<SHORT_IMAGE>"
 
-2. Enable the JMX integration you want to use by renaming the corresponding `conf.yaml.example` file into `conf.yaml` in the [Agent integration directory][2]. For instance for tomcat you would rename `/etc/datadog-agent/conf.d/tomcat.d/conf.yaml.example` into: `/etc/datadog-agent/conf.d/tomcat.d/conf.yaml`
+            init_config:
+              is_jmx: true
 
-3. Replace the parameters values from `conf.yaml` file to fit the Agent Autodiscovery logic. The configuration files have host parameter values by default, use the [Autodiscovery Template Variables][3] instead. In the following Tomcat configuration example, the `host` parameter value is changed from `localhost` to `%%host%%`:
+            instances:
+              - host: "%%host%%"
+                port: "<JMX_PORT>"
+```
 
-    ```yaml
-    init_config:
-        ## @param is_jmx - boolean - required
-        ## Whether or not this file is a configuration for a JMX integration.
-        #
-        is_jmx: true
-
-        ## @param collect_default_metrics - boolean - required
-        ## Whether or not the check should collect all default metrics.
-        #
-        collect_default_metrics: true
-
-    instances:
-        ## @param host - string - required
-        ## Tomcat JMX hostname to connect to.
-        #
-        - host: '%%host%%'
-
-          ## @param port - integer - required
-          ## Tomcat JMX port to connect to.
-          #
-          port: 9012
-    ```
-
-4. To specify to the Agent that you want to apply this configuration file to your application containers, configure an `ad_identifiers` parameter at the beginning of your `conf.yaml` file:
-
-    ```yaml
-    ad_identifiers:
-        - '<CUSTOM_AD_IDENTIFIER>'
-
-    init_config:
-        # (...)
-    instances:
-        # (...)
-    ```
-
-     **Note**: The example above uses a custom `ad_identifers` value, but you can specify the [container short image][4] as `ad_identifiers` if needed.
-5. [Restart your Agent][5]
-
-[1]: /getting_started/agent/autodiscovery/#with-the-agent-on-a-host
-[2]: /agent/guide/agent-configuration-files/#agent-configuration-directory
-[3]: /agent/faq/template_variables/
-[4]: /agent/guide/ad_identifiers/#short-image-container-identifiers
-[5]: /agent/guide/agent-commands/#restart-the-agent
 {{% /tab %}}
+
+{{% tab "Custom Image" %}}
+### Custom Agent image with configuration files
+If you can't mount those files in the Agent container (like on AWS ECS), you should re-build the Agent docker image with the desired configuration files in it. For example:
+
+  ```Dockerfile
+  FROM gcr.io/datadoghq/agent:latest-jmx
+  COPY <PATH_JMX_CONF_FILE> conf.d/tomcat.d/
+  COPY <PATH_JMX_METRICS_FILE> conf.d/tomcat.d/
+  ```
+
+Then use this new custom image as your regular containerized Agent.
+{{% /tab %}}
+
 {{< /tabs >}}
 
-### Container preparation
-
-#### Docker
-
-Once the Agent is configured and running, use the `com.datadoghq.ad.check.id:"<CUSTOM_AD_IDENTIFIER>"` label for your application container to apply the check configuration through Autodiscovery:
-
-**Dockerfile**:
+### Expose JMX Server
+Similar to the autodiscovery annotations sample, you still need to setup the JMX Server in a way that allows the Agent to access it. This is the same structure as before:
 
 ```yaml
-LABEL "com.datadoghq.ad.check.id"= '<CUSTOM_AD_IDENTIFIER>'
-```
-
-**docker-compose.yaml**:
-
-```yaml
-labels:
-    com.datadoghq.ad.check.id: '<CUSTOM_AD_IDENTIFIER>'
-```
-
-**docker run command**:
-
-```shell
--l com.datadoghq.ad.check.id= '<CUSTOM_AD_IDENTIFIER>'
-```
-
-**Docker Swarm**:
-
-When using Swarm mode for Docker Cloud, labels must be applied to the image:
-
-```yaml
-version: '1.0'
-services:
-# ...
-project:
-    image: '<IMAGE_NAME>'
-    labels:
-        com.datadoghq.ad.check.id: '<CUSTOM_AD_IDENTIFIER>'
-```
-
-**Note**: If the Agent and your JMX container are on the same network bridge, you need to instantiate your JMX server with `-Djava.rmi.server.hostname=<CONTAINER_NAME>"` where `<CONTAINER_NAME>` is your JMX-application container name.
+spec:
+  containers:
+    - # (...)
+      env:
+      - name: POD_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      - name: JAVA_OPTS
+        value: >-
+          -Dcom.sun.management.jmxremote
+          -Dcom.sun.management.jmxremote.authenticate=false
+          -Dcom.sun.management.jmxremote.ssl=false
+          -Dcom.sun.management.jmxremote.local.only=false
+          -Dcom.sun.management.jmxremote.port=<JMX_PORT>
+          -Dcom.sun.management.jmxremote.rmi.port=<JMX_PORT>
+          -Djava.rmi.server.hostname=$(POD_IP)   
+```          
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent/kubernetes/
-[2]: /integrations/activemq/
-[3]: /integrations/cassandra/
-[4]: /integrations/confluent_platform/
-[5]: /integrations/hive/
-[6]: /integrations/jboss_wildfly/
-[7]: /integrations/kafka/
-[8]: /integrations/solr/
-[9]: /integrations/presto/
-[10]: /integrations/tomcat/
-[11]: /agent/guide/ad_identifiers/
+[11]: /containers/guide/ad_identifiers/?tab=kubernetes
+[12]: /tracing/metrics/runtime_metrics/java/
+[28]: /containers/guide/template_variables/
+[29]: /containers/guide/ad_identifiers/?tab=kubernetes#custom-autodiscovery-container-identifiers
+[30]: https://kubernetes.io/docs/concepts/workloads/pods/downward-api/
+[31]: /integrations/java/
+
+[41]: /integrations/activemq/
+[42]: https://github.com/DataDog/integrations-core/blob/master/activemq/datadog_checks/activemq/data/metrics.yaml
+[43]: https://github.com/DataDog/integrations-core/blob/master/activemq/datadog_checks/activemq/data/conf.yaml.example
+[44]: /integrations/cassandra/
+[45]: https://github.com/DataDog/integrations-core/blob/master/cassandra/datadog_checks/cassandra/data/metrics.yaml
+[46]: https://github.com/DataDog/integrations-core/blob/master/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+[47]: /integrations/confluent_platform/
+[48]: https://github.com/DataDog/integrations-core/blob/master/confluent_platform/datadog_checks/confluent_platform/data/metrics.yaml
+[49]: https://github.com/DataDog/integrations-core/blob/master/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
+[50]: /integrations/hazelcast/
+[51]: https://github.com/DataDog/integrations-core/blob/master/hazelcast/datadog_checks/hazelcast/data/metrics.yaml
+[52]: https://github.com/DataDog/integrations-core/blob/master/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+[53]: /integrations/hive/
+[54]: https://github.com/DataDog/integrations-core/blob/master/hive/datadog_checks/hive/data/metrics.yaml
+[55]: https://github.com/DataDog/integrations-core/blob/master/hive/datadog_checks/hive/data/conf.yaml.example
+[56]: /integrations/hivemq/
+[57]: https://github.com/DataDog/integrations-core/blob/master/hivemq/datadog_checks/hivemq/data/metrics.yaml
+[58]: https://github.com/DataDog/integrations-core/blob/master/hivemq/datadog_checks/hivemq/data/conf.yaml.example
+[59]: /integrations/hudi/
+[60]: https://github.com/DataDog/integrations-core/blob/master/hudi/datadog_checks/hudi/data/metrics.yaml
+[61]: https://github.com/DataDog/integrations-core/blob/master/hudi/datadog_checks/hudi/data/conf.yaml.example
+[62]: /integrations/ignite/
+[63]: https://github.com/DataDog/integrations-core/blob/master/ignite/datadog_checks/ignite/data/metrics.yaml
+[64]: https://github.com/DataDog/integrations-core/blob/master/ignite/datadog_checks/ignite/data/conf.yaml.example
+[66]: /integrations/jboss_wildfly/
+[67]: https://github.com/DataDog/integrations-core/blob/master/jboss_wildfly/datadog_checks/jboss_wildfly/data/metrics.yaml
+[68]: https://github.com/DataDog/integrations-core/blob/master/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+[69]: /integrations/kafka/
+[70]: https://github.com/DataDog/integrations-core/blob/master/kafka/datadog_checks/kafka/data/metrics.yaml
+[71]: https://github.com/DataDog/integrations-core/blob/master/kafka/datadog_checks/kafka/data/conf.yaml.example
+[72]: /integrations/presto/
+[73]: https://github.com/DataDog/integrations-core/blob/master/presto/datadog_checks/presto/data/metrics.yaml
+[74]: https://github.com/DataDog/integrations-core/blob/master/presto/datadog_checks/presto/data/conf.yaml.example
+[75]: /integrations/solr/
+[76]: https://github.com/DataDog/integrations-core/blob/master/solr/datadog_checks/solr/data/metrics.yaml
+[77]: https://github.com/DataDog/integrations-core/blob/master/solr/datadog_checks/solr/data/conf.yaml.example
+[78]: /integrations/sonarqube/
+[79]: https://github.com/DataDog/integrations-core/blob/master/sonarqube/datadog_checks/sonarqube/data/metrics.yaml
+[80]: https://github.com/DataDog/integrations-core/blob/master/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+[81]: /integrations/tomcat/
+[82]: https://github.com/DataDog/integrations-core/blob/master/tomcat/datadog_checks/tomcat/data/metrics.yaml
+[83]: https://github.com/DataDog/integrations-core/blob/master/tomcat/datadog_checks/tomcat/data/conf.yaml.example
+[84]: /integrations/weblogic/
+[85]: https://github.com/DataDog/integrations-core/blob/master/weblogic/datadog_checks/weblogic/data/metrics.yaml
+[86]: https://github.com/DataDog/integrations-core/blob/master/weblogic/datadog_checks/weblogic/data/conf.yaml.example

--- a/content/en/containers/guide/autodiscovery-with-jmx.md
+++ b/content/en/containers/guide/autodiscovery-with-jmx.md
@@ -20,7 +20,7 @@ further_reading:
 
 Leverage Datadog's JMX based integrations to collect the JMX-applications metrics from your pods in Kubernetes. In containerized environments there are a few differences in how the Agent connects to the JMX server. Autodiscovery features make it possible to dynamically setup these integrations.
 
-If you are using the Java tracer for your applications, you can alternatively take advantage of the [Java runtime metrics][12] feature to send these metrics to the Agent.
+If you are using the Java tracer for your applications, you can alternatively take advantage of the [Java runtime metrics][2] feature to send these metrics to the Agent.
 
 ## Prerequisites
 ### Agent JMX image
@@ -139,7 +139,7 @@ In this example:
 - The `<INTEGRATION_NAME>` matches the desired integration relative to the previous section
 - The `<JMX_PORT>` can be set as desired, as long as it matches between the annotations and `JAVA_OPTS`
 
-With this configuration the Datadog Agent discovers this pod and makes a request to the JMX Server relative to the `%%host%%` [Autodiscovery template variable][28], resolving to the IP address of the discovered pod. This is why the `java.rmi.server.hostname` is set to the `POD_IP` address previously populated with the [Kubernetes downward API][30].
+With this configuration the Datadog Agent discovers this pod and makes a request to the JMX Server relative to the `%%host%%` [Autodiscovery template variable][3], resolving to the IP address of the discovered pod. This is why the `java.rmi.server.hostname` is set to the `POD_IP` address previously populated with the [Kubernetes downward API][5].
 
 **Note**: The `JAVA_OPTS` environment variable is commonly used in Java based container images as a startup parameter (ex: `java $JAVA_OPTS -jar app.jar`). If you are using a custom application, or, your application doesn't follow this pattern set these system properties manually.
 
@@ -221,11 +221,11 @@ ad.datadoghq.com/<CONTAINER_IDENTIFIER>.checks: |
   }
 ```          
 
-See the [JMX Integration docs][31] for more information about the formatting for these metrics.
+See the [JMX Integration docs][6] for more information about the formatting for these metrics.
 
 ## Autodiscovery configuration files
 
-If you need to pass a more complex custom configuration for your Datadog-JMX integration, having all the configurations within the annotations may be impractical. In these cases leverage [Autodiscovery Container Identifiers][11] to pass custom integration configuration files as well as a custom `metrics.yaml` file.
+If you need to pass a more complex custom configuration for your Datadog-JMX integration, having all the configurations within the annotations may be impractical. In these cases leverage [Autodiscovery Container Identifiers][1] to pass custom integration configuration files as well as a custom `metrics.yaml` file.
 
 ### Agent file format
 
@@ -256,11 +256,11 @@ instances:
 
 Replace `<SHORT_IMAGE>` with the short image name of your desired container. For example the container image `gcr.io/CompanyName/my-app:latest` would have short image name of `my-app`. As the Datadog Agent discovers that container it sets up the JMX configuration as described in this file. 
 
-You can alternatively reference and specify [custom identifiers to you containers][29] if you do not want to base this on the short image name. 
+You can alternatively reference and specify [custom identifiers to you containers][4] if you do not want to base this on the short image name.
 
-The configuration files similar to the annotations can use [Autodiscovery Template Variables][28], in this case the `host` configuration is using `%%host%%` to resolve to the IP Address of the discovered container.
+The configuration files similar to the annotations can use [Autodiscovery template variables][3], in this case the `host` configuration is using `%%host%%` to resolve to the IP Address of the discovered container.
 
-Consult the [JMX Integration docs][31] as well as the [example configurations for the pre-provided integrations](#available-jmx-integrations) for more information about structuring your `init_config` and `instances` configuration for the `<METRICS_TO_COLLECT>`.
+Consult the [JMX Integration docs][6] as well as the [example configurations for the pre-provided integrations](#available-jmx-integrations) for more information about structuring your `init_config` and `instances` configuration for the `<METRICS_TO_COLLECT>`.
 
 {{< tabs >}}
 {{% tab "Helm" %}}
@@ -357,13 +357,12 @@ spec:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[11]: /containers/guide/ad_identifiers/?tab=kubernetes
-[12]: /tracing/metrics/runtime_metrics/java/
-[28]: /containers/guide/template_variables/
-[29]: /containers/guide/ad_identifiers/?tab=kubernetes#custom-autodiscovery-container-identifiers
-[30]: https://kubernetes.io/docs/concepts/workloads/pods/downward-api/
-[31]: /integrations/java/
-
+[1]: /containers/guide/ad_identifiers/?tab=kubernetes
+[2]: /tracing/metrics/runtime_metrics/java/
+[3]: /containers/guide/template_variables/
+[4]: /containers/guide/ad_identifiers/?tab=kubernetes#custom-autodiscovery-container-identifiers
+[5]: https://kubernetes.io/docs/concepts/workloads/pods/downward-api/
+[6]: /integrations/java/
 [41]: /integrations/activemq/
 [42]: https://github.com/DataDog/integrations-core/blob/master/activemq/datadog_checks/activemq/data/metrics.yaml
 [43]: https://github.com/DataDog/integrations-core/blob/master/activemq/datadog_checks/activemq/data/conf.yaml.example


### PR DESCRIPTION
_WIP for now_ while checking in with other Container team folk.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Big PR to revamp the setup instructions for JMX Autodiscovery, almost a full re-write. 

- There were several sections in the original that were duplicated, such as using the `-jmx` based image and listing the JMX integrations. These were moved into a `Prerequisites` section as these are common between Autodiscovery Annotations vs File.
  - Add the newer JMX Integrations not previously listed
- Removed host install pattern as its hardly used for containerized environments. Added Helm/Operator instructions in lieu for Kubernetes side.
- Removed language for the Docker custom identifier, as the [linked doc](https://docs.datadoghq.com/containers/guide/autodiscovery-with-jmx/?tab=containeragent#custom-autodiscovery-container-identifiers) can show that better. Just use the more common short image name pattern in the samples.
- Clarify all the components of the Autodiscovery Annotations (especially with respect to `JAVA_OPTS`, `java.rmi.server.hostname=$(POD_IP)`, port)
- Move to Autodiscovery v2 syntax
- Make the distinction and choice between Annotation vs File more apparent
- Fix the file setup instructions for the missing steps (JMX Server, how to mount)
- Remove unnecessary / wrong parameters and notes
- Added link for Java Runtime Metrics managed and sent by the APM Tracer

### Motivation
<!-- What inspired you to submit this pull request?-->
Wanted to clear up the patterns for setting up JMX integration as this doc hasn't always been the most clear. This hopefully explains the patterns of when to use annotations vs file more clearly. As well as provide more context into why all the settings are necessary.

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

Preview: https://docs-staging.datadoghq.com/jack.davenport/k8s-jmx/containers/guide/autodiscovery-with-jmx/?tab=helm
Current: https://docs.datadoghq.com/containers/guide/autodiscovery-with-jmx/?tab=containeragent


### Additional Notes
<!-- Anything else we should know when reviewing?-->
This doc was in a bit of a weird state as it was showing Kubernetes primarily in the annotations, generic container and host setup for the file instructions, and then docker labels at the end. With this change its going to be primarily a Kubernetes centric doc. The name of this doc doesn't really reflect that but don't think we need to change it. 

It may make sense to add Docker centric instructions (such as the Docker Labels and how to set the `java.rmi.server.hostname` parameter) in the future. But wanted to get this big change settled first. 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
