### PR TITLE
DOCS-5829 Use Synthetic Reusable Shortcodes in Synthetic Monitoring Documentation

### DIFF
--- a/content/en/synthetics/api_tests/dns_tests.md
+++ b/content/en/synthetics/api_tests/dns_tests.md
@@ -85,47 +85,7 @@ DNS tests can run:
 * [**Within your CI/CD pipelines**][2].
 * **On-demand** to run your tests whenever makes the most sense for your team.
 
-### Define alert conditions
-
-Set alert conditions to determine the circumstances under which you want a test to fail and trigger an alert.
-
-#### Alerting rule
-
-When you set the alert conditions to: `An alert is triggered if your test fails for X minutes from any n of N locations`, an alert is triggered only if these two conditions are true:
-
-* At least one location was in failure (at least one assertion failed) during the last *X* minutes;
-* At one moment during the last *X* minutes, at least *n* locations were in failure.
-
-#### Fast retry
-
-Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
-
-Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
-
-### Configure the test monitor
-
-A notification is sent by your test based on the [alerting conditions](#define-alert-conditions) previously defined. Use this section to define how and what to message your teams.
-
-1. [Similar to how you configure monitors][5], select **users and/or services** that should receive notifications either by adding a `@notification`to the message or by searching for team members and connected integrations with the dropdown box.
-
-2. Enter the notification **message** for your test. This field allows standard [Markdown formatting][6] and supports the following [conditional variables][7]:
-
-    | Conditional Variable       | Description                                                         |
-    |----------------------------|---------------------------------------------------------------------|
-    | `{{#is_alert}}`            | Show when the test alerts.                                          |
-    | `{{^is_alert}}`            | Show unless the test alerts.                                        |
-    | `{{#is_recovery}}`         | Show when the test recovers from an alert.                          |
-    | `{{^is_recovery}}`         | Show unless the test recovers from an alert.                        |
-    | `{{#is_renotify}}`         | Show when the monitor renotifies.                                   |
-    | `{{^is_renotify}}`         | Show unless the monitor renotifies.                                 |
-    | `{{#is_priority}}`         | Show when the monitor matches priority (P1 to P5).                  |
-    | `{{^is_priority}}`         | Show unless the monitor matches priority (P1 to P5).                |
-
-3. Specify how often you want your test to **re-send the notification message** in case of test failure. To prevent renotification on failing tests, leave the option as `Never renotify if the monitor has not been resolved`.
-
-4. Click **Create** to save your test configuration and monitor.
-
-For more information, see [Using Synthetic Test Monitors][8].
+{{% synthetics-alerting-monitoring %}}
 
 {{% synthetics-variables %}} 
 

--- a/content/en/synthetics/api_tests/grpc_tests.md
+++ b/content/en/synthetics/api_tests/grpc_tests.md
@@ -146,47 +146,7 @@ gRPC tests can run:
 * [**Within your CI/CD pipelines**][3] to start shipping without fearing faulty code might impact your customers experience.
 * **On-demand** to run your tests whenever makes the most sense for your team.
 
-### Define alert conditions
-
-Set alert conditions to determine the circumstances under which you want a test to fail and trigger an alert.
-
-#### Alerting rule
-
-When you set the alert conditions to: `An alert is triggered if any assertion fails for X minutes from any n of N locations`, an alert is triggered only if these two conditions are true:
-
-* At least one location was in failure (at least one assertion failed) during the last *X* minutes;
-* At one moment during the last *X* minutes, at least *n* locations were in failure.
-
-#### Fast retry
-
-Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
-
-Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
-
-### Configure the test monitor
-
-A notification is sent by your test based on the [alerting conditions](#define-alert-conditions) previously defined. Use this section to define how and what to message your teams.
-
-1. [Similar to how you configure monitors][5], select **users and/or services** that should receive notifications either by adding a `@notification`to the message or by searching for team members and connected integrations with the dropdown box.
-
-2. Enter the notification **message** for your test. This field allows standard [Markdown formatting][6] and supports the following [conditional variables][7]:
-
-    | Conditional Variable       | Description                                                         |
-    |----------------------------|---------------------------------------------------------------------|
-    | `{{#is_alert}}`            | Show when the test alerts.                                          |
-    | `{{^is_alert}}`            | Show unless the test alerts.                                        |
-    | `{{#is_recovery}}`         | Show when the test recovers from an alert.                          |
-    | `{{^is_recovery}}`         | Show unless the test recovers from an alert.                        |
-    | `{{#is_renotify}}`         | Show when the monitor renotifies.                                   |
-    | `{{^is_renotify}}`         | Show unless the monitor renotifies.                                 |
-    | `{{#is_priority}}`         | Show when the monitor matches priority (P1 to P5).                  |
-    | `{{^is_priority}}`         | Show unless the monitor matches priority (P1 to P5).                |
-
-3. Specify how often you want your test to **re-send the notification message** in case of test failure. To prevent renotification on failing tests, leave the option as `Never renotify if the monitor has not been resolved`.
-
-4. Click **Create** to save your test configuration and monitor.
-
-For more information, see [Using Synthetic Test Monitors][8].
+{{% synthetics-alerting-monitoring %}}
 
 {{% synthetics-variables %}}
 

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -150,50 +150,10 @@ Select the **Locations** to run your HTTP test from. HTTP tests can run from bot
 HTTP tests can run:
 
 * **On a schedule** to ensure your most important endpoints are always accessible to your users. Select the frequency at which you want Datadog to run your HTTP test.
-* [**Within your CI/CD pipelines**][2] to start shipping without fearing faulty code might impact your customers experience.
+* [**Within your CI/CD pipelines**][2] to start shipping without fearing faulty code might impact your customers' experience.
 * **On-demand** to run your tests whenever makes the most sense for your team.
 
-### Define alert conditions
-
-Set alert conditions to determine the circumstances under which you want a test to fail and trigger an alert.
-
-#### Alerting rule
-
-When you set the alert conditions to: `An alert is triggered if your test fails for X minutes from any n of N locations`, an alert is triggered only if these two conditions are true:
-
-* At least one location was in failure (at least one assertion failed) during the last *X* minutes;
-* At one moment during the last *X* minutes, at least *n* locations were in failure.
-
-#### Fast retry
-
-Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
-
-Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
-
-### Configure the test monitor
-
-A notification is sent by your test based on the [alerting conditions](#define-alert-conditions) previously defined. Use this section to define how and what to message your teams.
-
-1. [Similar to how you configure monitors][7], select **users and/or services** that should receive notifications either by adding a `@notification`to the message or by searching for team members and connected integrations with the dropdown box.
-
-2. Enter the notification **message** for your test. This field allows standard [Markdown formatting][8] and supports the following [conditional variables][9]:
-
-    | Conditional Variable       | Description                                                         |
-    |----------------------------|---------------------------------------------------------------------|
-    | `{{#is_alert}}`            | Show when the test alerts.                                          |
-    | `{{^is_alert}}`            | Show unless the test alerts.                                        |
-    | `{{#is_recovery}}`         | Show when the test recovers from an alert.                          |
-    | `{{^is_recovery}}`         | Show unless the test recovers from an alert.                        |
-    | `{{#is_renotify}}`         | Show when the monitor renotifies.                                   |
-    | `{{^is_renotify}}`         | Show unless the monitor renotifies.                                 |
-    | `{{#is_priority}}`         | Show when the monitor matches priority (P1 to P5).                  |
-    | `{{^is_priority}}`         | Show unless the monitor matches priority (P1 to P5).                |
-
-3. Specify how often you want your test to **re-send the notification message** in case of test failure. To prevent renotification on failing tests, leave the option as `Never renotify if the monitor has not been resolved`.
-
-4. Click **Create** to save your test configuration and monitor.
-
-For more information, see [Using Synthetic Test Monitors][10].
+{{% synthetics-alerting-monitoring %}}
 
 {{% synthetics-variables %}}
 

--- a/content/en/synthetics/api_tests/icmp_tests.md
+++ b/content/en/synthetics/api_tests/icmp_tests.md
@@ -80,47 +80,7 @@ ICMP tests can run:
 * [**Within your CI/CD pipelines**][2].
 * **On-demand** to run your tests whenever makes the most sense for your team.
 
-### Define alert conditions
-
-You can set alert conditions to determine the circumstances under which a test should fail and trigger an alert.
-
-#### Alerting rule
-
-When you set the alert conditions to: `An alert is triggered if your test fails for X minutes from any n of N locations`, an alert is triggered only if these two conditions are true:
-
-* At least one location was in failure (at least one assertion failed) during the last *X* minutes.
-* At one moment during the last *X* minutes, at least *n* locations were in failure.
-
-#### Fast retry
-
-Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
-
-Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
-
-### Configure the test monitor
-
-Your test sends a notification based on the [alerting conditions](#define-alert-conditions) previously defined. Use this section to define how and what to message your teams.
-
-1. [Similar to how you configure monitors][4], select **users and/or services** that should receive notifications either by adding a `@notification` to the message or by searching for team members and connected integrations with the dropdown box.
-
-2. Enter the notification **message** for your test. This field allows standard [Markdown formatting][5] and supports the following [conditional variables][6]:
-
-    | Conditional Variable       | Description                                                         |
-    |----------------------------|---------------------------------------------------------------------|
-    | `{{#is_alert}}`            | Show when the test alerts.                                          |
-    | `{{^is_alert}}`            | Show unless the test alerts.                                        |
-    | `{{#is_recovery}}`         | Show when the test recovers from an alert.                          |
-    | `{{^is_recovery}}`         | Show unless the test recovers from an alert.                        |
-    | `{{#is_renotify}}`         | Show when the monitor renotifies.                                   |
-    | `{{^is_renotify}}`         | Show unless the monitor renotifies.                                 |
-    | `{{#is_priority}}`         | Show when the monitor matches priority (P1 to P5).                  |
-    | `{{^is_priority}}`         | Show unless the monitor matches priority (P1 to P5).                |
-
-3. Specify how often you want your test to **resend the notification message** in the case of test failure. To prevent renotifications from failing tests, leave the option as `Never renotify if the monitor has not been resolved`.
-
-4. Click **Create** to save your test configuration and monitor.
-
-For more information, see [Using Synthetic Test Monitors][7].
+{{% synthetics-alerting-monitoring %}}
 
 {{% synthetics-variables %}}
 

--- a/content/en/synthetics/api_tests/ssl_tests.md
+++ b/content/en/synthetics/api_tests/ssl_tests.md
@@ -96,47 +96,7 @@ SSL tests can run:
 * [**Within your CI/CD pipelines**][2].
 * **On-demand** to run your tests whenever makes the most sense for your team.
 
-### Define alert conditions
-
-Set alert conditions to determine the circumstances under which you want a test to fail and trigger an alert.
-
-#### Alerting rule
-
-When you set the alert conditions to: `An alert is triggered if your test fails for X minutes from any n of N locations`, an alert is triggered only if these two conditions are true:
-
-* At least one location was in failure (at least one assertion failed) during the last *X* minutes.
-* At one moment during the last *X* minutes, at least *n* locations were in failure.
-
-#### Fast retry
-
-Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
-
-Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
-
-### Configure the test monitor
-
-A notification is sent by your test based on the [alerting conditions](#define-alert-conditions) previously defined. Use this section to define how and what to message your teams.
-
-1. [Similar to how you configure monitors][5], select **users and/or services** that should receive notifications either by adding a `@notification`to the message or by searching for team members and connected integrations with the dropdown box.
-
-2. Enter the notification **message** for your test. This field allows standard [Markdown formatting][6] and supports the following [conditional variables][7]:
-
-    | Conditional Variable       | Description                                                         |
-    |----------------------------|---------------------------------------------------------------------|
-    | `{{#is_alert}}`            | Show when the test alerts.                                          |
-    | `{{^is_alert}}`            | Show unless the test alerts.                                        |
-    | `{{#is_recovery}}`         | Show when the test recovers from an alert.                          |
-    | `{{^is_recovery}}`         | Show unless the test recovers from an alert.                        |
-    | `{{#is_renotify}}`         | Show when the monitor renotifies.                                   |
-    | `{{^is_renotify}}`         | Show unless the monitor renotifies.                                 |
-    | `{{#is_priority}}`         | Show when the monitor matches priority (P1 to P5).                  |
-    | `{{^is_priority}}`         | Show unless the monitor matches priority (P1 to P5).                |
-
-3. Specify how often you want your test to **re-send the notification message** in case of test failure. To prevent renotification on failing tests, leave the option as `Never renotify if the monitor has not been resolved`.
-
-4. Click **Create** to save your test configuration and monitor.
-
-For more information, see [Using Synthetic Test Monitors][8].
+{{% synthetics-alerting-monitoring %}}
 
 {{% synthetics-variables %}}
 

--- a/content/en/synthetics/api_tests/tcp_tests.md
+++ b/content/en/synthetics/api_tests/tcp_tests.md
@@ -79,47 +79,7 @@ TCP tests can run:
 * [**Within your CI/CD pipelines**][2].
 * **On-demand** to run your tests whenever makes the most sense for your team.
 
-### Define alert conditions
-
-Set alert conditions to determine the circumstances under which you want a test to fail and trigger an alert.
-
-#### Alerting rule
-
-When you set the alert conditions to: `An alert is triggered if your test fails for X minutes from any n of N locations`, an alert is triggered only if these two conditions are true:
-
-* At least one location was in failure (at least one assertion failed) during the last *X* minutes.
-* At one moment during the last *X* minutes, at least *n* locations were in failure.
-
-#### Fast retry
-
-Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
-
-Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
-
-### Configure the test monitor
-
-A notification is sent by your test based on the [alerting conditions](#define-alert-conditions) previously defined. Use this section to define how and what to message your teams.
-
-1. [Similar to how you configure monitors][4], select **users and/or services** that should receive notifications either by adding a `@notification`to the message or by searching for team members and connected integrations with the dropdown box.
-
-2. Enter the notification **message** for your test. This field allows standard [Markdown formatting][5] and supports the following [conditional variables][6]:
-
-    | Conditional Variable       | Description                                                         |
-    |----------------------------|---------------------------------------------------------------------|
-    | `{{#is_alert}}`            | Show when the test alerts.                                          |
-    | `{{^is_alert}}`            | Show unless the test alerts.                                        |
-    | `{{#is_recovery}}`         | Show when the test recovers from an alert.                          |
-    | `{{^is_recovery}}`         | Show unless the test recovers from an alert.                        |
-    | `{{#is_renotify}}`         | Show when the monitor renotifies.                                   |
-    | `{{^is_renotify}}`         | Show unless the monitor renotifies.                                 |
-    | `{{#is_priority}}`         | Show when the monitor matches priority (P1 to P5).                  |
-    | `{{^is_priority}}`         | Show unless the monitor matches priority (P1 to P5).                |
-
-3. Specify how often you want your test to **re-send the notification message** in case of test failure. To prevent renotification on failing tests, leave the option as `Never renotify if the monitor has not been resolved`.
-
-4. Click **Create** to save your test configuration and monitor.
-
-For more information, see [Using Synthetic Test Monitors][7].
+{{% synthetics-alerting-monitoring %}}
 
 {{% synthetics-variables %}}
 

--- a/content/en/synthetics/api_tests/udp_tests.md
+++ b/content/en/synthetics/api_tests/udp_tests.md
@@ -78,47 +78,7 @@ UDP tests can run:
 - [**Within your CI/CD pipelines**][2].
 - **On-demand** to run your tests whenever makes the most sense for your team.
 
-### Define alert conditions
-
-You can set alert conditions to determine the circumstances under which a test should fail and trigger an alert.
-
-#### Fast retry
-
-Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
-
-Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
-
-#### Alerting rule
-
-When you set the alert conditions to `An alert is triggered if your test fails for X minutes from any n of N locations`, an alert is triggered only if these two conditions are true:
-
-* At least one location was in failure (at least one assertion failed) during the last *X* minutes;
-* At one moment during the last *X* minutes, at least *n* locations were in failure.
-
-### Configure the test monitor
-
-A notification is sent by your test based on the [alerting conditions](#define-alert-conditions) previously defined. Use this section to define how and what to message your teams.
-
-1. [Similar to how you configure monitors][5], select **users and/or services** that should receive notifications either by adding an `@notification`to the message or by searching for team members and connected integrations with the dropdown box.
-
-2. Enter the notification **message** for your test. This field allows standard [Markdown formatting][6] and supports the following [conditional variables][7]:
-
-    | Conditional Variable       | Description                                                         |
-    |----------------------------|---------------------------------------------------------------------|
-    | `{{#is_alert}}`            | Show when the test alerts.                                          |
-    | `{{^is_alert}}`            | Show unless the test alerts.                                        |
-    | `{{#is_recovery}}`         | Show when the test recovers from an alert.                          |
-    | `{{^is_recovery}}`         | Show unless the test recovers from an alert.                        |
-    | `{{#is_renotify}}`         | Show when the monitor renotifies.                                   |
-    | `{{^is_renotify}}`         | Show unless the monitor renotifies.                                 |
-    | `{{#is_priority}}`         | Show when the monitor matches priority (P1 to P5).                  |
-    | `{{^is_priority}}`         | Show unless the monitor matches priority (P1 to P5).                |
-
-3. Specify how often you want your test to **re-send the notification message** in case of test failure. To prevent renotification on failing tests, leave the option as `Never renotify if the monitor has not been resolved`.
-
-4. Click **Create** to save your test configuration and monitor.
-
-For more information, see [Using Synthetic Test Monitors][8].
+{{% synthetics-alerting-monitoring %}}
 
 {{% synthetics-variables %}}
 

--- a/content/en/synthetics/api_tests/websocket_tests.md
+++ b/content/en/synthetics/api_tests/websocket_tests.md
@@ -95,50 +95,10 @@ Select the **Locations** to run your WebSocket test from. WebSocket tests can ru
 WebSocket tests can run:
 
 * **On a schedule** to ensure your most important endpoints are always accessible to your users. Select the frequency at which you want Datadog to run your WebSocket test.
-* [**Within your CI/CD pipelines**][2] to start shipping without fearing faulty code might impact your customers experience.
+* [**Within your CI/CD pipelines**][2] to start shipping without fearing faulty code might impact your customers' experience.
 * **On-demand** to run your tests whenever makes the most sense for your team.
 
-### Define alert conditions
-
-Set alert conditions to determine the circumstances under which you want a test to fail and trigger an alert.
-
-#### Alerting rule
-
-When you set the alert conditions to: `An alert is triggered if your test fails for X minutes from any n of N locations`, an alert is triggered only if these two conditions are true:
-
-* At least one location was in failure (at least one assertion failed) during the last *X* minutes;
-* At one moment during the last *X* minutes, at least *n* locations were in failure.
-
-#### Fast retry
-
-Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
-
-Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
-
-### Configure the test monitor
-
-A notification is sent by your test based on the [alerting conditions](#define-alert-conditions) previously defined. Use this section to define how and what to message your teams.
-
-1. [Similar to how you configure monitors][5], select **users and/or services** that should receive notifications either by adding a `@notification` to the message or by searching for team members and connected integrations with the dropdown box.
-
-2. Enter the notification **message** for your test. This field allows standard [Markdown formatting][6] and supports the following [conditional variables][7]:
-
-    | Conditional Variable       | Description                                                         |
-    |----------------------------|---------------------------------------------------------------------|
-    | `{{#is_alert}}`            | Show when the test alerts.                                          |
-    | `{{^is_alert}}`            | Show unless the test alerts.                                        |
-    | `{{#is_recovery}}`         | Show when the test recovers from an alert.                          |
-    | `{{^is_recovery}}`         | Show unless the test recovers from an alert.                        |
-    | `{{#is_renotify}}`         | Show when the monitor renotifies.                                   |
-    | `{{^is_renotify}}`         | Show unless the monitor renotifies.                                 |
-    | `{{#is_priority}}`         | Show when the monitor matches priority (P1 to P5).                  |
-    | `{{^is_priority}}`         | Show unless the monitor matches priority (P1 to P5).                |
-
-3. Specify how often you want your test to **re-send the notification message** in case of test failure. To prevent renotification on failing tests, leave the option as `Never renotify if the monitor has not been resolved`.
-
-4. Click **Create** to save your test configuration and monitor.
-
-For more information, see [Using Synthetic Test Monitors][8].
+{{% synthetics-alerting-monitoring %}}
 
 {{% synthetics-variables %}} 
 

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -107,31 +107,7 @@ Define the configuration of your browser test.
   
 7. Set the **test frequency**: The intervals vary from every five minutes to once per week. To request one-minute frequency, [contact Support][2].
 
-## Variables
-
-### Create local variables
-
-To create a local variable, click **Create a Local Variable** at the top right hand corner. You can select one of the following available builtins:
-
-`{{ numeric(n) }}`
-: Generates a numeric string with `n` digits.
-
-`{{ alphabetic(n) }}`
-: Generates an alphabetic string with `n` letters.
-
-`{{ alphanumeric(n) }}`
-: Generates an alphanumeric string with `n` characters.
-
-`{{ uuid }}`
-: Generates a version 4 universally unique identifier (UUID).
-
-`{{ date(n unit, format) }}`
-: Generates a date in one of Datadog's accepted formats with a value corresponding to the UTC date the test is initiated at + or - `n` units.
-
-`{{ timestamp(n, unit) }}` 
-: Generates a timestamp in one of Datadog's accepted units with a value corresponding to the UTC timestamp the test is initiated at + or - `n` units.
-
-To obfuscate local variable values in test results, select **Hide and obfuscate variable value**. Once you have defined the variable string, click **Add Variable**.
+{{% synthetics-variables %}}
 
 ### Use global variables
 

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -138,7 +138,7 @@ You can customize alert conditions to define the circumstances under which you w
 
 A notification is sent according to the set of alerting conditions. Use this section to define how and what to message your teams.
 
-1. Enter a **message** for the browser test. This field allows standard [Markdown formatting][5] and supports the following [conditional variables][6]:
+1. Enter a **message** for the browser test. This field allows standard [Markdown formatting][6] and supports the following [conditional variables][17]:
 
     | Conditional Variable       | Description                                                         |
     |----------------------------|---------------------------------------------------------------------|
@@ -211,3 +211,4 @@ You can restrict access to a browser test based on the roles in your organizatio
 [14]: /account_management/rbac/#create-a-custom-role
 [15]: /continuous_testing/testing_tunnel
 [16]: /synthetics/guide/browser-tests-passkeys
+[17]: /monitors/notify/variables/?tab=is_alert#conditional-variables

--- a/content/en/synthetics/browser_tests/actions.md
+++ b/content/en/synthetics/browser_tests/actions.md
@@ -250,14 +250,14 @@ You can select one of the following available builtins:
 `{{ alphanumeric(n) }}`
 : Generates an alphanumeric string with `n` characters.
 
-`{{ uuid }}`
-: Generates a version 4 universally unique identifier (UUID).
-
 `{{ date(n unit, format) }}`
 : Generates a date in one of Datadog's accepted formats with a value corresponding to the UTC date the test is initiated at + or - `n` units.
 
 `{{ timestamp(n, unit) }}` 
 : Generates a timestamp in one of Datadog's accepted units with a value corresponding to the UTC timestamp the test is initiated at + or - `n` units.
+
+`{{ uuid }}`
+: Generates a version 4 universally unique identifier (UUID).
 
 To obfuscate local variable values in test results, select **Hide and obfuscate variable value**. Once you have defined the variable string, click **Add Variable**.
 

--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -171,49 +171,11 @@ You can extract up to ten variables per test step. Once created, this variable c
 
 Multistep API tests can run:
 
-* **On a schedule** to ensure your most important endpoints are always accessible to your users. Select the frequency you want Datadog to run your Multistep API test.
-
-{{< img src="synthetics/api_tests/schedule.png" alt="Run API tests on schedule" style="width:90%;" >}}
-
-* [**Within your CI/CD pipelines**][4] to start shipping without fearing faulty code might impact your customers experience.
+* **On a schedule** to ensure your most important endpoints are always accessible to your users. Select the frequency you want Datadog to run your multistep API test.
+* [**Within your CI/CD pipelines**][4] to start shipping without fearing faulty code might impact your customers' experience.
 * **On-demand** to run your tests whenever makes the most sense for your teams.
 
-### Define alert conditions
-
-Set alert conditions to determine the circumstances under which you want a test to fail and trigger an alert.
-
-#### Alerting rule
-
-When you set the alert conditions to: `An alert is triggered if any assertion fails for X minutes from any n of N locations`, an alert is triggered only if these two conditions are true:
-
-* At least one location was in failure (at least one assertion failed) during the last *X* minutes;
-* At one moment during the last *X* minutes, at least *n* locations were in failure.
-
-#### Fast retry
-
-Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
-
-Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
-
-### Configure the test monitor
-
-A notification is sent by your test based on the [alerting conditions](#define-alert-conditions) previously defined. Use this section to define how and what to message your team.
-
-1. [Similar to monitors][10], select **users and/or services** that should receive notifications either by adding an `@notification` to the message or by searching for team members and connected integrations with the dropdown box.
-
-2. Enter the notification **message** for your test. This field allows standard [Markdown formatting][11] and supports the following [conditional variables][12]:
-
-    | Conditional Variable       | Description                                                         |
-    |----------------------------|---------------------------------------------------------------------|
-    | `{{#is_alert}}`            | Show when the test alerts.                                          |
-    | `{{^is_alert}}`            | Show unless the test alerts.                                        |
-    | `{{#is_recovery}}`         | Show when the test recovers from alert.                             |
-    | `{{^is_recovery}}`         | Show unless the test recovers from alert.                           |
-
-3. Specify how often you want your test to **re-send the notification message** in case of test failure. To prevent renotification on failing tests, leave the option as `Never renotify if the monitor has not been resolved`.
-4. Click **Create** to save your test configuration and monitor.
-
-For more information, see [Using Synthetic Test Monitors][13].
+{{% synthetics-alerting-monitoring %}}
 
 {{% synthetics-variables %}}
 

--- a/content/en/synthetics/multistep.md
+++ b/content/en/synthetics/multistep.md
@@ -215,35 +215,11 @@ A notification is sent by your test based on the [alerting conditions](#define-a
 
 For more information, see [Using Synthetic Test Monitors][13].
 
-## Variables
+{{% synthetics-variables %}}
 
 ### Extract variables
 
 In addition to creating local variables, you can [extract variables from any step](#extract-variables-from-the-response) of your multistep API test and [re-inject the values in subsequent steps](#use-variables).
-
-### Create local variables
-
-To create a local variable, click **Create a Local Variable** at the top right hand corner. You can select one of the following available builtins:
-
-`{{ numeric(n) }}`
-: Generates a numeric string with `n` digits.
-
-`{{ alphabetic(n) }}`
-: Generates an alphabetic string with `n` letters.
-
-`{{ alphanumeric(n) }}`
-: Generates an alphanumeric string with `n` characters.
-
-`{{ uuid }}`
-: Generates a version 4 universally unique identifier (UUID).
-
-`{{ date(n unit, format) }}`
-: Generates a date in one of Datadog's accepted formats with a value corresponding to the UTC date the test is initiated at + or - `n` units.
-
-`{{ timestamp(n, unit) }}` 
-: Generates a timestamp in one of Datadog's accepted units with a value corresponding to the UTC timestamp the test is initiated at + or - `n` units.
-
-To obfuscate local variable values in test results, select **Hide and obfuscate variable value**. Once you have defined the variable string, click **Add Variable**.
 
 ### Use variables
 

--- a/layouts/shortcodes/synthetics-alerting-monitoring.md
+++ b/layouts/shortcodes/synthetics-alerting-monitoring.md
@@ -25,14 +25,14 @@ A notification is sent by your test based on the [alerting conditions](#define-a
 
     | Conditional Variable       | Description                                                         |
     |----------------------------|---------------------------------------------------------------------|
-    | `{{#is_alert}}`            | Show when the test alerts.                                          |
-    | `{{^is_alert}}`            | Show unless the test alerts.                                        |
-    | `{{#is_recovery}}`         | Show when the test recovers from alert.                             |
-    | `{{^is_recovery}}`         | Show unless the test recovers from alert.                           |
-    | `{{#is_renotify}}`         | Show when the monitor renotifies.                                   |
-    | `{{^is_renotify}}`         | Show unless the monitor renotifies.                                 |
-    | `{{#is_priority}}`         | Show when the monitor matches priority (P1 to P5).                  |
-    | `{{^is_priority}}`         | Show unless the monitor matches priority (P1 to P5).                |
+    | &#x7b;&#x7b; #is_alert &#x7d;&#x7d;            | Show when the test alerts.                                          |
+    | &#x7b;&#x7b; ^is_alert &#x7d;&#x7d;            | Show unless the test alerts.                                        |
+    | &#x7b;&#x7b; #is_recovery &#x7d;&#x7d;         | Show when the test recovers from alert.                             |
+    | &#x7b;&#x7b; ^is_recovery &#x7d;&#x7d;         | Show unless the test recovers from alert.                           |
+    | &#x7b;&#x7b; #is_renotify &#x7d;&#x7d;         | Show when the monitor renotifies.                                   |
+    | &#x7b;&#x7b; ^is_renotify &#x7d;&#x7d;         | Show unless the monitor renotifies.                                 |
+    | &#x7b;&#x7b; #is_priority &#x7d;&#x7d;         | Show when the monitor matches priority (P1 to P5).                  |
+    | &#x7b;&#x7b; ^is_priority &#x7d;&#x7d;         | Show unless the monitor matches priority (P1 to P5).                |
 
 3. Specify how often you want your test to **re-send the notification message** in case of test failure. To prevent renotification on failing tests, leave the option as `Never renotify if the monitor has not been resolved`.
 

--- a/layouts/shortcodes/synthetics-alerting-monitoring.md
+++ b/layouts/shortcodes/synthetics-alerting-monitoring.md
@@ -1,0 +1,46 @@
+### Define alert conditions
+
+Set alert conditions to determine the circumstances under which you want a test to fail and trigger an alert.
+
+#### Alerting rule
+
+When you set the alert conditions to: `An alert is triggered if any assertion fails for X minutes from any n of N locations`, an alert is triggered only if these two conditions are true:
+
+* At least one location was in failure (at least one assertion failed) during the last *X* minutes;
+* At one moment during the last *X* minutes, at least *n* locations were in failure.
+
+#### Fast retry
+
+Your test can trigger retries `X` times after `Y` ms in case of a failed test result. Customize the retry interval to suit your alerting sensibility.
+
+Location uptime is computed on a per-evaluation basis (whether the last test result before evaluation was up or down). The total uptime is computed based on the configured alert conditions. Notifications sent are based on the total uptime.
+
+### Configure the test monitor
+
+A notification is sent by your test based on the [alerting conditions](#define-alert-conditions) previously defined. Use this section to define how and what to message your team.
+
+1. [Similar to how you configure monitors][101], select **users and/or services** that should receive notifications either by adding an `@notification` to the message or by searching for team members and connected integrations with the dropdown menu.
+
+2. Enter the notification **message** for your test. This field allows standard [Markdown formatting][104] and supports the following [conditional variables][102]:
+
+    | Conditional Variable       | Description                                                         |
+    |----------------------------|---------------------------------------------------------------------|
+    | `{{#is_alert}}`            | Show when the test alerts.                                          |
+    | `{{^is_alert}}`            | Show unless the test alerts.                                        |
+    | `{{#is_recovery}}`         | Show when the test recovers from alert.                             |
+    | `{{^is_recovery}}`         | Show unless the test recovers from alert.                           |
+    | `{{#is_renotify}}`         | Show when the monitor renotifies.                                   |
+    | `{{^is_renotify}}`         | Show unless the monitor renotifies.                                 |
+    | `{{#is_priority}}`         | Show when the monitor matches priority (P1 to P5).                  |
+    | `{{^is_priority}}`         | Show unless the monitor matches priority (P1 to P5).                |
+
+3. Specify how often you want your test to **re-send the notification message** in case of test failure. To prevent renotification on failing tests, leave the option as `Never renotify if the monitor has not been resolved`.
+
+4. Click **Create** to save your test configuration and monitor.
+
+For more information, see [Using Synthetic Test Monitors][103].
+
+[101]: /monitors/notify/?tab=is_alert#notify-your-team
+[102]: /monitors/notify/variables/?tab=is_alert#conditional-variables
+[103]: /synthetics/guide/synthetic-test-monitors/
+[104]: http://daringfireball.net/projects/markdown/syntax

--- a/layouts/shortcodes/synthetics-variables.md
+++ b/layouts/shortcodes/synthetics-variables.md
@@ -13,13 +13,13 @@ To create a local variable, click **Create a Local Variable**. You can select on
 &#x7b;&#x7b; alphanumeric(n) &#x7d;&#x7d;
 : Generates an alphanumeric string with `n` characters.
 
-&#x7b;&#x7b; uuid &#x7d;&#x7d;
-: Generates a version 4 universally unique identifier (UUID).
-
 &#x7b;&#x7b; date(n unit, format) &#x7d;&#x7d;
 : Generates a date in one of Datadog's accepted formats with a value corresponding to the UTC date the test is initiated at + or - `n` units.
 
 &#x7b;&#x7b; timestamp(n, unit) &#x7d;&#x7d;
 : Generates a timestamp in one of Datadog's accepted units with a value corresponding to the UTC timestamp the test is initiated at +/- `n` units.
+
+&#x7b;&#x7b; uuid &#x7d;&#x7d;
+: Generates a version 4 universally unique identifier (UUID).
 
 To obfuscate local variable values in test results, select **Hide and obfuscate variable value**. Once you have defined the variable string, click **Add Variable**.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Finds more instances of the `synthetics-variables` shortcode and adds a `synthetics-alerting-monitoring` shortcode.  

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-5829, ready to merge.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
