### PR TITLE
fix sidenav search bar not showing - [WEB-3815]

### DIFF
--- a/layouts/partials/sidenav/main-sidenav.html
+++ b/layouts/partials/sidenav/main-sidenav.html
@@ -5,8 +5,11 @@
         <div class="col">
 
             <p class="h4 text-brand-primary"><a class="text-primary" href="{{ "" | absLangURL  }}">{{ i18n "datadog_docs" }}</a></p>
-            
-            {{ if ne $dot.File.ContentBaseName "search" }}
+            {{/*  
+                load searchbar if not on search results page, else
+                append the searchbar asynchronously (async-loading.js)   
+            */}}
+            {{ if ne $dot.File.Path "search.md" }}
             {{ partial "search.html" . }}
             {{ else }}
             <div id="async-searchbar-mount"></div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

The `.sidenav` searchbar should **not** appear on the `search results` page only.

fixes a bug where the search bar would not show on pages with a [ContentBaseName (defaulted to TranslationBaseName)](https://gohugo.io/variables/files/#prose) of 'search'. 

this included the [search results page](https://docs.datadoghq.com/search/) and all other pages that ended in `/search` (ex: https://docs.datadoghq.com/tracing/trace_explorer/search/)

uses `File.Path` variable to specify the `search results` (`search.md`) page


### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-3815

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/stefon.simmons/web-3815/tracing/trace_explorer/search/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
