### PR TITLE
[DOCS-5770] adding info on network access restrictions

### DIFF
--- a/content/en/agent/guide/use-community-integrations.md
+++ b/content/en/agent/guide/use-community-integrations.md
@@ -18,7 +18,7 @@ Community developed integrations for the Datadog Agent are stored in the Datadog
 
 ## Setup
 
-For new users, download, and install the latest version of the [Datadog Agent][2].
+For new users, download and install the latest version of the [Datadog Agent][2].
 
 ### Installation
 
@@ -71,15 +71,17 @@ For Agent < v7.21 / v6.21:
 5. Configure your integration similar to core [integrations][3].
 6. [Restart the Agent][4].
 
+[1]: https://github.com/DataDog/integrations-extras
+[2]: /agent/guide/agent-configuration-files/#agent-configuration-directory
+[3]: /getting_started/integrations/
+[4]: /agent/guide/agent-commands/#restart-the-agent
+
+
 {{% /tab %}}
 {{< /tabs >}}
 
 If your site restricts network access, ensure your have added all of the [`ip-ranges`][5] to your inclusion list, or download the integration manually.
 
-[1]: https://github.com/DataDog/integrations-extras
-[2]: /agent/guide/agent-configuration-files/#agent-configuration-directory
-[3]: /getting_started/integrations/
-[4]: /agent/guide/agent-commands/#restart-the-agent
 [5]: /agent/guide/network
 
 

--- a/content/en/agent/guide/use-community-integrations.md
+++ b/content/en/agent/guide/use-community-integrations.md
@@ -18,7 +18,7 @@ Community developed integrations for the Datadog Agent are stored in the Datadog
 
 ## Setup
 
-For new users, download and install the latest version of the [Datadog Agent][2].
+For new users, download, and install the latest version of the [Datadog Agent][2].
 
 ### Installation
 
@@ -71,13 +71,17 @@ For Agent < v7.21 / v6.21:
 5. Configure your integration similar to core [integrations][3].
 6. [Restart the Agent][4].
 
+{{% /tab %}}
+{{< /tabs >}}
+
+If your site restricts network access, ensure your have added all of the [`ip-ranges`][5] to your inclusion list, or download the integration manually.
 
 [1]: https://github.com/DataDog/integrations-extras
 [2]: /agent/guide/agent-configuration-files/#agent-configuration-directory
 [3]: /getting_started/integrations/
 [4]: /agent/guide/agent-commands/#restart-the-agent
-{{% /tab %}}
-{{< /tabs >}}
+[5]: /agent/guide/network
+
 
 <br>
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds a brief sentence describing how to handle issues if a user's site blocks access to network traffic.

### Motivation
[DOCS-5770](https://datadoghq.atlassian.net/browse/DOCS-5770)

Ready to merge

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5770]: https://datadoghq.atlassian.net/browse/DOCS-5770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ