### PR TITLE
Remove 128-bit trace ID feature flags for Java tracer

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -266,18 +266,6 @@ When `true`, user principal is collected. Available for versions 0.61+.
 **Default**: `true`<br>
 When `true`, the tracer collects [telemetry data][6]. Available for versions 0.104+. Defaults to `true` for versions 0.115+.
 
-`dd.trace.128.bit.traceid.generation.enabled`
-: **Environment Variable**: `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED`<br>
-**Default**: `false` <br>
-Enable generation of 128-bit trace IDs. By default, only 64-bit IDs are generated.
-
-`dd.trace.128.bit.traceid.logging.enabled`
-: **Environment Variable**: `DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED`<br>
-**Default**: `false` <br>
-Enable printing of the full 128-bit ID when formatting a span within logs using MDC.
-When false (default), only the low 64-bits of the trace ID are printed, formatted as an integer. This means if the trace ID is only 64 bits, the full ID is printed.
-When true, the trace ID is printed as a full 128-bit ID in hexadecimal format, except if the ID itself is only 64 bits - in which case, it is formatted as an integer.
-
 **Note**:
 
 - If the same key type is set for both, the system property configuration takes priority.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->



### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

The documented feature is not yet ready to be used by customers.
This commit could be reverted as soon as the feature is ready.


### Motivation
<!-- What inspired you to submit this pull request?-->

Same as #18878 and #18938 but for Java tracer.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [x] Review the changed files.
- [x] Review the URLs listed in the [Preview](#preview) section.
- [x] Check images for PII
- [x] Review any mentions of "Contact Datadog support" for internal support documentation.
