### PR TITLE
[STAT-410] update --site option to env var

### DIFF
--- a/content/en/continuous_integration/static_analysis/_index.md
+++ b/content/en/continuous_integration/static_analysis/_index.md
@@ -176,3 +176,4 @@ The content of the violation is shown in tabs:
 [3]: /integrations/github/
 [4]: /account_management/api-app-keys/
 [5]: https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=sarif
+[103]: /getting_started/site/

--- a/content/en/continuous_integration/static_analysis/_index.md
+++ b/content/en/continuous_integration/static_analysis/_index.md
@@ -89,18 +89,18 @@ Prerequisites:
 
 Configure the following environment variables:
 
-| Name         | Description                                                                                                                | Required |
-|--------------|----------------------------------------------------------------------------------------------------------------------------|----------|
-| `DD_API_KEY` | Your Datadog API key. This key is created by your [Datadog organization][101] and should be stored as a secret.              | Yes     |
-| `DD_APP_KEY` | Your Datadog application key. This key is created by your [Datadog organization][102] and should be stored as a secret.      | Yes     |
+| Name         | Description                                                                                                                | Required | Default         |
+|--------------|----------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
+| `DD_API_KEY` | Your Datadog API key. This key is created by your [Datadog organization][101] and should be stored as a secret.            | Yes      |                 |
+| `DD_APP_KEY` | Your Datadog application key. This key is created by your [Datadog organization][102] and should be stored as a secret.    | Yes      |                 |
+| `DD_SITE`    | The [Datadog site][103] to send information to. Your Datadog site is {{< region-param key="dd_site" code="true" >}}.       | No       | `datadoghq.com` |
 
 Provide the following inputs:
 
-| Name         | Description                                                                                                                | Required | Default         |
-|--------------|----------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
-| `service` | The name of the service to tag the results with.                                                                                | Yes     |                 |
-| `env`     | The environment to tag the results with. `ci` is a helpful value for this input.                                                                           | No    | `none`          |
-| `site`    | The [Datadog site][103] to send information to. Your Datadog site is {{< region-param key="dd_site" code="true" >}}.                                                                                 | No    | {{< region-param key="dd_site" code="true" >}}  |
+| Name       | Description                                                                                                                | Required | Default         |
+|------------|----------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
+| `service`  | The name of the service to tag the results with.                                                                           | Yes      |                 |
+| `env`      | The environment to tag the results with. `ci` is a helpful value for this input.                                           | No       | `none`          |
 
 Add the following to your CI pipeline:
 
@@ -114,7 +114,7 @@ unzip /tmp/ddog-static-analyzer -d /tmp
 /tmp/cli-1.0-SNAPSHOT/bin/cli --directory . -t true -o results.sarif -f sarif
 
 # Upload results
-datadog-ci sarif upload results.sarif --service "$DD_SERVICE" --env "$DD_ENV" --site "$DD_SITE"
+datadog-ci sarif upload results.sarif --service "$DD_SERVICE" --env "$DD_ENV"
 ```
 
 [101]: /account_management/api-app-keys/#api-keys
@@ -131,17 +131,18 @@ You can send results from third-party static analysis tools to Datadog, provided
 To upload a SARIF report:
 
 1. Ensure the [`DD_API_KEY` and `DD_APP_KEY` variables are defined][4].
-2. Install the `datadog-ci` utility:
+2. Optional: Set a [`DD_SITE` variable][103] (default: `datadoghq.com`).
+3. Install the `datadog-ci` utility:
    
    ```bash
    npm install -g @datadog/datadog-ci
    ```
 
-3. Run the third-party static analysis tool on your code and output the results in the SARIF format.
-4. Upload the results to Datadog:
+4. Run the third-party static analysis tool on your code and output the results in the SARIF format.
+5. Upload the results to Datadog:
 
    ```bash
-   datadog-ci sarif upload $OUTPUT_LOCATION --service <datadog-service> --env <datadog-env> --site <dd-site>
+   datadog-ci sarif upload $OUTPUT_LOCATION --service <datadog-service> --env <datadog-env>
    ```
 
 ## Run Static Analysis in a CI pipeline

--- a/content/en/continuous_integration/static_analysis/_index.md
+++ b/content/en/continuous_integration/static_analysis/_index.md
@@ -126,6 +126,10 @@ datadog-ci sarif upload results.sarif --service "$DD_SERVICE" --env "$DD_ENV"
 
 ### Upload third-party static analysis results to Datadog
 
+<div class="alert alert-info">
+  SARIF importing has been tested for Snyk, CodeQL, Semgrep, Checkov, and Sysdig. Please reach out to <a href="/help">Datadog Support</a> if you experience any issues with other SARIF-compliant tools.
+</div>
+
 You can send results from third-party static analysis tools to Datadog, provided they are in the interoperable [Static Analysis Results Interchange Format (SARIF) Format][5]. 
 
 To upload a SARIF report:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The `datadog-ci upload sarif` command does not accept a `--site` option. Instead it should be a `DD_SITE` environment variable.

### Motivation
A user reported they followed our docs and they couldn't upload their SARIF report as `--site` was not supported.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
