### PR TITLE
Source Code Integration: add instructions for embedding git commit metadata for .NET & Python

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -121,36 +121,47 @@ Ensure your service meets all the following requirements:
 {{% /tab %}}
 
 {{% tab "Python" %}}
-First, upgrade the [Python tracer](https://app.datadoghq.com/apm/service-setup?architecture=host-based&language=python) to v1.12 or higher.
+First, upgrade the [Python tracer][1] to v1.12 or higher.
 
-For standard library:
-1. Install **ddtrace** package
-2. Add `import ddtrace.sourcecode.setuptools_auto` as the first import to the setup.py
-3. Set the environment variable **DD_MAIN_PACKAGE** to the name of the primary Python package.
+For the standard library:
+1. Install the `ddtrace` package.
+2. Add `import ddtrace.sourcecode.setuptools_auto` as the first import to `setup.py`.
+3. Set the environment variable `DD_MAIN_PACKAGE` to the name of the primary Python package.
 
-For unified python project settings file:
-1. Install **hatch-datadog-build-metadata** plugin and configure it to embed git metadata (if project already has urls they must be reconfigured as dynamic and moved to other config section), see official [README](https://github.com/DataDog/hatch-datadog-build-metadata#readme).
-2. Set the environment variable **DD_MAIN_PACKAGE**, to the name of the primary Python package.
+For the unified Python project settings file:
+1. Install the [`hatch-datadog-build-metadata` plugin][2] and configure it to embed git metadata. If the project already has URLs, you must reconfigure them as dynamic and move them to another config section.
+2. Set the environment variable `DD_MAIN_PACKAGE` to the name of the primary Python package.
+
+[1]: https://app.datadoghq.com/apm/service-setup?architecture=host-based&language=python
+[2]: https://github.com/DataDog/hatch-datadog-build-metadata
 {{% /tab %}}
 
 {{% tab ".NET" %}}
-Datadog is able to leverage [Microsot SourceLink](https://github.com/dotnet/sourcelink#readme) to extract the git commit SHA and repository URL directly from your .NET assembly. To use this approach:
-1. Open your project file (.csproj) in your IDE, and add a reference to one of the following nuget packages, based on where your git repository is hosted:
-   - **GitHub:** [Microsoft.SourceLink.GitHub](https://www.nuget.org/packages/Microsoft.SourceLink.GitHub)
-   - **Bitbucket:** [Microsoft.SourceLink.Bitbucket](https://www.nuget.org/packages/Microsoft.SourceLink.Bitbucket)
-   - **GitLab:** [Microsoft.SourceLink.GitLab](https://www.nuget.org/packages/Microsoft.SourceLink.GitLab)
-   - **Azure DevOps:** [Microsoft.SourceLink.AzureRepos.Git](https://www.nuget.org/packages/Microsoft.SourceLink.AzureRepos.Git)
-   - **Azure DevOps Server:** [Microsoft.SourceLink.AzureDevOpsServer.Git](https://www.nuget.org/packages/Microsoft.SourceLink.AzureDevOpsServer.Git)
-2. Upgrade the [.NET tracer](https://github.com/DataDog/dd-trace-dotnet/releases) to v2.25.0 or higher
-3. Ensure that your .pdb files are deployed alongside your .NET assemblies (.dll or .exe), in the same folder.
+Datadog can use [Microsot SourceLink][1] to extract the git commit SHA and repository URL directly from your .NET assembly. To use this approach:
+1. Open your project file (`.csproj`) in your IDE, and add a reference to one of the following NuGet packages, based on where your git repository is hosted:
+   - **GitHub:** [Microsoft.SourceLink.GitHub][2]
+   - **Bitbucket:** [Microsoft.SourceLink.Bitbucket][3]
+   - **GitLab:** [Microsoft.SourceLink.GitLab]()
+   - **Azure DevOps:** [Microsoft.SourceLink.AzureRepos.Git][5]
+   - **Azure DevOps Server:** [Microsoft.SourceLink.AzureDevOpsServer.Git][6]
+2. Upgrade the [.NET tracer][7] to v2.25.0 or higher
+3. Ensure that your `.pdb` files are deployed alongside your .NET assemblies (`.dll` or `.exe`) in the same folder.
+
+[1]: https://github.com/dotnet/sourcelink
+[2]: https://www.nuget.org/packages/Microsoft.SourceLink.GitHub
+[3]: https://www.nuget.org/packages/Microsoft.SourceLink.Bitbucket
+[4]: https://www.nuget.org/packages/Microsoft.SourceLink.GitLab
+[5]: https://www.nuget.org/packages/Microsoft.SourceLink.AzureRepos.Git
+[6]: https://www.nuget.org/packages/Microsoft.SourceLink.AzureDevOpsServer.Git
+[7]: https://github.com/DataDog/dd-trace-dotnet/releases
 {{% /tab %}}
 
 {{< /tabs >}}
 
-#### Build inside a docker container
-If your build process is executed in CI within a docker container, perform the following steps to ensure that the build can access git information:
+#### Build inside a Docker container
+If your build process is executed in CI within a Docker container, perform the following steps to ensure that the build can access git information:
 
-1. Add the following text to your `.dockerignore` file. This ensures that the build process is able to access a subset of the .git folder, enabling it to determine the git commit hash and repository url. 
+1. Add the following text to your `.dockerignore` file. This ensures that the build process is able to access a subset of the `.git` folder, enabling it to determine the git commit hash and repository URL. 
 
 ```
 !.git/HEAD

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -17,7 +17,7 @@ further_reading:
 ## Overview
 
 <div class="alert alert-info">
-The source code integration supports:</br></br>Languages:<ul><li>Go</li><li>Java</li><li>JavaScript (doesn't support transpiled JavaScript)</li><li>Python</li><li>Ruby</li></ul></br>Git providers:<ul><li>GitHub</li><li>GitLab</li><li>BitBucket</li><li>Azure DevOps</li></ul></br> Self-hosted instances or private URLs are not supported.
+The source code integration supports:</br></br>Languages:<ul><li>Go</li><li>Java</li><li>JavaScript (doesn't support transpiled JavaScript)</li><li>Python</li><li>.NET</li><li>Ruby</li></ul></br>Git providers:<ul><li>GitHub</li><li>GitLab</li><li>BitBucket</li><li>Azure DevOps</li></ul></br> Self-hosted instances or private URLs are not supported.
 </div>
 
 Datadog's source code integration allows you to connect your telemetry with your Git repositories hosted in GitHub, GitLab, Bitbucket, or Azure DevOps. Once you have enabled the [source code integration][7], you can debug stack traces, slow profiles, and other issues by quickly accessing the relevant lines of your source code. 
@@ -119,6 +119,32 @@ Ensure your service meets all the following requirements:
 
 [1]: https://tip.golang.org/doc/go1.18
 {{% /tab %}}
+
+{{% tab "Python" %}}
+First, upgrade the [Python tracer](https://app.datadoghq.com/apm/service-setup?architecture=host-based&language=python) to v1.12 or higher.
+
+For standard library:
+1. Install **ddtrace** package
+2. Add `import ddtrace.sourcecode.setuptools_auto` as the first import to the setup.py
+3. Set the environment variable **DD_MAIN_PACKAGE** to the name of the primary Python package.
+
+For unified python project settings file:
+1. Install **hatch-datadog-build-metadata** plugin and configure it to embed git metadata (if project already has urls they must be reconfigured as dynamic and moved to other config section), see official [README](https://github.com/DataDog/hatch-datadog-build-metadata#readme).
+2. Set the environment variable **DD_MAIN_PACKAGE**, to the name of the primary Python package.
+{{% /tab %}}
+
+{{% tab "Python" %}}
+Datadog is able to leverage [Microsot SourceLink](https://github.com/dotnet/sourcelink#readme) to extract the git commit SHA and repository URL directly from your .NET assembly. To use this approach:
+1. Open your project file (.csproj) in your IDE, and add a reference to one of the following nuget packages, based on where your git repository is hosted:
+   - **GitHub:** [Microsoft.SourceLink.GitHub](https://www.nuget.org/packages/Microsoft.SourceLink.GitHub)
+   - **Bitbucket:** [Microsoft.SourceLink.Bitbucket](https://www.nuget.org/packages/Microsoft.SourceLink.Bitbucket)
+   - **GitLab:** [Microsoft.SourceLink.GitLab](https://www.nuget.org/packages/Microsoft.SourceLink.GitLab)
+   - **Azure DevOps:** [Microsoft.SourceLink.AzureRepos.Git](https://www.nuget.org/packages/Microsoft.SourceLink.AzureRepos.Git)
+   - **Azure DevOps Server:** [Microsoft.SourceLink.AzureDevOpsServer.Git](https://www.nuget.org/packages/Microsoft.SourceLink.AzureDevOpsServer.Git)
+2. Upgrade the [.NET tracer](https://github.com/DataDog/dd-trace-dotnet/releases) to v2.25.0 or higher
+3. Ensure that your .pdb files are deployed alongside your .NET assemblies (.dll or .exe), in the same folder.
+{{% /tab %}}
+
 {{< /tabs >}}
 
 ## Configure your repositories

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -155,8 +155,7 @@ If your build process is executed in CI within a docker container, perform the f
 ```
 !.git/HEAD
 !.git/config
-!.git/refs/heads/master
-!.git/refs/heads/main
+!.git/refs
 ```
 
 2. Add the following line of code to your `Dockerfile`. Ensure that it is placed before the actual build is ran.

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -148,9 +148,9 @@ Datadog is able to leverage [Microsot SourceLink](https://github.com/dotnet/sour
 {{< /tabs >}}
 
 #### Build inside a docker container
-If your build process is executed in CI within a docker container, you will need to go through the following additional steps to ensure that the build can access the git information:
+If your build process is executed in CI within a docker container, perform the following steps to ensure that the build can access git information:
 
-1. Add the following text to your `.dockerignore` file. This will ensure that the build process is able to access a subset of the .git folder, in order to determine the git commit hash and repository url. 
+1. Add the following text to your `.dockerignore` file. This ensures that the build process is able to access a subset of the .git folder, enabling it to determine the git commit hash and repository url. 
 
 ```
 !.git/HEAD

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -133,7 +133,7 @@ For unified python project settings file:
 2. Set the environment variable **DD_MAIN_PACKAGE**, to the name of the primary Python package.
 {{% /tab %}}
 
-{{% tab "Python" %}}
+{{% tab ".NET" %}}
 Datadog is able to leverage [Microsot SourceLink](https://github.com/dotnet/sourcelink#readme) to extract the git commit SHA and repository URL directly from your .NET assembly. To use this approach:
 1. Open your project file (.csproj) in your IDE, and add a reference to one of the following nuget packages, based on where your git repository is hosted:
    - **GitHub:** [Microsoft.SourceLink.GitHub](https://www.nuget.org/packages/Microsoft.SourceLink.GitHub)
@@ -150,7 +150,7 @@ Datadog is able to leverage [Microsot SourceLink](https://github.com/dotnet/sour
 #### Build inside a docker container
 If your build process is executed in CI within a docker container, you will need to go through the following additional steps to ensure that the build can access the git information:
 
-1. Add the following text to your .dockerignore file:
+1. Add the following text to your `.dockerignore` file. This will ensure that the build process is able to access a subset of the .git folder, in order to determine the git commit hash and repository url. 
 
 ```
 !.git/HEAD
@@ -159,9 +159,7 @@ If your build process is executed in CI within a docker container, you will need
 !.git/refs/heads/main
 ```
 
-This will ensure that the build process is able to access a subset of the .git folder, in order to determine the git commit hash and repository url. 
-
-2. Add the following line of code to your `Dockerfile`
+2. Add the following line of code to your `Dockerfile`. Ensure that it is placed before the actual build is ran.
 
 ```
 COPY .git ./.git

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -147,6 +147,27 @@ Datadog is able to leverage [Microsot SourceLink](https://github.com/dotnet/sour
 
 {{< /tabs >}}
 
+#### Build inside a docker container
+If your build process is executed in CI within a docker container, you will need to go through the following additional steps to ensure that the build can access the git information:
+
+1. Add the following text to your .dockerignore file:
+
+```
+!.git/HEAD
+!.git/config
+!.git/refs/heads/master
+!.git/refs/heads/main
+```
+
+This will ensure that the build process is able to access a subset of the .git folder, in order to determine the git commit hash and repository url. 
+
+2. Add the following line of code to your `Dockerfile`
+
+```
+COPY .git ./.git
+```
+
+
 ## Configure your repositories
 
 {{< tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

1. Add instructions on how customers can embed git metadata in their deployed artifacts for Python and .NET (adding to the instructions we already had for Go)
2. Add instructions on extra steps customers will need to take if they want to embed git metadata in their deployed artifact if their CI build process runs inside a docker container. These instructions apply to all languages (including Go).
3. 
### Motivation
These instructions will enable developers to introduce Source Code Integration for their services without requiring the assistance of an IT/Ops person.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
