### PR TITLE
Improve mobile logs documentation

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2456,54 +2456,59 @@ main:
     url: logs/log_collection/flutter/
     parent: log_collection
     weight: 104
+  - name: React Native
+    identifier: log_react_native
+    url: logs/log_collection/reactnative/
+    parent: log_collection
+    weight: 105
   - name: Roku
     identifier: log_roku
     url: logs/log_collection/roku/
     parent: log_collection
-    weight: 105
+    weight: 106
   - name: C#
     url: logs/log_collection/csharp/
     parent: log_collection
-    weight: 106
+    weight: 107
   - name: Go
     identifier: log_go
     url: logs/log_collection/go/
     parent: log_collection
-    weight: 107
+    weight: 108
   - name: Java
     url: logs/log_collection/java/
     parent: log_collection
     identifier: log_collection_java
-    weight: 108
+    weight: 109
   - name: NodeJS
     url: logs/log_collection/nodejs/
     parent: log_collection
-    weight: 109
+    weight: 110
   - name: PHP
     identifier: log_php
     url: logs/log_collection/php/
     parent: log_collection
-    weight: 110
+    weight: 111
   - name: Python
     identifier: log_python
     url: logs/log_collection/python/
     parent: log_collection
-    weight: 111
+    weight: 112
   - name: Ruby
     url: logs/log_collection/ruby/
     parent: log_collection
     identifier: log_collection_ruby
-    weight: 112
+    weight: 113
   - name: OpenTelemetry
     url: opentelemetry/otel_logs/
     parent: log_collection
     identifier: log_collection_opentelemetry
-    weight: 113
+    weight: 114
   - name: Other Integrations
     url: integrations/#cat-log-collection
     identifier: other_integrations
     parent: log_collection
-    weight: 114
+    weight: 115
   - name: Log Configuration
     url: logs/log_configuration/
     parent: log_management

--- a/content/en/account_management/api-app-keys.md
+++ b/content/en/account_management/api-app-keys.md
@@ -32,10 +32,10 @@ The recommended best practice for scoping application keys is to grant your keys
 
 ## Client tokens
 
-For security reasons, API keys cannot be used to send data from a browser, mobile, or tv app, as they would be exposed client-side. Instead, end user facing applications use client tokens to send data to Datadog.
+For security reasons, API keys cannot be used to send data from a browser, mobile, or TV app, as they would be exposed client-side. Instead, end user facing applications use client tokens to send data to Datadog.
 
  Several types of clients submit data that requires a client token, including the following examples:
-- The log collectors for [web browser][6], [Android][12], [iOS][13], [React Native][14], [Flutter][15] and [Roku][16] submit logs.
+- The log collectors for [web browser][6], [Android][12], [iOS][13], [React Native][14], [Flutter][15], and [Roku][16] submit logs.
 - [Real User Monitoring][7] applications submit events and logs.
 
 Client tokens are unique to your organization. To manage your client tokens, go to **Organization Settings**, then click the **Client Tokens** tab.

--- a/content/en/account_management/api-app-keys.md
+++ b/content/en/account_management/api-app-keys.md
@@ -32,10 +32,10 @@ The recommended best practice for scoping application keys is to grant your keys
 
 ## Client tokens
 
-For security reasons, API keys cannot be used to send data from a browser, as they would be exposed client-side in the JavaScript code. Instead, web browsers and other clients use client tokens to send data to Datadog.
+For security reasons, API keys cannot be used to send data from a browser, mobile or tv app, as they would be exposed client-side in the JavaScript code. Instead, end user facing applications use client tokens to send data to Datadog.
 
  Several types of clients submit data that requires a client token, including the following examples:
-- The [web browser log collector][6] submits logs.
+- The log collectors for [web browser][6], [Android][12], [iOS][13], [React Native][14], [Flutter][15] and [Roku][16] submit logs.
 - [Real User Monitoring][7] applications submit events and logs.
 
 Client tokens are unique to your organization. To manage your client tokens, go to **Organization Settings**, then click the **Client Tokens** tab.
@@ -132,3 +132,8 @@ Need help? Contact [Datadog support][10].
 [9]: /api/latest/service-accounts/
 [10]: /help/
 [11]: /account_management/org_settings/service_accounts/
+[12]: /logs/log_collection/android/
+[13]: /logs/log_collection/ios/
+[14]: /logs/log_collection/reactnative/
+[15]: /logs/log_collection/flutter/
+[16]: /logs/log_collection/roku/

--- a/content/en/account_management/api-app-keys.md
+++ b/content/en/account_management/api-app-keys.md
@@ -40,7 +40,7 @@ For security reasons, API keys cannot be used to send data from a browser, mobil
 
 Client tokens are unique to your organization. To manage your client tokens, go to **Organization Settings**, then click the **Client Tokens** tab.
 
-**Note:** When a user who created a client token is deactivated, the client token remains active.
+**Note**: When a user who created a client token is deactivated, the client token remains active.
 
 ## Add an API key or client token
 

--- a/content/en/account_management/api-app-keys.md
+++ b/content/en/account_management/api-app-keys.md
@@ -32,7 +32,7 @@ The recommended best practice for scoping application keys is to grant your keys
 
 ## Client tokens
 
-For security reasons, API keys cannot be used to send data from a browser, mobile or tv app, as they would be exposed client-side in the JavaScript code. Instead, end user facing applications use client tokens to send data to Datadog.
+For security reasons, API keys cannot be used to send data from a browser, mobile, or tv app, as they would be exposed client-side. Instead, end user facing applications use client tokens to send data to Datadog.
 
  Several types of clients submit data that requires a client token, including the following examples:
 - The log collectors for [web browser][6], [Android][12], [iOS][13], [React Native][14], [Flutter][15] and [Roku][16] submit logs.

--- a/content/en/logs/log_collection/android.md
+++ b/content/en/logs/log_collection/android.md
@@ -29,7 +29,7 @@ Send logs to Datadog from your Android applications with [Datadog's `dd-sdk-andr
     }
     ```
 
-2. Initialize the library with your application context, tracking consent, and the [Datadog client token][2] and Application ID generated when you create a new RUM application in the Datadog UI (see [Getting Started with Android RUM Collection][6] for more information). For security reasons, you must use a client token: you cannot use [Datadog API keys][3] to configure the `dd-sdk-android` library as they would be exposed client-side in the Android application APK byte code. For more information about setting up a client token, see the [client token documentation][2]. The `APP_VARIANT_NAME` specifies the variant of the application that generates data.
+2. Initialize the library with your application context, tracking consent, and the [Datadog client token][2] and Application ID generated when you create a new RUM application in the Datadog UI (see [Getting Started with Android RUM Collection][6] for more information). For security reasons, you must use a client token: you cannot use [Datadog API keys][3] to configure the `dd-sdk-android` library as they would be exposed client-side in the Android application APK byte code. For more information about setting up a client token, see the [client token documentation][2]. The `APP_VARIANT_NAME` specifies the variant of the application that generates data. 
 
 {{< site-region region="us" >}}
 {{< tabs >}}
@@ -408,26 +408,26 @@ Send logs to Datadog from your Android applications with [Datadog's `dd-sdk-andr
 
 The following methods in `Configuration.Builder` can be used when creating the Datadog Configuration to initialize the library:
 
-| Method                              | Description                                                                                                                                                                               |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `constructor(logsEnabled = true)`   | Set to `true` to enable sending logs to Datadog.                                                                                                                                          |
-| `addPlugin(DatadogPlugin, Feature)` | Adds a plugin implementation for a specific feature (CRASH, LOG, TRACE, RUM). The plugin will be registered once the feature is initialized and unregistered when the feature is stopped. |
+| Method                           | Description                                                                                                                                                                                                                                                             |
+|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `constructor(logsEnabled = true)`     | Set to `true` to enable sending logs to Datadog.                                                                                                                                                                                                                                  |
+| `addPlugin(DatadogPlugin, Feature)`   | Adds a plugin implementation for a specific feature (CRASH, LOG, TRACE, RUM). The plugin will be registered once the feature is initialized and unregistered when the feature is stopped. |
 
 ### Logger initialization
 
 The following methods in `Logger.Builder` can be used when initializing the logger to send logs to Datadog:
 
-| Method                            | Description                                                                                                                                                                                                                     |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `setNetworkInfoEnabled(true)`     | Add the `network.client.connectivity` attribute to all logs. The data logged by default is `connectivity` (`Wifi`, `3G`, `4G`...) and `carrier_name` (`AT&T - US`). `carrier_name` is only available for Android API level 28+. |
-| `setServiceName(<SERVICE_NAME>)`  | Set `<SERVICE_NAME>` as value for the `service` [standard attribute][4] attached to all logs sent to Datadog.                                                                                                                   |
-| `setLogcatLogsEnabled(true)`      | Set to `true` to use Logcat as a logger.                                                                                                                                                                                        |
-| `setDatadogLogsEnabled(true)`     | Set to `true` to send logs to Datadog.                                                                                                                                                                                          |
-| `setBundleWithTraceEnabled(true)` | Set to `true` (default) to bundle the logs with the active trace in your application. This parameter lets you display all the logs sent during a specific trace by using the Datadog dashboard.                                 |
-| `setBundleWithRumEnabled(true)`   | Set to `true` (default) to bundle the logs with the current RUM context in your application. This parameter lets you display all the logs sent while a specific View is active by using the Datadog RUM Explorer.               |
-| `setLoggerName(<LOGGER_NAME>)`    | Set `<LOGGER_NAME>` as the value for the `logger.name` attribute attached to all logs sent to Datadog.                                                                                                                          |
-| `setSampleRate(<SAMPLE_RATE>)`    | Set the sampling rate for this logger. All the logs produced by the logger instance are randomly sampled according to the provided sample rate (default 1.0 = all logs). **Note**: The Logcat logs are not sampled.             |
-| `build()`                         | Build a new logger instance with all options set.                                                                                                                                                                               |
+| Method                           | Description                                                                                                                                                                                                                                                             |
+|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `setNetworkInfoEnabled(true)`    | Add the `network.client.connectivity` attribute to all logs. The data logged by default is `connectivity` (`Wifi`, `3G`, `4G`...) and `carrier_name` (`AT&T - US`). `carrier_name` is only available for Android API level 28+.                                     |
+| `setServiceName(<SERVICE_NAME>)` | Set `<SERVICE_NAME>` as value for the `service` [standard attribute][4] attached to all logs sent to Datadog.                                                                                                                                                           |
+| `setLogcatLogsEnabled(true)`     | Set to `true` to use Logcat as a logger.                                                                                                                                                                                                                                  |
+| `setDatadogLogsEnabled(true)`    | Set to `true` to send logs to Datadog.                                                                                                                                                                                                                                  |
+| `setBundleWithTraceEnabled(true)`| Set to `true` (default) to bundle the logs with the active trace in your application. This parameter lets you display all the logs sent during a specific trace by using the Datadog dashboard.                                                        |
+| `setBundleWithRumEnabled(true)`| Set to `true` (default) to bundle the logs with the current RUM context in your application. This parameter lets you display all the logs sent while a specific View is active by using the Datadog RUM Explorer.                                                        |
+| `setLoggerName(<LOGGER_NAME>)`   | Set `<LOGGER_NAME>` as the value for the `logger.name` attribute attached to all logs sent to Datadog.                                                                                                                                                                  |
+| `setSampleRate(<SAMPLE_RATE>)`   | Set the sampling rate for this logger. All the logs produced by the logger instance are randomly sampled according to the provided sample rate (default 1.0 = all logs). **Note**: The Logcat logs are not sampled.            |
+| `build()`                        | Build a new logger instance with all options set.                                                                                                                                                                                                                       |
 
 ### Global configuration
 

--- a/content/en/logs/log_collection/android.md
+++ b/content/en/logs/log_collection/android.md
@@ -233,47 +233,6 @@ Send logs to Datadog from your Android applications with [Datadog's `dd-sdk-andr
 {{< /tabs >}}
 {{< /site-region >}}
 
-{{< site-region region="ap1" >}}
-{{< tabs >}}
-{{% tab "Kotlin" %}}
-```kotlin
-    class SampleApplication : Application() {
-        override fun onCreate() {
-            super.onCreate()
-            val configuration = Configuration.Builder(
-                    logsEnabled = true,
-                    tracesEnabled = true,
-                    crashReportsEnabled = true,
-                    rumEnabled = true
-                )
-                .useSite(DatadogSite.AP1)
-                .build()
-            val credentials = Credentials(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>, <APPLICATION_ID>)
-            Datadog.initialize(this, credentials, configuration, trackingConsent)
-        }
-    }
-```
-{{% /tab %}}
-{{% tab "Java" %}}
-```java
-    public class SampleApplication extends Application {
-        @Override
-        public void onCreate() {
-            super.onCreate();
-            Configuration configuration =
-                    new Configuration.Builder(true, true, true, true)
-                            .useSite(DatadogSite.AP1)
-                            .build();
-            Credentials credentials = new Credentials( < CLIENT_TOKEN >, <ENV_NAME >, <APP_VARIANT_NAME >, <
-            APPLICATION_ID >);
-            Datadog.initialize(this, credentials, configuration, trackingConsent);
-        }
-    }
-```
-{{% /tab %}}
-{{< /tabs >}}
-{{< /site-region >}}
-
    To be compliant with the GDPR regulation, the SDK requires the tracking consent value at initialization.
    The tracking consent can be one of the following values:
    * `TrackingConsent.PENDING`: The SDK starts collecting and batching the data but does not send it to the data

--- a/content/en/logs/log_collection/android.md
+++ b/content/en/logs/log_collection/android.md
@@ -29,7 +29,7 @@ Send logs to Datadog from your Android applications with [Datadog's `dd-sdk-andr
     }
     ```
 
-2. Initialize the library with your application context, tracking consent, and the [Datadog client token][2] and Application ID generated when you create a new RUM application in the Datadog UI (see [Getting Started with Android RUM Collection][6] for more information). For security reasons, you must use a client token: you cannot use [Datadog API keys][3] to configure the `dd-sdk-android` library as they would be exposed client-side in the Android application APK byte code. For more information about setting up a client token, see the [client token documentation][2]. The `APP_VARIANT_NAME` specifies the variant of the application that generates data. 
+2. Initialize the library with your application context, tracking consent, and the [Datadog client token][2] and Application ID generated when you create a new RUM application in the Datadog UI (see [Getting Started with Android RUM Collection][6] for more information). For security reasons, you must use a client token: you cannot use [Datadog API keys][3] to configure the `dd-sdk-android` library as they would be exposed client-side in the Android application APK byte code. For more information about setting up a client token, see the [client token documentation][2]. The `APP_VARIANT_NAME` specifies the variant of the application that generates data.
 
 {{< site-region region="us" >}}
 {{< tabs >}}
@@ -233,6 +233,47 @@ Send logs to Datadog from your Android applications with [Datadog's `dd-sdk-andr
 {{< /tabs >}}
 {{< /site-region >}}
 
+{{< site-region region="ap1" >}}
+{{< tabs >}}
+{{% tab "Kotlin" %}}
+```kotlin
+    class SampleApplication : Application() {
+        override fun onCreate() {
+            super.onCreate()
+            val configuration = Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    crashReportsEnabled = true,
+                    rumEnabled = true
+                )
+                .useSite(DatadogSite.AP1)
+                .build()
+            val credentials = Credentials(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>, <APPLICATION_ID>)
+            Datadog.initialize(this, credentials, configuration, trackingConsent)
+        }
+    }
+```
+{{% /tab %}}
+{{% tab "Java" %}}
+```java
+    public class SampleApplication extends Application {
+        @Override
+        public void onCreate() {
+            super.onCreate();
+            Configuration configuration =
+                    new Configuration.Builder(true, true, true, true)
+                            .useSite(DatadogSite.AP1)
+                            .build();
+            Credentials credentials = new Credentials( < CLIENT_TOKEN >, <ENV_NAME >, <APP_VARIANT_NAME >, <
+            APPLICATION_ID >);
+            Datadog.initialize(this, credentials, configuration, trackingConsent);
+        }
+    }
+```
+{{% /tab %}}
+{{< /tabs >}}
+{{< /site-region >}}
+
    To be compliant with the GDPR regulation, the SDK requires the tracking consent value at initialization.
    The tracking consent can be one of the following values:
    * `TrackingConsent.PENDING`: The SDK starts collecting and batching the data but does not send it to the data
@@ -367,26 +408,26 @@ Send logs to Datadog from your Android applications with [Datadog's `dd-sdk-andr
 
 The following methods in `Configuration.Builder` can be used when creating the Datadog Configuration to initialize the library:
 
-| Method                           | Description                                                                                                                                                                                                                                                             |
-|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `constructor(logsEnabled = true)`     | Set to `true` to enable sending logs to Datadog.                                                                                                                                                                                                                                  |
-| `addPlugin(DatadogPlugin, Feature)`   | Adds a plugin implementation for a specific feature (CRASH, LOG, TRACE, RUM). The plugin will be registered once the feature is initialized and unregistered when the feature is stopped. |
+| Method                              | Description                                                                                                                                                                               |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `constructor(logsEnabled = true)`   | Set to `true` to enable sending logs to Datadog.                                                                                                                                          |
+| `addPlugin(DatadogPlugin, Feature)` | Adds a plugin implementation for a specific feature (CRASH, LOG, TRACE, RUM). The plugin will be registered once the feature is initialized and unregistered when the feature is stopped. |
 
 ### Logger initialization
 
 The following methods in `Logger.Builder` can be used when initializing the logger to send logs to Datadog:
 
-| Method                           | Description                                                                                                                                                                                                                                                             |
-|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `setNetworkInfoEnabled(true)`    | Add the `network.client.connectivity` attribute to all logs. The data logged by default is `connectivity` (`Wifi`, `3G`, `4G`...) and `carrier_name` (`AT&T - US`). `carrier_name` is only available for Android API level 28+.                                     |
-| `setServiceName(<SERVICE_NAME>)` | Set `<SERVICE_NAME>` as value for the `service` [standard attribute][4] attached to all logs sent to Datadog.                                                                                                                                                           |
-| `setLogcatLogsEnabled(true)`     | Set to `true` to use Logcat as a logger.                                                                                                                                                                                                                                  |
-| `setDatadogLogsEnabled(true)`    | Set to `true` to send logs to Datadog.                                                                                                                                                                                                                                  |
-| `setBundleWithTraceEnabled(true)`| Set to `true` (default) to bundle the logs with the active trace in your application. This parameter lets you display all the logs sent during a specific trace by using the Datadog dashboard.                                                        |
-| `setBundleWithRumEnabled(true)`| Set to `true` (default) to bundle the logs with the current RUM context in your application. This parameter lets you display all the logs sent while a specific View is active by using the Datadog RUM Explorer.                                                        |
-| `setLoggerName(<LOGGER_NAME>)`   | Set `<LOGGER_NAME>` as the value for the `logger.name` attribute attached to all logs sent to Datadog.                                                                                                                                                                  |
-| `setSampleRate(<SAMPLE_RATE>)`   | Set the sampling rate for this logger. All the logs produced by the logger instance are randomly sampled according to the provided sample rate (default 1.0 = all logs). **Note**: The Logcat logs are not sampled.            |
-| `build()`                        | Build a new logger instance with all options set.                                                                                                                                                                                                                       |
+| Method                            | Description                                                                                                                                                                                                                     |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setNetworkInfoEnabled(true)`     | Add the `network.client.connectivity` attribute to all logs. The data logged by default is `connectivity` (`Wifi`, `3G`, `4G`...) and `carrier_name` (`AT&T - US`). `carrier_name` is only available for Android API level 28+. |
+| `setServiceName(<SERVICE_NAME>)`  | Set `<SERVICE_NAME>` as value for the `service` [standard attribute][4] attached to all logs sent to Datadog.                                                                                                                   |
+| `setLogcatLogsEnabled(true)`      | Set to `true` to use Logcat as a logger.                                                                                                                                                                                        |
+| `setDatadogLogsEnabled(true)`     | Set to `true` to send logs to Datadog.                                                                                                                                                                                          |
+| `setBundleWithTraceEnabled(true)` | Set to `true` (default) to bundle the logs with the active trace in your application. This parameter lets you display all the logs sent during a specific trace by using the Datadog dashboard.                                 |
+| `setBundleWithRumEnabled(true)`   | Set to `true` (default) to bundle the logs with the current RUM context in your application. This parameter lets you display all the logs sent while a specific View is active by using the Datadog RUM Explorer.               |
+| `setLoggerName(<LOGGER_NAME>)`    | Set `<LOGGER_NAME>` as the value for the `logger.name` attribute attached to all logs sent to Datadog.                                                                                                                          |
+| `setSampleRate(<SAMPLE_RATE>)`    | Set the sampling rate for this logger. All the logs produced by the logger instance are randomly sampled according to the provided sample rate (default 1.0 = all logs). **Note**: The Logcat logs are not sampled.             |
+| `build()`                         | Build a new logger instance with all options set.                                                                                                                                                                               |
 
 ### Global configuration
 

--- a/content/en/logs/log_collection/reactnative.md
+++ b/content/en/logs/log_collection/reactnative.md
@@ -23,8 +23,8 @@ Send logs to Datadog from your React Native Mobile applications with [Datadog's 
 
 1. To install with NPM, run:
 
-```sh
-npm install @datadog/mobile-react-native
+   ```sh
+   npm install @datadog/mobile-react-native
 ```
 
 To install with Yarn, run:
@@ -39,9 +39,9 @@ Install the added pod:
 (cd ios && pod install)
 ```
 
-Versions `1.0.0-rc5` and higher require you to have `compileSdkVersion = 31` in the Android application setup, which implies that you should use Build Tools version 31, Android Gradle Plugin version 7, and Gradle version 7 or higher. To modify the versions, change the values in the `buildscript.ext` block of your application's top-level `build.gradle` file. Datadog recommends using React Native version 0.67 or higher.
+   Versions `1.0.0-rc5` and higher require you to have `compileSdkVersion = 31` in the Android application setup, which implies that you should use Build Tools version 31, Android Gradle Plugin version 7, and Gradle version 7 or higher. To modify the versions, change the values in the `buildscript.ext` block of your application's top-level `build.gradle` file. Datadog recommends using React Native version 0.67 or higher.
 
-1. Initialize the library with your application context, tracking consent, and the [Datadog client token][2] and Application ID generated when you create a RUM application in the Datadog UI (see [Getting Started with React Native RUM Collection][6] for more information). For security reasons, you must use a client token: you cannot use [Datadog API keys][3] to configure the `dd-sdk-reactnative` library as they would be exposed client-side in the mobile application. For more information about setting up a client token, see the [client token documentation][2]. 
+2. Initialize the library with your application context, tracking consent, and the [Datadog client token][2] and Application ID generated when you create a RUM application in the Datadog UI (see [Getting Started with React Native RUM Collection][6] for more information). For security reasons, you must use a client token; you cannot use [Datadog API keys][3] to configure the `dd-sdk-reactnative` library, as they would be exposed client-side in the mobile application. For more information about setting up a client token, see the [client token documentation][2]. 
 {{< site-region region="us" >}}
 ```js
 import {
@@ -154,13 +154,13 @@ config.site = 'AP1';
 {{< /site-region >}}
 
    
-2. Import the React Native logger:
+3. Import the React Native logger:
 
    ```javascript
    import { DdLogs } from '@datadog/mobile-react-native';
    ```
 
-1. Send a custom log entry directly to Datadog with one of the following functions:
+4. Send a custom log entry directly to Datadog with one of the following functions:
 
     ```javascript
         DdLogs.debug('A debug message.', { customAttribute: 'something' })

--- a/content/en/logs/log_collection/reactnative.md
+++ b/content/en/logs/log_collection/reactnative.md
@@ -1,0 +1,191 @@
+---
+title: React Native Log Collection
+kind: documentation
+description: Collect logs from your React Native Mobile applications.
+further_reading:
+- link: https://github.com/DataDog/dd-sdk-reactnative
+  tag: GitHub
+  text: dd-sdk-reactnative Source code
+- link: logs/explorer
+  tag: Documentation
+  text: Learn how to explore your logs
+---
+
+Send logs to Datadog from your React Native Mobile applications with [Datadog's `dd-sdk-reactnative` client-side logging library][1] and leverage the following features:
+
+* Log to Datadog in JSON format natively.
+* Add `context` and extra custom attributes to each log sent.
+* Forward JavaScript caught exceptions.
+* Record real client IP addresses and User-Agents.
+* Optimized network usage with automatic bulk posts.
+
+## Setup
+
+1. To install with NPM, run:
+
+```sh
+npm install @datadog/mobile-react-native
+```
+
+To install with Yarn, run:
+
+```sh
+yarn add @datadog/mobile-react-native
+```
+
+Install the added pod:
+
+```sh
+(cd ios && pod install)
+```
+
+Versions `1.0.0-rc5` and higher require you to have `compileSdkVersion = 31` in the Android application setup, which implies that you should use Build Tools version 31, Android Gradle Plugin version 7, and Gradle version 7 or higher. To modify the versions, change the values in the `buildscript.ext` block of your application's top-level `build.gradle` file. Datadog recommends using React Native version 0.67 or higher.
+
+1. Initialize the library with your application context, tracking consent, and the [Datadog client token][2] and Application ID generated when you create a new RUM application in the Datadog UI (see [Getting Started with React Native RUM Collection][6] for more information). For security reasons, you must use a client token: you cannot use [Datadog API keys][3] to configure the `dd-sdk-reactnative` library as they would be exposed client-side in the mobile application. For more information about setting up a client token, see the [client token documentation][2]. 
+{{< site-region region="us" >}}
+```js
+import {
+    DdSdkReactNative,
+    DdSdkReactNativeConfiguration
+} from '@datadog/mobile-react-native';
+
+const config = new DdSdkReactNativeConfiguration(
+    '<CLIENT_TOKEN>',
+    '<ENVIRONMENT_NAME>',
+    '<RUM_APPLICATION_ID>',
+    true, // track user interactions (such as a tap on buttons).
+    true, // track XHR resources
+    true // track errors
+);
+config.site = 'US1';
+```
+{{< /site-region >}}
+{{< site-region region="us3" >}}
+```js
+import {
+    DdSdkReactNative,
+    DdSdkReactNativeConfiguration
+} from '@datadog/mobile-react-native';
+
+const config = new DdSdkReactNativeConfiguration(
+    '<CLIENT_TOKEN>',
+    '<ENVIRONMENT_NAME>',
+    '<RUM_APPLICATION_ID>',
+    true, // track user interactions (such as a tap on buttons).
+    true, // track XHR resources
+    true // track errors
+);
+config.site = 'US3';
+```
+{{< /site-region >}}
+{{< site-region region="us5" >}}
+```js
+import {
+    DdSdkReactNative,
+    DdSdkReactNativeConfiguration
+} from '@datadog/mobile-react-native';
+
+const config = new DdSdkReactNativeConfiguration(
+    '<CLIENT_TOKEN>',
+    '<ENVIRONMENT_NAME>',
+    '<RUM_APPLICATION_ID>',
+    true, // track User interactions (e.g.: Tap on buttons).
+    true, // track XHR Resources
+    true // track Errors
+);
+config.site = 'US5';
+
+await DdSdkReactNative.initialize(config);
+```
+{{< /site-region >}}
+{{< site-region region="eu" >}}
+```js
+import {
+    DdSdkReactNative,
+    DdSdkReactNativeConfiguration
+} from '@datadog/mobile-react-native';
+
+const config = new DdSdkReactNativeConfiguration(
+    '<CLIENT_TOKEN>',
+    '<ENVIRONMENT_NAME>',
+    '<RUM_APPLICATION_ID>',
+    true, // track User interactions (e.g.: Tap on buttons).
+    true, // track XHR Resources
+    true // track Errors
+);
+config.site = 'EU1';
+```
+{{< /site-region >}}
+{{< site-region region="gov" >}}
+```js
+import {
+    DdSdkReactNative,
+    DdSdkReactNativeConfiguration
+} from '@datadog/mobile-react-native';
+
+const config = new DdSdkReactNativeConfiguration(
+    '<CLIENT_TOKEN>',
+    '<ENVIRONMENT_NAME>',
+    '<RUM_APPLICATION_ID>',
+    true, // track User interactions (e.g.: Tap on buttons).
+    true, // track XHR Resources
+    true // track Errors
+);
+config.site = 'US1_FED';
+```
+{{< /site-region >}}
+{{< site-region region="ap1" >}}
+```js
+import {
+    DdSdkReactNative,
+    DdSdkReactNativeConfiguration
+} from '@datadog/mobile-react-native';
+
+const config = new DdSdkReactNativeConfiguration(
+    '<CLIENT_TOKEN>',
+    '<ENVIRONMENT_NAME>',
+    '<RUM_APPLICATION_ID>',
+    true, // track User interactions (e.g.: Tap on buttons).
+    true, // track XHR Resources
+    true // track Errors
+);
+config.site = 'AP1';
+```
+{{< /site-region >}}
+
+   
+2. Import the React Native logger
+
+   ```javascript
+   import { DdLogs } from '@datadog/mobile-react-native';
+   ```
+
+1. Send a custom log entry directly to Datadog with one of the following functions:
+
+    ```javascript
+        DdLogs.debug('A debug message.', { customAttribute: 'something' })
+        DdLogs.info('Some relevant information ?', { customCount: 42 })
+        DdLogs.warn('An important warning…', {})
+        DdLogs.error('An error was met!', {})
+    ```
+
+    **Note**: All logging methods can have a context object with custom attributes.
+   
+## Batch collection
+
+All the logs are first stored on the local device in batches. Each batch follows the intake specification. They are sent as soon as network is available, and the battery is high enough to ensure the Datadog SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
+
+This means that even if users open your application while being offline, no data will be lost.
+
+The data on disk will automatically be discarded if it gets too old to ensure the SDK doesn't use too much disk space.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://github.com/DataDog/dd-sdk-reactnative
+[2]: /account_management/api-app-keys/#client-tokens
+[3]: /account_management/api-app-keys/#api-keys
+[4]: /logs/processing/attributes_naming_convention/
+[5]: /tagging/
+[6]: /real_user_monitoring/reactnative/?tab=us

--- a/content/en/logs/log_collection/reactnative.md
+++ b/content/en/logs/log_collection/reactnative.md
@@ -154,7 +154,7 @@ config.site = 'AP1';
 {{< /site-region >}}
 
    
-2. Import the React Native logger
+2. Import the React Native logger:
 
    ```javascript
    import { DdLogs } from '@datadog/mobile-react-native';

--- a/content/en/logs/log_collection/reactnative.md
+++ b/content/en/logs/log_collection/reactnative.md
@@ -41,7 +41,7 @@ Install the added pod:
 
 Versions `1.0.0-rc5` and higher require you to have `compileSdkVersion = 31` in the Android application setup, which implies that you should use Build Tools version 31, Android Gradle Plugin version 7, and Gradle version 7 or higher. To modify the versions, change the values in the `buildscript.ext` block of your application's top-level `build.gradle` file. Datadog recommends using React Native version 0.67 or higher.
 
-1. Initialize the library with your application context, tracking consent, and the [Datadog client token][2] and Application ID generated when you create a new RUM application in the Datadog UI (see [Getting Started with React Native RUM Collection][6] for more information). For security reasons, you must use a client token: you cannot use [Datadog API keys][3] to configure the `dd-sdk-reactnative` library as they would be exposed client-side in the mobile application. For more information about setting up a client token, see the [client token documentation][2]. 
+1. Initialize the library with your application context, tracking consent, and the [Datadog client token][2] and Application ID generated when you create a RUM application in the Datadog UI (see [Getting Started with React Native RUM Collection][6] for more information). For security reasons, you must use a client token: you cannot use [Datadog API keys][3] to configure the `dd-sdk-reactnative` library as they would be exposed client-side in the mobile application. For more information about setting up a client token, see the [client token documentation][2]. 
 {{< site-region region="us" >}}
 ```js
 import {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add the missing React native logs collection page. Also make the client token paragraph more complete, we don't just do Browser monitoring...

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
