### PR TITLE
integration fix

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -848,10 +848,10 @@ class Integrations:
                         print(e)
                         print('An error occurred formatting markdown links from integration readme file(s), exiting the build now...')
                         sys.exit(1)
-            else:
-                if exists(out_name):
-                    print(f"removing {integration_name} due to is_public/display_on_public_websites flag, {out_name}")
-                    remove(out_name)
+            # else:
+            #     if exists(out_name):
+            #         print(f"removing {integration_name} due to is_public/display_on_public_websites flag, {out_name}")
+            #         remove(out_name)
 
     def add_integration_frontmatter(
         self, file_name, content, dependencies=[], integration_id="", integration_version="", manifest_json=None, extra_fm=None

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -60,6 +60,18 @@
           # https://github.com/DataDog/dd-go/blob/prod/networks/model/domain/azure_services.go
           - networks/model/domain/azure_services.go
 
+      - repo_name: integrations-internal-core
+        contents:
+
+        - action: integrations
+          branch: main
+          globs:
+          - "*/metadata.csv"
+          - "*/manifest.json"
+          - "*/assets/service_checks.json"
+          - "*/README.md"
+          - "*/datadog_checks/*/__about__.py"
+
       - repo_name: dogweb
 
         contents:
@@ -110,18 +122,6 @@
 
         - action: integrations
           branch: master
-          globs:
-          - "*/metadata.csv"
-          - "*/manifest.json"
-          - "*/assets/service_checks.json"
-          - "*/README.md"
-          - "*/datadog_checks/*/__about__.py"
-
-      - repo_name: integrations-internal-core
-        contents:
-
-        - action: integrations
-          branch: main
           globs:
           - "*/metadata.csv"
           - "*/manifest.json"
@@ -439,7 +439,7 @@
             path_to_remove: 'rulesets/python-pandas/'
             front_matters:
               disable_edit: true
-              
+
       - repo_name: datadog-cdk-constructs
         contents:
         - action: pull-and-push-file

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -60,18 +60,6 @@
           # https://github.com/DataDog/dd-go/blob/prod/networks/model/domain/azure_services.go
           - networks/model/domain/azure_services.go
 
-      - repo_name: integrations-internal-core
-        contents:
-
-        - action: integrations
-          branch: main
-          globs:
-          - "*/metadata.csv"
-          - "*/manifest.json"
-          - "*/assets/service_checks.json"
-          - "*/README.md"
-          - "*/datadog_checks/*/__about__.py"
-
       - repo_name: dogweb
 
         contents:
@@ -122,6 +110,18 @@
 
         - action: integrations
           branch: master
+          globs:
+          - "*/metadata.csv"
+          - "*/manifest.json"
+          - "*/assets/service_checks.json"
+          - "*/README.md"
+          - "*/datadog_checks/*/__about__.py"
+
+      - repo_name: integrations-internal-core
+        contents:
+
+        - action: integrations
+          branch: main
           globs:
           - "*/metadata.csv"
           - "*/manifest.json"

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: true
+    cache_enabled: false
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: false
+    cache_enabled: true
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -60,18 +60,6 @@
           # https://github.com/DataDog/dd-go/blob/prod/networks/model/domain/azure_services.go
           - networks/model/domain/azure_services.go
 
-      - repo_name: integrations-internal-core
-        contents:
-
-          - action: integrations
-            branch: main
-            globs:
-              - "*/metadata.csv"
-              - "*/manifest.json"
-              - "*/assets/service_checks.json"
-              - "*/README.md"
-              - "*/datadog_checks/*/__about__.py"
-
       - repo_name: dogweb
 
         contents:
@@ -122,6 +110,18 @@
 
         - action: integrations
           branch: master
+          globs:
+          - "*/metadata.csv"
+          - "*/manifest.json"
+          - "*/assets/service_checks.json"
+          - "*/README.md"
+          - "*/datadog_checks/*/__about__.py"
+
+      - repo_name: integrations-internal-core
+        contents:
+
+        - action: integrations
+          branch: main
           globs:
           - "*/metadata.csv"
           - "*/manifest.json"

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -60,6 +60,18 @@
           # https://github.com/DataDog/dd-go/blob/prod/networks/model/domain/azure_services.go
           - networks/model/domain/azure_services.go
 
+      - repo_name: integrations-internal-core
+        contents:
+
+          - action: integrations
+            branch: main
+            globs:
+              - "*/metadata.csv"
+              - "*/manifest.json"
+              - "*/assets/service_checks.json"
+              - "*/README.md"
+              - "*/datadog_checks/*/__about__.py"
+
       - repo_name: dogweb
 
         contents:
@@ -110,18 +122,6 @@
 
         - action: integrations
           branch: master
-          globs:
-          - "*/metadata.csv"
-          - "*/manifest.json"
-          - "*/assets/service_checks.json"
-          - "*/README.md"
-          - "*/datadog_checks/*/__about__.py"
-
-      - repo_name: integrations-internal-core
-        contents:
-
-        - action: integrations
-          branch: main
           globs:
           - "*/metadata.csv"
           - "*/manifest.json"


### PR DESCRIPTION
### What does this PR do?
 
Stop removing integrations when encountering a duplicate.
This needs to be refactored to remove after processing is complete but for now lets disable this.

### Motivation

Noticed some integrations were missing as part of the transition from dogweb to integrations-internal-core

### Preview

Both scenario examples and both should exist on site

(enabled in dogwe, disabled in internal) 
https://docs-staging.datadoghq.com/david.jones/integration-fix/integrations/?q=splunk
(disabled in dogweb, enabled in internal
https://docs-staging.datadoghq.com/david.jones/integration-fix/integrations/?q=onelogin

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
