### PR TITLE
[DOCS-5646] Move and Rename DBM Traces Page

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1712,6 +1712,11 @@ main:
     parent: tracing
     identifier: tracing_other_telemetry
     weight: 5
+  - name: Connect DBM and Traces
+    url: database_monitoring/connect_dbm_and_apm/
+    parent: tracing_other_telemetry
+    identifier: tracing_connect_dbm
+    weight: 400
   - name: Connect Logs and Traces
     url: tracing/other_telemetry/connect_logs_and_traces/
     parent: tracing_other_telemetry
@@ -2378,31 +2383,36 @@ main:
     parent: dbm_setup_sql_server
     identifier: dbm_troubleshooting_sql_server
     weight: 107
+  - name: Connecting DBM and Traces
+    url: database_monitoring/connect_dbm_and_apm/
+    parent: dbm
+    identifier: dbm_connect_dbm_and_apm
+    weight: 5
   - name: Data Collected
     url: database_monitoring/data_collected
     parent: dbm
     identifier: dbm_data_collected
-    weight: 5
+    weight: 6
   - name: Exploring Query Metrics
     url: database_monitoring/query_metrics/
     parent: dbm
     identifier: dbm_query_metrics
-    weight: 6
+    weight: 7
   - name: Exploring Query Samples
     url: database_monitoring/query_samples/
     parent: dbm
     identifier: dbm_query_samples
-    weight: 7
+    weight: 8
   - name: Troubleshooting
     url: database_monitoring/troubleshooting/
     parent: dbm
     identifier: dbm_troubleshooting
-    weight: 8
+    weight: 9
   - name: Guides
     url: database_monitoring/guide/
     parent: dbm
     identifier: dbm_guides
-    weight: 9
+    weight: 10
   - name: Universal Service Monitoring
     url: universal_service_monitoring/
     pre: usm

--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -1,7 +1,9 @@
 ---
-title: Connecting DBM and APM
-kind: guide
+title: Connect Database Monitoring and Traces
+kind: documentation
 beta: true
+aliases: 
+- /database_monitoring/guide/connect_dbm_and_apm/
 ---
 {{< site-region region="gov" >}}
 <div class="alert alert-warning">Database Monitoring is not supported for this site.</div>

--- a/content/en/database_monitoring/guide/_index.md
+++ b/content/en/database_monitoring/guide/_index.md
@@ -15,7 +15,6 @@ cascade:
 
 {{< whatsnext desc="General guides:" >}}
     {{< nextlink href="database_monitoring/guide/heroku-postgres" >}}Setting up Heroku Postgres for Database Monitoring{{< /nextlink >}}
-    {{< nextlink href="database_monitoring/guide/connect_dbm_and_apm" >}}Connecting DBM and APM{{< /nextlink >}}
     {{< nextlink href="database_monitoring/guide/tag_database_statements" >}}Tagging Database Statements{{< /nextlink >}}
 {{< /whatsnext >}}
 

--- a/content/en/tracing/other_telemetry/_index.md
+++ b/content/en/tracing/other_telemetry/_index.md
@@ -10,6 +10,13 @@ further_reading:
 
 Correlating data by various Datadog products gives context to help estimate the business impact and find the root cause of an issue in a few clicks. Set up connections between incoming data to facilitate quick pivots in your explorers and dashboards.
 
+## Connect Database Monitoring and Traces
+
+Inject trace IDs into DBM data collection to correlate the two data sources. View database information in APM and APM information in DBM to see a comprehensive, unified view of your system's performance. See [Connect DBM and Traces][4] to set it up.
+
+{{< img src="database_monitoring/dbm_filter_by_calling_service.png" alt="Filter your database hosts by the APM services that call them.">}}
+
+
 ## Connect Logs and Traces
 
 Inject trace IDs into logs, and leverage unified service tagging to find the exact logs associated with a specific service and version, or all logs correlated to an observed trace. See [Connect Logs and Traces][1] to set it up.
@@ -35,3 +42,4 @@ Follow the data from failing synthetic tests directly through to the root causes
 [1]: /tracing/other_telemetry/connect_logs_and_traces/
 [2]: /real_user_monitoring/connect_rum_and_traces/
 [3]: /synthetics/apm/
+[4]: /database_monitoring/connect_dbm_and_apm/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- Rename "Connecting DBM and APM" to "Connect Database Monitoring and Traces".
- Move "Connect Database Monitoring and Traces" out of `/guides` subdirectory up to DBM.
- Redirect and add to nav menu at `/tracing/other_telemetry/`.
- Add alias to redirect old URL to new URL.
- Add new section to Connect APM Data with Other Telemetry page.

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/browse/DOCS-5646

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
I purposefully put separate nav bar titles for APM and DBM links because they use different standards "Connecting" vs. "Connect".

- [Update URL in web-ui repo](https://github.com/DataDog/web-ui/pull/97500).
- Determine if we still want to remove beta banner.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
