### PR TITLE
[DOCS-5879] clarifying that envars in ASM protect should point to file path

### DIFF
--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -2,7 +2,14 @@ The blocked requests feature JSON or HTML content. If the [`Accept` HTTP header]
 
 Both sets of content is embedded in the Datadog Tracer library package and loaded locally. See examples of the templates for [HTML][101] and [JSON][102] in the Datadog Java tracer source code on GitHub.
 
-The HTML and JSON content can both be changed using the `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML` and `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON` environment variables. Alternatively, you can use the `dd.appsec.http.blocked.template.html` or `dd.appsec.http.blocked.template.json` configuration entries.
+The HTML and JSON content can both be changed using the `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML` and `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON` environment variables within your application deployment file. Alternatively, you can use the `dd.appsec.http.blocked.template.html` or `dd.appsec.http.blocked.template.json` configuration entries.
+
+Example:
+
+```
+DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=<path_to_file.html>
+```
+
 
 By default, the page shown in response to a blocked action looks like this:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR clarifying that envars in ASM protect should point to file path, after stemming from a support ticket where there was confusion in how to set the `envars` 

### Motivation
[DOCS-5879](https://datadoghq.atlassian.net/browse/DOCS-5879)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
