### PR TITLE
Adding setup instructions for Oracle Autonomous Database

### DIFF
--- a/content/en/database_monitoring/setup_oracle/_index.md
+++ b/content/en/database_monitoring/setup_oracle/_index.md
@@ -113,7 +113,7 @@ The Agent doesn't require any external Oracle clients.
 
 ### Upgrading from a previous Agent release
 
-Execute all `grant` permission commands according to the documentation for your hosting type, because new features need access to the system views that were not previously granted to the Datadog database user account.
+Execute all `grant` permission commands according to the documentation for your hosting type, because new features need access to system views that were not previously granted to the Datadog database user account.
 
 ## Setup
 

--- a/content/en/database_monitoring/setup_oracle/_index.md
+++ b/content/en/database_monitoring/setup_oracle/_index.md
@@ -57,7 +57,7 @@ The Agent does not need to run on the same server nor the same platform as the m
 
 Datadog recommends you install the version listed in the [Latest Agent version](#latest-agent-version). It contains all the implemented Oracle monitoring features and bug fixes.
 
-If the latest Agent version is an official Datadog Agent release, like `7.46.0`, follow the instructions in [Official release](#official-release). If the latest Agent version is a beta build, such as `7.44.1~dbm~oracle~beta~0.28`, follow the instructions in [Beta build](#beta-build).
+If the latest Agent version is an official Datadog Agent release, like `7.46.0`, follow the instructions in [Official release](#official-release). If the latest Agent version is a beta build, such as `7.44.1~dbm~oracle~beta~0.30`, follow the instructions in [Beta build](#beta-build).
 
 #### Official release
 
@@ -73,7 +73,7 @@ Set `DD_API_KEY` and run the following commands to install the beta release, for
 
 ```shell
 export DD_AGENT_DIST_CHANNEL=beta
-export DD_AGENT_MINOR_VERSION="44.1~dbm~oracle~beta~0.28-1"
+export DD_AGENT_MINOR_VERSION="44.1~dbm~oracle~beta~0.30-1"
 
 DD_API_KEY= DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
@@ -87,7 +87,7 @@ Download the MSI file for the [beta build][4].
 Set `APIKEY` and run the following command in the command prompt inside the directory where you downloaded the installer, for example:
 
 ```shell
-start /wait msiexec /qn /i datadog-agent-7.44.1-dbm-oracle-beta-0.28-1.x86_64.msi APIKEY="" SITE="datadoghq.com"
+start /wait msiexec /qn /i datadog-agent-7.44.1-dbm-oracle-beta-0.30-1.x86_64.msi APIKEY="" SITE="datadoghq.com"
 ```
 
 ##### Docker
@@ -97,19 +97,23 @@ The docker beta images can be found [here][9].
 Set `DD_API_KEY` and run the following command to install the beta release, for example:
 
 ```shell
-docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY="" -e DD_SITE="datadoghq.com" gcr.io/datadoghq/agent:7.44.1-dbm-oracle-beta-0.28
+docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY="" -e DD_SITE="datadoghq.com" gcr.io/datadoghq/agent:7.44.1-dbm-oracle-beta-0.30
 ```
 
 ##### Latest Agent version
 
 The following beta builds contain implemented Oracle DBM features:
-- Linux: `7.44.1~dbm~oracle~beta~0.28-1`
-- Windows: `7.44.1-dbm-oracle-beta-0.28-1`
-- Docker: `7.44.1-dbm-oracle-beta-0.28`
+- Linux: `7.44.1~dbm~oracle~beta~0.30-1`
+- Windows: `7.44.1-dbm-oracle-beta-0.30-1`
+- Docker: `7.44.1-dbm-oracle-beta-0.30`
 
 ### Oracle client
 
 The Agent doesn't require any external Oracle clients.
+
+### Upgrading from a previous Agent release
+
+Execute all `grant` permission commands according to the documentation for your hosting type, because new features need access to the system views that were not previously granted to the Datadog database user account.
 
 ## Setup
 
@@ -120,7 +124,7 @@ For setup instructions, select your hosting type:
 [1]: https://app.datadoghq.com/integrations
 [2]: https://app.datadoghq.com/integrations/oracle
 [3]: https://app.datadoghq.com/account/settings/agent/latest
-[4]: https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-agent-7.44.1-dbm-oracle-beta-0.28-1.x86_64.msi
+[4]: https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-agent-7.44.1-dbm-oracle-beta-0.30-1.x86_64.msi
 [5]: https://app.datadoghq.com/dash/integration/30990/dbm-oracle-database-overview
 [6]: https://yum.datadoghq.com/beta/7/x86_64/
 [7]: https://apt.datadoghq.com/dists/beta/7/

--- a/content/en/database_monitoring/setup_oracle/autonomous_database.md
+++ b/content/en/database_monitoring/setup_oracle/autonomous_database.md
@@ -1,7 +1,7 @@
 ---
-title: Setting Up Database Monitoring for RDS Oracle
+title: Setting Up Database Monitoring for Oracle Autonomous Database
 kind: documentation
-description: Install and configure Database Monitoring for RDS Oracle
+description: Install and configure Database Monitoring for Oracle Autonomous Database
 private: true
 is_beta: true
 further_reading:
@@ -44,54 +44,61 @@ CREATE USER datadog IDENTIFIED BY your_password ;
 
 ```SQL
 grant create session to datadog ;
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SESSION','DATADOG','SELECT',p_grant_option => false); 
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$DATABASE','DATADOG','SELECT',p_grant_option => false); 
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$CONTAINERS','DATADOG','SELECT',p_grant_option => false); 
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SQLSTATS','DATADOG','SELECT',p_grant_option => false); 
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SQL','DATADOG','SELECT',p_grant_option => false); 
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$INSTANCE','DATADOG','SELECT',p_grant_option => false); 
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SQL_PLAN_STATISTICS_ALL','DATADOG','SELECT',p_grant_option => false); 
-exec rdsadmin.rdsadmin_util.grant_sys_object('DBA_FEATURE_USAGE_STATISTICS','DATADOG','SELECT',p_grant_option => false); 
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$PROCESS','DATADOG','SELECT',p_grant_option => false); 
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SESSION','DATADOG','SELECT',p_grant_option => false); 
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$CON_SYSMETRIC','DATADOG','SELECT',p_grant_option => false); 
-exec rdsadmin.rdsadmin_util.grant_sys_object('CDB_TABLESPACE_USAGE_METRICS','DATADOG','SELECT',p_grant_option => false); 
-exec rdsadmin.rdsadmin_util.grant_sys_object('CDB_TABLESPACES','DATADOG','SELECT',p_grant_option => false); 
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SQLCOMMAND','DATADOG','SELECT',p_grant_option => false);
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$DATAFILE','DATADOG','SELECT',p_grant_option => false);
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SGAINFO','DATADOG','SELECT',p_grant_option => false);
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SYSMETRIC','DATADOG','SELECT',p_grant_option => false);
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$PDBS','DATADOG','SELECT',p_grant_option => false);
-exec rdsadmin.rdsadmin_util.grant_sys_object('CDB_SERVICES','DATADOG','SELECT',p_grant_option => false);
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$OSSTAT','DATADOG','SELECT',p_grant_option => false);
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$PARAMETER','DATADOG','SELECT',p_grant_option => false);
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SQLSTATS','DATADOG','SELECT',p_grant_option => false);
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$CONTAINERS','DATADOG','SELECT',p_grant_option => false);
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SQL_PLAN_STATISTICS_ALL','DATADOG','SELECT',p_grant_option => false);
-exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SQL','DATADOG','SELECT',p_grant_option => false);
+grant select on v$session to datadog ;
+grant select on v$database to datadog ;
+grant select on v$containers to datadog;
+grant select on v$sqlstats to datadog ;
+grant select on v$instance to datadog ;
+grant select on dba_feature_usage_statistics to datadog ;
+grant select on V$SQL_PLAN_STATISTICS_ALL to datadog ;
+grant select on V$PROCESS to datadog ;
+grant select on V$SESSION to datadog ;
+grant select on V$CON_SYSMETRIC to datadog ;
+grant select on CDB_TABLESPACE_USAGE_METRICS to datadog ;
+grant select on CDB_TABLESPACES to datadog ;
+grant select on V$SQLCOMMAND to datadog ;
+grant select on V$DATAFILE to datadog ;
+grant select on V$SYSMETRIC to datadog ;
+grant select on V$SGAINFO to datadog ;
+grant select on V$PDBS to datadog ;
+grant select on CDB_SERVICES to datadog ;
+grant select on V$OSSTAT to datadog ;
+grant select on V$PARAMETER to datadog ;
+grant select on V$SQLSTATS to datadog ;
+grant select on V$CONTAINERS to datadog ;
+grant select on V$SQL_PLAN_STATISTICS_ALL to datadog ;
+grant select on V$SQL to datadog ;
 ```
 
 ## Configure the Agent
+
+Download the wallet zip file from the Oracle Cloud and unzip it.
 
 To start collecting Oracle telemetry, first [install the Datadog Agent][1]. 
 
 Create the Oracle Agent conf file `/etc/datadog-agent/conf.d/oracle-dbm.d/conf.yaml`. See the [sample conf file][2] for all available configuration options.
 
+Set the `protocol` and `wallet` configuration parameters.
+
 ```yaml
 init_config:
 instances:
-  - server: '<RDS_INSTANCE_ENDPOINT_1>:<PORT>'
+  - server: '<HOST_1>:<PORT>'
     service_name: "<SERVICE_NAME>" # The Oracle CDB service name
     username: 'datadog'
     password: '<PASSWORD>'
+    protocol: TCPS
+    wallet: <YOUR_WALLET_DIRECTORY>
     dbm: true
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
-  - server: '<RDS_INSTANCE_ENDPOINT_2>:<PORT>'
+  - server: '<HOST_2>:<PORT>'
     service_name: "<SERVICE_NAME>" # The Oracle CDB service name
     username: 'datadog'
     password: '<PASSWORD>'
+    protocol: TCPS
+    wallet: <YOUR_WALLET_DIRECTORY>
     dbm: true
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'

--- a/content/en/database_monitoring/setup_oracle/rac.md
+++ b/content/en/database_monitoring/setup_oracle/rac.md
@@ -25,13 +25,35 @@ Database Monitoring provides deep visibility into your Oracle databases by expos
 
 Complete the following steps to enable Database Monitoring with your database:
 
-1. Configure the Agent for each RAC node by following the instructions for [self-hosted Oracle databases][7].
+Configure the Agent for each RAC node. by following the instructions for [self-hosted Oracle databases][7].
 
-2. Add the following custom tag to each node:
-    ```yaml
-    tags:
-      - rac_cluster:your_cluster_name
-    ```
+You must configure the Agent for each RAC node, because the Agent collects information from every node separately by querying `V$` views. The Agent doesn't query and `GV$` views to avoid generating interconnect traffic. The collected data from each RAC node is aggregated in the front end.
+
+```yaml
+init_config:
+instances:
+  - server: '<RAC_NODE_1>:<PORT>'
+    service_name: "<CDB_SERVICE_NAME>" # The Oracle CDB service name
+    username: 'c##datadog'
+    password: '<PASSWORD>'
+    dbm: true
+    tags:  # Optional
+      - 'service:<CUSTOM_SERVICE>'
+      - 'env:<CUSTOM_ENV>'
+  - server: '<RAC_NODE_2>:<PORT>'
+    service_name: "<CDB_SERVICE_NAME>" # The Oracle CDB service name
+    username: 'c##datadog'
+    password: '<PASSWORD>'
+    dbm: true
+    tags:  # Optional
+      - rac_cluster:<CLUSTER_NAME>
+      - 'service:<CUSTOM_SERVICE>'
+      - 'env:<CUSTOM_ENV>'
+```
+
+The Agent connects only to CDB. It queries the information about PDBs while connected to CDB. Don't create connections to individual PDBs.
+
+Set the `rac_cluster` configuration parameter to the name of your RAC cluster or some user friendly alias. The `rac_cluster` filter helps you select all RAC nodes in the dashboard. You can set an additional filter for the database of interest.
 
 ### Validate
 

--- a/content/en/database_monitoring/setup_oracle/selfhosted.md
+++ b/content/en/database_monitoring/setup_oracle/selfhosted.md
@@ -64,11 +64,27 @@ grant select on V_$SQLCOMMAND to c##datadog ;
 grant select on V_$DATAFILE to c##datadog ;
 grant select on V_$SYSMETRIC to c##datadog ;
 grant select on V_$SGAINFO to c##datadog ;
+grant select on V_$PDBS to c##datadog ;
+grant select on CDB_SERVICES to c##datadog ;
+grant select on V_$OSSTAT to c##datadog ;
+grant select on V_$PARAMETER to c##datadog ;
+grant select on V_$SQLSTATS to c##datadog ;
+grant select on V_$CONTAINERS to c##datadog ;
+grant select on V_$SQL_PLAN_STATISTICS_ALL to c##datadog ;
+grant select on V_$SQL to c##datadog ;
+```
+
+If you conifgured custom queries that run on a PDB, you must grant `set container` privilege to the `C##DATADOG` user:
+
+```SQL
+connect / as sysdba
+alter session set container = your_pdb ;
+grant set container to c##datadog ;
 ```
 
 ### Create view
 
-Log on as `sysdba`, create a new `view`, and give the Agent user access to it:
+Log on as `sysdba`, create a new `view` in the `sysdba` schema, and give the Agent user access to it:
 
 ```SQL
 CREATE OR REPLACE VIEW dd_session AS
@@ -171,7 +187,7 @@ Create the Oracle Agent conf file `/etc/datadog-agent/conf.d/oracle-dbm.d/conf.y
 init_config:
 instances:
   - server: '<HOSTNAME_1>:<PORT>'
-    service_name: "<SERVICE_NAME>" # The Oracle CDB service name
+    service_name: "<CDB_SERVICE_NAME>" # The Oracle CDB service name
     username: 'c##datadog'
     password: '<PASSWORD>'
     dbm: true
@@ -179,7 +195,7 @@ instances:
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
   - server: '<HOSTNAME_2>:<PORT>'
-    service_name: "<SERVICE_NAME>" # The Oracle CDB service name
+    service_name: "<CDB_SERVICE_NAME>" # The Oracle CDB service name
     username: 'c##datadog'
     password: '<PASSWORD>'
     dbm: true
@@ -187,6 +203,8 @@ instances:
       - 'service:<CUSTOM_SERVICE>'
       - 'env:<CUSTOM_ENV>'
 ```
+
+The Agent connects only to CDB. It queries the information about PDBs while connected to CDB. Don't create connections to individual PDBs.
 
 Use the `service` and `env` tags to link your database telemetry to other telemetry through a common tagging scheme. See [Unified Service Tagging][3] to learn more about how these tags are used in Datadog.
 

--- a/layouts/partials/dbm/dbm-setup-oracle.html
+++ b/layouts/partials/dbm/dbm-setup-oracle.html
@@ -34,6 +34,14 @@
           </div>
         </a>
       </div>
+      <div class="col">
+        <a class="card h-100" href="/database_monitoring/setup_oracle/autonomous_database">
+          <div class="card-body text-center py-2 px-1">
+            {{ partial "img.html" (dict "root" . "src" "integrations_logos/oracle.png" "class" "img-fluid" "alt" "Selfhosted" "width" "175") }}
+            <br/>Autonomous Database
+          </div>
+        </a>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### What does this PR do?
- Adding setup instructions for Oracle Autonomous Database
- Filling gaps with RAC setup based on experience with beta customers

### Motivation
- Add setup instructions for new hosting type
- Improve the documentation to reduce the interactions with customers trying to set up monitoring for Oracle databases.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
