### PR TITLE
Update indentation of `priorityClassCreate`

### DIFF
--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -277,8 +277,8 @@ agents:
         requests:
           cpu: 100m
           memory: 200Mi
-    
-    priorityClassCreate: true
+
+  priorityClassCreate: true
 
 providers:
   gke:


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
`priorityClassCreate` was in the wrong place, causing the priority class for the agent not to get created. It needs to be under `agents:`, not `containers:` This is shown here in our helm chart: https://github.com/DataDog/helm-charts/blob/15298a04148064b03b8c6322ed3c118db9767ee5/charts/datadog/values.yaml#L1600

### Motivation
customer opened escalation that their agent was not running properly after following this documentation 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
