### PR TITLE
Rename AWS GuardDuty -> Amazon GuardDuty to match the product name

### DIFF
--- a/content/en/getting_started/cloud_siem/_index.md
+++ b/content/en/getting_started/cloud_siem/_index.md
@@ -54,7 +54,7 @@ This guide walks you through best practices for getting started with Cloud SIEM.
     - [Cloud Audit logs][6]
     - [Identity Provider logs][7]
     - SaaS and Workspace logs
-    - Third-party security integrations (for example, AWS GuardDuty)
+    - Third-party security integrations (for example, Amazon GuardDuty)
 
 2. Enable [Cloud SIEM][8].
 

--- a/content/en/integrations/amazon_guardduty.md
+++ b/content/en/integrations/amazon_guardduty.md
@@ -4,24 +4,24 @@ categories:
     - aws
     - log collection
     - security
-description: Gather your AWS GuardDuty logs.
+description: Gather your Amazon GuardDuty logs.
 doc_link: /integrations/amazon_guardduty/
 has_logo: true
 dependencies:
     ['https://github.com/DataDog/documentation/blob/master/content/en/integrations/amazon_guardduty.md']
-integration_title: AWS GuardDuty
+integration_title: Amazon GuardDuty
 is_public: true
 kind: integration
 name: amazon_guardduty
-public_title: Datadog-AWS GuardDuty Integration
-short_description: Gather your AWS GuardDuty logs.
+public_title: Datadog-Amazon GuardDuty Integration
+short_description: Gather your Amazon GuardDuty logs.
 version: '1.0'
 integration_id: "amazon-guardduty"
 ---
 
 ## Overview
 
-Datadog integrates with AWS GuardDuty through a Lambda function that ships GuardDuty findings to Datadog's Log Management solution.
+Datadog integrates with Amazon GuardDuty through a Lambda function that ships GuardDuty findings to Datadog's Log Management solution.
 
 ## Setup
 

--- a/content/fr/integrations/amazon_guardduty.md
+++ b/content/fr/integrations/amazon_guardduty.md
@@ -6,22 +6,22 @@ categories:
 - security
 dependencies:
 - https://github.com/DataDog/documentation/blob/master/content/en/integrations/amazon_guardduty.md
-description: Rassemblez vos logs AWS GuardDuty.
+description: Rassemblez vos logs Amazon GuardDuty.
 doc_link: /integrations/amazon_guardduty/
 has_logo: true
 integration_id: amazon-guardduty
-integration_title: AWS GuardDuty
+integration_title: Amazon GuardDuty
 is_public: true
 kind: integration
 name: amazon_guardduty
-public_title: Intégration Datadog/AWS GuardDuty
-short_description: Rassemblez vos logs AWS GuardDuty.
+public_title: Intégration Datadog/Amazon GuardDuty
+short_description: Rassemblez vos logs Amazon GuardDuty.
 version: '1.0'
 ---
 
 ## Présentation
 
-Datadog s'intègre à AWS GuardDuty par l'intermédiaire d'une fonction Lambda qui transmet les résultats de GuardDuty à la solution Log Management de Datadog.
+Datadog s'intègre à Amazon GuardDuty par l'intermédiaire d'une fonction Lambda qui transmet les résultats de GuardDuty à la solution Log Management de Datadog.
 
 ## Configuration
 

--- a/content/ja/getting_started/cloud_siem/_index.md
+++ b/content/ja/getting_started/cloud_siem/_index.md
@@ -54,7 +54,7 @@ title: Cloud SIEM の概要
     - [クラウド監査ログ][6]。
     - [ID プロバイダーログ][7]
     - SaaS と Workspace のログ
-    - サードパーティセキュリティインテグレーション (例: AWS GuardDuty)
+    - サードパーティセキュリティインテグレーション (例: Amazon GuardDuty)
 
 2. [Cloud SIEM][8] を有効にします。
 

--- a/content/ja/integrations/amazon_guardduty.md
+++ b/content/ja/integrations/amazon_guardduty.md
@@ -6,22 +6,22 @@ categories:
 - security
 dependencies:
 - https://github.com/DataDog/documentation/blob/master/content/en/integrations/amazon_guardduty.md
-description: AWS GuardDuty ログを収集
+description: Amazon GuardDuty ログを収集
 doc_link: /integrations/amazon_guardduty/
 has_logo: true
 integration_id: amazon-guardduty
-integration_title: AWS GuardDuty
+integration_title: Amazon GuardDuty
 is_public: true
 kind: integration
 name: amazon_guardduty
-public_title: Datadog-AWS GuardDuty インテグレーション
-short_description: AWS GuardDuty ログを収集
+public_title: Datadog-Amazon GuardDuty インテグレーション
+short_description: Amazon GuardDuty ログを収集
 version: '1.0'
 ---
 
 ## 概要
 
-Datadog は、GuardDuty の調査結果を Datadog のログ管理ソリューションに送信する Lambda 関数を通じて AWS GuardDuty と統合されます。
+Datadog は、GuardDuty の調査結果を Datadog のログ管理ソリューションに送信する Lambda 関数を通じて Amazon GuardDuty と統合されます。
 
 ## セットアップ
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Renames AWS GuardDuty to Amazon GuardDuty 

### Motivation
To match the marketing name used by AWS

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
