### PR TITLE
[AZI-1514] update docs to use NodeJS 18 in Azure log forwarder

### DIFF
--- a/content/en/logs/guide/azure-logging-guide.md
+++ b/content/en/logs/guide/azure-logging-guide.md
@@ -7,8 +7,6 @@ further_reading:
   text: "Learn how to explore your logs"
 ---
 
-<div class="alert alert-warning">On September 11 2023, <a href="https://nodejs.org/en/blog/announcements/nodejs16-eol">Node.JS 16</a> will reach end of life. Datadog plans to update support for the newer version prior to deprecation. </div>
-
 ## Overview
 
 Use this guide to set up logging from your Azure subscriptions to Datadog.
@@ -150,7 +148,7 @@ Create a new Function App or use an existing Function App and skip to the next s
 
 1. In the Azure portal, navigate to the **Function Apps** overview and click **Create**.
 2. Select a subscription, resource group, region, and enter a name for your function app.
-3. Select **Publish to Code, Runtime stack to Node.js, and Version to 16 LTS**.
+3. Select **Publish to Code, Runtime stack to Node.js, and Version to 18 LTS**.
 4. Select an operating system and plan type.
 5. Click **Next:Hosting**.
 6. Select a storage account.
@@ -231,7 +229,7 @@ If you are unfamiliar with Azure functions, see [Getting started with Azure Func
 
 1. In the [Azure portal][2], navigate to the **Function Apps** overview and click **Create**.
 2. Select a subscription, resource group, region, and enter a name for your function apps. 
-3. Select **Publish to Code, Runtime stack to Node.js, and Version to 16 LTS**.
+3. Select **Publish to Code, Runtime stack to Node.js, and Version to 18 LTS**.
 4. Select Operating System **Windows** and a plan type.
 5. Click **Next:Hosting**.
 6. Select a storage account.

--- a/content/ja/logs/guide/azure-logging-guide.md
+++ b/content/ja/logs/guide/azure-logging-guide.md
@@ -148,7 +148,7 @@ Datadog-Azure [関数を Event Hub トリガー][2]でセットアップし、Da
 
 1. Azure ポータルで、**Function Apps** 概要に移動し、**Create** をクリックします。
 2. サブスクリプション、リソースグループ、地域を選択し、関数アプリの名前を入力します。
-3. **Publish to Code, Runtime stack to Node.js, and Version to 16 LTS** を選択します。
+3. **Publish to Code, Runtime stack to Node.js, and Version to 18 LTS** を選択します。
 4. オペレーティングシステムとプランタイプを選択します。
 5. **Next:Hosting** をクリックします。
 6. ストレージアカウントを選択します。
@@ -229,7 +229,7 @@ Azure 関数に馴染みのない方は、[Azure 関数入門][7]をご覧くだ
 
 1. [Azure ポータル][2]で、**Function Apps** 概要に移動し、**Create** をクリックします。
 2. サブスクリプション、リソースグループ、地域を選択し、関数アプリの名前を入力します。
-3. **Publish to Code, Runtime stack to Node.js, and Version to 16 LTS** を選択します。
+3. **Publish to Code, Runtime stack to Node.js, and Version to 18 LTS** を選択します。
 4. オペレーティングシステム **Windows** とプランタイプを選択します。
 5. **Next:Hosting** をクリックします。
 6. ストレージアカウントを選択します。


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
https://datadoghq.atlassian.net/browse/AZI-1514

Updates the Azure log forwarder documentation to recommend using NodeJS 18. Also removes a banner referencing the NodeJS 16 end of life.
We have already tested that the log forwarder works correctly with NodeJS 18 and updated the Deploy To Azure button to deploy the function using 18.

### Motivation
<!-- What inspired you to submit this pull request?-->
NodeJs 16 end of life in Azure

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
