### PR TITLE
[PROF-7966] Document Ruby profiler incompatibility with passenger

### DIFF
--- a/content/en/profiler/profiler_troubleshooting/ruby.md
+++ b/content/en/profiler/profiler_troubleshooting/ruby.md
@@ -69,6 +69,7 @@ Rarely, native extensions or libraries called by them may have missing or incorr
 The following incompatibilities are known:
 * Using the `mysql2` gem together with versions of `libmysqlclient` [older than 8.0.0][9]. The affected `libmysqlclient` version is known to be present on Ubuntu 18.04, but not 20.04 or later releases.
 * [Using the `rugged` gem.][10]
+* [Using the `passenger` gem/Phusion Passenger web server.][11] (Auto-detected starting from 1.13.0+)
 
 In these cases, the profiler automatically detects the incompatibility and applies a workaround.
 
@@ -101,3 +102,4 @@ Doing this enables Datadog to add them to the auto-detection list, and to work w
 [8]: https://man7.org/linux/man-pages/man7/signal.7.html#:~:text=Interruption%20of%20system%20calls%20and%20library%20functions%20by%20signal%20handlers
 [9]: https://bugs.mysql.com/bug.php?id=83109
 [10]: https://github.com/DataDog/dd-trace-rb/issues/2721
+[11]: https://github.com/DataDog/dd-trace-rb/issues/2976

--- a/content/en/profiler/profiler_troubleshooting/ruby.md
+++ b/content/en/profiler/profiler_troubleshooting/ruby.md
@@ -69,7 +69,7 @@ Rarely, native extensions or libraries called by them may have missing or incorr
 The following incompatibilities are known:
 * Using the `mysql2` gem together with versions of `libmysqlclient` [older than 8.0.0][9]. The affected `libmysqlclient` version is known to be present on Ubuntu 18.04, but not 20.04 or later releases.
 * [Using the `rugged` gem.][10]
-* [Using the `passenger` gem/Phusion Passenger web server.][11] (Auto-detected starting from 1.13.0+)
+* [Using the `passenger` gem/Phusion Passenger web server][11] (Auto-detected starting from 1.13.0 or later).
 
 In these cases, the profiler automatically detects the incompatibility and applies a workaround.
 


### PR DESCRIPTION
**What does this PR do?**:

This PR extends the Ruby profiler incompatibility list added in https://github.com/DataDog/documentation/pull/17370 with a new known issue with the Phusion Passenger web server, reported by a customer in https://github.com/DataDog/dd-trace-rb/issues/2976 .

**Motivation**:

Make sure the list is kept up-to-date, so customers can reference it.

**Additional Notes**:

Like the `rugged` gem and unlike `mysql2`, there's currently no known versions of Phusion Passenger without this issue.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
