### PR TITLE
DOCS-5801 Add Three Beta Banners In Intelligent Test Runner Documentation

### DIFF
--- a/content/en/continuous_integration/intelligent_test_runner/_index.md
+++ b/content/en/continuous_integration/intelligent_test_runner/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Intelligent Test Runner
 kind: documentation
-is_beta: true
 further_reading:
   - link: "https://www.datadoghq.com/blog/streamline-ci-testing-with-datadog-intelligent-test-runner/"
     tag: "Blog"
@@ -10,8 +9,6 @@ further_reading:
     tag: "Blog"
     text: "Monitor all your CI pipelines with Datadog"
 ---
-
-<div class="alert alert-warning">Intelligent Test Runner is a beta product.</div>
 
 Intelligent Test Runner is Datadog's test impact analysis solution. It automatically selects and runs only the relevant tests for a given commit based on the code being changed. Significantly reduce time spent testing and overall CI costs, while maintaining test coverage.
 
@@ -30,7 +27,7 @@ To override Intelligent Test Runner and run all tests, add `ITR:NoSkip` (case in
 
 ## Set up Datadog library
 
-Prior to setting up Intelligent Test Runner, you must set up [Test Visibility][1] for your particular language. If you are reporting data through the Agent, use v6.40+/v7.40+.
+Prior to setting up Intelligent Test Runner, you must set up [Test Visibility][1] for your particular language. If you are reporting data through the Agent, use v6.40 or 7.40 and later.
 
 {{< whatsnext desc="Choose a language to set up Intelligent Test Runner in Datadog:" >}}
     {{< nextlink href="continuous_integration/intelligent_test_runner/dotnet" >}}.NET{{< /nextlink >}}
@@ -47,7 +44,7 @@ Once you have set up your Datadog library for Intelligent Test Runner, configure
 
 Due to the limitations described above, the default branch of your repository is automatically excluded from having Intelligent Test Runner enabled. Datadog recommends this configuration to ensure that all of your tests run prior to reaching production.
 
-If there are other branches you want to exclude, add them from the Intelligent Test Runner settings page. The query bar supports using the wildcard character `*` to exclude any branches that match, such as `release_*`
+If there are other branches you want to exclude, add them on the Test Service Settings page. The query bar supports using the wildcard character `*` to exclude any branches that match, such as `release_*`.
 
 {{< img src="continuous_integration/itr_configuration.png" alt="Select branches to exclude from intelligent test runner" style="width:80%;">}}
 
@@ -59,7 +56,7 @@ You can explore the time savings you get from Intelligent Test Runner by looking
 
 {{< img src="continuous_integration/itr_savings.png" alt="Intelligent test runner enabled in a test session showing its time savings." style="width:80%;">}}
 
-When Intelligent Test Runner is active and skipping tests, purple text displays the amount of time saved on each test session or on each commit. The duration bar also changes color to purple so you can quickly identify which test sessions are using Intelligent Test Runner in the [Test Runs][3] page.
+When Intelligent Test Runner is active and skipping tests, purple text displays the amount of time saved on each test session or on each commit. The duration bar also changes color to purple so you can quickly identify which test sessions are using Intelligent Test Runner on the [Test Runs][3] page.
 
 ## Explore adoption and global savings
 
@@ -77,5 +74,5 @@ The dashboard also tracks adoption of Intelligent Test Runner throughout your or
 
 [1]: /continuous_integration/tests/
 [2]: https://app.datadoghq.com/ci/settings/test-service
-[3]: https://app.datadoghq.com//ci/test-runs
+[3]: https://app.datadoghq.com/ci/test-runs
 [4]: https://app.datadoghq.com/dash/integration/30941/ci-visibility-intelligent-test-runner-beta

--- a/content/en/continuous_integration/intelligent_test_runner/swift.md
+++ b/content/en/continuous_integration/intelligent_test_runner/swift.md
@@ -1,6 +1,7 @@
 ---
 title: Intelligent Test Runner for Swift
 kind: documentation
+is_beta: true
 further_reading:
     - link: "/continuous_integration/tests"
       tag: "Documentation"
@@ -9,6 +10,8 @@ further_reading:
       tag: "Documentation"
       text: "Troubleshooting CI"
 ---
+
+{{< callout url="#" btn_hidden="true" >}}Intelligent Test Runner for Swift is in beta.{{< /callout >}} 
 
 ## Compatibility
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

7/25: I found out we are not waiting for a Python beta doc page to be published for Dash. 

### Motivation
<!-- What inspired you to submit this pull request?-->

DOCS-5801, ready to merge.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
