### PR TITLE
[CWS] Update Datadog Operator for CWS instructions to include RC

### DIFF
--- a/content/en/security/cloud_workload_security/setup.md
+++ b/content/en/security/cloud_workload_security/setup.md
@@ -100,10 +100,10 @@ Follow the [in-app instructions][6] in the Datadog app for the best experience, 
     # values.yaml file
     spec:
       features:
+        remoteConfiguration:
+          enabled: true
         cws:
           enabled: true
-        remoteConfiguration:
-          enabled: true // Default: false
     ```
 
     See the [Datadog Operator documentation][2] for additional configuration options.

--- a/content/en/security/cloud_workload_security/setup.md
+++ b/content/en/security/cloud_workload_security/setup.md
@@ -102,6 +102,8 @@ Follow the [in-app instructions][6] in the Datadog app for the best experience, 
       features:
         cws:
           enabled: true
+        remoteConfiguration:
+          enabled: true // Default: false
     ```
 
     See the [Datadog Operator documentation][2] for additional configuration options.


### PR DESCRIPTION
CWS setup instructions should always include RC instructions. 

https://docs.datadoghq.com/security/cloud_workload_security/setup/?tab=kubernetesoperator

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
