### PR TITLE
integration id can be nested under icon sometimes

### DIFF
--- a/layouts/partials/grouped-item-listings.html
+++ b/layouts/partials/grouped-item-listings.html
@@ -24,7 +24,7 @@
     <div class="js-group-header mb-1 d-flex align-items-center active" id="">
       <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2">
         {{ range last 1 $v.Pages }}
-          {{ $basename := .Params.integration_id | default .Params.source }}
+          {{ $basename := .Params.integration_id | default .Params.icon.integration_id | default .Params.source }}
           {{ $int_logo := partial "integrations-logo.html" (dict "context" $ctx "basename" $basename "variant" "avatar" "fallback" "cloud") }}
           {{ if $int_logo }}
             <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}"/>
@@ -53,7 +53,7 @@
     <div class="group-{{ .Key }} mb-2 ms-4 d-none">
       {{ range $v.Pages }}
         <a class="mb-1 font-semibold mix js-single-rule {{ range $i, $e := .Params.rule_category }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" href="{{.Permalink}}" data-name="{{ lower .Title }} {{ .File.TranslationBaseName }}">
-          {{ $basename := .Params.integration_id | default .Params.source }}
+          {{ $basename := .Params.integration_id | default .Params.icon.integration_id | default .Params.source }}
           {{ if in .Params.scope "." }}
             <!-- e.g gcp.project use source -->
             {{ $basename = .Params.source }}


### PR DESCRIPTION
### What does this PR do?

Fix where some actions the icon is under a different object

### Motivation

slack

### Preview
https://docs-staging.datadoghq.com/david.jones/action-integration-logo/service_management/workflows/actions_catalog/#openai

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
