### PR TITLE
Fix guide link for Splunk Observability Pipelines

### DIFF
--- a/content/en/observability_pipelines/guide/_index.md
+++ b/content/en/observability_pipelines/guide/_index.md
@@ -13,7 +13,7 @@ cascade:
 ---
 
 {{< whatsnext desc="General guides:" >}}
-    {{< nextlink href="/observability_pipelines/guide/setup_splunk_environment" >}}Set Up Observability Pipelines in your Splunk Environment{{< /nextlink >}}
+    {{< nextlink href="/observability_pipelines/setup/splunk" >}}Set Up Observability Pipelines in your Splunk Environment{{< /nextlink >}}
     {{< nextlink href="/observability_pipelines/guide/custom-metrics-governance" >}}Custom Metrics Governance{{< /nextlink >}}
     {{< nextlink href="/observability_pipelines/guide/control_log_volume_and_size" >}}Control Log Volume and Size{{< /nextlink >}}
     {{< nextlink href="/observability_pipelines/guide/ingest_aws_s3_logs_with_the_observability_pipelines_worker" >}}Ingest AWS S3 Logs with the Observability Pipelines Worker{{< /nextlink >}}

--- a/content/en/observability_pipelines/setup/splunk.md
+++ b/content/en/observability_pipelines/setup/splunk.md
@@ -3,6 +3,7 @@ title: Set Up Observability Pipelines in your Splunk Environment
 kind: documentation
 aliases:
   - /integrations/observability_pipelines/splunk
+  - /observability_pipelines/guide/setup_splunk_environment
 further_reading:
   - link: "/observability_pipelines/working_with_data/"
     tag: "Documentation"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix the link for the guide index page

### Motivation
<!-- What inspired you to submit this pull request?-->
Came up on documentation

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
