### PR TITLE
Add specific language examples on how to configure the ASM blocking responses and compatibility version

### DIFF
--- a/content/en/security/application_security/enabling/compatibility/_index.md
+++ b/content/en/security/application_security/enabling/compatibility/_index.md
@@ -18,6 +18,7 @@ The following ASM capabilities are supported relative to each language's tracing
 | -------------------------------- | ----------------------------------|----------------------------|----------------------------|----------------------------|----------------------------|----------------------------|----------------------------|
 | Threat Detection| 1.8.0 | 2.23.0 | 3.13.1 | 1.9.0   | 1.47.0  | 1.9.0| 0.84.0 |
 | Threat Protection | 1.9.0 | 2.26.0 | 3.19.0| 1.10.0  |  v1.50.0|  1.11.0    | 0.86.0   |
+| Customize protection behavior | 1.11.0 | 2.27.0 | 4.1.0| 1.19.0  |  v1.53.0|  1.15.0    | 0.86.0   |
 | Vulnerability Management for Open Source Software (OSS)  | 1.1.4 | 2.16.0 |2.23.0 for Node.js 12+, or 3.10.0 for Node.js 14+ | 1.5.0 | 1.49.0 | 1.11.0 | 0.90.0 |
 | Vulnerability Management for Code-level (beta)   |1.15.0| private beta | 2.32.0 for NodeJS 12+, or 3.19.0 for NodeJS 14+ | private beta | not supported<br/>| not supported| not supported|
 | Automatic user activity event tracking | 1.20.0 | 2.32.0 | 2.38.0 for NodeJS 12+, or 3.25.0 for NodeJS 14+, or 4.4.0 for NodeJS 16+ | 1.17.0 | not supported | 1.14.0 | 0.89.0 |

--- a/content/en/security/application_security/enabling/compatibility/_index.md
+++ b/content/en/security/application_security/enabling/compatibility/_index.md
@@ -18,7 +18,7 @@ The following ASM capabilities are supported relative to each language's tracing
 | -------------------------------- | ----------------------------------|----------------------------|----------------------------|----------------------------|----------------------------|----------------------------|----------------------------|
 | Threat Detection| 1.8.0 | 2.23.0 | 3.13.1 | 1.9.0   | 1.47.0  | 1.9.0| 0.84.0 |
 | Threat Protection | 1.9.0 | 2.26.0 | 3.19.0| 1.10.0  |  v1.50.0|  1.11.0    | 0.86.0   |
-| Customize protection behavior | 1.11.0 | 2.27.0 | 4.1.0| 1.19.0  |  v1.53.0|  1.15.0    | 0.86.0   |
+| Customize response to blocked requests | 1.11.0 | 2.27.0 | 4.1.0| 1.19.0  |  v1.53.0|  1.15.0    | 0.86.0   |
 | Vulnerability Management for Open Source Software (OSS)  | 1.1.4 | 2.16.0 |2.23.0 for Node.js 12+, or 3.10.0 for Node.js 14+ | 1.5.0 | 1.49.0 | 1.11.0 | 0.90.0 |
 | Vulnerability Management for Code-level (beta)   |1.15.0| private beta | 2.32.0 for NodeJS 12+, or 3.19.0 for NodeJS 14+ | private beta | not supported<br/>| not supported| not supported|
 | Automatic user activity event tracking | 1.20.0 | 2.32.0 | 2.38.0 for NodeJS 12+, or 3.25.0 for NodeJS 14+, or 4.4.0 for NodeJS 16+ | 1.17.0 | not supported | 1.14.0 | 0.89.0 |

--- a/content/en/security/application_security/enabling/compatibility/dotnet.md
+++ b/content/en/security/application_security/enabling/compatibility/dotnet.md
@@ -14,7 +14,7 @@ The following ASM capabilities are supported in the .NET library, for the specif
 | -------------------------------- | ----------------------------|
 | Threat Detection | 2.23.0|
 | Threat Protection  | 2.26.0|
-| Customize protection behavior | 2.27.0 |
+| Customize response to blocked requests | 2.27.0 |
 | Vulnerability Management for Open Source Software (OSS) |  2.16.0  |
 | Vulnerability Management for Code-level (beta)| private beta  |
 | Automatic user activity event tracking | 2.32.0 |

--- a/content/en/security/application_security/enabling/compatibility/dotnet.md
+++ b/content/en/security/application_security/enabling/compatibility/dotnet.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Compatibility Requirements 
+title: .NET Compatibility Requirements
 kind: documentation
 code_lang: dotnet
 type: multi-code-lang
@@ -14,22 +14,23 @@ The following ASM capabilities are supported in the .NET library, for the specif
 | -------------------------------- | ----------------------------|
 | Threat Detection | 2.23.0|
 | Threat Protection  | 2.26.0|
+| Customize protection behavior | 2.27.0 |
 | Vulnerability Management for Open Source Software (OSS) |  2.16.0  |
 | Vulnerability Management for Code-level (beta)| private beta  |
 | Automatic user activity event tracking | 2.32.0 |
 
 The minimum tracer version to get all supported ASM capabilities for .NET is 2.26.0.
 
-**Note**: Threat Protection requires enabling [Remote Configuration][3], which is included in the listed minimum tracer version.  
+**Note**: Threat Protection requires enabling [Remote Configuration][3], which is included in the listed minimum tracer version.
 
 ### Supported deployment types
 |Type   | Threat Detection support |  Vulnerability Management for OSS support |
 | ---   |   ---             |           ----        |
 | Docker | {{< X >}}  | {{< X >}} |
-| Kubernetes | {{< X >}}  | {{< X >}} | 
+| Kubernetes | {{< X >}}  | {{< X >}} |
 | Amazon ECS | {{< X >}}  | {{< X >}} |
 | AWS Fargate | {{< X >}}  | {{< X >}} |
-| AWS Lambda | {{< X >}} | | 
+| AWS Lambda | {{< X >}} | |
 | Azure App Service | {{< X >}}  | {{< X >}} |
 
 **Note**: Azure App Service is supported for **web applications only**. ASM doesn't support Azure Functions.
@@ -38,7 +39,7 @@ The minimum tracer version to get all supported ASM capabilities for .NET is 2.2
 
 ### Supported .NET versions
 
-| .NET Framework Version  | Microsoft End of Life | Support level                       | Package version             | 
+| .NET Framework Version  | Microsoft End of Life | Support level                       | Package version             |
 | ----------------------- | --------------------- | ----------------------------------- | --------------------------- |
 | 4.8                     |                       | GA   | latest                      |
 | 4.7.2                   |                       | GA | latest                      |

--- a/content/en/security/application_security/enabling/compatibility/go.md
+++ b/content/en/security/application_security/enabling/compatibility/go.md
@@ -1,5 +1,5 @@
 ---
-title: Go Compatibility Requirements 
+title: Go Compatibility Requirements
 kind: documentation
 code_lang: go
 type: multi-code-lang
@@ -14,22 +14,23 @@ The following ASM capabilities are supported in the Go library, for the specifie
 | -------------------------------- | ----------------------------|
 | Threat Detection| 1.47.0  |
 | Threat Protection |  1.50.0   |
+| Customize protection behavior | 1.53.0 |
 | Vulnerability Management for Open Source Software (OSS) | 1.49.0 |
 | Vulnerability Management for Code-level (beta) | not supported |
 | Automatic user activity event tracking | not supported |
 
 The minimum tracer version to get all supported ASM capabilities for Go is 1.50.0.
 
-**Note**: Threat Protection requires enabling [Remote Configuration][1], which is included in the listed minimum tracer version.  
+**Note**: Threat Protection requires enabling [Remote Configuration][1], which is included in the listed minimum tracer version.
 
 ### Supported deployment types
 |Type | Threat Detection support | Vulnerability Management for OSS support |
 | ---           |   ---             |           ----            |
 | Docker        | {{< X >}}         | {{< X >}}                 |
-| Kubernetes    | {{< X >}}         | {{< X >}}                 | 
+| Kubernetes    | {{< X >}}         | {{< X >}}                 |
 | Amazon ECS    | {{< X >}}         | {{< X >}}                 |
 | AWS Fargate   | {{< X >}}         | {{< X >}}                 |
-| AWS Lambda    | {{< X >}}         |                           |  
+| AWS Lambda    | {{< X >}}         |                           |
 
 ## Language and framework compatibility
 
@@ -37,7 +38,7 @@ The minimum tracer version to get all supported ASM capabilities for Go is 1.50.
 
 The Datadog Go Tracing library is open source. View the [GitHub repository][2] for more information.
 
-The Datadog Go Tracing Library has a [version support policy][3] defined for Go versions. The two latest releases of Go are fully supported, while the third newest release is considered in [maintenance][4]. Older versions may function, but no support is provided by default. For special requests, [contact support][5]. 
+The Datadog Go Tracing Library has a [version support policy][3] defined for Go versions. The two latest releases of Go are fully supported, while the third newest release is considered in [maintenance][4]. Older versions may function, but no support is provided by default. For special requests, [contact support][5].
 
 You must be running Datadog Agent v5.21.1+
 

--- a/content/en/security/application_security/enabling/compatibility/go.md
+++ b/content/en/security/application_security/enabling/compatibility/go.md
@@ -14,7 +14,7 @@ The following ASM capabilities are supported in the Go library, for the specifie
 | -------------------------------- | ----------------------------|
 | Threat Detection| 1.47.0  |
 | Threat Protection |  1.50.0   |
-| Customize protection behavior | 1.53.0 |
+| Customize response to blocked requests | 1.53.0 |
 | Vulnerability Management for Open Source Software (OSS) | 1.49.0 |
 | Vulnerability Management for Code-level (beta) | not supported |
 | Automatic user activity event tracking | not supported |

--- a/content/en/security/application_security/enabling/compatibility/java.md
+++ b/content/en/security/application_security/enabling/compatibility/java.md
@@ -14,7 +14,7 @@ The following ASM capabilities are supported in the Java library, for the specif
 | -------------------------------- | ----------------------------|
 | Threat Detection | 1.8.0  |
 | Threat Protection| 1.9.0 |
-| Customize protection behavior | 1.11.0 |
+| Customize response to blocked requests | 1.11.0 |
 | Vulnerability Management for Open Source Software (OSS) | 1.1.4 |
 | Vulnerability Management for Code-level (beta) | 1.15.0|
 | Automatic user activity event tracking | 1.20.0 |

--- a/content/en/security/application_security/enabling/compatibility/java.md
+++ b/content/en/security/application_security/enabling/compatibility/java.md
@@ -1,5 +1,5 @@
 ---
-title: Java Compatibility Requirements 
+title: Java Compatibility Requirements
 kind: documentation
 code_lang: java
 type: multi-code-lang
@@ -14,22 +14,23 @@ The following ASM capabilities are supported in the Java library, for the specif
 | -------------------------------- | ----------------------------|
 | Threat Detection | 1.8.0  |
 | Threat Protection| 1.9.0 |
+| Customize protection behavior | 1.11.0 |
 | Vulnerability Management for Open Source Software (OSS) | 1.1.4 |
 | Vulnerability Management for Code-level (beta) | 1.15.0|
 | Automatic user activity event tracking | 1.20.0 |
 
 The minimum tracer version to get all supported ASM capabilities for Java is 1.15.0.
 
-**Note**: Threat Protection requires enabling [Remote Configuration][2], which is included in the listed minimum tracer version.      
+**Note**: Threat Protection requires enabling [Remote Configuration][2], which is included in the listed minimum tracer version.
 
 ### Supported deployment types
 |Type           | Threat Detection support |  Vulnerability Management for OSS support |
 | ---           |   ---             |           ----            |
 | Docker        | {{< X >}}         | {{< X >}}                 |
-| Kubernetes    | {{< X >}}         | {{< X >}}                 | 
+| Kubernetes    | {{< X >}}         | {{< X >}}                 |
 | Amazon ECS    | {{< X >}}         | {{< X >}}                 |
 | AWS Fargate   | {{< X >}}         | {{< X >}}                 |
-| AWS Lambda    | {{< X >}}         |                           |   
+| AWS Lambda    | {{< X >}}         |                           |
 | Azure App Service | {{< X >}}     | {{< X >}}                 |
 
 **Note**: Azure App Service is supported for **web applications only**. ASM doesn't support Azure Functions.
@@ -49,7 +50,7 @@ Datadog does not officially support any early-access versions of Java.
 
 
 
-                                                                                                                                 
+
 
 ### Web framework compatibility
 
@@ -108,7 +109,7 @@ Datadog does not officially support any early-access versions of Java.
 
 ### Data store compatibility
 
-`dd-java-agent` includes support for automatically tracing the following database frameworks/drivers. 
+`dd-java-agent` includes support for automatically tracing the following database frameworks/drivers.
 
 **Datastore tracing provides:**
 

--- a/content/en/security/application_security/enabling/compatibility/nodejs.md
+++ b/content/en/security/application_security/enabling/compatibility/nodejs.md
@@ -1,12 +1,12 @@
 ---
-title: Node.js Compatibility Requirements 
+title: Node.js Compatibility Requirements
 kind: documentation
 code_lang: nodejs
 type: multi-code-lang
 code_lang_weight: 50
 ---
 
-## ASM capabilities 
+## ASM capabilities
 
 The following ASM capabilities are supported in the Node.js library, for the specified tracer version:
 
@@ -14,6 +14,7 @@ The following ASM capabilities are supported in the Node.js library, for the spe
 | -------------------------------- | ----------------------------|
 | Threat Detection  | 3.13.1|
 | Threat Protection  | 3.19.0  |
+| Customize protection behavior | 4.1.0 |
 | Vulnerability Management for Open Source Software (OSS) |  2.23.0 for NodeJS 12+, or 3.10.0 for NodeJS 14+ |
 | Vulnerability Management for Code-level (beta)  | 2.32.0 for NodeJS 12+, or 3.19.0 for NodeJS 14+ |
 | Automatic user activity event tracking | 2.38.0 for NodeJS 12+, or 3.25.0 for NodeJS 14+, or 4.4.0 for NodeJS 16+ |
@@ -21,17 +22,17 @@ The following ASM capabilities are supported in the Node.js library, for the spe
 The minimum tracer version to get all supported ASM capabilities for Node.js is 3.19.0.
 
 
-**Note**: 
+**Note**:
 - Threat Protection requires enabling [Remote Configuration][2], which is included in the listed minimum tracer version.
 
 ### Supported deployment types
 |Type | Threat Detection support | Vulnerability Management for OSS support |
 | ---           |   ---             |           ----            |
 | Docker        | {{< X >}}         | {{< X >}}                 |
-| Kubernetes    | {{< X >}}         | {{< X >}}                 | 
+| Kubernetes    | {{< X >}}         | {{< X >}}                 |
 | Amazon ECS    | {{< X >}}         | {{< X >}}                 |
 | AWS Fargate   | {{< X >}}         | {{< X >}}                 |
-| AWS Lambda    | {{< X >}}         | beta                      |   
+| AWS Lambda    | {{< X >}}         | beta                      |
 
 ## Language and framework compatibility
 

--- a/content/en/security/application_security/enabling/compatibility/nodejs.md
+++ b/content/en/security/application_security/enabling/compatibility/nodejs.md
@@ -14,7 +14,7 @@ The following ASM capabilities are supported in the Node.js library, for the spe
 | -------------------------------- | ----------------------------|
 | Threat Detection  | 3.13.1|
 | Threat Protection  | 3.19.0  |
-| Customize protection behavior | 4.1.0 |
+| Customize response to blocked requests | 4.1.0 |
 | Vulnerability Management for Open Source Software (OSS) |  2.23.0 for NodeJS 12+, or 3.10.0 for NodeJS 14+ |
 | Vulnerability Management for Code-level (beta)  | 2.32.0 for NodeJS 12+, or 3.19.0 for NodeJS 14+ |
 | Automatic user activity event tracking | 2.38.0 for NodeJS 12+, or 3.25.0 for NodeJS 14+, or 4.4.0 for NodeJS 16+ |

--- a/content/en/security/application_security/enabling/compatibility/php.md
+++ b/content/en/security/application_security/enabling/compatibility/php.md
@@ -1,5 +1,5 @@
 ---
-title: PHP Compatibility Requirements 
+title: PHP Compatibility Requirements
 kind: documentation
 code_lang: php
 type: multi-code-lang
@@ -14,6 +14,7 @@ The following ASM capabilities are supported in the PHP library, for the specifi
 | -------------------------------- |----------------------------|
 | Threat Detection | 0.84.0                     |
 | Threat Protection  | 0.86.0                     |
+| Customize protection behavior | 0.86.0 |
 | Vulnerability Management for Open Source Software (OSS) | 0.90.0              |
 | Vulnerability Management for Code-level (beta) | not supported              |
 | Automatic user activity event tracking | 0.89.0                     |
@@ -27,10 +28,10 @@ The minimum tracer version to get all supported ASM capabilities for PHP is 0.86
 |Type | Threat Detection support | Vulnerability Management for OSS support |
 | ---           |   ---             |           ----            |
 | Docker        | {{< X >}}         |                           |
-| Kubernetes    | {{< X >}}         |                           | 
+| Kubernetes    | {{< X >}}         |                           |
 | Amazon ECS    | {{< X >}}         |                           |
 | AWS Fargate   |                   |                           |
-| AWS Lambda    |                   |                           |   
+| AWS Lambda    |                   |                           |
 
 ## Language and framework compatibility
 
@@ -124,7 +125,7 @@ The following frameworks aren't directly instrumented by ASM, but indirectly sup
 
 | Framework         | Versions | Threat Detection supported?    | Threat Protection supported?|
 |-------------------|-----------------|-----------------|---------------|
-| Amazon RDS        | Any supported PHP | {{< X >}}  |   {{< X >}} | 
+| Amazon RDS        | Any supported PHP | {{< X >}}  |   {{< X >}} |
 | Eloquent       | Laravel supported versions | {{< X >}} | {{< X >}} |
 | Memcached        | Any supported PHP |   {{< X >}}    | {{< X >}} |
 | MySQLi        | Any supported PHP | {{< X >}} | {{< X >}} |

--- a/content/en/security/application_security/enabling/compatibility/php.md
+++ b/content/en/security/application_security/enabling/compatibility/php.md
@@ -14,7 +14,7 @@ The following ASM capabilities are supported in the PHP library, for the specifi
 | -------------------------------- |----------------------------|
 | Threat Detection | 0.84.0                     |
 | Threat Protection  | 0.86.0                     |
-| Customize protection behavior | 0.86.0 |
+| Customize response to blocked requests | 0.86.0 |
 | Vulnerability Management for Open Source Software (OSS) | 0.90.0              |
 | Vulnerability Management for Code-level (beta) | not supported              |
 | Automatic user activity event tracking | 0.89.0                     |

--- a/content/en/security/application_security/enabling/compatibility/python.md
+++ b/content/en/security/application_security/enabling/compatibility/python.md
@@ -13,7 +13,7 @@ The following ASM capabilities are supported in the Python library, for the spec
 | -------------------------------- | ----------------------------|
 | Threat Detection | 1.9.0   |
 | Threat Protection | 1.10.0  |
-| Customize protection behavior | 1.19.0 |
+| Customize response to blocked requests | 1.19.0 |
 | Vulnerability Management for Open Source Software (OSS) | 1.5.0  |
 | Vulnerability Management for Code-level (beta)  |  private beta  |
 | Automatic user activity event tracking | 1.17.0 |

--- a/content/en/security/application_security/enabling/compatibility/python.md
+++ b/content/en/security/application_security/enabling/compatibility/python.md
@@ -1,5 +1,5 @@
 ---
-title: Python Compatibility Requirements 
+title: Python Compatibility Requirements
 kind: documentation
 code_lang: python
 type: multi-code-lang
@@ -13,20 +13,21 @@ The following ASM capabilities are supported in the Python library, for the spec
 | -------------------------------- | ----------------------------|
 | Threat Detection | 1.9.0   |
 | Threat Protection | 1.10.0  |
+| Customize protection behavior | 1.19.0 |
 | Vulnerability Management for Open Source Software (OSS) | 1.5.0  |
 | Vulnerability Management for Code-level (beta)  |  private beta  |
 | Automatic user activity event tracking | 1.17.0 |
 
-**Note**: Threat Protection requires enabling [Remote Configuration][2], which is included in the listed minimum tracer version. 
+**Note**: Threat Protection requires enabling [Remote Configuration][2], which is included in the listed minimum tracer version.
 
 ### Supported deployment types
 |Type | Threat Detection support | Vulnerability Management for OSS support |
 | ---           |   ---             |           ----            |
 | Docker        | {{< X >}}         | {{< X >}}                 |
-| Kubernetes    | {{< X >}}         | {{< X >}}                 | 
+| Kubernetes    | {{< X >}}         | {{< X >}}                 |
 | Amazon ECS    | {{< X >}}         | {{< X >}}                 |
 | AWS Fargate   | {{< X >}}         | {{< X >}}                 |
-| AWS Lambda    | {{< X >}}         |                           |   
+| AWS Lambda    | {{< X >}}         |                           |
 
 
 ## Language and framework compatibility
@@ -64,7 +65,7 @@ And the library supports the following runtimes:
 
 
 | Framework                | Versions    | Threat Detection supported? | Threat Protection supported? |
-| ------------------------ | ----------- | --------------- | ---------------------------------------------- | 
+| ------------------------ | ----------- | --------------- | ---------------------------------------------- |
 | Django    | 1.8   |  {{< X >}} | {{< X >}}  |
 | Flask     | 0.10  |  {{< X >}} | {{< X >}}  |
 

--- a/content/en/security/application_security/enabling/compatibility/ruby.md
+++ b/content/en/security/application_security/enabling/compatibility/ruby.md
@@ -14,7 +14,7 @@ The following ASM capabilities are supported in the Ruby library, for the specif
 | -------------------------------- | ----------------------------|
 | Threat Detection  | 1.9.0  |
 | Threat Protection | 1.11.0 |
-| Customize protection behavior | 1.15.0 |
+| Customize response to blocked requests | 1.15.0 |
 | Vulnerability Management for Open Source Software (OSS) | 1.11.0 |
 | Vulnerability Management for Code-level (beta) | not supported |
 | Automatic user activity event tracking | 1.14.0 |

--- a/content/en/security/application_security/enabling/compatibility/ruby.md
+++ b/content/en/security/application_security/enabling/compatibility/ruby.md
@@ -14,6 +14,7 @@ The following ASM capabilities are supported in the Ruby library, for the specif
 | -------------------------------- | ----------------------------|
 | Threat Detection  | 1.9.0  |
 | Threat Protection | 1.11.0 |
+| Customize protection behavior | 1.15.0 |
 | Vulnerability Management for Open Source Software (OSS) | 1.11.0 |
 | Vulnerability Management for Code-level (beta) | not supported |
 | Automatic user activity event tracking | 1.14.0 |

--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -13,7 +13,7 @@ DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=<path_to_file.html>
 
 Alternatively, you can use the configuration entry.
 
-{{< programming-lang-wrapper langs="java,dotnet,go,ruby,php,nodejs,python" >}}
+{{< programming-lang-wrapper langs="java,dotnet,ruby,php,nodejs,python" >}}
 
 {{< programming-lang lang="java" >}}
 
@@ -27,15 +27,6 @@ Alternatively, you can use the configuration entry.
 ```csharp
 
 ```
-{{< /programming-lang >}}
-
-{{< programming-lang lang="go" >}}
-
-
-```go
-
-```
-
 {{< /programming-lang >}}
 
 {{< programming-lang lang="ruby" >}}

--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -1,14 +1,90 @@
-The blocked requests feature JSON or HTML content. If the [`Accept` HTTP header][103] is pointing to HTML, like `text/html`, the HTML content is used. Otherwise, the JSON one is used. 
+The blocked requests feature JSON or HTML content. If the [`Accept` HTTP header][103] is pointing to HTML, like `text/html`, the HTML content is used. Otherwise, the JSON one is used.
 
-Both sets of content is embedded in the Datadog Tracer library package and loaded locally. See examples of the templates for [HTML][101] and [JSON][102] in the Datadog Java tracer source code on GitHub.
+Both sets of content are embedded in the Datadog Tracer library package and loaded locally. See examples of the templates for [HTML][101] and [JSON][102] in the Datadog Java tracer source code on GitHub.
 
-The HTML and JSON content can both be changed using the `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML` and `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON` environment variables within your application deployment file. Alternatively, you can use the `dd.appsec.http.blocked.template.html` or `dd.appsec.http.blocked.template.json` configuration entries.
+The HTML and JSON content can both be changed using the `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML` and `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON` environment variables within your application deployment file.
 
 Example:
 
 ```
 DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=<path_to_file.html>
 ```
+
+
+Alternatively, you can use the configuration entry.
+
+{{< programming-lang-wrapper langs="java,dotnet,go,ruby,php,nodejs,python" >}}
+
+{{< programming-lang lang="java" >}}
+
+```java
+
+```
+{{< /programming-lang >}}
+
+{{< programming-lang lang="dotnet" >}}
+
+```csharp
+
+```
+{{< /programming-lang >}}
+
+{{< programming-lang lang="go" >}}
+
+
+```go
+
+```
+
+{{< /programming-lang >}}
+
+{{< programming-lang lang="ruby" >}}
+
+```ruby
+# config/initializers/datadog.rb
+
+Datadog.configure do |c|
+  # To configure the text/html blocking page
+  c.appsec.block.templates.html = '<path_to_file.html>'
+  # To configure the application/json blocking page
+  c.appsec.block.templates.json = '<path_to_file.json>'
+  # customize the status code that would be use on the blocking page
+  c.appsec.block.status = 401
+  # Only apply when the status code is [301, 302, 303, 307, 308]
+  # The value would be used to populate the Location HTTP header
+  c.appsec.block.location = "https://youhavebeenredirected.com"
+end
+```
+
+{{< /programming-lang >}}
+
+{{< programming-lang lang="php" >}}
+
+```php
+
+```
+
+{{< /programming-lang >}}
+
+{{< programming-lang lang="nodejs" >}}
+
+
+```javascript
+
+```
+
+{{< /programming-lang >}}
+
+{{< programming-lang lang="python" >}}
+
+
+```python
+
+```
+
+{{< /programming-lang >}}
+
+{{< /programming-lang-wrapper >}}
 
 
 By default, the page shown in response to a blocked action looks like this:

--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -62,7 +62,12 @@ datadog.appsec.http_blocked_template_json = <path_to_file.json>
 
 
 ```javascript
-
+require('dd-trace').init({
+  appsec: {
+    blockedTemplateHtml: '<path_to_file.html>',
+    blockedTemplateJson: '<path_to_file.json>'
+  }
+})
 ```
 
 {{< /programming-lang >}}

--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -39,11 +39,6 @@ Datadog.configure do |c|
   c.appsec.block.templates.html = '<path_to_file.html>'
   # To configure the application/json blocking page
   c.appsec.block.templates.json = '<path_to_file.json>'
-  # customize the status code that would be use on the blocking page
-  c.appsec.block.status = 401
-  # Only apply when the status code is [301, 302, 303, 307, 308]
-  # The value would be used to populate the Location HTTP header
-  c.appsec.block.location = "https://youhavebeenredirected.com"
 end
 ```
 

--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -18,7 +18,8 @@ Alternatively, you can use the configuration entry.
 {{< programming-lang lang="java" >}}
 
 ```java
-
+dd.appsec.http.blocked.template.html = '<path_to_file.html>'
+dd.appsec.http.blocked.template.json = '<path_to_file.json>'
 ```
 {{< /programming-lang >}}
 

--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -52,7 +52,13 @@ end
 {{< programming-lang lang="php" >}}
 
 ```php
+; 98-ddtrace.ini
 
+; Customises the HTML output provided on a blocked request
+;datadog.appsec.http_blocked_template_html = <path_to_file.html>
+
+; Customises the JSON output provided on a blocked request
+;datadog.appsec.http_blocked_template_json = <path_to_file.json>
 ```
 
 {{< /programming-lang >}}

--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -13,18 +13,11 @@ DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=<path_to_file.html>
 
 Alternatively, you can use the configuration entry.
 
-{{< programming-lang-wrapper langs="java,dotnet,ruby,php,nodejs" >}}
+{{< programming-lang-wrapper langs="java,ruby,php,nodejs" >}}
 
 {{< programming-lang lang="java" >}}
 
 ```java
-
-```
-{{< /programming-lang >}}
-
-{{< programming-lang lang="dotnet" >}}
-
-```csharp
 
 ```
 {{< /programming-lang >}}

--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -13,17 +13,14 @@ DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=<path_to_file.html>
 
 Alternatively, you can use the configuration entry.
 
-{{< programming-lang-wrapper langs="java,ruby,php,nodejs" >}}
-
-{{< programming-lang lang="java" >}}
+For Java, add the following:
 
 ```java
 dd.appsec.http.blocked.template.html = '<path_to_file.html>'
 dd.appsec.http.blocked.template.json = '<path_to_file.json>'
 ```
-{{< /programming-lang >}}
 
-{{< programming-lang lang="ruby" >}}
+For Ruby, add the following:
 
 ```ruby
 # config/initializers/datadog.rb
@@ -36,9 +33,7 @@ Datadog.configure do |c|
 end
 ```
 
-{{< /programming-lang >}}
-
-{{< programming-lang lang="php" >}}
+For PHP, add the following:
 
 ```dosini
 ; 98-ddtrace.ini
@@ -50,9 +45,7 @@ datadog.appsec.http_blocked_template_html = <path_to_file.html>
 datadog.appsec.http_blocked_template_json = <path_to_file.json>
 ```
 
-{{< /programming-lang >}}
-
-{{< programming-lang lang="nodejs" >}}
+For Node.js, add the following:
 
 
 ```javascript
@@ -63,11 +56,6 @@ require('dd-trace').init({
   }
 })
 ```
-
-{{< /programming-lang >}}
-
-{{< /programming-lang-wrapper >}}
-
 
 By default, the page shown in response to a blocked action looks like this:
 

--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -51,14 +51,14 @@ end
 
 {{< programming-lang lang="php" >}}
 
-```php
+```dosini
 ; 98-ddtrace.ini
 
 ; Customises the HTML output provided on a blocked request
-;datadog.appsec.http_blocked_template_html = <path_to_file.html>
+datadog.appsec.http_blocked_template_html = <path_to_file.html>
 
 ; Customises the JSON output provided on a blocked request
-;datadog.appsec.http_blocked_template_json = <path_to_file.json>
+datadog.appsec.http_blocked_template_json = <path_to_file.json>
 ```
 
 {{< /programming-lang >}}

--- a/layouts/shortcodes/asm-protection-page-configuration.md
+++ b/layouts/shortcodes/asm-protection-page-configuration.md
@@ -13,7 +13,7 @@ DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=<path_to_file.html>
 
 Alternatively, you can use the configuration entry.
 
-{{< programming-lang-wrapper langs="java,dotnet,ruby,php,nodejs,python" >}}
+{{< programming-lang-wrapper langs="java,dotnet,ruby,php,nodejs" >}}
 
 {{< programming-lang lang="java" >}}
 
@@ -67,15 +67,6 @@ datadog.appsec.http_blocked_template_json = <path_to_file.json>
 
 
 ```javascript
-
-```
-
-{{< /programming-lang >}}
-
-{{< programming-lang lang="python" >}}
-
-
-```python
 
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add specific examples per language on how to configure ASM blocking responses. 
Also, adds the compatibility information per language and on the index page

### Motivation
<!-- What inspired you to submit this pull request?-->

The growing numbers of Ruby customers trying to configure the blocking responses using a tracer version that doesn't support such feature

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
