### PR TITLE
Add configmap.count and secret.count metrics to KSM Core documentation

### DIFF
--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -175,6 +175,9 @@ datadog:
 `kubernetes_state.apiservice.condition`
 : The condition of this API service. Tags:`apiservice` `condition` `status`.
 
+`kubernetes_state.configmap.count`
+: Number of ConfigMaps. Tags:`kube_namespace`.
+
 `kubernetes_state.daemonset.count`
 : Number of DaemonSets. Tags:`kube_namespace`.
 
@@ -387,6 +390,9 @@ datadog:
 
 `kubernetes_state.pdb.pods_total`
 : Total number of pods counted by this disruption budget. Tags:`kube_namespace` `poddisruptionbudget`.
+
+`kubernetes_state.secret.count`
+: Number of Secrets. Tags:`kube_namespace`
 
 `kubernetes_state.secret.type`
 : Type about secret. Tags:`kube_namespace` `secret` `type`.


### PR DESCRIPTION
`kubernetes_state.configmap.count` and `kubernetes_state.secret.count` metrics were added to the KSM core check for agent `7.46` via this PR [#17314 ](https://github.com/DataDog/datadog-agent/pull/17314)

This PR updates the documentation to reflect these new metrics

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
