### PR TITLE
Ruby:Clarify tracer propagation default configuration

### DIFF
--- a/content/en/tracing/trace_collection/trace_context_propagation/ruby.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/ruby.md
@@ -16,17 +16,17 @@ Datadog APM tracer supports [B3][6] and [W3C (TraceParent)][7] header extraction
 
 Distributed headers injection and extraction is controlled by configuring injection and extraction styles. The following styles are supported:
 
-- `Datadog`: The default
+- `Datadog`: Datadog style headers
 - `b3multi`: B3 multiple-headers
 - `b3`: B3 single-header
 - `tracecontext`: W3C Trace Context
-- `none`: No-op.
+- `none`: No-op
 
 Injection styles can be configured using:
 
 - Environment Variable: `DD_TRACE_PROPAGATION_STYLE_INJECT=Datadog,b3`
 
-The value of the environment variable is a comma-separated list of header styles that are enabled for injection. By default only Datadog injection style is enabled.
+The value of the environment variable is a comma-separated list of header styles that are enabled for injection. By default only `Datadog` injection style is enabled.
 
 Extraction styles can be configured using:
 
@@ -35,6 +35,8 @@ Extraction styles can be configured using:
 The value of the environment variable is a comma-separated list of header styles that are enabled for extraction. 
 
 If multiple extraction styles are enabled extraction attempt is done on the order those styles are configured and first successful extracted value is used.
+
+The default extraction styles are, in order, `Datadog`, `b3multi`, and `b3`.
 
 You can also enable or disable the use of these formats in code by using `Datadog.configure`:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

The default value for APM Ruby tracing propagation is not easily understandable from our current documentation.

### Motivation
<!-- What inspired you to submit this pull request?-->

This PR ensures that the public documentation for Ruby APM reflects the current default values for propagation styles.

The value has not changed: this PR just clarifies the language in this section.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
