### PR TITLE
Update advanced_configuration -> Raising the sample rate (adding unit…

### DIFF
--- a/content/en/database_monitoring/setup_postgres/advanced_configuration.md
+++ b/content/en/database_monitoring/setup_postgres/advanced_configuration.md
@@ -47,7 +47,7 @@ instances:
 
 If you have queries that are relatively infrequent or execute quickly, raise the sampling rate by lowering the `collection_interval` value to collect samples more frequently.
 
-Set the `collection_interval` in your database instance configuration of the Datadog Agent. The default value is 1. Lower the value to a smaller interval:
+Set the `collection_interval` in your database instance configuration of the Datadog Agent. The default value is 1 second and can be seen in the <a href="https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example#L332C9-L336" target="_blank">postgres/conf.yaml.example</a>. Lower the value to a smaller interval:
 
 ```yaml
 instances:

--- a/content/en/database_monitoring/setup_postgres/advanced_configuration.md
+++ b/content/en/database_monitoring/setup_postgres/advanced_configuration.md
@@ -47,7 +47,9 @@ instances:
 
 If you have queries that are relatively infrequent or execute quickly, raise the sampling rate by lowering the `collection_interval` value to collect samples more frequently.
 
-Set the `collection_interval` in your database instance configuration of the Datadog Agent. The default value is 1 second and can be seen in the <a href="https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example#L332C9-L336" target="_blank">postgres/conf.yaml.example</a>. Lower the value to a smaller interval:
+Set the `collection_interval` in your database instance configuration of the Datadog Agent. The default value is 1 second and can be seen in the <a href="https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example#L332C9-L336" target="_blank">`postgres/conf.yaml.example`</a>.
+
+Lower the value to a smaller interval:
 
 ```yaml
 instances:


### PR DESCRIPTION
…s and link)

I had a chat today where the client wanted confirmation that the "Raising the sampling rate" section was in seconds. I have added that the interval is in seconds, and provided a link to the postgres/conf.yaml.example where this value can be seen.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
