### PR TITLE
Update Container Apps docs with new installation structure

### DIFF
--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -10,215 +10,376 @@ further_reading:
 ## Overview
 Azure Container Apps is a fully managed serverless platform for deploying and scaling container-based applications. Datadog provides monitoring and log collection for Container Apps through the [Azure integration][1]. Datadog also provides a solution, now in beta, for instrumenting your Container Apps applications with a purpose-built Agent to enable tracing, custom metrics, and direct log collection.
 
-  <div class="alert alert-warning">This feature is in beta. You can provide feedback through your standard support channels. During the beta period, Container Apps monitoring and APM tracing are available without a direct cost. Existing APM customers may incur increased span ingestion and volume costs. </div>
-
-## Getting started
-
 ### Prerequisites
 
 Make sure you have a [Datadog API Key][6] and are using a programming language [supported by a Datadog tracing library][2].
 
-### 1. Instrument your application
+## Instrument your application
 
-{{< programming-lang-wrapper langs="go,python,nodejs,java,dotnet,ruby" >}}
-{{< programming-lang lang="go" >}}
+You can instrument your application in one of two ways: [Dockerfile](#dockerfile) or [buildpack](#buildpack).
 
-#### Install Agent with Dockerfile
+### Dockerfile
 
-You can instrument your application with a Datadog Agent by adding the following lines to your Dockerfile. You may need to adjust these examples depending on your existing Dockerfile setup.
-
-```
-# copy the Datadog `serverless-init` into your Docker image
-COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
-
-# change the entrypoint to wrap your application into the Datadog serverless-init process
-ENTRYPOINT ["/app/datadog-init"]
-
-# optionally add Datadog tags
-ENV DD_SERVICE=datadog-demo-run-go
-ENV DD_ENV=datadog-demo
-ENV DD_VERSION=1
-
-# execute your binary application wrapped in the entrypoint. Adapt this line to your needs
-CMD ["/path/to/your-go-binary"]
-```
-
-#### Install tracing library
-Follow [these instructions][2] to install and configure the Go tracing library in your application to capture and submit traces. 
-
-
-[Sample code for a simple Go application][1].
-
-
-[1]: https://github.com/DataDog/crpb/tree/main/go
-[2]: /tracing/trace_collection/dd_libraries/go/?tab=containers#installation-and-getting-started
-
-{{< /programming-lang >}}
-{{< programming-lang lang="python" >}}
-
-#### Install Agent with Dockerfile
-
-Instrument your application with the Datadog Agent by adding the following lines to your Dockerfile. You may need to adjust these examples depending on your existing Dockerfile setup.
-
-```
-# copy the Datadog `serverless-init` into your Docker image
-COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
-
-# install the python tracing library here or in requirements.txt
-RUN pip install --no-cache-dir ddtrace==1.7.3
-
-# optionally add Datadog tags
-ENV DD_SERVICE=datadog-demo-run-python
-ENV DD_ENV=datadog-demo
-ENV DD_VERSION=1
-
-# change the entrypoint to wrap your application into the Datadog serverless-init process
-ENTRYPOINT ["/app/datadog-init"]
-
-# execute your binary application wrapped in the entrypoint, launched by the Datadog trace library. Adapt this line to your needs
-CMD ["ddtrace-run", "python", "app.py"]
-```
-#### Install tracing library
-Follow [these instructions][2] to install and configure the Python tracing library in your application to capture and submit traces. 
-
-[Sample code for a simple Python application][1].
-
-[1]: https://github.com/DataDog/crpb/tree/main/python
-[2]: /tracing/trace_collection/dd_libraries/python/?tab=containers#instrument-your-application
-
-{{< /programming-lang >}}
+{{< programming-lang-wrapper langs="nodejs,python,java,go,dotnet,ruby,php" >}}
 {{< programming-lang lang="nodejs" >}}
 
-#### Install Agent with Dockerfile
-
-Instrument your application with the Datadog Agent by adding the following lines to your Dockerfile. You may need to adjust these examples depending on your existing Dockerfile setup.
+Add the following instructions and arguments to your Dockerfile.
 
 ```
-# copy the Datadog `serverless-init` into your Docker image
 COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
-
-# install the Datadog js tracing library, either here or in package.json
-
-RUN npm i dd-trace@2.2.0
-
-# enable the Datadog tracing library
-ENV NODE_OPTIONS="--require dd-trace/init"
-
-# optionally add Datadog tags
+COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
 ENV DD_SERVICE=datadog-demo-run-nodejs
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-
-# change the entrypoint to wrap your application into the Datadog serverless-init process
 ENTRYPOINT ["/app/datadog-init"]
-
-# execute your binary application wrapped in the entrypoint. Adapt this line to your needs
 CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
-
 ```
-#### Install tracing library
-Follow [these instructions][2] to install and configure the Node tracing library in your application to capture and submit traces. 
 
-[Sample code for a simple Node.js application][1].
+#### Explanation
 
-[1]: https://github.com/DataDog/crpb/tree/main/js
-[2]: /tracing/trace_collection/dd_libraries/nodejs/?tab=containers#instrument-your-application
+1. Copy the Datadog `serverless-init` into your Docker image.
 
+   ```
+   COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
+   ```
+
+2. Copy the Datadog Node.JS tracer into your Docker image. 
+
+   ```
+   COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
+   ```
+
+   If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
+
+3. (Optional) Add Datadog tags.
+
+   ```
+   ENV DD_SERVICE=datadog-demo-run-nodejs
+   ENV DD_ENV=datadog-demo
+   ENV DD_VERSION=1
+   ```
+
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
+
+   ```
+   ENTRYPOINT ["/app/datadog-init"]
+   ```
+
+5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
+   ```
+   CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
+   ```
+
+[1]: /tracing/trace_collection/dd_libraries/nodejs/?tab=containers#instrument-your-application
+{{< /programming-lang >}}
+{{< programming-lang lang="python" >}}
+
+Add the following instructions and arguments to your Dockerfile.
+```
+COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
+RUN pip install --target /dd_tracer/python/ ddtrace
+ENV DD_SERVICE=datadog-demo-run-python
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+ENTRYPOINT ["/app/datadog-init"]
+CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
+```
+
+#### Explanation
+
+1. Copy the Datadog `serverless-init` into your Docker image.
+   ```
+   COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
+   ```
+
+2. Install the Datadog Python tracer. 
+   ```
+   RUN pip install --target /dd_tracer/python/ ddtrace
+   ```
+   If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
+
+3. (Optional) Add Datadog tags.
+   ```
+   ENV DD_SERVICE=datadog-demo-run-python
+   ENV DD_ENV=datadog-demo
+   ENV DD_VERSION=1
+   ```
+
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process
+   ```
+   ENTRYPOINT ["/app/datadog-init"]
+   ```
+
+5. Execute your binary application wrapped in the entrypoint, launched by the Datadog trace library. Adapt this line to your needs.
+   ```
+   CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
+   ```
+
+[1]: /tracing/trace_collection/dd_libraries/python/?tab=containers#instrument-your-application
 {{< /programming-lang >}}
 {{< programming-lang lang="java" >}}
 
-#### Install Agent with Dockerfile
-
-Instrument your application with the Datadog Agent by adding the following lines to your Dockerfile. You may need to adjust these examples depending on your existing Dockerfile setup.
+Add the following instructions and arguments to your Dockerfile.
 
 ```
-# copy the Datadog `serverless-init` into your Docker image
 COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
-
-# optionally add Datadog tags
+ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-
-# change the entrypoint to wrap your application into the Datadog serverless-init process
 ENTRYPOINT ["/app/datadog-init"]
-
-# execute your binary application wrapped in the entrypoint. Adapt this line to your needs
 CMD ["./mvnw", "spring-boot:run"]
-
 ```
 
-#### Install tracing library
-Follow [these instructions][2] to install and configure the Java tracing library in your application to capture and submit traces. 
+#### Explanation
 
-[Sample code for a simple Java application][1].
+1. Copy the Datadog `serverless-init` into your Docker image.
+   ```
+   COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
+   ```
 
-[1]: https://github.com/DataDog/crpb/tree/main/java
-[2]: /tracing/trace_collection/dd_libraries/java/?tab=containers#instrument-your-application
+2. Add the Datadog Java tracer to your Docker image. 
+   ```
+   ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+   ```
+   If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
 
+3. (Optional) Add Datadog tags.
+   ```
+   ENV DD_SERVICE=datadog-demo-run-java
+   ENV DD_ENV=datadog-demo
+   ENV DD_VERSION=1
+   ```
+
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process
+   ```
+   ENTRYPOINT ["/app/datadog-init"]
+   ```
+
+5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
+   ```
+   CMD ["./mvnw", "spring-boot:run"]
+   ```
+
+[1]: /tracing/trace_collection/dd_libraries/java/?tab=containers#instrument-your-application
+{{< /programming-lang >}}
+{{< programming-lang lang="go" >}}
+
+Add the following instructions and arguments to your Dockerfile.
+
+```
+COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
+RUN go install github.com/datadog/orchestrion@latest
+RUN orchestrion -w ./
+RUN go mod tidy
+ENTRYPOINT ["/app/datadog-init"]
+ENV DD_SERVICE=datadog-demo-run-go
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+CMD ["/path/to/your-go-binary"]
+```
+
+**Note**: Instead of using Orchestrion, you can also [manually install the Go tracer][1].
+
+#### Explanation
+
+1. Copy the Datadog `serverless-init` into your Docker image.
+   ```
+   COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
+   ```
+
+2. Install Orchestrion, which modifies the source code and automatically adds tracing. Do this before you `go build` your app.
+   ```
+   RUN go install github.com/datadog/orchestrion@latest
+   RUN orchestrion -w ./
+   RUN go mod tidy
+   ```
+   If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
+
+3. Change the entrypoint to wrap your application into the Datadog `serverless-init` process
+   ```
+   ENTRYPOINT ["/app/datadog-init"]
+   ```
+
+4. (Optional) Add Datadog tags.
+   ```
+   ENV DD_SERVICE=datadog-demo-run-go
+   ENV DD_ENV=datadog-demo
+   ENV DD_VERSION=1
+   ```
+
+5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
+   ```
+   CMD ["/path/to/your-go-binary"]
+   ```
+
+[1]: /tracing/trace_collection/library_config/go/ 
 {{< /programming-lang >}}
 {{< programming-lang lang="dotnet" >}}
 
-#### Install Agent with Dockerfile
-
-Instrument your application with the Datadog Agent by adding the following lines to your Dockerfile. You may need to adjust these examples depending on your existing Dockerfile setup.
+Add the following instructions and arguments to your Dockerfile.
 
 ```
-# copy the Datadog `serverless-init` into your Docker image
 COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
-
-# optionally add Datadog tags
+COPY --from=datadog/dd-lib-dotnet-init /datadog-init/monitoring-home/ /dd_tracer/dotnet/
 ENV DD_SERVICE=datadog-demo-run-dotnet
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-
-# change the entrypoint to wrap your application into the Datadog serverless-init process
 ENTRYPOINT ["/app/datadog-init"]
-
-# execute your binary application wrapped in the entrypoint. Adapt this line to your needs
 CMD ["dotnet", "helloworld.dll"]
-
 ```
 
-#### Install tracing library
-Follow the instructions to install and configure the [.NET Core tracing library][1] and the [.NET Framework tracing library][2]. 
+#### Explanation
 
-[1]: /tracing/trace_collection/dd_libraries/dotnet-core?tab=containers#custom-instrumentation
-[2]: /tracing/trace_collection/dd_libraries/dotnet-framework/?tab=containers#custom-instrumentation
+1. Copy the Datadog `serverless-init` into your Docker image.
+   ```
+   COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
+   ```
 
+2. Copy the Datadog .NET tracer into your Docker image.
+   ```
+   COPY --from=datadog/dd-lib-dotnet-init /datadog-init/monitoring-home/ /dd_tracer/dotnet/
+   ```
+   If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
+
+3. (Optional) Add Datadog tags.
+   ```
+   ENV DD_SERVICE=datadog-demo-run-dotnet
+   ENV DD_ENV=datadog-demo
+   ENV DD_VERSION=1
+   ```
+
+4. Change the entrypoint to wrap your application into the Datadog `serverless-init` process.
+   ```
+   ENTRYPOINT ["/app/datadog-init"]
+   ```
+
+5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
+   ```
+   CMD ["dotnet", "helloworld.dll"]
+   ```
+
+[1]: /tracing/trace_collection/dd_libraries/dotnet-core/?tab=linux#custom-instrumentation
 {{< /programming-lang >}}
 {{< programming-lang lang="ruby" >}}
 
-#### Install Agent with Dockerfile
+[Manually install][1] the Ruby tracer before you deploy your application. See the [example application][2].
 
-Instrument your application with the Datadog Agent by adding the following lines to your Dockerfile. You may need to adjust these examples depending on your existing Dockerfile setup.
+Add the following instructions and arguments to your Dockerfile.
 
 ```
-# copy the Datadog `serverless-init` into your Docker image
 COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
-
-# optionally add Datadog tags
 ENV DD_SERVICE=datadog-demo-run-ruby
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-
-# change the entrypoint to wrap your application into the Datadog serverless-init process
+ENV DD_TRACE_PROPAGATION_STYLE=datadog
 ENTRYPOINT ["/app/datadog-init"]
-
-# execute your binary application wrapped in the entrypoint. Adapt this line to your needs
-CMD ["rails", "server", "-b", "0.0.0.0"] (adapt this line to your needs)
-
+CMD ["rails", "server", "-b", "0.0.0.0"]
 ```
 
-#### Install tracing library
+#### Explanation
 
-Follow [these instructions][2] to install and configure the Ruby tracing library in your application to capture and submit traces. 
+1. Copy the Datadog `serverless-init` into your Docker image.
+   ```
+   COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
+   ```
 
-[Sample code for a simple Ruby application][1].
+2. (Optional) add Datadog tags
+   ```
+   ENV DD_SERVICE=datadog-demo-run-ruby
+   ENV DD_ENV=datadog-demo
+   ENV DD_VERSION=1
+   ```
 
-[1]: https://github.com/DataDog/crpb/tree/main/ruby-on-rails
-[2]: /tracing/trace_collection/dd_libraries/ruby/?tab=containers#instrument-your-application
+3. This environment variable is needed for trace propagation to work properly in Cloud Run. Ensure that you set this variable for all Datadog-instrumented downstream services.
+   ```
+   ENV DD_TRACE_PROPAGATION_STYLE=datadog
+   ```
 
+4. Change the entrypoint to wrap your application into the Datadog `serverless-init` process.
+   ```
+   ENTRYPOINT ["/app/datadog-init"]
+   ```
+
+5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
+   ```
+   CMD ["rails", "server", "-b", "0.0.0.0"]
+   ```
+
+
+[1]: /tracing/trace_collection/dd_libraries/ruby/?tab=containers#instrument-your-application
+[2]: https://github.com/DataDog/crpb/tree/main/ruby-on-rails
+
+{{< /programming-lang >}}
+{{< programming-lang lang="php" >}}
+
+Add the following instructions and arguments to your Dockerfile.
+```
+COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
+ADD https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php /datadog-setup.php
+RUN php /datadog-setup.php --php-bin=all
+ENV DD_SERVICE=datadog-demo-run-ruby
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+ENTRYPOINT ["/app/datadog-init"]
+
+# use the following for an apache and mod_php based image
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+EXPOSE 8080
+CMD ["apache2-foreground"]
+
+# use the following for an nginx and php-fpm based image
+RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
+EXPOSE 8080
+CMD php-fpm; nginx -g daemon off;
+```
+
+**Note**: The datadog-init ENTRYPOINT wraps your process and collects logs from it. To get logs working properly, you must ensure your apache, nginx, or php processes are writing output to stdout.
+
+#### Explanation
+
+
+1. Copy the Datadog `serverless-init` into your Docker image.
+   ```
+   COPY --from=datadog/serverless-init /datadog-init /app/datadog-init
+   ```
+
+2. Copy and install the Datadog PHP tracer.
+   ```
+   ADD https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php /datadog-setup.php
+   RUN php /datadog-setup.php --php-bin=all
+   ```
+   If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
+
+3. (Optional) Add Datadog tags.
+   ```
+   ENV DD_SERVICE=datadog-demo-run-ruby
+   ENV DD_ENV=datadog-demo
+   ENV DD_VERSION=1
+   ```
+
+4. Change the entrypoint to wrap your application into the Datadog serverless-init process
+   ```
+   ENTRYPOINT ["/app/datadog-init"]
+   ```
+
+5. Execute your application.
+   
+   Use the following for an apache and mod_php based image:
+   ```
+   RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+   EXPOSE 8080
+   CMD ["apache2-foreground"]
+   ```
+
+   Use the following for an nginx and php-fpm based image:
+   ```
+   RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
+   EXPOSE 8080
+   CMD php-fpm; nginx -g daemon off;
+   ```
+
+[1]: /tracing/trace_collection/dd_libraries/php/?tab=containers#install-the-extension
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 
@@ -228,6 +389,8 @@ Once the container is built and pushed to your registry, the last step is to set
 - `DD_API_KEY`: Datadog API key, used to send data to your Datadog account. It should be configured as a [Azure Secret][7] for privacy and safety issue.
 - `DD_SITE`: Datadog endpoint and website. Select your site on the right side of this page. Your site is: {{< region-param key="dd_site" code="true" >}}.
 - `DD_TRACE_ENABLED`: set to `true` to enable tracing
+- `DD_AZURE_SUBSCRIPTION_ID`: the Azure Subscription ID associated with the Container App resource 
+- `DD_AZURE_RESOURCE_GROUP`: the Azure Resouce group associated with the Container App resource
 
 For more environment variables and their function, see [Additional Configurations](#additional-configurations).
 
@@ -255,6 +418,10 @@ Once the deployment is completed, your metrics and traces are sent to Datadog. I
 
 - **Custom Metrics:** You can submit custom metrics using a [DogStatsd client][3]. For monitoring Cloud Run and other serverless applications, use [distribution][8] metrics. Distributions provide `avg`, `sum`, `max`, `min`, and `count` aggregations by default. On the Metric Summary page, you can enable percentile aggregations (p50, p75, p90, p95, p99) and also manage tags. To monitor a distribution for a gauge metric type, use `avg` for both the [time and space aggregations][9]. To monitor a distribution for a count metric type, use `sum` for both the time and space aggregations.
 
+- **Trace Sampling:**  To manage the APM traced request sampling rate for serverless applications, set the DD_TRACE_SAMPLE_RATE environment variable on the function to a value between 0.000 (no tracing of Container App requests) and 1.000 (trace all Container App requests).
+
+Metrics are calculated based on 100% of the application’s traffic, and remain accurate regardless of any sampling configuration.
+
 ### Environment Variables
 
 | Variable | Description |
@@ -262,6 +429,7 @@ Once the deployment is completed, your metrics and traces are sent to Datadog. I
 |`DD_API_KEY`| [Datadog API Key][6] - **Required**|
 | `DD_SITE` | [Datadog site][4] - **Required** |
 | `DD_LOGS_ENABLED` | When true, send logs (stdout and stderr) to Datadog. Defaults to false. |
+| `DD_TRACE_SAMPLE_RATE`|  Controls the trace ingestion sample rate `0.0` and `1.0`|
 | `DD_SERVICE`      | See [Unified Service Tagging][5].                                       |
 | `DD_VERSION`      | See [Unified Service Tagging][5].                                       |
 | `DD_ENV`          | See [Unified Service Tagging][5].                                       |


### PR DESCRIPTION
Updating Container App docs to include the dockerfile install instructions we have been reviewing in Cloud Run repo. Also includes update to call out additional required environment variables for Container apps.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
