### PR TITLE
Fix iOS/Android words usages in the docs

### DIFF
--- a/content/en/account_management/audit_trail/events.md
+++ b/content/en/account_management/audit_trail/events.md
@@ -195,8 +195,8 @@ See the [Audit Trail documentation][2] for more information on setting up and co
 ### Real User Monitoring events
 | Name | Description of audit event                                          | Query in audit explorer                           |
 | ---- | ------------------------------------------------------------------- | --------------------------------------------------|
-| [RUM application created][68] | A user created or deleted an application in RUM and the type of the application (Browser, Flutter, IOS, React Native, Android). | `@evt.name:"Real User Monitoring" @asset.type:real_user_monitoring_application @action:(created OR deleted)` |
-| [RUM application modified][69] | A user modified an application in RUM, the new value of the application, and the type of the application (Browser, Flutter, IOS, React Native, Android). | `@evt.name:"Real User Monitoring" @asset.type:real_user_monitoring_application @action:modified` |
+| [RUM application created][68] | A user created or deleted an application in RUM and the type of the application (Browser, Flutter, iOS, React Native, Android). | `@evt.name:"Real User Monitoring" @asset.type:real_user_monitoring_application @action:(created OR deleted)` |
+| [RUM application modified][69] | A user modified an application in RUM, the new value of the application, and the type of the application (Browser, Flutter, iOS, React Native, Android). | `@evt.name:"Real User Monitoring" @asset.type:real_user_monitoring_application @action:modified` |
 
 ### Security Notification events
 | Name                 | Description of audit event                                                       | Query in audit explorer                                           |

--- a/content/en/agent/guide/datadog-agent-manager-windows.md
+++ b/content/en/agent/guide/datadog-agent-manager-windows.md
@@ -29,7 +29,7 @@ The Datadog Agent Manager GUI is browser-based. The port the GUI runs on can be 
 | Firefox       | 38                           |                         |
 | Chrome        | 60                           |                         |
 | Safari        | 8                            |                         |
-| IOS           | 12                           |  Mobile Safari          |
+| iOS           | 12                           |  Mobile Safari          |
 
 ### Start the Datadog Agent Manager
 

--- a/content/en/real_user_monitoring/android/mobile_vitals.md
+++ b/content/en/real_user_monitoring/android/mobile_vitals.md
@@ -1,7 +1,7 @@
 ---
 title: Mobile Vitals
 kind: documentation
-description: Discover insights about your iOS application's health and performance.
+description: Discover insights about your Android application's health and performance.
 further_reading:
 - link: https://github.com/DataDog/dd-sdk-android
   tag: GitHub

--- a/content/fr/agent/guide/datadog-agent-manager-windows.md
+++ b/content/fr/agent/guide/datadog-agent-manager-windows.md
@@ -28,7 +28,7 @@ L'interface graphique de Datadog Agent Manager repose sur l'utilisation d'un nav
 | Firefox       | 38                           |                         |
 | Chrome        | 60                           |                         |
 | Safari        | 8                            |                         |
-| IOS           | 12                           |  Safari mobile          |
+| iOS           | 12                           |  Safari mobile          |
 
 ### Démarrer Datadog Agent Manager
 

--- a/content/fr/real_user_monitoring/android/_index.md
+++ b/content/fr/real_user_monitoring/android/_index.md
@@ -50,7 +50,7 @@ dependencies {
 
 1. Accédez à [**UX Monitoring** > **RUM Applications** > **New Application**][2].
 2. Sélectionnez le type d'application `android` et attribuez un nom à l'application, afin de générer un ID d'application Datadog unique ainsi qu'un token client.
-3. Pour instrumenter vos vues Web, cliquez sur le bouton **Instrument your webviews**. Pour en savoir plus, consultez la section [Suivi des vues Web iOS][13].
+3. Pour instrumenter vos vues Web, cliquez sur le bouton **Instrument your webviews**. Pour en savoir plus, consultez la section [Suivi des vues Web][13].
 4. Pour désactiver la collecte automatique des IP client ou des données de géolocalisation, décochez les cases correspondant à ces paramètres. Pour en savoir plus, consultez la section [Données RUM recueillies (Android)][15].
 
    {{< img src="real_user_monitoring/android/android-new-application.png" alt="Créer une application RUM application pour Android dans Datadog" style="width:90%;">}}

--- a/content/fr/real_user_monitoring/guide/alerting-with-rum.md
+++ b/content/fr/real_user_monitoring/guide/alerting-with-rum.md
@@ -27,7 +27,7 @@ Vous pouvez utiliser les facettes recueillies par RUM, notamment les [facettes e
 
 {{< img src="real_user_monitoring/guide/alerting-with-rum/high-rum-views-errors.png" alt="Requête de recherche pour une alerte se déclenchant lorsqu'une vue compte plus de huit erreurs" style="width:100%;">}}
 
-La requête de recherche de l'exemple ci-dessus permet à un monitor RUM de surveiller les vues de l'application Shopist IOS, à l'aide de facettes comme `Application ID` et `View Path`. Cet exemple de monitor génère des alertes lorsqu'une vue compte un nombre élevé d'erreurs (par exemple, plus de huit).
+La requête de recherche de l'exemple ci-dessus permet à un monitor RUM de surveiller les vues de l'application Shopist iOS, à l'aide de facettes comme `Application ID` et `View Path`. Cet exemple de monitor génère des alertes lorsqu'une vue compte un nombre élevé d'erreurs (par exemple, plus de huit).
 
 ## Exporter votre requête vers un monitor
 

--- a/content/ja/agent/guide/datadog-agent-manager-windows.md
+++ b/content/ja/agent/guide/datadog-agent-manager-windows.md
@@ -29,7 +29,7 @@ Datadog Agent Manager GUI はブラウザベースです。GUI が実行され�
 | Firefox       | 38                           |                         |
 | Chrome        | 60                           |                         |
 | Safari        | 8                            |                         |
-| IOS           | 12                           |  Mobile Safari          |
+| iOS           | 12                           |  Mobile Safari          |
 
 ### Datadog Agent Manager を起動する
 

--- a/content/ja/real_user_monitoring/android/mobile_vitals.md
+++ b/content/ja/real_user_monitoring/android/mobile_vitals.md
@@ -1,5 +1,5 @@
 ---
-description: iOS アプリケーションの健全性とパフォーマンスに関するインサイトを発見することができます。
+description: Android アプリケーションの健全性とパフォーマンスに関するインサイトを発見することができます。
 further_reading:
 - link: https://github.com/DataDog/dd-sdk-android
   tag: GitHub

--- a/content/ko/agent/guide/datadog-agent-manager-windows.md
+++ b/content/ko/agent/guide/datadog-agent-manager-windows.md
@@ -29,7 +29,7 @@ Datadog Agent Manager GUI는 브라우저 기반입니다. GUI 실행 포트는 
 | Firefox       | 38                           |                         |
 | Chrome        | 60                           |                         |
 | Safari        | 8                            |                         |
-| IOS           | 12                           |  모바일 Safari          |
+| iOS           | 12                           |  모바일 Safari          |
 
 ### Datadog Agent Manager 시작하기
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
I noticed that in some docs iOS is used instead of Android, and some docs have iOS written as IOS, which is wrong.

This PR fixes both issues.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
