### PR TITLE
DOCS-5645: Remove private beta from DBM docs

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2307,7 +2307,7 @@ main:
     url: database_monitoring/setup_postgres/
     parent: dbm
     identifier: dbm_setup_postgres
-    weight: 2
+    weight: 5
   - name: Self-hosted
     url: database_monitoring/setup_postgres/selfhosted
     parent: dbm_setup_postgres
@@ -2347,7 +2347,7 @@ main:
     url: database_monitoring/setup_mysql/
     parent: dbm
     identifier: dbm_setup_mysql
-    weight: 3
+    weight: 10
   - name: Self-hosted
     url: database_monitoring/setup_mysql/selfhosted
     parent: dbm_setup_mysql
@@ -2387,7 +2387,7 @@ main:
     url: database_monitoring/setup_sql_server/
     parent: dbm
     identifier: dbm_setup_sql_server
-    weight: 4
+    weight: 15
   - name: Self-hosted
     url: database_monitoring/setup_sql_server/selfhosted/
     parent: dbm_setup_sql_server
@@ -2413,36 +2413,71 @@ main:
     parent: dbm_setup_sql_server
     identifier: dbm_troubleshooting_sql_server
     weight: 107
+  - name: Setting up Oracle
+    url: database_monitoring/setup_oracle/
+    parent: dbm
+    identifier: dbm_setup_oracle
+    weight: 20
+  - name: Self-hosted
+    url: database_monitoring/setup_oracle/selfhosted/
+    parent: dbm_setup_oracle
+    identifier: dbm_setup_oracle_selfhosted
+    weight: 101
+  - name: RDS
+    url: database_monitoring/setup_oracle/rds/
+    parent: dbm_setup_oracle
+    identifier: dbm_setup_oracle_rds
+    weight: 105
+  - name: RAC
+    url: database_monitoring/setup_oracle/rac/
+    parent: dbm_setup_oracle
+    identifier: dbm_setup_oracle_rac
+    weight: 110
+  - name: Exadata
+    url: database_monitoring/setup_oracle/exadata/
+    parent: dbm_setup_oracle
+    identifier: dbm_setup_oracle_exadata
+    weight: 115
+  - name: Exadata
+    url: database_monitoring/setup_oracle/exadata/
+    parent: dbm_setup_oracle
+    identifier: dbm_setup_oracle_exadata
+    weight: 120
+  - name: Autonomous Database
+    url: database_monitoring/setup_oracle/autonomous_database/
+    parent: dbm_setup_oracle
+    identifier: dbm_setup_oracle_autonomous_database
+    weight: 125
   - name: Connecting DBM and Traces
     url: database_monitoring/connect_dbm_and_apm/
     parent: dbm
     identifier: dbm_connect_dbm_and_apm
-    weight: 5
+    weight: 25
   - name: Data Collected
     url: database_monitoring/data_collected
     parent: dbm
     identifier: dbm_data_collected
-    weight: 6
+    weight: 30
   - name: Exploring Query Metrics
     url: database_monitoring/query_metrics/
     parent: dbm
     identifier: dbm_query_metrics
-    weight: 7
+    weight: 35
   - name: Exploring Query Samples
     url: database_monitoring/query_samples/
     parent: dbm
     identifier: dbm_query_samples
-    weight: 8
+    weight: 40
   - name: Troubleshooting
     url: database_monitoring/troubleshooting/
     parent: dbm
     identifier: dbm_troubleshooting
-    weight: 9
+    weight: 45
   - name: Guides
     url: database_monitoring/guide/
     parent: dbm
     identifier: dbm_guides
-    weight: 10
+    weight: 50
   - name: Universal Service Monitoring
     url: universal_service_monitoring/
     pre: usm

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2413,7 +2413,7 @@ main:
     parent: dbm_setup_sql_server
     identifier: dbm_troubleshooting_sql_server
     weight: 107
-  - name: Setting up Oracle
+  - name: Setting Up Oracle
     url: database_monitoring/setup_oracle/
     parent: dbm
     identifier: dbm_setup_oracle

--- a/content/en/database_monitoring/setup_oracle/_index.md
+++ b/content/en/database_monitoring/setup_oracle/_index.md
@@ -3,8 +3,6 @@ title: Setting up Oracle
 kind: documentation
 description: Setting up Database Monitoring on an Oracle database
 disable_sidebar: true
-private: true
-is_beta: true
 ---
 
 {{< site-region region="gov" >}}
@@ -12,7 +10,7 @@ is_beta: true
 {{< /site-region >}}
 
 <div class="alert alert-info">
-The features described on this page are in private beta.
+The features described on this page are in beta.
 </div>
 
 ## Supported Oracle versions, features, and architectures

--- a/content/en/database_monitoring/setup_oracle/_index.md
+++ b/content/en/database_monitoring/setup_oracle/_index.md
@@ -10,13 +10,13 @@ disable_sidebar: true
 {{< /site-region >}}
 
 <div class="alert alert-info">
-The features described on this page are in beta.
+The features described on this page are in beta. Contact your Customer Success Manager to provide feedback or ask for help.
 </div>
 
 ## Supported Oracle versions, features, and architectures
 
 - **Versions**: 19c and 21c
-- **Deployment configurations**: Self-managed, RDS, RAC, Exadata
+- **Deployment configurations**: Self-managed, RDS, RAC, Exadata, Autonomous database
 - **Architecture**: Multi-tenant
 
 ## Prerequisites
@@ -111,6 +111,12 @@ The Agent doesn't require any external Oracle clients.
 
 Execute all `grant` permission commands according to the documentation for your hosting type. New features need access to system views that were not previously granted to the Datadog database user account.
 
+## Custom queries
+
+Database Monitoring supports custom queries for Oracle databases. To learn more about the configuration options available, see the [conf.yaml.example][11].
+
+<div class="alert alert-warning">Running custom queries may result in additional costs or fees assessed by Oracle.</div>
+
 ## Setup
 
 For setup instructions, select your hosting type:
@@ -127,3 +133,4 @@ For setup instructions, select your hosting type:
 [8]: https://ddagent-windows-stable.s3.amazonaws.com/
 [9]: https://hub.docker.com/r/datadog/agent/tags?page=1&name=oracle
 [10]: /database_monitoring/architecture/
+[11]: https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example

--- a/content/en/database_monitoring/setup_oracle/_index.md
+++ b/content/en/database_monitoring/setup_oracle/_index.md
@@ -16,7 +16,7 @@ The features described on this page are in beta. Contact your Customer Success M
 ## Supported Oracle versions, features, and architectures
 
 - **Versions**: 19c and 21c
-- **Deployment configurations**: Self-managed, RDS, RAC, Exadata, Autonomous database
+- **Deployment configurations**: Self-managed, RDS, RAC, Exadata, Autonomous Database
 - **Architecture**: Multi-tenant
 
 ## Prerequisites

--- a/content/en/database_monitoring/setup_oracle/autonomous_database.md
+++ b/content/en/database_monitoring/setup_oracle/autonomous_database.md
@@ -2,8 +2,6 @@
 title: Setting Up Database Monitoring for Oracle Autonomous Database
 kind: documentation
 description: Install and configure Database Monitoring for Oracle Autonomous Database
-private: true
-is_beta: true
 further_reading:
 - link: "/integrations/oracle/"
   tag: "Documentation"
@@ -16,7 +14,7 @@ further_reading:
 {{< /site-region >}}
 
 <div class="alert alert-info">
-The features described on this page are in private beta.
+The features described on this page are in beta.
 </div>
 
 Database Monitoring provides deep visibility into your Oracle databases by exposing query samples to profile your different workloads and diagnose issues.

--- a/content/en/database_monitoring/setup_oracle/autonomous_database.md
+++ b/content/en/database_monitoring/setup_oracle/autonomous_database.md
@@ -14,7 +14,7 @@ further_reading:
 {{< /site-region >}}
 
 <div class="alert alert-info">
-The features described on this page are in beta.
+The features described on this page are in beta. Contact your Customer Success Manager to provide feedback or ask for help.
 </div>
 
 Database Monitoring provides deep visibility into your Oracle databases by exposing query samples to profile your different workloads and diagnose issues.

--- a/content/en/database_monitoring/setup_oracle/exadata.md
+++ b/content/en/database_monitoring/setup_oracle/exadata.md
@@ -2,8 +2,6 @@
 title: Setting Up Database Monitoring for Oracle Exadata
 kind: documentation
 description: Install and configure Database Monitoring for Oracle Exadata
-private: true
-is_beta: true
 further_reading:
 - link: "/integrations/oracle/"
   tag: "Documentation"
@@ -16,7 +14,7 @@ further_reading:
 {{< /site-region >}}
 
 <div class="alert alert-info">
-The features described on this page are in private beta.
+The features described on this page are in beta.
 </div>
 
 Database Monitoring provides deep visibility into your Oracle databases by exposing query samples to profile your different workloads and diagnose issues.

--- a/content/en/database_monitoring/setup_oracle/exadata.md
+++ b/content/en/database_monitoring/setup_oracle/exadata.md
@@ -14,7 +14,7 @@ further_reading:
 {{< /site-region >}}
 
 <div class="alert alert-info">
-The features described on this page are in beta.
+The features described on this page are in beta. Contact your Customer Success Manager to provide feedback or ask for help.
 </div>
 
 Database Monitoring provides deep visibility into your Oracle databases by exposing query samples to profile your different workloads and diagnose issues.

--- a/content/en/database_monitoring/setup_oracle/rac.md
+++ b/content/en/database_monitoring/setup_oracle/rac.md
@@ -14,7 +14,7 @@ further_reading:
 {{< /site-region >}}
 
 <div class="alert alert-info">
-The features described on this page are in private beta.
+The features described on this page are in private beta. Contact your Customer Success Manager to provide feedback or ask for help.
 </div>
 
 Database Monitoring provides deep visibility into your Oracle databases by exposing query samples to profile your different workloads and diagnose issues.

--- a/content/en/database_monitoring/setup_oracle/rac.md
+++ b/content/en/database_monitoring/setup_oracle/rac.md
@@ -2,8 +2,6 @@
 title: Setting Up Database Monitoring for Oracle RAC
 kind: documentation
 description: Install and configure Database Monitoring for Oracle RAC
-private: true
-is_beta: true
 further_reading:
 - link: "/integrations/oracle/"
   tag: "Documentation"

--- a/content/en/database_monitoring/setup_oracle/rds.md
+++ b/content/en/database_monitoring/setup_oracle/rds.md
@@ -2,8 +2,6 @@
 title: Setting Up Database Monitoring for RDS Oracle
 kind: documentation
 description: Install and configure Database Monitoring for RDS Oracle
-private: true
-is_beta: true
 further_reading:
 - link: "/integrations/oracle/"
   tag: "Documentation"
@@ -16,7 +14,7 @@ further_reading:
 {{< /site-region >}}
 
 <div class="alert alert-info">
-The features described on this page are in private beta.
+The features described on this page are in beta.
 </div>
 
 Database Monitoring provides deep visibility into your Oracle databases by exposing query samples to profile your different workloads and diagnose issues.

--- a/content/en/database_monitoring/setup_oracle/rds.md
+++ b/content/en/database_monitoring/setup_oracle/rds.md
@@ -14,7 +14,7 @@ further_reading:
 {{< /site-region >}}
 
 <div class="alert alert-info">
-The features described on this page are in beta.
+The features described on this page are in beta. Contact your Customer Success Manager to provide feedback or ask for help.
 </div>
 
 Database Monitoring provides deep visibility into your Oracle databases by exposing query samples to profile your different workloads and diagnose issues.

--- a/content/en/database_monitoring/setup_oracle/selfhosted.md
+++ b/content/en/database_monitoring/setup_oracle/selfhosted.md
@@ -2,8 +2,6 @@
 title: Setting Up Database Monitoring for Self-Hosted Oracle
 kind: documentation
 description: Install and configure Database Monitoring for Self-Hosted Oracle
-private: true
-is_beta: true
 further_reading:
 - link: "/integrations/oracle/"
   tag: "Documentation"
@@ -16,7 +14,7 @@ further_reading:
 {{< /site-region >}}
 
 <div class="alert alert-info">
-The features described on this page are in private beta.
+The features described on this page are in beta.
 </div>
 
 Database Monitoring provides deep visibility into your Oracle databases by exposing query samples to profile your different workloads and diagnose issues.

--- a/content/en/database_monitoring/setup_oracle/selfhosted.md
+++ b/content/en/database_monitoring/setup_oracle/selfhosted.md
@@ -14,7 +14,7 @@ further_reading:
 {{< /site-region >}}
 
 <div class="alert alert-info">
-The features described on this page are in beta.
+The features described on this page are in beta. Contact your Customer Success Manager to provide feedback or ask for help.
 </div>
 
 Database Monitoring provides deep visibility into your Oracle databases by exposing query samples to profile your different workloads and diagnose issues.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Removes private beta from Oracle DBM docs.

### Motivation
DOCS-5645

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
