### PR TITLE
[incident-app] add zoom integration docs to Incident Management docs

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1244,6 +1244,12 @@ main:
     parent: incidents
     identifier: incidents_clipboard
     weight: 4
+  # will uncomment this when the zoom integration is publicly released
+  # - name: Zoom Integration
+  #   url: service_management/incident_management/zoom_integration
+  #   parent: incidents
+  #   identifier: zoom_integration
+  #   weight: 5
   - name: Mobile Application
     url: service_management/mobile/
     identifier: mobile

--- a/content/en/service_management/incident_management/zoom_integration.md
+++ b/content/en/service_management/incident_management/zoom_integration.md
@@ -1,0 +1,46 @@
+---
+title: Zoom Integration
+kind: documentation
+description: Connect Zoom to Datadog to help your team collaborate
+private: true
+---
+
+## Overview
+
+Connect Zoom to Datadog to help your team collaborate by quickly creating Zoom meetings for active incidents.
+
+## Setup
+
+### Installation
+
+First, in the Incident Management settings, a user must enable the **Automatically create a meeting in Zoom for every incident** toggle. This setting replaces the **Add Video Call** button with a **Start Zoom Call** button for one-click Zoom meeting creation from the incident overview page.
+
+Next, when a user first clicks the **Start Zoom Call** button, they are prompted to add the Datadog Zoom App and allow it to view and manage information on their behalf.
+
+## Usage
+
+After the app has been installed, users are able to click the **Start Zoom Call** button from a incident to create a new Zoom call and link it to the incident automatically.
+
+## Permissions
+
+Datadog for Zoom requires the following OAuth Scopes. For more information, see the [Zoom OAuth scopes documentation][2].
+
+### User-level Scopes
+
+| Scopes                   | Request Reason                                                                                                 |
+|--------------------------|----------------------------------------------------------------------------------------------------------------|
+| `meeting:write`          | Create meetings when users click **Start Zoom Call** in the Incident Management product.                         |
+
+## Removing the App
+
+1. Log in to your Zoom account and navigate to the Zoom App Marketplace.
+2. Click **Manage** >> **Added Apps**, or search for the **Datadog** app.
+3. Click the **Datadog** app.
+4. Click **Remove**.
+
+## Troubleshooting
+
+Need help? Contact [Datadog support][1].
+
+[1]: https://docs.datadoghq.com/help/
+[2]: https://developers.zoom.us/docs/integrations/oauth-scopes/

--- a/content/en/service_management/incident_management/zoom_integration.md
+++ b/content/en/service_management/incident_management/zoom_integration.md
@@ -7,19 +7,22 @@ private: true
 
 ## Overview
 
-Connect Zoom to Datadog to help your team collaborate by quickly creating Zoom meetings for active incidents.
+By connecting Zoom and Datadog, you can quickly create Zoom meetings to collaborate with your team on active incidents.
 
 ## Setup
 
 ### Installation
 
-First, in the Incident Management settings, a user must enable the **Automatically create a meeting in Zoom for every incident** toggle. This setting replaces the **Add Video Call** button with a **Start Zoom Call** button for one-click Zoom meeting creation from the incident overview page.
+To install the Datadog for Zoom app:
 
-Next, when a user first clicks the **Start Zoom Call** button, they are prompted to add the Datadog Zoom App and allow it to view and manage information on their behalf.
+1. In Datadog, find the Incidents Settings page under **Service Management**.
+2. Go to **Integrations** and enable the **Automatically create a meeting in Zoom for every incident** toggle. This setting replaces the **Add Video Call** button with a **Start Zoom Call** button for one-click Zoom meeting creation from Datadog's incident overview page.
+
+3. When you click the **Start Zoom Call** button, you are prompted to add the Datadog Zoom App. Be sure to allow it to view and manage information on Zoom's behalf.
 
 ## Usage
 
-After the app has been installed, users are able to click the **Start Zoom Call** button from a incident to create a new Zoom call and link it to the incident automatically.
+Once the app has been installed, you can click the **Start Zoom Call** button from an incident to create a new Zoom call and link it to the incident automatically.
 
 ## Permissions
 
@@ -32,9 +35,10 @@ Datadog for Zoom requires the following OAuth Scopes. For more information, see 
 | `meeting:write`          | Create meetings when users click **Start Zoom Call** in the Incident Management product.                         |
 
 ## Removing the App
+To remove the Datadog for Zoom app:
 
-1. Log in to your Zoom account and navigate to the Zoom App Marketplace.
-2. Click **Manage** >> **Added Apps**, or search for the **Datadog** app.
+1. Log into your Zoom account and navigate to the Zoom App Marketplace.
+2. Click **Manage** > **Added Apps**, or search for the **Datadog** app.
 3. Click the **Datadog** app.
 4. Click **Remove**.
 
@@ -42,5 +46,5 @@ Datadog for Zoom requires the following OAuth Scopes. For more information, see 
 
 Need help? Contact [Datadog support][1].
 
-[1]: https://docs.datadoghq.com/help/
+[1]: /help/
 [2]: https://developers.zoom.us/docs/integrations/oauth-scopes/

--- a/content/en/service_management/incident_management/zoom_integration.md
+++ b/content/en/service_management/incident_management/zoom_integration.md
@@ -17,7 +17,6 @@ To install the Datadog for Zoom app:
 
 1. In Datadog, find the Incidents Settings page under **Service Management**.
 2. Go to **Integrations** and enable the **Automatically create a meeting in Zoom for every incident** toggle. This setting replaces the **Add Video Call** button with a **Start Zoom Call** button for one-click Zoom meeting creation from Datadog's incident overview page.
-
 3. When you click the **Start Zoom Call** button, you are prompted to add the Datadog Zoom App. Be sure to allow it to view and manage information on Zoom's behalf.
 
 ## Usage


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Add documentation for installing, using, and removing the Zoom integration for Incident Management. These docs should be private/hidden for now until the integration is approved by Zoom.

### Motivation
<!-- What inspired you to submit this pull request?-->

Our Zoom App must have publicly accessible documentation to be accepted onto the Zoom App Marketplace

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

some more context in this thread in slack https://dd.slack.com/archives/C0DESMBQU/p1690312669997819

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
