### PR TITLE
Updating Docker Log collection with note about Docker Compose

### DIFF
--- a/content/en/containers/docker/log.md
+++ b/content/en/containers/docker/log.md
@@ -131,6 +131,12 @@ The commands related to log collection are:
 `-v /var/lib/docker/containers:/var/lib/docker/containers:ro` 
 : To collect containers logs from files. Available in the Datadog Agent 6.27.0/7.27.0+
 
+**Note**: If using Docker-Compose, the value for `DD_CONTAINER_EXCLUDE` should not be quoted. The environment variable in your docker-compose.yaml file should look like this:
+
+```yaml
+environment:
+    - DD_CONTAINER_EXCLUDE=image:datadog/agent:*
+```
 
 [1]: https://github.com/DataDog/datadog-agent/tree/main/Dockerfiles/agent
 [2]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/agent

--- a/content/en/containers/docker/log.md
+++ b/content/en/containers/docker/log.md
@@ -131,7 +131,7 @@ The commands related to log collection are:
 `-v /var/lib/docker/containers:/var/lib/docker/containers:ro` 
 : To collect containers logs from files. Available in the Datadog Agent 6.27.0/7.27.0+
 
-**Note**: If using Docker-Compose, the value for `DD_CONTAINER_EXCLUDE` should not be quoted. The environment variable in your docker-compose.yaml file should look like this:
+**Note**: If using Docker Compose, the value for `DD_CONTAINER_EXCLUDE` must not be quoted. Configure the environment variable in your docker-compose.yaml file like the example below:
 
 ```yaml
 environment:


### PR DESCRIPTION
### What does this PR do?

Updates the page on [Docker Log collection](https://docs.datadoghq.com/containers/docker/log/?tab=dockercompose) with a note about Docker Compose.

### Motivation

Every now and again customers run in to the issue https://github.com/DataDog/datadog-agent/issues/17804 when trying out the Agent. The reason this issue happens is because Docker Compose does not parse the environment variables and so passes a quoted value to the Agent.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
