### PR TITLE
Remove beta label from ITR docs

### DIFF
--- a/content/en/continuous_integration/intelligent_test_runner/_index.md
+++ b/content/en/continuous_integration/intelligent_test_runner/_index.md
@@ -19,7 +19,7 @@ Intelligent Test Runner works by analyzing your test suite to determine the code
 
 By minimizing the number of tests run per commit, Intelligent Test Runner reduces the frequency of flaky tests disrupting your pipelines. Flaky tests are tests that may pass or fail at random given the same commit. This can be particularly frustrating when the test flaking is unrelated to the code change being tested. After enabling Intelligent Test Runner for your test services, you can limit each commit to its relevant tests to ensure that flaky tests unrelated to your code change don't end up arbitrarily breaking your build.
 
-### Limitations during beta
+### Limitations
 
 There are known limitations in the current implementation of Intelligent Test Runner that can cause it to skip tests that should be run under certain conditions. Specifically, Intelligent Test Runner is not able to detect changes in library dependencies, compiler options, external services or changes to data files in data-driven tests.
 

--- a/content/en/continuous_integration/intelligent_test_runner/_index.md
+++ b/content/en/continuous_integration/intelligent_test_runner/_index.md
@@ -75,4 +75,4 @@ The dashboard also tracks adoption of Intelligent Test Runner throughout your or
 [1]: /continuous_integration/tests/
 [2]: https://app.datadoghq.com/ci/settings/test-service
 [3]: https://app.datadoghq.com/ci/test-runs
-[4]: https://app.datadoghq.com/dash/integration/30941/ci-visibility-intelligent-test-runner-beta
+[4]: https://app.datadoghq.com/dash/integration/30941/ci-visibility-intelligent-test-runner

--- a/content/en/continuous_integration/intelligent_test_runner/java.md
+++ b/content/en/continuous_integration/intelligent_test_runner/java.md
@@ -1,6 +1,7 @@
 ---
 title: Intelligent Test Runner for Java
 kind: documentation
+is_beta: true
 further_reading:
     - link: "/continuous_integration/tests"
       tag: "Documentation"
@@ -9,6 +10,8 @@ further_reading:
       tag: "Documentation"
       text: "Troubleshooting CI"
 ---
+
+{{< callout url="#" btn_hidden="true" >}}Intelligent Test Runner for Java in beta.{{< /callout >}}
 
 ## Compatibility
 

--- a/content/en/continuous_integration/intelligent_test_runner/java.md
+++ b/content/en/continuous_integration/intelligent_test_runner/java.md
@@ -1,7 +1,6 @@
 ---
 title: Intelligent Test Runner for Java
 kind: documentation
-is_beta: true
 further_reading:
     - link: "/continuous_integration/tests"
       tag: "Documentation"
@@ -10,8 +9,6 @@ further_reading:
       tag: "Documentation"
       text: "Troubleshooting CI"
 ---
-
-{{< callout url="#" btn_hidden="true" >}}Intelligent Test Runner for Java in beta.{{< /callout >}} 
 
 ## Compatibility
 

--- a/content/en/continuous_integration/intelligent_test_runner/swift.md
+++ b/content/en/continuous_integration/intelligent_test_runner/swift.md
@@ -1,6 +1,7 @@
 ---
 title: Intelligent Test Runner for Swift
 kind: documentation
+is_beta: true
 further_reading:
     - link: "/continuous_integration/tests"
       tag: "Documentation"
@@ -9,6 +10,8 @@ further_reading:
       tag: "Documentation"
       text: "Troubleshooting CI"
 ---
+
+{{< callout url="#" btn_hidden="true" >}}Intelligent Test Runner for Swift is in beta.{{< /callout >}}
 
 ## Compatibility
 

--- a/content/en/continuous_integration/intelligent_test_runner/swift.md
+++ b/content/en/continuous_integration/intelligent_test_runner/swift.md
@@ -1,7 +1,6 @@
 ---
 title: Intelligent Test Runner for Swift
 kind: documentation
-is_beta: true
 further_reading:
     - link: "/continuous_integration/tests"
       tag: "Documentation"
@@ -10,8 +9,6 @@ further_reading:
       tag: "Documentation"
       text: "Troubleshooting CI"
 ---
-
-{{< callout url="#" btn_hidden="true" >}}Intelligent Test Runner for Swift is in beta.{{< /callout >}} 
 
 ## Compatibility
 


### PR DESCRIPTION
### What does this PR do?

This PR removes the beta labels from the Intelligent Test Runner documentation.
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
