### PR TITLE
Update FIPS proxy version to 0.5.4

### DIFF
--- a/content/en/containers/amazon_ecs/_index.md
+++ b/content/en/containers/amazon_ecs/_index.md
@@ -237,7 +237,7 @@ To send data to Datadog's GOVCLOUD datacenter, add the `fips-proxy` sidecar cont
      (...)
           {
             "name": "fips-proxy",
-            "image": "datadog/fips-proxy:0.5.3",
+            "image": "datadog/fips-proxy:0.5.4",
             "portMappings": [
                 {
                     "containerPort": 9803,


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Update version of FIPS Proxy

### Motivation

New FIPS Proxy version has been released

### Preview

https://docs-staging.datadoghq.com/nicolas.guerguadj/ecs-fips-0.5.4/containers/amazon_ecs/?tab=awscli#fips-proxy-for-govcloud-environments (US1 Fed site only)

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
