### PR TITLE
Move SAML role mapping to its own page

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -4012,38 +4012,42 @@ main:
     identifier: account_management_saml
     parent: account_management
     weight: 4
+  - name: User Group Mapping
+    url: account_management/saml/mapping/
+    parent: account_management_saml
+    weight: 401
   - name: Active Directory
     url: account_management/saml/activedirectory/
     parent: account_management_saml
-    weight: 401
+    weight: 402
   - name: Auth0
     url: account_management/saml/auth0/
     parent: account_management_saml
-    weight: 402
+    weight: 403
   - name: Azure
     url: account_management/saml/azure/
     parent: account_management_saml
-    weight: 403
+    weight: 404
   - name: Google
     url: account_management/saml/google/
     parent: account_management_saml
-    weight: 404
+    weight: 405
   - name: NoPassword
     url: account_management/saml/lastpass/
     parent: account_management_saml
-    weight: 405
+    weight: 406
   - name: Okta
     url: account_management/saml/okta/
     parent: account_management_saml
-    weight: 406
+    weight: 407
   - name: SafeNet
     url: account_management/saml/safenet/
     parent: account_management_saml
-    weight: 407
+    weight: 408
   - name: Troubleshooting
     url: account_management/saml/troubleshooting/
     parent: account_management_saml
-    weight: 408
+    weight: 409
   - name: API and Application Keys
     url: account_management/api-app-keys/
     parent: account_management

--- a/content/en/account_management/saml/_index.md
+++ b/content/en/account_management/saml/_index.md
@@ -95,7 +95,7 @@ If **sn** and **givenName** are provided, they are used to update the user's nam
 
 ## Additional features
 
-To map attributes in your Identity Provider (IdP)'s response to Datadog roles and teams, see [SAML group mapping][22]. 
+To map attributes in your identity provider's response to Datadog roles and teams, see [SAML group mapping][22].
 
 The following features can be enabled through the [SAML Configuration dialog][19]:
 

--- a/content/en/account_management/saml/_index.md
+++ b/content/en/account_management/saml/_index.md
@@ -93,39 +93,9 @@ If **eduPersonPrincipalName** exists in the AttributeStatement, the value of thi
 
 If **sn** and **givenName** are provided, they are used to update the user's name in their Datadog profile.
 
-## Mapping SAML attributes to Datadog roles
-
-With Datadog, you can map attributes in your IdP's response to Datadog roles. Users with the Access Management permission can assign or remove Datadog roles based on a user's SAML-assigned attributes.
-
-It's important to understand what is sent in an assertion before turning on mappings as mappings require correct attributes. Every IdP has specific mappings. For example, Azure works with object IDs, and Okta requires you to set attributes in [Okta settings][22]. Datadog recommends cross-referencing with [built-in browser tooling][23] such as Chrome Dev Tools or browser extensions and [validating your SAML assertions][24] **before** creating mappings.
-
-1. [Cross-reference][23] and [validate][24] your SAML assertion to understand your IdP's attributes.
-
-2. Go to **Organization Settings** and click the **SAML Group Mappings** tab.
-
-3. Click **New Mapping**.
-
-4. Specify the SAML identity provider `key-value` pair that you want to associate with an existing Datadog role (either default or custom). **Note**: These entries are case-sensitive.
-
-   For example, if you want all users whose `member_of` attribute has a value of `Development` to be assigned to a custom Datadog role called `Devs`:
-
-    {{< img src="account_management/saml/create_mapping.png" alt="Creating a SAML mapping to Datadog Role" >}}
-
-   **Note**: Every identity provider is different. Some allow you to set your attribute key or label. Others provide one by default. Datadog recommends you use an assertion inspector on your login to view the details of your particular assertion to understand how your Identity Provider is sending your group membership.
-
-5. If you have not already done so, enable mappings by clicking **Enable Mappings**.
-
-When a user logs in who has the specified identity provider attribute, they are automatically assigned the Datadog role. Likewise, if someone has that identity provider attribute removed, they lose access to the role (unless another mapping adds it).
-
-<div class="alert alert-warning">
-  <strong>Important:</strong> If a user does <i>not</i> match any mapping, they lose any roles they had previously and are prevented from logging into the org with SAML. Double-check your mapping definitions and inspect your own assertions before enabling Mappings to prevent any scenarios where your users are unable to login.
-</div>
-
-You can make changes to a mapping by clicking the **pencil** icon or removing it by clicking the **garbage** icon. These actions affect only the mapping, not the identity provider attributes or the Datadog roles.
-
-Alternatively, you can create and change mappings of SAML attributes to Datadog roles with the `authn_mappings` endpoint. For more information, see [Federated Authentication to Role Mapping API][25].
-
 ## Additional features
+
+To map attributes in your Identity Provider (IdP)'s response to Datadog roles and teams, see [SAML group mapping][22]. 
 
 The following features can be enabled through the [SAML Configuration dialog][19]:
 
@@ -151,7 +121,7 @@ If you do not use the updated SP metadata, Datadog is not able to associate the 
 
 ### SAML strict
 
-You can make your organization SAML Strict by disabling other login method types in the the **Login Methods** UI. When this option is configured, all users must, by default, log in with SAML. An existing username/password or Google OAuth login does not work. This ensures that all users with access to Datadog must have valid credentials in your company's identity provider/directory service to access your Datadog account. Org administrators can set per-user [overrides][26] to allow certain users to be SAML Strict exempt.
+You can make your organization SAML Strict by disabling other login method types in the the **Login Methods** UI. When this option is configured, all users must, by default, log in with SAML. An existing username/password or Google OAuth login does not work. This ensures that all users with access to Datadog must have valid credentials in your company's identity provider/directory service to access your Datadog account. Org administrators can set per-user [overrides][23] to allow certain users to be SAML Strict exempt.
 
 ### Self-updating Datadog SP metadata
 
@@ -184,8 +154,5 @@ Certain Identity Providers (such as Microsoft's ADFS) can be configured to pull 
 [19]: https://app.datadoghq.com/saml/saml_setup
 [20]: https://app.datadoghq.com/account/team
 [21]: /account_management/multi_organization/#setting-up-saml
-[22]: https://help.okta.com/en/prod/Content/Topics/users-groups-profiles/usgp-add-custom-user-attributes.htm
-[23]: https://support.okta.com/help/s/article/How-to-View-a-SAML-Response-in-Your-Browser-for-Troubleshooting?language=en_US
-[24]: https://www.samltool.com/validate_response.php
-[25]: /account_management/authn_mapping/
-[26]: /account_management/login_methods/#reviewing-user-overrides
+[22]: /account_management/saml/mapping/
+[23]: /account_management/login_methods/#reviewing-user-overrides

--- a/content/en/account_management/saml/mapping.md
+++ b/content/en/account_management/saml/mapping.md
@@ -1,6 +1,10 @@
 ---
 title: SAML Group Mapping
 kind: documentation
+further_reading:
+- link: "/account_management/saml/"
+  tag: "Documentation"
+  text: "Single sign on with SAML"
 ---
 
 ## Mapping SAML attributes to Datadog roles
@@ -31,7 +35,7 @@ When a user logs in who has the specified identity provider attribute, they are 
   <strong>Important:</strong> If a user does <i>not</i> match any mapping, they lose any roles they had previously and are prevented from logging into the org with SAML. Double-check your mapping definitions and inspect your own assertions before enabling Mappings to prevent any scenarios where your users are unable to login.
 </div>
 
-You can make changes to a mapping by clicking the **pencil** icon or removing it by clicking the **garbage** icon. These actions affect only the mapping, not the identity provider attributes or the Datadog roles.
+You can make changes to a mapping by clicking the **pencil** icon or remove it by clicking the **garbage** icon. These actions affect only the mapping, not the identity provider attributes or the Datadog roles.
 
 Alternatively, you can create and change mappings of SAML attributes to Datadog roles with the `authn_mappings` endpoint. For more information, see [Federated Authentication to Role Mapping API][4].
 

--- a/content/en/account_management/saml/mapping.md
+++ b/content/en/account_management/saml/mapping.md
@@ -1,0 +1,41 @@
+---
+title: SAML Group Mapping
+kind: documentation
+---
+
+## Mapping SAML attributes to Datadog roles
+
+With Datadog, you can map attributes in your Identity Provider (IdP)'s response to Datadog roles. Users with the Access Management permission can assign or remove Datadog roles based on a user's SAML-assigned attributes.
+
+It's important to understand what is sent in an assertion before turning on mappings, as mappings require correct attributes. Every IdP has specific mappings. For example, Azure works with object IDs, and Okta requires you to set attributes in [Okta settings][1]. Datadog recommends cross-referencing with [built-in browser tooling][2] such as Chrome Dev Tools or browser extensions and [validating your SAML assertions][3] **before** creating mappings.
+
+1. [Cross-reference][2] and [validate][3] your SAML assertion to understand your IdP's attributes.
+
+2. Go to **Organization Settings** and click the **SAML Group Mappings** tab.
+
+3. Click **New Mapping**.
+
+4. Specify the SAML identity provider `key-value` pair that you want to associate with an existing Datadog role (either default or custom). **Note**: These entries are case-sensitive.
+
+   For example, if you want all users whose `member_of` attribute has a value of `Development` to be assigned to a custom Datadog role called `Devs`:
+
+    {{< img src="account_management/saml/create_mapping.png" alt="Creating a SAML mapping to Datadog Role" >}}
+
+   **Note**: Every identity provider is different. Some allow you to set your attribute key or label. Others provide one by default. Datadog recommends you use an assertion inspector on your login to view the details of your particular assertion to understand how your Identity Provider is sending your group membership.
+
+5. If you have not already done so, enable mappings by clicking **Enable Mappings**.
+
+When a user logs in who has the specified identity provider attribute, they are automatically assigned the Datadog role. Likewise, if someone has that identity provider attribute removed, they lose access to the role (unless another mapping adds it).
+
+<div class="alert alert-warning">
+  <strong>Important:</strong> If a user does <i>not</i> match any mapping, they lose any roles they had previously and are prevented from logging into the org with SAML. Double-check your mapping definitions and inspect your own assertions before enabling Mappings to prevent any scenarios where your users are unable to login.
+</div>
+
+You can make changes to a mapping by clicking the **pencil** icon or removing it by clicking the **garbage** icon. These actions affect only the mapping, not the identity provider attributes or the Datadog roles.
+
+Alternatively, you can create and change mappings of SAML attributes to Datadog roles with the `authn_mappings` endpoint. For more information, see [Federated Authentication to Role Mapping API][4].
+
+[1]: https://help.okta.com/en/prod/Content/Topics/users-groups-profiles/usgp-add-custom-user-attributes.htm
+[2]: https://support.okta.com/help/s/article/How-to-View-a-SAML-Response-in-Your-Browser-for-Troubleshooting?language=en_US
+[3]: https://www.samltool.com/validate_response.php
+[4]: /account_management/authn_mapping/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Moves the section on user group mapping from the main SAML setup page to its own page.

### Motivation
I need to add some more information on user mapping, and it will make the SAML page too long. Moving the mapping content to its own page makes it easier to understand. The additional user mapping documentation will come in a follow-on PR.

The content in the new `mapping.md` file is copied and pasted from the previous location. It is identical except for one small grammar fix.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
ready to merge

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
