### PR TITLE
remove tcp queue length alias

### DIFF
--- a/content/en/integrations/_index.md
+++ b/content/en/integrations/_index.md
@@ -4,7 +4,6 @@ kind: documentation
 disable_sidebar: true
 aliases:
     - /integrations/verisign_openhybrid/
-    - /integrations/tcp_queue_length/
     - /integrations/snyk/
 description: Gather data from all of your systems, apps, & services
 cascade:


### PR DESCRIPTION
### What does this PR do?

`tcp-queue-length` was originally a disabled integration (https://github.com/DataDog/documentation/pull/8764)

It seems to be enabled again now https://docs.datadoghq.com/integrations/?q=tcp%20queue however clicking on the integration tile redirects you to integrations.

This pr removes the alias we had previous when it was disabled.

### Motivation

Slack

### Preview

Visiting https://docs-staging.datadoghq.com/david.jones/tcp-queue-enable/integrations/?q=tcp%20queue and clicking on tcp queue length should work https://docs-staging.datadoghq.com/david.jones/tcp-queue-enable/integrations/tcp_queue_length/

also visiting directly should work 

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
