### PR TITLE
Initial documentation page for the Datadog Extension for Visual Studio IDE

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3845,11 +3845,16 @@ main:
     parent: ide_integrations
     identifier: ide_integrations_idea
     weight: 801
-  - name: Visual Studio Code
+  - name: VS Code
     url: developers/ide_integrations/vscode/
     parent: ide_integrations
     identifier: ide_integrations_vscode
     weight: 802
+  - name: Visual Studio
+    url: developers/ide_integrations/visual_studio/
+    parent: ide_integrations
+    identifier: ide_integrations_visual_studio
+    weight: 803
   - name: Community
     url: developers/community/
     parent: dev_tools

--- a/config/_default/menus/menus.ja.yaml
+++ b/config/_default/menus/menus.ja.yaml
@@ -9765,6 +9765,11 @@ main:
   parent: ide_integrations
   url: developers/ide_integrations/vscode/
   weight: 802
+- identifier: ide_integrations_visualstudio
+  name: Visual Studio
+  parent: ide_integrations
+  url: developers/ide_integrations/visualstudio/
+  weight: 803
 - identifier: dev_community
   name: コミュニティ
   parent: dev_tools

--- a/content/en/developers/ide_integrations/_index.md
+++ b/content/en/developers/ide_integrations/_index.md
@@ -12,4 +12,5 @@ Use Datadog integrations in your preferred integrated development environment (I
 {{< whatsnext desc="See the documentation for information about the following integrations:">}}
     {{< nextlink href="developers/ide_integrations/idea/" >}}<u>IntelliJ IDEA</u>: Improve software performance by providing meaningful code-level insights in IDEA based on real-time observability data.{{< /nextlink >}}
     {{< nextlink href="developers/ide_integrations/vscode/" >}}<u>Visual Studio Code</u>: Improve code reliability by running Synthetic tests in VS Code on local environments.{{< /nextlink >}}
+    {{< nextlink href="developers/ide_integrations/visual_studio/" >}}<u>Visual Studio</u>: The Datadog extension for .NET developers.{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/developers/ide_integrations/visual_studio/_index.md
+++ b/content/en/developers/ide_integrations/visual_studio/_index.md
@@ -20,10 +20,9 @@ The Datadog plugin for Visual Studio users helps you to improve software perform
 
 The **Code Insights** view keeps you informed about:
 
-- Issues from Error Tracking
-- Vulnerability reports by Application Security Management
-- Flaky tests detected by CI Visibility
-- Profiling insights from Watchdog Insights
+- Issues from [Error Tracking][5]
+- [Vulnerability][6] reports by Application Security Management
+- Profiling insights from [Watchdog Insights][7]
 
 The **Continuous Profiler** helps you to reduce latency and lower cloud costs by highlighting code lines that:
 
@@ -65,3 +64,6 @@ Let us know what you think about the extension! Provide feedback on our [discuss
 [2]: /getting_started/profiler/
 [3]: https://www.datadoghq.com/
 [4]: https://marketplace.visualstudio.com/items?itemName=Datadog.VisualStudio
+[5]: https://docs.datadoghq.com/tracing/error_tracking/
+[6]: https://docs.datadoghq.com/security/application_security/vulnerability_management/
+[7]: https://docs.datadoghq.com/watchdog/insights

--- a/content/en/developers/ide_integrations/visual_studio/_index.md
+++ b/content/en/developers/ide_integrations/visual_studio/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Datadog Extension for Visual Studio
 kind: documentation
-disable_toc: false
+description: The Datadog extension for .NET developers
 is_beta: true
 further_reading:
 - link: "/getting_started/profiler/"

--- a/content/en/developers/ide_integrations/visual_studio/_index.md
+++ b/content/en/developers/ide_integrations/visual_studio/_index.md
@@ -38,15 +38,26 @@ The **Continuous Profiler** helps you to reduce latency and lower cloud costs by
 - **Datadog Account** The plugin requires a Datadog account. If you're new to Datadog, go to the [Datadog website][3] to learn more about Datadog's observability tools and sign up for a free trial.
 - **Continuous Profiler**: To display profiling data and insights, the plugin requires the Continuous Profiler to be configured for your Services. For more information, see [Getting Started with the Continuous Profiler][2]
 
-## Setup
-
-1. Download and install the extension from the official [Visual Studio Marketplace][4]
-2. In Visual Studio, go to Tools -> Options -> Datadog
-3. Click **Sign In**, to sign-in with your Datadog account
-
 ## Getting Started
 
-1. Open your .NET solution in Visual Studio
+### Download and install the extension
+
+1. In Visual Studio, go to Extensions -> Manage Extensions
+2. Search for **Datadog**
+3. Click **Download**
+4. Restart Visual Studio
+
+Alternatively, you can download the extension from the official [Visual Studio Marketplace][4]
+
+### Sign-in with your Datadog account
+
+1. In Visual Studio, go to Tools -> Options -> Datadog
+2. Click the **Sign In** button
+3. In the browser window that opens, select your site and organization, then authorize access to the platform
+
+### Link a service
+
+1. Open a .NET solution file with Visual Studio
 2. Go to Extensions -> Datadog -> Linked Services
 3. Click the **Add Service** button
 4. Select the services that are related to your .NET solution

--- a/content/en/developers/ide_integrations/visual_studio/_index.md
+++ b/content/en/developers/ide_integrations/visual_studio/_index.md
@@ -12,25 +12,30 @@ further_reading:
 
 
 {{< callout url="#" btn_hidden="true">}}
-  The Datadog plugin for Visual Studio is in public beta. It is intended for .NET developers who use the <a href="https://docs.datadoghq.com/profiler/#pagetitle">Continuous Profiler</a> for their .NET services. If the plugin stops working unexpectedly, check for plugin updates or <a href=#feedback>reach out to the team</a>.
+  The Datadog extension for Visual Studio is in public beta. It is intended for .NET developers who use the <a href="https://docs.datadoghq.com/profiler/#pagetitle">Continuous Profiler</a> for their .NET services. If the plugin stops working unexpectedly, check for updates or <a href=#feedback>reach out to the team</a>.
 {{< /callout >}}
 
 ## Overview
 
-The Datadog extension for Visual Studio helps you to...
+The Datadog extension for Visual Studio helps you to improve software performance by providing meaningful code-level insights in the IDE based on real-time observability data. Together with the Continuous Profiler, the plugin helps you to reduce latency and lower cloud costs by highlighting code lines that:
+
+* Consume the most CPU
+* Allocate the most memory
+* Spend the most time on locks, disk I/O, socket I/O, and more
 
 ## Requirements
 
-- **A Datadog account**: The plugin requires a Datadog account. If you're new to Datadog, go to the [Datadog website][3] to learn more about Datadog's observability tools and sign up for a free trial.
-- **Continuous Profiling**: To display code-level insights, the plugin requires Continuous Profiling instrumented on your .NET Services. For more information, see [Getting Started with the Continuous Profiler][2].
+* **Visual Studio 2022** version 17 or higher
+* **Datadog Account** The plugin requires a Datadog account. If you're new to Datadog, go to the [Datadog website][3] to learn more about Datadog's observability tools and sign up for a free trial.
+* **Continuous Profiling** To display code-level insights, the plugin requires Continuous Profiling instrumented on your .NET Services. For more information, see [Getting Started with the Continuous Profiler][2].
 
-## Setup
+## Installation
 
-Install the Datadog Extension from the Visual Studio Marketplace.
+Download and install the extension from the official [Visual Studio Marketplace][4].
 
 ## Feedback
 
-Let us know what you think about the plugin! Provide feedback on our [discussion forum][1], or send an e-mail to `team-ide-integration@datadoghq.com`.
+Let us know what you think about the extension! Provide feedback on our [discussion forum][1], or send an e-mail to `team-ide-integration@datadoghq.com`.
 
 ## Further reading
 
@@ -39,4 +44,4 @@ Let us know what you think about the plugin! Provide feedback on our [discussion
 [1]: https://github.com/DataDog/datadog-for-visual-studio/discussions
 [2]: /getting_started/profiler/
 [3]: https://www.datadoghq.com/
-[4]: https://plugins.jetbrains.com/plugin/19495-datadog
+[4]: https://marketplace.visualstudio.com/items?itemName=Datadog.VisualStudio

--- a/content/en/developers/ide_integrations/visual_studio/_index.md
+++ b/content/en/developers/ide_integrations/visual_studio/_index.md
@@ -1,0 +1,41 @@
+---
+title: Datadog Extension for Visual Studio
+kind: documentation
+disable_toc: false
+is_beta: true
+further_reading:
+- link: "/getting_started/profiler/"
+  tag: "Documentation"
+  text: "Getting started with Continuous Profiler."
+---
+
+
+{{< callout url="#" btn_hidden="true">}}
+  The Datadog plugin for Visual Studio is in public beta. It is intended for .NET developers who use the <a href="https://docs.datadoghq.com/profiler/#pagetitle">Continuous Profiler</a> for their .NET services. If the plugin stops working unexpectedly, check for plugin updates or <a href=#feedback>reach out to the team</a>.
+{{< /callout >}}
+
+## Overview
+
+The Datadog extension for Visual Studio helps you to...
+
+## Requirements
+
+- **A Datadog account**: The plugin requires a Datadog account. If you're new to Datadog, go to the [Datadog website][3] to learn more about Datadog's observability tools and sign up for a free trial.
+- **Continuous Profiling**: To display code-level insights, the plugin requires Continuous Profiling instrumented on your .NET Services. For more information, see [Getting Started with the Continuous Profiler][2].
+
+## Setup
+
+Install the Datadog Extension from the Visual Studio Marketplace.
+
+## Feedback
+
+Let us know what you think about the plugin! Provide feedback on our [discussion forum][1], or send an e-mail to `team-ide-integration@datadoghq.com`.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://github.com/DataDog/datadog-for-visual-studio/discussions
+[2]: /getting_started/profiler/
+[3]: https://www.datadoghq.com/
+[4]: https://plugins.jetbrains.com/plugin/19495-datadog

--- a/content/en/developers/ide_integrations/visual_studio/_index.md
+++ b/content/en/developers/ide_integrations/visual_studio/_index.md
@@ -16,21 +16,42 @@ further_reading:
 
 ## Overview
 
-The Datadog extension for Visual Studio helps you to improve software performance by providing meaningful code-level insights in the IDE based on real-time observability data. Together with the Continuous Profiler, the plugin helps you to reduce latency and lower cloud costs by highlighting code lines that:
+The Datadog plugin for Visual Studio users helps you to improve software performance by providing meaningful code-level insights in the IDE based on real-time observability data.
 
-* Consume the most CPU
-* Allocate the most memory
-* Spend the most time on locks, disk I/O, socket I/O, and more
+The **Code Insights** view keeps you informed about:
+
+- Issues from Error Tracking
+- Vulnerability reports by Application Security Management
+- Flaky tests detected by CI Visibility
+- Profiling insights from Watchdog Insights
+
+The **Continuous Profiler** helps you to reduce latency and lower cloud costs by highlighting code lines that:
+
+- Consume the most CPU
+- Allocate the most memory
+- Spend the most time on locks, disk I/O, and socket I/O
 
 ## Requirements
 
-* **Visual Studio 2022** version 17 or higher
-* **Datadog Account** The plugin requires a Datadog account. If you're new to Datadog, go to the [Datadog website][3] to learn more about Datadog's observability tools and sign up for a free trial.
-* **Continuous Profiling** To display code-level insights, the plugin requires Continuous Profiling instrumented on your .NET Services. For more information, see [Getting Started with the Continuous Profiler][2].
+- Windows operating system version 10 or higher (64-bit OS is highly recommended for optimal performance)
+- Visual Studio 2022 Community, Professional or Enterprise edition (64-bit)
+- .NET Framework 4.8 or higher
+- **Datadog Account** The plugin requires a Datadog account. If you're new to Datadog, go to the [Datadog website][3] to learn more about Datadog's observability tools and sign up for a free trial.
+- **Continuous Profiler**: To display profiling data and insights, the plugin requires the Continuous Profiler to be configured for your Services. For more information, see [Getting Started with the Continuous Profiler][2]
 
 ## Setup
 
-Download and install the extension from the official [Visual Studio Marketplace][4].
+1. Download and install the extension from the official [Visual Studio Marketplace][4]
+2. In Visual Studio, go to Tools -> Options -> Datadog
+3. Click **Sign In**, to sign-in with your Datadog account
+
+## Getting Started
+
+1. Open your .NET solution in Visual Studio
+2. Go to Extensions -> Datadog -> Linked Services
+3. Click the **Add Service** button
+4. Select the services that are related to your .NET solution
+5. Save the .NET solution file
 
 ## Feedback
 

--- a/content/en/developers/ide_integrations/visual_studio/_index.md
+++ b/content/en/developers/ide_integrations/visual_studio/_index.md
@@ -55,30 +55,13 @@ Alternatively, you can download the extension from the official [Visual Studio M
 2. Click the **Sign In** button
 3. In the browser window that opens, select your site and organization, then authorize access to the platform
 
-### Link a service
+### Link services
 
 1. Open a .NET solution file with Visual Studio
 2. Go to Extensions -> Datadog -> Linked Services
 3. Click the **Add Service** button
 4. Select the services that are related to your .NET solution
 5. Save the .NET solution file
-
-## Usage
-
-After you add a service to your solution, right-click on the service and click **Profile** to open a Profiling tab for the service. A profiling tab displays data for only one service, but you can have multiple tabs open simultaneously.
-
-The Profiling tab shows Continuous Profiling information for the service in a selected environment, aggregated over a specific time frame. Available views are:
-
-- Top list: Displays a list of the most resource intensive methods for the current profiling measure.
-- Flame graph: A flame graph representing stack traces in the profiles.
-
-You can specify the following parameters for the profiling data:
-
-- The profile type to be displayed
-- The environment in which the service is running
-- The time frame for the profile samples to be aggregated
-
-The available profiling types usually include options like **CPU Time** and **Allocated Memory**, but are determined by the platform and vary by language.
 
 ## Feedback
 

--- a/content/en/developers/ide_integrations/visual_studio/_index.md
+++ b/content/en/developers/ide_integrations/visual_studio/_index.md
@@ -33,7 +33,7 @@ The **Continuous Profiler** helps you to reduce latency and lower cloud costs by
 
 ## Requirements
 
-- Windows operating system version 10 or higher (64-bit OS is highly recommended for optimal performance)
+- Windows operating system version 10 or higher
 - Visual Studio 2022 Community, Professional or Enterprise edition (64-bit)
 - .NET Framework 4.8 or higher
 - **Datadog Account** The plugin requires a Datadog account. If you're new to Datadog, go to the [Datadog website][3] to learn more about Datadog's observability tools and sign up for a free trial.

--- a/content/en/developers/ide_integrations/visual_studio/_index.md
+++ b/content/en/developers/ide_integrations/visual_studio/_index.md
@@ -32,9 +32,9 @@ The **Continuous Profiler** helps you to reduce latency and lower cloud costs by
 
 ## Requirements
 
-- Windows operating system version 10 or higher
+- Windows 10 or higher
+- .NET Framework 4.7.2 or higher
 - Visual Studio 2022 Community, Professional or Enterprise edition (64-bit)
-- .NET Framework 4.8 or higher
 - **Datadog Account** The plugin requires a Datadog account. If you're new to Datadog, go to the [Datadog website][3] to learn more about Datadog's observability tools and sign up for a free trial.
 - **Continuous Profiler**: To display profiling data and insights, the plugin requires the Continuous Profiler to be configured for your Services. For more information, see [Getting Started with the Continuous Profiler][2]
 
@@ -62,6 +62,23 @@ Alternatively, you can download the extension from the official [Visual Studio M
 3. Click the **Add Service** button
 4. Select the services that are related to your .NET solution
 5. Save the .NET solution file
+
+## Usage
+
+After you add a service to your solution, right-click on the service and click **Profile** to open a Profiling tab for the service. A profiling tab displays data for only one service, but you can have multiple tabs open simultaneously.
+
+The Profiling tab shows Continuous Profiling information for the service in a selected environment, aggregated over a specific time frame. Available views are:
+
+- Top list: Displays a list of the most resource intensive methods for the current profiling measure.
+- Flame graph: A flame graph representing stack traces in the profiles.
+
+You can specify the following parameters for the profiling data:
+
+- The profile type to be displayed
+- The environment in which the service is running
+- The time frame for the profile samples to be aggregated
+
+The available profiling types usually include options like **CPU Time** and **Allocated Memory**, but are determined by the platform and vary by language.
 
 ## Feedback
 

--- a/content/en/developers/ide_integrations/visual_studio/_index.md
+++ b/content/en/developers/ide_integrations/visual_studio/_index.md
@@ -2,6 +2,7 @@
 title: Datadog Extension for Visual Studio
 kind: documentation
 description: The Datadog extension for .NET developers
+disable_toc: false
 is_beta: true
 further_reading:
 - link: "/getting_started/profiler/"

--- a/content/en/developers/ide_integrations/visual_studio/_index.md
+++ b/content/en/developers/ide_integrations/visual_studio/_index.md
@@ -10,7 +10,6 @@ further_reading:
   text: "Getting started with Continuous Profiler."
 ---
 
-
 {{< callout url="#" btn_hidden="true">}}
   The Datadog extension for Visual Studio is in public beta. It is intended for .NET developers who use the <a href="https://docs.datadoghq.com/profiler/#pagetitle">Continuous Profiler</a> for their .NET services. If the plugin stops working unexpectedly, check for updates or <a href=#feedback>reach out to the team</a>.
 {{< /callout >}}
@@ -29,7 +28,7 @@ The Datadog extension for Visual Studio helps you to improve software performanc
 * **Datadog Account** The plugin requires a Datadog account. If you're new to Datadog, go to the [Datadog website][3] to learn more about Datadog's observability tools and sign up for a free trial.
 * **Continuous Profiling** To display code-level insights, the plugin requires Continuous Profiling instrumented on your .NET Services. For more information, see [Getting Started with the Continuous Profiler][2].
 
-## Installation
+## Setup
 
 Download and install the extension from the official [Visual Studio Marketplace][4].
 


### PR DESCRIPTION
### What does this PR do?
Adds an initial documentation page for the [Datadog extension for Visual Studio](https://marketplace.visualstudio.com/items?itemName=Datadog.VisualStudio)

### Motivation
Help users find information on how to install and run the extension.

### Preview 
https://docs-staging.datadoghq.com/david.gilbert/IDE-1307/developers/ide_integrations/visual_studio/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
