### PR TITLE
Update notify_slack

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,6 +35,7 @@ before_script:
   - "[ -d local/bin ] && find local/bin/ -type f -exec cp {} /usr/local/bin \\;"  # load scripts
   - "[ -d local/etc ] && find local/etc/ -type f -exec cp {} /etc \\;"  # load configs
   - "[ -f /usr/local/bin/helpers.sh ] && source /usr/local/bin/helpers.sh"  # source helpers so they are available in the container
+  - chmod +x /usr/local/bin/*.py # make python scripts executable by the runner
   - "[ -f /etc/profile ] && source /etc/profile" # for golang on path
   - mkdir -p logs
   # set common env variables for this shell
@@ -103,7 +104,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-18221182
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-18270636
   tags:
     - "arch:amd64"
   rules:
@@ -142,7 +143,7 @@ build_preview:
     - in-isolation deploy_site > logs/deploy.txt
     # remove static images so we can skip from artifact passed in gitlab
     - remove_static_from_repo
-    - notify_slack "Your branch ${CI_COMMIT_REF_NAME} is ready for preview.\n<${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." "#31b834" "true"
+    - python3 /usr/local/bin/notify_slack.py  "Your branch ${CI_COMMIT_REF_NAME} is ready for preview.\n<${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." --status="#31b834" --previewSite="true"
     - ci_pass_step "${CI_PROJECT_NAME}-${CI_JOB_NAME}" # run at completion of job, if job fails at any point prior this won't run
   artifacts:
     paths:
@@ -173,7 +174,7 @@ link_checks_preview:
   after_script:
     - "[ -f /usr/local/bin/helpers.sh ] && source /usr/local/bin/helpers.sh"  # source helpers
     - RESULT="⛈ htmltest result; the following issues were found:\n$(tail -n +2 ./tmp/.htmltest/htmltest.log)\n--------------------" # output all but first line
-    - if grep -q "not exist" tmp/.htmltest/htmltest.log; then notify_slack "${RESULT}" "#31b834"; fi
+    - if grep -q "not exist" tmp/.htmltest/htmltest.log; then python3 /usr/local/bin/notify_slack.py "${RESULT}" --status="#31b834"; fi
   artifacts:
     paths:
       - ./tmp/.htmltest
@@ -281,7 +282,7 @@ build_live:
     LOCAL: "False"
   script:
     - dog --config "$HOME/.dogrc" event post "documentation deploy ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" --alert_type "info" --tags="${DEFAULT_TAGS}"
-    - notify_slack "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_SHA:0:8}> sent to gitlab for production deployment. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}|details>" "#FFD700"
+    - python3 /usr/local/bin/notify_slack.py "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_SHA:0:8}> sent to gitlab for production deployment. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}|details>" --status="#FFD700"
     - touch Makefile.config
     - make clean-examples
     - make dependencies
@@ -321,7 +322,7 @@ test_live_link_checks:
   after_script:
     - "[ -f /usr/local/bin/helpers.sh ] && source /usr/local/bin/helpers.sh"  # source helpers
     - RESULT="⛈ htmltest result; the following issues were found:\n$(tail -n +2 ./tmp/.htmltest/htmltest.log)\n--------------------" # output all but first line
-    - if grep -q "not exist" tmp/.htmltest/htmltest.log; then notify_slack "${RESULT}" "#31b834"; fi
+    - if grep -q "not exist" tmp/.htmltest/htmltest.log; then python3 /usr/local/bin/notify_slack.py "${RESULT}" --status="#31b834"; fi
   artifacts:
     paths:
       - ./tmp/.htmltest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -143,7 +143,7 @@ build_preview:
     - in-isolation deploy_site > logs/deploy.txt
     # remove static images so we can skip from artifact passed in gitlab
     - remove_static_from_repo
-    - python3 /usr/local/bin/notify_slack.py  "Your branch ${CI_COMMIT_REF_NAME} is ready for preview. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." --status="#31b834" --previewSite="true"
+    - notify_slack.py  "Your branch ${CI_COMMIT_REF_NAME} is ready for preview. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." --status="#31b834" --previewSite="true"
     - ci_pass_step "${CI_PROJECT_NAME}-${CI_JOB_NAME}" # run at completion of job, if job fails at any point prior this won't run
   artifacts:
     paths:
@@ -174,7 +174,7 @@ link_checks_preview:
   after_script:
     - "[ -f /usr/local/bin/helpers.sh ] && source /usr/local/bin/helpers.sh"  # source helpers
     - RESULT="⛈ htmltest result; the following issues were found:\n$(tail -n +2 ./tmp/.htmltest/htmltest.log)\n--------------------" # output all but first line
-    - if grep -q "not exist" tmp/.htmltest/htmltest.log; then python3 /usr/local/bin/notify_slack.py "${RESULT}" --status="#31b834"; fi
+    - if grep -q "not exist" tmp/.htmltest/htmltest.log; then notify_slack.py "${RESULT}" --status="#31b834"; fi
   artifacts:
     paths:
       - ./tmp/.htmltest
@@ -282,7 +282,7 @@ build_live:
     LOCAL: "False"
   script:
     - dog --config "$HOME/.dogrc" event post "documentation deploy ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" --alert_type "info" --tags="${DEFAULT_TAGS}"
-    - python3 /usr/local/bin/notify_slack.py "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_SHA:0:8}> sent to gitlab for production deployment. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}|details>" --status="#FFD700"
+    - notify_slack.py "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_SHA:0:8}> sent to gitlab for production deployment. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}|details>" --status="#FFD700"
     - touch Makefile.config
     - make clean-examples
     - make dependencies
@@ -322,7 +322,7 @@ test_live_link_checks:
   after_script:
     - "[ -f /usr/local/bin/helpers.sh ] && source /usr/local/bin/helpers.sh"  # source helpers
     - RESULT="⛈ htmltest result; the following issues were found:\n$(tail -n +2 ./tmp/.htmltest/htmltest.log)\n--------------------" # output all but first line
-    - if grep -q "not exist" tmp/.htmltest/htmltest.log; then python3 /usr/local/bin/notify_slack.py "${RESULT}" --status="#31b834"; fi
+    - if grep -q "not exist" tmp/.htmltest/htmltest.log; then notify_slack.py "${RESULT}" --status="#31b834"; fi
   artifacts:
     paths:
       - ./tmp/.htmltest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,7 +127,7 @@ build_preview:
   variables:
     URL: ${PREVIEW_DOMAIN}
     CONFIG: ${PREVIEW_CONFIG}
-    MESSAGE: ":gift_heart: Your preview site is available!\nNow running tests..."
+    MESSAGE: ":gift_heart: Your preview site is available! Now running tests..."
     CONFIGURATION_FILE: "./local/bin/py/build/configurations/pull_config_preview.yaml"
     LOCAL: "False"
   script:
@@ -143,7 +143,7 @@ build_preview:
     - in-isolation deploy_site > logs/deploy.txt
     # remove static images so we can skip from artifact passed in gitlab
     - remove_static_from_repo
-    - python3 /usr/local/bin/notify_slack.py  "Your branch ${CI_COMMIT_REF_NAME} is ready for preview.\n<${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." --status="#31b834" --previewSite="true"
+    - python3 /usr/local/bin/notify_slack.py  "Your branch ${CI_COMMIT_REF_NAME} is ready for preview. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}| checks running>." --status="#31b834" --previewSite="true"
     - ci_pass_step "${CI_PROJECT_NAME}-${CI_JOB_NAME}" # run at completion of job, if job fails at any point prior this won't run
   artifacts:
     paths:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

- Updates to the latest image that uses the new `notify_slack.py` script for slack notifications
- Adds the ability to have collaborators receive notifications by using the branch naming convention of `user1/user2/branch-name`

### Motivation
<!-- What inspired you to submit this pull request?-->
Image imporvements
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Successful pipeline run: https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/303628573

No docs site changes
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
