### PR TITLE
Fix metrics port env variable

### DIFF
--- a/content/en/containers/cluster_agent/commands.md
+++ b/content/en/containers/cluster_agent/commands.md
@@ -77,8 +77,8 @@ The following environment variables are supported:
 `DD_KUBERNETES_INFORMERS_RESTCLIENT_TIMEOUT`  
 : Timeout (in seconds) of the client communicating with the API server. Defaults to `60` seconds.
 
-`DD_EXPVAR_PORT`                              
-: Port for fetching [expvar][2] public variables from the Datadog Cluster Agent. Defaults to port `5000`.
+`DD_METRICS_PORT`                              
+: Port to expose Datadog Cluster Agent metrics. Defaults to port `5000`.
 
 `DD_EXTERNAL_METRICS_PROVIDER_BATCH_WINDOW`   
 : Time waited (in seconds) to process a batch of metrics from multiple autoscalers. Defaults to `10` seconds.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

This env variable [doesn't exist since a long time ago](https://github.com/DataDog/datadog-agent/commit/25fc4c80d08dc7592b254f79c08ac4ab4344efa8) (5 years) but documentation was never changed

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
