### PR TITLE
[CWS] fix the indentation for the daemonset instructions

### DIFF
--- a/content/en/security/cloud_workload_security/setup.md
+++ b/content/en/security/cloud_workload_security/setup.md
@@ -172,13 +172,14 @@ Add the following settings to the `env` section of `security-agent` and `system-
             env:
               - name: DD_REMOTE_CONFIGURATION_ENABLED
                 value: "true"
-              - name: system-probe
-                [...]
-                env:
-                  - name: DD_RUNTIME_SECURITY_CONFIG_ENABLED
-                    value: "true"
-                  - name: DD_RUNTIME_SECURITY_CONFIG_REMOTE_CONFIGURATION_ENABLED
-                    value: "true" [...]
+          - name: system-probe
+            [...]
+            env:
+              - name: DD_RUNTIME_SECURITY_CONFIG_ENABLED
+                value: "true"
+              - name: DD_RUNTIME_SECURITY_CONFIG_REMOTE_CONFIGURATION_ENABLED
+                value: "true"
+          [...]
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
