### PR TITLE
Rtrieu/docs 5833 rum trace correlation setup update

### DIFF
--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -23,14 +23,15 @@ The RUM Browser SDK supports all modern desktop and mobile browsers including IE
 To set up RUM Browser Monitoring, create a RUM application:
 
 1. In Datadog, navigate to the [**RUM Applications** page][1] and click the **New Application** button.
-  - Enter a name for your application and click **Generate Client Token**. This generates a `clientToken` and an `applicationId` for your application.
-  - Choose the installation type for the RUM Browser SDK: [npm](#npm), or a hosted version ([CDN async](#cdn-async) or [CDN sync](#cdn-sync)).
-  - Define the environment name and service name for your application to use unified service tagging for [RUM & Session Replay][19]. Set a version number for your deployed application in the initialization snippet. For more information, see [Tagging](#tagging).
-  - Set the sampling rate of total user sessions collected and use the slider to set the percentage of total [Browser RUM & Session Replay][11] sessions collected. Browser RUM & Session Replay sessions include resources, long tasks, and replay recordings. For more information about configuring the percentage of Browser RUM & Session Replay sessions collected from the total amount of user sessions, see [Configure Your Setup For Browser and Browser RUM & Session Replay Sampling][21].
-  - Click the **Session Replay Enabled** toggle to access replay recordings in [Session Replay][17].
-  - Select a [privacy setting][18] for Session Replay in the dropdown menu.
+   - Enter a name for your application and click **Generate Client Token**. This generates a `clientToken` and an `applicationId` for your application.
+   - Choose the installation type for the RUM Browser SDK: [npm](#npm), or a hosted version ([CDN async](#cdn-async) or [CDN sync](#cdn-sync)).
+   - Define the environment name and service name for your application to use unified service tagging for [RUM & Session Replay][19]. Set a version number for your deployed application in the initialization snippet. For more information, see [Tagging](#tagging).
+   - Set the sampling rate of total user sessions collected and use the slider to set the percentage of total [Browser RUM & Session Replay][11] sessions collected. Browser RUM & Session Replay sessions include resources, long tasks, and replay recordings. For more information about configuring the percentage of Browser RUM & Session Replay sessions collected from the total amount of user sessions, see [Configure Your Setup For Browser and Browser RUM & Session Replay Sampling][21].
+   - Click the **Session Replay Enabled** toggle to access replay recordings in [Session Replay][17].
+   - Select a [privacy setting][18] for Session Replay in the dropdown menu.
 2. Deploy the changes to your application. Once your deployment is live, Datadog collects events from your users' browsers.
 3. Visualize the [data collected][2] in [dashboards][3] or create a search query in the [RUM Explorer][16].
+4. (Optional) [Connect RUM and Traces][12] to start linking requests from your web and mobile applications to their corresponding backend traces. You can refer to this list of [initialization parameters](#initialization-parameters).
 
 Until Datadog starts receiving data, your application appears as `pending` on the **RUM Applications** page.
 

--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -31,7 +31,7 @@ To set up RUM Browser Monitoring, create a RUM application:
    - Select a [privacy setting][18] for Session Replay in the dropdown menu.
 2. Deploy the changes to your application. Once your deployment is live, Datadog collects events from your users' browsers.
 3. Visualize the [data collected][2] in [dashboards][3] or create a search query in the [RUM Explorer][16].
-4. (Optional) [Connect RUM and Traces][12] to start linking requests from your web and mobile applications to their corresponding backend traces. You can refer to this list of [initialization parameters](#initialization-parameters).
+4. (Optional) Initialize the RUM SDK with the `allowedTracingUrls` parameter to [Connect RUM and Traces][12] if you want to start linking requests from your web and mobile applications to their corresponding backend traces. See the full list of [initialization parameters](#initialization-parameters).
 
 Until Datadog starts receiving data, your application appears as `pending` on the **RUM Applications** page.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds an optional step for browser RUM setup to connect RUM and Traces.

### Motivation
Make it more obvious users can easily do this, since it's a differentiator for our product, as per [DOCS-5833](https://datadoghq.atlassian.net/browse/DOCS-5833).

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Ready to merge.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5833]: https://datadoghq.atlassian.net/browse/DOCS-5833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ