### PR TITLE
[OPW] Update the buffer values to make cloud deployments easier.

### DIFF
--- a/static/resources/yaml/observability_pipelines/datadog/aws_eks.yaml
+++ b/static/resources/yaml/observability_pipelines/datadog/aws_eks.yaml
@@ -159,4 +159,4 @@ pipelineConfig:
       default_api_key: "${DD_API_KEY}"
       buffer:
         type: disk
-        max_size: 51539607552
+        max_size: 42949672959

--- a/static/resources/yaml/observability_pipelines/datadog/azure_aks.yaml
+++ b/static/resources/yaml/observability_pipelines/datadog/azure_aks.yaml
@@ -150,4 +150,4 @@ pipelineConfig:
       default_api_key: "${DD_API_KEY}"
       buffer:
         type: disk
-        max_size: 51539607552
+        max_size: 42949672959

--- a/static/resources/yaml/observability_pipelines/datadog/google_gke.yaml
+++ b/static/resources/yaml/observability_pipelines/datadog/google_gke.yaml
@@ -152,4 +152,4 @@ pipelineConfig:
       default_api_key: "${DD_API_KEY}"
       buffer:
         type: disk
-        max_size: 51539607552
+        max_size: 42949672959

--- a/static/resources/yaml/observability_pipelines/quickstart/aws_eks.yaml
+++ b/static/resources/yaml/observability_pipelines/quickstart/aws_eks.yaml
@@ -117,9 +117,6 @@ pipelineConfig:
         - parse_syslog
       encoding:
         codec: json
-      buffer:
-          type: disk
-          max_size: 154618822656
     datadog_logs:
       type: datadog_logs
       inputs:

--- a/static/resources/yaml/observability_pipelines/quickstart/azure_aks.yaml
+++ b/static/resources/yaml/observability_pipelines/quickstart/azure_aks.yaml
@@ -108,9 +108,6 @@ pipelineConfig:
         - parse_syslog
       encoding:
         codec: json
-      buffer:
-          type: disk
-          max_size: 154618822656
     datadog_logs:
       type: datadog_logs
       inputs:

--- a/static/resources/yaml/observability_pipelines/quickstart/google_gke.yaml
+++ b/static/resources/yaml/observability_pipelines/quickstart/google_gke.yaml
@@ -110,9 +110,6 @@ pipelineConfig:
         - parse_syslog
       encoding:
         codec: json
-      buffer:
-          type: disk
-          max_size: 154618822656
     datadog_logs:
       type: datadog_logs
       inputs:

--- a/static/resources/yaml/observability_pipelines/splunk/aws_eks.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/aws_eks.yaml
@@ -118,7 +118,7 @@ pipelineConfig:
       compression: gzip
       buffer:
           type: disk
-          max_size: 154618822656
+          max_size: 150323855359
     splunk_logs:
       type: splunk_hec_logs
       inputs:
@@ -129,4 +129,4 @@ pipelineConfig:
         codec: json
       buffer:
           type: disk
-          max_size: 154618822656
+          max_size: 150323855359

--- a/static/resources/yaml/observability_pipelines/splunk/azure_aks.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/azure_aks.yaml
@@ -111,7 +111,7 @@ pipelineConfig:
       compression: gzip
       buffer:
           type: disk
-          max_size: 154618822656
+          max_size: 150323855359
     splunk_logs:
       type: splunk_hec_logs
       inputs:
@@ -122,4 +122,4 @@ pipelineConfig:
         codec: json
       buffer:
           type: disk
-          max_size: 154618822656
+          max_size: 150323855359

--- a/static/resources/yaml/observability_pipelines/splunk/google_gke.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/google_gke.yaml
@@ -113,7 +113,7 @@ pipelineConfig:
       compression: gzip
       buffer:
           type: disk
-          max_size: 154618822656
+          max_size: 150323855359
     splunk_logs:
       type: splunk_hec_logs
       inputs:
@@ -124,4 +124,4 @@ pipelineConfig:
         codec: json
       buffer:
           type: disk
-          max_size: 154618822656
+          max_size: 150323855359


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Testing with GKE for the quickstart values failed due to buffer overflows from the available storage on their persistent drives.

I've tuned the values down a little to allow OPW pods to start.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
