### PR TITLE
Remove public beta banners from IntelliJ and VS Code pages.

### DIFF
--- a/content/en/developers/ide_integrations/idea/_index.md
+++ b/content/en/developers/ide_integrations/idea/_index.md
@@ -15,10 +15,6 @@ further_reading:
   text: "Learn about the JetBrains Toolbox."
 ---
 
-{{< callout url="#" btn_hidden="true">}}
-  The Datadog plugin for IntelliJ IDEA and GoLand is in public beta. It is intended for developers who use Datadog products, such as the <a href="https://docs.datadoghq.com/logs/explorer/">Log Explorer</a> and the <a href="https://docs.datadoghq.com/profiler/#pagetitle">Continuous Profiler</a>, for their Java and Go services. If the plugin stops working unexpectedly, check for plugin updates or <a href=#feedback>reach out to the team</a>.
-{{< /callout >}}
-
 ## Overview
 
 The Datadog plugin for the IntelliJ Platform (IDEA and GoLand) helps you to improve software performance by providing meaningful code-level insights in the IDE based on real-time observability data.

--- a/content/en/developers/ide_integrations/vscode/_index.md
+++ b/content/en/developers/ide_integrations/vscode/_index.md
@@ -15,10 +15,6 @@ further_reading:
   text: "Learn about Source Code Integration."
 ---
 
-{{< callout url="#" btn_hidden="true">}}
-  The Datadog extension for VS Code is in public beta. It is intended for all developers that use Datadog products, and especially those using <a href="https://docs.datadoghq.com/synthetics/#pagetitle">Synthetic tests</a>. If the extension stops working unexpectedly, check for extension updates or <a href=#feedback>reach out to the team</a>.
-{{< /callout >}}
-
 ## Overview
 
 The Datadog extension for Visual Studio Code (VS Code) integrates with Datadog to accelerate your development.


### PR DESCRIPTION
### What does this PR do?
Removes the notification that the IDE integrations for IntelliJ and VS Code are in public beta.

### Motivation
The IntelliJ plugin and the VS Code extension will be announced as GA at DASH this week.

<!-- ### Preview -->
https://docs-staging.datadoghq.com/david.gilbert/IDE-1482/developers/ide_integrations/idea/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
