### PR TITLE
Update orchestrion references in Cloud Run and Container App docs

### DIFF
--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -30,6 +30,11 @@ Images are tagged based on semantic versioning, with each new version receiving 
 
 * `1`, `1-alpine`: use these to track the latest minor releases, without breaking chagnes
 * `1.x.x`, `1.x.x-alpine`: use these to pin to a precise version of the library
+
+<div class="alert alert-info">
+The latest tag of /serverless-init will be applied to Beta9 through 9/1/2023 to provide additional time for Beta users to adjust and include the additional required `DD_AZURE_SUBSCRIPTION_ID` and `DD_RESOURCE_GROUP` variables
+</div>
+
 * `latest`, `latest-apline`: use these to follow the latest version release, which may include breaking changes
 
 {{< programming-lang-wrapper langs="nodejs,python,java,go,dotnet,ruby,php" >}}

--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -219,7 +219,7 @@ CMD ["/path/to/your-go-binary"]
 
 #### Orchestrion
 
-**Note**: [Orchestrion][2] is a tool for automatically instrumentation of Go code, which is currently in Private Beta. With Orchestrion, it is possible to instrument your Go applications via Dockerfile instruction. If you are interested in participating in the Beta or providing feedback on Orchestrion, please open a Github issue or reach out to support. 
+**Note**: [Orchestrion][2] is a tool for automatically instrumenting Go code, which is currently in Private Beta. With Orchestrion, it is possible to instrument your Go applications through Dockerfile. If you are interested in participating in the Beta or providing feedback on Orchestrion, please open a Github issue or reach out to support. 
 
 ```
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init

--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -200,7 +200,7 @@ CMD ["/path/to/your-go-binary"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Change the entrypoint to wrap your application into the Datadog `serverless-init` process
+2. Change the entrypoint to wrap your application into the Datadog `serverless-init` process.
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```

--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -177,7 +177,44 @@ CMD ["./mvnw", "spring-boot:run"]
 {{< /programming-lang >}}
 {{< programming-lang lang="go" >}}
 
-Add the following instructions and arguments to your Dockerfile.
+[Manually install][1] the Go tracer before you deploy your application. Add the following instructions and arguments to your Dockerfile.
+
+```
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ENTRYPOINT ["/app/datadog-init"]
+ENV DD_SERVICE=datadog-demo-run-go
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+CMD ["/path/to/your-go-binary"]
+```
+
+#### Explanation
+
+1. Copy the Datadog `serverless-init` into your Docker image.
+   ```
+   COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+   ```
+
+2. Change the entrypoint to wrap your application into the Datadog `serverless-init` process
+   ```
+   ENTRYPOINT ["/app/datadog-init"]
+   ```
+
+3. (Optional) Add Datadog tags.
+   ```
+   ENV DD_SERVICE=datadog-demo-run-go
+   ENV DD_ENV=datadog-demo
+   ENV DD_VERSION=1
+   ```
+
+4. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
+   ```
+   CMD ["/path/to/your-go-binary"]
+   ```
+
+#### Orchestrion
+
+**Note**: [Orchestrion][2] is a tool for automatically instrumentation of Go code, which is currently in Private Beta. With Orchestrion, it is possible to instrument your Go applications via Dockerfile instruction. If you are interested in participating in the Beta or providing feedback on Orchestrion, please open a Github issue or reach out to support. 
 
 ```
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
@@ -191,41 +228,8 @@ ENV DD_VERSION=1
 CMD ["/path/to/your-go-binary"]
 ```
 
-**Note**: Instead of using Orchestrion, you can also [manually install the Go tracer][1].
-
-#### Explanation
-
-1. Copy the Datadog `serverless-init` into your Docker image.
-   ```
-   COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-   ```
-
-2. Install Orchestrion, which modifies the source code and automatically adds tracing. Do this before you `go build` your app.
-   ```
-   RUN go install github.com/datadog/orchestrion@latest
-   RUN orchestrion -w ./
-   RUN go mod tidy
-   ```
-   If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
-
-3. Change the entrypoint to wrap your application into the Datadog `serverless-init` process
-   ```
-   ENTRYPOINT ["/app/datadog-init"]
-   ```
-
-4. (Optional) Add Datadog tags.
-   ```
-   ENV DD_SERVICE=datadog-demo-run-go
-   ENV DD_ENV=datadog-demo
-   ENV DD_VERSION=1
-   ```
-
-5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
-   ```
-   CMD ["/path/to/your-go-binary"]
-   ```
-
 [1]: /tracing/trace_collection/library_config/go/ 
+[2]: https://github.com/DataDog/orchestrion
 {{< /programming-lang >}}
 {{< programming-lang lang="dotnet" >}}
 

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -180,7 +180,44 @@ CMD ["./mvnw", "spring-boot:run"]
 {{< /programming-lang >}}
 {{< programming-lang lang="go" >}}
 
-Add the following instructions and arguments to your Dockerfile.
+[Manually install][1] the Go tracer before you deploy your application. Add the following instructions and arguments to your Dockerfile.
+
+```
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ENTRYPOINT ["/app/datadog-init"]
+ENV DD_SERVICE=datadog-demo-run-go
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+CMD ["/path/to/your-go-binary"]
+```
+
+#### Explanation
+
+1. Copy the Datadog `serverless-init` into your Docker image.
+   ```
+   COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+   ```
+
+2. Change the entrypoint to wrap your application into the Datadog `serverless-init` process
+   ```
+   ENTRYPOINT ["/app/datadog-init"]
+   ```
+
+3. (Optional) Add Datadog tags.
+   ```
+   ENV DD_SERVICE=datadog-demo-run-go
+   ENV DD_ENV=datadog-demo
+   ENV DD_VERSION=1
+   ```
+
+4. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
+   ```
+   CMD ["/path/to/your-go-binary"]
+   ```
+
+#### Orchestrion
+
+**Note**: [Orchestrion][2] is a tool for automatically instrumentation of Go code, which is currently in Private Beta. With Orchestrion, it is possible to instrument your Go applications via Dockerfile instruction. If you are interested in participating in the Beta or providing feedback on Orchestrion, please open a Github issue or reach out to support. 
 
 ```
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
@@ -194,41 +231,8 @@ ENV DD_VERSION=1
 CMD ["/path/to/your-go-binary"]
 ```
 
-**Note**: Instead of using Orchestrion, you can also [manually install the Go tracer][1].
-
-#### Explanation
-
-1. Copy the Datadog `serverless-init` into your Docker image.
-   ```
-   COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-   ```
-
-2. Install Orchestrion, which modifies the source code and automatically adds tracing. Do this before you `go build` your app.
-   ```
-   RUN go install github.com/datadog/orchestrion@latest
-   RUN orchestrion -w ./
-   RUN go mod tidy
-   ```
-   If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
-
-3. Change the entrypoint to wrap your application into the Datadog `serverless-init` process
-   ```
-   ENTRYPOINT ["/app/datadog-init"]
-   ```
-
-4. (Optional) Add Datadog tags.
-   ```
-   ENV DD_SERVICE=datadog-demo-run-go
-   ENV DD_ENV=datadog-demo
-   ENV DD_VERSION=1
-   ```
-
-5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
-   ```
-   CMD ["/path/to/your-go-binary"]
-   ```
-
 [1]: /tracing/trace_collection/library_config/go/ 
+[2]: https://github.com/DataDog/orchestrion
 {{< /programming-lang >}}
 {{< programming-lang lang="dotnet" >}}
 

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -33,6 +33,9 @@ Images are tagged based on semantic versioning, with each new version receiving 
 
 * `1`, `1-alpine`: use these to track the latest minor releases, without breaking chagnes
 * `1.x.x`, `1.x.x-alpine`: use these to pin to a precise version of the library
+<div class="alert alert-info">
+The latest tag of /serverless-init will be applied to Beta9 through 9/1/2023 to provide additional time for Azure Container App Beta users to adjust to a breaking change in 1.0
+</div>
 * `latest`, `latest-apline`: use these to follow the latest version release, which may include breaking changes
 
 {{< programming-lang-wrapper langs="nodejs,python,java,go,dotnet,ruby,php" >}}

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -220,7 +220,7 @@ CMD ["/path/to/your-go-binary"]
 
 #### Orchestrion
 
-**Note**: [Orchestrion][2] is a tool for automatically instrumentation of Go code, which is currently in Private Beta. With Orchestrion, it is possible to instrument your Go applications via Dockerfile instruction. If you are interested in participating in the Beta or providing feedback on Orchestrion, please open a Github issue or reach out to support. 
+**Note**: [Orchestrion][2] is a tool for automatically instrumenting Go code, which is currently in Private Beta. With Orchestrion, it is possible to instrument your Go applications through Dockerfile. If you are interested in participating in the Beta or providing feedback on Orchestrion, please open a Github issue or reach out to support. 
 
 ```
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -201,7 +201,7 @@ CMD ["/path/to/your-go-binary"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Change the entrypoint to wrap your application into the Datadog `serverless-init` process
+2. Change the entrypoint to wrap your application into the Datadog `serverless-init` process:
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -183,7 +183,7 @@ CMD ["./mvnw", "spring-boot:run"]
 {{< /programming-lang >}}
 {{< programming-lang lang="go" >}}
 
-[Manually install][1] the Go tracer before you deploy your application. Add the following instructions and arguments to your Dockerfile.
+[Manually install][1] the Go tracer before you deploy your application. Add the following instructions and arguments to your Dockerfile:
 
 ```
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init


### PR DESCRIPTION
Switching back to a manual tracer sample, and label Orchestrion information as private beta

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
