### PR TITLE
add 'Copy' btn to all code examples

### DIFF
--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -1,6 +1,7 @@
 import { updateTOC, buildTOCMap } from './table-of-contents';
 import initCodeTabs from './codetabs';
 import { redirectToRegion, hideTOCItems } from '../region-redirects';
+import { initCopyCode } from './copy-code';
 import { initializeIntegrations } from './integrations';
 import { initializeGroupedListings } from './grouped-item-listings';
 import {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName } from '../helpers/helpers';
@@ -228,7 +229,8 @@ function loadPage(newUrl) {
             redirectCodeLang();
             toggleMultiCodeLangNav(pageCodeLang);
             hideTOCItems(true)
-
+            initCopyCode()
+            
             // Gtag virtual pageview
             gtag('config', gaTag, { page_path: pathName });
 

--- a/assets/scripts/components/copy-code.js
+++ b/assets/scripts/components/copy-code.js
@@ -1,55 +1,61 @@
 // Script to add copy-clipboard functionality to code snippets within the code-block shortcode and fenced codeblocks
 
+function initCopyCode () {
+    // Add copy button to fenced codeblocks of specific languages
+    const dataLangs = ['shell']
+    const highlights = document.querySelectorAll("div.highlight")
 
-// Add copy button to fenced codeblocks of specific languages
-const dataLangs = ['shell']
-const highlights = document.querySelectorAll("div.highlight")
+    highlights.forEach(highlightEl => {
+        const codeLang = highlightEl.querySelector('[data-lang]').dataset.lang
+        const isNotInCodeBlockShortcode = !highlightEl.parentElement.classList.contains('code-snippet')
 
-highlights.forEach(highlightEl => {
-    const codeLang = highlightEl.querySelector('[data-lang]').dataset.lang
-    const isNotInCodeBlockShortcode = !highlightEl.parentElement.classList.contains('code-snippet')
-
-    const shouldAddCopyBtn = dataLangs.includes(codeLang) && isNotInCodeBlockShortcode
-    if(shouldAddCopyBtn){
-        highlightEl.classList.add('code-snippet','fenced')
-        const copyBtn = `
-        <div class="code-button-wrapper position-absolute">
-            <button class="btn text-primary js-copy-button">Copy</button>
-        </div>
-        `
-        highlightEl.insertAdjacentHTML('beforeend', copyBtn)
-    }
-})
-
-
-// Add Event Listener
-const copyButtons = document.querySelectorAll('.js-copy-button');
-
-if (copyButtons.length) {
-    copyButtons.forEach(btn => {
-        btn.addEventListener('click', (e) => copyCode(e, btn));
-    });
-}
-
-
-
-// EVENT FUNCTION
-function copyCode (event, btn){
-    const codeSnippetElement = event.target
-    .closest('.code-snippet')
-    .querySelector('.chroma');
-    
-    // Create a range object
-    const range = document.createRange();
-    // Select the node
-    range.selectNode(codeSnippetElement);
-    // create system clipboard object
-    const Clipboard = navigator.clipboard
-    // write code snippet text
-    Clipboard.writeText(codeSnippetElement.innerText).then(() => {
-        btn.textContent = "Copied!";
-        setTimeout(function() {
-            btn.textContent = "Copy"
-        }, 1000)
+        const shouldAddCopyBtn = dataLangs.includes(codeLang) && isNotInCodeBlockShortcode
+        if(shouldAddCopyBtn){
+            highlightEl.classList.add('code-snippet','fenced')
+            const copyBtn = `
+            <div class="code-button-wrapper position-absolute">
+                <button class="btn text-primary js-copy-button">Copy</button>
+            </div>
+            `
+            highlightEl.insertAdjacentHTML('beforeend', copyBtn)
+        }
     })
+
+
+
+    // Add Event Listener
+    const copyButtons = document.querySelectorAll('.js-copy-button');
+
+    if (copyButtons.length) {
+        copyButtons.forEach(btn => {
+            btn.addEventListener('click', (e) => copyCode(e, btn));
+        });
+    }
+
+
+
+    // EVENT FUNCTION
+    function copyCode (event, btn){
+        const codeSnippetElement = event.target
+        .closest('.code-snippet')
+        .querySelector('.chroma');
+        
+        // Create a range object
+        const range = document.createRange();
+        // Select the node
+        range.selectNode(codeSnippetElement);
+        // create system clipboard object
+        const Clipboard = navigator.clipboard
+        // write code snippet text
+        Clipboard.writeText(codeSnippetElement.innerText).then(() => {
+            btn.textContent = "Copied!";
+            setTimeout(function() {
+                btn.textContent = "Copy"
+            }, 1000)
+        })
+    }
 }
+
+initCopyCode()
+
+module.exports = {initCopyCode}

--- a/assets/scripts/components/copy-code.js
+++ b/assets/scripts/components/copy-code.js
@@ -2,7 +2,7 @@
 
 function initCopyCode () {
     // Add copy button to fenced codeblocks of specific languages
-    const dataLangs = ['shell']
+    const dataLangs = ['shell', 'java', 'go', 'python', 'ruby', 'typescript', 'java']
     const highlights = document.querySelectorAll("div.highlight")
 
     highlights.forEach(highlightEl => {

--- a/assets/scripts/components/copy-code.js
+++ b/assets/scripts/components/copy-code.js
@@ -1,28 +1,8 @@
-// Script to add copy-clipboard functionality to copy buttons within code-block shortcodes, fenced codeblocks and highlight hugo functions
+// Script to add copy-clipboard functionality to copy buttons
+// Script to add copy buttons to markdown fenced (```), and {{ highlight }} hugo function code blocks
 
 function initCopyCode () {
-    // Add copy button to certain codeblocks of specific languages
-    const fencedLang = ['shell']
-    const pulledLang = ['java', 'go', 'python', 'ruby', 'typescript', 'java'] // using the highlight hugo function
-    const highlights = document.querySelectorAll("div.highlight")
-
-    highlights.forEach(highlightEl => {
-        const codeLang = highlightEl.querySelector('[data-lang]').dataset.lang
-        const isNotInCodeBlockShortcode = !highlightEl.parentElement.classList.contains('code-snippet')
-
-        const shouldAddCopyBtn = [...fencedLang, ...pulledLang].includes(codeLang) && isNotInCodeBlockShortcode
-        if(shouldAddCopyBtn){
-            highlightEl.classList.add('code-snippet', 'fenced')
-            const copyBtn = `
-            <div class="code-button-wrapper position-absolute">
-                <button class="btn text-primary js-copy-button">Copy</button>
-            </div>
-            `
-            highlightEl.insertAdjacentHTML('beforeend', copyBtn)
-        }
-    })
-
-
+    addCopyButton()
 
     // Add Event Listener
     const copyButtons = document.querySelectorAll('.js-copy-button');
@@ -33,28 +13,51 @@ function initCopyCode () {
         });
     }
 
+}
 
 
-    // EVENT FUNCTION
-    function copyCode (event, btn){
-        const codeSnippetElement = event.target
-        .closest('.code-snippet')
-        .querySelector('.chroma');
-        
-        // Create a range object
-        const range = document.createRange();
-        // Select the node
-        range.selectNode(codeSnippetElement);
-        // create system clipboard object
-        const Clipboard = navigator.clipboard
-        // write code snippet text
-        Clipboard.writeText(codeSnippetElement.innerText).then(() => {
-            btn.textContent = "Copied!";
-            setTimeout(function() {
-                btn.textContent = "Copy"
-            }, 1000)
-        })
-    }
+// Adds copy button to code examples that use the highlight hugo function or are fenced code blocks in markdown
+function addCopyButton () {
+    const fencedLang = ['shell'] // target specific fenced codeblocks by language
+    const pulledLang = ['java', 'go', 'python', 'ruby', 'typescript', 'json', 'yaml'] // target specific highlight hugo functions by language 
+    const highlights = document.querySelectorAll("div.highlight")
+
+    highlights.forEach(highlightEl => {
+        const codeLang = highlightEl.querySelector('[data-lang]').dataset.lang
+        const isNotInCodeBlockShortcode = !highlightEl.parentElement.classList.contains('code-snippet')
+
+        const shouldAddCopyBtn = [...fencedLang, ...pulledLang].includes(codeLang) && isNotInCodeBlockShortcode
+        if(shouldAddCopyBtn){
+            highlightEl.classList.add('code-snippet', 'appended-copy-btn')
+            const copyBtn = `
+            <div class="code-button-wrapper position-absolute">
+                <button class="btn text-primary js-copy-button">Copy</button>
+            </div>
+            `
+            highlightEl.insertAdjacentHTML('beforeend', copyBtn)
+        }
+    })
+}
+
+// EVENT FUNCTION for copy functionality
+function copyCode (event, btn){
+    const codeSnippetElement = event.target
+    .closest('.code-snippet')
+    .querySelector('.chroma');
+    
+    // Create a range object
+    const range = document.createRange();
+    // Select the node
+    range.selectNode(codeSnippetElement);
+    // create system clipboard object
+    const Clipboard = navigator.clipboard
+    // write code snippet text
+    Clipboard.writeText(codeSnippetElement.innerText).then(() => {
+        btn.textContent = "Copied!";
+        setTimeout(function() {
+            btn.textContent = "Copy"
+        }, 1000)
+    })
 }
 
 initCopyCode()

--- a/assets/scripts/components/copy-code.js
+++ b/assets/scripts/components/copy-code.js
@@ -1,17 +1,18 @@
-// Script to add copy-clipboard functionality to code snippets within the code-block shortcode and fenced codeblocks
+// Script to add copy-clipboard functionality to copy buttons within code-block shortcodes, fenced codeblocks and highlight hugo functions
 
 function initCopyCode () {
-    // Add copy button to fenced codeblocks of specific languages
-    const dataLangs = ['shell', 'java', 'go', 'python', 'ruby', 'typescript', 'java']
+    // Add copy button to certain codeblocks of specific languages
+    const fencedLang = ['shell']
+    const pulledLang = ['java', 'go', 'python', 'ruby', 'typescript', 'java'] // using the highlight hugo function
     const highlights = document.querySelectorAll("div.highlight")
 
     highlights.forEach(highlightEl => {
         const codeLang = highlightEl.querySelector('[data-lang]').dataset.lang
         const isNotInCodeBlockShortcode = !highlightEl.parentElement.classList.contains('code-snippet')
 
-        const shouldAddCopyBtn = dataLangs.includes(codeLang) && isNotInCodeBlockShortcode
+        const shouldAddCopyBtn = [...fencedLang, ...pulledLang].includes(codeLang) && isNotInCodeBlockShortcode
         if(shouldAddCopyBtn){
-            highlightEl.classList.add('code-snippet','fenced')
+            highlightEl.classList.add('code-snippet', 'fenced')
             const copyBtn = `
             <div class="code-button-wrapper position-absolute">
                 <button class="btn text-primary js-copy-button">Copy</button>

--- a/assets/scripts/components/copy-code.js
+++ b/assets/scripts/components/copy-code.js
@@ -19,16 +19,16 @@ function initCopyCode () {
 // Adds copy button to code examples that use the highlight hugo function or are fenced code blocks in markdown
 function addCopyButton () {
     const fencedLang = ['shell'] // target specific fenced codeblocks by language
-    const pulledLang = ['java', 'go', 'python', 'ruby', 'typescript', 'json', 'yaml'] // target specific highlight hugo functions by language 
     const highlights = document.querySelectorAll("div.highlight")
 
     highlights.forEach(highlightEl => {
         const codeLang = highlightEl.querySelector('[data-lang]').dataset.lang
-        const isNotInCodeBlockShortcode = !highlightEl.parentElement.classList.contains('code-snippet')
+        const isNestedInAppendableContainer = highlightEl.parentElement.classList.contains('append-copy-btn') //  
+        const isFencedCodeExample = [...fencedLang].includes(codeLang) // markdown fenced code block
 
-        const shouldAddCopyBtn = [...fencedLang, ...pulledLang].includes(codeLang) && isNotInCodeBlockShortcode
+        const shouldAddCopyBtn = isFencedCodeExample || isNestedInAppendableContainer
         if(shouldAddCopyBtn){
-            highlightEl.classList.add('code-snippet', 'appended-copy-btn')
+            highlightEl.classList.add('code-snippet', 'js-appended-copy-btn')
             const copyBtn = `
             <div class="code-button-wrapper position-absolute">
                 <button class="btn text-primary js-copy-button">Copy</button>

--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -273,7 +273,7 @@ details {
     }
 }
 
-.code-snippet.appended-copy-btn {
+.code-snippet.js-appended-copy-btn {
     position: relative;
     padding-right: 0 !important;
     pre {

--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -273,7 +273,7 @@ details {
     }
 }
 
-.code-snippet.fenced {
+.code-snippet.appended-copy-btn {
     position: relative;
     padding-right: 0 !important;
     pre {

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -86,10 +86,7 @@
       </h5>
     </div>
     <div id="{{ $operationid | lower }}-{{ $version }}-request-example-{{ $i }}" class="collapse {{if eq $i 0}}show{{ end }}" data-bs-parent="#accordion-{{ $operationid | lower }}-{{ $version }}-{{ $lang.name }}">
-      <div class="card-body p-0 code-snippet">
-        <div class="code-button-wrapper position-absolute">
-            <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
-        </div>
+      <div class="card-body p-0">
         {{ highlight $body $lang.syntax "" }}
       </div>
     </div>
@@ -235,62 +232,61 @@
 
 <!-- Go, Python, Ruby, Typescript, Java etc. -->
 {{ with (index $codeExampleLookup $operationid) }}
-    {{ $items := . }}
-    {{ $s := newScratch }}
-    {{ range $k, $lang := $context.Site.Params.code_languages }}
-      {{ $newItems := slice }}
-      {{ $file_extension := $k }}
-      {{ $count := 0 }}
-      {{ range $i, $item := $items }}
-        {{ $fileStr := (printf "%s%s.%s" $operationid $item.suffix $file_extension) }}
-        {{ with $resourcePage.Resources.Match $fileStr }}
-          {{ with . }}
-            {{ $newItems = $newItems | append $item }}
-            {{ $count = add $count 1 }}
-          {{ end }}
+  {{ $items := . }}
+  {{ $s := newScratch }}
+  {{ range $k, $lang := $context.Site.Params.code_languages }}
+    {{ $newItems := slice }}
+    {{ $file_extension := $k }}
+    {{ $count := 0 }}
+    {{ range $i, $item := $items }}
+      {{ $fileStr := (printf "%s%s.%s" $operationid $item.suffix $file_extension) }}
+      {{ with $resourcePage.Resources.Match $fileStr }}
+        {{ with . }}
+          {{ $newItems = $newItems | append $item }}
+          {{ $count = add $count 1 }}
         {{ end }}
       {{ end }}
-      {{ $s.SetInMap "itemCounts" $lang.name $count }}
-      {{ $s.SetInMap "items" $lang.name $newItems }}
     {{ end }}
+    {{ $s.SetInMap "itemCounts" $lang.name $count }}
+    {{ $s.SetInMap "items" $lang.name $newItems }}
+  {{ end }}
 
-    {{ range $k, $lang := $context.Site.Params.code_languages }}
-      {{ $file_extension := $k }}
-      {{ $numOfCodeExamples := (index ($s.Get "itemCounts") $lang.name) }}
-      {{ $myItems := (index ($s.Get "items") $lang.name) }}
-      {{ if gt $numOfCodeExamples 0 }}
-      <div class="code-snippet-wrapper js-code-block" data-code-lang-block="{{ $lang.name }}">
-        {{ if gt $numOfCodeExamples 1 }}<div class="example-accordion" id="accordion-{{ $operationid | lower }}-{{ $version }}-{{ $lang.name }}">{{ end }}
-          {{ range $i, $item := $myItems | first 3 }}
-              {{ $fileStr := (printf "%s%s.%s" $operationid $item.suffix $file_extension) }}
-              {{ with $resourcePage.Resources.Match $fileStr }}
-                  {{ range . }}
-                    {{ if gt $numOfCodeExamples 1 }}
-                      {{ partial "accordion-card" (dict "count" $i "item" $item "body" .Content "lang" $lang "operationid" $operationid "version" $version ) }}
-                    {{ else }}
-                      <div class="card">
-                        <div class="card-header p-0">
-                          <h5 class="m-0">
-                            <button class="btn btn-link collapsed font-bold" disabled>
-                              {{ $item.description }}
-                            </button>
-                          </h5>
-                        </div>
+  {{ range $k, $lang := $context.Site.Params.code_languages }}
+    {{ $file_extension := $k }}
+    {{ $numOfCodeExamples := (index ($s.Get "itemCounts") $lang.name) }}
+    {{ $myItems := (index ($s.Get "items") $lang.name) }}
+    {{ if gt $numOfCodeExamples 0 }}
+    <div class="code-snippet-wrapper js-code-block" data-code-lang-block="{{ $lang.name }}">
+      {{ if gt $numOfCodeExamples 1 }}<div class="example-accordion" id="accordion-{{ $operationid | lower }}-{{ $version }}-{{ $lang.name }}">{{ end }}
+        {{ range $i, $item := $myItems | first 3 }}
+            {{ $fileStr := (printf "%s%s.%s" $operationid $item.suffix $file_extension) }}
+            {{ with $resourcePage.Resources.Match $fileStr }}
+                {{ range . }}
+                  {{ if gt $numOfCodeExamples 1 }}
+                    {{ partial "accordion-card" (dict "count" $i "item" $item "body" .Content "lang" $lang "operationid" $operationid "version" $version ) }}
+                  {{ else }}
+                    <div class="card">
+                      <div class="card-header p-0">
+                        <h5 class="m-0">
+                          <button class="btn btn-link collapsed font-bold" disabled>
+                            {{ $item.description }}
+                          </button>
+                        </h5>
                       </div>
-                      {{ highlight .Content $lang.syntax "" }}
-                    {{ end }}
+                    </div>
+                    {{ highlight .Content $lang.syntax "" }}
                   {{ end }}
-              {{ end }}
-          {{ end }}
-        {{ if gt $numOfCodeExamples 1 }}</div>{{ end }}
-        {{ if ne $lang.extension "sh" }}
-            {{ partial "code-example-instructions" (dict "context" $context "lang" $lang "endpoint" $endpoint "securitySchemes" $securitySchemes) }}
+                {{ end }}
+            {{ end }}
         {{ end }}
-      </div>
+      {{ if gt $numOfCodeExamples 1 }}</div>{{ end }}
+      {{ if ne $lang.extension "sh" }}
+          {{ partial "code-example-instructions" (dict "context" $context "lang" $lang "endpoint" $endpoint "securitySchemes" $securitySchemes) }}
       {{ end }}
+    </div>
     {{ end }}
+  {{ end }}
 {{ else }}
-
   <!-- if its not multiple examples then just output -->
   {{ with $resourcePage.Resources.Match (printf "%s%s" $operationid ".*" ) }}
     {{ range . }}

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -86,7 +86,7 @@
       </h5>
     </div>
     <div id="{{ $operationid | lower }}-{{ $version }}-request-example-{{ $i }}" class="collapse {{if eq $i 0}}show{{ end }}" data-bs-parent="#accordion-{{ $operationid | lower }}-{{ $version }}-{{ $lang.name }}">
-      <div class="card-body p-0">
+      <div class="card-body p-0 append-copy-btn">
         {{ highlight $body $lang.syntax "" }}
       </div>
     </div>
@@ -134,7 +134,7 @@
                             <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
                         </div>
 
-                        {{/* Do not change indent of html below as it will change the indentation of the curl code block. CURL code examples not using `highlight` hugo function */}}
+                        {{/* Do not change indent of html below as it will change the indentation of the curl code block. CURL code examples dont use `highlight` hugo function */}}
                         <pre class="chroma">
                           <code class="language-fallback" data-lang="fallback">
                           {{- with $endpoint.action.requestBody -}}
@@ -256,7 +256,7 @@
     {{ $numOfCodeExamples := (index ($s.Get "itemCounts") $lang.name) }}
     {{ $myItems := (index ($s.Get "items") $lang.name) }}
     {{ if gt $numOfCodeExamples 0 }}
-    <div class="code-snippet-wrapper js-code-block" data-code-lang-block="{{ $lang.name }}">
+    <div class="code-snippet-wrapper js-code-block append-copy-btn" data-code-lang-block="{{ $lang.name }}">
       {{ if gt $numOfCodeExamples 1 }}<div class="example-accordion" id="accordion-{{ $operationid | lower }}-{{ $version }}-{{ $lang.name }}">{{ end }}
         {{ range $i, $item := $myItems | first 3 }}
             {{ $fileStr := (printf "%s%s.%s" $operationid $item.suffix $file_extension) }}
@@ -295,10 +295,7 @@
         {{ $lang := index $context.Site.Params.code_languages $file_extension }}
         {{ if ne $file_extension "sh"}}
           <div class="code-snippet-wrapper js-code-block" data-code-lang-block="{{ $lang.name }}">
-            <div>
-              <div class="code-button-wrapper position-absolute">
-                  <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
-              </div>
+            <div class="append-copy-btn">
               <div class="card">
                 <div class="card-header p-0">
                   <h5 class="m-0">

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -136,38 +136,39 @@
                         <div class="code-button-wrapper position-absolute">
                             <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
                         </div>
+
+                        {{/* Do not change indent of html below as it will change the indentation of the curl code block. CURL code examples not using `highlight` hugo function */}}
                         <pre class="chroma">
-  {{/* Do not change indent of html below as it will change the indentation of the curl code block */}}
-  <code class="language-fallback" data-lang="fallback">
-  {{- with $endpoint.action.requestBody -}}
-      {{- with .content -}}
-          {{- range $contentType, $requestBody := . -}}
-              {{- with $requestBody.examples -}}
-                  {{- range $exampleId, $exampleDefinition := . -}}
-                      {{- $exampleValue := "" }}
-                      {{- with $exampleDefinition.externalValue -}}
-                        {{- with $resourcePage.Resources.GetMatch (path.Base .) -}}
-                          {{- $exampleValue = .Content }}
-                        {{- end -}}
-                      {{- else -}}
-                        {{- $exampleValue = $exampleDefinition.value -}}
-                        {{- if (or (hasPrefix $contentType "application/json") (hasPrefix $contentType "text/json")) -}}
-                            {{- $exampleValue = $exampleValue | jsonify (dict "indent" "  ") -}}
-                        {{- end -}}
-                      {{- end -}}
-{{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleId" $exampleId "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
-                  {{- end -}}
-              {{- else -}}
-{{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
-              {{- end -}}
-          {{- end -}}
-      {{- end -}}
-  {{- else -}}
-{{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
-  {{- end -}}
-  </code>
-  {{/* Do not change indent of html above as it will change the indentation of the curl code block */}}
+                          <code class="language-fallback" data-lang="fallback">
+                          {{- with $endpoint.action.requestBody -}}
+                              {{- with .content -}}
+                                  {{- range $contentType, $requestBody := . -}}
+                                      {{- with $requestBody.examples -}}
+                                          {{- range $exampleId, $exampleDefinition := . -}}
+                                            {{- $exampleValue := "" }}
+                                            {{- with $exampleDefinition.externalValue -}}
+                                              {{- with $resourcePage.Resources.GetMatch (path.Base .) -}}
+                                                {{- $exampleValue = .Content }}
+                                              {{- end -}}
+                                            {{- else -}}
+                                              {{- $exampleValue = $exampleDefinition.value -}}
+                                              {{- if (or (hasPrefix $contentType "application/json") (hasPrefix $contentType "text/json")) -}}
+                                                  {{- $exampleValue = $exampleValue | jsonify (dict "indent" "  ") -}}
+                                              {{- end -}}
+                                            {{- end -}}
+                                            {{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleId" $exampleId "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
+                                          {{- end -}}
+                                      {{- else -}}
+                                        {{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
+                                      {{- end -}}
+                                  {{- end -}}
+                              {{- end -}}
+                          {{- else -}}
+                            {{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
+                          {{- end -}}
+                          </code>
                         </pre>
+                        {{/* Do not change indent of html above as it will change the indentation of the curl code block */}}
 
                       </div>
                     </div>
@@ -181,45 +182,51 @@
 
           {{ if or (eq $fileNonExistCount $fileCount) (not (index $codeExampleLookup $operationid)) }}
             <div class="card">
-            <div class="card-header p-0">
-              <h5 class="m-0">
-                <button class="btn btn-link font-bold" disabled>
-                  {{ $endpoint.action.summary }}
-                </button>
-              </h5>
-            </div>
-            <pre class="chroma">
-{{/* Do not change indent of html below as it will change the indentation of the curl code block */}}
-<code class="language-fallback" data-lang="fallback">
-{{- with $endpoint.action.requestBody -}}
-    {{- with .content -}}
-        {{- range $contentType, $requestBody := . -}}
-            {{- with $requestBody.examples -}}
-                {{- range $exampleId, $exampleDefinition := . -}}
-                    {{- $exampleValue := "" }}
-                    {{- with $exampleDefinition.externalValue -}}
-                      {{- with $resourcePage.Resources.GetMatch (path.Base .) -}}
-                        {{- $exampleValue = .Content }}
+              <div class="card-header p-0">
+                <h5 class="m-0">
+                  <button class="btn btn-link font-bold" disabled>
+                    {{ $endpoint.action.summary }}
+                  </button>
+                </h5>
+              </div>
+              <div class="card-body p-0 code-snippet">
+                <div class="code-button-wrapper position-absolute">
+                    <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
+                </div>
+
+                {{/* Do not change indent of html below as it will change the indentation of the curl code block */}}
+                <pre class="chroma">
+                  <code class="language-fallback" data-lang="fallback">
+                  {{- with $endpoint.action.requestBody -}}
+                      {{- with .content -}}
+                          {{- range $contentType, $requestBody := . -}}
+                              {{- with $requestBody.examples -}}
+                                  {{- range $exampleId, $exampleDefinition := . -}}
+                                      {{- $exampleValue := "" }}
+                                      {{- with $exampleDefinition.externalValue -}}
+                                        {{- with $resourcePage.Resources.GetMatch (path.Base .) -}}
+                                          {{- $exampleValue = .Content }}
+                                        {{- end -}}
+                                      {{- else -}}
+                                        {{- $exampleValue = $exampleDefinition.value -}}
+                                        {{- if (or (hasPrefix $contentType "application/json") (hasPrefix $contentType "text/json")) -}}
+                                            {{- $exampleValue = $exampleValue | jsonify (dict "indent" "  ") -}}
+                                        {{- end -}}
+                                      {{- end -}}
+                  {{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleId" $exampleId "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
+                                  {{- end -}}
+                              {{- else -}}
+                  {{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
+                              {{- end -}}
+                          {{- end -}}
                       {{- end -}}
-                    {{- else -}}
-                      {{- $exampleValue = $exampleDefinition.value -}}
-                      {{- if (or (hasPrefix $contentType "application/json") (hasPrefix $contentType "text/json")) -}}
-                          {{- $exampleValue = $exampleValue | jsonify (dict "indent" "  ") -}}
-                      {{- end -}}
-                    {{- end -}}
-{{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleId" $exampleId "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
-                {{- end -}}
-            {{- else -}}
-{{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
-            {{- end -}}
-        {{- end -}}
-    {{- end -}}
-{{- else -}}
-{{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
-{{- end -}}
-</code>
-{{/* Do not change indent of html above as it will change the indentation of the curl code block */}}
-           </pre>
+                  {{- else -}}
+                  {{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
+                  {{- end -}}
+                  </code>
+                </pre>
+                {{/* Do not change indent of html above as it will change the indentation of the curl code block */}}
+              </div>
             </div>
           {{ end }}
       </div>
@@ -292,10 +299,10 @@
         {{ $lang := index $context.Site.Params.code_languages $file_extension }}
         {{ if ne $file_extension "sh"}}
           <div class="code-snippet-wrapper js-code-block" data-code-lang-block="{{ $lang.name }}">
-            <div class="code-snippet">
-              {{/*  <div class="code-button-wrapper position-absolute">
+            <div>
+              <div class="code-button-wrapper position-absolute">
                   <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
-              </div>  */}}
+              </div>
               <div class="card">
                 <div class="card-header p-0">
                   <h5 class="m-0">

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -296,12 +296,14 @@
               <div class="code-button-wrapper position-absolute">
                   <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
               </div>
-              <div class="card-header p-0">
-                <h5 class="m-0">
-                  <button class="btn btn-link collapsed font-bold" disabled>
-                    {{ $endpoint.action.summary }}
-                  </button>
-                </h5>
+              <div class="card">
+                <div class="card-header p-0">
+                  <h5 class="m-0">
+                    <button class="btn btn-link collapsed font-bold" disabled>
+                      {{ $endpoint.action.summary }}
+                    </button>
+                  </h5>
+                </div>
               </div>
               {{ highlight $file_content $lang.syntax "" }}
             </div>

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -262,15 +262,15 @@
                       {{ partial "accordion-card" (dict "count" $i "item" $item "body" .Content "lang" $lang "operationid" $operationid "version" $version ) }}
                     {{ else }}
                       <div class="card">
-                      <div class="card-header p-0">
-                        <h5 class="m-0">
-                          <button class="btn btn-link collapsed font-bold" disabled>
-                            {{ $item.description }}
-                          </button>
-                        </h5>
+                        <div class="card-header p-0">
+                          <h5 class="m-0">
+                            <button class="btn btn-link collapsed font-bold" disabled>
+                              {{ $item.description }}
+                            </button>
+                          </h5>
+                        </div>
                       </div>
                       {{ highlight .Content $lang.syntax "" }}
-                      </div>
                     {{ end }}
                   {{ end }}
               {{ end }}
@@ -293,9 +293,9 @@
         {{ if ne $file_extension "sh"}}
           <div class="code-snippet-wrapper js-code-block" data-code-lang-block="{{ $lang.name }}">
             <div class="code-snippet">
-              <div class="code-button-wrapper position-absolute">
+              {{/*  <div class="code-button-wrapper position-absolute">
                   <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
-              </div>
+              </div>  */}}
               <div class="card">
                 <div class="card-header p-0">
                   <h5 class="m-0">

--- a/layouts/partials/api/request-body.html
+++ b/layouts/partials/api/request-body.html
@@ -97,51 +97,46 @@
                           </div>
                           <div role="tabpanel" class="tab-pane js-tab-example" id="{{ $operationid | lower }}-{{ $version }}-request-example">
                               <div class="code-snippet-wrapper">
-                                  <div class="code-snippet">
 
-                                      {{ $fileNonExistCount := 0 }}
-                                      {{ $fileCount := 0 }}
-                                      {{ with (index $codeExampleLookup $operationid) }}
-                                        {{ $fileCount = len . }}
-                                        <div class="example-accordion" id="accordion-{{ $operationid | lower }}-{{ $version }}-json">
+                                {{ $fileNonExistCount := 0 }}
+                                {{ $fileCount := 0 }}
+                                {{ with (index $codeExampleLookup $operationid) }}
+                                  {{ $fileCount = len . }}
+                                  <div class="example-accordion" id="accordion-{{ $operationid | lower }}-{{ $version }}-json">
 
-                                        {{ range $i, $item := . | first 3 }}
+                                  {{ range $i, $item := . | first 3 }}
 
-                                            {{ with $resourcePage.Resources.Match (printf "request.%s%s.json" $operationid $item.suffix ) }}
-                                            <div class="card">
-                                              {{ if gt $fileCount 1 }}
-                                              <div class="card-header p-0">
-                                                <h5 class="m-0">
-                                                  <button class="btn btn-link {{if gt $i 0}}collapsed{{ end}}" data-bs-toggle="collapse" data-bs-target="#{{ $operationid | lower }}-{{ $version }}-request-example-{{ $i }}" aria-expanded="true" aria-controls="collapseOne">
-                                                    {{ $item.description }}
-                                                  </button>
-                                                </h5>
-                                              </div>
-                                              {{ end }}
-                                              <div id="{{ $operationid | lower }}-{{ $version }}-request-example-{{ $i }}" class="collapse {{if eq $i 0}}show{{ end }}" data-bs-parent="#accordion-{{ $operationid | lower }}-{{ $version }}-json">
-                                                <div class="card-body p-0 code-snippet">
-                                                    <div class="code-button-wrapper position-absolute">
-                                                        <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
-                                                    </div>
-                                                    {{ range . }}
-                                                      {{ (highlight (.Content) "json" "") }}
-                                                    {{ end }}
-                                                </div>
-                                              </div>
-                                            </div>
-                                            {{ else }}
-                                              {{ $fileNonExistCount = add $fileNonExistCount 1 }}
-                                            {{ end }}
-                                        {{ end }}
-
+                                      {{ with $resourcePage.Resources.Match (printf "request.%s%s.json" $operationid $item.suffix ) }}
+                                      <div class="card">
+                                        {{ if gt $fileCount 1 }}
+                                        <div class="card-header p-0">
+                                          <h5 class="m-0">
+                                            <button class="btn btn-link {{if gt $i 0}}collapsed{{ end}}" data-bs-toggle="collapse" data-bs-target="#{{ $operationid | lower }}-{{ $version }}-request-example-{{ $i }}" aria-expanded="true" aria-controls="collapseOne">
+                                              {{ $item.description }}
+                                            </button>
+                                          </h5>
                                         </div>
+                                        {{ end }}
+                                        <div id="{{ $operationid | lower }}-{{ $version }}-request-example-{{ $i }}" class="collapse {{if eq $i 0}}show{{ end }}" data-bs-parent="#accordion-{{ $operationid | lower }}-{{ $version }}-json">
+                                          <div class="card-body p-0">
+                                              {{ range . }}
+                                                {{ (highlight (.Content) "json" "") }}
+                                              {{ end }}
+                                          </div>
+                                        </div>
+                                      </div>
+                                      {{ else }}
+                                        {{ $fileNonExistCount = add $fileNonExistCount 1 }}
                                       {{ end }}
-
-                                      {{ if or (eq $fileNonExistCount $fileCount) (not (index $codeExampleLookup $operationid)) }}
-                                          {{ print $json | safeHTML }}
-                                      {{ end }}
+                                  {{ end }}
 
                                   </div>
+                                {{ end }}
+
+                                {{ if or (eq $fileNonExistCount $fileCount) (not (index $codeExampleLookup $operationid)) }}
+                                    {{ print $json | safeHTML }}
+                                {{ end }}
+
                               </div>
                           </div>
                       </div>

--- a/layouts/partials/api/request-body.html
+++ b/layouts/partials/api/request-body.html
@@ -118,7 +118,7 @@
                                         </div>
                                         {{ end }}
                                         <div id="{{ $operationid | lower }}-{{ $version }}-request-example-{{ $i }}" class="collapse {{if eq $i 0}}show{{ end }}" data-bs-parent="#accordion-{{ $operationid | lower }}-{{ $version }}-json">
-                                          <div class="card-body p-0">
+                                          <div class="card-body p-0 append-copy-btn">
                                               {{ range . }}
                                                 {{ (highlight (.Content) "json" "") }}
                                               {{ end }}

--- a/layouts/partials/api/response.html
+++ b/layouts/partials/api/response.html
@@ -104,12 +104,8 @@
                             </div>
                             <div role="tabpanel" class="tab-pane js-tab-example" id="{{ $operationid }}-{{ $response_code }}-example">
                                 <div class="code-snippet-wrapper">
-                                    <div class="code-snippet">
-                                        <div class="code-button-wrapper position-absolute">
-                                            <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
-                                        </div>
-                                        {{ $json }}
-                                    </div>
+                                    {{/*  $json = highlight hugo function  */}}
+                                    {{ $json }}
                                 </div>
                             </div>
                         </div>

--- a/layouts/partials/api/response.html
+++ b/layouts/partials/api/response.html
@@ -103,8 +103,8 @@
 
                             </div>
                             <div role="tabpanel" class="tab-pane js-tab-example" id="{{ $operationid }}-{{ $response_code }}-example">
-                                <div class="code-snippet-wrapper">
-                                    {{/*  $json = highlight hugo function  */}}
+                                <div class="code-snippet-wrapper append-copy-btn">
+                                    {{/*  $json is a highlight hugo function  */}}
                                     {{ $json }}
                                 </div>
                             </div>

--- a/layouts/reference/single.html
+++ b/layouts/reference/single.html
@@ -64,7 +64,7 @@
                         </h5>
                       </div>
                       <div id="{{ $data.metadata.logical_name | lower }}-example-simple" class="collapse show" data-bs-parent="#{{ $data.metadata.logical_name | lower }}-accordion-parent" style>
-                        <div class="card-body p-0">
+                        <div class="card-body p-0 append-copy-btn">
                             {{ highlight $data.simple "yaml" "" }}
                         </div>
                       </div>
@@ -78,7 +78,7 @@
                         </h5>
                       </div>
                       <div id="{{ $data.metadata.logical_name | lower }}-example-advanced" class="collapse" data-bs-parent="#{{ $data.metadata.logical_name | lower }}-accordion-parent" style>
-                        <div class="card-body p-0">
+                        <div class="card-body p-0 append-copy-btn">
                             {{ highlight $data.advanced "yaml" "" }}
                         </div>
                       </div>

--- a/layouts/reference/single.html
+++ b/layouts/reference/single.html
@@ -64,12 +64,8 @@
                         </h5>
                       </div>
                       <div id="{{ $data.metadata.logical_name | lower }}-example-simple" class="collapse show" data-bs-parent="#{{ $data.metadata.logical_name | lower }}-accordion-parent" style>
-                        <div class="card-body p-0 code-snippet">
-                            <div class="code-button-wrapper position-absolute">
-                                <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
-                            </div>
+                        <div class="card-body p-0">
                             {{ highlight $data.simple "yaml" "" }}
-
                         </div>
                       </div>
                     </div>
@@ -82,10 +78,7 @@
                         </h5>
                       </div>
                       <div id="{{ $data.metadata.logical_name | lower }}-example-advanced" class="collapse" data-bs-parent="#{{ $data.metadata.logical_name | lower }}-accordion-parent" style>
-                        <div class="card-body p-0 code-snippet">
-                            <div class="code-button-wrapper position-absolute">
-                                <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
-                            </div>
+                        <div class="card-body p-0">
                             {{ highlight $data.advanced "yaml" "" }}
                         </div>
                       </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

- ensures copy btn appears in code examples (request and response) on hover
- load the `click copy btn` event listener and add copy buttons on async loading

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-3877

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->


Check that a copy button appears on hover in the top right of any language code examples, request, response examples

- https://docs-staging.datadoghq.com/stefon.simmons/fix-missing-copy-btns/dynamic_instrumentation/enabling/java?tab=commandarguments

- https://docs-staging.datadoghq.com/stefon.simmons/fix-missing-copy-btns/observability_pipelines/reference/sources/

- includes accordion code example:
  - https://docs-staging.datadoghq.com/stefon.simmons/fix-missing-copy-btns/api/latest/metrics/

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
