### PR TITLE
Add alias link in Infra VM docs

### DIFF
--- a/content/en/security/infrastructure_vulnerabilities/setup.md
+++ b/content/en/security/infrastructure_vulnerabilities/setup.md
@@ -5,6 +5,8 @@ further_reading:
 - link: "/security/infrastructure_vulnerability/"
   tag: "Documentation"
   text: "CSM Vulnerabilities"
+aliases:
+  - /security/infrastructure_vulnerability/setup/
 ---
 
 {{< site-region region="gov" >}}


### PR DESCRIPTION
Add alias

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds an alias for the old URL for Infra VM.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
