### PR TITLE
APM > Trace Context Propagation > Standardize W3C text and formatting

### DIFF
--- a/content/en/tracing/trace_collection/trace_context_propagation/_index.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/_index.md
@@ -2,7 +2,7 @@
 title: Propagating the Trace Context
 kind: documentation
 type: multi-code-lang
-description: 'Extract and inject Datadog, B3, and W3C headers to propagate the context of a distributed trace.'
+description: 'Extract and inject Datadog, B3, and W3C Trace Context headers to propagate the context of a distributed trace.'
 aliases:
 further_reading:
     - link: 'tracing/glossary/'

--- a/content/en/tracing/trace_collection/trace_context_propagation/cpp.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/cpp.md
@@ -12,7 +12,7 @@ further_reading:
 
 ## Overview
 
-Datadog APM tracer supports [B3 headers extraction][11] and injection for distributed tracing.
+Datadog APM tracer supports [B3][11] headers extraction and injection for distributed tracing.
 
 Distributed headers injection and extraction is controlled by configuring injection/extraction styles. The supported styles for C++ are:
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/dotnet.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/dotnet.md
@@ -17,10 +17,10 @@ You can configure injection and extraction styles for distributed headers.
 
 The .NET Tracer supports the following styles:
 
-- W3C Trace Context: `tracecontext` (`W3C` is deprecated)
+- W3C Trace Context: `tracecontext` (`W3C` alias is deprecated)
 - Datadog: `Datadog`
-- B3 Multi Header: `b3multi` (`B3` is deprecated)
-- B3 Single Header: `B3 single header` (`B3SingleHeader` is deprecated)
+- B3 Multi Header: `b3multi` (`B3` alias is deprecated)
+- B3 Single Header: `B3 single header` (`B3SingleHeader` alias is deprecated)
 
 You can use the following environment variables to configure injection and extraction styles:
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/dotnet.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/dotnet.md
@@ -11,13 +11,13 @@ further_reading:
 ---
 
 
-The Datadog APM Tracer supports [B3][5] and [W3C (TraceParent)][6] headers extraction and injection for distributed tracing.
+The Datadog APM Tracer supports [B3][5] and [W3C Trace Context][6] headers extraction and injection for distributed tracing.
 
 You can configure injection and extraction styles for distributed headers.
 
 The .NET Tracer supports the following styles:
 
-- W3C: `tracecontext` (`W3C` is deprecated)
+- W3C Trace Context: `tracecontext` (`W3C` is deprecated)
 - Datadog: `Datadog`
 - B3 Multi Header: `b3multi` (`B3` is deprecated)
 - B3 Single Header: `B3 single header` (`B3SingleHeader` is deprecated)
@@ -29,7 +29,7 @@ You can use the following environment variables to configure injection and extra
 
 The environment variable values are comma-separated lists of header styles enabled for injection or extraction. If multiple extraction styles are enabled, the extraction attempt is completed in the order of configured styles, and uses the first successful extracted value.
 
-Starting from version 2.22.0, the default injection style is `tracecontext, Datadog`, so the W3C context is used, followed by the Datadog headers. Prior to version 2.22.0, only the `Datadog` injection style is enabled.
+Starting from version 2.22.0, the default injection style is `tracecontext, Datadog`, so the W3C Trace Context is used, followed by the Datadog headers. Prior to version 2.22.0, only the `Datadog` injection style is enabled.
 
 In most cases, headers extraction and injection are transparent. There are some known cases where your distributed trace can be disconnected. For instance, when reading messages from a distributed queue, some libraries may lose the span context. It also happens if you set `DD_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED` to `false` when consuming Kafka messages. In that case, you can add a custom trace using the following code:
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/go.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/go.md
@@ -11,7 +11,7 @@ further_reading:
 ---
 
 
-The Datadog APM tracer supports extraction and injection of [B3][8] and [W3C][10] headers for distributed tracing.
+The Datadog APM tracer supports extraction and injection of [B3][8] and [W3C Trace Context][10] headers for distributed tracing.
 
 Distributed headers injection and extraction is controlled by
 configuring injection/extraction styles. Supported styles are:

--- a/content/en/tracing/trace_collection/trace_context_propagation/java.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/java.md
@@ -11,7 +11,7 @@ further_reading:
 ---
 
 
-The Datadog APM Tracer supports [B3][13] and [W3C (Trace Context)][14] header extraction and injection for distributed tracing.
+The Datadog APM Tracer supports [B3][13] and [W3C Trace Context][14] header extraction and injection for distributed tracing.
 
 You can configure injection and extraction styles for distributed headers.
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/nodejs.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/nodejs.md
@@ -10,7 +10,7 @@ further_reading:
       text: 'Monitor OpenTelemetry-instrumented apps with support for W3C Trace Context'
 ---
 
-The Datadog APM Tracer supports [B3][5] and [W3C (TraceParent)][6] header extraction and injection for distributed tracing.
+The Datadog APM Tracer supports [B3][5] and [W3C Trace Context][6] header extraction and injection for distributed tracing.
 
 You can configure injection and extraction styles for distributed headers.
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/nodejs.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/nodejs.md
@@ -17,7 +17,7 @@ You can configure injection and extraction styles for distributed headers.
 The Node.js Tracer supports the following styles:
 
 - Datadog: `Datadog`
-- B3 Multi Header: `b3multi` (`B3` is deprecated)
+- B3 Multi Header: `b3multi` (`B3` alias is deprecated)
 - W3C Trace Context: `tracecontext`
 - B3 Single Header: `B3 single header`
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/php.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/php.md
@@ -18,7 +18,7 @@ The PHP Tracer supports the following styles:
 
 - Datadog: `Datadog`
 - W3C Trace Context: `tracecontext`
-- B3 Multi Header: `b3multi` (`B3` is deprecated)
+- B3 Multi Header: `b3multi` (`B3` alias is deprecated)
 - B3 Single Header: `B3 single header`
 
 You can use the following environment variables to configure the PHP tracing library injection and extraction styles. For instance:

--- a/content/en/tracing/trace_collection/trace_context_propagation/php.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/php.md
@@ -10,14 +10,14 @@ further_reading:
       text: 'Monitor OpenTelemetry-instrumented apps with support for W3C Trace Context'
 ---
 
-The Datadog APM Tracer supports [B3][7] and [W3C][10] headers extraction and injection for distributed tracing.
+The Datadog APM Tracer supports [B3][7] and [W3C Trace Context][10] headers extraction and injection for distributed tracing.
 
 You can configure injection and extraction styles for distributed headers.
 
 The PHP Tracer supports the following styles:
 
 - Datadog: `Datadog`
-- W3C: `tracecontext`
+- W3C Trace Context: `tracecontext`
 - B3 Multi Header: `b3multi` (`B3` is deprecated)
 - B3 Single Header: `B3 single header`
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/python.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/python.md
@@ -10,7 +10,7 @@ further_reading:
       text: 'Monitor OpenTelemetry-instrumented apps with support for W3C Trace Context'
 ---
 
-The Datadog APM tracer supports extraction and injection of [B3][2] and [W3C][3] headers for distributed tracing.
+The Datadog APM tracer supports extraction and injection of [B3][2] and [W3C Trace Context][3] headers for distributed tracing.
 
 Distributed headers injection and extraction is controlled by
 configuring injection and extraction styles. Supported styles are:

--- a/content/en/tracing/trace_collection/trace_context_propagation/ruby.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/ruby.md
@@ -16,11 +16,11 @@ Datadog APM tracer supports [B3][6] and [W3C Trace Context][7] header extraction
 
 Distributed headers injection and extraction is controlled by configuring injection and extraction styles. The following styles are supported:
 
-- `Datadog`: Datadog style headers
-- `b3multi`: B3 multiple-headers
-- `b3`: B3 single-header
-- `tracecontext`: W3C Trace Context
-- `none`: No-op
+- Datadog: `Datadog`
+- B3 Multi Header: `b3multi`
+- B3 Single Header: `b3`
+- W3C Trace Context: `tracecontext`
+- No-op: `none`
 
 Injection styles can be configured using:
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/ruby.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/ruby.md
@@ -12,7 +12,7 @@ further_reading:
 
 ### B3 headers extraction and injection
 
-Datadog APM tracer supports [B3][6] and [W3C (TraceParent)][7] header extraction and injection for distributed tracing.
+Datadog APM tracer supports [B3][6] and [W3C Trace Context][7] header extraction and injection for distributed tracing.
 
 Distributed headers injection and extraction is controlled by configuring injection and extraction styles. The following styles are supported:
 
@@ -32,7 +32,7 @@ Extraction styles can be configured using:
 
 - Environment Variable: `DD_TRACE_PROPAGATION_STYLE_EXTRACT=Datadog,b3`
 
-The value of the environment variable is a comma-separated list of header styles that are enabled for extraction. 
+The value of the environment variable is a comma-separated list of header styles that are enabled for extraction.
 
 If multiple extraction styles are enabled extraction attempt is done on the order those styles are configured and first successful extracted value is used.
 


### PR DESCRIPTION
### What does this PR do?
This PR adds some standardization to the Trace Context Propagation page:
- Standardizes references to "W3C" as "W3C Trace Context"
- Standardizes the format of the supported propagators list

### Motivation
I wanted to make sure we were consistent when we refer to the W3C Trace Context headers

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
