### PR TITLE
Remove incorrect information about supported SQL comment formats

### DIFF
--- a/content/en/database_monitoring/guide/tag_database_statements.md
+++ b/content/en/database_monitoring/guide/tag_database_statements.md
@@ -18,12 +18,9 @@ Supported databases
 Supported Agent versions
 : 7.36.1+
 
-Supported tagging formats
-: [sqlcommenter][2], [marginalia][3]
-
 
 ## Manual tag injection
-Using any database API supporting execution of SQL statements, add a comment in your statement with tags formatted as per the [sqlcommenter][2] or [marginalia][3] formats.
+Using any database API supporting execution of SQL statements, add a comment in your statement with tags formatted as `<YOUR_KEY>:'<YOUR_VALUE>'`. The value must be in quotes.
 
 ```sql
 /*key='val'*/ SELECT * from FOO
@@ -41,7 +38,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Tag SQL statement with key:val
+	// Tag SQL statement with key:'val'
 	rows, err := db.Query("/*key='val'*/ SELECT * from FOO")
 	if err != nil {
 		log.Fatal(err)
@@ -65,6 +62,4 @@ When you select a query, the custom tags are shown on the **Sample Details** pag
 {{< img src="database_monitoring/dbm_explain_plan_with_custom_tags.png" alt="View custom tags on explain plans.">}}
 
 [1]: /database_monitoring/#getting-started
-[2]: https://google.github.io/sqlcommenter
-[3]: https://github.com/basecamp/marginalia
 [4]: /database_monitoring/query_samples/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes inaccurate examples, and removes references to SQL comment formats that are not compatible with the updated examples.

### Motivation
DOCS-5964

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
