### PR TITLE
Update CODEOWNERS to add dotnet-tracing as owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,7 +63,7 @@ content/en/logs/log_collection/ios.md                            @Datadog/rum-mo
 # Traces
 content/en/tracing/trace_collection/dd_libraries/android.md     @Datadog/rum-mobile @DataDog/documentation
 content/en/tracing/trace_collection/dd_libraries/ios.md         @Datadog/rum-mobile @DataDog/documentation
-content/en/tracing/**/**/*dotnet*                               @DataDog/tracing-dotnet @DataDog/documentation
+content/en/tracing/**/*dotnet*                              @DataDog/tracing-dotnet @DataDog/documentation
 
 # Mobile SDK
 content/en/real_user_monitoring/android/                        @Datadog/rum-mobile @DataDog/documentation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,7 +63,7 @@ content/en/logs/log_collection/ios.md                            @Datadog/rum-mo
 # Traces
 content/en/tracing/trace_collection/dd_libraries/android.md     @Datadog/rum-mobile @DataDog/documentation
 content/en/tracing/trace_collection/dd_libraries/ios.md         @Datadog/rum-mobile @DataDog/documentation
-content/en/tracing/**/*dotnet*                              @DataDog/tracing-dotnet @DataDog/documentation
+content/en/tracing/**/*dotnet*                                  @DataDog/tracing-dotnet @DataDog/documentation
 
 # Mobile SDK
 content/en/real_user_monitoring/android/                        @Datadog/rum-mobile @DataDog/documentation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,7 @@ content/en/logs/log_collection/ios.md                            @Datadog/rum-mo
 # Traces
 content/en/tracing/trace_collection/dd_libraries/android.md     @Datadog/rum-mobile @DataDog/documentation
 content/en/tracing/trace_collection/dd_libraries/ios.md         @Datadog/rum-mobile @DataDog/documentation
+content/en/tracing/**/**/*dotnet*                               @DataDog/tracing-dotnet @DataDog/documentation
 
 # Mobile SDK
 content/en/real_user_monitoring/android/                        @Datadog/rum-mobile @DataDog/documentation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds the .NET tracer group as code owners for relevant pages of the documentation.

### Motivation
So that we can beware of changes happening and add comments where needed to make sure the changes are relevant and not misleading.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
