### PR TITLE
Adding details about storedProcedures not being supported.

### DIFF
--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -47,7 +47,7 @@ APM tracer integrations support a *Propagation Mode*, which controls the amount 
 |                                          | [mysql2][7]          |           | {{< X >}} |                                        |
 | **Python:** [dd-trace-py][11] >= 1.9.0   |                      |           |           |                                        |
 |                                          | [psycopg2][12]       | {{< X >}} |           |                                        |
-| **.NET** [dd-trace-dotnet][15] >= 2.26.0 |                      |           |           |                                        |
+| **.NET** [dd-trace-dotnet][15] >= 2.35.0 | [CommandType.StoredProcedure][25] are unsupported.|           |           |                                        |
 |                                          | [Npgsql][16]         | {{< X >}} |           |                                        |
 |                                          | [MySql.Data][17]     |           | {{< X >}} |                                        |
 |                                          | [MySqlConnector][18] |           | {{< X >}} |                                        |
@@ -415,3 +415,4 @@ View historical performance of similar queries to those executed in your trace, 
 [22]: https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/
 [23]: https://github.com/DataDog/dd-trace-java
 [24]: https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/ado-net-overview
+[25]: https://learn.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.commandtype?view=dotnet-plat-ext-7.0#remarks:~:text=[…]%20should%20set


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updates the DBM<>APM link table to add note about Stored Procedures not being supported and direct to use latest versio of the tracer instead which includes the fix [2.35.0
](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.35.0)
### Motivation
<!-- What inspired you to submit this pull request?-->
To prevent customers from using a version that could give them issues and to also bring awareness of what we support.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
