### PR TITLE
maximo/thorough documenting logfile rotation config

### DIFF
--- a/content/en/tracing/trace_collection/library_config/dotnet-core.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-core.md
@@ -192,7 +192,7 @@ Added in version 1.17.0. <br>
 **Default**: `%ProgramData%\Datadog .NET Tracer\logs\` on Windows, `/var/log/datadog/dotnet` on Linux
 
 `DD_TRACE_LOGFILE_RETENTION_DAYS`
-: During the tracer's startup, this configuration uses the tracer's current log directory to delete log files equal to and older than the given amount of days. Added in version 2.19.0. <br>
+: During the tracer's startup, this configuration uses the tracer's current log directory to delete log files the same age and older than the given number of days. Added in version 2.19.0. <br>
 **Default**: `31`
 
 `DD_TRACE_LOGGING_RATE`

--- a/content/en/tracing/trace_collection/library_config/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-framework.md
@@ -208,7 +208,7 @@ Added in version 1.17.0. <br>
 **Default**: `%ProgramData%\Datadog .NET Tracer\logs\`
 
 `DD_TRACE_LOGFILE_RETENTION_DAYS`
-: During the tracer's startup, this configuration uses the tracer's current log directory to delete log files equal to and older than the given amount of days. Added in version 2.19.0. <br>
+: During the tracer's startup, this configuration uses the tracer's current log directory to delete log files the same age and older than the given number of days. Added in version 2.19.0. <br>
 **Default**: `31`
 
 `DD_TRACE_LOGGING_RATE`

--- a/content/en/tracing/trace_collection/library_config/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-framework.md
@@ -207,6 +207,10 @@ Added in version 1.17.0. <br>
 : Sets the directory for .NET Tracer logs. <br>
 **Default**: `%ProgramData%\Datadog .NET Tracer\logs\`
 
+`DD_TRACE_LOGFILE_RETENTION_DAYS`
+: During the tracer's startup, this configuration uses the tracer's current log directory to delete log files equal to and older than the given amount of days. Added in version 2.19.0. <br>
+**Default**: `31`
+
 `DD_TRACE_LOGGING_RATE`
 : Sets rate limiting for log messages. If set, unique log lines are written once per `x` seconds. For example, to log a given message once per 60 seconds, set to `60`. Setting to `0` disables log rate limiting. Added in version 1.24.0. Disabled by default.
 

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -176,6 +176,8 @@ Logs files are saved in the following directories by default. Use the `DD_TRACE_
 
 **Note:**: On Linux, you must create the logs directory before you enabled debug mode.
 
+Starting on version `2.19.0` the `DD_TRACE_LOGFILE_RETENTION_DAYS` configuration was introduced, during the tracer's startup it looks at the current logging directory then deletes log files equal to and older than the given amount of days, the default value is **31**, use said configuration to change this timeframe.
+
 For more details on how to configure the .NET Tracer, see the [Configuration][2] section.
 
 There are two types of logs that are created in these paths:

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -176,7 +176,7 @@ Logs files are saved in the following directories by default. Use the `DD_TRACE_
 
 **Note:**: On Linux, you must create the logs directory before you enabled debug mode.
 
-Starting on version `2.19.0` the `DD_TRACE_LOGFILE_RETENTION_DAYS` configuration was introduced, during the tracer's startup it looks at the current logging directory then deletes log files equal to and older than the given amount of days, the default value is **31**, use said configuration to change this timeframe.
+Since version `2.19.0`, you can use the `DD_TRACE_LOGFILE_RETENTION_DAYS` setting to configure the tracer to delete log files from the current logging directory on startup. The tracer deletes log files the same age and older than the given number of days, with a default value of `31`.
 
 For more details on how to configure the .NET Tracer, see the [Configuration][2] section.
 

--- a/content/en/tracing/troubleshooting/tracer_startup_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_startup_logs.md
@@ -49,7 +49,7 @@ Log files are saved in the following directories by default. Use the `DD_TRACE_L
 
 **Note:** On Linux, you must create the logs directory before you enable debug mode.
 
-Starting on version `2.19.0` the `DD_TRACE_LOGFILE_RETENTION_DAYS` configuration was introduced, during the tracer's startup it looks at the current logging directory then deletes log files equal to and older than the given amount of days, the default value is **31**, use said configuration to change this timeframe.
+Since version `2.19.0`, you can use the `DD_TRACE_LOGFILE_RETENTION_DAYS` setting to configure the tracer to delete log files from the current logging directory on startup. The tracer deletes log files the same age and older than the given number of days, with a default value of `31`.
 
 - `dotnet-tracer-managed-{processName}-{timestamp}.log` contains the configuration logs.
 

--- a/content/en/tracing/troubleshooting/tracer_startup_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_startup_logs.md
@@ -49,6 +49,8 @@ Log files are saved in the following directories by default. Use the `DD_TRACE_L
 
 **Note:** On Linux, you must create the logs directory before you enable debug mode.
 
+Starting on version `2.19.0` the `DD_TRACE_LOGFILE_RETENTION_DAYS` configuration was introduced, during the tracer's startup it looks at the current logging directory then deletes log files equal to and older than the given amount of days, the default value is **31**, use said configuration to change this timeframe.
+
 - `dotnet-tracer-managed-{processName}-{timestamp}.log` contains the configuration logs.
 
 - `dotnet-tracer-native.log` contains the diagnostics logs, if any are generated.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Documenting the `DD_TRACE_LOGFILE_RETENTION_DAYS` setting on the .NET Framework configuration page and also related tracer logs pages where it is relevant for customers looking into our logging.

### Motivation
<!-- What inspired you to submit this pull request?-->
There have been two cases where customer's use cases could be solved with this feature, but because it wasn't documented they had to open support cases to learn about it, now documented in the appropriate places we should see less or none of those cases.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
