### PR TITLE
[ACCESS-1829] Have docs reflect `standard` deprecation

### DIFF
--- a/content/en/account_management/rbac/permissions.md
+++ b/content/en/account_management/rbac/permissions.md
@@ -27,7 +27,7 @@ By default, existing users are associated with one of the three out-of-the-box r
 - Datadog Standard
 - Datadog Read-Only
 
-All users can read all data types. Admin and Standard users have write permissions on assets. Admin users have additional read and write permissions for sensitive assets relating to user management, org management, billing, and usage.
+All users with one of these roles can read all data types. Admin and Standard users have write permissions on assets. Admin users have additional read and write permissions for sensitive assets relating to user management, org management, billing, and usage.
 
 **Note**: When adding a new custom role to a user, make sure to remove the out-of-the-box Datadog role associated with that user in order to enforce the new role permissions.
 

--- a/content/en/account_management/rbac/permissions.md
+++ b/content/en/account_management/rbac/permissions.md
@@ -21,27 +21,17 @@ After creating a role, assign or remove permissions to this role directly by [up
 
 ## Overview
 
-### General permissions
-
-General permissions provide the base level of access for your role. [Advanced Permissions](#advanced-permissions) are explicitly defined permissions that augment the base permissions.
-
-{{< permissions group="General" >}}
-
-**Note**: There is no `read-only` permission as it is defined by the lack of the `standard` permission for a role.
-
-### Advanced permissions
-
 By default, existing users are associated with one of the three out-of-the-box roles:
 
 - Datadog Admin
 - Datadog Standard
-- Datadog Read-Only.
+- Datadog Read-Only
 
-All users can read all data types. Admin and Standard users have write permissions on assets.
+All users can read all data types. Admin and Standard users have write permissions on assets. Admin users have additional read and write permissions for sensitive assets relating to user management, org management, billing, and usage.
 
 **Note**: When adding a new custom role to a user, make sure to remove the out-of-the-box Datadog role associated with that user in order to enforce the new role permissions.
 
-In addition to the general permissions, you can define more granular permissions for specific assets or data types. In the tables below, find the details of these options and the impact they have on each available permission.
+Each asset type has corresponding read and write permissions. In the tables below, find the details of these permissions.
 
 {{% permissions %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Updates role-permission docs now that the `standard` permission is deprecated.

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/browse/ACCESS-1829

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
I've looked through the repo to find more references to the `standard` permission, but haven't found any so far.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
