### PR TITLE
agent-metrics: remove receiver.ratelimit

### DIFF
--- a/content/en/tracing/troubleshooting/agent_apm_metrics.md
+++ b/content/en/tracing/troubleshooting/agent_apm_metrics.md
@@ -82,10 +82,6 @@ Number of payloads accepted by the Agent.
 : **Type**: Count<br>
 Number of payloads rejected by the receiver because of the sampling.
 
-`datadog.trace_agent.receiver.ratelimit`
-: **Type**: Gauge<br>
-If lower than `1`, it means payloads are being refused due to high resource usage (cpu or memory).
-
 `datadog.trace_agent.receiver.spans_dropped`
 : **Type**: Count<br>
 Number of spans dropped by the Agent.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR removes the `datadog.trace_agent.receiver.ratelimit` metric from the agent metrics page. This metric is removed in this PR: https://github.com/DataDog/datadog-agent/pull/17917 and in existing agent versions is not usually helpful for users diagnosing issues with their agents.

### Motivation
https://github.com/DataDog/datadog-agent/pull/17917

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->



### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
