### PR TITLE
Fix the docs for Mobile SR setup page

### DIFF
--- a/content/en/real_user_monitoring/session_replay/mobile/setup_and_configuration.md
+++ b/content/en/real_user_monitoring/session_replay/mobile/setup_and_configuration.md
@@ -32,11 +32,17 @@ To set up Mobile Session Replay for Android:
 
 1. Make sure you've [setup and initialized the Datadog Android RUM SDK][2] with views instrumentation enabled.
 
-2. Declare the Datadog Session Replay as a [dependency][3].
+2. Declare the Datadog Session Replay as a dependency:
+  {{< code-block lang="kotlin" filename="build.gradle" disable_copy="false" collapsible="true" >}}
+    implementation("com.datadoghq:dd-sdk-android-rum:[datadog_version]")
+    implementation("com.datadoghq:dd-sdk-android-session-replay:[datadog_version]")
+    // in case you need material support
+    implementation("com.datadoghq:dd-sdk-android-session-replay-material:[datadog_version]")
+   {{< /code-block >}}
 
 3. Enable Session Replay in your app:
 
-   {{< code-block lang="kotlin" filename="build.gradle" disable_copy="false" collapsible="true" >}}
+   {{< code-block lang="kotlin" filename="Application.kt" disable_copy="false" collapsible="true" >}}
    val sessionReplayConfig = SessionReplayConfiguration.Builder([sampleRate])
     // in case you need material extension support
     .addExtensionSupport(MaterialExtensionSupport()) 
@@ -93,7 +99,7 @@ This sample rate is applied in addition to the RUM sample rate. For example, if 
 {{< tabs >}}
 {{% tab "Android" %}}
 
-{{< code-block lang="kotlin" filename="build.gradle" disable_copy="false" collapsible="true" >}}
+{{< code-block lang="kotlin" filename="Application.kt" disable_copy="false" collapsible="true" >}}
 val sessionReplayConfig = SessionReplayConfiguration.Builder([sampleRate])
  ...
 .build()
@@ -118,7 +124,7 @@ To validate whether Session Replay data is being sent from the app, you can enab
 {{< tabs >}}
 {{% tab "Android" %}}
 
-{{< code-block lang="java" filename="build.gradle" disable_copy="false" collapsible="true" >}}
+{{< code-block lang="kotlin" filename="Application.kt" disable_copy="false" collapsible="true" >}}
 Datadog.setVerbosity(Log.DEBUG)
 {{< /code-block >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds small fixes on the `setup_and_configuration` page for Mobile Session Replay
### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
