### PR TITLE
[Serverless] Fix .NET logo

### DIFF
--- a/layouts/partials/serverless/serverless-apm-recommendations.html
+++ b/layouts/partials/serverless/serverless-apm-recommendations.html
@@ -40,7 +40,7 @@
             <div class="col">
                 <a class="card h-100" href="/serverless/distributed_tracing#net">
                     <div class="card-body text-center py-2 px-1">
-                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet-framework.png" "class" "img-fluid" "alt" ".NET" "width" "400") }}
+                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".NET" "width" "400") }}
                     </div>
                 </a>
             </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Change [Distributed Tracing with AWS Lambda Serverless Applications](https://docs.datadoghq.com/serverless/distributed_tracing/#runtime-recommendations) page to use the ".NET" logo instead of the ".NET Framework" logo.

Before:
![image](https://github.com/DataDog/documentation/assets/1851278/695bdbba-8ddf-417c-a69e-dab8e4952022)

### Motivation
AWS Lambda only supports .NET 6+, not the legacy .NET Framework.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
N/A

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
