### PR TITLE
Add Oracle setup tiles to DBM > Getting Started

### DIFF
--- a/content/en/database_monitoring/_index.md
+++ b/content/en/database_monitoring/_index.md
@@ -46,6 +46,11 @@ Datadog Database Monitoring supports self-hosted and managed cloud versions of *
 {{< partial name="dbm/dbm-setup-mysql" >}}
 <p></p>
 
+### Oracle
+
+{{< partial name="dbm/dbm-setup-oracle" >}}
+<p></p>
+
 ### SQL Server
 
 {{< partial name="dbm/dbm-setup-sql-server" >}}

--- a/layouts/partials/dbm/dbm-setup-oracle.html
+++ b/layouts/partials/dbm/dbm-setup-oracle.html
@@ -1,7 +1,7 @@
 {{ $dot := . }}
 <div class="dbm-setup-oracle">
   <div class="container cards-dd">
-    <div class="row row-cols-2 row-cols-sm-4 g-2 g-xl-3 justify-content-sm-center">
+    <div class="row row-cols-2 row-cols-sm-5 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
         <a class="card h-100" href="/database_monitoring/setup_oracle/selfhosted">
           <div class="card-body text-center py-2 px-1">
@@ -38,7 +38,7 @@
         <a class="card h-100" href="/database_monitoring/setup_oracle/autonomous_database">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/oracle.png" "class" "img-fluid" "alt" "Selfhosted" "width" "175") }}
-            <br/>Autonomous Database
+            <br/>Autonomous<br/>Database
           </div>
         </a>
       </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
The index page for DBM was missing the Oracle setup tiles, so they've been added here. I also tweaked the appearance of the Oracle setup partial, which was awkwardly laid out due to a long line of text in one of the tiles.

### Motivation
DOCS-5985

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
