### PR TITLE
Update link check on schedule with correct rules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -382,7 +382,7 @@ manage_ignored_translations:on-schedule:
 # its too noisy to run all the time but we want some insight so its running on schedule
 link_checks:on-schedule:
   <<: *base_template
-  <<: *live_rules
+  <<: *live_schedule_rules
   stage: post-deploy
   cache: {}
   environment: "live"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
- Sets the correct rule set for the `link_checks:on-schedule` job so that it only runs on schedule and not on every master deploy
### Motivation
<!-- What inspired you to submit this pull request?-->
Shout out to @kayayarai for catching this, it was running on all master deploys due to the wrong ruleset being applied in CI (and @hestonhoffman for the heads up about it)
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
