### PR TITLE
Search result title and content snippet mark element rollback

### DIFF
--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -6,10 +6,11 @@ export function getHitData(hit, qry = '') {
     const regexQry = new RegExp(`(${orMatches})`, 'gi');
     let highlightedTitle = (hit._highlightResult.title.value || title);
     let highlightedContent = (hit._highlightResult.content.value || '');
-    if(qry) {
-      highlightedTitle = highlightedTitle.replace(regexQry, '<mark>$1</mark>');
-      highlightedContent = highlightedContent.replace(regexQry, '<mark>$1</mark>');
-    }
+    
+    // if(qry) {
+    //   highlightedTitle = highlightedTitle.replace(regexQry, '<mark>$1</mark>');
+    //   highlightedContent = highlightedContent.replace(regexQry, '<mark>$1</mark>');
+    // }
 
     return {
         relpermalink: cleanRelPermalink,

--- a/assets/scripts/components/algolia/searchbarHits.js
+++ b/assets/scripts/components/algolia/searchbarHits.js
@@ -1,5 +1,5 @@
 import { getHitData } from './getHitData';
-import { truncateContentAtHighlight } from '../../helpers/truncateContent';
+import { truncateContent } from '../../helpers/truncateContent';
 import { bodyClassContains } from '../../helpers/helpers';
 import connectHits from 'instantsearch.js/es/connectors/hits/connectHits';
 
@@ -88,7 +88,7 @@ const renderHits = (renderOptions, isFirstRender) => {
         const joinedListItems = hitsArray
             .map((item) => {
                 const hit = getHitData(item, renderOptions.results.query);
-                const displayContent = truncateContentAtHighlight(hit.content, 145);
+                const displayContent = truncateContent(hit.content, 145);
                 const cleanRelpermalink = `${basePathName}${hit.relpermalink}`.replace('//', '/');
                 const section_header = hit.section_header ? `&raquo; ${hit.section_header}` : '';
 

--- a/assets/scripts/components/algolia/searchpageHits.js
+++ b/assets/scripts/components/algolia/searchpageHits.js
@@ -1,5 +1,5 @@
 import { getHitData } from './getHitData';
-import { truncateContentAtHighlight } from '../../helpers/truncateContent';
+import { truncateContent } from '../../helpers/truncateContent';
 import connectHits from 'instantsearch.js/es/connectors/hits/connectHits';
 
 const renderHits = (renderOptions, isFirstRender) => {
@@ -37,7 +37,7 @@ const renderHits = (renderOptions, isFirstRender) => {
         return hitsArray
             .map((item) => {
                 const hit = getHitData(item, renderOptions.results.query);
-                const displayContent = truncateContentAtHighlight(hit.content, 300);
+                const displayContent = truncateContent(hit.content, 300);
                 const cleanRelpermalink = `${basePathName}${hit.relpermalink}`.replace('//', '/');
 
                 return `


### PR DESCRIPTION
### What does this PR do?
Rolling back some work done to manually include `<mark>` element for snippet and title highlighting, to avoid https://dd.slack.com/archives/C0DESMBQU/p1691518439384279

### Motivation
https://dd.slack.com/archives/C0DESMBQU/p1691518439384279

### Preview
https://docs-staging.datadoghq.com/brian.deutsch/search-results-headers/search/?s=set%20up%20tracing%20on%20a%20teamcity

do some QA on search and make sure results dont have any strange strings/generally look good

### Additional Notes


---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
