### PR TITLE
Fix host setup instructions for CSM Vulnerabilities

### DIFF
--- a/content/en/security/infrastructure_vulnerabilities/setup.md
+++ b/content/en/security/infrastructure_vulnerabilities/setup.md
@@ -165,14 +165,10 @@ agents:
 {{% tab "Hosts" %}}
 
 ```yaml
-agents:
-  containers:
-    agent:
-      env:
-        - name: DD_SBOM_ENABLED
-          value: "true"
-        - name: DD_SBOM_HOST_ENABLED
-          value: "true"
+sbom:
+  enabled: true
+  host:
+    enabled: true
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Fixes the host setup instructions for CSM Infra VM.

### Motivation
<!-- What inspired you to submit this pull request?-->
Request by PM.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Ready to merge.
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
