### PR TITLE
[APM .NET] Remove WCF from list of supported .NET Core integrations

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/dotnet-core.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-core.md
@@ -85,7 +85,6 @@ The [latest version of the .NET Tracer][4] can automatically instrument the foll
 | Service Fabric Remoting         | `Microsoft.ServiceFabric.Services.Remoting` 4.0.470+                                                 | `ServiceRemoting`    |
 | SQLite                          | `System.Data.Sqlite` 2.0.0+ </br>`Microsoft.Data.Sqlite` 1.0.0+                                      | `Sqlite`             |
 | SQL Server                      | `System.Data` 4.0.0+</br>`System.Data.SqlClient` 4.0.0+</br>`Microsoft.Data.SqlClient` 1.0.0+        | `SqlClient`          |
-| WCF (server)                    | built-in                                                                                             | `Wcf`                |
 | WebClient / WebRequest          | `System.Net.Requests` 4.0+                                                                           | `WebRequest`         |
 
 Don't see your desired frameworks? Datadog is continually adding additional support. [Check with the Datadog team][5] for help.


### PR DESCRIPTION
### What does this PR do?
Updates the list of supported integrations for .NET 

### Motivation
We don't support WCF on .NET Core

### Additional Notes
Added accidentally in this PR: https://github.com/DataDog/documentation/pull/11200

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
