### PR TITLE
Add tcpout configuration for Splunk forwarders.

### DIFF
--- a/content/en/observability_pipelines/setup/splunk.md
+++ b/content/en/observability_pipelines/setup/splunk.md
@@ -495,7 +495,21 @@ By default, a 288GB EBS drive is allocated to each instance, and the sample conf
 ## Connect Splunk forwarders to the Observability Pipelines Worker
 After you install and configure the Observability Pipelines Worker to send logs to your Splunk index, you must update your existing collectors to point to the Worker.
 
-You can update most Splunk collectors with the IP/URL of the host (or load balancer) associated with the Observability Pipelines Worker.
+### Heavy/Universal Forwarder
+The sample configurations provided allow for sending raw Splunk data over TCP to the Worker. You can do this by adding the following content to your Splunk `outputs.conf` and restart your forwarder:
+
+```
+[tcpout]
+compressed=false
+sendCookedData=false
+defaultGroup=opw
+
+[tcpout:opw]
+server=<OPW LOAD BALANCER/DNS>:8089
+```
+
+### HEC
+For collectors that send data over HEC, you must update the collector to point to the load balancer IP / DNS you provisioned earlier.
 
 For Terraform installs, the `lb-dns` output provides the necessary value.
 

--- a/content/en/observability_pipelines/setup/splunk.md
+++ b/content/en/observability_pipelines/setup/splunk.md
@@ -338,16 +338,32 @@ sources:
     address: 0.0.0.0:8088
     valid_tokens:
         - $${SPLUNK_TOKEN}
+  splunk_tcpout:
+    type: socket
+    mode: tcp
+    address: 0.0.0.0:8089
 
 transforms:
+  ## This step removes some extra metadata added by the `socket` source
+  ## that isn't needed in Splunk.
+  cleanup_socket:
+    type: remap
+    inputs:
+      - splunk_tcpout
+    source: |
+      del(.source_type)
+      del(.host)
+      del(.port)
+
   ## This is a placeholder for your own remap (or other transform)
   ## steps with tags set up. Datadog recommends these tag assignments.
   ## They show which data has been moved over to OP and what still needs
   ## to be moved.
-  LOGS_YOUR_STEPS:
+  logs_enrich:
     type: remap
     inputs:
       - splunk_receiver
+      - cleanup_socket
     source: |
       .sender = "observability_pipelines_worker"
       .opw_aggregator = get_hostname!()

--- a/static/resources/yaml/observability_pipelines/splunk/aws_eks.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/aws_eks.yaml
@@ -84,8 +84,23 @@ pipelineConfig:
       address: 0.0.0.0:8088
       valid_tokens:
           - ${SPLUNK_TOKEN}
+    splunk_tcpout:
+      type: socket
+      mode: tcp
+      address: 0.0.0.0:8089
 
   transforms:
+    ## This step removes some extra metadata added by the `socket` source
+    ## that isn't needed in Splunk.
+    cleanup_socket:
+      type: remap
+      inputs:
+        - splunk_tcpout
+      source: |
+        del(.source_type)
+        del(.host)
+        del(.port)
+
     ## This is a placeholder for your own remap (or other transform)
     ## steps with tags set up. Datadog recommends these tag assignments.
     ## They show which data has been moved over to OP and what still needs
@@ -94,6 +109,7 @@ pipelineConfig:
       type: remap
       inputs:
         - splunk_receiver
+        - cleanup_socket
       source: |
         .sender = "observability_pipelines_worker"
         .opw_aggregator = get_hostname!()

--- a/static/resources/yaml/observability_pipelines/splunk/azure_aks.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/azure_aks.yaml
@@ -77,8 +77,23 @@ pipelineConfig:
       address: 0.0.0.0:8088
       valid_tokens:
           - ${SPLUNK_TOKEN}
+    splunk_tcpout:
+      type: socket
+      mode: tcp
+      address: 0.0.0.0:8089
 
   transforms:
+    ## This step removes some extra metadata added by the `socket` source
+    ## that isn't needed in Splunk.
+    cleanup_socket:
+      type: remap
+      inputs:
+        - splunk_tcpout
+      source: |
+        del(.source_type)
+        del(.host)
+        del(.port)
+
     ## This is a placeholder for your own remap (or other transform)
     ## steps with tags set up. Datadog recommends these tag assignments.
     ## They show which data has been moved over to OP and what still needs
@@ -87,6 +102,7 @@ pipelineConfig:
       type: remap
       inputs:
         - splunk_receiver
+        - cleanup_socket
       source: |
         .sender = "observability_pipelines_worker"
         .opw_aggregator = get_hostname!()

--- a/static/resources/yaml/observability_pipelines/splunk/google_gke.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/google_gke.yaml
@@ -79,8 +79,23 @@ pipelineConfig:
       address: 0.0.0.0:8088
       valid_tokens:
           - ${SPLUNK_TOKEN}
+    splunk_tcpout:
+      type: socket
+      mode: tcp
+      address: 0.0.0.0:8089
 
   transforms:
+    ## This step removes some extra metadata added by the `socket` source
+    ## that isn't needed in Splunk.
+    cleanup_socket:
+      type: remap
+      inputs:
+        - splunk_tcpout
+      source: |
+        del(.source_type)
+        del(.host)
+        del(.port)
+
     ## This is a placeholder for your own remap (or other transform)
     ## steps with tags set up. Datadog recommends these tag assignments.
     ## They show which data has been moved over to OP and what still needs
@@ -89,6 +104,7 @@ pipelineConfig:
       type: remap
       inputs:
         - splunk_receiver
+        - cleanup_socket
       source: |
         .sender = "observability_pipelines_worker"
         .opw_aggregator = get_hostname!()

--- a/static/resources/yaml/observability_pipelines/splunk/pipeline.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/pipeline.yaml
@@ -6,8 +6,23 @@ sources:
     address: 0.0.0.0:8088
     valid_tokens:
         - ${SPLUNK_TOKEN}
+  splunk_tcpout:
+    type: socket
+    mode: tcp
+    address: 0.0.0.0:8089
 
 transforms:
+  ## This step removes some extra metadata added by the `socket` source
+  ## that isn't needed in Splunk.
+  cleanup_socket:
+    type: remap
+    inputs:
+      - splunk_tcpout
+    source: |
+      del(.source_type)
+      del(.host)
+      del(.port)
+
   ## This is a placeholder for your own remap (or other transform)
   ## steps with tags set up. Datadog recommends these tag assignments.
   ## They show which data has been moved over to OP and what still needs
@@ -16,6 +31,7 @@ transforms:
     type: remap
     inputs:
       - splunk_receiver
+      - cleanup_socket
     source: |
       .sender = "observability_pipelines_worker"
       .opw_aggregator = get_hostname!()


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR adds some new configuration we discovered today that allows us to directly interface with the Splunk forwarders.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
