### PR TITLE
[DOCS-6033] Add single step APM to nav menu.

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1327,6 +1327,11 @@ main:
     parent: tracing
     identifier: tracing_trace_collection
     weight: 2
+  - name: Single Step APM Instrumentation
+    url: tracing/trace_collection/single-step-apm/
+    parent: tracing_trace_collection
+    identifier: single_step_apm
+    weight: 100
   - name: Instrumenting with Datadog Tracing Libraries
     url: tracing/trace_collection/dd_libraries/
     parent: tracing_trace_collection


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add [Single Step APM Instrumentation](https://docs.datadoghq.com/tracing/trace_collection/single-step-apm) to the nav menu.

### Motivation
Request from @vidurkhannadatadog 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Put above Instrumenting with Datadog Tracing Libraries to emphasize the single-step path for users.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
