### PR TITLE
increase size of images

### DIFF
--- a/content/en/monitors/types/watchdog.md
+++ b/content/en/monitors/types/watchdog.md
@@ -52,7 +52,7 @@ After your selections are made, the graph at the top of the monitor creation pag
 {{% /tab %}}
 {{% tab "Infrastructure" %}}
 
-{{< img src="/monitors/monitor_types/watchdog/watchdog-monitor-infra.png" alt="Configuring a Watchdog Monitor on Infrastructure" style="width:55%;">}}
+{{< img src="/monitors/monitor_types/watchdog/watchdog-monitor-infra.png" alt="Configuring a Watchdog Monitor on Infrastructure" style="width:80%;">}}
 
 ### Select sources {#select-sources-2}
 
@@ -71,7 +71,7 @@ After your selections are made, the graph at the top of the monitor creation pag
 
 A logs alert indicates that either a new pattern of error logs has been detected or that there has been an increase in an existing pattern of error logs.
 
-{{< img src="/monitors/monitor_types/watchdog/log_anomaly_monitor.png" alt="The Watchdog monitor's edit page showing the alert category set to logs, alert type as log anomaly, env set to production, service set to ad-server, and the monitor's title is Anomaly Detected in Production Ad Server" style="width:80%;">}}
+{{< img src="/monitors/monitor_types/watchdog/log_anomaly_monitor.png" alt="The Watchdog monitor's edit page showing the alert category set to logs, alert type as log anomaly, env set to production, service set to ad-server, and the monitor's title is Anomaly Detected in Production Ad Server" style="width:55%;">}}
 
 ### Select sources {#select-sources-3}
 

--- a/content/en/monitors/types/watchdog.md
+++ b/content/en/monitors/types/watchdog.md
@@ -31,7 +31,7 @@ In this section, choose between an APM, Infrastructure, or Logs alert:
 
 An APM alert is created when Watchdog detects anomalous behavior on your system's services or their child resources.
 
-{{< img src="/monitors/monitor_types/watchdog/watchdog-monitor-apm.png" alt="Configuring a Watchdog Monitor on APM" style="width:55%;">}}
+{{< img src="/monitors/monitor_types/watchdog/watchdog-monitor-apm.png" alt="Configuring a Watchdog Monitor on APM" style="width:80%;">}}
 
 ### Select sources {#select-sources-1}
 
@@ -71,7 +71,7 @@ After your selections are made, the graph at the top of the monitor creation pag
 
 A logs alert indicates that either a new pattern of error logs has been detected or that there has been an increase in an existing pattern of error logs.
 
-{{< img src="/monitors/monitor_types/watchdog/log_anomaly_monitor.png" alt="The Watchdog monitor's edit page showing the alert category set to logs, alert type as log anomaly, env set to production, service set to ad-server, and the monitor's title is Anomaly Detected in Production Ad Server" style="width:55%;">}}
+{{< img src="/monitors/monitor_types/watchdog/log_anomaly_monitor.png" alt="The Watchdog monitor's edit page showing the alert category set to logs, alert type as log anomaly, env set to production, service set to ad-server, and the monitor's title is Anomaly Detected in Production Ad Server" style="width:80%;">}}
 
 ### Select sources {#select-sources-3}
 


### PR DESCRIPTION
### What does this PR do?
Increase the size of images for APM and infrastructure watchdog monitors

### Motivation
Images were fairly small for those two and did not take that much vertical space so increasing the size would improve visibility

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
