### PR TITLE
[ci-visibility] Remove duplicated `--report-tags` and `--report-metrics`

### DIFF
--- a/content/en/continuous_integration/tests/junit_upload.md
+++ b/content/en/continuous_integration/tests/junit_upload.md
@@ -201,15 +201,13 @@ This is the full list of options available when using the `datadog-ci junit uplo
 
 `--report-tags`
 : Key-value pairs in the form `key:value`. Works like the `--tags` parameter but these tags are only applied at the session level and are **not** merged with the environment variable `DD_TAGS`<br/>
-**Environment variable**: (none)<br/>
 **Default**: (none)<br/>
-**Example**: `coverage_enabled:true`<br/>
+**Example**: `test.code_coverage.enabled:true`<br/>
 
 `--report-metrics`
 : Key-value pairs in the form `key:123`. Works like the `--metrics` parameter but these tags are only applied at the session level and are **not** merged with the environment variable `DD_METRICS`<br/>
-**Environment variable**: (none)<br/>
 **Default**: (none)<br/>
-**Example**: `coverage_percentage:35`<br/>
+**Example**: `test.code_coverage.lines_pct:82`<br/>
 
 `--xpath-tag`
 : Key and xpath expression in the form `key=expression`. These provide a way to customize tags for test in the file (the `--xpath-tag` parameter can be specified multiple times).<br/>
@@ -244,17 +242,6 @@ See [Providing metadata with XPath expressions](#providing-metadata-with-xpath-e
 `--verbose`
 : Flag used to add extra verbosity to the output of the command<br/>
 **Default**: `false`<br/>
-
-`--report-tags`
-: Key-value pairs in the form of `key:value` to be attached to the session instead of to every test.<br/>
-**Default**: (none)<br/>
-**Example**: `team:backend`<br/>
-
-`--report-metrics`
-: Key-value numerical pairs in the form of `key:number` to be attached to the session instead of to every test.<br/>
-**Default**: (none)<br/>
-**Example**: `test.code_coverage.lines_pct:82`<br/>
-
 
 
 Positional arguments


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
