### PR TITLE
Recommend Go 1.21 or newer for profiling timeline beta

### DIFF
--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -77,7 +77,7 @@ Setting these variables will record up to 1 minute (or 5 MiB) of execution traci
 
 While recording execution traces, your application may observe an increase in CPU usage similar to a garbage collection. Although this should not have a significant impact for most applications, Go 1.21 includes [patches][3] to eliminate this overhead.
 
-This capability requires `dd-trace-go` version 1.37.0+ (1.52.0+ for timeline beta) and works best with Go version 1.18 or newer (1.21 or newer for timeline beta).
+This capability requires `dd-trace-go` version 1.37.0+ (1.52.0+ for timeline beta) and works best with Go version 1.18 or later (1.21 or later for timeline beta).
 
 [1]: /profiler/enabling/go
 [2]: https://github.com/DataDog/dd-trace-go/issues/2099

--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -75,9 +75,9 @@ os.Setenv("DD_PROFILING_EXECUTION_TRACE_PERIOD", "15m")
 
 Setting these variables will record up to 1 minute (or 5 MiB) of execution tracing data [every 15 minutes][2].
 
-While recording execution traces, your application may observe an increase in CPU usage similar to a garbage collection. Although this should not have a significant impact for most applications, the upcoming go1.21 release includes [patches][3] to eliminate this overhead.
+While recording execution traces, your application may observe an increase in CPU usage similar to a garbage collection. Although this should not have a significant impact for most applications, Go 1.21 includes [patches][3] to eliminate this overhead.
 
-This capability requires `dd-trace-go` version 1.37.0+ (1.52.0+ for timeline beta) and works best with Go version 1.18 or newer.
+This capability requires `dd-trace-go` version 1.37.0+ (1.52.0+ for timeline beta) and works best with Go version 1.18 or newer (1.21 or newer for timeline beta).
 
 [1]: /profiler/enabling/go
 [2]: https://github.com/DataDog/dd-trace-go/issues/2099


### PR DESCRIPTION
### What does this PR do?

Recommends Go 1.21 or newer for using the Go profiling timeline feature.

### Motivation

Go 1.21 has been [released](https://go.dev/blog/go1.21). This Go release includes changes which
significantly reduce thea overhead of data collection for the Go
profiling timeline feature. So, we should recommend that version of Go
(or newer) to users who are interested in the feature.

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
