### PR TITLE
Remove Outputpath from Step Functions documentation

### DIFF
--- a/content/en/serverless/step_functions/installation.md
+++ b/content/en/serverless/step_functions/installation.md
@@ -150,6 +150,7 @@ Alternatively, if you have business logic defined in the payload, you could also
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "Payload": {
+          ...
           "Execution.$": "$$.Execution",
           "State.$": "$$.State",
           "StateMachine.$": "$$.StateMachine"

--- a/content/en/serverless/step_functions/installation.md
+++ b/content/en/serverless/step_functions/installation.md
@@ -117,11 +117,10 @@ For developers using [Serverless Framework][4] to deploy serverless applications
 
 4. Enable tracing on your Step Function by adding a `DD_TRACE_ENABLED` tag. Set the value to `true`.
 5. Set up tags. Open your AWS console and go to your Step Functions state machine. Open the *Tags* section and add `env:<ENV_NAME>` and `service:<SERVICE_NAME>` tags. The `env` tag is required to see traces in Datadog, and it defaults to `dev`. The `service` tag defaults to the state machine's name.
-6. For Node.js and Python runtimes, you can link your Step Function traces to Lambda traces. On the Lambda Task, `Parameters` keys with the following: 
+6. For Node.js and Python runtimes, you can link your Step Function traces to Lambda traces. On the Lambda Task, Set `Parameters` key with the following: 
 
    ```json
    "Parameters": {
-     ...
      "Payload.$": "States.JsonMerge($$, $, false)",
      ...
    }

--- a/content/en/serverless/step_functions/installation.md
+++ b/content/en/serverless/step_functions/installation.md
@@ -117,7 +117,7 @@ For developers using [Serverless Framework][4] to deploy serverless applications
 
 4. Enable tracing on your Step Function by adding a `DD_TRACE_ENABLED` tag. Set the value to `true`.
 5. Set up tags. Open your AWS console and go to your Step Functions state machine. Open the *Tags* section and add `env:<ENV_NAME>` and `service:<SERVICE_NAME>` tags. The `env` tag is required to see traces in Datadog, and it defaults to `dev`. The `service` tag defaults to the state machine's name.
-6. For Node.js and Python runtimes, you can link your Step Function traces to Lambda traces. On the Lambda Task, Set `Parameters` key with the following: 
+6. For Node.js and Python runtimes, you can link your Step Function traces to Lambda traces. On the Lambda Task, set the `Parameters` key with the following: 
 
    ```json
    "Parameters": {

--- a/content/en/serverless/step_functions/installation.md
+++ b/content/en/serverless/step_functions/installation.md
@@ -117,13 +117,13 @@ For developers using [Serverless Framework][4] to deploy serverless applications
 
 4. Enable tracing on your Step Function by adding a `DD_TRACE_ENABLED` tag. Set the value to `true`.
 5. Set up tags. Open your AWS console and go to your Step Functions state machine. Open the *Tags* section and add `env:<ENV_NAME>` and `service:<SERVICE_NAME>` tags. The `env` tag is required to see traces in Datadog, and it defaults to `dev`. The `service` tag defaults to the state machine's name.
-6. For Node.js and Python runtimes, you can link your Step Function traces to Lambda traces. On the Lambda Task, set the `OutputPath` and `Parameters` keys with the following: 
+6. For Node.js and Python runtimes, you can link your Step Function traces to Lambda traces. On the Lambda Task, `Parameters` keys with the following: 
 
    ```json
-   "OutputPath": "$.Payload",
    "Parameters": {
+     ...
      "Payload.$": "States.JsonMerge($$, $, false)",
-     "FunctionName": "${lambdaArn}"
+     ...
    }
    ```
 
@@ -135,7 +135,6 @@ For developers using [Serverless Framework][4] to deploy serverless applications
 "Lambda Read From DynamoDB": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
-      "OutputPath": "$.Payload",
       "Parameters": {
         "Payload.$": "States.JsonMerge($$, $, false)",
         "FunctionName": "${lambdaArn}"
@@ -150,10 +149,8 @@ Alternatively, if you have business logic defined in the payload, you could also
 "Lambda Read From DynamoDB": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
-      "OutputPath": "$.Payload",
       "Parameters": {
         "Payload": {
-          ...
           "Execution.$": "$$.Execution",
           "State.$": "$$.State",
           "StateMachine.$": "$$.StateMachine"


### PR DESCRIPTION
Setting `OutputPath` field is not a requirement. It was originally added because demo org has some specific purpose which I believe is not for everyone. 