### PR TITLE
Add terraform tab to Lambda layer installation

### DIFF
--- a/content/en/serverless/installation/dotnet.md
+++ b/content/en/serverless/installation/dotnet.md
@@ -143,6 +143,85 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 [2]: https://github.com/DataDog/dd-trace-dotnet/releases
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
+{{% tab "Terraform" %}}
+1. Add the correct Lambda Layer to your `aws_lambda_function` [Terraform resource][1] `layers` argument
+
+Replace <AWS_REGION> with a valid AWS region such as us-east-1. The available RUNTIME options are Node12-x, Node14-x, Node16-x and Node18-x.
+
+{{% tab "AWS Commercial Region with x86-based Lambda" %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-dotnet:{{< latest-lambda-layer-version layer="dd-trace-dotnet" >}}`
+{{% /tab %}}
+
+{{% tab "AWS Commercial Region with arm64-based Lambda " %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-dotnet-ARM:{{< latest-lambda-layer-version layer="dd-trace-dotnet" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions with x86-based Lambda" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:dd-trace-dotnet:{{< latest-lambda-layer-version layer="dd-trace-dotnet" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions with arm64-based Lambda" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:dd-trace-dotnet-ARM:{{< latest-lambda-layer-version layer="dd-trace-dotnet" >}}`
+{{% /tab %}}
+
+2. Add the correct Lambda Extension to the `layers` argument
+
+Replace <AWS_REGION> with a valid AWS region such as us-east-1. 
+
+{{% tab "AWS Commercial Region with x86-based Lambda" %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS Commercial Region with arm64-based Lambda " %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension-ARM:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions with x86-based Lambda" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions with arm64-based Lambda" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-Extension-ARM:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+3. Set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/datadog_wrapper`.
+
+
+#### Full example
+
+```sh
+resource "aws_lambda_function" "lambda" {
+  "function_name" = ...
+  …
+
+  # Remember sure to choose the right layers based on your Lambda architecture and AWS regions
+
+  layers = [
+    "arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-dotnet:{{< latest-lambda-layer-version layer="dd-trace-dotnet" >}}",
+    "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:45"
+  ]
+
+  handler = "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler"
+
+  environment {
+    variables = {
+      DD_SITE                     = <DATADOG SITE>
+      DD_API_KEY_SECRET_ARN       = <API KEY>
+      AWS_LAMBDA_EXEC_WRAPPER     = "/opt/datadog_wrapper"
+    }
+  }
+}
+```
+
+To fill in the environment variables,
+- Set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/datadog_wrapper`
+- Replace <DATADOG_SITE> with datadoghq.com (ensure the correct SITE is selected on the right).
+- Replace <DATADOG_API_KEY_SECRET_ARN> with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob).The secretsmanager:GetSecretValue permission is required. For quick testing, you can use apiKey instead and set the Datadog API key in plaintext.
+- Set the environment variable DD_LAMBDA_HANDLER to your original handler, for example, myfunc.handler.
+
+[1]https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function.html#lambda-layers
+{{% /tab %}}
+
 {{% tab "Custom" %}}
 
 1. Install the Datadog Tracer

--- a/content/en/serverless/installation/java.md
+++ b/content/en/serverless/installation/java.md
@@ -217,6 +217,75 @@ The [Datadog CDK construct][1] automatically installs Datadog on your functions 
 [1]: https://gallery.ecr.aws/datadog/lambda-extension
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
+{{% tab "Terraform" %}}
+1. Add the correct Lambda Layer to your `aws_lambda_function` [Terraform resource][1] `layers` argument
+
+Replace <AWS_REGION> with a valid AWS region such as us-east-1.
+
+{{% tab "AWS Commercial Regions" %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-java:{{< latest-lambda-layer-version layer="dd-trace-java" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:dd-trace-java:{{< latest-lambda-layer-version layer="dd-trace-java" >}}`
+{{% /tab %}}
+
+2. Add the correct Lambda Extension to the `layers` argument
+
+Replace <AWS_REGION> with a valid AWS region such as us-east-1. 
+
+{{% tab "AWS Commercial Region with x86-based Lambda" %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS Commercial Region with arm64-based Lambda " %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension-ARM:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions with x86-based Lambda" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions with arm64-based Lambda" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-Extension-ARM:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+3. Set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/datadog_wrapper`.
+
+
+#### Full example
+
+```sh
+resource "aws_lambda_function" "lambda" {
+  "function_name" = ...
+  …
+
+  # Remember sure to choose the right layers based on your Lambda architecture and AWS regions
+
+  layers = [
+    "arn:aws:lambda:<AWS_REGION>:464622532012:layer:dd-trace-java:{{< latest-lambda-layer-version layer="dd-trace-java" >}}",
+    "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:45"
+  ]
+
+  handler = "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler"
+
+  environment {
+    variables = {
+      DD_SITE                     = <DATADOG SITE>
+      DD_API_KEY_SECRET_ARN       = <API KEY>
+      DD_LAMBDA_EXEC_WRAPPER      = "`/opt/datadog_wrapper"
+    }
+  }
+}
+```
+
+To fill in the environment variables,
+- Replace <DATADOG_SITE> with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
+- Replace <DATADOG_API_KEY_SECRET_ARN> with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob).The secretsmanager:GetSecretValue permission is required. For quick testing, you can use apiKey instead and set the Datadog API key in plaintext.
+- Set the environment variable DD_LAMBDA_HANDLER to your original handler, for example, myfunc.handler.
+
+[1]https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function.html#lambda-layers
+{{% /tab %}}
 {{% tab "Custom" %}}
 
 1. Install the Datadog Tracer

--- a/content/en/serverless/installation/nodejs.md
+++ b/content/en/serverless/installation/nodejs.md
@@ -255,6 +255,73 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 [2]: https://docs.datadoghq.com/serverless/guide/handler_wrapper
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
+{{% tab "Terraform" %}}
+1. Add the correct Lambda Layer to your `aws_lambda_function` [Terraform resource][1] `layers` argument
+
+Replace <AWS_REGION> with a valid AWS region such as us-east-1. The available RUNTIME options are Node12-x, Node14-x, Node16-x and Node18-x.
+
+{{% tab "AWS Commercial Regions" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:96`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:96`
+{{% /tab %}}
+
+2. Add the correct Lambda Extension to the `layers` argument
+
+{{% tab "AWS Commercial Region with x86-based Lambda" %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS Commercial Region with arm64-based Lambda " %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension-ARM:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions with x86-based Lambda" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions with arm64-based Lambda" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-Extension-ARM:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+3. Set your Lambda `handler` argument to `/opt/nodejs/node_modules/datadog-lambda-js/handler.handle` 
+
+
+#### Full example
+
+```sh
+resource "aws_lambda_function" "lambda" {
+  "function_name" = ...
+  …
+
+  # Remember sure to choose the right layers based on your Lambda architecture and AWS regions
+
+  layers = [
+    "arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:96",
+    "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:45"
+  ]
+
+  handler = "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler"
+
+  environment {
+    variables = {
+      DD_SITE                     = <DATADOG SITE>
+      DD_API_KEY_SECRET_ARN       = <API KEY>
+      DD_LAMBDA_HANDLER           = <LAMBDA HANDLER>
+    }
+  }
+}
+```
+
+To fill in the environment variables,
+- Replace <DATADOG_SITE> with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
+- Replace <DATADOG_API_KEY_SECRET_ARN> with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob).The secretsmanager:GetSecretValue permission is required. For quick testing, you can use apiKey instead and set the Datadog API key in plaintext.
+- Set the environment variable DD_LAMBDA_HANDLER to your original handler, for example, myfunc.handler.
+
+[1]https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function.html#lambda-layers
+{{% /tab %}}
 {{% tab "Custom" %}}
 
 <div class="alert alert-info">If you are not using a serverless development tool that Datadog supports, such as the Serverless Framework or AWS CDK, Datadog strongly encourages you instrument your serverless applications with the <a href="./?tab=datadogcli">Datadog CLI</a>.</div>

--- a/content/en/serverless/installation/python.md
+++ b/content/en/serverless/installation/python.md
@@ -246,6 +246,84 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 [2]: https://docs.datadoghq.com/serverless/guide/handler_wrapper
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
+{{% tab "Terraform" %}}
+1. Add the correct Lambda Layer to your `aws_lambda_function` [Terraform resource][1] `layers` argument
+
+Replace `<AWS_REGION>` with a valid AWS region, such as `us-east-1`. The available `RUNTIME` options are `Python37`, `Python38` and `Python39`.
+
+
+{{% tab "AWS Commercial Region with x86-based Lambda" %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="python" >}}`
+{{% /tab %}}
+
+{{% tab "AWS Commercial Region with arm64-based Lambda " %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>-ARM:{{< latest-lambda-layer-version layer="python" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions with x86-based Lambda" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="python" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions with arm64-based Lambda" %}}
+` arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>-ARM:{{< latest-lambda-layer-version layer="python" >}}`
+{{% /tab %}}
+
+2. Add the correct Lambda Extension to the `layers` argument
+
+Replace <AWS_REGION> with a valid AWS region such as us-east-1. 
+
+{{% tab "AWS Commercial Region with x86-based Lambda" %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS Commercial Region with arm64-based Lambda " %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension-ARM:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions with x86-based Lambda" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions with arm64-based Lambda" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-Extension-ARM:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+3. Set your Lambda `handler` argument to `datadog_lambda.handler.handler`. 
+
+
+#### Full example
+
+```sh
+resource "aws_lambda_function" "lambda" {
+  "function_name" = ...
+  …
+
+  # Remember sure to choose the right layers based on your Lambda architecture and AWS regions
+
+  layers = [
+    "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="python" >}}",
+    "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:45"
+  ]
+
+  handler = "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler"
+
+  environment {
+    variables = {
+      DD_SITE                     = <DATADOG SITE>
+      DD_API_KEY_SECRET_ARN       = <API KEY>
+      DD_LAMBDA_HANDLER           = <LAMBDA HANDLER>
+    }
+  }
+}
+```
+
+To fill in the environment variables,
+- Replace <DATADOG_SITE> with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
+- Replace <DATADOG_API_KEY_SECRET_ARN> with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob).The secretsmanager:GetSecretValue permission is required. For quick testing, you can use apiKey instead and set the Datadog API key in plaintext.
+- Set the environment variable DD_LAMBDA_HANDLER to your original handler, for example, `myfunc.handler`.
+`
+[1]https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function.html#lambda-layers
+{{% /tab %}}
 {{% tab "Custom" %}}
 
 <div class="alert alert-info">If you are not using a serverless development tool that Datadog supports, such as the Serverless Framework or AWS CDK, Datadog strongly encourages you instrument your serverless applications with the <a href="./?tab=datadogcli">Datadog CLI</a>.</div>

--- a/content/en/serverless/installation/ruby.md
+++ b/content/en/serverless/installation/ruby.md
@@ -220,6 +220,90 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 [1]: https://gallery.ecr.aws/datadog/lambda-extension
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
+{{% tab "Terraform" %}}
+1. Add the correct Lambda Layer to your `aws_lambda_function` [Terraform resource][1] `layers` argument
+
+Replace <AWS_REGION> with a valid AWS region such as us-east-1. The available RUNTIME options are Ruby2-7, and Ruby3-2.
+
+{{% tab "AWS Commercial Regions" %}}
+`arn:aws:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:96`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:96`
+{{% /tab %}}
+
+2. Add the correct Lambda Extension to the `layers` argument
+
+Replace <AWS_REGION> with a valid AWS region such as us-east-1. 
+
+{{% tab "AWS Commercial Region with x86-based Lambda" %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS Commercial Region with arm64-based Lambda " %}}
+`arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension-ARM:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions with x86-based Lambda" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+{{% tab "AWS GovCloud Regions with arm64-based Lambda" %}}
+`arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-Extension-ARM:{{< latest-lambda-layer-version layer="extension" >}}`
+{{% /tab %}}
+
+3. Configure your Lambda functions
+
+    Enable Datadog APM and wrap your Lambda handler function using the wrapper provided by the Datadog Lambda library.
+
+    ```ruby
+    require 'datadog/lambda'
+
+    Datadog::Lambda.configure_apm do |c|
+    # Enable the instrumentation
+    end
+
+    def handler(event:, context:)
+        Datadog::Lambda.wrap(event, context) do
+            return { statusCode: 200, body: 'Hello World' }
+        end
+    end
+
+
+#### Full example
+
+```sh
+resource "aws_lambda_function" "lambda" {
+  "function_name" = ...
+  …
+
+  # Remember sure to choose the right layers based on your Lambda architecture and AWS regions
+
+  layers = [
+    "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:96",
+    "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:45"
+  ]
+
+  handler = "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler"
+
+  environment {
+    variables = {
+      DD_SITE                     = <DATADOG SITE>
+      DD_API_KEY_SECRET_ARN       = <API KEY>
+      DD_LAMBDA_HANDLER           = <LAMBDA HANDLER>
+    }
+  }
+}
+```
+
+To fill in the environment variables,
+- Replace <DATADOG_SITE> with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
+- Replace <DATADOG_API_KEY_SECRET_ARN> with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob).The secretsmanager:GetSecretValue permission is required. For quick testing, you can use apiKey instead and set the Datadog API key in plaintext.
+- Set the environment variable DD_LAMBDA_HANDLER to your original handler, for example, myfunc.handler.
+
+[1]https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function.html#lambda-layers
+{{% /tab %}}
 {{% tab "Custom" %}}
 
 <div class="alert alert-info">If you are not using a serverless development tool that Datadog supports, such as the Serverless Framework, Datadog strongly encourages you instrument your serverless applications with the <a href="./?tab=datadogcli">Datadog CLI</a>.</div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds a new option for Terraform in .NET, Java, Node, Python, and Ruby
This is very similar to the 'Custom' tab but is slightly more guided and provides a sample configuration

### Motivation
More interest from customers trying to instrument Lambda with Terraform and having to learn it by themselves

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
