### PR TITLE
Correct Service Catalog `service.datadog.yaml` information

### DIFF
--- a/content/en/tracing/service_catalog/setup.md
+++ b/content/en/tracing/service_catalog/setup.md
@@ -46,7 +46,7 @@ To install the GitHub integration, navigate to the [integration tile][7] and cli
 
 ### Service definition YAML files
 
-Datadog scans for the `service.datadog.yaml` file at the root of each repository with read permissions. You can register multiple services in one YAML file by creating multiple YAML documents. Separate each document with three dashes (`---`).
+Datadog scans for `service.datadog.yaml` files anywhere within each repository with read permissions. You can register multiple services by creating multiple `service.datadog.yaml` files or in one YAML file by creating multiple YAML documents. Separate each document with three dashes (`---`).
 
 ### Modify service definition
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Corrects information in regards to supported `service.datadog.yaml` file locations for the Service Catalog GitHub integration.

### Motivation
<!-- What inspired you to submit this pull request?-->
I found out through experimentation that the documentation was inaccurate. It would have saved me time to have the corrected information, hoping others can benefit from the corrections.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
