### PR TITLE
add details on recovery window values

### DIFF
--- a/content/en/monitors/types/anomaly.md
+++ b/content/en/monitors/types/anomaly.md
@@ -56,7 +56,18 @@ Trigger window
 : How much time is required for the metric to be anomalous before the alert triggers. **Note**: If the alert window is too short, you might get false alarms due to spurious noise.
 
 Recovery window
-: How much time is required for the metric to not be considered anomalous so the alert recovers.
+: How much time is required for the metric to not be considered anomalous so the alert recovers. It is recommended to set it to the same as the `trigger window`. 
+
+**Note**: The range of accepted value for the `Recovery Window` depends on the `Trigger Window` and the `Alert Threshold` to make sure the monitor can't both satisfy the recovery and alert condition at the same time.
+Example:
+* `Threshold`: 50%
+* `Trigger window`: 4h
+The range of accepted values for recovery window is between 121 minutes (`4h*(1-0.5) +1 min = 121 minutes`) and 4h. Indeed setting a recovery window below 121 minutes could lead to a 4h timeframe with both 50% of anomalous point and the last 120 minutes with no anomalous points.
+
+Another example:
+* `Threshold`: 80%
+* `Trigger window`: 4h
+The range of accepted values for recovery window is between 121 minutes (`4h*(1-0.8) +1 min = 49 minutes`) and 4h.
 
 ### Advanced options
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add details about the recovery window and it's allowed range of values.

### Motivation
A validation existing in the UI that is being added in the API as well and it needed to be documented for users to understand why specific values were not accepted

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
