### PR TITLE
CSM Misconfigurations: Add resource evaluation frequency

### DIFF
--- a/content/en/security/misconfigurations/_index.md
+++ b/content/en/security/misconfigurations/_index.md
@@ -23,6 +23,8 @@ Strengthen your security posture and achieve continuous compliance by detecting,
 
 View a high-level overview of your security posture on the [Overview page][1]. Examine the details of findings and analyze historical configurations with the [Misconfigurations Explorer][2].
 
+CSM Misconfigurations evaluates resources in increments between 15 minutes and 4 hours (depending on type). Datadog generates new findings as soon as a scan is completed, and stores a complete history of all findings for the past 15 months so they are available in case of an investigation or audit.
+
 {{< img src="security/csm/csm_overview.png" alt="The Security Inbox on the Cloud Security Management overview shows a list of prioritized security issues to remediate" width="100%">}}
 
 ## Maintain compliance with industry frameworks and benchmarks


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds resource evaluation frequency to CSM Misconfigurations overview page.

### Motivation
<!-- What inspired you to submit this pull request?-->
Request by PM.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Ready to merge.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
