### PR TITLE
[DOCS-5551] Update connect logs and traces for PHP monolog

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -163,7 +163,7 @@ If your application uses JSON logs format, you can add a first-level key `dd` th
 ?>
 ```
 
-For monolog v3:
+For monolog v3, add the following configuration:
 
 ```php
 <?php
@@ -178,6 +178,8 @@ For monolog v3:
 ?>
 ```
 
+If you are ingesting your logs as JSON, go to [Preprocessing for JSON logs][8] and add `extra.dd.trace_id` to the **Trace Id Attributes** field.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -189,3 +191,4 @@ For monolog v3:
 [5]: https://github.com/laminas/laminas-log
 [6]: /getting_started/tagging/unified_service_tagging
 [7]: /logs/log_configuration/pipelines
+[8]: https://app.datadoghq.com/logs/pipelines/remapping

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -116,7 +116,7 @@ For instance, you would append those two attributes to your logs with:
 ?>
 ```
 
-If the logger implements the [**monolog/monolog** library][4], use `Logger::pushProcessor()` to automatically append the identifiers to all log messages. For monolog v1:
+If the logger implements the [**monolog/monolog** library][4], use `Logger::pushProcessor()` to automatically append the identifiers to all log messages. For monolog v1, add the following configuration:
 
 ```php
 <?php
@@ -132,7 +132,7 @@ If the logger implements the [**monolog/monolog** library][4], use `Logger::push
 ?>
 ```
 
-For monolog v2:
+For monolog v2, add the following configuration:
 
 ```php
 <?php

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -147,22 +147,7 @@ For monolog v2:
   ?>
 ```
 
-For monolog v3:
-
-```php
-<?php
-  $logger->pushProcessor(function ($record) {
-        $context = \DDTrace\current_context();
-        $record->extra['dd'] = [
-            'trace_id' => $context['trace_id'],
-            'span_id'  => $context['span_id'],
-        ];
-        return $record;
-    });
-?>
-```
-
-If your application uses json logs format instead of appending trace_id and span_id to the log message you can add first-level key "dd" containing these ids:
+If your application uses JSON logs format, you can add a first-level key `dd` that contains the `trace_id` and `span_id`, instead of appending `trace_id` and `span_id` to the log message:
 
 ```php
 <?php
@@ -175,6 +160,21 @@ If your application uses json logs format instead of appending trace_id and span
 
       return $record;
   });
+?>
+```
+
+For monolog v3:
+
+```php
+<?php
+  $logger->pushProcessor(function ($record) {
+        $context = \DDTrace\current_context();
+        $record->extra['dd'] = [
+            'trace_id' => $context['trace_id'],
+            'span_id'  => $context['span_id'],
+        ];
+        return $record;
+    });
 ?>
 ```
 


### PR DESCRIPTION
### What does this PR do?

Moves the information about adding the first-level `dd` key to monolog 2 section because it doesn't work for monolog 3. Also adds info on adding `extra.dd.trace_id`.

### Motivation

User opened an [issue](https://github.com/DataDog/documentation/issues/18272).

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
