### PR TITLE
[STAT-492] Add static-analysis.datadog.yml documentation

### DIFF
--- a/content/en/continuous_integration/static_analysis/_index.md
+++ b/content/en/continuous_integration/static_analysis/_index.md
@@ -45,12 +45,6 @@ Using Static Analysis provides organizations with the following benefits:
 
 To use Datadog Static Analysis, add a `static-analysis.datadog.yml` file to your repository's root directory to specify which rulesets to use.
 
-```yaml
-rulesets:
-  - <ruleset-name>
-  - <ruleset-name>
-```
-
 For example, for Python rules:
 
 ```yaml
@@ -59,6 +53,14 @@ rulesets:
   - python-best-practices
   - python-inclusive
 ```
+
+A `static-analysis.datadog.yml` file supports the following:
+
+| Name               | Description                                                                               | Required | Default |
+|--------------------|-------------------------------------------------------------------------------------------|----------|---------|
+| `rulesets`         | A list of ruleset names. [View all available rulesets][6].                                | `true`   |         |
+| `ignore-paths`     | A list of relative paths to ignore. It supports using globbing patterns.                  | `false`  |         |
+| `ignore-gitignore` | Controls if the Datadog Static Analysis will analyze the content in a `.gitignore` file.  | `false`  | `true`  |
 
 Configure your [Datadog API and application keys][4] and run Static Analysis in the respective CI provider.
 
@@ -199,4 +201,5 @@ The content of the violation is shown in tabs:
 [3]: /integrations/github/
 [4]: /account_management/api-app-keys/
 [5]: https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=sarif
+[6]: /rules
 [103]: /getting_started/site/

--- a/content/en/continuous_integration/static_analysis/_index.md
+++ b/content/en/continuous_integration/static_analysis/_index.md
@@ -60,7 +60,7 @@ A `static-analysis.datadog.yml` file supports the following:
 |--------------------|-------------------------------------------------------------------------------------------|----------|---------|
 | `rulesets`         | A list of ruleset names. [View all available rulesets][6].                                | `true`   |         |
 | `ignore-paths`     | A list of relative paths to ignore. It supports using globbing patterns.                  | `false`  |         |
-| `ignore-gitignore` | Controls if the Datadog Static Analysis will analyze the content in a `.gitignore` file.  | `false`  | `true`  |
+| `ignore-gitignore` | Determines whether Datadog Static Analysis will analyze the content in a `.gitignore` file.  | `false`  | `true`  |
 
 Configure your [Datadog API and application keys][4] and run Static Analysis in the respective CI provider.
 

--- a/content/en/continuous_integration/static_analysis/_index.md
+++ b/content/en/continuous_integration/static_analysis/_index.md
@@ -201,5 +201,5 @@ The content of the violation is shown in tabs:
 [3]: /integrations/github/
 [4]: /account_management/api-app-keys/
 [5]: https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=sarif
-[6]: /rules
+[6]: /continuous_integration/static_analysis/rules
 [103]: /getting_started/site/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Adds a section detailing with fields that the `static-analysis.datadog.yml` file supports.

### Motivation
<!-- What inspired you to submit this pull request?-->
We've added support for two new fields, `ignore-paths` and `ignore-gitignore`, that are not documented anywhere.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
