### PR TITLE
Add custom redirects for integrations

### DIFF
--- a/config/_default/integration_redirects.yaml
+++ b/config/_default/integration_redirects.yaml
@@ -1,2 +1,1 @@
-akamai_datastream_2:
-  aliases: ['/integrations/akamai_datastream']
+akamai_datastream_2: ['/integrations/akamai_datastream']

--- a/config/_default/integration_redirects.yaml
+++ b/config/_default/integration_redirects.yaml
@@ -1,0 +1,2 @@
+akamai_datastream_2:
+  aliases: ['integrations/akamai_datastream']

--- a/config/_default/integration_redirects.yaml
+++ b/config/_default/integration_redirects.yaml
@@ -1,2 +1,2 @@
 akamai_datastream_2:
-  aliases: ['integrations/akamai_datastream']
+  aliases: ['/integrations/akamai_datastream']

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -386,7 +386,6 @@ class Integrations:
         set is_public to false to hide integrations we merge later
         :param file_name: path to a manifest json file
         """
-        
         names = [
             d.get("name", "").lower()
             for d in self.datafile_json

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -899,8 +899,8 @@ class Integrations:
                 # Add custom aliases
                 for redirect, aliases in CUSTOM_REDIRECTS.items():
                     if redirect == item.get('name'):
-                        for alias in aliases['aliases']:
-                            item.setdefault('aliases', []).append(alias)         
+                        for alias in aliases:
+                            item.setdefault('aliases', []).append(alias)
                 # remove aliases that point to the page they're located on
                 # get the current slug from the doc_link
                 if item.get('name'):

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -901,11 +901,7 @@ class Integrations:
                 for redirect, aliases in CUSTOM_REDIRECTS.items():
                     if redirect == item.get('name'):
                         for alias in aliases['aliases']:
-                            item.setdefault('aliases', []).append(alias)
-                #        if item.get('aliases'): 
-                #            item["aliases"] += aliases["aliases"]
-                #        else:
-                #            item["aliases"] = aliases["aliases"]         
+                            item.setdefault('aliases', []).append(alias)         
                 # remove aliases that point to the page they're located on
                 # get the current slug from the doc_link
                 if item.get('name'):

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import sys
 from collections import defaultdict
+from pathlib import Path
 
 import yaml
 import markdown2
@@ -45,6 +46,8 @@ finally:
             for tag in get_non_deprecated_classifiers():
                 file_content.append(f'| {tag["name"]} | {tag["description"]} |\n')
             file.write(''.join(file_content) + '\n')
+
+CUSTOM_REDIRECTS = yaml.safe_load(Path('config/_default/integration_redirects.yaml').read_text())
 
 class Integrations:
     def __init__(self, source_file, temp_directory, integration_mutations):
@@ -383,7 +386,7 @@ class Integrations:
         set is_public to false to hide integrations we merge later
         :param file_name: path to a manifest json file
         """
-
+        
         names = [
             d.get("name", "").lower()
             for d in self.datafile_json
@@ -894,6 +897,15 @@ class Integrations:
                 item["draft"] = not item.get("is_public", False)
                 item["integration_id"] = item.get("integration_id", integration_id)
                 item["integration_version"] = item.get("integration_version", integration_version)
+                # Add custom aliases
+                for redirect, aliases in CUSTOM_REDIRECTS.items():
+                    if redirect == item.get('name'):
+                        for alias in aliases['aliases']:
+                            item.setdefault('aliases', []).append(alias)
+                #        if item.get('aliases'): 
+                #            item["aliases"] += aliases["aliases"]
+                #        else:
+                #            item["aliases"] = aliases["aliases"]         
                 # remove aliases that point to the page they're located on
                 # get the current slug from the doc_link
                 if item.get('name'):

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: true
+    cache_enabled: false
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: false
+    cache_enabled: true
 
 - data:
     - org_name: jenkinsci


### PR DESCRIPTION
Adds a redirect config for adding custom redirects to integrations. Currently, it's not easy to add redirects when an integration is deleted or renamed.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
