### PR TITLE
Fix broken link in CSM Vulnerabilities docs

### DIFF
--- a/content/en/security/infrastructure_vulnerabilities/setup.md
+++ b/content/en/security/infrastructure_vulnerabilities/setup.md
@@ -2,7 +2,7 @@
 title: Setting up Cloud Security Management Vulnerabilities
 kind: documentation
 further_reading:
-- link: "/security/infrastructure_vulnerability/"
+- link: "/security/infrastructure_vulnerabilities/"
   tag: "Documentation"
   text: "CSM Vulnerabilities"
 aliases:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fix broken link in Further Reading section.

### Motivation
<!-- What inspired you to submit this pull request?-->


<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
