### PR TITLE
(maint) Escape special characters in orphan script

### DIFF
--- a/local/bin/py/translations/orphaned_translations.py
+++ b/local/bin/py/translations/orphaned_translations.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import re
 
 
 def get_orphaned_translated_files_by_language(language_code):
@@ -35,6 +36,7 @@ def get_translation_languages():
 
 
 def is_git_ignored(file):
+    file = re.escape(file)
     is_ignored = os.popen(f'git check-ignore {file}').read()
     return len(is_ignored) > 0
 


### PR DESCRIPTION
Escapes special characters in file names for the orphaned file finding script

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
