### PR TITLE
Revert "TLS DEPRECATION: Use cloudfront instead of raw s3 uri in documentation (#19264)"

### DIFF
--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -42,13 +42,13 @@ If installing the Datadog Agent on a domain environment, see the [installation r
 
 1. Download the [Datadog Agent installer][1] to install the latest version of the Agent.
 
-   <div class="alert alert-info">If you need to install a specific version of the Agent, see the <a href="https://windows-agent.datadoghq.com/installers.json">installer list</a>.</div>
+   <div class="alert alert-info">If you need to install a specific version of the Agent, see the <a href="https://s3.amazonaws.com/ddagent-windows-stable/installers.json">installer list</a>.</div>
 
 2. Run the installer (as **Administrator**) by opening `datadog-agent-7-latest.amd64.msi`.
 3. Follow the prompts, accept the license agreement, and enter your [Datadog API key][2].
 4. When the install finishes, you are given the option to launch the Datadog Agent Manager.
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 
 {{% /tab %}}
@@ -105,7 +105,7 @@ Each configuration item is added as a property to the command line. The followin
 
 **Note**: If a valid `datadog.yaml` is found and has an API key configured, that file takes precedence over all specified command line options.
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
 [2]: /agent/proxy/
 [3]: /agent/faq/windows-agent-ddagent-user/
 [4]: /network_monitoring/performance
@@ -117,7 +117,7 @@ Agent 7 only supports Python 3. Before upgrading, confirm that your custom check
 If you're upgrading from a Datadog Agent version < 5.12.0, first upgrade to a more recent version of Agent 5 (>= 5.12.0 but < 6.0.0) using the [EXE installer][2] and then upgrade to Datadog Agent version >= 6.
 
 [1]: /agent/guide/python-3/
-[2]: https://windows-agent.datadoghq.com/ddagent-cli-latest.exe
+[2]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.exe
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/agent/faq/agent-downgrade-major.md
+++ b/content/en/agent/faq/agent-downgrade-major.md
@@ -15,7 +15,7 @@ First, [uninstall Agent v7 from your system][1].
 Then, if you followed the instructions to [upgrade from v6 to v7][2], run the following Agent installation command in order to downgrade your Agent from version 7 to version 6:
 
 ```shell
-DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent6.sh)"
+DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh)"
 ```
 
 The command works on all supported versions of Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu, and SUSE.
@@ -34,9 +34,9 @@ The command works on all supported versions of Amazon Linux, CentOS, Debian, Fed
 **Note**: Links to all available versions of the Windows Installer are [provided in JSON format][4].
 
 [1]: /agent/guide/how-do-i-uninstall-the-agent/
-[2]: https://windows-agent.datadoghq.com/datadog-agent-6-latest.amd64.msi
+[2]: https://ddagent-windows-stable.s3.amazonaws.com/datadog-agent-6-latest.amd64.msi
 [3]: https://app.datadoghq.com/organization-settings/api-keys
-[4]: https://windows-agent.datadoghq.com/installers.json
+[4]: https://s3.amazonaws.com/ddagent-windows-stable/installers.json
 {{% /tab %}}
 {{% tab "MacOS" %}}
 
@@ -45,7 +45,7 @@ First, [uninstall Agent v7 from your system][1].
 Then, if you followed the instructions to [upgrade from v6 to v7][2], run the Agent installation command with the environment variable `DD_AGENT_MAJOR_VERSION=6` in order to downgrade your Agent from version 7 to version 6:
 
 ```shell
-DD_AGENT_MAJOR_VERSION=6 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_AGENT_MAJOR_VERSION=6 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 [1]: /agent/guide/how-do-i-uninstall-the-agent/

--- a/content/en/agent/faq/certificate_verify_failed-error.md
+++ b/content/en/agent/faq/certificate_verify_failed-error.md
@@ -110,7 +110,7 @@ restart-service -Force datadogagent
   After `datadog.conf` has been updated, restart the Datadog Service from the Windows Service Manager.
 
 
-[1]: https://windows-agent.datadoghq.com/ddagent-cli-latest.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.msi
 [2]: https://app.datadoghq.com/account/settings/agent/5?platform=overview
 [3]: /agent/versions/upgrade_to_agent_v7/?tab=linux#from-agent-v5-to-agent-v7
 [4]: /agent/versions/upgrade_to_agent_v6/?tab=linux

--- a/content/en/agent/faq/circleci-incident-impact-on-datadog-agent.md
+++ b/content/en/agent/faq/circleci-incident-impact-on-datadog-agent.md
@@ -136,9 +136,9 @@ We released new versions of **Agent installation methods** to ensure they make h
   * [Datadog Puppet module][12] release [3.20.0][13]
   * [Datadog SaltStack formula][14] release [3.5][15]
   * Datadog Agent 6/7 Linux install scripts, released to the following locations with version 1.13.0 at 13:00 UTC on January 12th, 2023:
-    * [https://install.datadoghq.com/scripts/install_script_agent6.sh][16]
-    * [https://install.datadoghq.com/scripts/install_script_agent7.sh][17]
-    * [https://install.datadoghq.com/scripts/install_script.sh][18] (Deprecated and no longer recommended, but updated.)
+    * [https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh][16]
+    * [https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh][17]
+    * [https://s3.amazonaws.com/dd-agent/scripts/install_script.sh][18] (Deprecated and no longer recommended, but updated.)
   * [Datadog Agent 5 Linux install script][19] released to its [download location][19] at 16:25 UTC on January 12th, 2023
 
 
@@ -158,7 +158,7 @@ We released new versions of **Agent installation methods** to ensure they make h
 [13]: https://github.com/DataDog/puppet-datadog-agent/releases/tag/v3.20.0
 [14]: https://github.com/DataDog/datadog-formula
 [15]: https://github.com/DataDog/datadog-formula/releases/tag/3.5
-[16]: https://install.datadoghq.com/scripts/install_script_agent6.sh
-[17]: https://install.datadoghq.com/scripts/install_script_agent7.sh
-[18]: https://install.datadoghq.com/scripts/install_script.sh
+[16]: https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh
+[17]: https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh
+[18]: https://s3.amazonaws.com/dd-agent/scripts/install_script.sh
 [19]: https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh

--- a/content/en/agent/guide/agent-fips-proxy.md
+++ b/content/en/agent/guide/agent-fips-proxy.md
@@ -73,7 +73,7 @@ DD_API_KEY=<DD_API_KEY> \
 DD_SITE="ddog-gov.com" \
 DD_FIPS_MODE=1 \
 bash -c "$(curl -L \
-   https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+   https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 Setting the `DD_FIPS_MODE` environment variable installs the FIPS package along with the Agent, and configures the Agent to use the proxy. There are no additional configuration steps if you're using this method, but you should [verify the installation](#verify-your-installation).

--- a/content/en/agent/guide/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/guide/linux-agent-2022-key-rotation.md
@@ -184,7 +184,7 @@ Agent v5 users on DEB-based systems (Debian/Ubuntu) are also required to trust t
 [2]: https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
 [3]: https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public
 [4]: https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
-[5]: https://install.datadoghq.com/scripts/install_script.sh
+[5]: https://s3.amazonaws.com/dd-agent/scripts/install_script.sh
 [6]: https://github.com/DataDog/chef-datadog
 [7]: https://github.com/DataDog/ansible-datadog
 [8]: https://github.com/DataDog/puppet-datadog-agent

--- a/content/en/agent/iot/_index.md
+++ b/content/en/agent/iot/_index.md
@@ -52,7 +52,7 @@ Exact resource requirements depend on usage. Datadog found the following when te
 To automatically download and install the correct IoT Agent for your operating system and chipset architecture, use the following command:
 
 ```shell
-DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" DD_AGENT_FLAVOR=datadog-iot-agent bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" DD_AGENT_FLAVOR=datadog-iot-agent bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 #### Manual

--- a/content/en/agent/versions/upgrade_between_agent_minor_versions.md
+++ b/content/en/agent/versions/upgrade_between_agent_minor_versions.md
@@ -15,19 +15,19 @@ The recommended way to upgrade between minor versions of Agent 6 and 7 is to use
 
 Upgrading to a given Agent 6 minor version:
 
-: `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent6.sh)"`
+: `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent6.sh)"`
 
 Upgrading to the latest Agent 6 minor version:
 
-: `bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent6.sh)"`
+: `bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent6.sh)"`
 
 Upgrading to a given Agent 7 minor version:
 
-: `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
+: `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent7.sh)"`
 
 Upgrading to the latest Agent 7 minor version:
 
-: `bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
+: `bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent7.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -36,11 +36,11 @@ Download and install the specific version's installation package.
 
 URL to download a specific Agent 6 minor version:
 
-: `https://windows-agent.datadoghq.com/ddagent-cli-6.<minor_version>.<bugfix_version>.msi`
+: `https://ddagent-windows-stable.s3.amazonaws.com/ddagent-cli-6.<minor_version>.<bugfix_version>.msi`
 
 URL to download a specific Agent 7 minor version
 
-: `https://windows-agent.datadoghq.com/ddagent-cli-7.<minor_version>.<bugfix_version>.msi`
+: `https://ddagent-windows-stable.s3.amazonaws.com/ddagent-cli-7.<minor_version>.<bugfix_version>.msi`
 
 {{% /tab %}}
 {{% tab "MacOS" %}}
@@ -49,11 +49,11 @@ URL to download a specific Agent 7 minor version
 
 Command to upgrade to the latest Agent 6 minor version:
 
-: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"`
+: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_mac_os.sh)"`
 
 Command to upgrade to the latest Agent 7 minor version:
 
-: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"`
+: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_mac_os.sh)"`
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/versions/upgrade_to_agent_v6.md
+++ b/content/en/agent/versions/upgrade_to_agent_v6.md
@@ -22,7 +22,7 @@ If you have Agent v5 already installed, a script is available to automatically i
 The Agent v6 installer can automatically convert v5 configurations during the upgrade:
 
 The following command works on Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu, and SUSE:
-: `DD_UPGRADE=true bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent6.sh)"`
+: `DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh)"`
 
 **Note:** The import process won't automatically move **custom** Agent checks. This is by design as Datadog cannot guarantee full backwards compatibility out of the box.
 
@@ -37,7 +37,7 @@ There is no one step install for Windows platforms, refer to the [Manual Upgrade
 The Agent v6 installer can automatically convert v5 configurations during the upgrade:
 
 ```shell
-DD_UPGRADE=true bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 **Note:** The import process won't automatically move **custom** Agent checks. This is by design as Datadog cannot guarantee full backwards compatibility out of the box.
@@ -397,7 +397,7 @@ With:
 
 **Note**: `datadog.conf` is automatically upgraded to `datadog.yaml` on upgrade.
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-6-latest.amd64.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi
 {{% /tab %}}
 {{% tab "MacOS" %}}
 

--- a/content/en/agent/versions/upgrade_to_agent_v7.md
+++ b/content/en/agent/versions/upgrade_to_agent_v7.md
@@ -19,7 +19,7 @@ Agent v7 only supports Python 3 custom checks. <a href="/agent/guide/python-3">C
 Run the following Agent installation command in order to upgrade your Agent from version 6 to version 7:
 
 The following command works on Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu, and SUSE:
-: `DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
+: `DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -31,16 +31,16 @@ The following command works on Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ub
 
 **Note**: Links to all available versions of the Windows Installer are [provided in JSON format][3].
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
+[1]: https://ddagent-windows-stable.s3.amazonaws.com/datadog-agent-7-latest.amd64.msi
 [2]: https://app.datadoghq.com/organization-settings/api-keys
-[3]: https://windows-agent.datadoghq.com/installers.json
+[3]: https://s3.amazonaws.com/ddagent-windows-stable/installers.json
 {{% /tab %}}
 {{% tab "MacOS" %}}
 
 Run the Agent installation command with the environment variable `DD_AGENT_MAJOR_VERSION=7` in order to upgrade your Agent from version 6 to version 7:
 
 ```shell
-DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 {{% /tab %}}
@@ -54,7 +54,7 @@ DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https
 Run the Agent installation command with the environment variable `DD_UPGRADE="true"` in order to upgrade your Agent from version 5 to version 7. The Agent v7 installer can automatically convert v5 configurations during the upgrade:
 
 The following command works on Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu, and SUSE:
-: `DD_UPGRADE="true" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
+: `DD_UPGRADE="true" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -69,7 +69,7 @@ The following command works on Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ub
 Run the Agent installation command with the environment variable `DD_AGENT_MAJOR_VERSION=7` and `DD_UPGRADE="true"` in order to upgrade your Agent from version 5 to version 7. The Agent v7 installer can automatically convert v5 configurations during the upgrade:
 
 ```shell
-DD_UPGRADE="true" DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_UPGRADE="true" DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 {{% /tab %}}

--- a/content/en/database_monitoring/setup_oracle/_index.md
+++ b/content/en/database_monitoring/setup_oracle/_index.md
@@ -71,7 +71,7 @@ Set `DD_API_KEY` and run the following commands to install the beta release, for
 export DD_AGENT_DIST_CHANNEL=beta
 export DD_AGENT_MINOR_VERSION="46.0~dbm~oracle~beta~0.33-1"
 
-DD_API_KEY= DD_SITE="datadoghq.com" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_API_KEY= DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 ##### Windows
@@ -126,11 +126,11 @@ For setup instructions, select your hosting type:
 [1]: https://app.datadoghq.com/integrations
 [2]: https://app.datadoghq.com/integrations/oracle
 [3]: https://app.datadoghq.com/account/settings/agent/latest
-[4]: https://windows-agent.datadoghq.com/beta/datadog-agent-7.46.0-dbm-oracle-beta-0.33-1.x86_64.msi
+[4]: https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-agent-7.46.0-dbm-oracle-beta-0.33-1.x86_64.msi
 [5]: https://app.datadoghq.com/dash/integration/30990/dbm-oracle-database-overview
 [6]: https://yum.datadoghq.com/beta/7/x86_64/
 [7]: https://apt.datadoghq.com/dists/beta/7/
-[8]: https://windows-agent.datadoghq.com/
+[8]: https://ddagent-windows-stable.s3.amazonaws.com/
 [9]: https://hub.docker.com/r/datadog/agent/tags?page=1&name=oracle
 [10]: /database_monitoring/architecture/
 [11]: https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example

--- a/content/en/getting_started/agent/_index.md
+++ b/content/en/getting_started/agent/_index.md
@@ -105,7 +105,7 @@ In the Datadog UI, go to the Agent Installation page for Ubuntu by navigating to
 Example Ubuntu one-line install command:
 
 ```shell
-DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 Go to the in-app [Agent Installation page][18] for your operating system for the most up-to-date installation instructions.

--- a/content/en/getting_started/tracing/_index.md
+++ b/content/en/getting_started/tracing/_index.md
@@ -41,7 +41,7 @@ vagrant ssh
 To install the Datadog Agent on a host, use the [one line install command][6] updated with your [Datadog API key][7]:
 
 ```shell
-DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 ### Validation

--- a/content/en/tracing/guide/tutorial-enable-go-host.md
+++ b/content/en/tracing/guide/tutorial-enable-go-host.md
@@ -44,7 +44,7 @@ See [Tracing Go Applications][2] for general comprehensive tracing setup documen
 If you haven't installed a Datadog Agent on your machine, go to [**Integrations > Agent**][5] and select your operating system. For example, on most Linux platforms, you can install the Agent by running the following script, replacing `<YOUR_API_KEY>` with your [Datadog API key][3]:
 
 {{< code-block lang="shell" >}}
-DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"{{< /code-block >}}
+DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"{{< /code-block >}}
 
 To send data to a Datadog site other than `datadoghq.com`, replace the `DD_SITE` environment variable with [your Datadog site][6].
 

--- a/content/en/tracing/guide/tutorial-enable-java-container-agent-host.md
+++ b/content/en/tracing/guide/tutorial-enable-java-container-agent-host.md
@@ -41,7 +41,7 @@ If you haven't installed a Datadog Agent on your machine, install one now.
 1. Go to [**Integrations > Agent**][5] and select your operating system. For example, on most Linux platforms, you can install the Agent by running the following script, replacing `<YOUR_API_KEY>` with your [Datadog API key][3]:
 
    {{< code-block lang="shell" >}}
-DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
    {{< /code-block >}}
 
    To send data to a Datadog site other than `datadoghq.com`, replace the `DD_SITE` environment variable with [your Datadog site][6].

--- a/content/en/tracing/guide/tutorial-enable-java-host.md
+++ b/content/en/tracing/guide/tutorial-enable-java-host.md
@@ -40,7 +40,7 @@ See [Tracing Java Applications][2] for general comprehensive tracing setup docum
 If you haven't installed a Datadog Agent on your machine, go to [**Integrations > Agent**][5] and select your operating system. For example, on most Linux platforms, you can install the Agent by running the following script, replacing `<YOUR_API_KEY>` with your [Datadog API key][3]:
 
 {{< code-block lang="shell" >}}
-DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 {{< /code-block >}}
 
 To send data to a Datadog site other than `datadoghq.com`, replace the `DD_SITE` environment variable with [your Datadog site][6].

--- a/content/en/tracing/guide/tutorial-enable-python-container-agent-host.md
+++ b/content/en/tracing/guide/tutorial-enable-python-container-agent-host.md
@@ -40,7 +40,7 @@ See [Tracing Python Applications][2] for general comprehensive tracing setup doc
 If you haven't installed a Datadog Agent on your machine, go to [**Integrations > Agent**][5] and select your operating system. For example, on most Linux platforms, you can install the Agent by running the following script, replacing `<YOUR_API_KEY>` with your [Datadog API key][3]:
 
 {{< code-block lang="shell" >}}
-DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 {{< /code-block >}}
 
 To send data to a Datadog site other than `datadoghq.com`, replace the `DD_SITE` environment variable with [your Datadog site][6].

--- a/content/en/tracing/guide/tutorial-enable-python-host.md
+++ b/content/en/tracing/guide/tutorial-enable-python-host.md
@@ -40,7 +40,7 @@ See [Tracing Python Applications][2] for general comprehensive tracing setup doc
 If you haven't installed a Datadog Agent on your machine, go to [**Integrations > Agent**][5] and select your operating system. For example, on most Linux platforms, you can install the Agent by running the following script, replacing `<YOUR_API_KEY>` with your [Datadog API key][3]:
 
 {{< code-block lang="shell" >}}
-DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 {{< /code-block >}}
 
 To send data to a Datadog site other than `datadoghq.com`, replace the `DD_SITE` environment variable with [your Datadog site][6].

--- a/content/en/tracing/trace_collection/library_injection_local.md
+++ b/content/en/tracing/trace_collection/library_injection_local.md
@@ -246,13 +246,13 @@ When both the Agent and your services are running on a host, real or virtual, Da
 If the host does not yet have a Datadog Agent installed, or if you want to upgrade your Datadog Agent installation, use the the Datadog Agent install script to install both the injection libraries and the Datadog Agent:
 
 ```shell
-DD_APM_INSTRUMENTATION_ENABLED=host DD_API_KEY=<YOUR KEY> DD_SITE="<YOUR SITE>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_APM_INSTRUMENTATION_ENABLED=host DD_API_KEY=<YOUR KEY> DD_SITE="<YOUR SITE>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 By default, running the script installs support for Java, Node.js, Python, Ruby, and .NET. If you want to specify which language support is installed, also set the `DD_APM_INSTRUMENTATION_LANGUAGES` environment variable. The valid values are `java`, `js`, `python`, `ruby`, and `dotnet`. Use a comma-separated list to specify more than one language: 
 
 ```shell
-DD_APM_INSTRUMENTATION_LANGUAGES=java,js DD_APM_INSTRUMENTATION_ENABLED=host DD_API_KEY=<YOUR KEY> DD_SITE="<YOUR SITE>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_APM_INSTRUMENTATION_LANGUAGES=java,js DD_APM_INSTRUMENTATION_ENABLED=host DD_API_KEY=<YOUR KEY> DD_SITE="<YOUR SITE>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 Exit and open a new shell to use the injection library.
@@ -547,13 +547,13 @@ Any newly started processes are intercepted and the specified instrumentation li
 If the host does not yet have a Datadog Agent installed, or if you want to upgrade your Datadog Agent installation, use the the Datadog Agent install script to install both the injection libraries and the Datadog Agent:
 
 ```shell
-DD_APM_INSTRUMENTATION_ENABLED=all DD_API_KEY=<YOUR KEY> DD_SITE="<YOUR SITE>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_APM_INSTRUMENTATION_ENABLED=all DD_API_KEY=<YOUR KEY> DD_SITE="<YOUR SITE>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 By default, running the script installs support for Java, Node.js, Python, Ruby, and .NET. If you want to specify which language support is installed, also set the `DD_APM_INSTRUMENTATION_LANGUAGES` environment variable. The valid values are `java`, `js`, `python`, `ruby`, and `dotnet`. Use a comma-separated list to specify more than one language: 
 
 ```shell
-DD_APM_INSTRUMENTATION_LANGUAGES=java,js DD_APM_INSTRUMENTATION_ENABLED=all DD_API_KEY=<YOUR KEY> DD_SITE="<YOUR SITE>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_APM_INSTRUMENTATION_LANGUAGES=java,js DD_APM_INSTRUMENTATION_ENABLED=all DD_API_KEY=<YOUR KEY> DD_SITE="<YOUR SITE>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 ## Install only library injection
@@ -789,13 +789,13 @@ Any newly started processes are intercepted and the specified instrumentation li
 Use the `install_script_docker_injection` shell script to automatically install Docker injection support. Docker must already be installed on the host machine.
 
 ```shell
-bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_docker_injection.sh)"
+bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_docker_injection.sh)"
 ```
 
 This installs language libraries for all supported languages. To install specific languages, set the `DD_APM_INSTRUMENTATION_LANGUAGES` variable. The valid values are `java`, `js`, `python`, `ruby`, and `dotnet`:
 
 ```shell
-DD_APM_INSTRUMENTATION_LANGUAGES=java,js bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_docker_injection.sh)"
+DD_APM_INSTRUMENTATION_LANGUAGES=java,js bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_docker_injection.sh)"
 ```
 
 ## Configure Docker injection

--- a/content/en/tracing/trace_collection/single-step-apm.md
+++ b/content/en/tracing/trace_collection/single-step-apm.md
@@ -29,7 +29,7 @@ For example, on an Ubuntu host:
 1. Run the one-line install command:
 
    ```shell
-   DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE=”<YOUR_DD_SITE>” DD_APM_INSTRUMENTATION_ENABLED=host bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)”
+   DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE=”<YOUR_DD_SITE>” DD_APM_INSTRUMENTATION_ENABLED=host bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)”
    ```
    This installs, configures, and starts the Agent with APM and [Remote Configuration][1] enabled, and sets up library injection for automatic instrumentation of all services on the host or VM. 
 2. Restart the services on the host or VM.
@@ -46,7 +46,7 @@ For example, for a Docker Linux container:
 
 1. Install the library injector:
    ```shell
-   DD_APM_INSTRUMENTATION_ENABLED=docker bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+   DD_APM_INSTRUMENTATION_ENABLED=docker bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
    ```
 2. Configure the Agent in Docker:
    ```shell

--- a/content/es/agent/basic_agent_usage/ansible.md
+++ b/content/es/agent/basic_agent_usage/ansible.md
@@ -306,8 +306,8 @@ Cuando la variable `datadog_windows_download_url` no está definida, se usa el p
 
 | Versión del Agent | URL predeterminada del paquete MSI de Windows                                                  |
 |---------------|----------------------------------------------------------------------------------|
-| 6             | https://windows-agent.datadoghq.com/datadog-agent-6-latest.amd64.msi |
-| 7             | https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi |
+| 6             | https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi |
+| 7             | https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi |
 
 Para sobreescribir este comportamiento predeterminado, cambia esta variable por algo que no sea una cadena vacía.
 
@@ -317,8 +317,8 @@ Cuando la variable `datadog_macos_download_url` no está definida, se usa el paq
 
 | Versión del Agent | URL predeterminada del paquete DMG de macOS                                |
 |---------------|--------------------------------------------------------------|
-| 6             | https://install.datadoghq.com/datadog-agent-6-latest.dmg |
-| 7             | https://install.datadoghq.com/datadog-agent-7-latest.dmg |
+| 6             | https://s3.amazonaws.com/dd-agent/datadog-agent-6-latest.dmg |
+| 7             | https://s3.amazonaws.com/dd-agent/datadog-agent-7-latest.dmg |
 
 Para sobreescribir el comportamiento por defecto, cambia esta variable a un valor distinto de una cadena vacía.
 

--- a/content/es/agent/basic_agent_usage/windows.md
+++ b/content/es/agent/basic_agent_usage/windows.md
@@ -42,13 +42,13 @@ Para instalar el Datadog Agent en un entorno de dominio, consulta los [requisito
 
 1. Descarga el [instalador del Datadog Agent][1] para instalar la última versión del Agent.
 
-   <div class="alert alert-info">Si necesitas instalar una versión específica del Agent, consulta la <a href="https://windows-agent.datadoghq.com/installers.json">lista de instaladores</a>.</div>
+   <div class="alert alert-info">Si necesitas instalar una versión específica del Agent, consulta la <a href="https://s3.amazonaws.com/ddagent-windows-stable/installers.json">lista de instaladores</a>.</div>
 
 2. Abre `datadog-agent-7-latest.amd64.msi` y ejecuta el instalador (como **Administrador**).
 3. Sigue las indicaciones, acepta el acuerdo de licencia e introduce tu [clave de API de Datadog][2].
 4. Cuando termines la instalación, tendrás opción de iniciar el Datadog Agent Manager.
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 
 {{% /tab %}}
@@ -104,7 +104,7 @@ Todos los elementos de la configuración se añaden a la línea de comandos como
 
 **Nota**: Si se encuentra un `datadog.yaml` válido y tiene una clave de API configurada, ese archivo tendrá prioridad sobre todas las opciones de la línea de comandos especificadas.
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
 [2]: /es/agent/proxy/
 [3]: /es/agent/faq/windows-agent-ddagent-user/
 [4]: /es/network_monitoring/performance
@@ -116,7 +116,7 @@ El Agent 7 solo es compatible con Python 3. Antes de actualizarlo, confirma qu
 Si vas a actualizarte a partir de una versión del Datadog Agent anterior a la 5.12.0, primero debes pasarte a una versión más reciente del Agent 5 (igual o posterior a la 5.12.0, pero anterior a la 6.0.0) usando el [instalador EXE][2] y, luego, actualizar el Datadog Agent a una versión igual o posterior a la 6.
 
 [1]: /es/agent/guide/python-3/
-[2]: https://windows-agent.datadoghq.com/ddagent-cli-latest.exe
+[2]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.exe
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/es/agent/faq/agent-downgrade-major.md
+++ b/content/es/agent/faq/agent-downgrade-major.md
@@ -15,7 +15,7 @@ En primer lugar, [desinstala la v7 del Agent del sistema][1].
 A continuación, si seguiste las instrucciones para [pasar de la v6 a la v7][2], ejecuta el siguiente comando de instalación del Agent para cambiar de la versión 7 a la versión 6 del Agent:
 
 ```shell
-DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent6.sh)"
+DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh)"
 ```
 
 El comando funciona en todas las versiones compatibles de Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu y SUSE.
@@ -34,9 +34,9 @@ El comando funciona en todas las versiones compatibles de Amazon Linux, CentOS, 
 **Nota**: Los enlaces a todas las versiones disponibles de Windows Installer se ofrecen [en formato JSON][4].
 
 [1]: /es/agent/guide/how-do-i-uninstall-the-agent/
-[2]: https://windows-agent.datadoghq.com/datadog-agent-6-latest.amd64.msi
+[2]: https://ddagent-windows-stable.s3.amazonaws.com/datadog-agent-6-latest.amd64.msi
 [3]: https://app.datadoghq.com/organization-settings/api-keys
-[4]: https://windows-agent.datadoghq.com/installers.json
+[4]: https://s3.amazonaws.com/ddagent-windows-stable/installers.json
 {{% /tab %}}
 {{% tab "MacOS" %}}
 
@@ -45,7 +45,7 @@ En primer lugar, [desinstala la v7 del Agent del sistema][1].
 A continuación, si seguiste las instrucciones para [pasar de la v6 a la v7][2], ejecuta el comando de instalación del Agent con la variable de entorno `DD_AGENT_MAJOR_VERSION=6` para cambiar de la versión 7 a la versión 6 del Agent:
 
 ```shell
-DD_AGENT_MAJOR_VERSION=6 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_AGENT_MAJOR_VERSION=6 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 [1]: /es/agent/guide/how-do-i-uninstall-the-agent/

--- a/content/es/agent/faq/certificate_verify_failed-error.md
+++ b/content/es/agent/faq/certificate_verify_failed-error.md
@@ -110,7 +110,7 @@ restart-service -Force datadogagent
   Una vez que se haya actualizado `datadog.conf`, reinicia el servicio de Datadog desde el administrador de servicios de Windows.
 
 
-[1]: https://windows-agent.datadoghq.com/ddagent-cli-latest.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.msi
 [2]: https://app.datadoghq.com/account/settings?agent_version=5#agent
 [3]: /es/agent/versions/upgrade_to_agent_v7/?tab=linux#from-agent-v5-to-agent-v7
 [4]: /es/agent/versions/upgrade_to_agent_v6/?tab=linux

--- a/content/es/agent/guide/linux-agent-2022-key-rotation.md
+++ b/content/es/agent/guide/linux-agent-2022-key-rotation.md
@@ -184,7 +184,7 @@ Los usuarios del Agent v5 que utilicen sistemas basados en DEB (Debian/Ubuntu) 
 [2]: https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
 [3]: https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public
 [4]: https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
-[5]: https://install.datadoghq.com/scripts/install_script.sh
+[5]: https://s3.amazonaws.com/dd-agent/scripts/install_script.sh
 [6]: https://github.com/DataDog/chef-datadog
 [7]: https://github.com/DataDog/ansible-datadog
 [8]: https://github.com/DataDog/puppet-datadog-agent

--- a/content/es/agent/iot/_index.md
+++ b/content/es/agent/iot/_index.md
@@ -52,7 +52,7 @@ Los requisitos exactos de un recurso varían en función del uso que hace de ell
 Para descargar e instalar automáticamente el IoT Agent correcto para tu sistema operativo y la arquitectura de tu conjunto de chips, usa el siguiente comando:
 
 ```shell
-DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" DD_AGENT_FLAVOR=datadog-iot-agent bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" DD_AGENT_FLAVOR=datadog-iot-agent bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 #### Manual

--- a/content/es/agent/versions/upgrade_between_agent_minor_versions.md
+++ b/content/es/agent/versions/upgrade_between_agent_minor_versions.md
@@ -15,19 +15,19 @@ El método recomendado para actualizar entre versiones secundarias del Agent 6 
 
 Actualizar a una versión secundaria concreta del Agent 6:
 
-: `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent6.sh)"`
+: `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent6.sh)"`
 
 Actualizar a la última versión secundaria del Agent 6:
 
-: `bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent6.sh)"`
+: `bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent6.sh)"`
 
 Actualizar a una versión secundaria concreta del Agent 7:
 
-: `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
+: `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent7.sh)"`
 
 Actualizar a la última versión secundaria del Agent 7:
 
-: `bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
+: `bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent7.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -36,11 +36,11 @@ Descarga e instala el paquete de instalación de una versión concreta.
 
 URL para descargar una versión secundaria concreta del Agent 6:
 
-: `https://windows-agent.datadoghq.com/ddagent-cli-6.<minor_version>.<bugfix_version>.msi`
+: `https://ddagent-windows-stable.s3.amazonaws.com/ddagent-cli-6.<minor_version>.<bugfix_version>.msi`
 
 URL para descargar una versión secundaria concreta del Agent 7:
 
-: `https://windows-agent.datadoghq.com/ddagent-cli-7.<minor_version>.<bugfix_version>.msi`
+: `https://ddagent-windows-stable.s3.amazonaws.com/ddagent-cli-7.<minor_version>.<bugfix_version>.msi`
 
 {{% /tab %}}
 {{% tab "MacOS" %}}
@@ -49,11 +49,11 @@ URL para descargar una versión secundaria concreta del Agent 7:
 
 Comando para actualizar a la última versión secundaria del Agent 6:
 
-: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"`
+: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_mac_os.sh)"`
 
 Comando para actualizar a la última versión secundaria del Agent 7:
 
-: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"`
+: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_mac_os.sh)"`
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/es/agent/versions/upgrade_to_agent_v6.md
+++ b/content/es/agent/versions/upgrade_to_agent_v6.md
@@ -22,7 +22,7 @@ Si ya has instalado el Agent v5, hay un script disponible para instalar el nuev
 El instalador del Agent v6 puede convertir automáticamente las configuraciones de la versión 5 durante la actualización:
 
 El siguiente comando funciona en Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu y SUSE:
-: `DD_UPGRADE=true bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent6.sh)"`
+: `DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh)"`
 
 **Nota:** El proceso de importación no moverá automáticamente los checks **personalizados** del Agent. Esto es así por diseño, ya que Datadog no puede garantizar una compatibilidad completa con versiones anteriores de forma predefinida.
 
@@ -37,7 +37,7 @@ No existe una instalación en un paso para plataformas Windows; consulta la secc
 El instalador del Agent v6 puede convertir automáticamente las configuraciones de la versión 5 durante la actualización:
 
 ```shell
-DD_UPGRADE=true bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 **Nota:** El proceso de importación no moverá automáticamente los checks **personalizados** del Agent. Esto es así por diseño, ya que Datadog no puede garantizar una compatibilidad completa con versiones anteriores de forma predefinida.
@@ -389,7 +389,7 @@ Con:
 
 **Nota**: `datadog.conf` se actualiza automáticamente a `datadog.yaml` al actualizar.
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-6-latest.amd64.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi
 {{% /tab %}}
 {{% tab "MacOS" %}}
 

--- a/content/es/agent/versions/upgrade_to_agent_v7.md
+++ b/content/es/agent/versions/upgrade_to_agent_v7.md
@@ -19,7 +19,7 @@ La versión 7 del Agent solo es compatible con checks personalizados de Python�
 Ejecuta el siguiente comando de instalación del Agent para actualizar tu Agent de la versión 6 a la versión 7:
 
 El siguiente comando funciona en Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu y SUSE:
-: `DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
+: `DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -31,16 +31,16 @@ El siguiente comando funciona en Amazon Linux, CentOS, Debian, Fedora, Red Hat, 
 
 **Nota**: Los enlaces a todas las versiones disponibles de Windows Installer se ofrecen [en formato JSON][3].
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
+[1]: https://ddagent-windows-stable.s3.amazonaws.com/datadog-agent-7-latest.amd64.msi
 [2]: https://app.datadoghq.com/organization-settings/api-keys
-[3]: https://windows-agent.datadoghq.com/installers.json
+[3]: https://s3.amazonaws.com/ddagent-windows-stable/installers.json
 {{% /tab %}}
 {{% tab "MacOS" %}}
 
 Ejecuta el comando de instalación del Agent con la variable de entorno `DD_AGENT_MAJOR_VERSION=7` para actualizar tu Agent de la versión 6 a la versión 7:
 
 ```shell
-DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 {{% /tab %}}
@@ -54,7 +54,7 @@ DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https
 Ejecuta el comando de instalación del Agent con la variable de entorno `DD_UPGRADE="true"` para actualizar tu Agent de la versión 5 a la 7. El instalador del Agent v7 puede convertir automáticamente las configuraciones de la versión 5 durante la actualización:
 
 El siguiente comando funciona en Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu y SUSE:
-: `DD_UPGRADE="true" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
+: `DD_UPGRADE="true" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -69,7 +69,7 @@ El siguiente comando funciona en Amazon Linux, CentOS, Debian, Fedora, Red Hat, 
 Ejecuta el comando de instalación del Agent con la variable de entorno `DD_AGENT_MAJOR_VERSION=7` y `DD_UPGRADE="true"` para actualizar tu Agent de la versión 5 a la 7. El instalador del Agent v7 puede convertir automáticamente las configuraciones de la versión 5 durante la actualización:
 
 ```shell
-DD_UPGRADE="true" DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_UPGRADE="true" DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 {{% /tab %}}

--- a/content/es/getting_started/agent/_index.md
+++ b/content/es/getting_started/agent/_index.md
@@ -102,7 +102,7 @@ En la IU de Datadog, dirígete a **Integrations > Agent** (Integraciones > Agent
 Ejemplo de comando de instalación de una línea en Ubuntu:
 
 ```shell
-DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 En la aplicación, dirígete a la página [Agent Installation (Instalación del Agent)][18] correspondiente a tu sistema operativo y consulta las instrucciones de instalación más recientes.

--- a/content/fr/agent/basic_agent_usage/ansible.md
+++ b/content/fr/agent/basic_agent_usage/ansible.md
@@ -298,8 +298,8 @@ Lorsque la variable `datadog_windows_download_url` n'est pas définie, le packag
 
 | # | URL par défaut du package MSI Windows                                                  |
 |---|----------------------------------------------------------------------------------|
-| 6 | https://windows-agent.datadoghq.com/datadog-agent-6-latest.amd64.msi |
-| 7 | https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi |
+| 6 | https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi |
+| 7 | https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi |
 
 Pour remplacer le comportement par défaut, définissez cette variable sur autre chose qu'une chaîne vide.
 

--- a/content/fr/agent/basic_agent_usage/windows.md
+++ b/content/fr/agent/basic_agent_usage/windows.md
@@ -38,7 +38,7 @@ Si vous installez l'Agent Datadog dans un environnement de domaine, consultez le
 3. Suivez les instructions à l'écran, acceptez l'accord de licence et entrez votre [clé d'API Datadog][2].
 4. Une fois l'installation terminée, le programme vous propose de lancer Datadog Agent Manager.
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
 {{% tab "Ligne de commande" %}}
@@ -93,7 +93,7 @@ Chaque élément de configuration est ajouté en tant que propriété dans la li
 
 **Remarque** : si un fichier `datadog.yaml` valide est trouvé et qu'une clé d'API y est configurée, ce fichier est prioritaire sur toutes les options de ligne de commande spécifiées.
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
 [2]: /fr/agent/proxy/
 [3]: /fr/agent/faq/windows-agent-ddagent-user/
 [4]: /fr/network_monitoring/performance
@@ -105,7 +105,7 @@ L'Agent 7 prend uniquement en charge Python 3. Avant d'effectuer une mise à n
 Si vous utilisez une version < 5.12.0 de l'Agent Datadog, procédez d'abord à la mise à niveau vers une version plus récente de l'Agent 5 (>= 5.12.0, mais < 6.0.0) à l'aide du [fichier d'installation EXE][2], puis effectuez la mise à niveau vers une version >= 6 de l'Agent Datadog.
 
 [1]: /fr/agent/guide/python-3/
-[2]: https://windows-agent.datadoghq.com/ddagent-cli-latest.exe
+[2]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.exe
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/fr/agent/faq/certificate_verify_failed-error.md
+++ b/content/fr/agent/faq/certificate_verify_failed-error.md
@@ -110,7 +110,7 @@ restart-service -Force datadogagent
   Après la mise à jour de `datadog.conf`, redémarrez le service Datadog à partir du gestionnaire de services Windows.
 
 
-[1]: https://windows-agent.datadoghq.com/ddagent-cli-latest.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.msi
 [2]: https://app.datadoghq.com/account/settings?agent_version=5#agent
 [3]: /fr/agent/versions/upgrade_to_agent_v7/?tab=linux#from-agent-v5-to-agent-v7
 [4]: /fr/agent/versions/upgrade_to_agent_v6/?tab=linux

--- a/content/fr/agent/guide/linux-agent-2022-key-rotation.md
+++ b/content/fr/agent/guide/linux-agent-2022-key-rotation.md
@@ -184,7 +184,7 @@ Les personnes qui utilisent la version 5 de l'Agent sur des systèmes basés su
 [2]: https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
 [3]: https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public
 [4]: https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
-[5]: https://install.datadoghq.com/scripts/install_script.sh
+[5]: https://s3.amazonaws.com/dd-agent/scripts/install_script.sh
 [6]: https://github.com/DataDog/chef-datadog
 [7]: https://github.com/DataDog/ansible-datadog
 [8]: https://github.com/DataDog/puppet-datadog-agent

--- a/content/fr/agent/iot/_index.md
+++ b/content/fr/agent/iot/_index.md
@@ -52,7 +52,7 @@ Les besoins exacts en ressources dépendent de l'utilisation faite de l'Agent Io
 Pour télécharger et installer automatiquement l'Agent IoT adapté à votre système d'exploitation et à l'architecture de votre chipset, utilisez la commande suivante :
 
 ```shell
-DD_API_KEY=<VOTRE_CLÉ_API_DATADOG> DD_SITE="{{< region-param key="dd_site" >}}" DD_AGENT_FLAVOR=datadog-iot-agent bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_API_KEY=<VOTRE_CLÉ_API_DATADOG> DD_SITE="{{< region-param key="dd_site" >}}" DD_AGENT_FLAVOR=datadog-iot-agent bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 #### Méthode manuelle

--- a/content/fr/agent/versions/upgrade_between_agent_minor_versions.md
+++ b/content/fr/agent/versions/upgrade_between_agent_minor_versions.md
@@ -15,19 +15,19 @@ Pour passer d'une version mineure de l'Agent 6 à une version mineure de l'Agen
 
 Passer à une version mineure précise de l'Agent 6 :
 
-: `DD_AGENT_MINOR_VERSION=<version_mineure_souhaitée> bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent6.sh)"`
+: `DD_AGENT_MINOR_VERSION=<version_mineure_souhaitée> bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent6.sh)"`
 
 Passer à la dernière version mineure de l'Agent 6 :
 
-: `bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent6.sh)"`
+: `bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent6.sh)"`
 
 Passer à une version mineure précise de l'Agent 7 :
 
-: `DD_AGENT_MINOR_VERSION=<version_mineure_souhaitée> bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
+: `DD_AGENT_MINOR_VERSION=<version_mineure_souhaitée> bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent7.sh)"`
 
 Passer à la dernière version mineure de l'Agent 7 :
 
-: `bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
+: `bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent7.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -36,11 +36,11 @@ Téléchargez et installez le package d'installation de la version spécifique.
 
 URL permettant de télécharger une version mineure spécifique de l'Agent 6 :
 
-: `https://windows-agent.datadoghq.com/ddagent-cli-6.<version_mineure>.<version_correction>.msi`
+: `https://ddagent-windows-stable.s3.amazonaws.com/ddagent-cli-6.<version_mineure>.<version_correction>.msi`
 
 URL permettant de télécharger une version mineure spécifique de l'Agent 7 :
 
-: `https://windows-agent.datadoghq.com/ddagent-cli-7.<version_mineure>.<version_correction>.msi`
+: `https://ddagent-windows-stable.s3.amazonaws.com/ddagent-cli-7.<version_mineure>.<version_correction>.msi`
 
 {{% /tab %}}
 {{% tab "macOS" %}}
@@ -49,11 +49,11 @@ URL permettant de télécharger une version mineure spécifique de l'Agent 7 :
 
 Commande à utiliser pour passer à la dernière version mineure de l'Agent 6 :
 
-: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"`
+: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_mac_os.sh)"`
 
 Commande à utiliser pour passer à la dernière version mineure de l'Agent 7 :
 
-: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"`
+: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_mac_os.sh)"`
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/fr/agent/versions/upgrade_to_agent_v6.md
+++ b/content/fr/agent/versions/upgrade_to_agent_v6.md
@@ -22,7 +22,7 @@ Si l'Agent v5 est déjà installé, un script est disponible pour installer ou 
 Le programme d'installation de l'Agent v6 peut automatiquement convertir les configurations v5 lors de l'upgrade :
 
 La commande suivante fonctionne sous Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu et SUSE :
-: `DD_UPGRADE=true bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"`
+: `DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"`
 
 **Remarque** : le processus d'importation n'importe pas automatiquement les checks **custom** de l'Agent. Ce comportement est délibéré : nous ne pouvons par garantir la compatibilité totale et immédiate de ces checks.
 
@@ -37,7 +37,7 @@ L'installation en une étape n'est pas disponible pour Windows. Référez-vous �
 Le programme d'installation de l'Agent v6 peut automatiquement convertir les configurations v5 lors de l'upgrade :
 
 ```shell
-DD_UPGRADE=true bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 **Remarque** : le processus d'importation n'importe pas automatiquement les checks **custom** de l'Agent. Ce comportement est délibéré : nous ne pouvons par garantir la compatibilité totale et immédiate de ces checks.
@@ -392,7 +392,7 @@ Où :
 
 **Remarque** : `datadog.conf` est automatiquement converti en `datadog.yaml` lors de l'upgrade.
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-6-latest.amd64.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi
 {{% /tab %}}
 {{% tab "macOS" %}}
 

--- a/content/fr/agent/versions/upgrade_to_agent_v7.md
+++ b/content/fr/agent/versions/upgrade_to_agent_v7.md
@@ -19,7 +19,7 @@ L'Agent v7 prend uniquement en charge les checks custom écrits en Python 3. <
 Pour passer de la version 6 à la version 7 de l'Agent, exécutez la commande d'installation de l'Agent avec la variable d'environnement `DD_AGENT_MAJOR_VERSION=7` :
 
 La commande suivante fonctionne sous Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu et SUSE :
-: `DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<CLÉ_API_DATADOG>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"`
+: `DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<CLÉ_API_DATADOG>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -31,16 +31,16 @@ La commande suivante fonctionne sous Amazon Linux, CentOS, Debian, Fedora, Red�
 
 **Remarque** : les liens vers les différentes versions du programme d'installation Windows sont [fournis au format JSON][3].
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
+[1]: https://ddagent-windows-stable.s3.amazonaws.com/datadog-agent-7-latest.amd64.msi
 [2]: https://app.datadoghq.com/organization-settings/api-keys
-[3]: https://windows-agent.datadoghq.com/installers.json
+[3]: https://s3.amazonaws.com/ddagent-windows-stable/installers.json
 {{% /tab %}}
 {{% tab "macOS" %}}
 
 Pour passer de la version 6 à la version 7 de l'Agent, exécutez la commande d'installation de l'Agent avec la variable d'environnement `DD_AGENT_MAJOR_VERSION=7` :
 
 ```shell
-DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<CLÉ_API_DATADOG>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<CLÉ_API_DATADOG>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 {{% /tab %}}
@@ -54,7 +54,7 @@ DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<CLÉ_API_DATADOG>" bash -c "$(curl -L http
 Pour passer de la version 5 à la version 7 de l'Agent, exécutez la commande d'installation avec les variables d'environnement `DD_AGENT_MAJOR_VERSION=7` et `DD_UPGRADE="true"`. Le programme d'installation de l'Agent v7 peut automatiquement convertir les configurations v5 durant l'upgrade :
 
 La commande suivante fonctionne sous Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ubuntu et SUSE :
-: `DD_AGENT_MAJOR_VERSION=7 DD_UPGRADE="true" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"`
+: `DD_AGENT_MAJOR_VERSION=7 DD_UPGRADE="true" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -69,7 +69,7 @@ La commande suivante fonctionne sous Amazon Linux, CentOS, Debian, Fedora, Red�
 Pour passer de la version 5 à la version 7 de l'Agent, exécutez la commande d'installation avec les variables d'environnement `DD_AGENT_MAJOR_VERSION=7` et `DD_UPGRADE="true"`. Le programme d'installation de l'Agent v7 peut automatiquement convertir les configurations v5 durant l'upgrade :
 
 ```shell
-DD_UPGRADE="true" DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_UPGRADE="true" DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 {{% /tab %}}

--- a/content/fr/getting_started/agent/_index.md
+++ b/content/fr/getting_started/agent/_index.md
@@ -106,7 +106,7 @@ Dans l'interface Datadog, cliquez sur **Integrations > Agent** pour accéder à
 Exemple de commande d'installation Ubuntu d'une ligne :
 
 ```shell
-DD_API_KEY=<CLÉ_API_DATADOG> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_API_KEY=<CLÉ_API_DATADOG> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 Pour obtenir les dernières instructions d'installation, accédez à la [page d'installation de l'Agent][18] pour votre système d'exploitation dans l'application.

--- a/content/fr/getting_started/tracing/_index.md
+++ b/content/fr/getting_started/tracing/_index.md
@@ -38,7 +38,7 @@ vagrant ssh
 Pour installer l'Agent Datadog sur un host, utilisez la [commande d'installation d'une ligne][6] en indiquant votre [clé d'API Datadog][7] :
 
 ```shell
-DD_API_KEY=<CLÉ_API_DATADOG> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+DD_API_KEY=<CLÉ_API_DATADOG> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 ```
 
 ### Validation

--- a/content/fr/integrations/databricks.md
+++ b/content/fr/integrations/databricks.md
@@ -99,7 +99,7 @@ if [[ \${DB_IS_DRIVER} = "TRUE" ]]; then
   DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:\${SPARK_LOCAL_IP}","spark_node:driver"
 
   # INSTALLER LA DERNIÈRE VERSION DE L'AGENT DATADOG 7
-  DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=DD_TAGS bash -c "\$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+  DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=DD_TAGS bash -c "\$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 
   # ATTENDRE QUE L'AGENT DATADOG SOIT INSTALLÉ
   while [ -z \$datadoginstalled ]; do
@@ -183,7 +183,7 @@ if [[ \${DB_IS_DRIVER} = "TRUE" ]]; then
   DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:\${SPARK_LOCAL_IP}","spark_node:driver"
 
   # INSTALLER LA DERNIÈRE VERSION DE L'AGENT DATADOG 7 POUR LES NŒUDS DRIVER ET WORKER 
-  DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+  DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 
   # ATTENDRE QUE L'AGENT DATADOG SOIT INSTALLÉ
   while [ -z \$datadoginstalled ]; do
@@ -228,7 +228,7 @@ else
   DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:\${SPARK_LOCAL_IP}","spark_node:worker"
 
   # INSTALLER LA DERNIÈRE VERSION DE L'AGENT DATADOG 7 SUR LES NŒUDS DRIVER ET WORKER 
-  DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+  DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 
 fi
 
@@ -270,7 +270,7 @@ if [ \$DB_IS_DRIVER ]; then
   DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:\${SPARK_LOCAL_IP}","spark_node:driver"
 
   # INSTALLER LA DERNIÈRE VERSION DE L'AGENT DATADOG 7 SUR LES NŒUDS DRIVER ET WORKER
-  DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+  DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 
   # ATTENDRE QUE L'AGENT DATADOG SOIT INSTALLÉ
   while [ -z \$datadoginstalled ]; do

--- a/content/ja/agent/basic_agent_usage/ansible.md
+++ b/content/ja/agent/basic_agent_usage/ansible.md
@@ -311,8 +311,8 @@ Datadog Ansible ロールは、Linux のみを対象として、Datadog Agent v5
 
 | Agent バージョン | デフォルトの Windows MSI パッケージ URL                                                  |
 |---------------|----------------------------------------------------------------------------------|
-| 6             | https://windows-agent.datadoghq.com/datadog-agent-6-latest.amd64.msi |
-| 7             | https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi |
+| 6             | https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi |
+| 7             | https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi |
 
 デフォルトの動作を上書きするには、この変数に空の文字列ではなく、何か別の値を設定してください。
 
@@ -322,8 +322,8 @@ Datadog Ansible ロールは、Linux のみを対象として、Datadog Agent v5
 
 | Agent バージョン | macOS DMG パッケージのデフォルトの URL                                |
 |---------------|--------------------------------------------------------------|
-| 6             | https://install.datadoghq.com/datadog-agent-6-latest.dmg |
-| 7             | https://install.datadoghq.com/datadog-agent-7-latest.dmg |
+| 6             | https://s3.amazonaws.com/dd-agent/datadog-agent-6-latest.dmg |
+| 7             | https://s3.amazonaws.com/dd-agent/datadog-agent-7-latest.dmg |
 
 デフォルトの動作を上書きするには、この変数に空の文字列ではなく、何か別の値を設定してください。
 

--- a/content/ja/agent/basic_agent_usage/windows.md
+++ b/content/ja/agent/basic_agent_usage/windows.md
@@ -42,13 +42,13 @@ Datadog Agent をドメイン環境にインストールするには、[Agent �
 
 1. [Datadog Agent インストーラー][1]をダウンロードし、最新バージョンの Agent をインストールします。
 
-   <div class="alert alert-info">特定のバージョンの Agent をインストールする必要がある場合は、<a href="https://windows-agent.datadoghq.com/installers.json">インストーラーリスト</a>を参照してください。</div>
+   <div class="alert alert-info">特定のバージョンの Agent をインストールする必要がある場合は、<a href="https://s3.amazonaws.com/ddagent-windows-stable/installers.json">インストーラーリスト</a>を参照してください。</div>
 
 2. `datadog-agent-7-latest.amd64.msi` を開き、インストーラーを (**管理者**として) 実行します。
 3. プロンプトに従ってライセンス契約に同意し、[Datadog API キー][2]を入力します。
 4. インストールが終了したら、オプションから Datadog Agent Manager を起動できます。
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 
 {{% /tab %}}
@@ -105,7 +105,7 @@ Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.m
 
 **注**: 有効な `datadog.yaml` が見つかり、API キーが設定されている場合は、そのファイルが、指定されているすべてのコマンドラインオプションより優先されます。
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
 [2]: /ja/agent/proxy/
 [3]: /ja/agent/faq/windows-agent-ddagent-user/
 [4]: /ja/network_monitoring/performance
@@ -117,7 +117,7 @@ Agent 7 は Python 3 のみをサポートします。アップグレードす�
 < 5.12.0 の Datadog Agent バージョンからアップグレードする場合は、最初に [EXE インストーラー][2]を使用して Agent 5 のより新しいバージョン（>= 5.12.0 だが < 6.0.0）にアップグレードしてから、 Datadog Agent バージョン >= 6 にアップグレードします。
 
 [1]: /ja/agent/guide/python-3/
-[2]: https://windows-agent.datadoghq.com/ddagent-cli-latest.exe
+[2]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.exe
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/ja/agent/faq/agent-downgrade-major.md
+++ b/content/ja/agent/faq/agent-downgrade-major.md
@@ -15,7 +15,7 @@ title: Agent を以前のメジャーバージョンにダウングレードす�
 次に、[v6 から v7 へのアップグレード][2]手順に従った場合、Agent をバージョン 7 からバージョン 6 にダウングレードするために、以下の Agent インストールコマンドを実行します。
 
 ```shell
-DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent6.sh)"
+DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh)"
 ```
 
 このコマンドは、Amazon Linux、CentOS、Debian、Fedora、Red Hat、Ubuntu、および SUSE のサポートされているすべてのバージョンで動作します。
@@ -34,9 +34,9 @@ DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://install.datadoghq.com/
 **注**: Windows インストーラーの利用可能な全バージョンのリンクは、[JSON 形式で提供されています][4]。
 
 [1]: /ja/agent/guide/how-do-i-uninstall-the-agent/
-[2]: https://windows-agent.datadoghq.com/datadog-agent-6-latest.amd64.msi
+[2]: https://ddagent-windows-stable.s3.amazonaws.com/datadog-agent-6-latest.amd64.msi
 [3]: https://app.datadoghq.com/organization-settings/api-keys
-[4]: https://windows-agent.datadoghq.com/installers.json
+[4]: https://s3.amazonaws.com/ddagent-windows-stable/installers.json
 {{% /tab %}}
 {{% tab "MacOS" %}}
 
@@ -45,7 +45,7 @@ DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://install.datadoghq.com/
 次に、[v6 から v7 へのアップグレード][2]手順に従った場合、Agent をバージョン 7 からバージョン 6 にダウングレードするために、環境変数 `DD_AGENT_MAJOR_VERSION=6` で Agent インストールコマンドを実行します。
 
 ```shell
-DD_AGENT_MAJOR_VERSION=6 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_AGENT_MAJOR_VERSION=6 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 [1]: /ja/agent/guide/how-do-i-uninstall-the-agent/

--- a/content/ja/agent/faq/certificate_verify_failed-error.md
+++ b/content/ja/agent/faq/certificate_verify_failed-error.md
@@ -110,7 +110,7 @@ restart-service -Force datadogagent
   `datadog.conf` が更新された後、Windows サービスマネージャーから Datadog サービスを再起動します。
 
 
-[1]: https://windows-agent.datadoghq.com/ddagent-cli-latest.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.msi
 [2]: https://app.datadoghq.com/account/settings/agent/5?platform=overview
 [3]: /ja/agent/versions/upgrade_to_agent_v7/?tab=linux#from-agent-v5-to-agent-v7
 [4]: /ja/agent/versions/upgrade_to_agent_v6/?tab=linux

--- a/content/ja/agent/faq/circleci-incident-impact-on-datadog-agent.md
+++ b/content/ja/agent/faq/circleci-incident-impact-on-datadog-agent.md
@@ -136,9 +136,9 @@ RPM の GPG 署名キーはフィンガープリント `60A389A44A0C32BAE3C03F0B
   * [Datadog Puppet モジュール][12]リリース [3.20.0][13]
   * [Datadog SaltStack 式][14]リリース [3.5][15]
   * Datadog Agent 6/7 Linux インストールスクリプト、2023 年 1 月 12 日 13 時 (UTC) にバージョン 1.13.0 を以下の場所にリリースしました。
-    * [https://install.datadoghq.com/scripts/install_script_agent6.sh][16]
-    * [https://install.datadoghq.com/scripts/install_script_agent7.sh][17]
-    * [https://install.datadoghq.com/scripts/install_script.sh][18] (非推奨となり、もはや推奨されませんが、更新されました。)
+    * [https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh][16]
+    * [https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh][17]
+    * [https://s3.amazonaws.com/dd-agent/scripts/install_script.sh][18] (非推奨となりましたが、更新しました。)
   * [Datadog Agent 5 Linux インストールスクリプト][19]が 2023 年 1 月 12 日 16:25 UTC にその[ダウンロード場所][19]にリリースされました
 
 
@@ -158,7 +158,7 @@ RPM の GPG 署名キーはフィンガープリント `60A389A44A0C32BAE3C03F0B
 [13]: https://github.com/DataDog/puppet-datadog-agent/releases/tag/v3.20.0
 [14]: https://github.com/DataDog/datadog-formula
 [15]: https://github.com/DataDog/datadog-formula/releases/tag/3.5
-[16]: https://install.datadoghq.com/scripts/install_script_agent6.sh
-[17]: https://install.datadoghq.com/scripts/install_script_agent7.sh
-[18]: https://install.datadoghq.com/scripts/install_script.sh
+[16]: https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh
+[17]: https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh
+[18]: https://s3.amazonaws.com/dd-agent/scripts/install_script.sh
 [19]: https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh

--- a/content/ja/agent/guide/agent-fips-proxy.md
+++ b/content/ja/agent/guide/agent-fips-proxy.md
@@ -78,7 +78,7 @@ DD_API_KEY=<DD_API_KEY> \
 DD_SITE="ddog-gov.com" \
 DD_FIPS_MODE=1 \
 bash -c "$(curl -L \
-  https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+   https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 環境変数 `DD_FIPS_MODE` を設定すると、Agent と一緒に FIPS パッケージがインストールされ、Agent がプロキシを使用するように構成されます。この方法を使用する場合、追加の構成手順はありませんが、[インストールを検証する](#verify-your-installation)必要があります。

--- a/content/ja/agent/guide/linux-agent-2022-key-rotation.md
+++ b/content/ja/agent/guide/linux-agent-2022-key-rotation.md
@@ -184,7 +184,7 @@ DEB ベースのシステム (Debian/Ubuntu) の Agent v5 ユーザーは、ロ�
 [2]: https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
 [3]: https://keys.datadoghq.com/DATADOG_APT_KEY_382E94DE.public
 [4]: https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
-[5]: https://install.datadoghq.com/scripts/install_script.sh
+[5]: https://s3.amazonaws.com/dd-agent/scripts/install_script.sh
 [6]: https://github.com/DataDog/chef-datadog
 [7]: https://github.com/DataDog/ansible-datadog
 [8]: https://github.com/DataDog/puppet-datadog-agent

--- a/content/ja/agent/iot/_index.md
+++ b/content/ja/agent/iot/_index.md
@@ -52,7 +52,7 @@ IoT Agent は、x64、arm64 (ARMv8)、ARMv7 アーキテクチャで実行中の
 ご使用中のオペレーティングシステムおよびチップセットアーキテクチャに適切な IoT Agent を自動的にダウンロードしてインストールするには、以下のコマンドを使用します。
 
 ```shell
-DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" DD_AGENT_FLAVOR=datadog-iot-agent bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" DD_AGENT_FLAVOR=datadog-iot-agent bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 #### 手動

--- a/content/ja/agent/versions/upgrade_between_agent_minor_versions.md
+++ b/content/ja/agent/versions/upgrade_between_agent_minor_versions.md
@@ -15,19 +15,19 @@ Agent 6 と 7 のマイナーバージョン間のアップグレードは、`in
 
 所定の Agent 6 マイナーバージョンにアップグレードします。
 
-: `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent6.sh)"`
+: `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent6.sh)"`
 
 最新の Agent 6 マイナーバージョンにアップグレードします。
 
-: `bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent6.sh)"`
+: `bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent6.sh)"`
 
 所定の Agent 7 マイナーバージョンにアップグレードします。
 
-: `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
+: `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent7.sh)"`
 
 最新の Agent 7 マイナーバージョンにアップグレードします。
 
-: `bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
+: `bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent7.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -36,11 +36,11 @@ Agent 6 と 7 のマイナーバージョン間のアップグレードは、`in
 
 特定の Agent 6 マイナーバージョンをダウンロードするための URL:
 
-: `https://windows-agent.datadoghq.com/ddagent-cli-6.<minor_version>.<bugfix_version>.msi`
+: `https://ddagent-windows-stable.s3.amazonaws.com/ddagent-cli-6.<minor_version>.<bugfix_version>.msi`
 
 特定の Agent 7 マイナーバージョンをダウンロードするための URL:
 
-: `https://windows-agent.datadoghq.com/ddagent-cli-7.<minor_version>.<bugfix_version>.msi`
+: `https://ddagent-windows-stable.s3.amazonaws.com/ddagent-cli-7.<minor_version>.<bugfix_version>.msi`
 
 {{% /tab %}}
 {{% tab "MacOS" %}}
@@ -49,11 +49,11 @@ Agent 6 と 7 のマイナーバージョン間のアップグレードは、`in
 
 最新の Agent 6 マイナーバージョンにアップグレードするためのコマンド:
 
-: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"`
+: `DD_AGENT_MAJOR_VERSION=6 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_mac_os.sh)"`
 
 最新の Agent 7 マイナーバージョンにアップグレードするためのコマンド:
 
-: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"`
+: `DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_mac_os.sh)"`
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/ja/agent/versions/upgrade_to_agent_v6.md
+++ b/content/ja/agent/versions/upgrade_to_agent_v6.md
@@ -22,7 +22,7 @@ Agent v5 が既にインストールされている場合は、新しい Agent �
 Agent v6 インストーラは、アップグレード時に v5 の構成を自動的に変換できます。
 
 以下のコマンドは、Amazon Linux、CentOS、Debian、Fedora、Red Hat、Ubuntu、および SUSE で動作します。
-: `DD_UPGRADE=true bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent6.sh)"`
+: `DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent6.sh)"`
 
 **注:** インポート処理では、**カスタム** Agent チェックは自動的に移動されません。これは、Datadog がそのままの状態での完全な下位互換性は保証できないためです。
 
@@ -37,7 +37,7 @@ Windows プラットフォーム用のワンステップインストールはあ
 Agent v6 インストーラは、アップグレード時に v5 の構成を自動的に変換できます。
 
 ```shell
-DD_UPGRADE=true bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_UPGRADE=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 **注:** インポート処理では、**カスタム** Agent チェックは自動的に移動されません。これは、Datadog がそのままの状態での完全な下位互換性は保証できないためです。
@@ -397,7 +397,7 @@ DD_UPGRADE=true bash -c "$(curl -L https://install.datadoghq.com/scripts/install
 
 **注**: アップグレード時に、`datadog.conf` は自動的に `datadog.yaml` にアップグレードされます。
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-6-latest.amd64.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi
 {{% /tab %}}
 {{% tab "MacOS" %}}
 

--- a/content/ja/agent/versions/upgrade_to_agent_v7.md
+++ b/content/ja/agent/versions/upgrade_to_agent_v7.md
@@ -19,7 +19,7 @@ Agent v7 は Python 3 のカスタムチェックにのみ対応しています�
 Agent をバージョン 6 からバージョン 7 にアップグレードするために、以下の Agent インストールコマンドを実行します。
 
 以下のコマンドは、Amazon Linux、CentOS、Debian、Fedora、Red Hat、Ubuntu、および SUSE で動作します。
-: `DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
+: `DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -31,16 +31,16 @@ Agent をバージョン 6 からバージョン 7 にアップグレードす�
 
 **注**: Windows インストーラーの利用可能な全バージョンのリンクは、[JSON 形式で提供されています][3]。
 
-[1]: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
+[1]: https://ddagent-windows-stable.s3.amazonaws.com/datadog-agent-7-latest.amd64.msi
 [2]: https://app.datadoghq.com/organization-settings/api-keys
-[3]: https://windows-agent.datadoghq.com/installers.json
+[3]: https://s3.amazonaws.com/ddagent-windows-stable/installers.json
 {{% /tab %}}
 {{% tab "MacOS" %}}
 
 Agent をバージョン 6 からバージョン 7 にアップグレードするには、環境変数 `DD_AGENT_MAJOR_VERSION=7` を使用して Agent インストールコマンドを実行します。
 
 ```shell
-DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 {{% /tab %}}
@@ -54,7 +54,7 @@ DD_AGENT_MAJOR_VERSION=7 DD_API_KEY="<DATADOG_API_KEY>" bash -c "$(curl -L https
 Agent をバージョン 5 からバージョン 7 にアップグレードするには、環境変数 `DD_UPGRADE="true"` を使用して Agent インストールコマンドを実行します。Agent v7 インストーラーにより、v5 のコンフィギュレーションがアップグレード中に自動的に変換されます。
 
 以下のコマンドは、Amazon Linux、CentOS、Debian、Fedora、Red Hat、Ubuntu、および SUSE で動作します。
-: `DD_UPGRADE="true" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
+: `DD_UPGRADE="true" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"`
 
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -69,7 +69,7 @@ Agent をバージョン 5 からバージョン 7 にアップグレードす�
 Agent をバージョン 5 からバージョン 7 にアップグレードするには、環境変数 `DD_AGENT_MAJOR_VERSION=7` と `DD_UPGRADE="true"` を使用して Agent インストールコマンドを実行します。Agent v7 インストーラーにより、v5 のコンフィギュレーションがアップグレード中に自動的に変換されます。
 
 ```shell
-DD_UPGRADE="true" DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://install.datadoghq.com/scripts/install_mac_os.sh)"
+DD_UPGRADE="true" DD_AGENT_MAJOR_VERSION=7 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_mac_os.sh)"
 ```
 
 {{% /tab %}}

--- a/content/ja/database_monitoring/setup_oracle/_index.md
+++ b/content/ja/database_monitoring/setup_oracle/_index.md
@@ -73,7 +73,7 @@ RHEL と Ubuntu のベータビルドがあるリポジトリはそれぞれ[こ
 export DD_AGENT_DIST_CHANNEL=beta
 export DD_AGENT_MINOR_VERSION="46.0~dbm~oracle~beta~0.32-1"
 
-DD_API_KEY= DD_SITE="datadoghq.com" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_API_KEY= DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 ##### Windows
@@ -122,10 +122,10 @@ Agent は外部の Oracle クライアントを必要としません。
 [1]: https://app.datadoghq.com/integrations
 [2]: https://app.datadoghq.com/integrations/oracle
 [3]: https://app.datadoghq.com/account/settings/agent/latest
-[4]: https://windows-agent.datadoghq.com/beta/datadog-agent-7.46.0-dbm-oracle-beta-0.32-1.x86_64.msi
+[4]: https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-agent-7.46.0-dbm-oracle-beta-0.32-1.x86_64.msi
 [5]: https://app.datadoghq.com/dash/integration/30990/dbm-oracle-database-overview
 [6]: https://yum.datadoghq.com/beta/7/x86_64/
 [7]: https://apt.datadoghq.com/dists/beta/7/
-[8]: https://windows-agent.datadoghq.com/
+[8]: https://ddagent-windows-stable.s3.amazonaws.com/
 [9]: https://hub.docker.com/r/datadog/agent/tags?page=1&name=oracle
 [10]: /ja/database_monitoring/architecture/

--- a/content/ja/getting_started/agent/_index.md
+++ b/content/ja/getting_started/agent/_index.md
@@ -105,7 +105,7 @@ Datadog UI で、**Integrations &gt; Agent** に移動し、Ubuntu を選択し�
 Ubuntu の 1 行インストールコマンドの例:
 
 ```shell
-DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 最新のインストール方法については、お使いの OS のアプリ内 [Agent インストールページ][18]をご覧ください。

--- a/content/ja/getting_started/tracing/_index.md
+++ b/content/ja/getting_started/tracing/_index.md
@@ -41,7 +41,7 @@ vagrant ssh
 [Datadog API キー][7]を付加した [1 行のインストールコマンド][6]を使用して、Datadog Host Agent をインストールします。
 
 ```shell
-DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
 
 ### 検証

--- a/content/ja/integrations/databricks.md
+++ b/content/ja/integrations/databricks.md
@@ -118,7 +118,7 @@ if [[ \${DB_IS_DRIVER} = "TRUE" ]]; then
   DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:\${SPARK_LOCAL_IP}","spark_node:driver"
 
   # 最新の Datadog Agent 7 をインストールします
-  DD_INSTALL_ONLY=true DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+  DD_INSTALL_ONLY=true DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
   # Datadog Agent がインストールされるのを待ちます
   while [ -z \$datadoginstalled ]; do
@@ -210,7 +210,7 @@ if [[ \${DB_IS_DRIVER} = "TRUE" ]]; then
   DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:\${SPARK_LOCAL_IP}","spark_node:driver"
 
   # 最新の Datadog Agent 7 をドライバーノードとワーカーノードにインストールします
-  DD_INSTALL_ONLY=true DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+  DD_INSTALL_ONLY=true DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
   # Datadog Agent がインストールされるのを待ちます
   while [ -z \$datadoginstalled ]; do
@@ -263,7 +263,7 @@ else
   DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:\${SPARK_LOCAL_IP}","spark_node:worker"
 
   # 最新の Datadog Agent 7 をドライバーノードとワーカーノードにインストールします
-  DD_INSTALL_ONLY=true DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+  DD_INSTALL_ONLY=true DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
   # バージョン 7.40 以降で Agent が失敗しないように datadog.yaml でホスト名を明示的に構成します
   # 変更点は https://github.com/DataDog/datadog-agent/issues/14152 をご覧ください
@@ -312,7 +312,7 @@ if [ \$DB_IS_DRIVER ]; then
   DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:\${SPARK_LOCAL_IP}","spark_node:driver"
 
   # 最新の Datadog Agent 7 をドライバーノードとワーカーノードにインストールします
-  DD_INSTALL_ONLY=true DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+  DD_INSTALL_ONLY=true DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
   # Datadog Agent がインストールされるのを待ちます
   while [ -z \$datadoginstalled ]; do

--- a/content/ja/tracing/guide/tutorial-enable-java-container-agent-host.md
+++ b/content/ja/tracing/guide/tutorial-enable-java-container-agent-host.md
@@ -41,7 +41,7 @@ Datadog Agent をマシンにインストールしていない場合は、今す
 1. [**Integrations > Agent**][5] にアクセスし、お使いの OS を選択してください。例えば、ほとんどの Linux プラットフォームでは、`<YOUR_API_KEY>` を [Datadog API キー][3]に置き換えて、以下のスクリプトを実行することで Agent をインストールすることができます。
 
    {{< code-block lang="shell" >}}
-DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
    {{< /code-block >}}
 
    `datadoghq.com` 以外の Datadog サイトにデータを送信するには、`DD_SITE` 環境変数を [Datadog サイト][6]に置き換えてください。

--- a/content/ja/tracing/guide/tutorial-enable-java-host.md
+++ b/content/ja/tracing/guide/tutorial-enable-java-host.md
@@ -40,7 +40,7 @@ Java の一般的なトレース設定ドキュメントについては、[Java 
 Datadog Agent をマシンにインストールしていない場合は、[**Integrations > Agent**][5] にアクセスし、お使いの OS を選択してください。例えば、ほとんどの Linux プラットフォームでは、`<YOUR_API_KEY>` を [Datadog API キー][3]に置き換えて、以下のスクリプトを実行することで Agent をインストールすることができます。
 
 {{< code-block lang="shell" >}}
-DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 {{< /code-block >}}
 
 `datadoghq.com` 以外の Datadog サイトにデータを送信するには、`DD_SITE` 環境変数を [Datadog サイト][6]に置き換えてください。

--- a/content/ja/tracing/guide/tutorial-enable-python-container-agent-host.md
+++ b/content/ja/tracing/guide/tutorial-enable-python-container-agent-host.md
@@ -40,7 +40,7 @@ Python の一般的なトレース設定ドキュメントについては、[Pyt
 Datadog Agent をマシンにインストールしていない場合は、[**Integrations > Agent**][5] にアクセスし、お使いの OS を選択してください。例えば、ほとんどの Linux プラットフォームでは、`<YOUR_API_KEY>` を [Datadog API キー][3]に置き換えて、以下のスクリプトを実行することで Agent をインストールすることができます。
 
 {{< code-block lang="shell" >}}
-DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 {{< /code-block >}}
 
 `datadoghq.com` 以外の Datadog サイトにデータを送信するには、`DD_SITE` 環境変数を [Datadog サイト][6]に置き換えてください。

--- a/content/ja/tracing/guide/tutorial-enable-python-host.md
+++ b/content/ja/tracing/guide/tutorial-enable-python-host.md
@@ -40,7 +40,7 @@ Python の一般的なトレース設定ドキュメントについては、[Pyt
 Datadog Agent をマシンにインストールしていない場合は、[**Integrations > Agent**][5] にアクセスし、お使いの OS を選択してください。例えば、ほとんどの Linux プラットフォームでは、`<YOUR_API_KEY>` を [Datadog API キー][3]に置き換えて、以下のスクリプトを実行することで Agent をインストールすることができます。
 
 {{< code-block lang="shell" >}}
-DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=<YOUR_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 {{< /code-block >}}
 
 `datadoghq.com` 以外の Datadog サイトにデータを送信するには、`DD_SITE` 環境変数を [Datadog サイト][6]に置き換えてください。

--- a/content/ko/agent/faq/certificate_verify_failed-error.md
+++ b/content/ko/agent/faq/certificate_verify_failed-error.md
@@ -110,7 +110,7 @@ restart-service -Force datadogagent
   `datadog.conf`를 업데이트한 후, 윈도우즈 서비스 관리자에서 Datadog 서비스를 재시작하세요.
 
 
-[1]: https://windows-agent.datadoghq.com/ddagent-cli-latest.msi
+[1]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.msi
 [2]: https://app.datadoghq.com/account/settings?agent_version=5#agent
 [3]: /ko/agent/versions/upgrade_to_agent_v7/?tab=linux#from-agent-v5-to-agent-v7
 [4]: /ko/agent/versions/upgrade_to_agent_v6/?tab=linux

--- a/content/ko/agent/iot/_index.md
+++ b/content/ko/agent/iot/_index.md
@@ -52,7 +52,7 @@ IoT Agent는 x64, arm64(ARMv8), ARMv7 아키텍처에서 실행 중인 Linux 기
 사용 중인 운영 체제와 칩셋 아키텍처에 적합한 IoT Agent를 자동으로 다운로드하여 설치하려면 다음 명령어를 사용하세요.
 
 ```shell
-DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" DD_AGENT_MAJOR_VERSION=7 DD_AGENT_FLAVOR=datadog-iot-agent bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" DD_AGENT_MAJOR_VERSION=7 DD_AGENT_FLAVOR=datadog-iot-agent bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 ```
 
 #### 수동

--- a/content/ko/getting_started/agent/_index.md
+++ b/content/ko/getting_started/agent/_index.md
@@ -104,7 +104,7 @@ Datadog UI에서 **Integrations > Agent**로 이동해 우분투용 [Agent 설�
 호스트 상에 Datadog Agent를 설치하려면 [Datadog API 키][2]로 업데이트된 [원 라인 설치 명령][19]을 사용합니다.
 
 ```shell
-DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 ```
 
 ### 검증

--- a/content/ko/getting_started/tracing/_index.md
+++ b/content/ko/getting_started/tracing/_index.md
@@ -38,7 +38,7 @@ vagrant ssh
 호스트 상에 Datadog Agent를 설치하려면  [Datadog API 키][7]와 함께 업데이트된 [원라인 설치 명령어][6]를 사용하세요.
 
 ```shell
-DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script.sh)"
+DD_API_KEY=<DATADOG_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 ```
 
 ### 검증

--- a/static/config/99datadog-amazon-linux-2.config
+++ b/static/config/99datadog-amazon-linux-2.config
@@ -21,7 +21,7 @@ files:
     mode: "000700"
     owner: root
     group: root
-    source: https://install.datadoghq.com/scripts/install_script_agent7.sh
+    source: https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh
 
 container_commands:
     05setup_datadog:

--- a/static/config/99datadog-windows.config
+++ b/static/config/99datadog-windows.config
@@ -4,7 +4,7 @@ packages:
     DotnetAPM: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.8.0/datadog-dotnet-apm-2.8.0-x64.msi
 files:
   "c:\\Datadog\\datadog-agent-7-latest.amd64.msi":
-    source: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
+    source: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
 
 commands:
   00_setup-env1: # Eg: Sets .NET APM's tracing library configuration to env:dev

--- a/static/config/99datadog.config
+++ b/static/config/99datadog.config
@@ -21,7 +21,7 @@ files:
     mode: "000700"
     owner: root
     group: root
-    source: https://install.datadoghq.com/scripts/install_script_agent7.sh
+    source: https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh
 
 container_commands:
     05setup_datadog:

--- a/static/resources/json/dd-agent-install-eu-site.json
+++ b/static/resources/json/dd-agent-install-eu-site.json
@@ -21,7 +21,7 @@
 			},
 			"inputs": {
 				"runCommand": [
-					"wget -O ddinstall.sh https://install.datadoghq.com/scripts/install_script_agent7.sh",
+					"wget -O ddinstall.sh https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh",
 					"export DD_API_KEY=$(aws --region <AWS_REGION> ssm get-parameters --names dd-api-key-for-ssm --with-decryption --query Parameters[].Value --output text)",
 					"export DD_SITE=datadoghq.eu",
 					"bash ./ddinstall.sh"

--- a/static/resources/json/dd-agent-install-us-site.json
+++ b/static/resources/json/dd-agent-install-us-site.json
@@ -21,7 +21,7 @@
 			},
 			"inputs": {
 				"runCommand": [
-					"wget -O ddinstall.sh https://install.datadoghq.com/scripts/install_script_agent7.sh",
+					"wget -O ddinstall.sh https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh",
 					"export DD_API_KEY=$(aws --region <AWS_REGION> ssm get-parameters --names dd-api-key-for-ssm --with-decryption --query Parameters[].Value --output text)",
 					"bash ./ddinstall.sh"
 				],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This reverts commit e247f4119cb27e04fe5ad184a66bf184a192b64e.

### Motivation
<!-- What inspired you to submit this pull request?-->

Moving the install script locations behind cloudfront was planned, but ultimately not implemented.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
