### PR TITLE
Remove extra 'the' in definition

### DIFF
--- a/content/en/glossary/terms/flame_graph.md
+++ b/content/en/glossary/terms/flame_graph.md
@@ -3,4 +3,4 @@ title: flame graph
 core_product:
   - apm
 ---
-A flame graph is a visualization of a trace, where bars represent spans and show the the span's execution time as well as what called it and what calls it made. Flame graphs are also used to represent profiles.
+A flame graph is a visualization of a trace, where bars represent spans and show the span's execution time as well as what called it and what calls it made. Flame graphs are also used to represent profiles.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Remove typo in flame graph definition.

### Motivation
<!-- What inspired you to submit this pull request?-->
Hotjar feedback [DOCS-6081](https://datadoghq.atlassian.net/browse/DOCS-6081)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Read to merge after review.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-6081]: https://datadoghq.atlassian.net/browse/DOCS-6081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ