### PR TITLE
Revert "Add custom redirects for integrations (#19376)"

### DIFF
--- a/config/_default/integration_redirects.yaml
+++ b/config/_default/integration_redirects.yaml
@@ -1,1 +1,0 @@
-akamai_datastream_2: ['/integrations/akamai_datastream']

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -8,7 +8,6 @@ import re
 import shutil
 import sys
 from collections import defaultdict
-from pathlib import Path
 
 import yaml
 import markdown2
@@ -46,8 +45,6 @@ finally:
             for tag in get_non_deprecated_classifiers():
                 file_content.append(f'| {tag["name"]} | {tag["description"]} |\n')
             file.write(''.join(file_content) + '\n')
-
-CUSTOM_REDIRECTS = yaml.safe_load(Path('config/_default/integration_redirects.yaml').read_text())
 
 class Integrations:
     def __init__(self, source_file, temp_directory, integration_mutations):
@@ -386,6 +383,7 @@ class Integrations:
         set is_public to false to hide integrations we merge later
         :param file_name: path to a manifest json file
         """
+
         names = [
             d.get("name", "").lower()
             for d in self.datafile_json
@@ -896,11 +894,6 @@ class Integrations:
                 item["draft"] = not item.get("is_public", False)
                 item["integration_id"] = item.get("integration_id", integration_id)
                 item["integration_version"] = item.get("integration_version", integration_version)
-                # Add custom aliases
-                for redirect, aliases in CUSTOM_REDIRECTS.items():
-                    if redirect == item.get('name'):
-                        for alias in aliases:
-                            item.setdefault('aliases', []).append(alias)
                 # remove aliases that point to the page they're located on
                 # get the current slug from the doc_link
                 if item.get('name'):


### PR DESCRIPTION
There's a better way to add redirects for integrations using front matter cascades with Hugo, so we're going to use that method instead.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
