### PR TITLE
(maint) Fix small security rule redirect issue

### DIFF
--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -136,7 +136,7 @@ def security_rules(content, content_dir):
                 "aliases": [
                     # f"{data.get('defaultRuleId', '').strip()}",
                     # f"/security_monitoring/default_rules/{data.get('defaultRuleId', '').strip()}",
-                    f"/security_monitoring/default_rules/{p.stem}"
+                    f"/security_monitoring/default_rules/{p.stem.lower()}"
                 ],
                 "rule_category": [],
                 "integration_id": "",


### PR DESCRIPTION
At least one of the [security rule filenames use capitalization](https://github.com/DataDog/security-monitoring/blob/main/cloud-siem/log-detection/production/kubernetes/kubernetes-pod-created-with-hostNetwork.md). The filenames are used to insert aliases (redirects) into the docs at build time, and caps don't work in redirects. This should fix it. 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
