### PR TITLE
Remove the com.datadoghq.internal bundle from the action catalog doc

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -629,6 +629,7 @@
             bundle_excludes:
               - "com.datadoghq.test"
               - "com.datadoghq.sample"
+              - "com.datadoghq.internal"
 
       - repo_name: web-ui
         contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: true
+    cache_enabled: false
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: false
+    cache_enabled: true
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -630,6 +630,7 @@
             bundle_excludes:
               - "com.datadoghq.test"
               - "com.datadoghq.sample"
+              - "com.datadoghq.internal"
 
       - repo_name: web-ui
         contents:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR removes the "Datadog Internal" bundle from the action catalog page https://docs.datadoghq.com/service_management/workflows/actions_catalog/

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Preview link to the catalog https://docs-staging.datadoghq.com/gabriel.plassard/exclude-workflow-internal-from-doc/service_management/workflows/actions_catalog/

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
