### PR TITLE
Change description of the Monitor delete action

### DIFF
--- a/content/en/monitors/manage/_index.md
+++ b/content/en/monitors/manage/_index.md
@@ -33,7 +33,7 @@ After searching, select one or more monitors to update using the checkboxes next
 | Mute       | [Mute][3] the selected monitors for `1h`, `4h`, `12h`, `1d`, `1w`, or `Forever`. |
 | Unmute     | If the selected monitors are muted, unmute them.                                 |
 | Resolve    | [Resolve][4] the alert for the selected monitors.                                |
-| Delete     | Permanently delete the selected monitors.                                        |
+| Delete     | Delete the selected monitors.                                                    |
 | Edit Tags  | Edit the monitor tags for the selected monitors.                                 |
 | Edit Teams | Edit the [teams][5] for the selected monitors.                                  |
 


### PR DESCRIPTION
### What does this PR do?
Change description of the delete action in the monitor manage doc

### Motivation
Monitor delete is not a permanent action since now the users are able to restore their recently deleted monitors from the settings page.
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
