### PR TITLE
RUM-926: Update the limit for Android mapping file uploads to 300 MB

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/android.md
+++ b/content/en/real_user_monitoring/error_tracking/android.md
@@ -153,7 +153,7 @@ tasks["minify${variant}WithR8"].finalizedBy { tasks["uploadMapping${variant}"] }
 
 ## Limitations
 
-Mapping files are limited to 200 MB when targeting our US1 or EU1 sites, and 50 MB for other sites. If your project has a mapping file larger than this, use one of the following options to reduce the file size:
+Mapping files are limited to 300 MB (except AP1 and GovCloud sites, where the limit is 50 MB). If your project has a mapping file larger than this, use one of the following options to reduce the file size:
 
 - Set the `mappingFileTrimIndents` option to `true`. This reduces your file size by 5%, on average.
 - Set a map of `mappingFilePackagesAliases`: This replaces package names with shorter aliases. **Note**: Datadog's stacktrace uses the same alias instead of the original package name, so it's better to use this option for third party dependencies.

--- a/content/en/real_user_monitoring/error_tracking/android.md
+++ b/content/en/real_user_monitoring/error_tracking/android.md
@@ -153,7 +153,12 @@ tasks["minify${variant}WithR8"].finalizedBy { tasks["uploadMapping${variant}"] }
 
 ## Limitations
 
-Mapping files are limited to 300 MB (except AP1 and GovCloud sites, where the limit is 50 MB). If your project has a mapping file larger than this, use one of the following options to reduce the file size:
+{{< site-region region="us,us3,us5,eu" >}}
+Mapping files are limited to 300 MB. If your project has a mapping file larger than this, use one of the following options to reduce the file size:
+{{< /site-region >}}
+{{< site-region region="ap1,gov" >}}
+Mapping files are limited to 50 MB. If your project has a mapping file larger than this, use one of the following options to reduce the file size:
+{{< /site-region >}}
 
 - Set the `mappingFileTrimIndents` option to `true`. This reduces your file size by 5%, on average.
 - Set a map of `mappingFilePackagesAliases`: This replaces package names with shorter aliases. **Note**: Datadog's stacktrace uses the same alias instead of the original package name, so it's better to use this option for third party dependencies.

--- a/content/en/real_user_monitoring/error_tracking/android.md
+++ b/content/en/real_user_monitoring/error_tracking/android.md
@@ -154,10 +154,10 @@ tasks["minify${variant}WithR8"].finalizedBy { tasks["uploadMapping${variant}"] }
 ## Limitations
 
 {{< site-region region="us,us3,us5,eu" >}}
-Mapping files are limited to 300 MB. If your project has a mapping file larger than this, use one of the following options to reduce the file size:
+Mapping files are limited to **300** MB. If your project has a mapping file larger than this, use one of the following options to reduce the file size:
 {{< /site-region >}}
 {{< site-region region="ap1,gov" >}}
-Mapping files are limited to 50 MB. If your project has a mapping file larger than this, use one of the following options to reduce the file size:
+Mapping files are limited to **50** MB. If your project has a mapping file larger than this, use one of the following options to reduce the file size:
 {{< /site-region >}}
 
 - Set the `mappingFileTrimIndents` option to `true`. This reduces your file size by 5%, on average.

--- a/content/en/real_user_monitoring/error_tracking/reactnative.md
+++ b/content/en/real_user_monitoring/error_tracking/reactnative.md
@@ -49,14 +49,12 @@ config.nativeCrashReportEnabled = true; // enable native crash reporting
 
 ## Limitations
 
-<div class="alert alert-warning"><p>
 {{< site-region region="us,us3,us5,eu" >}}
 Datadog can accept uploads up to 300 MB.
 {{< /site-region >}}
 {{< site-region region="ap1,gov" >}}
 Datadog can accept uploads up to 50 MB.
 {{< /site-region >}}
-</p></div>
 
 To compute the size of your source maps and bundle, run the following command:
 

--- a/content/en/real_user_monitoring/error_tracking/reactnative.md
+++ b/content/en/real_user_monitoring/error_tracking/reactnative.md
@@ -50,7 +50,12 @@ config.nativeCrashReportEnabled = true; // enable native crash reporting
 ## Limitations
 
 <div class="alert alert-warning"><p>
-Datadog can accept uploads up to 300 MB (except AP1 and GovCloud sites, where the limit is 50 MB).
+{{< site-region region="us,us3,us5,eu" >}}
+Datadog can accept uploads up to 300 MB.
+{{< /site-region >}}
+{{< site-region region="ap1,gov" >}}
+Datadog can accept uploads up to 50 MB.
+{{< /site-region >}}
 </p></div>
 
 To compute the size of your source maps and bundle, run the following command:

--- a/content/en/real_user_monitoring/error_tracking/reactnative.md
+++ b/content/en/real_user_monitoring/error_tracking/reactnative.md
@@ -50,10 +50,10 @@ config.nativeCrashReportEnabled = true; // enable native crash reporting
 ## Limitations
 
 {{< site-region region="us,us3,us5,eu" >}}
-Datadog can accept uploads up to 300 MB.
+Datadog can accept uploads up to **300** MB.
 {{< /site-region >}}
 {{< site-region region="ap1,gov" >}}
-Datadog can accept uploads up to 50 MB.
+Datadog can accept uploads up to **50** MB.
 {{< /site-region >}}
 
 To compute the size of your source maps and bundle, run the following command:

--- a/content/en/real_user_monitoring/error_tracking/reactnative.md
+++ b/content/en/real_user_monitoring/error_tracking/reactnative.md
@@ -50,7 +50,7 @@ config.nativeCrashReportEnabled = true; // enable native crash reporting
 ## Limitations
 
 <div class="alert alert-warning"><p>
-Datadog can accept uploads up to 200 MB for US1 or EU1 sites, 50 MB for other sites.
+Datadog can accept uploads up to 300 MB (except AP1 and GovCloud sites, where the limit is 50 MB).
 </p></div>
 
 To compute the size of your source maps and bundle, run the following command:

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -22,10 +22,10 @@ Configure your JavaScript bundler such that when minifying your source code, it 
 
 <div class="alert alert-warning">
 {{< site-region region="us,us3,us5,eu" >}}
-Ensure that the size of each source map augmented with the size of the related minified file does not exceed the limit of **300 MB**.
+Ensure that the size of each source map augmented with the size of the related minified file does not exceed the limit of **300** MB.
 {{< /site-region >}}
 {{< site-region region="ap1,gov" >}}
-Ensure that the size of each source map augmented with the size of the related minified file does not exceed the limit of **50 MB**.
+Ensure that the size of each source map augmented with the size of the related minified file does not exceed the limit of **50** MB.
 {{< /site-region >}}
 </div>
 

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -18,7 +18,7 @@ If your front-end JavaScript source code is minified, upload your source maps to
 
 ## Instrument your code
 
-Configure your JavaScript bundler such that when minifying your source code, it generates source maps that directly include the related source code in the `sourcesContent` attribute. Also, ensure that the size of each source map augmented with the size of the related minified file does not exceed the limit of **200 MB** for US1 or EU1 sites, or **50 MB** for other sites.
+Configure your JavaScript bundler such that when minifying your source code, it generates source maps that directly include the related source code in the `sourcesContent` attribute. Also, ensure that the size of each source map augmented with the size of the related minified file does not exceed the limit of **300 MB** (except AP1 and GovCloud sites, where the limit is **50 MB**).
 
 See the following configurations for popular JavaScript bundlers.
 
@@ -75,7 +75,7 @@ See the following example:
         javascript.464388.js.map
 ```
 
-<div class="alert alert-warning">If the sum of the file size for <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds the <b>the 200 MB for US1 or EU1 sites (50 MB for other sites)</b> limit, reduce it by configuring your bundler to split the source code into multiple smaller chunks. For more information, see <a href="https://webpack.js.org/guides/code-splitting/">Code Splitting with WebpackJS</a>.</div>
+<div class="alert alert-warning">If the sum of the file size for <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds the <b>the 300 MB</b> limit (except AP1 and GovCloud sites, where the limit is 50 MB), reduce it by configuring your bundler to split the source code into multiple smaller chunks. For more information, see <a href="https://webpack.js.org/guides/code-splitting/">Code Splitting with WebpackJS</a>.</div>
 
 ## Upload your source maps
 

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -18,7 +18,16 @@ If your front-end JavaScript source code is minified, upload your source maps to
 
 ## Instrument your code
 
-Configure your JavaScript bundler such that when minifying your source code, it generates source maps that directly include the related source code in the `sourcesContent` attribute. Also, ensure that the size of each source map augmented with the size of the related minified file does not exceed the limit of **300 MB** (except AP1 and GovCloud sites, where the limit is **50 MB**).
+Configure your JavaScript bundler such that when minifying your source code, it generates source maps that directly include the related source code in the `sourcesContent` attribute. 
+
+<div class="alert alert-warning">
+{{< site-region region="us,us3,us5,eu" >}}
+Ensure that the size of each source map augmented with the size of the related minified file does not exceed the limit of **300 MB**.
+{{< /site-region >}}
+{{< site-region region="ap1,gov" >}}
+Ensure that the size of each source map augmented with the size of the related minified file does not exceed the limit of **50 MB**.
+{{< /site-region >}}
+</div>
 
 See the following configurations for popular JavaScript bundlers.
 

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -84,7 +84,14 @@ See the following example:
         javascript.464388.js.map
 ```
 
-<div class="alert alert-warning">If the sum of the file size for <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds the <b>the 300 MB</b> limit (except AP1 and GovCloud sites, where the limit is 50 MB), reduce it by configuring your bundler to split the source code into multiple smaller chunks. For more information, see <a href="https://webpack.js.org/guides/code-splitting/">Code Splitting with WebpackJS</a>.</div>
+<div class="alert alert-warning">
+{{< site-region region="us,us3,us5,eu" >}}
+If the sum of the file size for <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds the <b>the **300** MB</b> limit, reduce it by configuring your bundler to split the source code into multiple smaller chunks. For more information, see <a href="https://webpack.js.org/guides/code-splitting/">Code Splitting with WebpackJS</a>.
+{{< /site-region >}}
+{{< site-region region="ap1,gov" >}}
+If the sum of the file size for <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds the <b>the **50** MB</b> limit, reduce it by configuring your bundler to split the source code into multiple smaller chunks. For more information, see <a href="https://webpack.js.org/guides/code-splitting/">Code Splitting with WebpackJS</a>.
+{{< /site-region >}}
+</div>
 
 ## Upload your source maps
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR updates Android mapping file limit from 200 MB to 300 MB for all Datadog sites except AP1 and GovCloud.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
