### PR TITLE
[WEB-3753] Update cookie banner script

### DIFF
--- a/assets/scripts/cookie-banner.js
+++ b/assets/scripts/cookie-banner.js
@@ -13,30 +13,14 @@ window.addEventListener('load', function () {
         divA.id = "teconsent";
         divA.style = "cursor: pointer; color:#fff"
         divB.id = "consent-banner";
-        divB.style = "position:fixed; bottom:0px; right:0px; width:100%; z-index:999999";
+        divB.style = "position:fixed; bottom:0px; right:0px; width:100%;";
         document.body.appendChild(divA);
         document.body.appendChild(divB);
         
         // update Cookie link
         this.setTimeout(function () {
-            // const target = document.getElementById('truste-consent-track');
             const prefsElement = document.getElementById('teconsent');
             const cookieLink = document.querySelector('footer a[href*="/cookies"]');
-
-            // if (target) {
-            //     // update z-index on banner
-            //     const observer = new MutationObserver(function (mutations) {
-            //         mutations.forEach(function () {
-            //             if (target.style.display === 'none') {
-            //                 target.parentElement.style.zIndex = -1
-            //             } else {
-            //                 target.parentElement.style.setProperty('z-index', '999999', 'important');
-            //             }
-            //         });
-            //     });
-
-            //     observer.observe(target, { attributes: true, attributeFilter: ['style'] });
-            // }
 
             // replace Cookie link with Prefs div
             return (cookieLink && document.getElementById('teconsent').innerHTML.length > 0) ? cookieLink.replaceWith(prefsElement) : false;

--- a/assets/scripts/cookie-banner.js
+++ b/assets/scripts/cookie-banner.js
@@ -13,7 +13,7 @@ window.addEventListener('load', function () {
         divA.id = "teconsent";
         divA.style = "cursor: pointer; color:#fff"
         divB.id = "consent-banner";
-        divB.style = "position:fixed; bottom:0px; right:0px; width:100%; z-index:-1";
+        divB.style = "position:fixed; bottom:0px; right:0px; width:100%; z-index:999999";
         document.body.appendChild(divA);
         document.body.appendChild(divB);
         
@@ -34,10 +34,6 @@ window.addEventListener('load', function () {
                         }
                     });
                 });
-
-                if (target.style.display !== 'none') {
-                    target.parentElement.style.setProperty('z-index', '999999', 'important');
-                }
 
                 observer.observe(target, { attributes: true, attributeFilter: ['style'] });
             }

--- a/assets/scripts/cookie-banner.js
+++ b/assets/scripts/cookie-banner.js
@@ -26,7 +26,7 @@ window.addEventListener('load', function () {
             if (banner) {
                 // listen for click and remove banner to avoid interfering with 
                 document.addEventListener('click', function (event) {
-                    var targetElement = event.target;
+                    const targetElement = event.target;
                     if (targetElement.matches('#truste-consent-required') || targetElement.matches('#truste-consent-button')) {
                         banner.remove();
                     }

--- a/assets/scripts/cookie-banner.js
+++ b/assets/scripts/cookie-banner.js
@@ -40,6 +40,6 @@ window.addEventListener('load', function () {
 
             // replace Cookie link with Prefs div
             return (cookieLink && document.getElementById('teconsent').innerHTML.length > 0) ? cookieLink.replaceWith(prefsElement) : false;
-        }, 500);
+        }, 5000);
     }
 });

--- a/assets/scripts/cookie-banner.js
+++ b/assets/scripts/cookie-banner.js
@@ -19,11 +19,22 @@ window.addEventListener('load', function () {
         
         // update Cookie link
         this.setTimeout(function () {
+            const banner = document.getElementById('consent-banner');
             const prefsElement = document.getElementById('teconsent');
             const cookieLink = document.querySelector('footer a[href*="/cookies"]');
 
+            if (banner) {
+                // listen for click and remove banner to avoid interfering with 
+                document.addEventListener('click', function (event) {
+                    var targetElement = event.target;
+                    if (targetElement.matches('#truste-consent-required') || targetElement.matches('#truste-consent-button')) {
+                        banner.remove();
+                    }
+                });
+            }
+
             // replace Cookie link with Prefs div
             return (cookieLink && document.getElementById('teconsent').innerHTML.length > 0) ? cookieLink.replaceWith(prefsElement) : false;
-        }, 500);
+        }, 200);
     }
 });

--- a/assets/scripts/cookie-banner.js
+++ b/assets/scripts/cookie-banner.js
@@ -19,27 +19,27 @@ window.addEventListener('load', function () {
         
         // update Cookie link
         this.setTimeout(function () {
-            const target = document.getElementById('truste-consent-track');
+            // const target = document.getElementById('truste-consent-track');
             const prefsElement = document.getElementById('teconsent');
             const cookieLink = document.querySelector('footer a[href*="/cookies"]');
 
-            if (target) {
-                // update z-index on banner
-                const observer = new MutationObserver(function (mutations) {
-                    mutations.forEach(function () {
-                        if (target.style.display === 'none') {
-                            target.parentElement.style.zIndex = -1
-                        } else {
-                            target.parentElement.style.setProperty('z-index', '999999', 'important');
-                        }
-                    });
-                });
+            // if (target) {
+            //     // update z-index on banner
+            //     const observer = new MutationObserver(function (mutations) {
+            //         mutations.forEach(function () {
+            //             if (target.style.display === 'none') {
+            //                 target.parentElement.style.zIndex = -1
+            //             } else {
+            //                 target.parentElement.style.setProperty('z-index', '999999', 'important');
+            //             }
+            //         });
+            //     });
 
-                observer.observe(target, { attributes: true, attributeFilter: ['style'] });
-            }
+            //     observer.observe(target, { attributes: true, attributeFilter: ['style'] });
+            // }
 
             // replace Cookie link with Prefs div
             return (cookieLink && document.getElementById('teconsent').innerHTML.length > 0) ? cookieLink.replaceWith(prefsElement) : false;
-        }, 5000);
+        }, 500);
     }
 });


### PR DESCRIPTION
### What does this PR do?

When the GDPR banner first loads, its z-index is set to 999999, however, the code that was set up to update the z-index to -1 after the banner was closed was no longer working as there is a delay now on the banner display.

This is updated to listen for a click event on the relevant buttons and remove the element after the user either Accepts or Rejects the cookies.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-3753

### Preview 
In order to test, you have to be in a GDPR region or use a proxy (encrypt.me) to change your location:

https://docs-staging.datadoghq.com/nsollecito/web-3960/

Wait until the banner loads, click Accept or Reject and make sure you can still click the links in the footer after the element is removed.

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
