### PR TITLE
Update dual-shipping docs for orchestrator to include helm instuctions

### DIFF
--- a/content/en/agent/guide/dual-shipping.md
+++ b/content/en/agent/guide/dual-shipping.md
@@ -129,18 +129,18 @@ DD_PROCESS_ADDITIONAL_ENDPOINTS='{\"https://process.datadoghq.com\": [\"apikey2\
 
 ## Orchestrator
 
-### YAML configuration
-In `datadog.yaml`:
+### HELM configuration
+In Datadog `values.yaml`:
 ```yaml
-orchestrator_explorer:
-  [...]
-  orchestrator_additional_endpoints:
-    "https://orchestrator.datadoghq.com":
-    - apikey2
-    - apikey3
-    "https://orchestrator.datadoghq.eu":
-    - apikey4
+clusterAgent:
+...
+  datadog_cluster_yaml:
+    orchestrator_explorer:
+      orchestrator_additional_endpoints:
+        "https://orchestrator.ddog-gov.com":
+        - apikey2 
 ```
+
 
 ### Environment variable configuration
 


### PR DESCRIPTION
Adding helm instructions for dual shipping orchestrator data. There is no case where you'd add config to the `datadog.yaml` so I removed it to avoid confusion