### PR TITLE
Fix secret documentation broken link

### DIFF
--- a/content/en/agent/guide/secrets-management.md
+++ b/content/en/agent/guide/secrets-management.md
@@ -563,3 +563,4 @@ This command returns whether the permissions are valid for the Agent to view thi
 [4]: https://docs.docker.com/engine/swarm/secrets/
 [5]: https://github.com/DataDog/datadog-agent/blob/6.4.x/Dockerfiles/agent/OPENSHIFT.md#restricted-scc-operations
 [6]: /agent/guide/agent-commands/#restart-the-agent
+[7]: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets_scripts/secrets_tester.ps1


### PR DESCRIPTION
### What does this PR do?

Fix secret documentation broken link.

Merge fd521a41cda245c134e24135ed02738d25748ef5 seems to have broken the link

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
