### PR TITLE
[ci-visibility] Add note about test duration with ITR 

### DIFF
--- a/content/en/continuous_integration/intelligent_test_runner/javascript.md
+++ b/content/en/continuous_integration/intelligent_test_runner/javascript.md
@@ -68,7 +68,7 @@ NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app DD_CIV
 
 ### Cypress setup
 
-For Intelligent Test Runner for Cypress to work, you must instrument your web application with code coverage. You can read more about enabling code coverage in the [Cypress documentation][4]. To check that you've successfully enabled code coverage, navigate to your web app with Cypress and check the global variable `window.__coverage__`. This is what `dd-trace` uses to collect code coverage for Intelligent Test Runner.
+For Intelligent Test Runner for Cypress to work, you must instrument your web application with code coverage. You can read more about enabling code coverage in the [Cypress documentation][3]. To check that you've successfully enabled code coverage, navigate to your web app with Cypress and check the global variable `window.__coverage__`. This is what `dd-trace` uses to collect code coverage for Intelligent Test Runner.
 
 
 ## Suite skipping
@@ -77,7 +77,7 @@ Intelligent Test Runner for Javascript skips entire _test suites_ (test files) r
 
 ## Note about changing test durations
 
-In some frameworks, such as `jest`, there are cache mechanisms that make tests faster after other tests have run (see [jest cache][5] docs). If Intelligent Test Runner is skipping all but a few test files, these suites might run slower than they usually do. This is because they run with a colder cache than they usually do. Regardless of this, total execution time for your test command should still be reduced.
+In some frameworks, such as `jest`, there are cache mechanisms that make tests faster after other tests have run (see [jest cache][4] docs). If Intelligent Test Runner is skipping all but a few test files, these suites might run slower than they usually do. This is because they run with a colder cache. Regardless of this, total execution time for your test command should still be reduced.
 
 ## Further Reading
 
@@ -85,6 +85,5 @@ In some frameworks, such as `jest`, there are cache mechanisms that make tests f
 
 [1]: https://www.npmjs.com/package/nyc
 [2]: /continuous_integration/tests/javascript
-[3]: https://app.datadoghq.com/ci/settings/test-service
-[4]: https://docs.cypress.io/guides/tooling/code-coverage#Instrumenting-code
-[5]: https://jestjs.io/docs/cli#--cache
+[3]: https://docs.cypress.io/guides/tooling/code-coverage#Instrumenting-code
+[4]: https://jestjs.io/docs/cli#--cache

--- a/content/en/continuous_integration/intelligent_test_runner/javascript.md
+++ b/content/en/continuous_integration/intelligent_test_runner/javascript.md
@@ -68,11 +68,15 @@ NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-app DD_CIV
 
 ### Cypress setup
 
-For Intelligent Test Runner for Cypress to work, you must instrument your web application with code coverage. You can read more about enabling code coverage in the [Cypress documentation][3]. To check that you've successfully enabled code coverage, navigate to your web app with Cypress and check the global variable `window.__coverage__`. This is what `dd-trace` uses to collect code coverage for Intelligent Test Runner.
+For Intelligent Test Runner for Cypress to work, you must instrument your web application with code coverage. You can read more about enabling code coverage in the [Cypress documentation][4]. To check that you've successfully enabled code coverage, navigate to your web app with Cypress and check the global variable `window.__coverage__`. This is what `dd-trace` uses to collect code coverage for Intelligent Test Runner.
 
 
-#### Suite skipping
+## Suite skipping
 Intelligent Test Runner for Javascript skips entire _test suites_ (test files) rather than individual tests.
+
+## Note about changing test durations
+
+In some frameworks, such as `jest`, there are cache mechanisms that make tests faster after the running of tests has gone on for a while (see [jest cache][5] docs). If Intelligent Test Runner is skipping all but a few test files, these suites might run slower than they usually do. This is because they run with a colder cache than they usually do.
 
 ## Further Reading
 
@@ -80,4 +84,6 @@ Intelligent Test Runner for Javascript skips entire _test suites_ (test files) r
 
 [1]: https://www.npmjs.com/package/nyc
 [2]: /continuous_integration/tests/javascript
-[3]: https://docs.cypress.io/guides/tooling/code-coverage#Instrumenting-code
+[3]: https://app.datadoghq.com/ci/settings/test-service
+[4]: https://docs.cypress.io/guides/tooling/code-coverage#Instrumenting-code
+[5]: https://jestjs.io/docs/cli#--cache

--- a/content/en/continuous_integration/intelligent_test_runner/javascript.md
+++ b/content/en/continuous_integration/intelligent_test_runner/javascript.md
@@ -74,9 +74,10 @@ For Intelligent Test Runner for Cypress to work, you must instrument your web ap
 ## Suite skipping
 Intelligent Test Runner for Javascript skips entire _test suites_ (test files) rather than individual tests.
 
-## Note about changing test durations
 
-In some frameworks, such as `jest`, there are cache mechanisms that make tests faster after the running of tests has gone on for a while (see [jest cache][5] docs). If Intelligent Test Runner is skipping all but a few test files, these suites might run slower than they usually do. This is because they run with a colder cache than they usually do.
+## Note about changing test durations
+
+In some frameworks, such as `jest`, there are cache mechanisms that make tests faster after other tests have run (see [jest cache][5] docs). If Intelligent Test Runner is skipping all but a few test files, these suites might run slower than they usually do. This is because they run with a colder cache than they usually do. Regardless of this, total execution time for your test command should still be reduced.
 
 ## Further Reading
 

--- a/content/en/continuous_integration/intelligent_test_runner/javascript.md
+++ b/content/en/continuous_integration/intelligent_test_runner/javascript.md
@@ -75,7 +75,7 @@ For Intelligent Test Runner for Cypress to work, you must instrument your web ap
 Intelligent Test Runner for Javascript skips entire _test suites_ (test files) rather than individual tests.
 
 
-## Note about changing test durations
+## Inconsistent test durations
 
 In some frameworks, such as `jest`, there are cache mechanisms that make tests faster after other tests have run (see [jest cache][4] docs). If Intelligent Test Runner is skipping all but a few test files, these suites might run slower than they usually do. This is because they run with a colder cache. Regardless of this, total execution time for your test command should still be reduced.
 


### PR DESCRIPTION
### What does this PR do?
Add a note about changing durations for suites that run with intelligent test runner.

### Motivation
Let users know about this ITR quirk. 

### Preview

https://docs-staging.datadoghq.com/juan-fernandez/add-note-about-test-durations/continuous_integration/intelligent_test_runner/javascript

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
