### PR TITLE
Add note on Notes and Links page

### DIFF
--- a/content/en/dashboards/widgets/note.md
+++ b/content/en/dashboards/widgets/note.md
@@ -10,7 +10,8 @@ further_reading:
   text: "Learn how to build dashboards using JSON"
 ---
 
-The **Notes & Links** widget is similar to the [free text widget][1] but contains more formatting and display options.
+The **Notes & Links** widget is similar to the [free text widget][1] but contains more formatting and display options. 
+  Note. The Notes & Links widget does not support inline HTML. 
 
 ## Setup
 

--- a/content/en/dashboards/widgets/note.md
+++ b/content/en/dashboards/widgets/note.md
@@ -11,7 +11,8 @@ further_reading:
 ---
 
 The **Notes & Links** widget is similar to the [free text widget][1] but contains more formatting and display options. 
-  Note. The Notes & Links widget does not support inline HTML. 
+
+**Note**: The Notes & Links widget does not support inline HTML.
 
 ## Setup
 


### PR DESCRIPTION
### What does this PR do?
Adds a small disclaimer that the notes and links widget does not support inline HTML. Unsure if there is perhaps a more appropriate location within the page.

### Motivation
A support request: https://datadoghq.atlassian.net/browse/WEBPS-4961

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
