### PR TITLE
Change default log index count from 10 to 100

### DIFF
--- a/content/en/logs/log_configuration/indexes.md
+++ b/content/en/logs/log_configuration/indexes.md
@@ -37,7 +37,7 @@ The Log Explorer supports [queries across multiple indexes][7].
 
 ### Add indexes
 
-Use the "New Index" button to create a new index. There is a maximum number of indexes you can create for each account, set to 10 by default.
+Use the "New Index" button to create a new index. There is a maximum number of indexes you can create for each account, set to 100 by default.
 
 {{< img src="logs/indexes/add-index.png" alt="Add index" style="width:70%;">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Changes the default log index count from 10 to 100

### Motivation
Product has lifted the default limit, and since the docs say:

> [Contact Datadog support](https://docs.datadoghq.com/help) if you need to increase the maximum number of indexes for your account.

We'd prefer to keep the ticket count down by letting customers know they get 100 by default.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
Please hold on merging while I obtain final approval from the Logs Group PM.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
