### PR TITLE
Add Ruby Support + x86_64 Architectures Only

### DIFF
--- a/content/en/tracing/trace_collection/single-step-apm.md
+++ b/content/en/tracing/trace_collection/single-step-apm.md
@@ -7,10 +7,11 @@ is_beta: true
 <div class="alert alert-info">
 <strong>Single Step APM Instrumentation is in beta!</strong> <p> This feature is available in the latest Datadog Agent version.</p>
 <ul>
+<li>On x86_64 architectures only</li>
 <li>On Linux hosts and VMs</li>
 <li>On Docker containers</li>
 </ul>
-<p>It supports tracing Java, Python, Node.js, and .NET services. Try it out!</p> 
+<p>It supports tracing Java, Python, Ruby, Node.js, and .NET services. Try it out!</p> 
 
 <p>For Kubernetes deployments, a private beta is available for tracing Java, Python, Node.js, .NET and Ruby services. <a href="http://dtdg.co/apm-onboarding">Fill out this form to request access</a>.</p>
 </div>

--- a/content/en/tracing/trace_collection/single-step-apm.md
+++ b/content/en/tracing/trace_collection/single-step-apm.md
@@ -7,11 +7,10 @@ is_beta: true
 <div class="alert alert-info">
 <strong>Single Step APM Instrumentation is in beta!</strong> <p> This feature is available in the latest Datadog Agent version.</p>
 <ul>
-<li>On x86_64 architectures only</li>
 <li>On Linux hosts and VMs</li>
 <li>On Docker containers</li>
 </ul>
-<p>It supports tracing Java, Python, Ruby, Node.js, and .NET services. Try it out!</p> 
+<p>It supports tracing Java, Python, Ruby, Node.js, and .NET services on x86_64 architectures only. Try it out!</p> 
 
 <p>For Kubernetes deployments, a private beta is available for tracing Java, Python, Node.js, .NET and Ruby services. <a href="http://dtdg.co/apm-onboarding">Fill out this form to request access</a>.</p>
 </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Update Single Step APM note:
- Ruby is a supported language.
- Only  x86_64 architectures are supported.

### Motivation
<!-- What inspired you to submit this pull request?-->
Requested by @vidurkhannadatadog 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
