### PR TITLE
[DOCS-5570] Add service name variable to log collection docs

### DIFF
--- a/content/en/logs/log_collection/csharp.md
+++ b/content/en/logs/log_collection/csharp.md
@@ -283,8 +283,8 @@ Once [log collection is enabled][2], set up [custom log collection][3] to tail y
     logs:
 
       - type: file
-        path: "/path/to/your/csharp/log.log"
-        service: csharp
+        path: "<path_to_your_csharp_log>.log"
+        service: <service_name>
         source: csharp
         sourcecategory: sourcecode
         # For multiline logs, if they start by the date with the format yyyy-mm-dd uncomment the following processing rule

--- a/content/en/logs/log_collection/go.md
+++ b/content/en/logs/log_collection/go.md
@@ -94,8 +94,8 @@ Once [log collection is enabled][3], set up [custom log collection][4] to tail y
     logs:
 
       - type: file
-        path: "/path/to/your/go/log.log"
-        service: go
+        path: "<path_to_your_go_log>.log"
+        service: <service_name>
         source: go
         sourcecategory: sourcecode
     ```

--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -279,8 +279,8 @@ Once [log collection is enabled][4], set up [custom log collection][5] to tail y
     logs:
 
       - type: file
-        path: "/path/to/your/java/log.log"
-        service: java
+        path: "<path_to_your_java_log>.log"
+        service: <service_name>
         source: java
         sourcecategory: sourcecode
         # For multiline logs, if they start by the date with the format yyyy-mm-dd uncomment the following processing rule

--- a/content/en/logs/log_collection/nodejs.md
+++ b/content/en/logs/log_collection/nodejs.md
@@ -126,7 +126,7 @@ logs:
 
   - type: file
     path: "<FILE_NAME_PATH>.log"
-    service: nodejs
+    service: <SERVICE_NAME>
     source: nodejs
     sourcecategory: sourcecode
 ```

--- a/content/en/logs/log_collection/php.md
+++ b/content/en/logs/log_collection/php.md
@@ -191,7 +191,7 @@ instances:
 logs:
 
   - type: file
-    path: "<path_to_your_php_application-json>.log"
+    path: "<path_to_your_php_application_json>.log"
     service: "<service_name>"
     source: php
     sourcecategory: sourcecode

--- a/content/en/logs/log_collection/php.md
+++ b/content/en/logs/log_collection/php.md
@@ -191,8 +191,8 @@ instances:
 logs:
 
   - type: file
-    path: "/path/to/your/php/application-json.log"
-    service: "<SERVICE_NAME>"
+    path: "<path_to_your_php_application-json>.log"
+    service: "<service_name>"
     source: php
     sourcecategory: sourcecode
 ```

--- a/content/en/logs/log_collection/python.md
+++ b/content/en/logs/log_collection/python.md
@@ -59,7 +59,7 @@ Once [log collection][7] is enabled, set up [custom log collection][8] to tail y
 
       - type: file
         path: "<PATH_TO_PYTHON_LOG>.log"
-        service: "<YOUR_APPLICATION>"
+        service: "<SERVICE_NAME>"
         source: python
         sourcecategory: sourcecode
         # For multiline logs, if they start by the date with the format yyyy-mm-dd uncomment the following processing rule

--- a/content/en/logs/log_collection/ruby.md
+++ b/content/en/logs/log_collection/ruby.md
@@ -153,7 +153,7 @@ Once [log collection is enabled][3], do the following to set up [custom log coll
       logs:
         - type: file
           path: "<RUBY_LOG_FILE_PATH>.log"
-          service: ruby
+          service: <SERVICE_NAME>
           source: ruby
           sourcecategory: sourcecode
           ## Uncomment the following processing rule for multiline logs if they


### PR DESCRIPTION
### What does this PR do?

Adds service name variables to log collection docs and make path file variable format consistent with it. 

### Motivation

[DOCS-5570](https://datadoghq.atlassian.net/browse/DOCS-5570)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-5570]: https://datadoghq.atlassian.net/browse/DOCS-5570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ