### PR TITLE
Tracing: Update Ruby trace_id generation range

### DIFF
--- a/content/en/tracing/guide/span_and_trace_id_format.md
+++ b/content/en/tracing/guide/span_and_trace_id_format.md
@@ -16,7 +16,7 @@ Generally, the libraries generate IDs that are 64-bit unsigned integers. Specifi
 | Java       | Unsigned [1, $2^63-1$]   | Unsigned                      |
 | Go         | Unsigned [0, $2^63-1$]   | Signed or unsigned            |
 | Python     | Unsigned [0, $2^63$]     | Unsigned                      |
-| Ruby       | Unsigned [0, $2^63$]     | Unsigned                      |
+| Ruby       | Unsigned [1, $2^62-1$]   | Unsigned                      |
 | .NET       | Unsigned [0, $2^63$]     | Unsigned                      |
 | PHP        | [0, $2^63$]              | Signed                        |
 | C++        | Unsigned [0, $2^63-1$]   | Unsigned                      |


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

This PR updates the trace id generation page with the correct rage for the Ruby tracer.

### Motivation
<!-- What inspired you to submit this pull request?-->

We've had the trace id for Ruby being an integer from 1 to (2**62)-1 for quite some time: https://github.com/DataDog/dd-trace-rb/blob/09c08622ea7f7ca4e193ea6bca6daec4cde3e8cb/lib/datadog/tracing/utils.rb#L13-L20

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
