### PR TITLE
[OpenShift Operator] Document securityContext for log/apm via socket

### DIFF
--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -94,7 +94,7 @@ spec:
 
 ## Azure Kubernetes Service (AKS) {#AKS}
 
-AKS requires a specific configuration for the `Kubelet` integration due to how AKS has setup the SSL Certificates. Additionally, the optional [Admission Controller][3] feature requires a specific configuration to prevent an error when reconciling the webhook.
+AKS requires a specific configuration for the `Kubelet` integration due to how AKS has setup the SSL Certificates. Additionally, the optional [Admission Controller][1] feature requires a specific configuration to prevent an error when reconciling the webhook.
 
 {{< tabs >}}
 {{% tab "Helm" %}}
@@ -154,7 +154,7 @@ The `kubelet.tlsVerify=false` sets the environment variable `DD_KUBELET_TLS_VERI
 
 There is a known issue with the format of the AKS Kubelet certificate in older node image versions. As of Agent 7.35, it is required to use `tlsVerify: false` as the certificates did not contain a valid Subject Alternative Name (SAN).
 
-If all the nodes within your AKS cluster are using a supported node image version, you can use Kubelet TLS Verification. Your version must be at or above the [versions listed here for the 2022-10-30 release][4]. You must also update your Kubelet configuration to use the node name for the address and map in the custom certificate path.
+If all the nodes within your AKS cluster are using a supported node image version, you can use Kubelet TLS Verification. Your version must be at or above the [versions listed here for the 2022-10-30 release][2]. You must also update your Kubelet configuration to use the node name for the address and map in the custom certificate path.
 
 {{< tabs >}}
 {{% tab "Helm" %}}
@@ -235,7 +235,7 @@ Since Agent 7.26, no specific configuration is required for GKE (whether you run
 
 GKE Autopilot requires some configuration, shown below.
 
-Datadog recommends that you specify resource limits for the Agent container. Autopilot sets a relatively low default limit (50m CPU, 100Mi memory) that may quickly lead the Agent container to OOMKill depending on your environment. If applicable, also specify resource limits for the Trace Agent and Process Agent containers. Additionally, you may wish to create a priority class for the Agent in order to ensure it is scheduled. 
+Datadog recommends that you specify resource limits for the Agent container. Autopilot sets a relatively low default limit (50m CPU, 100Mi memory) that may quickly lead the Agent container to OOMKill depending on your environment. If applicable, also specify resource limits for the Trace Agent and Process Agent containers. Additionally, you may wish to create a priority class for the Agent in order to ensure it is scheduled.
 
 {{< tabs >}}
 {{% tab "Helm" %}}
@@ -383,6 +383,13 @@ spec:
         name: gcr.io/datadoghq/cluster-agent:latest
     nodeAgent:
       serviceAccountName: datadog-agent-scc
+      securityContext:
+        runAsUser: 0
+        seLinuxOptions:
+          level: s0
+          role: system_r
+          type: spc_t
+          user: system_u
       image:
         name: gcr.io/datadoghq/agent:latest
       tolerations:
@@ -393,6 +400,8 @@ spec:
           operator: Exists
           effect: NoSchedule
 ```
+
+**Note**: The nodeAgent Security Context override is necessary for the Log Collection and APM - Trace Collection via the `/var/run/datadog/apm/apm.socket` socket. It can be omitted if these features are not enabled.
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -534,8 +543,8 @@ spec:
 {{% /tab %}}
 {{< /tabs >}}
 
-More `values.yaml` examples can be found in the [Helm chart repository][1]
-More `DatadogAgent` examples can be found in the [Datadog Operator repository][2]
+More `values.yaml` examples can be found in the [Helm chart repository][3]
+More `DatadogAgent` examples can be found in the [Datadog Operator repository][4]
 
 ## vSphere Tanzu Kubernetes Grid (TKG) {#TKG}
 
@@ -605,7 +614,7 @@ spec:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/helm-charts/tree/main/examples/datadog
-[2]: https://github.com/DataDog/datadog-operator/tree/main/examples/datadogagent/v2alpha1
-[3]: /containers/cluster_agent/admission_controller
-[4]: https://github.com/Azure/AKS/releases/tag/2022-10-30
+[1]: /containers/cluster_agent/admission_controller
+[2]: https://github.com/Azure/AKS/releases/tag/2022-10-30
+[3]: https://github.com/DataDog/helm-charts/tree/main/examples/datadog
+[4]: https://github.com/DataDog/datadog-operator/tree/main/examples/datadogagent/v2alpha1

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -401,7 +401,7 @@ spec:
           effect: NoSchedule
 ```
 
-**Note**: The nodeAgent Security Context override is necessary for the Log Collection and APM - Trace Collection via the `/var/run/datadog/apm/apm.socket` socket. It can be omitted if these features are not enabled.
+**Note**: The nodeAgent Security Context override is necessary for Log Collection and APM - Trace Collection with the `/var/run/datadog/apm/apm.socket` socket. It can be omitted if these features are not enabled.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -235,7 +235,7 @@ Since Agent 7.26, no specific configuration is required for GKE (whether you run
 
 GKE Autopilot requires some configuration, shown below.
 
-Datadog recommends that you specify resource limits for the Agent container. Autopilot sets a relatively low default limit (50m CPU, 100Mi memory) that may quickly lead the Agent container to OOMKill depending on your environment. If applicable, also specify resource limits for the Trace Agent and Process Agent containers. Additionally, you may wish to create a priority class for the Agent in order to ensure it is scheduled.
+Datadog recommends that you specify resource limits for the Agent container. Autopilot sets a relatively low default limit (50m CPU, 100Mi memory) that may rapidly lead the Agent container to OOMKill depending on your environment. If applicable, also specify resource limits for the Trace Agent and Process Agent containers. Additionally, you may wish to create a priority class for the Agent to ensure it is scheduled.
 
 {{< tabs >}}
 {{% tab "Helm" %}}

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -235,7 +235,7 @@ Since Agent 7.26, no specific configuration is required for GKE (whether you run
 
 GKE Autopilot requires some configuration, shown below.
 
-Datadog recommends that you specify resource limits for the Agent container. Autopilot sets a relatively low default limit (50m CPU, 100Mi memory) that may rapidly lead the Agent container to OOMKill depending on your environment. If applicable, also specify resource limits for the Trace Agent and Process Agent containers. Additionally, you may wish to create a priority class for the Agent to ensure it is scheduled.
+Datadog recommends that you specify resource limits for the Agent container. Autopilot sets a relatively low default limit (50m CPU, 100Mi memory) that may lead the Agent container to quickly OOMKill depending on your environment. If applicable, also specify resource limits for the Trace Agent and Process Agent containers. Additionally, you may wish to create a priority class for the Agent to ensure it is scheduled.
 
 {{< tabs >}}
 {{% tab "Helm" %}}
@@ -401,7 +401,7 @@ spec:
           effect: NoSchedule
 ```
 
-**Note**: The nodeAgent Security Context override is necessary for Log Collection and APM - Trace Collection with the `/var/run/datadog/apm/apm.socket` socket. It can be omitted if these features are not enabled.
+**Note**: The nodeAgent Security Context override is necessary for Log Collection and APM Trace Collection with the `/var/run/datadog/apm/apm.socket` socket. If these features are not enabled, you can omit this override.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
### What does this PR do?
* Documents the necessary security context override for the nodeAgent in OpenShift when deploying with the Operator
    * With the Helm chart, this security context is set by default, so it works OOTB
* The `format-links.sh` pre-commit also modified the hyperlinks on this page.

### Motivation
* Discussion with container-ecosystems team on moving forward to enable these features within OpenShift when using the Operator : https://dd.slack.com/archives/C037CDX0WJV/p1692983558887469?thread_ts=1690186181.131549&cid=C037CDX0WJV

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
