### PR TITLE
Correct name of option in mapping Prometheus metrics guide

### DIFF
--- a/content/en/integrations/guide/prometheus-metrics.md
+++ b/content/en/integrations/guide/prometheus-metrics.md
@@ -75,7 +75,7 @@ However, if the parameter `send_monotonic_counter` is `false`, then this metric 
 
 For [Prometheus/OpenMetrics `histogram`][104], the `_count` and `_sum` values of the histogram are each mapped to Datadog's `gauge` type and include a `.count` and `.sum` suffix in their name, respectively.
 
-If the `send_histogram_buckets` parameter is `true`, `_bucket` samples are sent to Datadog with a `.bucket` suffix, and are also mapped to Datadog's `gauge` by default.
+If the `send_histograms_buckets` parameter is `true`, `_bucket` samples are sent to Datadog with a `.bucket` suffix, and are also mapped to Datadog's `gauge` by default.
 
 Setting the `send_distribution_counts_as_monotonic` parameter to `true` causes the `_count` and `_bucket` metrics to be sent as type `count` instead. Setting `send_distribution_sums_as_monotonic` does the same for `_sum` metrics.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Fix an error on an option name. 

### Motivation

Someone discovered a similar error elsewhere (https://github.com/DataDog/integrations-core/pull/15693), cross-checking I found out that this guide makes the same mistake. See for example https://github.com/DataDog/integrations-core/blob/feafdeb3694fbe8990a3ae4a87cd6b382457063f/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py#L25.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
