### PR TITLE
Add public docs for the Teams SAML capability

### DIFF
--- a/content/en/account_management/saml/mapping.md
+++ b/content/en/account_management/saml/mapping.md
@@ -17,6 +17,8 @@ You can map attributes to the following principals:
 
  Users with the Access Management permission can assign or remove Datadog principals based on a user's SAML-assigned attributes.
 
+ Setting up a mapping from SAML attributes to Datadog entities allows you to manage users solely in your identity provider. The system then provisions users in Datadog according to the mappings you set up.
+
 ## Prerequisites
 
 It's important to understand what is sent in an assertion before turning on mappings, as mappings require correct attributes. Every IdP has specific mappings. For example, Azure works with object IDs, and Okta requires you to set attributes in [Okta settings][3]. Datadog recommends cross-referencing with [built-in browser tooling][4] such as Chrome Dev Tools or browser extensions and [validating your SAML assertions][5] **before** creating mappings.
@@ -78,6 +80,8 @@ Alternatively, you can create and change mappings of SAML attributes to Datadog 
 7. If you have not already done so, enable mappings by clicking **Enable Mappings**.
 
 Make changes to a mapping by clicking the pencil (**Edit**) icon, or remove a mapping by clicking the garbage (**Delete**) icon. These actions affect only the mapping, not the identity provider attributes or the Datadog Team.
+
+**Note:** Unlike Roles, Teams do not affect the login experience in any way. Datadog uses Team mapping purely as a provisioning source. For example, when a user does not belong to any Teams, they can still sign in to Datadog.
 
 [1]: /account_management/rbac/
 [2]: /account_management/teams/

--- a/content/en/account_management/saml/mapping.md
+++ b/content/en/account_management/saml/mapping.md
@@ -21,7 +21,7 @@ You can map attributes to the following principals:
 
 ## Prerequisites
 
-It's important to understand what is sent in an assertion before turning on mappings, as mappings require correct attributes. Every IdP has specific mappings. For example, Azure works with object IDs, and Okta requires you to set attributes in [Okta settings][3]. Datadog recommends cross-referencing with [built-in browser tooling][4] such as Chrome Dev Tools or browser extensions and [validating your SAML assertions][5] **before** creating mappings.
+It's important to understand what is sent in an assertion before turning on mappings, as mappings require correct attributes. Every IdP has specific mappings. For example, Azure works with object IDs, and Okta requires you to set attributes in [Okta settings][3]. Datadog recommends cross-referencing with [built-in browser tooling][4] such as Chrome DevTools or browser extensions and [validating your SAML assertions][5] **before** creating mappings.
 
 ## Map SAML attributes to Datadog roles
 

--- a/content/en/account_management/saml/mapping.md
+++ b/content/en/account_management/saml/mapping.md
@@ -7,19 +7,31 @@ further_reading:
   text: "Single sign on with SAML"
 ---
 
-## Mapping SAML attributes to Datadog roles
+## Overview
 
-With Datadog, you can map attributes in your Identity Provider (IdP)'s response to Datadog roles. Users with the Access Management permission can assign or remove Datadog roles based on a user's SAML-assigned attributes.
+With Datadog, you can map attributes in your Identity Provider (IdP)'s response to Datadog entities.
 
-It's important to understand what is sent in an assertion before turning on mappings, as mappings require correct attributes. Every IdP has specific mappings. For example, Azure works with object IDs, and Okta requires you to set attributes in [Okta settings][1]. Datadog recommends cross-referencing with [built-in browser tooling][2] such as Chrome Dev Tools or browser extensions and [validating your SAML assertions][3] **before** creating mappings.
+You can map attributes to the following principals:
+- [Datadog roles][1]
+- [Datadog Teams (beta)][2]
 
-1. [Cross-reference][2] and [validate][3] your SAML assertion to understand your IdP's attributes.
+ Users with the Access Management permission can assign or remove Datadog principals based on a user's SAML-assigned attributes.
+
+## Prerequisites
+
+It's important to understand what is sent in an assertion before turning on mappings, as mappings require correct attributes. Every IdP has specific mappings. For example, Azure works with object IDs, and Okta requires you to set attributes in [Okta settings][3]. Datadog recommends cross-referencing with [built-in browser tooling][4] such as Chrome Dev Tools or browser extensions and [validating your SAML assertions][5] **before** creating mappings.
+
+## Map SAML attributes to Datadog roles
+
+1. [Cross-reference][4] and [validate][5] your SAML assertion to understand your IdP's attributes.
 
 2. Go to **Organization Settings** and click the **SAML Group Mappings** tab.
 
-3. Click **New Mapping**.
+3. If it is visible, ensure the **Role Mappings** tab is selected.
 
-4. Specify the SAML identity provider `key-value` pair that you want to associate with an existing Datadog role (either default or custom). **Note**: These entries are case-sensitive.
+4. Click **New Mapping**. A dialog box appears.
+
+5. Specify the SAML identity provider `key-value` pair that you want to associate with an existing Datadog role (either default or custom). **Note**: These entries are case-sensitive.
 
    For example, if you want all users whose `member_of` attribute has a value of `Development` to be assigned to a custom Datadog role called `Devs`:
 
@@ -27,7 +39,7 @@ It's important to understand what is sent in an assertion before turning on mapp
 
    **Note**: Every identity provider is different. Some allow you to set your attribute key or label. Others provide one by default. Datadog recommends you use an assertion inspector on your login to view the details of your particular assertion to understand how your Identity Provider is sending your group membership.
 
-5. If you have not already done so, enable mappings by clicking **Enable Mappings**.
+6. If you have not already done so, enable mappings by clicking **Enable Mappings**.
 
 When a user logs in who has the specified identity provider attribute, they are automatically assigned the Datadog role. Likewise, if someone has that identity provider attribute removed, they lose access to the role (unless another mapping adds it).
 
@@ -35,11 +47,41 @@ When a user logs in who has the specified identity provider attribute, they are 
   <strong>Important:</strong> If a user does <i>not</i> match any mapping, they lose any roles they had previously and are prevented from logging into the org with SAML. Double-check your mapping definitions and inspect your own assertions before enabling Mappings to prevent any scenarios where your users are unable to login.
 </div>
 
-You can make changes to a mapping by clicking the **pencil** icon or remove it by clicking the **garbage** icon. These actions affect only the mapping, not the identity provider attributes or the Datadog roles.
+Make changes to a mapping by clicking the pencil (**Edit**) icon, or remove a mapping by clicking the garbage (**Delete**) icon. These actions affect only the mapping, not the identity provider attributes or the Datadog roles.
 
-Alternatively, you can create and change mappings of SAML attributes to Datadog roles with the `authn_mappings` endpoint. For more information, see [Federated Authentication to Role Mapping API][4].
+Alternatively, you can create and change mappings of SAML attributes to Datadog roles with the `authn_mappings` endpoint. For more information, see [Federated Authentication to Role Mapping API][6].
 
-[1]: https://help.okta.com/en/prod/Content/Topics/users-groups-profiles/usgp-add-custom-user-attributes.htm
-[2]: https://support.okta.com/help/s/article/How-to-View-a-SAML-Response-in-Your-Browser-for-Troubleshooting?language=en_US
-[3]: https://www.samltool.com/validate_response.php
-[4]: /account_management/authn_mapping/
+## Map SAML attributes to Teams
+
+{{< callout url="/help/" >}}
+  Mapping SAML attributes to Teams is in beta. To request access, contact Support.
+{{< /callout >}}
+
+1. [Cross-reference][4] and [validate][5] your SAML assertion to understand your IdP's attributes.
+
+2. Go to **Organization Settings** and click the **SAML Group Mappings** tab.
+
+3. Ensure the **Team Mappings** tab is selected.
+
+4. Click **New Mapping**. A dialog box appears.
+
+5. Specify the SAML identity provider `key-value` pair that you want to associate with a Datadog Team. **Note**: These entries are case-sensitive.
+
+    **Note**: Every identity provider is different. Some allow you to set your attribute key or label. Others provide one by default. Datadog recommends you use an assertion inspector on your login to view the details of your particular assertion to understand how your Identity Provider is sending your group membership.
+
+6. Select a **Team** from the dropdown menu.
+
+7. To add an additional mapping, click **Add Row**.
+
+8. When you are done adding mappings, click **Create**.
+
+7. If you have not already done so, enable mappings by clicking **Enable Mappings**.
+
+Make changes to a mapping by clicking the pencil (**Edit**) icon, or remove a mapping by clicking the garbage (**Delete**) icon. These actions affect only the mapping, not the identity provider attributes or the Datadog Team.
+
+[1]: /account_management/rbac/
+[2]: /account_management/teams/
+[3]: https://help.okta.com/en/prod/Content/Topics/users-groups-profiles/usgp-add-custom-user-attributes.htm
+[4]: https://support.okta.com/help/s/article/How-to-View-a-SAML-Response-in-Your-Browser-for-Troubleshooting?language=en_US
+[5]: https://www.samltool.com/validate_response.php
+[6]: /account_management/authn_mapping/

--- a/content/en/account_management/saml/mapping.md
+++ b/content/en/account_management/saml/mapping.md
@@ -53,7 +53,7 @@ Alternatively, you can create and change mappings of SAML attributes to Datadog 
   Mapping SAML attributes to Teams is in beta. To request access, contact Support.
 {{< /callout >}}
 
-1. Ensure you selected either **SAML** or **All sources** when choosing your [provisioning source] for team memberships.
+1. Ensure you selected either **SAML** or **All sources** when choosing your [provisioning source][7] for team memberships.
 2. [Cross-reference][4] and [validate][5] your SAML assertion to understand your IdP's attributes.
 3. Go to **Organization Settings** and click the **SAML Group Mappings** tab.
 4. Ensure the **Team Mappings** tab is selected.
@@ -75,3 +75,4 @@ Make changes to a mapping by clicking the pencil (**Edit**) icon, or remove a ma
 [4]: https://support.okta.com/help/s/article/How-to-View-a-SAML-Response-in-Your-Browser-for-Troubleshooting?language=en_US
 [5]: https://www.samltool.com/validate_response.php
 [6]: /account_management/authn_mapping/
+[7]: /account_management/teams/#choose-provisioning-source

--- a/content/en/account_management/saml/mapping.md
+++ b/content/en/account_management/saml/mapping.md
@@ -13,7 +13,7 @@ With Datadog, you can map attributes in your Identity Provider (IdP)'s response 
 
 You can map attributes to the following principals:
 - [Datadog roles][1]
-- [Datadog Teams (beta)][2]
+- [Datadog Teams][2]
 
  Users with the Access Management permission can assign or remove Datadog principals based on a user's SAML-assigned attributes.
 
@@ -26,21 +26,15 @@ It's important to understand what is sent in an assertion before turning on mapp
 ## Map SAML attributes to Datadog roles
 
 1. [Cross-reference][4] and [validate][5] your SAML assertion to understand your IdP's attributes.
-
 2. Go to **Organization Settings** and click the **SAML Group Mappings** tab.
-
 3. If it is visible, ensure the **Role Mappings** tab is selected.
-
 4. Click **New Mapping**. A dialog box appears.
-
 5. Specify the SAML identity provider `key-value` pair that you want to associate with an existing Datadog role (either default or custom). **Note**: These entries are case-sensitive.
-
    For example, if you want all users whose `member_of` attribute has a value of `Development` to be assigned to a custom Datadog role called `Devs`:
 
     {{< img src="account_management/saml/create_mapping.png" alt="Creating a SAML mapping to Datadog Role" >}}
 
    **Note**: Every identity provider is different. Some allow you to set your attribute key or label. Others provide one by default. Datadog recommends you use an assertion inspector on your login to view the details of your particular assertion to understand how your Identity Provider is sending your group membership.
-
 6. If you have not already done so, enable mappings by clicking **Enable Mappings**.
 
 When a user logs in who has the specified identity provider attribute, they are automatically assigned the Datadog role. Likewise, if someone has that identity provider attribute removed, they lose access to the role (unless another mapping adds it).
@@ -59,25 +53,17 @@ Alternatively, you can create and change mappings of SAML attributes to Datadog 
   Mapping SAML attributes to Teams is in beta. To request access, contact Support.
 {{< /callout >}}
 
-1. [Cross-reference][4] and [validate][5] your SAML assertion to understand your IdP's attributes.
-
-2. Go to **Organization Settings** and click the **SAML Group Mappings** tab.
-
-3. Ensure the **Team Mappings** tab is selected.
-
-4. Click **New Mapping**. A dialog box appears.
-
-5. Specify the SAML identity provider `key-value` pair that you want to associate with a Datadog Team. **Note**: These entries are case-sensitive.
-
+1. Ensure you selected either **SAML** or **All sources** when choosing your [provisioning source] for team memberships.
+2. [Cross-reference][4] and [validate][5] your SAML assertion to understand your IdP's attributes.
+3. Go to **Organization Settings** and click the **SAML Group Mappings** tab.
+4. Ensure the **Team Mappings** tab is selected.
+5. Click **New Mapping**. A dialog box appears.
+6. Specify the SAML identity provider `key-value` pair that you want to associate with a Datadog Team. **Note**: These entries are case-sensitive.
     **Note**: Every identity provider is different. Some allow you to set your attribute key or label. Others provide one by default. Datadog recommends you use an assertion inspector on your login to view the details of your particular assertion to understand how your Identity Provider is sending your group membership.
-
-6. Select a **Team** from the dropdown menu.
-
-7. To add an additional mapping, click **Add Row**.
-
-8. When you are done adding mappings, click **Create**.
-
-7. If you have not already done so, enable mappings by clicking **Enable Mappings**.
+8. Select a **Team** from the dropdown menu.
+9. To add an additional mapping, click **Add Row**.
+10. When you are done adding mappings, click **Create**.
+11. If you have not already done so, enable mappings by clicking **Enable Mappings**.
 
 Make changes to a mapping by clicking the pencil (**Edit**) icon, or remove a mapping by clicking the garbage (**Delete**) icon. These actions affect only the mapping, not the identity provider attributes or the Datadog Team.
 

--- a/content/en/account_management/teams.md
+++ b/content/en/account_management/teams.md
@@ -58,9 +58,9 @@ Datadog supports associating the following resources with team handles:
 - [Dashboards][2]
 - [Incidents][3]
 - [Monitors][4]
-- [Resource Catalog][14]
-- [Service Catalog][5]
-- [Service Level Objectives][6]
+- [Resource Catalog][5]
+- [Service Catalog][6]
+- [Service Level Objectives][7]
 - Synthetic Tests, Global Variables, Private Locations
 
 ## Filter
@@ -78,14 +78,14 @@ The table below describes the products in which you can use the team filter:
 
 | Product List Page       | Filter basis                                                                     |
 |-------------------------|----------------------------------------------------------------------------------|
-| [Dashboards][7]         | Team handle                                                                      |
-| [Resource Catalog][14]   | Team handle                                                                      |
-| [Service Catalog][8]    | Team handle                                                                      |
-| [Incidents][9]          | Team handle                                                                      |
-| [Monitors][10]          | Team handle                                                                      |
-| [APM Error Tracking][11] | Service owned by teams (determined by ownership inside the [Service Catalog][8]) |
-| [Logs Error Tracking][12] | Service owned by teams (determined by ownership inside the [Service Catalog][8]) |
-| [Service Level Objectives][13] | Team handle                                                                 |
+| [Dashboards][8]         | Team handle                                                                      |
+| [Resource Catalog][5]   | Team handle                                                                      |
+| [Service Catalog][9]    | Team handle                                                                      |
+| [Incidents][10]          | Team handle                                                                      |
+| [Monitors][11]          | Team handle                                                                      |
+| [APM Error Tracking][12] | Service owned by teams (determined by ownership inside the [Service Catalog][9]) |
+| [Logs Error Tracking][13] | Service owned by teams (determined by ownership inside the [Service Catalog][9]) |
+| [Service Level Objectives][14] | Team handle                                                                 |
 | [Data Streams Monitoring][15]  | Team handle                                                                 |
 | [Synthetic Tests][16]          | Team handle                                                                 |
 
@@ -108,6 +108,10 @@ Under the team's settings, specify which users can modify the team membership. T
 
 Users with the `user_access_manage` permission can set default rules on who can add or remove members, or edit team details. Set default rules with the **Default Settings** button on the team directory page. Override these policies for an individual team on the team details panel.
 
+### SAML attribute mapping
+
+To manage teams and team membership using SAML attributes, see [Map SAML attributes to Teams][17].
+
 ### Delegate team management
 
 For an open membership model, configure your default team settings so **Anyone in the organization** can add or remove members. Assign the `teams_manage` permission to the appropriate roles to let anyone create teams or edit team details.
@@ -120,15 +124,16 @@ To enforce a strict membership model, configure your default team settings so **
 [2]: /dashboards/#edit-details
 [3]: /service_management/incident_management/incident_details#overview-section
 [4]: /monitors/configuration/?tab=thresholdalert#add-metadata
-[5]: /tracing/service_catalog/setup#add-service-definition-metadata
-[6]: /service_management/service_level_objectives/#slo-tags
-[7]: https://app.datadoghq.com/dashboard/lists
-[8]: https://app.datadoghq.com/services
-[9]: https://app.datadoghq.com/incidents
-[10]: https://app.datadoghq.com/monitors/manage
-[11]: https://app.datadoghq.com/apm/error-tracking
-[12]: https://app.datadoghq.com/logs/error-tracking
-[13]: https://app.datadoghq.com/slo/manage
-[14]: /security/misconfigurations/resource_catalog
+[5]: /security/misconfigurations/resource_catalog
+[6]: /tracing/service_catalog/setup#add-service-definition-metadata
+[7]: /service_management/service_level_objectives/#slo-tags
+[8]: https://app.datadoghq.com/dashboard/lists
+[9]: https://app.datadoghq.com/services
+[10]: https://app.datadoghq.com/incidents
+[11]: https://app.datadoghq.com/monitors/manage
+[12]: https://app.datadoghq.com/apm/error-tracking
+[13]: https://app.datadoghq.com/logs/error-tracking
+[14]: https://app.datadoghq.com/slo/manage
 [15]: https://app.datadoghq.com/data-streams
 [16]: https://app.datadoghq.com/synthetics
+[17]: /account_management/saml/mapping/#map-saml-attributes-to-teams

--- a/content/en/account_management/teams.md
+++ b/content/en/account_management/teams.md
@@ -56,7 +56,7 @@ All sources
 1. Click **Settings**.
 1. Select one of the options under **Team Provisioning Sources**.
 
-To manage teams and team membership using SAML attributes, see [Map SAML attributes to Teams][2].
+If you have teams with existing members, picking the SAML strict option overrides your settings and removes team members from those teams. Picking the All Sources option preserves existing memberships. To manage teams and team membership using SAML attributes, see [Map SAML attributes to Teams][2].
 
 ## Team handle
 

--- a/content/en/account_management/teams.md
+++ b/content/en/account_management/teams.md
@@ -34,10 +34,29 @@ The [team directory page][1] lists all teams within your organization. Use the *
 
 ### Modify team
 
-1. On the [team directory page][1], click the team you would like to modify. A side panel appears with the team details.
+1. On the [team directory page][1], click the team you wish to modify. A side panel appears with the team details.
 1. Mouse over the item you wish to modify. A pencil icon appears.
 1. Click the pencil icon. A pop-up window appears.
 1. Make your changes, then click the appropriate button to save your changes.
+
+### Choose provisioning source
+
+Choose from three options to determine how admins and team managers may update team membership:
+
+UI and API
+: Update membership through UI actions and API calls only
+
+SAML
+: Use a *SAML strict* model so the identity provider data determines team membership
+
+All sources
+: Use SAML as a starting point, and allow overrides through the UI and API
+
+1. On the [team directory page][1], select the team. A side panel appears with team details.
+1. Click **Settings**.
+1. Select one of the options under **Team Provisioning Sources**.
+
+To manage teams and team membership using SAML attributes, see [Map SAML attributes to Teams][2].
 
 ## Team handle
 
@@ -55,12 +74,12 @@ Team handles that aren't associated with a defined team in Datadog behave simila
 
 Datadog supports associating the following resources with team handles:
 
-- [Dashboards][2]
-- [Incidents][3]
-- [Monitors][4]
-- [Resource Catalog][5]
-- [Service Catalog][6]
-- [Service Level Objectives][7]
+- [Dashboards][3]
+- [Incidents][4]
+- [Monitors][5]
+- [Resource Catalog][6]
+- [Service Catalog][7]
+- [Service Level Objectives][8]
 - Synthetic Tests, Global Variables, Private Locations
 
 ## Filter
@@ -78,16 +97,16 @@ The table below describes the products in which you can use the team filter:
 
 | Product List Page       | Filter basis                                                                     |
 |-------------------------|----------------------------------------------------------------------------------|
-| [Dashboards][8]         | Team handle                                                                      |
-| [Resource Catalog][5]   | Team handle                                                                      |
-| [Service Catalog][9]    | Team handle                                                                      |
-| [Incidents][10]          | Team handle                                                                      |
-| [Monitors][11]          | Team handle                                                                      |
-| [APM Error Tracking][12] | Service owned by teams (determined by ownership inside the [Service Catalog][9]) |
-| [Logs Error Tracking][13] | Service owned by teams (determined by ownership inside the [Service Catalog][9]) |
-| [Service Level Objectives][14] | Team handle                                                                 |
-| [Data Streams Monitoring][15]  | Team handle                                                                 |
-| [Synthetic Tests][16]          | Team handle                                                                 |
+| [Dashboards][9]         | Team handle                                                                      |
+| [Resource Catalog][6]   | Team handle                                                                      |
+| [Service Catalog][10]    | Team handle                                                                      |
+| [Incidents][11]          | Team handle                                                                      |
+| [Monitors][12]          | Team handle                                                                      |
+| [APM Error Tracking][13] | Service owned by teams (determined by ownership inside the [Service Catalog][10]) |
+| [Logs Error Tracking][14] | Service owned by teams (determined by ownership inside the [Service Catalog][10]) |
+| [Service Level Objectives][15] | Team handle                                                                 |
+| [Data Streams Monitoring][16]  | Team handle                                                                 |
+| [Synthetic Tests][17]          | Team handle                                                                 |
 
 
 ## Permissions
@@ -110,7 +129,7 @@ Users with the `user_access_manage` permission can set default rules on who can 
 
 ### SAML attribute mapping
 
-To manage teams and team membership using SAML attributes, see [Map SAML attributes to Teams][17].
+To manage teams and team membership using SAML attributes, see [Map SAML attributes to Teams][2].
 
 ### Delegate team management
 
@@ -121,19 +140,19 @@ If you prefer a team-driven membership model, set your default team settings so 
 To enforce a strict membership model, configure your default team settings so **Only users with user_access_manage** can add or remove members. Assign the `teams_manage` permission only to organization administrators.
 
 [1]: https://app.datadoghq.com/organization-settings/teams
-[2]: /dashboards/#edit-details
-[3]: /service_management/incident_management/incident_details#overview-section
-[4]: /monitors/configuration/?tab=thresholdalert#add-metadata
-[5]: /security/misconfigurations/resource_catalog
-[6]: /tracing/service_catalog/setup#add-service-definition-metadata
-[7]: /service_management/service_level_objectives/#slo-tags
-[8]: https://app.datadoghq.com/dashboard/lists
-[9]: https://app.datadoghq.com/services
-[10]: https://app.datadoghq.com/incidents
-[11]: https://app.datadoghq.com/monitors/manage
-[12]: https://app.datadoghq.com/apm/error-tracking
-[13]: https://app.datadoghq.com/logs/error-tracking
-[14]: https://app.datadoghq.com/slo/manage
-[15]: https://app.datadoghq.com/data-streams
-[16]: https://app.datadoghq.com/synthetics
-[17]: /account_management/saml/mapping/#map-saml-attributes-to-teams
+[2]: /account_management/saml/mapping/#map-saml-attributes-to-teams
+[3]: /dashboards/#edit-details
+[4]: /service_management/incident_management/incident_details#overview-section
+[5]: /monitors/configuration/?tab=thresholdalert#add-metadata
+[6]: /security/misconfigurations/resource_catalog
+[7]: /tracing/service_catalog/setup#add-service-definition-metadata
+[8]: /service_management/service_level_objectives/#slo-tags
+[9]: https://app.datadoghq.com/dashboard/lists
+[10]: https://app.datadoghq.com/services
+[11]: https://app.datadoghq.com/incidents
+[12]: https://app.datadoghq.com/monitors/manage
+[13]: https://app.datadoghq.com/apm/error-tracking
+[14]: https://app.datadoghq.com/logs/error-tracking
+[15]: https://app.datadoghq.com/slo/manage
+[16]: https://app.datadoghq.com/data-streams
+[17]: https://app.datadoghq.com/synthetics


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add information on using the new SAML attribute to Datadog Teams mapping capability:
- Reorganizes the existing SAML mapping page. Adds an introduction and creates separate sections for Roles and Teams.
- Populates the Teams section on the SAML mapping page with instructions for setting up mapping.
- On the Teams page, explains the three different provisioning options.

### Motivation
Document the new feature
https://datadoghq.atlassian.net/browse/DOCS-5819

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Ready to merge

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
