### PR TITLE
open external ddog app links in new tab - [WEB-3930]

### DIFF
--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -67,7 +67,8 @@ $(document).ready(function () {
     const newLinks = document.getElementsByTagName('a');
     for (let i = 0; i < newLinks.length; i++) {
         if (
-            !newLinks[i].href.includes('datadoghq.com') &&
+            !newLinks[i].href.includes('docs.datadoghq.com') &&
+            !newLinks[i].href.includes('docs-staging.datadoghq.com') &&
             !newLinks[i].href.includes('localhost:1313')
         ) {
             $(`a[href='${newLinks[i].href}']`).attr('target', '_blank');

--- a/assets/scripts/region-redirects.js
+++ b/assets/scripts/region-redirects.js
@@ -157,6 +157,7 @@ function showRegionSnippet(newSiteRegion) {
     if (externalLinks) {
         externalLinks.forEach(link => {
             link.href = `https://${config.dd_full_site[newSiteRegion]}${link.pathname}${link.search}${link.hash}`;
+            link.target = '_blank'
         });
     }
 }

--- a/assets/scripts/region-redirects.js
+++ b/assets/scripts/region-redirects.js
@@ -157,7 +157,6 @@ function showRegionSnippet(newSiteRegion) {
     if (externalLinks) {
         externalLinks.forEach(link => {
             link.href = `https://${config.dd_full_site[newSiteRegion]}${link.pathname}${link.search}${link.hash}`;
-            link.target = '_blank'
         });
     }
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
open external sites (not `docs.datadoghq.com`, `docs-staging.datadoghq.com` or `localhost:1313`) in a new tab.

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-3930

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

check that docs links open in same tab and all other links open in new tab: 
https://docs-staging.datadoghq.com/stefon.simmons/ddog-app-as-external-link

example pages:
- https://docs-staging.datadoghq.com/stefon.simmons/ddog-app-as-external-link/service_management/incident_management/

- https://docs-staging.datadoghq.com/stefon.simmons/ddog-app-as-external-link/real_user_monitoring/error_tracking/ios/?tab=cocoapods#further-reading

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
