### PR TITLE
Small Homepage Security Tile Microcopy Nit

### DIFF
--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -67,7 +67,7 @@ nav_sections:
       - title: Security
         link: security/
         icon: security-platform
-        desc: Detect threats, vulnerabilities, and misconfigurations in your applications and infrastructure
+        desc: Detect threats, vulnerabilities, and misconfigurations
       - title: Synthetic Monitoring
         link: synthetics/
         icon: synthetics


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Small, non-urgent question on the microcopy for the [Security tile](https://docs.datadoghq.com/) on the [Docs landing page](https://docs.datadoghq.com/): the “in your applications and infrastructure” is causing the tile to need a third row, if we were to remove it, all the tiles would be consistent with two rows. I looked at the Documentation Site’s [landing page heatmap](https://dd-corpsite.datadoghq.com/rum/heatmap/view/clickmap?from_ts=1672560000000&live=false&query=%40application.id%3A3493b4e7-ab12-4852-8836-ba96af7bc745+%40view.name%3A%22%2F%22+%40display.viewport.width%3A%5B768+TO+1280%5D&to_ts=1690411860000) from the start of the year and there’s been no activity with the in your applications and infrastructure, so I’m thinking it may be alright to remove it. Any thoughts?

### Motivation
<!-- What inspired you to submit this pull request?-->

Posted in #k9-public-docs.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
