### PR TITLE
Datadog /help page enriched with Learning Center / Foundation Enablement / Webinars

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -59,6 +59,26 @@
     "other": "The <a href=\"http://chat.datadoghq.com/\" target=\"_blank\" rel=\"noopener\">Slack Community program</a> is a network built by Datadog users for Datadog users to help each other find answers to questions or to share product tips and tricks."
   },
 
+  "foundation_enablement_sentence": {
+    "other": "<a href=\"https://dtdg.co/fe_sessions\" target=\"_blank\" rel=\"noopener\">Sign up</a> for one of our free, live, expert led foundation enablement sessions on a variety of Datadog features and products."
+  },
+
+  "learning_center_sentence": {
+    "other": "Take a free self-guided, <a href=\"https://dtdg.co/47QnE99\" target=\"_blank\" rel=\"noopener\">hands-on course</a> to learn and practice key Datadog concepts."
+  },
+
+  "learning_resources": {
+    "other": "Learning Resources"
+  },
+
+  "learning_sentence": {
+    "other": "Enrich your knowledge in the Datadog platform through live or self-guided resources."
+  },
+
+  "webinars_sentence": {
+    "other": "Attend upcoming or watch recorded <a href=\"https://dtdg.co/3PeuldT\" target=\"_blank\" rel=\"noopener\">Datadog webinars</a> for free on a variety of product topics."
+  },
+
   "agent_started_sentence": {
     "other": "To get started using the Agent, select your platform."
   },
@@ -226,6 +246,18 @@
 
   "event_stream_messaging": {
     "other": "contact us<br>on slack"
+  },
+
+  "learning_center": {
+    "other": "datadog<br>learning center"
+  },
+
+  "foundation_enablement": {
+    "other": "join a live<br>enablement session"
+  },
+
+  "webinars": {
+    "other": "Datadog<br>webinars"
   },
 
   "questions": {

--- a/layouts/partials/support/support.html
+++ b/layouts/partials/support/support.html
@@ -52,24 +52,73 @@
     </div>
 
     <hr/>
-    <div class="row foot">
-        <div class="col"></div>
-        <div class="col-8 col-md-6 col-lg-4">
-            <div class="row">
-                <div class="col text-center">
-                    <a href="http://status.datadoghq.com/" target="_blank" rel="noopener">
-                        {{ partial "img.html" (dict "root" . "src" "icon_status.png" "class" "" "alt" "status" "height" "50") }}
-                        <span>{{ i18n "status_page" }}</span>
+    <div class="learning">
+        <div class="text-start mb-4">
+            <h2>{{ i18n "learning_resources" }}</h2>
+            <p class="mt-3"><i>{{ i18n "learning_sentence" }}</i></p>
+        </div>
+
+        <div class="container cards-dd tile-nav">
+            <div class="row row-cols-1 row-cols-sm-3 g-3 g-sm-4 mb-2 mb-sm-3">
+                <div class="col">
+                    <a class="card h-100" href="https://dtdg.co/fe_sessions">
+                        <div class="card-body text-center py-2 px-1">
+                            {{ partial "img.html" (dict "root" . "src" "icon_fe.png" "class" "" "alt" "Foundation Enablement" "width" "42.5") }}
+                            <p class="title">{{ i18n "foundation_enablement" | safeHTML }}</p>
+                        </div>
                     </a>
                 </div>
-                <div class="col text-center">
-                    <a href="https://twitter.com/DatadogOps" target="_blank" rel="noopener">
-                        {{ partial "img.html" (dict "root" . "src" "icon_twitter.png" "class" "" "alt" "twitter" "height" "50") }}
-                        <span>{{ i18n "ops_twitter" }}</span>
+                <div class="col">
+                    <a class="card h-100" href="https://dtdg.co/47QnE99">
+                        <div class="card-body text-center py-2 px-1">
+                            {{ partial "img.html" (dict "root" . "src" "icon_lc.png" "class" "" "alt" "Learning Center" "width" "42.5") }}
+                            <p class="title">{{ i18n "learning_center" | safeHTML }}</p>
+                        </div>
+                    </a>
+                </div>
+                <div class="col">
+                    <a class="card h-100" href="https://dtdg.co/3PeuldT">
+                        <div class="card-body text-center py-2 px-1">
+                            {{ partial "img.html" (dict "root" . "src" "icon_webinar.png" "class" "" "alt" "Datadog Webinars" "width" "42.5") }}
+                            <p class="title">{{ i18n "webinars" | safeHTML }}</p>
+                        </div>
                     </a>
                 </div>
             </div>
         </div>
-        <div class="col"></div>
+
+        <div class="row">
+            <div class="col-12 col-md-4 mb-4">
+                <p>{{ i18n "foundation_enablement_sentence" | safeHTML }}</p>
+            </div>
+            <div class="col-12 col-md-4 mb-4">
+                <p>{{ i18n "learning_center_sentence" | safeHTML}}</p>
+            </div>
+            <div class="col-12 col-md-4 mb-4">
+                <p>{{ i18n "webinars_sentence" | safeHTML}}</p>
+            </div>
+        </div>
+
+        <hr/>
+        <div class="row foot">
+            <div class="col"></div>
+            <div class="col-8 col-md-6 col-lg-4">
+                <div class="row">
+                    <div class="col text-center">
+                        <a href="http://status.datadoghq.com/" target="_blank" rel="noopener">
+                            {{ partial "img.html" (dict "root" . "src" "icon_status.png" "class" "" "alt" "status" "height" "50") }}
+                            <span>{{ i18n "status_page" }}</span>
+                        </a>
+                    </div>
+                    <div class="col text-center">
+                        <a href="https://twitter.com/DatadogOps" target="_blank" rel="noopener">
+                            {{ partial "img.html" (dict "root" . "src" "icon_twitter.png" "class" "" "alt" "twitter" "height" "50") }}
+                            <span>{{ i18n "ops_twitter" }}</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col"></div>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
What does this PR do?
Added a new section on docs.datadoghq.com/help titled Learning Resources with cards, icons and text+links to Learning Center, Foundation Enablement courses and Datadog Webinars
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
