### PR TITLE
Add alternative instructions for ENTRYPOINT in serverless-init

### DIFF
--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -35,7 +35,7 @@ Images are tagged based on semantic versioning, with each new version receiving 
 The latest tag of /serverless-init will be applied to Beta9 through 9/1/2023 to provide additional time for Beta users to adjust and include the additional required `DD_AZURE_SUBSCRIPTION_ID` and `DD_RESOURCE_GROUP` variables
 </div>
 
-* `latest`, `latest-apline`: use these to follow the latest version release, which may include breaking changes
+* `latest`, `latest-alpine`: use these to follow the latest version release, which may include breaking changes
 
 {{< programming-lang-wrapper langs="nodejs,python,java,go,dotnet,ruby,php" >}}
 {{< programming-lang lang="nodejs" >}}

--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -76,7 +76,7 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
 
    ```
    ENTRYPOINT ["/app/datadog-init"]
@@ -122,7 +122,7 @@ CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```
@@ -168,7 +168,7 @@ CMD ["./mvnw", "spring-boot:run"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```
@@ -200,7 +200,7 @@ CMD ["/path/to/your-go-binary"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Change the entrypoint to wrap your application into the Datadog `serverless-init` process.
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```
@@ -270,7 +270,7 @@ CMD ["dotnet", "helloworld.dll"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application into the Datadog `serverless-init` process.
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```
@@ -317,7 +317,7 @@ CMD ["rails", "server", "-b", "0.0.0.0"]
    ENV DD_TRACE_PROPAGATION_STYLE=datadog
    ```
 
-4. Change the entrypoint to wrap your application into the Datadog `serverless-init` process.
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```
@@ -379,7 +379,7 @@ CMD php-fpm; nginx -g daemon off;
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application into the Datadog serverless-init process
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```
@@ -458,6 +458,31 @@ Metrics are calculated based on 100% of the application’s traffic, and remain 
 | `DD_ENV`          | See [Unified Service Tagging][5].                                       |
 | `DD_SOURCE`       | See [Unified Service Tagging][5].                                       |
 | `DD_TAGS`         | See [Unified Service Tagging][5].                                       |
+
+## Alternative configurations
+
+### Alternatives to Entrypoint
+
+If you have already defined an entrypoint inside of your Dockerfile, you can instead modify the CMD argument.
+
+**Note**: As long as your command to run is passed as an argument to datadog-init, you will receive full instrumentation.
+
+The below code snippet illustates how to modify your Dockerfile to instrument Container Apps without modifying your entrypoint.
+
+```
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ENTRYPOINT ["/app/datadog-init"]
+
+CMD ["your", "start", "command"]
+```
+
+would become this:
+
+```
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+
+CMD ["/app/datadog-init", "your", "start", "command"]
+```
 
 ## Troubleshooting
 

--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -42,7 +42,7 @@ The latest tag of /serverless-init will be applied to Beta9 through 9/1/2023 to 
 
 Add the following instructions and arguments to your Dockerfile.
 
-```
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
 ENV DD_SERVICE=datadog-demo-run-nodejs
@@ -56,13 +56,13 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
 
 1. Copy the Datadog `serverless-init` into your Docker image.
 
-   ```
+   ```dockerfile
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
 2. Copy the Datadog Node.JS tracer into your Docker image. 
 
-   ```
+   ```dockerfile
    COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
    ```
 
@@ -70,29 +70,44 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
 
 3. (Optional) Add Datadog tags.
 
-   ```
+   ```dockerfile
    ENV DD_SERVICE=datadog-demo-run-nodejs
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+   **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-node).
 
-   ```
+   ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
-   ```
+   ```dockerfile
    CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
    ```
+
+#### Alternative configuration: CMD argument {#alt-node}
+If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
+ENV DD_SERVICE=datadog-demo-run-nodejs
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+CMD ["/app/datadog-init", "/nodejs/bin/node", "/path/to/your/app.js"]
+{{< /highlight >}}
+
+As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/nodejs/?tab=containers#instrument-your-application
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}
 
 Add the following instructions and arguments to your Dockerfile.
-```
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 RUN pip install --target /dd_tracer/python/ ddtrace
 ENV DD_SERVICE=datadog-demo-run-python
@@ -105,32 +120,48 @@ CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
 #### Explanation
 
 1. Copy the Datadog `serverless-init` into your Docker image.
-   ```
+   ```dockerfile
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
 2. Install the Datadog Python tracer. 
-   ```
+   ```dockerfile
    RUN pip install --target /dd_tracer/python/ ddtrace
    ```
    If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
 
 3. (Optional) Add Datadog tags.
-   ```
+   ```dockerfile
    ENV DD_SERVICE=datadog-demo-run-python
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
-   ```
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+   **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-python).
+
+   ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your binary application wrapped in the entrypoint, launched by the Datadog trace library. Adapt this line to your needs.
-   ```
+   ```dockerfile
    CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
    ```
+
+#### Alternative configuration: CMD argument {#alt-python}
+If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+RUN pip install --target /dd_tracer/python/ ddtrace
+ENV DD_SERVICE=datadog-demo-run-python
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+CMD ["/app/datadog-init", "/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
+{{< /highlight >}}
+
+As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/python/?tab=containers#instrument-your-application
 {{< /programming-lang >}}
@@ -138,7 +169,7 @@ CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
 
 Add the following instructions and arguments to your Dockerfile.
 
-```
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
@@ -151,32 +182,47 @@ CMD ["./mvnw", "spring-boot:run"]
 #### Explanation
 
 1. Copy the Datadog `serverless-init` into your Docker image.
-   ```
+   ```dockerfile
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
 2. Add the Datadog Java tracer to your Docker image. 
-   ```
+   ```dockerfile
    ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
    ```
    If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
 
 3. (Optional) Add Datadog tags.
-   ```
+   ```dockerfile
    ENV DD_SERVICE=datadog-demo-run-java
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
-   ```
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+   **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-java).
+   ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
-   ```
+   ```dockerfile
    CMD ["./mvnw", "spring-boot:run"]
    ```
+
+#### Alternative configuration: CMD argument {#alt-java}
+If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+ENV DD_SERVICE=datadog-demo-run-java
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+CMD ["/app/datadog-init", "./mvnw", "spring-boot:run"]
+{{< /highlight >}}
+
+As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/java/?tab=containers#instrument-your-application
 {{< /programming-lang >}}
@@ -184,7 +230,7 @@ CMD ["./mvnw", "spring-boot:run"]
 
 [Manually install][1] the Go tracer before you deploy your application. Add the following instructions and arguments to your Dockerfile.
 
-```
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ENTRYPOINT ["/app/datadog-init"]
 ENV DD_SERVICE=datadog-demo-run-go
@@ -196,32 +242,48 @@ CMD ["/path/to/your-go-binary"]
 #### Explanation
 
 1. Copy the Datadog `serverless-init` into your Docker image.
-   ```
+   ```dockerfile
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
-   ```
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+   **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-go).
+   ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 3. (Optional) Add Datadog tags.
-   ```
+   ```dockerfile
    ENV DD_SERVICE=datadog-demo-run-go
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
 
 4. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
-   ```
+   ```dockerfile
    CMD ["/path/to/your-go-binary"]
    ```
 
+#### Alternative configuration: CMD argument {#alt-go}
+If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
+
+{{< highlight dockerfile "hl_lines=5" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ENV DD_SERVICE=datadog-demo-run-go
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+CMD ["/app/datadog-init", "/path/to/your-go-binary"]
+{{< /highlight >}}
+
+As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
+
 #### Orchestrion
 
-**Note**: [Orchestrion][2] is a tool for automatically instrumenting Go code, which is currently in Private Beta. With Orchestrion, it is possible to instrument your Go applications through Dockerfile. If you are interested in participating in the Beta or providing feedback on Orchestrion, please open a Github issue or reach out to support. 
+<div class="alert alert-warning">Orchestrion is in Private Beta. If you are interested in participating in the Beta or providing feedback on Orchestrion, <a href="https://github.com/DataDog/orchestrion/issues">open a GitHub issue</a> or <a href="/help">contact Datadog Support</a>.</div>
 
-```
+[Orchestrion][2] is a tool for automatically instrumenting Go code. With Orchestrion, it is possible to instrument your Go applications through Dockerfile.
+
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 RUN go install github.com/datadog/orchestrion@latest
 RUN orchestrion -w ./
@@ -240,7 +302,7 @@ CMD ["/path/to/your-go-binary"]
 
 Add the following instructions and arguments to your Dockerfile.
 
-```
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 COPY --from=datadog/dd-lib-dotnet-init /datadog-init/monitoring-home/ /dd_tracer/dotnet/
 ENV DD_SERVICE=datadog-demo-run-dotnet
@@ -253,32 +315,47 @@ CMD ["dotnet", "helloworld.dll"]
 #### Explanation
 
 1. Copy the Datadog `serverless-init` into your Docker image.
-   ```
+   ```dockerfile
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
 2. Copy the Datadog .NET tracer into your Docker image.
-   ```
+   ```dockerfile
    COPY --from=datadog/dd-lib-dotnet-init /datadog-init/monitoring-home/ /dd_tracer/dotnet/
    ```
    If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
 
 3. (Optional) Add Datadog tags.
-   ```
+   ```dockerfile
    ENV DD_SERVICE=datadog-demo-run-dotnet
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
-   ```
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+   **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-dotnet).
+   ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
-   ```
+   ```dockerfile
    CMD ["dotnet", "helloworld.dll"]
    ```
+
+#### Alternative configuration: CMD argument {#alt-dotnet}
+If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+COPY --from=datadog/dd-lib-dotnet-init /datadog-init/monitoring-home/ /dd_tracer/dotnet/
+ENV DD_SERVICE=datadog-demo-run-dotnet
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+CMD ["/app/datadog-init", "dotnet", "helloworld.dll"]
+{{< /highlight >}}
+
+As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/dotnet-core/?tab=linux#custom-instrumentation
 {{< /programming-lang >}}
@@ -288,7 +365,7 @@ CMD ["dotnet", "helloworld.dll"]
 
 Add the following instructions and arguments to your Dockerfile.
 
-```
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ENV DD_SERVICE=datadog-demo-run-ruby
 ENV DD_ENV=datadog-demo
@@ -301,32 +378,45 @@ CMD ["rails", "server", "-b", "0.0.0.0"]
 #### Explanation
 
 1. Copy the Datadog `serverless-init` into your Docker image.
-   ```
+   ```dockerfile
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
 2. (Optional) add Datadog tags
-   ```
+   ```dockerfile
    ENV DD_SERVICE=datadog-demo-run-ruby
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
 
 3. This environment variable is needed for trace propagation to work properly in Cloud Run. Ensure that you set this variable for all Datadog-instrumented downstream services.
-   ```
+   ```dockerfile
    ENV DD_TRACE_PROPAGATION_STYLE=datadog
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
+    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-ruby).
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
-   ```
+   ```dockerfile
    CMD ["rails", "server", "-b", "0.0.0.0"]
    ```
+#### Alternative configuration: CMD argument {#alt-ruby}
+If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
 
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ENV DD_SERVICE=datadog-demo-run-ruby
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+ENV DD_TRACE_PROPAGATION_STYLE=datadog
+CMD ["/app/datadog-init", "rails", "server", "-b", "0.0.0.0"]
+{{< /highlight >}}
+
+As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/ruby/?tab=containers#instrument-your-application
 [2]: https://github.com/DataDog/crpb/tree/main/ruby-on-rails
@@ -335,7 +425,7 @@ CMD ["rails", "server", "-b", "0.0.0.0"]
 {{< programming-lang lang="php" >}}
 
 Add the following instructions and arguments to your Dockerfile.
-```
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ADD https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php /datadog-setup.php
 RUN php /datadog-setup.php --php-bin=all
@@ -344,61 +434,85 @@ ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
 ENTRYPOINT ["/app/datadog-init"]
 
-# use the following for an apache and mod_php based image
+# use the following for an Apache and mod_php based image
 RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
 EXPOSE 8080
 CMD ["apache2-foreground"]
 
-# use the following for an nginx and php-fpm based image
+# use the following for an Nginx and php-fpm based image
 RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
 EXPOSE 8080
 CMD php-fpm; nginx -g daemon off;
 ```
 
-**Note**: The datadog-init ENTRYPOINT wraps your process and collects logs from it. To get logs working properly, you must ensure your apache, nginx, or php processes are writing output to stdout.
+**Note**: The `datadog-init` entrypoint wraps your process and collects logs from it. To get logs working properly, you must ensure your Apache, Nginx, or PHP processes are writing output to `stdout`.
 
 #### Explanation
 
 
 1. Copy the Datadog `serverless-init` into your Docker image.
-   ```
+   ```dockerfile
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
 2. Copy and install the Datadog PHP tracer.
-   ```
+   ```dockerfile
    ADD https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php /datadog-setup.php
    RUN php /datadog-setup.php --php-bin=all
    ```
    If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
 
 3. (Optional) Add Datadog tags.
-   ```
+   ```dockerfile
    ENV DD_SERVICE=datadog-demo-run-ruby
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
-   ```
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+   **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-php).
+   ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your application.
    
    Use the following for an apache and mod_php based image:
-   ```
+   ```dockerfile
    RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
    EXPOSE 8080
    CMD ["apache2-foreground"]
    ```
 
    Use the following for an nginx and php-fpm based image:
-   ```
+   ```dockerfile
    RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
    EXPOSE 8080
    CMD php-fpm; nginx -g daemon off;
    ```
+#### Alternative configuration: CMD argument {#alt-php}
+If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
+
+{{< highlight dockerfile "hl_lines=11 16" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ADD https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php /datadog-setup.php
+RUN php /datadog-setup.php --php-bin=all
+ENV DD_SERVICE=datadog-demo-run-ruby
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+
+# use the following for an Apache and mod_php based image
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+EXPOSE 8080
+CMD ["/app/datadog-init", "apache2-foreground"]
+
+# use the following for an Nginx and php-fpm based image
+RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
+EXPOSE 8080
+CMD php-fpm; nginx -g daemon off;
+{{< /highlight >}}
+
+As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/php/?tab=containers#install-the-extension
 {{< /programming-lang >}}
@@ -458,31 +572,6 @@ Metrics are calculated based on 100% of the application’s traffic, and remain 
 | `DD_ENV`          | See [Unified Service Tagging][5].                                       |
 | `DD_SOURCE`       | See [Unified Service Tagging][5].                                       |
 | `DD_TAGS`         | See [Unified Service Tagging][5].                                       |
-
-## Alternative configurations
-
-### Alternatives to entrypoint
-
-If you have already defined an entrypoint inside of your Dockerfile, you can instead modify the CMD argument.
-
-**Note**: As long as your command to run is passed as an argument to datadog-init, you will receive full instrumentation.
-
-The below code snippet illustates how to modify your Dockerfile to instrument Container Apps without modifying your entrypoint.
-
-```
-COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-ENTRYPOINT ["/app/datadog-init"]
-
-CMD ["your", "start", "command"]
-```
-
-would become this:
-
-```
-COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-
-CMD ["/app/datadog-init", "your", "start", "command"]
-```
 
 ## Troubleshooting
 

--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -461,7 +461,7 @@ Metrics are calculated based on 100% of the application’s traffic, and remain 
 
 ## Alternative configurations
 
-### Alternatives to Entrypoint
+### Alternatives to entrypoint
 
 If you have already defined an entrypoint inside of your Dockerfile, you can instead modify the CMD argument.
 

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -79,7 +79,7 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
 
    ```
    ENTRYPOINT ["/app/datadog-init"]
@@ -125,7 +125,7 @@ CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```
@@ -171,7 +171,7 @@ CMD ["./mvnw", "spring-boot:run"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```
@@ -203,7 +203,7 @@ CMD ["/path/to/your-go-binary"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Change the entrypoint to wrap your application into the Datadog `serverless-init` process:
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```
@@ -273,7 +273,7 @@ CMD ["dotnet", "helloworld.dll"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application into the Datadog `serverless-init` process.
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```
@@ -320,7 +320,7 @@ CMD ["rails", "server", "-b", "0.0.0.0"]
    ENV DD_TRACE_PROPAGATION_STYLE=datadog
    ```
 
-4. Change the entrypoint to wrap your application into the Datadog `serverless-init` process.
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```
@@ -382,7 +382,7 @@ CMD php-fpm; nginx -g daemon off;
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application into the Datadog serverless-init process
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
    ```
    ENTRYPOINT ["/app/datadog-init"]
    ```
@@ -478,6 +478,30 @@ Once the deployment is completed, your metrics and traces are sent to Datadog. I
 | `DD_SOURCE`       | See [Unified Service Tagging][6].                                  |
 | `DD_TAGS`         | See [Unified Service Tagging][6].                                  |
 
+## Alternative configurations
+
+### Alternatives to Entrypoint
+
+If you have already defined an entrypoint inside of your Dockerfile, you can instead modify the CMD argument.
+
+**Note**: As long as your command to run is passed as an argument to datadog-init, you will receive full instrumentation.
+
+The below code snippet illustates how to modify your Dockerfile to instrument Cloud Run without modifying your entrypoint.
+
+```
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ENTRYPOINT ["/app/datadog-init"]
+
+CMD ["your", "start", "command"]
+```
+
+would become this:
+
+```
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+
+CMD ["/app/datadog-init", "your", "start", "command"]
+```
 
 ## Troubleshooting
 

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -23,7 +23,7 @@ You can instrument your application in one of two ways: [Dockerfile](#dockerfile
 
 ### Dockerfile
 
-Datadog publishes new releases of the serverless-init container image to Google’s gcr.io, AWS’ ECR, and on Docker Hub:
+Datadog publishes new releases of the `serverless-init` container image to Google’s gcr.io, AWS’ ECR, and on Docker Hub:
 
 | dockerhub.io | gcr.io | public.ecr.aws |
 | ------------ | ------ | -------------- |
@@ -39,6 +39,12 @@ The latest tag of /serverless-init will be applied to Beta9 through 9/1/2023 to 
 </div>
 
 * `latest`, `latest-alpine`: use these to follow the latest version release, which may include breaking changes
+
+## How `serverless-init` works
+
+The `serverless-init` application wraps your process and executes it as a subprocess. It starts a DogStatsD listener for metrics and a Trace Agent listener for traces. It collects logs by wrapping the stdout/stderr streams of your application. After bootstrapping, serverless-init then launches your command as a subprocess.
+
+To get full instrumentation, ensure you are calling `datadog-init` as the first command that runs inside your Docker container. You can do this through by setting it as the entrypoint, or by setting it as the first argument in CMD.
 
 {{< programming-lang-wrapper langs="nodejs,python,java,go,dotnet,ruby,php" >}}
 {{< programming-lang lang="nodejs" >}}
@@ -90,7 +96,7 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
    ```dockerfile
    CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
    ```
-#### Alternative configuration: CMD argument {#alt-node}
+#### Alternative configuration {#alt-node}
 If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
 
 {{< highlight dockerfile "hl_lines=6" >}}
@@ -102,9 +108,9 @@ ENV DD_VERSION=1
 CMD ["/app/datadog-init", "/nodejs/bin/node", "/path/to/your/app.js"]
 {{< /highlight >}}
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-).
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. For more information, see [How `serverless-init` works](#how-serverless-init-works).
 
-{{< highlight dockerfile "hl_lines=7" >}}
+{{< highlight dockerfile "hl_lines=6-7" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
 ENV DD_SERVICE=datadog-demo-run-nodejs
@@ -161,7 +167,7 @@ CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
    ```dockerfile
    CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
    ```
-#### Alternative configuration: CMD argument {#alt-python}
+#### Alternative configuration {#alt-python}
 If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
 
 {{< highlight dockerfile "hl_lines=6" >}}
@@ -173,9 +179,9 @@ ENV DD_VERSION=1
 CMD ["/app/datadog-init", "/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
 {{< /highlight >}}
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-it-works)
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. For more information, see [How `serverless-init` works](#how-serverless-init-works).
 
-{{< highlight dockerfile "hl_lines=7" >}}
+{{< highlight dockerfile "hl_lines=6-7" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 RUN pip install --target /dd_tracer/python/ ddtrace
 ENV DD_SERVICE=datadog-demo-run-python
@@ -246,7 +252,7 @@ CMD ["/your_entrypoint.sh", "/nodejs/bin/node", "/path/to/your/app.js"]
    CMD ["./mvnw", "spring-boot:run"]
    ```
 
-#### Alternative configuration: CMD argument {#alt-java}
+#### Alternative configuration {#alt-java}
 If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
 
 {{< highlight dockerfile "hl_lines=6" >}}
@@ -258,9 +264,9 @@ ENV DD_VERSION=1
 CMD ["/app/datadog-init", "./mvnw", "spring-boot:run"]
 {{< /highlight >}}
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-it-works)
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. For more information, see [How `serverless-init` works](#how-serverless-init-works).
 
-{{< highlight dockerfile "hl_lines=7" >}}
+{{< highlight dockerfile "hl_lines=6-7" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
@@ -312,7 +318,7 @@ CMD ["/path/to/your-go-binary"]
    CMD ["/path/to/your-go-binary"]
    ```
 
-#### Alternative configuration: CMD argument {#alt-go}
+#### Alternative configuration {#alt-go}
 If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
 
 {{< highlight dockerfile "hl_lines=5" >}}
@@ -323,9 +329,9 @@ ENV DD_VERSION=1
 CMD ["/app/datadog-init", "/path/to/your-go-binary"]
 {{< /highlight >}}
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-it-works)
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. For more information, see [How `serverless-init` works](#how-serverless-init-works).
 
-{{< highlight dockerfile "hl_lines=6" >}}
+{{< highlight dockerfile "hl_lines=5-6" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ENV DD_SERVICE=datadog-demo-run-go
 ENV DD_ENV=datadog-demo
@@ -401,7 +407,7 @@ CMD ["dotnet", "helloworld.dll"]
    ```dockerfile
    CMD ["dotnet", "helloworld.dll"]
    ```
-#### Alternative configuration: CMD argument {#alt-dotnet}
+#### Alternative configuration {#alt-dotnet}
 If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
 
 {{< highlight dockerfile "hl_lines=6" >}}
@@ -413,9 +419,9 @@ ENV DD_VERSION=1
 CMD ["/app/datadog-init", "dotnet", "helloworld.dll"]
 {{< /highlight >}}
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-it-works)
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. For more information, see [How `serverless-init` works](#how-serverless-init-works).
 
-{{< highlight dockerfile "hl_lines=7" >}}
+{{< highlight dockerfile "hl_lines=6-7" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 COPY --from=datadog/dd-lib-dotnet-init /datadog-init/monitoring-home/ /dd_tracer/dotnet/
 ENV DD_SERVICE=datadog-demo-run-dotnet
@@ -474,7 +480,7 @@ CMD ["rails", "server", "-b", "0.0.0.0"]
    ```dockerfile
    CMD ["rails", "server", "-b", "0.0.0.0"]
    ```
-#### Alternative configuration: CMD argument {#alt-ruby}
+#### Alternative configuration {#alt-ruby}
 If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
 
 {{< highlight dockerfile "hl_lines=6" >}}
@@ -486,9 +492,9 @@ ENV DD_TRACE_PROPAGATION_STYLE=datadog
 CMD ["/app/datadog-init", "rails", "server", "-b", "0.0.0.0"]
 {{< /highlight >}}
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-it-works)
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. For more information, see [How `serverless-init` works](#how-serverless-init-works).
 
-{{< highlight dockerfile "hl_lines=7" >}}
+{{< highlight dockerfile "hl_lines=6-7" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ENV DD_SERVICE=datadog-demo-run-ruby
 ENV DD_ENV=datadog-demo
@@ -511,23 +517,23 @@ Add the following instructions and arguments to your Dockerfile.
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ADD https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php /datadog-setup.php
 RUN php /datadog-setup.php --php-bin=all
-ENV DD_SERVICE=datadog-demo-run-ruby
+ENV DD_SERVICE=datadog-demo-run-php
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
 ENTRYPOINT ["/app/datadog-init"]
 
-# use the following for an apache and mod_php based image
+# use the following for an Apache and mod_php based image
 RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
 EXPOSE 8080
 CMD ["apache2-foreground"]
 
-# use the following for an nginx and php-fpm based image
+# use the following for an Nginx and php-fpm based image
 RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
 EXPOSE 8080
 CMD php-fpm; nginx -g daemon off;
 ```
 
-**Note**: The `datadog-init` ENTRYPOINT wraps your process and collects logs from it. To get logs working properly, ensure that your Apache, NGINX, or PHP processes are writing output to `stdout`.
+**Note**: The `datadog-init` entrypoint wraps your process and collects logs from it. To get logs working properly, ensure that your Apache, Nginx, or PHP processes are writing output to `stdout`.
 
 #### Explanation
 
@@ -546,7 +552,7 @@ CMD php-fpm; nginx -g daemon off;
 
 3. (Optional) Add Datadog tags.
    ```dockerfile
-   ENV DD_SERVICE=datadog-demo-run-ruby
+   ENV DD_SERVICE=datadog-demo-run-php
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
@@ -559,45 +565,51 @@ CMD php-fpm; nginx -g daemon off;
 
 5. Execute your application.
    
-   Use the following for an apache and mod_php based image:
+   Use the following for an Apache and mod_php based image:
    ```dockerfile
    RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
    EXPOSE 8080
    CMD ["apache2-foreground"]
    ```
 
-   Use the following for an nginx and php-fpm based image:
+   Use the following for an Nginx and php-fpm based image:
    ```dockerfile
    RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
    EXPOSE 8080
    CMD php-fpm; nginx -g daemon off;
    ```
-#### Alternative configuration: CMD argument {#alt-php}
-If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
+#### Alternative configuration {#alt-php}
+If you already have an entrypoint defined inside your Dockerfile, and you are using an Apache and mod_php based image, you can instead modify the CMD argument.
 
-{{< highlight dockerfile "hl_lines=11 16" >}}
+{{< highlight dockerfile "hl_lines=9" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ADD https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php /datadog-setup.php
 RUN php /datadog-setup.php --php-bin=all
-ENV DD_SERVICE=datadog-demo-run-ruby
+ENV DD_SERVICE=datadog-demo-run-php
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-
 RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
 EXPOSE 8080
 CMD ["/app/datadog-init", "apache2-foreground"]
 {{< /highlight >}}
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-it-works)
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. For more information, see [How `serverless-init` works](#how-serverless-init-works).
 
-{{< highlight dockerfile "hl_lines=10" >}}
+{{< highlight dockerfile "hl_lines=7 12 17" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ADD https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php /datadog-setup.php
 RUN php /datadog-setup.php --php-bin=all
-ENV DD_SERVICE=datadog-demo-run-ruby
+ENV DD_SERVICE=datadog-demo-run-php
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
 ENTRYPOINT ["/app/datadog-init"]
+
+# use the following for an Apache and mod_php based image
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+EXPOSE 8080
+CMD ["your_entrypoint.sh", "apache2-foreground"]
+
+# use the following for an Nginx and php-fpm based image
 RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
 EXPOSE 8080
 CMD your_entrypoint.sh php-fpm; your_entrypoint.sh nginx -g daemon off;
@@ -679,13 +691,6 @@ Once the deployment is completed, your metrics and traces are sent to Datadog. I
 | `DD_ENV`          | See [Unified Service Tagging][6].                                  |
 | `DD_SOURCE`       | See [Unified Service Tagging][6].                                  |
 | `DD_TAGS`         | See [Unified Service Tagging][6].                                  |
-
-
-## How it works
-
-The serverless-init application works by wrapping your process and executing it as a subprocess. It starts a DogstatsD listener for metrics, a trace agent listener for traces, and collects logs via wrapping the stdout/stderr streams of your application. After bootstrapping, serverless-init then launches your command as a subprocess.
-
-To get full instrumentation, ensure you are calling `datadog-init` as the first command that runs inside your Docker container. You can do this through via setting it as the ENTRYPOINT, or by setting it as the first argument in CMD.
 
 ## Troubleshooting
 

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -102,6 +102,20 @@ ENV DD_VERSION=1
 CMD ["/app/datadog-init", "/nodejs/bin/node", "/path/to/your/app.js"]
 {{< /highlight >}}
 
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
+ENV DD_SERVICE=datadog-demo-run-nodejs
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+
+ENTRYPOINT ["/app/datadog-init"]
+
+CMD ["/your_entrypoint.sh", "/nodejs/bin/node", "/path/to/your/app.js"]
+{{< /highlight >}}
+
 As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/nodejs/?tab=containers#instrument-your-application
@@ -161,6 +175,19 @@ ENV DD_VERSION=1
 CMD ["/app/datadog-init", "/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
 {{< /highlight >}}
 
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+RUN pip install --target /dd_tracer/python/ ddtrace
+ENV DD_SERVICE=datadog-demo-run-python
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+
+ENTRYPOINT ["/app/datadog-init"]
+CMD ["your_entrypoint.sh", "/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
+{{< /highlight >}}
+
 As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/python/?tab=containers#instrument-your-application
@@ -178,6 +205,20 @@ ENV DD_VERSION=1
 ENTRYPOINT ["/app/datadog-init"]
 CMD ["./mvnw", "spring-boot:run"]
 ```
+
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
+ENV DD_SERVICE=datadog-demo-run-nodejs
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+
+ENTRYPOINT ["/app/datadog-init"]
+
+CMD ["/your_entrypoint.sh", "/nodejs/bin/node", "/path/to/your/app.js"]
+{{< /highlight >}}
 
 #### Explanation
 
@@ -220,6 +261,19 @@ ENV DD_SERVICE=datadog-demo-run-java
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
 CMD ["/app/datadog-init", "./mvnw", "spring-boot:run"]
+{{< /highlight >}}
+
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+ENV DD_SERVICE=datadog-demo-run-java
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+
+ENTRYPOINT ["/app/datadog-init"]
+CMD ["your_entrypoint.sh", "./mvnw", "spring-boot:run"]
 {{< /highlight >}}
 
 As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
@@ -273,6 +327,18 @@ ENV DD_SERVICE=datadog-demo-run-go
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
 CMD ["/app/datadog-init", "/path/to/your-go-binary"]
+{{< /highlight >}}
+
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ENV DD_SERVICE=datadog-demo-run-go
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+
+ENTRYPOINT ["/app/datadog-init"]
+CMD ["your_entrypoint.sh", "/path/to/your-go-binary"]
 {{< /highlight >}}
 
 As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
@@ -354,6 +420,19 @@ ENV DD_VERSION=1
 CMD ["/app/datadog-init", "dotnet", "helloworld.dll"]
 {{< /highlight >}}
 
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+COPY --from=datadog/dd-lib-dotnet-init /datadog-init/monitoring-home/ /dd_tracer/dotnet/
+ENV DD_SERVICE=datadog-demo-run-dotnet
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+
+ENTRYPOINT ["/app/datadog-init"]
+CMD ["your_entrypoint.sh", "dotnet", "helloworld.dll"]
+{{< /highlight >}}
+
 As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/dotnet-core/?tab=linux#custom-instrumentation
@@ -413,6 +492,19 @@ ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
 ENV DD_TRACE_PROPAGATION_STYLE=datadog
 CMD ["/app/datadog-init", "rails", "server", "-b", "0.0.0.0"]
+{{< /highlight >}}
+
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ENV DD_SERVICE=datadog-demo-run-ruby
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+ENV DD_TRACE_PROPAGATION_STYLE=datadog
+
+ENTRYPOINT ["/app/datadog-init"]
+CMD ["your_entrypoint.sh", "rails", "server", "-b", "0.0.0.0"]
 {{< /highlight >}}
 
 As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
@@ -500,15 +592,25 @@ ENV DD_SERVICE=datadog-demo-run-ruby
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
 
-# use the following for an apache and mod_php based image
 RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
 EXPOSE 8080
 CMD ["/app/datadog-init", "apache2-foreground"]
+{{< /highlight >}}
 
-# use the following for an nginx and php-fpm based image
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ADD https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php /datadog-setup.php
+RUN php /datadog-setup.php --php-bin=all
+ENV DD_SERVICE=datadog-demo-run-ruby
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+
+ENTRYPOINT ["/app/datadog-init"]
 RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
 EXPOSE 8080
-CMD php-fpm; nginx -g daemon off;
+CMD your_entrypoint.sh php-fpm; your_entrypoint.sh nginx -g daemon off;
 {{< /highlight >}}
 
 As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -480,7 +480,7 @@ Once the deployment is completed, your metrics and traces are sent to Datadog. I
 
 ## Alternative configurations
 
-### Alternatives to Entrypoint
+### Alternatives to entrypoint
 
 If you have already defined an entrypoint inside of your Dockerfile, you can instead modify the CMD argument.
 

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -102,17 +102,15 @@ ENV DD_VERSION=1
 CMD ["/app/datadog-init", "/nodejs/bin/node", "/path/to/your/app.js"]
 {{< /highlight >}}
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-).
 
-{{< highlight dockerfile "hl_lines=6" >}}
+{{< highlight dockerfile "hl_lines=7" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
 ENV DD_SERVICE=datadog-demo-run-nodejs
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-
 ENTRYPOINT ["/app/datadog-init"]
-
 CMD ["/your_entrypoint.sh", "/nodejs/bin/node", "/path/to/your/app.js"]
 {{< /highlight >}}
 
@@ -175,15 +173,14 @@ ENV DD_VERSION=1
 CMD ["/app/datadog-init", "/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
 {{< /highlight >}}
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-it-works)
 
-{{< highlight dockerfile "hl_lines=6" >}}
+{{< highlight dockerfile "hl_lines=7" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 RUN pip install --target /dd_tracer/python/ ddtrace
 ENV DD_SERVICE=datadog-demo-run-python
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-
 ENTRYPOINT ["/app/datadog-init"]
 CMD ["your_entrypoint.sh", "/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
 {{< /highlight >}}
@@ -206,17 +203,15 @@ ENTRYPOINT ["/app/datadog-init"]
 CMD ["./mvnw", "spring-boot:run"]
 ```
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-it-works)
 
-{{< highlight dockerfile "hl_lines=6" >}}
+{{< highlight dockerfile "hl_lines=7" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
 ENV DD_SERVICE=datadog-demo-run-nodejs
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-
 ENTRYPOINT ["/app/datadog-init"]
-
 CMD ["/your_entrypoint.sh", "/nodejs/bin/node", "/path/to/your/app.js"]
 {{< /highlight >}}
 
@@ -263,15 +258,14 @@ ENV DD_VERSION=1
 CMD ["/app/datadog-init", "./mvnw", "spring-boot:run"]
 {{< /highlight >}}
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-it-works)
 
-{{< highlight dockerfile "hl_lines=6" >}}
+{{< highlight dockerfile "hl_lines=7" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-
 ENTRYPOINT ["/app/datadog-init"]
 CMD ["your_entrypoint.sh", "./mvnw", "spring-boot:run"]
 {{< /highlight >}}
@@ -329,14 +323,13 @@ ENV DD_VERSION=1
 CMD ["/app/datadog-init", "/path/to/your-go-binary"]
 {{< /highlight >}}
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-it-works)
 
 {{< highlight dockerfile "hl_lines=6" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ENV DD_SERVICE=datadog-demo-run-go
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-
 ENTRYPOINT ["/app/datadog-init"]
 CMD ["your_entrypoint.sh", "/path/to/your-go-binary"]
 {{< /highlight >}}
@@ -420,15 +413,14 @@ ENV DD_VERSION=1
 CMD ["/app/datadog-init", "dotnet", "helloworld.dll"]
 {{< /highlight >}}
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-it-works)
 
-{{< highlight dockerfile "hl_lines=6" >}}
+{{< highlight dockerfile "hl_lines=7" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 COPY --from=datadog/dd-lib-dotnet-init /datadog-init/monitoring-home/ /dd_tracer/dotnet/
 ENV DD_SERVICE=datadog-demo-run-dotnet
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-
 ENTRYPOINT ["/app/datadog-init"]
 CMD ["your_entrypoint.sh", "dotnet", "helloworld.dll"]
 {{< /highlight >}}
@@ -494,15 +486,14 @@ ENV DD_TRACE_PROPAGATION_STYLE=datadog
 CMD ["/app/datadog-init", "rails", "server", "-b", "0.0.0.0"]
 {{< /highlight >}}
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-it-works)
 
-{{< highlight dockerfile "hl_lines=6" >}}
+{{< highlight dockerfile "hl_lines=7" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ENV DD_SERVICE=datadog-demo-run-ruby
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
 ENV DD_TRACE_PROPAGATION_STYLE=datadog
-
 ENTRYPOINT ["/app/datadog-init"]
 CMD ["your_entrypoint.sh", "rails", "server", "-b", "0.0.0.0"]
 {{< /highlight >}}
@@ -597,16 +588,15 @@ EXPOSE 8080
 CMD ["/app/datadog-init", "apache2-foreground"]
 {{< /highlight >}}
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead.
+If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-it-works)
 
-{{< highlight dockerfile "hl_lines=6" >}}
+{{< highlight dockerfile "hl_lines=10" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ADD https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php /datadog-setup.php
 RUN php /datadog-setup.php --php-bin=all
 ENV DD_SERVICE=datadog-demo-run-ruby
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-
 ENTRYPOINT ["/app/datadog-init"]
 RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
 EXPOSE 8080
@@ -690,6 +680,12 @@ Once the deployment is completed, your metrics and traces are sent to Datadog. I
 | `DD_SOURCE`       | See [Unified Service Tagging][6].                                  |
 | `DD_TAGS`         | See [Unified Service Tagging][6].                                  |
 
+
+## How it works
+
+The serverless-init application works by wrapping your process and executing it as a subprocess. It starts a DogstatsD listener for metrics, a trace agent listener for traces, and collects logs via wrapping the stdout/stderr streams of your application. After bootstrapping, serverless-init then launches your command as a subprocess.
+
+To get full instrumentation, ensure you are calling `datadog-init` as the first command that runs inside your Docker container. You can do this through via setting it as the ENTRYPOINT, or by setting it as the first argument in CMD.
 
 ## Troubleshooting
 

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -38,14 +38,14 @@ Images are tagged based on semantic versioning, with each new version receiving 
 The latest tag of /serverless-init will be applied to Beta9 through 9/1/2023 to provide additional time for Azure Container App Beta users to adjust to a breaking change in 1.0
 </div>
 
-* `latest`, `latest-apline`: use these to follow the latest version release, which may include breaking changes
+* `latest`, `latest-alpine`: use these to follow the latest version release, which may include breaking changes
 
 {{< programming-lang-wrapper langs="nodejs,python,java,go,dotnet,ruby,php" >}}
 {{< programming-lang lang="nodejs" >}}
 
 Add the following instructions and arguments to your Dockerfile.
 
-```
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
 ENV DD_SERVICE=datadog-demo-run-nodejs
@@ -59,13 +59,13 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
 
 1. Copy the Datadog `serverless-init` into your Docker image.
 
-   ```
+   ```dockerfile
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
 2. Copy the Datadog Node.JS tracer into your Docker image. 
 
-   ```
+   ```dockerfile
    COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
    ```
 
@@ -73,29 +73,43 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
 
 3. (Optional) Add Datadog tags.
 
-   ```
+   ```dockerfile
    ENV DD_SERVICE=datadog-demo-run-nodejs
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+   **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-node).
 
-   ```
+   ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
-   ```
+   ```dockerfile
    CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
    ```
+#### Alternative configuration: CMD argument {#alt-node}
+If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
+ENV DD_SERVICE=datadog-demo-run-nodejs
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+CMD ["/app/datadog-init", "/nodejs/bin/node", "/path/to/your/app.js"]
+{{< /highlight >}}
+
+As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/nodejs/?tab=containers#instrument-your-application
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}
 
 Add the following instructions and arguments to your Dockerfile.
-```
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 RUN pip install --target /dd_tracer/python/ ddtrace
 ENV DD_SERVICE=datadog-demo-run-python
@@ -108,32 +122,46 @@ CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
 #### Explanation
 
 1. Copy the Datadog `serverless-init` into your Docker image.
-   ```
+   ```dockerfile
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
 2. Install the Datadog Python tracer. 
-   ```
+   ```dockerfile
    RUN pip install --target /dd_tracer/python/ ddtrace
    ```
    If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
 
 3. (Optional) Add Datadog tags.
-   ```
+   ```dockerfile
    ENV DD_SERVICE=datadog-demo-run-python
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
-   ```
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+   **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-python).
+   ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your binary application wrapped in the entrypoint, launched by the Datadog trace library. Adapt this line to your needs.
-   ```
+   ```dockerfile
    CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
    ```
+#### Alternative configuration: CMD argument {#alt-python}
+If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+RUN pip install --target /dd_tracer/python/ ddtrace
+ENV DD_SERVICE=datadog-demo-run-python
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+CMD ["/app/datadog-init", "/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
+{{< /highlight >}}
+
+As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/python/?tab=containers#instrument-your-application
 {{< /programming-lang >}}
@@ -141,7 +169,7 @@ CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
 
 Add the following instructions and arguments to your Dockerfile.
 
-```
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
@@ -154,32 +182,47 @@ CMD ["./mvnw", "spring-boot:run"]
 #### Explanation
 
 1. Copy the Datadog `serverless-init` into your Docker image.
-   ```
+   ```dockerfile
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
 2. Add the Datadog Java tracer to your Docker image. 
-   ```
+   ```dockerfile
    ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
    ```
    If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
 
 3. (Optional) Add Datadog tags.
-   ```
+   ```dockerfile
    ENV DD_SERVICE=datadog-demo-run-java
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
-   ```
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+   **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-java).
+   ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
-   ```
+   ```dockerfile
    CMD ["./mvnw", "spring-boot:run"]
    ```
+
+#### Alternative configuration: CMD argument {#alt-java}
+If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+ENV DD_SERVICE=datadog-demo-run-java
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+CMD ["/app/datadog-init", "./mvnw", "spring-boot:run"]
+{{< /highlight >}}
+
+As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/java/?tab=containers#instrument-your-application
 {{< /programming-lang >}}
@@ -187,7 +230,7 @@ CMD ["./mvnw", "spring-boot:run"]
 
 [Manually install][1] the Go tracer before you deploy your application. Add the following instructions and arguments to your Dockerfile:
 
-```
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ENTRYPOINT ["/app/datadog-init"]
 ENV DD_SERVICE=datadog-demo-run-go
@@ -199,32 +242,48 @@ CMD ["/path/to/your-go-binary"]
 #### Explanation
 
 1. Copy the Datadog `serverless-init` into your Docker image.
-   ```
+   ```dockerfile
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
-   ```
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+   **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-go).
+   ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 3. (Optional) Add Datadog tags.
-   ```
+   ```dockerfile
    ENV DD_SERVICE=datadog-demo-run-go
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
 
 4. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
-   ```
+   ```dockerfile
    CMD ["/path/to/your-go-binary"]
    ```
 
+#### Alternative configuration: CMD argument {#alt-go}
+If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
+
+{{< highlight dockerfile "hl_lines=5" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ENV DD_SERVICE=datadog-demo-run-go
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+CMD ["/app/datadog-init", "/path/to/your-go-binary"]
+{{< /highlight >}}
+
+As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
+
 #### Orchestrion
 
-**Note**: [Orchestrion][2] is a tool for automatically instrumenting Go code, which is currently in Private Beta. With Orchestrion, it is possible to instrument your Go applications through Dockerfile. If you are interested in participating in the Beta or providing feedback on Orchestrion, please open a Github issue or reach out to support. 
+<div class="alert alert-warning">Orchestrion is in Private Beta. If you are interested in participating in the Beta or providing feedback on Orchestrion, <a href="https://github.com/DataDog/orchestrion/issues">open a GitHub issue</a> or <a href="/help">contact Datadog Support</a>.</div>
 
-```
+[Orchestrion][2] is a tool for automatically instrumenting Go code. With Orchestrion, it is possible to instrument your Go applications through Dockerfile.
+
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 RUN go install github.com/datadog/orchestrion@latest
 RUN orchestrion -w ./
@@ -243,7 +302,7 @@ CMD ["/path/to/your-go-binary"]
 
 Add the following instructions and arguments to your Dockerfile.
 
-```
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 COPY --from=datadog/dd-lib-dotnet-init /datadog-init/monitoring-home/ /dd_tracer/dotnet/
 ENV DD_SERVICE=datadog-demo-run-dotnet
@@ -256,32 +315,46 @@ CMD ["dotnet", "helloworld.dll"]
 #### Explanation
 
 1. Copy the Datadog `serverless-init` into your Docker image.
-   ```
+   ```dockerfile
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
 2. Copy the Datadog .NET tracer into your Docker image.
-   ```
+   ```dockerfile
    COPY --from=datadog/dd-lib-dotnet-init /datadog-init/monitoring-home/ /dd_tracer/dotnet/
    ```
    If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
 
 3. (Optional) Add Datadog tags.
-   ```
+   ```dockerfile
    ENV DD_SERVICE=datadog-demo-run-dotnet
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
-   ```
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
+   **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-dotnet).
+   ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
-   ```
+   ```dockerfile
    CMD ["dotnet", "helloworld.dll"]
    ```
+#### Alternative configuration: CMD argument {#alt-dotnet}
+If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
+
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+COPY --from=datadog/dd-lib-dotnet-init /datadog-init/monitoring-home/ /dd_tracer/dotnet/
+ENV DD_SERVICE=datadog-demo-run-dotnet
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+CMD ["/app/datadog-init", "dotnet", "helloworld.dll"]
+{{< /highlight >}}
+
+As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/dotnet-core/?tab=linux#custom-instrumentation
 {{< /programming-lang >}}
@@ -291,7 +364,7 @@ CMD ["dotnet", "helloworld.dll"]
 
 Add the following instructions and arguments to your Dockerfile.
 
-```
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ENV DD_SERVICE=datadog-demo-run-ruby
 ENV DD_ENV=datadog-demo
@@ -304,32 +377,45 @@ CMD ["rails", "server", "-b", "0.0.0.0"]
 #### Explanation
 
 1. Copy the Datadog `serverless-init` into your Docker image.
-   ```
+   ```dockerfile
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
 2. (Optional) add Datadog tags
-   ```
+   ```dockerfile
    ENV DD_SERVICE=datadog-demo-run-ruby
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
 
 3. This environment variable is needed for trace propagation to work properly in Cloud Run. Ensure that you set this variable for all Datadog-instrumented downstream services.
-   ```
+   ```dockerfile
    ENV DD_TRACE_PROPAGATION_STYLE=datadog
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
-   ```
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+   **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-ruby).
+   ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your binary application wrapped in the entrypoint. Adapt this line to your needs.
-   ```
+   ```dockerfile
    CMD ["rails", "server", "-b", "0.0.0.0"]
    ```
+#### Alternative configuration: CMD argument {#alt-ruby}
+If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
 
+{{< highlight dockerfile "hl_lines=6" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ENV DD_SERVICE=datadog-demo-run-ruby
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+ENV DD_TRACE_PROPAGATION_STYLE=datadog
+CMD ["/app/datadog-init", "rails", "server", "-b", "0.0.0.0"]
+{{< /highlight >}}
+
+As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/ruby/?tab=containers#instrument-your-application
 [2]: https://github.com/DataDog/crpb/tree/main/ruby-on-rails
@@ -338,7 +424,7 @@ CMD ["rails", "server", "-b", "0.0.0.0"]
 {{< programming-lang lang="php" >}}
 
 Add the following instructions and arguments to your Dockerfile.
-```
+```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ADD https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php /datadog-setup.php
 RUN php /datadog-setup.php --php-bin=all
@@ -364,44 +450,68 @@ CMD php-fpm; nginx -g daemon off;
 
 
 1. Copy the Datadog `serverless-init` into your Docker image.
-   ```
+   ```dockerfile
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
 2. Copy and install the Datadog PHP tracer.
-   ```
+   ```dockerfile
    ADD https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php /datadog-setup.php
    RUN php /datadog-setup.php --php-bin=all
    ```
    If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
 
 3. (Optional) Add Datadog tags.
-   ```
+   ```dockerfile
    ENV DD_SERVICE=datadog-demo-run-ruby
    ENV DD_ENV=datadog-demo
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. **Note**: If you already have an entrypoint defined inside your Dockerfile, you have [alternative configuration options](#alternative-configurations).
-   ```
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+   **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-php).
+   ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your application.
    
    Use the following for an apache and mod_php based image:
-   ```
+   ```dockerfile
    RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
    EXPOSE 8080
    CMD ["apache2-foreground"]
    ```
 
    Use the following for an nginx and php-fpm based image:
-   ```
+   ```dockerfile
    RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
    EXPOSE 8080
    CMD php-fpm; nginx -g daemon off;
    ```
+#### Alternative configuration: CMD argument {#alt-php}
+If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
+
+{{< highlight dockerfile "hl_lines=11 16" >}}
+COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+ADD https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php /datadog-setup.php
+RUN php /datadog-setup.php --php-bin=all
+ENV DD_SERVICE=datadog-demo-run-ruby
+ENV DD_ENV=datadog-demo
+ENV DD_VERSION=1
+
+# use the following for an apache and mod_php based image
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+EXPOSE 8080
+CMD ["/app/datadog-init", "apache2-foreground"]
+
+# use the following for an nginx and php-fpm based image
+RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
+EXPOSE 8080
+CMD php-fpm; nginx -g daemon off;
+{{< /highlight >}}
+
+As long as your command to run is passed as an argument to `datadog-init`, you will receive full instrumentation.
 
 [1]: /tracing/trace_collection/dd_libraries/php/?tab=containers#install-the-extension
 {{< /programming-lang >}}
@@ -478,30 +588,6 @@ Once the deployment is completed, your metrics and traces are sent to Datadog. I
 | `DD_SOURCE`       | See [Unified Service Tagging][6].                                  |
 | `DD_TAGS`         | See [Unified Service Tagging][6].                                  |
 
-## Alternative configurations
-
-### Alternatives to entrypoint
-
-If you have already defined an entrypoint inside of your Dockerfile, you can instead modify the CMD argument.
-
-**Note**: As long as your command to run is passed as an argument to datadog-init, you will receive full instrumentation.
-
-The below code snippet illustates how to modify your Dockerfile to instrument Cloud Run without modifying your entrypoint.
-
-```
-COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-ENTRYPOINT ["/app/datadog-init"]
-
-CMD ["your", "start", "command"]
-```
-
-would become this:
-
-```
-COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-
-CMD ["/app/datadog-init", "your", "start", "command"]
-```
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds alternative instructions for using CMD instead of ENTRYPOINT for instrumenting serverless-init.

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
