### PR TITLE
Update SAML mapping links to target the new page

### DIFF
--- a/content/en/account_management/authn_mapping/_index.md
+++ b/content/en/account_management/authn_mapping/_index.md
@@ -14,7 +14,7 @@ If you are using Federated Authentication mechanisms, this API allows you to aut
 
 **Note**: If you are a SAML user, and you have been using the existing beta Federated Mapping mechanism (`roles_v2_saml`), Datadog strongly recommends that you transition to using this API.
 
-You can also create and manage mappings in the Datadog UI, on the **Mappings** tab in User Management. See [Mapping SAML attributes to Datadog roles][1] for more information.
+You can also create and manage mappings in the Datadog UI, on the **Mappings** tab in User Management. See [SAML group mapping][1] for more information.
 
 ## Requests
 
@@ -608,5 +608,5 @@ curl -X POST \
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /account_management/saml/#mapping-saml-attributes-to-datadog-roles
+[1]: /account_management/saml/mapping
 [2]: /api/v2/roles/#list-roles

--- a/content/en/account_management/org_settings.md
+++ b/content/en/account_management/org_settings.md
@@ -149,7 +149,7 @@ You can choose to set your organization homepage to a Dashboard List or an indiv
 [4]: /account_management/org_settings/service_accounts
 [5]: /account_management/login_methods/
 [6]: /account_management/saml/
-[7]: /account_management/saml/#mapping-saml-attributes-to-datadog-roles
+[7]: /account_management/saml/mapping
 [8]: /account_management/api-app-keys/
 [9]: /account_management/rbac/
 [10]: /agent/remote_config/?tab=configurationyamlfile#how-it-works

--- a/content/en/account_management/saml/okta.md
+++ b/content/en/account_management/saml/okta.md
@@ -14,20 +14,20 @@ further_reading:
 
 ## Setup
 
-Follow Okta's [Create SAML app integrations][6] docs to configure Okta as a SAML IdP.
+Follow Okta's [Create SAML app integrations][1] docs to configure Okta as a SAML IdP.
 
 **Note**: It's recommended that you set up Datadog as an Okta application manually, as opposed to using a `pre-configured` configuration.
 
-**Note**: US1 customers can use the preset configuration in Okta's [How to Configure SAML 2.0 for Datadog][1] docs to configure Okta as a SAML IdP.
+**Note**: US1 customers can use the preset configuration in Okta's [How to Configure SAML 2.0 for Datadog][2] docs to configure Okta as a SAML IdP.
 
 ## General details
 
 | Okta IDP Input Field        | Expected Value                                                                                                                 |
 |-----------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| Single Sign On URL          | Assertion Consumer Service URL (Find this URL on the [Configure SAML][2] page, in the *Assertion Consumer Service URL* field.) |
+| Single Sign On URL          | Assertion Consumer Service URL (Find this URL on the [Configure SAML][3] page, in the *Assertion Consumer Service URL* field.) |
 | Recipient URL               | Assertion Consumer Service URL (or click the *Use this for Recipient URL and Destination URL* checkbox)                        |
 | Destination URL             | Assertion Consumer Service URL (or click the *Use this for Recipient URL and Destination URL* checkbox)                        |
-| Audience URI (SP Entity ID) | Service Provider Entity ID (Find this URL on the [Configure SAML][2] page, in the *Service Provider Entity ID* field.)         |
+| Audience URI (SP Entity ID) | Service Provider Entity ID (Find this URL on the [Configure SAML][3] page, in the *Service Provider Entity ID* field.)         |
 | Name ID Format              | EmailAddress                                                                                                                   |
 | Response                    | Signed                                                                                                                         |
 | Assertion Signature         | Signed                                                                                                                         |
@@ -48,24 +48,24 @@ Follow Okta's [Create SAML app integrations][6] docs to configure Okta as a SAML
 
 ## Group attribute statements (optional)
 
-This is required only if you are using [AuthN Mapping][3].
+This is required only if you are using [AuthN Mapping][4].
 
 | Name     | Name Format (optional) | Value                                                                                                                     |
 |----------|------------------------|---------------------------------------------------------------------------------------------------------------------------|
 | memberOf | Unspecified            | Matches regex `.*` (This method retrieves all groups. Contact your IDP administrator if this does not fit your use case.) |
 
 
-Additional information on configuring SAML for your Datadog account is available on the [SAML documentation page][4].
+Additional information on configuring SAML for your Datadog account is available on the [SAML documentation page][5].
 
-In the event that you need to upload an `IDP.XML` file to Datadog before being able to fully configure the application in Okta, see [acquiring the idp.xml metadata file for a SAML template App article][5] for field placeholder instructions.
+In the event that you need to upload an `IDP.XML` file to Datadog before being able to fully configure the application in Okta, see [acquiring the idp.xml metadata file for a SAML template App article][6] for field placeholder instructions.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-DataDog.html
-[2]: https://app.datadoghq.com/saml/saml_setup
-[3]: /account_management/saml/#mapping-saml-attributes-to-datadog-roles
-[4]: /account_management/saml/
-[5]: https://support.okta.com/help/s/article/How-do-we-download-the-IDP-XML-metadata-file-from-a-SAML-Template-App
-[6]: https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm?cshid=ext_Apps_App_Integration_Wizard-saml
+[1]: https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm?cshid=ext_Apps_App_Integration_Wizard-saml
+[2]: https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-DataDog.html
+[3]: https://app.datadoghq.com/saml/saml_setup
+[4]: /account_management/saml/mapping
+[5]: /account_management/saml/
+[6]: https://support.okta.com/help/s/article/How-do-we-download-the-IDP-XML-metadata-file-from-a-SAML-Template-App


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
I previously moved the SAML mapping information to its own page on [PR 19145](https://github.com/DataDog/documentation/pull/19145). At that time, I forgot to search for existing links to the anchor. It turns out that there are three references.

This PR updates the existing links to point to the new page.

I'm also using the link formatter, so it reordered the links in one of the files.

### Motivation
<!-- What inspired you to submit this pull request?-->
correct an error

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
ready to merge

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
