### PR TITLE
DOCS-5758 Add CI Visibility Vocabulary to Docs Glossary

### DIFF
--- a/content/en/continuous_integration/search/_index.md
+++ b/content/en/continuous_integration/search/_index.md
@@ -61,30 +61,23 @@ To see your tests, navigate to [**CI** > **Tests**][8] and select between the [*
 
 ### Branches view
 
-The [Branches][2] view of the Tests page lists all branches from all Test Services that have reported test results. This tab is useful for individual developers to quickly see the status of tests that run on their code branches and troubleshoot test failures.
+The [Branches][2] view of the Tests page lists all branches from all [test services][11] that have reported test results. This tab is useful for individual developers to quickly see the status of tests that run on their code branches and troubleshoot test failures.
 
 In this page, you can filter the list by name, test service, or commit SHA, or to show only your branches (branches that contain at least one commit authored by you) by enabling the **My branches** toggle and adding the email addresses you use in your Git configuration.
 
 #### Test results
 
-For each branch, the list shows test results for its latest commit: a consolidated number of tests broken down by status (which takes into account retries) and the number of new flaky tests introduced by the commit (a flaky test is defined as a test that both passes and fails on the same commit).
+For each branch, the list shows test results for its latest commit: a consolidated number of tests broken down by status (which takes into account retries) and the number of new [flaky tests][9] introduced by the commit.
 
 #### Test suite performance
 
-There is also information about the wall time of the most recent test suite run, and a comparison to the average wall time of the default branch. _Wall time_ is the real time elapsed while the test suite runs, which is less than the sum of all test times when tests are run concurrently. The comparison of your branch's wall time to the default branch's wall time can help you determine if your commit is introducing performance regressions to your test suite.
+There is also information about the [wall time][10] of the most recent test suite run, and a comparison to the average wall time of the default branch. The comparison of your branch's wall time to the default branch's wall time can help you determine if your commit is introducing performance [regressions][12] to your test suite.
 
 Hovering over the commit author avatar shows detailed information about the latest commit.
 
 #### Test regressions
 
-A test run is marked as a regression when its duration is both five times the mean and greater than the max duration for the same test in the default branch.
-
-A benchmark test run is marked as a regression when its duration is five times the standard deviation above the mean for the same test in the default branch. A benchmark test has `@test.type:benchmark`.
-
-The mean and the max of the default branch is calculated over the last week of test runs.
-
 Test regressions are evaluated per commit in an effort to tie performance regressions to specific code changes.
-
 #### Investigate for more details
 
 Click on the row to see test suite run details such as test results for the last commit on this branch (or you can switch branches), failing tests and the most common errors, slow tests, flaky tests, and a complete list of test runs over the time frame selected. You can filter this list of test runs by facet to get to the information you want to see most.
@@ -97,7 +90,7 @@ Click the CI provider link to examine the Resource, Service, or Analytics page f
 
 ### Default Branches view
 
-A _test service_ is a group of tests associated with, for example, a project or repo. It contains all the individual tests for your code, optionally organized into _test suites_ (which are like folders for your tests). The [Default Branches][3] view of the Tests page shows aggregated health metrics for the _default_ branch of each test service. This view is useful for teams to understand the overall health of the service over time.
+The [Default Branches][3] view of the Tests page shows aggregated health metrics for the _default_ branch of each test service. This view is useful for teams to understand the overall health of the service over time.
 
 The Default Branches view shows similar information to the Branches view, but applied to the default branch, and sorted by most recent. It compares the current wall time with the average default branch wall time, to give you an indication of how your test suite performance is trending over time.
 
@@ -155,3 +148,7 @@ Job log collection is supported for the following providers:
 [6]: /continuous_integration/pipelines/jenkins#enable-job-log-collection
 [7]: https://app.datadoghq.com/ci/pipelines
 [8]: https://app.datadoghq.com/ci/test-services
+[9]: /glossary/#flaky-test
+[10]: /glossary/#wall-time
+[11]: /glossary/#test-service
+[12]: /glossary/#test-regression

--- a/content/en/glossary/terms/flaky_test.md
+++ b/content/en/glossary/terms/flaky_test.md
@@ -6,4 +6,4 @@ core_product:
   - ci-cd
 
 ---
-A flaky test is a test that exhibit both a passing and failing status across multiple test runs for the same commit. If you commit some code and run it through CI, and a test fails, and you run it through CI again and the test passes, that test is unreliable as proof of quality code. For more information, <a href="/continuous_integration/search/?tab=tests#new-flaky-tests">see the documentation</a>.
+A flaky test is a test that exhibits both a passing and failing status across multiple test runs for the same commit. If you commit some code and run it through CI, and a test fails, and you run it through CI again and the test passes, that test is unreliable as proof of quality code. For more information, <a href="/continuous_integration/search/?tab=tests#new-flaky-tests">see the documentation</a>.

--- a/content/en/glossary/terms/flaky_test.md
+++ b/content/en/glossary/terms/flaky_test.md
@@ -1,0 +1,9 @@
+---
+# Glossary Term
+title: flaky test
+
+core_product:
+  - ci-cd
+
+---
+A flaky test is a test that exhibit both a passing and failing status across multiple test runs for the same commit. If you commit some code and run it through CI, and a test fails, and you run it through CI again and the test passes, that test is unreliable as proof of quality code. For more information, <a href="/continuous_integration/search/?tab=tests#new-flaky-tests">see the documentation</a>.

--- a/content/en/glossary/terms/test_regression.md
+++ b/content/en/glossary/terms/test_regression.md
@@ -1,0 +1,11 @@
+---
+# Glossary Term
+title: test regression
+
+core_product:
+  - ci-cd
+  
+---
+A test run is marked as a regression when its duration is both five times the mean and greater than the max duration for the same test in the default branch. A benchmark test run is marked as a regression when its duration is five times the standard deviation above the mean for the same test in the default branch. 
+
+A benchmark test has `@test.type:benchmark`. The mean and the max of the default branch is calculated over the last week of test runs. For more information, <a href="/continuous_integration/search/?tab=tests#test-regressions">see the documentation</a>.

--- a/content/en/glossary/terms/test_service.md
+++ b/content/en/glossary/terms/test_service.md
@@ -1,0 +1,9 @@
+---
+# Glossary Term
+title: test service
+
+core_product:
+  - ci-cd
+
+---
+A test service is a group of tests associated with, for example, a project or repo. It contains all the individual tests for your code, optionally organized into test suites, which are like folders for your tests. For more information, <a href="/continuous_integration/search/?tab=tests#test-suite-performance">see the documentation</a>.

--- a/content/en/glossary/terms/wall_time.md
+++ b/content/en/glossary/terms/wall_time.md
@@ -1,0 +1,9 @@
+---
+# Glossary Term
+title: wall time
+
+core_product:
+  - ci-cd
+
+---
+Wall time is the real time elapsed while the test suite runs, which is less than the sum of all test times when tests are run concurrently. For more information, <a href="/continuous_integration/search/?tab=tests#test-suite-performance">see the documentation</a>.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->

Adds "CI/CD" terminology to the Docs Glossary. Will create a WEB card asking to update the product tag to `Software Delivery`.

### Motivation
<!-- What inspired you to submit this pull request?-->

Chat with @kayayarai on Slack, thanks for showing me how to get started with contributing terms!

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
