### PR TITLE
Add DD_HTTP_SERVER_ROUTE_BASED_NAMING documentation

### DIFF
--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -292,6 +292,11 @@ CSV of URI mappings to normalize resource naming for outgoing requests (see [Map
 Works for Linux. Set to `true` to retain capabilities on Datadog background threads when you change the effective user ID. This option does not affect most setups, but some modules - to date Datadog is only aware of [Apache's mod-ruid2][5] - may invoke `setuid()` or similar syscalls, leading to crashes or loss of functionality as it loses capabilities.<br><br>
 **Note:** Enabling this option may compromise security. This option, standalone, does not pose a security risk. However, an attacker being able to exploit a vulnerability in PHP or web server may be able to escalate privileges with relative ease, if the web server or PHP were started with full capabilities, as the background threads will retain their original capabilities. Datadog recommends restricting the capabilities of the web server with the `setcap` utility.
 
+`DD_HTTP_SERVER_ROUTE_BASED_NAMING`
+: **INI**: `datadog.http_server_route_based_naming`<br>
+**Default**: `true`<br>
+Enable route-based naming for HTTP server requests. Set to `true` to use the integration-specific root span's resource name format. When `false`, the HTTP method and path are used instead. Added in version `0.89.0`.
+
 `DD_TRACE_SAMPLE_RATE`
 : **INI**: `datadog.trace.sample_rate`<br>
 **Default**: `1.0`<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Add missing documentation for `DD_HTTP_SERVER_ROUTE_BASED_NAMING` in the PHP tracer.

### Motivation
This configuration option was added in 0.89.0 with the PR Datadog/dd-trace-php#2138, and mention was made that it was missing in the issue Datadog/dd-trace-php#2231 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
