### PR TITLE
Update Go tracer compatibility requirements: Go 1.18 as minimum supported version

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/go.md
+++ b/content/en/tracing/trace_collection/dd_libraries/go.md
@@ -25,7 +25,7 @@ further_reading:
 
 ## Compatibility requirements
 
-The Go Tracer requires Go `1.17+` and Datadog Agent `>= 5.21.1`. For a full list of Datadog's Go version and framework support (including legacy and maintenance versions), see the [Compatibility Requirements][1] page.
+The Go Tracer requires Go `1.18+` and Datadog Agent `>= 5.21.1`. For a full list of Datadog's Go version and framework support (including legacy and maintenance versions), see the [Compatibility Requirements][1] page.
 
 ## Configure the Datadog Agent for APM
 


### PR DESCRIPTION
### What does this PR do?

Updates Go minimum supported version to 1.18 for Go tracer.

### Motivation

The team confirmed that `dd-trace-go` is no longer possible to compile in versions below 1.18 because some dependencies are using features from that version.

Also, Go 1.21 was released. According to our [support policy](https://github.com/DataDog/dd-trace-go#support-policy), we support "the two latest releases are GA supported and the version before that is in Maintenance. We do make efforts to support older releases, but generally these releases are considered Legacy". This causes sunsetting support for Go 1.17.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
