### PR TITLE
Add pie chart API fields to widget docs

### DIFF
--- a/content/en/dashboards/widgets/pie_chart.md
+++ b/content/en/dashboards/widgets/pie_chart.md
@@ -1,6 +1,7 @@
 ---
 title: Pie Chart Widget
 kind: documentation
+widget_type: "sunburst"
 description: "Graph proportions of one or more datasets."
 further_reading:
 - link: "/dashboards/graphing_json/"
@@ -60,6 +61,8 @@ Viewing the pie chart widget in full-screen reveals the standard set of [full-sc
 ## API
 
 This widget can be used with the [Dashboards API][6].
+
+<div class="alert alert-info">The widget type for Pie Chart is <strong>sunburst</strong>.</div>
 
 {{< dashboards-widgets-api >}}
 

--- a/content/en/dashboards/widgets/pie_chart.md
+++ b/content/en/dashboards/widgets/pie_chart.md
@@ -61,6 +61,8 @@ Viewing the pie chart widget in full-screen reveals the standard set of [full-sc
 
 This widget can be used with the [Dashboards API][6].
 
+{{< dashboards-widgets-api >}}
+
 ## Treemap widget
 
 Like the pie chart widget, the [treemap][7] can also be used to display nested proportions. The primary difference between the two is that the pie chart displays proportions in radial slices, and the treemap displays nested rectangles.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add correct widget_type and widget shortcode to the Pie Chart docs.

### Motivation
<!-- What inspired you to submit this pull request?-->
[DOCS-6117](https://datadoghq.atlassian.net/browse/DOCS-6117)

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->
Ready to merge after review.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-6117]: https://datadoghq.atlassian.net/browse/DOCS-6117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ