### PR TITLE
Oracle 0.34 update

### DIFF
--- a/content/en/database_monitoring/setup_oracle/_index.md
+++ b/content/en/database_monitoring/setup_oracle/_index.md
@@ -53,7 +53,7 @@ The Agent does not need to run on the same server nor the same platform as the m
 
 Datadog recommends you install the version listed in the [Latest Agent version](#latest-agent-version). It contains all the implemented Oracle monitoring features and bug fixes.
 
-If the latest Agent version is an official Datadog Agent release, like `7.46.0`, follow the instructions in [Official release](#official-release). If the latest Agent version is a beta build, such as `7.46.0~dbm~oracle~0.34`, follow the instructions in [Oracle DBM build](#oracle-dbm-build).
+If the latest Agent version is an official Datadog Agent release, like `7.46.0`, follow the instructions in [Official release](#official-release). If the latest Agent version is an Oracle DBM build, such as `7.46.0~dbm~oracle~0.34`, follow the instructions in [Oracle DBM build](#oracle-dbm-build).
 
 #### Official release
 

--- a/content/en/database_monitoring/setup_oracle/_index.md
+++ b/content/en/database_monitoring/setup_oracle/_index.md
@@ -65,7 +65,7 @@ The purpose of Oracle DBM builds is to provide features and bug fixes before the
 
 ##### Linux
 
-The repository with RHEL and Ubuntu Oracle DBM builds are [here][6] and [here][7], respectively.
+Download the [RHEL][6] and [Ubuntu Oracle DBM][7] builds from their respective repositories.
 
 Set `DD_API_KEY` and run the following commands to install the Oracle DBM release, for example:
 

--- a/content/en/database_monitoring/setup_oracle/_index.md
+++ b/content/en/database_monitoring/setup_oracle/_index.md
@@ -53,23 +53,25 @@ The Agent does not need to run on the same server nor the same platform as the m
 
 Datadog recommends you install the version listed in the [Latest Agent version](#latest-agent-version). It contains all the implemented Oracle monitoring features and bug fixes.
 
-If the latest Agent version is an official Datadog Agent release, like `7.46.0`, follow the instructions in [Official release](#official-release). If the latest Agent version is a beta build, such as `7.46.0~dbm~oracle~beta~0.33`, follow the instructions in [Beta build](#beta-build).
+If the latest Agent version is an official Datadog Agent release, like `7.46.0`, follow the instructions in [Official release](#official-release). If the latest Agent version is a beta build, such as `7.46.0~dbm~oracle~0.34`, follow the instructions in [Oracle DBM build](#oracle-dbm-build).
 
 #### Official release
 
 Follow the [instructions for your platform][3].
 
-#### Beta build
+#### Oracle DBM build
+
+The purpose of Oracle DBM builds is to provide features and bug fixes before they appear in the official Agent release. The basis of an Oracle DBM build is always a stable agent release.
 
 ##### Linux
 
-The repository with RHEL and Ubuntu beta builds are [here][6] and [here][7], respectively.
+The repository with RHEL and Ubuntu Oracle DBM builds are [here][6] and [here][7], respectively.
 
-Set `DD_API_KEY` and run the following commands to install the beta release, for example:
+Set `DD_API_KEY` and run the following commands to install the Oracle DBM release, for example:
 
 ```shell
 export DD_AGENT_DIST_CHANNEL=beta
-export DD_AGENT_MINOR_VERSION="46.0~dbm~oracle~beta~0.33-1"
+export DD_AGENT_MINOR_VERSION="46.0~dbm~oracle~0.34-1"
 
 DD_API_KEY= DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
@@ -78,30 +80,30 @@ DD_API_KEY= DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/
 
 The repository with Windows builds is [here][8].
 
-Download the MSI file for the [beta build][4].
+Download the MSI file for the [Oracle DBM build][4].
 
 Set `APIKEY` and run the following command in the command prompt inside the directory where you downloaded the installer, for example:
 
 ```shell
-start /wait msiexec /qn /i datadog-agent-7.46.0-dbm-oracle-beta-0.33-1.x86_64.msi APIKEY="" SITE="datadoghq.com"
+start /wait msiexec /qn /i datadog-agent-7.46.0-dbm-oracle-0.34-1.x86_64.msi APIKEY="" SITE="datadoghq.com"
 ```
 
 ##### Docker
 
-The docker beta images can be found [here][9].
+The docker Oracle DBM images can be found [here][9].
 
-Set `DD_API_KEY` and run the following command to install the beta release, for example:
+Set `DD_API_KEY` and run the following command to install the Oracle DBM release, for example:
 
 ```shell
-docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY="" -e DD_SITE="datadoghq.com" gcr.io/datadoghq/agent:7.46.0-dbm-oracle-beta-0.33
+docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY="" -e DD_SITE="datadoghq.com" gcr.io/datadoghq/agent:7.46.0-dbm-oracle-0.34
 ```
 
 ##### Latest Agent version
 
-The following beta builds contain implemented Oracle DBM features:
-- Linux: `7.46.0~dbm~oracle~beta~0.33-1`
-- Windows: `7.46.0-dbm-oracle-beta-0.33-1`
-- Docker: `7.46.0-dbm-oracle-beta-0.33`
+The following Oracle DBM builds contain implemented Oracle DBM features:
+- Linux: `7.46.0~dbm~oracle~0.34-1`
+- Windows: `7.46.0-dbm-oracle-0.34-1`
+- Docker: `7.46.0-dbm-oracle-0.34`
 
 ### Oracle client
 
@@ -126,7 +128,7 @@ For setup instructions, select your hosting type:
 [1]: https://app.datadoghq.com/integrations
 [2]: https://app.datadoghq.com/integrations/oracle
 [3]: https://app.datadoghq.com/account/settings/agent/latest
-[4]: https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-agent-7.46.0-dbm-oracle-beta-0.33-1.x86_64.msi
+[4]: https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-agent-7.46.0-dbm-oracle-0.34-1.x86_64.msi
 [5]: https://app.datadoghq.com/dash/integration/30990/dbm-oracle-database-overview
 [6]: https://yum.datadoghq.com/beta/7/x86_64/
 [7]: https://apt.datadoghq.com/dists/beta/7/

--- a/content/en/database_monitoring/setup_oracle/autonomous_database.md
+++ b/content/en/database_monitoring/setup_oracle/autonomous_database.md
@@ -66,6 +66,7 @@ grant select on V$SQLSTATS to datadog ;
 grant select on V$CONTAINERS to datadog ;
 grant select on V$SQL_PLAN_STATISTICS_ALL to datadog ;
 grant select on V$SQL to datadog ;
+grant select on V$PGASTAT to datadog ;
 ```
 
 ## Configure the Agent

--- a/content/en/database_monitoring/setup_oracle/rds.md
+++ b/content/en/database_monitoring/setup_oracle/rds.md
@@ -67,6 +67,7 @@ exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SQLSTATS','DATADOG','SELECT',p_
 exec rdsadmin.rdsadmin_util.grant_sys_object('V_$CONTAINERS','DATADOG','SELECT',p_grant_option => false);
 exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SQL_PLAN_STATISTICS_ALL','DATADOG','SELECT',p_grant_option => false);
 exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SQL','DATADOG','SELECT',p_grant_option => false);
+exec rdsadmin.rdsadmin_util.grant_sys_object('V_$PGASTAT','DATADOG','SELECT',p_grant_option => false);
 ```
 
 ## Configure the Agent

--- a/content/en/database_monitoring/setup_oracle/selfhosted.md
+++ b/content/en/database_monitoring/setup_oracle/selfhosted.md
@@ -70,6 +70,7 @@ grant select on V_$SQLSTATS to c##datadog ;
 grant select on V_$CONTAINERS to c##datadog ;
 grant select on V_$SQL_PLAN_STATISTICS_ALL to c##datadog ;
 grant select on V_$SQL to c##datadog ;
+grant select on V_$PGASTAT to c##datadog ;
 ```
 
 If you conifgured custom queries that run on a pluggable database (PDB), you must grant `set container` privilege to the `C##DATADOG` user:


### PR DESCRIPTION
### What does this PR do?

Updating documentation for the new Oracle DBM agent release. 

In this release we are changing the naming scheme for the image - we are removing `beta` from the name. Customers are generally using agent for monitoring non-Oracle components, and they were reluctant to use a beta agent for that. But `beta` applies only to the Oracle checks; the other checks are based on the latest stable release. The Oracle setup documentation clearly states that the Oracle checks are still in the beta phase, so we aren't deceiving customers with removing `beta` from the image name.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
