### PR TITLE
Add Laravel 9.x and 10.x compatibility

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/php.md
+++ b/content/en/tracing/trace_collection/compatibility/php.md
@@ -92,27 +92,27 @@ The following table enumerates some of the frameworks and versions Datadog succe
 
 **Web frameworks**:
 
-| Module         | Versions             | Support Type               | Instrumentation level           |
-|:-------------- |:---------------------|:---------------------------|:--------------------------------|
-| CakePHP        | 2.x                  | All supported PHP versions | Framework-level instrumentation |
-| CodeIgniter    | 2.x                  | PHP 7+                     | Framework-level instrumentation |
-| CodeIgniter    | 3.x                  | PHP 7+                     | Generic web tracing             |
-| Drupal         |                      | All supported PHP versions | Generic web tracing             |
-| FuelPHP        | 1.1                  | PHP 7+                     | Generic web tracing             |
-| Laminas        |                      | All supported PHP versions | Framework-level instrumentation |
-| Laravel        | 4.2, 5.x, 6.x        | All supported PHP versions | Framework-level instrumentation |
-| Laravel 8      | 8.x (tracer `0.52.0+`) | All supported PHP versions | Framework-level instrumentation |
-| Lumen          |   5.2+                 | All supported PHP versions | Framework-level instrumentation |
-| Magento        | 1, 2                 | All supported PHP versions | Generic web tracing             |
-| Neos Flow      | 1.1                  | All supported PHP versions | Generic web tracing             |
-| Phalcon        | 1.3, 3.4             | All supported PHP versions | Generic web tracing             |
-| RoadRunner     | 2.x                  | All supported PHP versions | Framework-level instrumentation |
-| Slim           | 2.x, 3.x, 4.x        | All supported PHP versions | Framework-level instrumentation |
-| Symfony        | 2.x, 3.3, 3.4, 4.x, 5.x, 6.x | All supported PHP versions | Framework-level instrumentation |
-| WordPress      | 4.x, 5.x             | PHP 7+                     | Framework-level instrumentation |
-| Yii            | 1.1, 2.0             | All supported PHP versions | Framework-level instrumentation |
-| Zend Framework | 1.12, 1.21           | All supported PHP versions | Framework-level instrumentation |
-| Zend Framework | 2.x                  | All supported PHP versions | Generic web tracing             |
+| Module         | Versions                          | Support Type               | Instrumentation level           |
+|:-------------- |:----------------------------------|:---------------------------|:--------------------------------|
+| CakePHP        | 2.x                               | All supported PHP versions | Framework-level instrumentation |
+| CodeIgniter    | 2.x                               | PHP 7+                     | Framework-level instrumentation |
+| CodeIgniter    | 3.x                               | PHP 7+                     | Generic web tracing             |
+| Drupal         |                                   | All supported PHP versions | Generic web tracing             |
+| FuelPHP        | 1.1                               | PHP 7+                     | Generic web tracing             |
+| Laminas        |                                   | All supported PHP versions | Framework-level instrumentation |
+| Laravel        | 4.2, 5.x, 6.x                     | All supported PHP versions | Framework-level instrumentation |
+| Laravel 8      | 8.x, 9.x, 10.x (tracer `0.52.0+`) | All supported PHP versions | Framework-level instrumentation |
+| Lumen          | 5.2+                              | All supported PHP versions | Framework-level instrumentation |
+| Magento        | 1, 2                              | All supported PHP versions | Generic web tracing             |
+| Neos Flow      | 1.1                               | All supported PHP versions | Generic web tracing             |
+| Phalcon        | 1.3, 3.4                          | All supported PHP versions | Generic web tracing             |
+| RoadRunner     | 2.x                               | All supported PHP versions | Framework-level instrumentation |
+| Slim           | 2.x, 3.x, 4.x                     | All supported PHP versions | Framework-level instrumentation |
+| Symfony        | 2.x, 3.3, 3.4, 4.x, 5.x, 6.x      | All supported PHP versions | Framework-level instrumentation |
+| WordPress      | 4.x, 5.x                          | PHP 7+                     | Framework-level instrumentation |
+| Yii            | 1.1, 2.0                          | All supported PHP versions | Framework-level instrumentation |
+| Zend Framework | 1.12, 1.21                        | All supported PHP versions | Framework-level instrumentation |
+| Zend Framework | 2.x                               | All supported PHP versions | Generic web tracing             |
 
 Note that even if you don't see your web framework in this list, it is supported out of the box with the latest release of the tracer.
 
@@ -122,11 +122,11 @@ Datadog is continuously adding more support for in-depth tracing for PHP web-fra
 
 Tracing from the CLI SAPI is disabled by default. To enable tracing of PHP CLI scripts, set `DD_TRACE_CLI_ENABLED=true`.
 
-| Module          | Versions | Support Type    |
-|:----------------|:---------|:----------------|
-| CakePHP Console | 2.x      | Fully Supported |
-| Laravel Artisan | 5.x, 8.x | Fully Supported |
-| Symfony CLI     | 4.x, 5.x, 6.x | Fully Supported |
+| Module          | Versions            | Support Type    |
+|:----------------|:--------------------|:----------------|
+| CakePHP Console | 2.x                 | Fully Supported |
+| Laravel Artisan | 5.x, 8.x, 9.x, 10.x | Fully Supported |
+| Symfony CLI     | 4.x, 5.x, 6.x       | Fully Supported |
 
 To request support for additional CLI libraries, contact our awesome [support team][3].
 

--- a/content/en/tracing/trace_collection/compatibility/php.md
+++ b/content/en/tracing/trace_collection/compatibility/php.md
@@ -93,7 +93,7 @@ The following table enumerates some of the frameworks and versions Datadog succe
 **Web frameworks**:
 
 | Module         | Versions                          | Support Type               | Instrumentation level           |
-|:-------------- |:----------------------------------|:---------------------------|:--------------------------------|
+|:---------------|:----------------------------------|:---------------------------|:--------------------------------|
 | CakePHP        | 2.x                               | All supported PHP versions | Framework-level instrumentation |
 | CodeIgniter    | 2.x                               | PHP 7+                     | Framework-level instrumentation |
 | CodeIgniter    | 3.x                               | PHP 7+                     | Generic web tracing             |
@@ -101,7 +101,7 @@ The following table enumerates some of the frameworks and versions Datadog succe
 | FuelPHP        | 1.1                               | PHP 7+                     | Generic web tracing             |
 | Laminas        |                                   | All supported PHP versions | Framework-level instrumentation |
 | Laravel        | 4.2, 5.x, 6.x                     | All supported PHP versions | Framework-level instrumentation |
-| Laravel 8      | 8.x, 9.x, 10.x (tracer `0.52.0+`) | All supported PHP versions | Framework-level instrumentation |
+| Laravel 8+     | 8.x, 9.x, 10.x (tracer `0.52.0+`) | All supported PHP versions | Framework-level instrumentation |
 | Lumen          | 5.2+                              | All supported PHP versions | Framework-level instrumentation |
 | Magento        | 1, 2                              | All supported PHP versions | Generic web tracing             |
 | Neos Flow      | 1.1                               | All supported PHP versions | Generic web tracing             |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

Updates the Laravel compatibility of the PHP Tracer to include Laravel 9.X & 10.X 

The tests were run in Datadog/dd-trace-php#2237

### Motivation
It was about time to make this official 😅 

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
