### PR TITLE
Add orchestrator explorer as a prereq for SCA

### DIFF
--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -22,7 +22,7 @@ Datadog Cloud Cost Management (CCM) automatically allocates EC2 compute cost in 
 1. Set up and configure [AWS Cloud Cost integration][1].
 2. (Optional) Enable [AWS Split Cost Allocation][5] for usage-based ECS allocation.
 1. At least one of the following must be running:
-    - [**Datadog Agent**][2] in a Kubernetes environment using EC2 instances.
+    - [**Datadog Agent**][2] in a Kubernetes environment using EC2 instances. Please also ensure that the [**Orchestrator Explorer**][6] is enabled in your agent configuration.
     - [**Datadog Container Monitoring**][3] in ECS tasks.
 
 ## Cost metrics
@@ -144,3 +144,4 @@ In addition to ECS task tags, the following out-of-the-box tags are applied to c
 [3]: /containers/amazon_ecs/?tab=awscli
 [4]: https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html
 [5]: https://docs.aws.amazon.com/cur/latest/userguide/enabling-split-cost-allocation-data.html
+[6]: https://docs.datadoghq.com/infrastructure/containers/orchestrator_explorer/?tab=datadogoperator

--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -22,7 +22,7 @@ Datadog Cloud Cost Management (CCM) automatically allocates EC2 compute cost in 
 1. Set up and configure [AWS Cloud Cost integration][1].
 2. (Optional) Enable [AWS Split Cost Allocation][5] for usage-based ECS allocation.
 1. At least one of the following must be running:
-    - [**Datadog Agent**][2] in a Kubernetes environment using EC2 instances. Ensure that the [**Orchestrator Explorer**][6] is enabled in your Agent configuration.
+    - [**Datadog Agent**][2] in a Kubernetes environment using EC2 instances. Ensure that you enable the [**Orchestrator Explorer**][6] in your Agent configuration.
     - [**Datadog Container Monitoring**][3] in ECS tasks.
 
 ## Cost metrics

--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -22,7 +22,7 @@ Datadog Cloud Cost Management (CCM) automatically allocates EC2 compute cost in 
 1. Set up and configure [AWS Cloud Cost integration][1].
 2. (Optional) Enable [AWS Split Cost Allocation][5] for usage-based ECS allocation.
 1. At least one of the following must be running:
-    - [**Datadog Agent**][2] in a Kubernetes environment using EC2 instances. Please also ensure that the [**Orchestrator Explorer**][6] is enabled in your agent configuration.
+    - [**Datadog Agent**][2] in a Kubernetes environment using EC2 instances. Please also ensure that the [**Orchestrator Explorer**][6] is enabled in your Agent configuration.
     - [**Datadog Container Monitoring**][3] in ECS tasks.
 
 ## Cost metrics

--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -144,4 +144,4 @@ In addition to ECS task tags, the following out-of-the-box tags are applied to c
 [3]: /containers/amazon_ecs/?tab=awscli
 [4]: https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html
 [5]: https://docs.aws.amazon.com/cur/latest/userguide/enabling-split-cost-allocation-data.html
-[6]: https://docs.datadoghq.com/infrastructure/containers/orchestrator_explorer/?tab=datadogoperator
+[6]: /containers/orchestrator_explorer/?tab=datadogoperator

--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -22,7 +22,7 @@ Datadog Cloud Cost Management (CCM) automatically allocates EC2 compute cost in 
 1. Set up and configure [AWS Cloud Cost integration][1].
 2. (Optional) Enable [AWS Split Cost Allocation][5] for usage-based ECS allocation.
 1. At least one of the following must be running:
-    - [**Datadog Agent**][2] in a Kubernetes environment using EC2 instances. Please also ensure that the [**Orchestrator Explorer**][6] is enabled in your Agent configuration.
+    - [**Datadog Agent**][2] in a Kubernetes environment using EC2 instances. Ensure that the [**Orchestrator Explorer**][6] is enabled in your Agent configuration.
     - [**Datadog Container Monitoring**][3] in ECS tasks.
 
 ## Cost metrics

--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -144,4 +144,4 @@ In addition to ECS task tags, the following out-of-the-box tags are applied to c
 [3]: /containers/amazon_ecs/?tab=awscli
 [4]: https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html
 [5]: https://docs.aws.amazon.com/cur/latest/userguide/enabling-split-cost-allocation-data.html
-[6]: /containers/orchestrator_explorer/?tab=datadogoperator
+[6]: /infrastructure/containers/orchestrator_explorer?tab=datadogoperator


### PR DESCRIPTION
### What does this PR do?
Adds orchestrator explorer as a prereq for CCM shared cost metrics.

### Motivation
Support issue where customer did not have this enabled. They did not have k8s shared cost metrics as a result.

### Additional Notes

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
