### PR TITLE
[DOCS-6144] Add site regions for Flex Logs

### DIFF
--- a/content/en/logs/log_configuration/flex_log.md
+++ b/content/en/logs/log_configuration/flex_log.md
@@ -15,6 +15,10 @@ further_reading:
   text: "Log Archives"
 ---
 
+{{< site-region region="eu,gov,us3,us5,ap1" >}}
+<div class="alert alert-warning">Flex Logs is not supported for the Datadog {{< region-param key="dd_site_name" >}} site.</div>
+{{< /site-region >}}
+
 {{< callout url="https://docs.google.com/forms/d/15FJG6RTFMmp7c7aRE8bcTy6B1Tt8ia4OmiesQa_zkZ4/viewform?edit_requested=true" btn_hidden="false" header="Request Access!">}}
 Flex Logs is in Limited Availability, but you can request access! Use this form to submit your request today.
 {{< /callout >}}

--- a/content/en/logs/log_configuration/flex_logs.md
+++ b/content/en/logs/log_configuration/flex_logs.md
@@ -3,6 +3,8 @@ title: Flex Logs
 kind: documentation
 description: Cost effective live query capabilities over long term retention of Logs
 private: true
+aliases:
+  - /logs/log_configuration/flex_log/
 further_reading:
 - link: "https://www.datadoghq.com/blog/flex-logging"
   tag: "Blog"


### PR DESCRIPTION
### What does this PR do?

Flex Logs is only supported for US1. Add site regions to doc. Also renames the page to flex_logs.md to be consistent with product name.

Ready to merge.

### Motivation

[DOCS-6144](https://datadoghq.atlassian.net/browse/DOCS-6144)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.


[DOCS-6144]: https://datadoghq.atlassian.net/browse/DOCS-6144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ